### PR TITLE
test: give the suite its own run directory instead of the real one

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,10 +50,19 @@ def _remove_test_home(root):
     a person needs to find it and clear it. Only the removal is guarded --
     anything else escapes, because a bug in this function is not a cleanup
     failure and should not be dressed up as one.
+
+    ``OSError`` is what the filesystem raises: permissions, a busy file, a full
+    disk. ``RecursionError`` is what the walk itself raises -- ``rmtree``
+    descends recursively, so a tree deep enough to exhaust the stack fails
+    without the filesystem objecting to anything. Both leave the root on disk
+    and both are the caller's to clear, so both get the message. Nothing wider:
+    a bare ``except Exception`` would also swallow a ``TypeError`` or a
+    ``NameError`` from this function itself and report a bug here as a
+    directory the machine refused to delete.
     """
     try:
         shutil.rmtree(root)
-    except OSError as e:
+    except (OSError, RecursionError) as e:
         sys.stderr.write(
             f"\nlionagi tests: could not remove the temporary run directory {root}\n"
             f"  {e}\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,12 +33,40 @@ import shutil
 import sys
 import tempfile
 
+
+def _remove_test_home(root):
+    """Delete the suite's temporary root, and say so on stderr if it survives.
+
+    Cleanup runs from ``atexit``, after the session pytest reported on is over,
+    so there is nothing left to fail: raising here would produce an unraisable
+    traceback attached to no test and could only confuse the result a reader
+    already has. Swallowing the error is worse — a permission problem, a busy
+    file or a full filesystem leaves a directory behind and the suite says
+    nothing, so a boundary the suite draws around itself is one it cannot
+    report on when it leaks.
+
+    So the failure is a message rather than an exception: it names the root
+    that is still on disk and the error that stopped the removal, which is what
+    a person needs to find it and clear it. Only the removal is guarded --
+    anything else escapes, because a bug in this function is not a cleanup
+    failure and should not be dressed up as one.
+    """
+    try:
+        shutil.rmtree(root)
+    except OSError as e:
+        sys.stderr.write(
+            f"\nlionagi tests: could not remove the temporary run directory {root}\n"
+            f"  {e}\n"
+            "  It is still on disk; remove it by hand.\n"
+        )
+
+
 if os.environ.get("LIONAGI_TEST_HOME"):
     os.environ["LIONAGI_HOME"] = os.environ["LIONAGI_TEST_HOME"]
 else:
     _TEST_LIONAGI_HOME = tempfile.mkdtemp(prefix="lionagi-tests-")
     os.environ["LIONAGI_HOME"] = _TEST_LIONAGI_HOME
-    atexit.register(shutil.rmtree, _TEST_LIONAGI_HOME, ignore_errors=True)
+    atexit.register(_remove_test_home, _TEST_LIONAGI_HOME)
 
 if "lionagi._paths" in sys.modules:
     # The constants are already bound to the old value, so the redirect above

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,15 +15,27 @@
 # isolation the default, and covers modules added later for free — patching
 # the constants after import would have to name every consumer.
 #
-# An explicit ``LIONAGI_HOME`` is honoured, so a caller can still point the
-# suite somewhere specific.
+# ``LIONAGI_HOME`` is the ordinary production variable: it is what a person sets
+# to point their own work at a particular store, and it is set in plenty of
+# shells and CI environments for reasons that have nothing to do with the suite.
+# So it is overwritten unconditionally rather than only when absent. Deferring to
+# it would let an ambient value silently switch the suite back to writing into
+# somebody's real store, and the boundary a test suite draws around itself must
+# not be something the environment can turn off by accident.
+#
+# ``LIONAGI_TEST_HOME`` is the deliberate way through, for an integration case
+# that needs the suite pointed at a specific directory. Setting it means the
+# suite writes outside the root it owns and cleans up: whatever lands under that
+# directory stays there after the run, interleaved with anything already in it.
 import atexit
 import os
 import shutil
 import sys
 import tempfile
 
-if not os.environ.get("LIONAGI_HOME"):
+if os.environ.get("LIONAGI_TEST_HOME"):
+    os.environ["LIONAGI_HOME"] = os.environ["LIONAGI_TEST_HOME"]
+else:
     _TEST_LIONAGI_HOME = tempfile.mkdtemp(prefix="lionagi-tests-")
     os.environ["LIONAGI_HOME"] = _TEST_LIONAGI_HOME
     atexit.register(shutil.rmtree, _TEST_LIONAGI_HOME, ignore_errors=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,43 @@
 # tests/conftest.py
-import json
+
+# ── Run directory isolation ─────────────────────────────────────────────
+#
+# Must stay above every other import in this file. ``lionagi._paths`` reads
+# ``LIONAGI_HOME`` once, at import, and derives ``RUNS_ROOT`` from it; seven
+# modules then bind those two constants into their own namespace by name. So
+# the value has to be in the environment before the first of those imports
+# runs, and this conftest is the earliest code the suite loads.
+#
+# Without it, isolating the run directory is opt-in per test file: a test that
+# calls ``allocate_run`` writes a manifest, branch snapshots and stream buffers
+# into whichever run directory the machine is actually using, interleaved with
+# the ones a person's own work depends on. Redirecting the root here makes
+# isolation the default, and covers modules added later for free — patching
+# the constants after import would have to name every consumer.
+#
+# An explicit ``LIONAGI_HOME`` is honoured, so a caller can still point the
+# suite somewhere specific.
+import atexit
+import os
+import shutil
 import sys
+import tempfile
+
+if not os.environ.get("LIONAGI_HOME"):
+    _TEST_LIONAGI_HOME = tempfile.mkdtemp(prefix="lionagi-tests-")
+    os.environ["LIONAGI_HOME"] = _TEST_LIONAGI_HOME
+    atexit.register(shutil.rmtree, _TEST_LIONAGI_HOME, ignore_errors=True)
+
+if "lionagi._paths" in sys.modules:
+    # The constants are already bound to the old value, so the redirect above
+    # did nothing and every run-directory write in this session lands in the
+    # real one. Fail here rather than let the suite report itself as isolated.
+    raise RuntimeError(
+        "lionagi._paths was imported before tests/conftest.py could redirect "
+        "LIONAGI_HOME; the run directory used by this session is not isolated."
+    )
+
+import json
 import types
 
 import pytest

--- a/tests/test_run_directory_isolation.py
+++ b/tests/test_run_directory_isolation.py
@@ -61,6 +61,12 @@ def test_report_bound_paths():
 # permissions: a process cannot unlink an entry from a directory it may not
 # write to, so ``rmtree`` walks in and stops on the file inside. The reporting
 # path under test is left alone -- stubbing it would only prove the stub ran.
+#
+# The paths are written down BEFORE the lock goes on, and that order is the
+# point: from the instant this directory becomes unremovable there is a file on
+# disk naming it and naming what has to be undone. The caller can then clear it
+# up whatever happens next -- including the cases where the caller never
+# receives a result at all, because this process hung or was killed.
 _UNREMOVABLE_PROBE_TEST = """
 import json
 import os
@@ -72,11 +78,26 @@ def test_leave_the_run_directory_unremovable():
     locked = home / "locked"
     locked.mkdir(parents=True, exist_ok=True)
     (locked / "kept").write_text("x")
-    locked.chmod(0o500)
     Path(os.environ["PROBE_RESULT"]).write_text(
         json.dumps({"lionagi_home": str(home), "locked": str(locked)})
     )
+    locked.chmod(0o500)
 """
+
+
+def _undo_lock_and_remove(reported: dict) -> None:
+    """Restore whatever a probe made unremovable, then delete its root.
+
+    Works from what the probe wrote down rather than from a live handle, so it
+    can run at any point after the probe locked the directory -- including
+    after a call that raised before it could hand anything back.
+    """
+    locked = reported.get("locked")
+    if locked and os.path.exists(locked):
+        os.chmod(locked, stat.S_IRWXU)
+    home = reported.get("lionagi_home")
+    if home:
+        shutil.rmtree(home, ignore_errors=True)
 
 
 @pytest.fixture
@@ -88,13 +109,23 @@ def probe(tmp_path):
     file in ``/tmp`` would collect nothing) while pytest's default
     ``norecursedirs`` keeps an ordinary suite run from picking it up. Passing
     the file path explicitly collects it anyway.
+
+    A probe that deliberately makes its own root unremovable writes the paths
+    down before it locks anything, so every root a call could leave behind is
+    named by a file this fixture already knows the location of. Reading those
+    back at teardown is what clears up after a call that never returned -- a
+    timeout, or a result that would not parse -- where the test itself never
+    learns which directory to go and unlock.
     """
+
+    reported_paths: list[Path] = []
 
     def _run(
         env_overrides: dict[str, str], source: str = _PROBE_TEST
     ) -> tuple[subprocess.CompletedProcess, dict]:
         probe_dir = Path(tempfile.mkdtemp(prefix=".run-isolation-probe-", dir=_TESTS_DIR))
-        result_path = tmp_path / "bound.json"
+        result_path = tmp_path / f"bound-{len(reported_paths)}.json"
+        reported_paths.append(result_path)
         try:
             (probe_dir / "test_probe.py").write_text(source)
 
@@ -127,7 +158,17 @@ def probe(tmp_path):
         finally:
             shutil.rmtree(probe_dir, ignore_errors=True)
 
-    return _run
+    yield _run
+
+    for result_path in reported_paths:
+        try:
+            reported = json.loads(result_path.read_text())
+        except (OSError, ValueError):
+            # No record, or an unusable one: there is nothing to act on. A
+            # probe that never got as far as writing never got as far as
+            # locking either.
+            continue
+        _undo_lock_and_remove(reported)
 
 
 def test_preset_lionagi_home_does_not_become_the_suite_root(probe, tmp_path):
@@ -221,12 +262,56 @@ def test_a_root_that_cannot_be_removed_is_reported(probe, tmp_path):
         )
     finally:
         # Whatever the assertions did, nothing unremovable outlives this test.
-        locked = Path(bound["locked"]) if bound else None
-        if locked is not None and locked.exists():
-            locked.chmod(stat.S_IRWXU)
         if bound:
-            shutil.rmtree(bound["lionagi_home"], ignore_errors=True)
+            _undo_lock_and_remove(bound)
 
     assert not Path(bound["lionagi_home"]).exists(), (
         "this test could not remove what it made unremovable"
     )
+
+
+def test_a_removal_that_exhausts_the_stack_is_reported_too(monkeypatch, capsys):
+    """Not every way a removal fails comes from the filesystem.
+
+    ``rmtree`` descends recursively, so a tree deep enough exhausts the stack
+    and raises ``RecursionError`` while every directory in it is perfectly
+    removable. The root is still left behind, so it has to reach the same
+    message -- not escape and become an ``atexit`` traceback, which is the one
+    outcome the reporting exists to prevent.
+    """
+    from tests.conftest import _remove_test_home
+
+    def _too_deep(_root):
+        raise RecursionError("maximum recursion depth exceeded")
+
+    monkeypatch.setattr(shutil, "rmtree", _too_deep)
+
+    _remove_test_home("/nowhere/deep-root")
+
+    reported = capsys.readouterr().err
+    assert "/nowhere/deep-root" in reported, (
+        f"the report does not name the root that was left behind:\n{reported}"
+    )
+    assert "maximum recursion depth exceeded" in reported, (
+        f"the report does not name the error that stopped the removal:\n{reported}"
+    )
+
+
+def test_a_bug_in_the_removal_is_not_dressed_up_as_a_cleanup_failure(monkeypatch, capsys):
+    """Only the filesystem's refusals are turned into a message.
+
+    Calling ``rmtree`` wrongly is a defect in this suite, not a directory the
+    machine would not delete, and reporting it as the latter would send a
+    reader hunting for a root that is not there.
+    """
+    from tests.conftest import _remove_test_home
+
+    def _misused(_root):
+        raise TypeError("rmtree() got an unexpected keyword argument")
+
+    monkeypatch.setattr(shutil, "rmtree", _misused)
+
+    with pytest.raises(TypeError):
+        _remove_test_home("/nowhere/deep-root")
+
+    assert "/nowhere/deep-root" not in capsys.readouterr().err

--- a/tests/test_run_directory_isolation.py
+++ b/tests/test_run_directory_isolation.py
@@ -12,11 +12,17 @@ Checking that from inside the running suite is not possible: by then the
 redirect has already happened and the original environment is gone. So this
 launches a second pytest with ``LIONAGI_HOME`` pre-set to a disposable
 directory and asks the collected code what it actually bound.
+
+The same subprocess is what makes the cleanup of that root observable: the
+removal runs at interpreter exit, after the session is over, so only a second
+process can watch a first one finish and read what it said on the way out.
 """
 
+import errno
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -51,9 +57,31 @@ def test_report_bound_paths():
 """
 
 
+# Makes the suite's own root impossible to delete, using nothing but file
+# permissions: a process cannot unlink an entry from a directory it may not
+# write to, so ``rmtree`` walks in and stops on the file inside. The reporting
+# path under test is left alone -- stubbing it would only prove the stub ran.
+_UNREMOVABLE_PROBE_TEST = """
+import json
+import os
+from pathlib import Path
+
+
+def test_leave_the_run_directory_unremovable():
+    home = Path(os.environ["LIONAGI_HOME"])
+    locked = home / "locked"
+    locked.mkdir(parents=True, exist_ok=True)
+    (locked / "kept").write_text("x")
+    locked.chmod(0o500)
+    Path(os.environ["PROBE_RESULT"]).write_text(
+        json.dumps({"lionagi_home": str(home), "locked": str(locked)})
+    )
+"""
+
+
 @pytest.fixture
 def probe(tmp_path):
-    """Run one probe pytest and hand back what lionagi bound inside it.
+    """Run one probe pytest and hand back what it reported from inside.
 
     The probe file lives in a dot-directory under ``tests/`` so that the real
     conftest applies to it (conftest discovery walks up the filesystem, so a
@@ -62,11 +90,13 @@ def probe(tmp_path):
     the file path explicitly collects it anyway.
     """
 
-    def _run(env_overrides: dict[str, str]) -> tuple[subprocess.CompletedProcess, dict]:
+    def _run(
+        env_overrides: dict[str, str], source: str = _PROBE_TEST
+    ) -> tuple[subprocess.CompletedProcess, dict]:
         probe_dir = Path(tempfile.mkdtemp(prefix=".run-isolation-probe-", dir=_TESTS_DIR))
         result_path = tmp_path / "bound.json"
         try:
-            (probe_dir / "test_probe.py").write_text(_PROBE_TEST)
+            (probe_dir / "test_probe.py").write_text(source)
 
             env = dict(os.environ)
             env.pop("LIONAGI_TEST_HOME", None)
@@ -148,3 +178,55 @@ def test_lionagi_test_home_is_the_deliberate_way_through(probe, tmp_path):
     assert bound, "probe produced no result file"
     assert Path(bound["lionagi_home"]) == chosen_home
     assert Path(bound["runs_root"]) == chosen_home / "runs"
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root may unlink from a directory it cannot write to, so nothing here is unremovable",
+)
+def test_a_root_that_cannot_be_removed_is_reported(probe, tmp_path):
+    """A cleanup that fails must say which directory it left behind, and why.
+
+    The suite deletes its temporary root from ``atexit``, which is past the
+    point where a failure can be a test result -- so the only thing that can
+    observe one is another process watching this one exit. The probe makes the
+    removal fail through ordinary permissions and this reads the exiting
+    process's stderr.
+    """
+    caller_home = tmp_path / "caller-store"
+    caller_home.mkdir()
+
+    completed, bound = probe({"LIONAGI_HOME": str(caller_home)}, source=_UNREMOVABLE_PROBE_TEST)
+
+    try:
+        assert completed.returncode == 0, (
+            f"probe pytest failed (rc={completed.returncode}):\n"
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
+        assert bound, "probe produced no result file"
+
+        home = Path(bound["lionagi_home"])
+        assert home.exists(), (
+            f"{home} was removed after all, so this test forced no failure and "
+            "proves nothing about how one is reported"
+        )
+        assert str(home) in completed.stderr, (
+            "the suite left a temporary run directory behind and said nothing that "
+            f"names it; stderr:\n{completed.stderr}"
+        )
+        # The error too, not just the path: a reader has to be able to tell a
+        # permission problem from a full disk.
+        assert os.strerror(errno.EACCES) in completed.stderr, (
+            f"the report does not name the error that stopped the removal:\n{completed.stderr}"
+        )
+    finally:
+        # Whatever the assertions did, nothing unremovable outlives this test.
+        locked = Path(bound["locked"]) if bound else None
+        if locked is not None and locked.exists():
+            locked.chmod(stat.S_IRWXU)
+        if bound:
+            shutil.rmtree(bound["lionagi_home"], ignore_errors=True)
+
+    assert not Path(bound["lionagi_home"]).exists(), (
+        "this test could not remove what it made unremovable"
+    )

--- a/tests/test_run_directory_isolation.py
+++ b/tests/test_run_directory_isolation.py
@@ -1,0 +1,150 @@
+"""The suite's run directory must be its own, whatever the environment says.
+
+``tests/conftest.py`` redirects ``LIONAGI_HOME`` to a temporary directory before
+any lionagi import, because ``lionagi._paths`` reads it once at import and
+derives ``RUNS_ROOT`` from it. The redirect is only worth anything if it also
+holds when the invoking environment already sets ``LIONAGI_HOME`` — that is the
+case where a developer's real store, or a persistent CI one, is what the suite
+would otherwise write into, and it is the case a conftest that only fills in a
+missing value gets wrong while looking correct.
+
+Checking that from inside the running suite is not possible: by then the
+redirect has already happened and the original environment is gone. So this
+launches a second pytest with ``LIONAGI_HOME`` pre-set to a disposable
+directory and asks the collected code what it actually bound.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_TESTS_DIR = Path(__file__).parent
+_REPO_ROOT = _TESTS_DIR.parent
+
+# Reports the constants as lionagi bound them, from inside a suite that loaded
+# the real tests/conftest.py. Writes rather than prints so the answer survives
+# whatever pytest does to captured output.
+_PROBE_TEST = """
+import json
+import os
+from pathlib import Path
+
+from lionagi import _paths
+
+
+def test_report_bound_paths():
+    Path(os.environ["PROBE_RESULT"]).write_text(
+        json.dumps(
+            {
+                "lionagi_home": str(_paths.LIONAGI_HOME),
+                "runs_root": str(_paths.RUNS_ROOT),
+                "env_lionagi_home": os.environ["LIONAGI_HOME"],
+            }
+        )
+    )
+"""
+
+
+@pytest.fixture
+def probe(tmp_path):
+    """Run one probe pytest and hand back what lionagi bound inside it.
+
+    The probe file lives in a dot-directory under ``tests/`` so that the real
+    conftest applies to it (conftest discovery walks up the filesystem, so a
+    file in ``/tmp`` would collect nothing) while pytest's default
+    ``norecursedirs`` keeps an ordinary suite run from picking it up. Passing
+    the file path explicitly collects it anyway.
+    """
+
+    def _run(env_overrides: dict[str, str]) -> tuple[subprocess.CompletedProcess, dict]:
+        probe_dir = Path(tempfile.mkdtemp(prefix=".run-isolation-probe-", dir=_TESTS_DIR))
+        result_path = tmp_path / "bound.json"
+        try:
+            (probe_dir / "test_probe.py").write_text(_PROBE_TEST)
+
+            env = dict(os.environ)
+            env.pop("LIONAGI_TEST_HOME", None)
+            env["PROBE_RESULT"] = str(result_path)
+            env.update(env_overrides)
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    str(probe_dir / "test_probe.py"),
+                    # -n0 beats the -n auto in addopts: the probe is one test and
+                    # xdist workers would only add startup cost.
+                    "-n0",
+                    "-q",
+                    "-p",
+                    "no:cacheprovider",
+                ],
+                cwd=_REPO_ROOT,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=300,
+            )
+            bound = json.loads(result_path.read_text()) if result_path.exists() else {}
+            return completed, bound
+        finally:
+            shutil.rmtree(probe_dir, ignore_errors=True)
+
+    return _run
+
+
+def test_preset_lionagi_home_does_not_become_the_suite_root(probe, tmp_path):
+    """A ``LIONAGI_HOME`` already in the environment must not be adopted."""
+    caller_home = tmp_path / "caller-store"
+    caller_home.mkdir()
+
+    completed, bound = probe({"LIONAGI_HOME": str(caller_home)})
+
+    assert completed.returncode == 0, (
+        f"probe pytest failed (rc={completed.returncode}):\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    assert bound, "probe produced no result file"
+
+    bound_home = Path(bound["lionagi_home"])
+    assert bound_home != caller_home, (
+        "the suite adopted the caller's LIONAGI_HOME as its run directory root; "
+        f"tests would write into {caller_home}"
+    )
+    assert caller_home not in bound_home.parents, (
+        f"the suite's root {bound_home} is inside the caller's store {caller_home}"
+    )
+    # Not merely different: a root the suite made for itself, under the
+    # temporary directory it cleans up at exit.
+    assert Path(tempfile.gettempdir()).resolve() in bound_home.resolve().parents
+    assert Path(bound["runs_root"]) == bound_home / "runs"
+    assert bound["env_lionagi_home"] == str(bound_home)
+
+    # The caller's directory is not just unbound, it is untouched.
+    assert list(caller_home.iterdir()) == []
+
+
+def test_lionagi_test_home_is_the_deliberate_way_through(probe, tmp_path):
+    """``LIONAGI_TEST_HOME`` points the suite somewhere specific, on purpose."""
+    caller_home = tmp_path / "caller-store"
+    caller_home.mkdir()
+    chosen_home = tmp_path / "chosen-store"
+
+    completed, bound = probe(
+        {"LIONAGI_HOME": str(caller_home), "LIONAGI_TEST_HOME": str(chosen_home)}
+    )
+
+    assert completed.returncode == 0, (
+        f"probe pytest failed (rc={completed.returncode}):\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    assert bound, "probe produced no result file"
+    assert Path(bound["lionagi_home"]) == chosen_home
+    assert Path(bound["runs_root"]) == chosen_home / "runs"

--- a/tests/test_run_directory_isolation.py
+++ b/tests/test_run_directory_isolation.py
@@ -91,13 +91,70 @@ def _undo_lock_and_remove(reported: dict) -> None:
     Works from what the probe wrote down rather than from a live handle, so it
     can run at any point after the probe locked the directory -- including
     after a call that raised before it could hand anything back.
+
+    Raises when the root is still there afterwards, naming the path and the
+    error. Attempting the removal and reporting that as having removed it is
+    the failure this whole module exists to catch: a directory nothing can
+    delete stays on disk and the suite says nothing about it. The removal is
+    therefore unguarded -- the error the filesystem gives is the only thing
+    that tells a reader whether to fix permissions or free some disk -- and the
+    path is checked again afterwards, because a removal that raises nothing has
+    still failed if the directory is there.
     """
     locked = reported.get("locked")
     if locked and os.path.exists(locked):
-        os.chmod(locked, stat.S_IRWXU)
+        try:
+            os.chmod(locked, stat.S_IRWXU)
+        except OSError as e:
+            raise RuntimeError(f"could not unlock {locked}: {e}") from e
     home = reported.get("lionagi_home")
-    if home:
-        shutil.rmtree(home, ignore_errors=True)
+    if not home or not os.path.exists(home):
+        # Nothing recorded, or the probe's own cleanup already got there --
+        # which is the ordinary case for a probe that locked nothing.
+        return
+    try:
+        shutil.rmtree(home)
+    except OSError as e:
+        raise RuntimeError(f"could not remove the probe run directory {home}: {e}") from e
+    if os.path.exists(home):
+        raise RuntimeError(
+            f"the probe run directory {home} is still on disk after a removal that raised nothing"
+        )
+
+
+def _recover_reported_roots(result_paths) -> None:
+    """Undo every recorded lock, and name every one that could not be undone.
+
+    Every record gets its turn even when an earlier one fails: the roots are
+    independent, and stopping at the first failure strands the later ones with
+    nothing coming back for them. The failures are collected and raised
+    together at the end, so a partial recovery cannot be read as a complete
+    one -- which is the same defect as a single removal that reports having
+    happened when it did not.
+
+    The per-record guard is deliberately wide. Nothing is swallowed by it:
+    whatever it catches is named in the consolidated failure, and catching
+    narrowly here would let one unexpected error decide that the remaining
+    roots are not worth attempting.
+    """
+    failures = []
+    for result_path in result_paths:
+        try:
+            reported = json.loads(Path(result_path).read_text())
+        except (OSError, ValueError):
+            # No record, or an unusable one: there is nothing to act on. A
+            # probe that never got as far as writing never got as far as
+            # locking either.
+            continue
+        try:
+            _undo_lock_and_remove(reported)
+        except Exception as e:  # noqa: BLE001 -- re-raised below, never discarded
+            failures.append(f"  {e}")
+    if failures:
+        raise RuntimeError(
+            "probe run directories were left behind and could not be recovered:\n"
+            + "\n".join(failures)
+        )
 
 
 @pytest.fixture
@@ -116,6 +173,9 @@ def probe(tmp_path):
     back at teardown is what clears up after a call that never returned -- a
     timeout, or a result that would not parse -- where the test itself never
     learns which directory to go and unlock.
+
+    The list of records is hung off the returned callable, so a test can drive
+    the same recovery this teardown runs and read what it reports.
     """
 
     reported_paths: list[Path] = []
@@ -158,17 +218,11 @@ def probe(tmp_path):
         finally:
             shutil.rmtree(probe_dir, ignore_errors=True)
 
+    _run.reported_paths = reported_paths
+
     yield _run
 
-    for result_path in reported_paths:
-        try:
-            reported = json.loads(result_path.read_text())
-        except (OSError, ValueError):
-            # No record, or an unusable one: there is nothing to act on. A
-            # probe that never got as far as writing never got as far as
-            # locking either.
-            continue
-        _undo_lock_and_remove(reported)
+    _recover_reported_roots(reported_paths)
 
 
 def test_preset_lionagi_home_does_not_become_the_suite_root(probe, tmp_path):
@@ -268,6 +322,79 @@ def test_a_root_that_cannot_be_removed_is_reported(probe, tmp_path):
     assert not Path(bound["lionagi_home"]).exists(), (
         "this test could not remove what it made unremovable"
     )
+
+
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root may unlink from a directory it cannot write to, so nothing here is unremovable",
+)
+def test_one_failed_recovery_neither_hides_itself_nor_strands_the_next_root(
+    probe, tmp_path, monkeypatch
+):
+    """Recovering two locked roots, where the first recovery cannot be done.
+
+    Two calls leave two roots that only the recorded paths can find again, and
+    the first is made irrecoverable: its unlocking is turned into a no-op, so
+    the recovery goes on to a removal that cannot succeed. That is the failure
+    worth forcing, because it is the one a removal asked to ignore its errors
+    would carry out and then report as done.
+
+    What has to hold is that the failure reaches the caller naming the root and
+    the reason, and that the second root is recovered anyway -- a loop that
+    stops at the first failure leaves it locked on disk with nothing coming
+    back for it.
+    """
+    caller_home = tmp_path / "caller-store"
+    caller_home.mkdir()
+
+    _, first = probe({"LIONAGI_HOME": str(caller_home)}, source=_UNREMOVABLE_PROBE_TEST)
+    _, second = probe({"LIONAGI_HOME": str(caller_home)}, source=_UNREMOVABLE_PROBE_TEST)
+
+    assert first and second, "a probe produced no result file"
+    first_home = Path(first["lionagi_home"])
+    second_home = Path(second["lionagi_home"])
+    assert first_home != second_home
+    assert first_home.exists() and second_home.exists(), (
+        "both probes were cleaned up after all, so this test forced no failure "
+        "and proves nothing about recovering from one"
+    )
+
+    real_chmod = os.chmod
+
+    def _leave_the_first_locked(path, mode, *args, **kwargs):
+        if str(path) == first["locked"]:
+            return None
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "chmod", _leave_the_first_locked)
+    try:
+        with pytest.raises(RuntimeError) as failure:
+            _recover_reported_roots(probe.reported_paths)
+
+        reported = str(failure.value)
+        assert str(first_home) in reported, (
+            f"the failed recovery does not name the root it left behind:\n{reported}"
+        )
+        assert os.strerror(errno.EACCES) in reported, (
+            f"the failed recovery does not name the error that stopped it:\n{reported}"
+        )
+        # The failure was real, not a message about a directory that went away
+        # on its own.
+        assert first_home.exists(), (
+            f"{first_home} was recovered after all, so the reported failure is false"
+        )
+        # And the point: the later record was still attempted.
+        assert not second_home.exists(), (
+            f"{second_home} is still locked on disk because an earlier recovery failed; "
+            "it was recorded and nothing else will come back for it"
+        )
+    finally:
+        monkeypatch.setattr(os, "chmod", real_chmod)
+        # Now that permissions can be restored, the same recovery finishes the
+        # job -- and says nothing, because there is nothing left to say.
+        _recover_reported_roots(probe.reported_paths)
+
+    assert not first_home.exists(), "this test could not remove what it made unremovable"
 
 
 def test_a_removal_that_exhausts_the_stack_is_reported_too(monkeypatch, capsys):


### PR DESCRIPTION
Tests that allocate a run write their manifest, branch snapshots and stream
buffers into whichever run directory the machine is actually using, interleaved
with the runs a person's own work depends on.

Isolation was opt-in per file: eleven test files patch `RUNS_ROOT` themselves.
That cannot be the mechanism, because `lionagi._paths` reads `LIONAGI_HOME` once
at import and seven modules bind the derived constants into their own namespaces
by name, so patching after import has to enumerate every consumer and goes stale
on the eighth. `tests/conftest.py` is the earliest code the suite loads, so it
sets `LIONAGI_HOME` to a temp directory there, before any lionagi import, and
registers cleanup at exit.

The redirect is unconditional. `LIONAGI_HOME` is the ordinary production
variable and is set in plenty of shells and CI environments for reasons that
have nothing to do with the suite; deferring to a value that is already there
would let the environment silently switch the suite back to writing into
somebody's real store. A boundary a test suite draws around itself should not be
something the environment can turn off by accident. Pointing the suite somewhere
specific is still possible, through `LIONAGI_TEST_HOME` — a separate variable
that cannot be set by accident, documented at the call site as deliberately
leaving the suite writing outside the root it owns and cleans up.

The conftest also raises if `lionagi._paths` is already in `sys.modules` when it
runs. At that point the redirect has silently done nothing and every write in the
session lands in the real directory, so it fails loudly rather than reporting
itself as isolated. That check asks *when* `_paths` was imported and never *what
value* it bound, which is why it is not the whole guard:
`tests/test_run_directory_isolation.py` asks the other question, by launching a
second pytest with `LIONAGI_HOME` pre-set to a disposable directory and reading
back the constants lionagi actually bound. It asserts they name a different,
suite-created root and that the caller's directory is left empty.

Closes #2475

## The issue names one file; there are eighteen

This was measured rather than grepped, because a test reaches the run directory
through any of eight modules without ever naming `RUNS_ROOT`. A throwaway pytest
plugin wrapped `open`, `Path.*`, `os.*`, `sqlite3.connect` and `shutil.*` and
raised *before* delegating on any write under the real `~/.lionagi` — detection
with no mutation of the live directory. A file known to be isolated ran in the
same invocation as a positive control, so a clean result means the instrument
looked and found nothing.

Sweep result: **65 offending nodeids across 18 files**. Ten of them write into
the run directory, from three files; the issue names one. `tests/cli/test_doctor.py`
and `tests/cli/orchestrate/test_role_config.py` do it too, so a fix scoped to the
named file would have read as complete while leaving most of it in place.

Fifty of the sixty-five trips are `sqlite3.connect` against the real `state.db` —
same family, different target, and this change moves those too.

## Where the issue drifts

It says ten files patch `RUNS_ROOT`; there are eleven. It says five
parameterizations; there are six. And it attributes the failure to
`_atomic_write_json`, but two `mkdir` calls run first — the anchoring cause it
names is right, the failing function is not.

## Verification

Pre-fix sweep: 48 failed, 15843 passed, 66 guard trips, rc 1. Post-fix:
6 failed, 15885 passed, 0 guard trips, rc taken from pytest itself rather than
after a pipe.

To read those numbers correctly: the 48 pre-fix failures are failures *under the
detection guard*, which raises on a write that would otherwise succeed silently.
Each one is a test that passed before the guard was installed and would pass
again without it — the guard converts a silent write into a visible stop, so the
48 count writes, not breakage. The 42 that disappear are not 42 tests repaired.
What the change repairs is the writing.

Correction to that measurement: both sweeps ran with `LIONAGI_HOME` unset, so
they measured the default case only. Under the earlier conditional redirect a run
with `LIONAGI_HOME` already set would have reproduced the pre-fix behaviour while
reporting itself as isolated, because the suite adopted the caller's value — the
post-fix zero held for the environment the sweep used and not for every
environment. With the redirect now unconditional the zero is a property of the
suite rather than of the shell it was launched from, and the new test is what
holds it there.

Full suite at this head, `LIONAGI_HOME` unset: **6 failed, 15887 passed, 19
skipped in 280s, rc 1** (rc from pytest, not from a pipe). The two added tests
account for the passed count moving by two. Five of the six failures are missing
optional extras — ollama, docling, asyncpg. The sixth,
`test_flow_timeout_shields_completed_branch_status_until_commit`, is a timing
race: it asserts a cancellation event is set, and its own log line shows planning
took 1.9s under twelve parallel workers. It passes on its own (rc 0). This change
cannot reach it — with `LIONAGI_HOME` unset the conftest takes the same branch it
took before — but calling it pre-existing rather than merely unrelated would need
a baseline run I did not do.

`--maxfail=5000` was used for the sweeps rather than the usual bound, because an
enumeration run must not be able to stop early. Saying so rather than leaving the
flag to be noticed.

The `PermissionError` the issue describes was never observed: this run directory
is writable, so pre-fix these tests passed and littered. The write is what was
reproduced, and that is the defect; the permission symptom is reasoned, not
measured.

Adjacent and not fixed: `find_lionagi_dirs()` walks the git root's `.lionagi`,
then cwd and every parent, then `Path.home()/.lionagi`. `LIONAGI_HOME` does not
enter that path at all, so this change does not isolate it.
