### PR TITLE
fix(operations): select the LNDL round transport from the effective model

### DIFF
--- a/lionagi/operations/chat/chat.py
+++ b/lionagi/operations/chat/chat.py
@@ -54,7 +54,9 @@ async def chat(
     # (potentially side-effecting) gather.
     ins = _build_instruction(branch, instruction, chat_param)
 
-    imodel = chat_param.imodel or branch.chat_model
+    # Sentinel status, not truthiness: a supplied model that defines __bool__
+    # as False is still a supplied model and must override the branch default.
+    imodel = branch.chat_model if chat_param._is_sentinel(chat_param.imodel) else chat_param.imodel
     await _emit_user_prompt_submit(branch, chat_param, ins, imodel=imodel)
 
     provider_ins, context_report = await _apply_context_providers(

--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -123,7 +123,11 @@ async def _run_round_chat(
     chat_param: ChatParam,
 ) -> str:
     """Run one inner-chat turn, dispatching to communicate() (API) or run_and_collect() (CLI) — mirrors operate()'s own selection."""
-    if isinstance(chat_param, RunParam) or getattr(branch.chat_model, "is_cli", False):
+    # A model carried on the chat param overrides the branch default for this
+    # call, so transport must follow the effective model's CLI flag rather than
+    # the branch's — the same precedence chat() and operate() apply.
+    effective_imodel = chat_param.imodel or branch.chat_model
+    if isinstance(chat_param, RunParam) or getattr(effective_imodel, "is_cli", False):
         from ..run.run import run_and_collect
 
         return await run_and_collect(branch, instruction, chat_param, skip_validation=True)

--- a/lionagi/operations/lndl_middle/lndl_middle.py
+++ b/lionagi/operations/lndl_middle/lndl_middle.py
@@ -126,7 +126,12 @@ async def _run_round_chat(
     # A model carried on the chat param overrides the branch default for this
     # call, so transport must follow the effective model's CLI flag rather than
     # the branch's — the same precedence chat() and operate() apply.
-    effective_imodel = chat_param.imodel or branch.chat_model
+    # Decided on sentinel status rather than truthiness: the parameter bag
+    # stores whatever the caller supplied, so a model object that defines
+    # __bool__ as False is still a supplied model and must win.
+    effective_imodel = (
+        branch.chat_model if chat_param._is_sentinel(chat_param.imodel) else chat_param.imodel
+    )
     if isinstance(chat_param, RunParam) or getattr(effective_imodel, "is_cli", False):
         from ..run.run import run_and_collect
 

--- a/lionagi/operations/operate/operate.py
+++ b/lionagi/operations/operate/operate.py
@@ -234,7 +234,9 @@ async def operate(
         # this call, so transport must follow the effective model's CLI flag
         # rather than the branch's — otherwise a per-call CLI model on an API
         # branch takes the non-streaming path.
-        effective_imodel = _cctx.imodel or branch.chat_model
+        # Sentinel status, not truthiness: a supplied model that defines
+        # __bool__ as False is still a supplied model and must win here.
+        effective_imodel = branch.chat_model if _cctx._is_sentinel(_cctx.imodel) else _cctx.imodel
         if isinstance(_cctx, RunParam) or getattr(effective_imodel, "is_cli", False):
             from ..run.run import run_and_collect
 

--- a/lionagi/operations/parse/parse.py
+++ b/lionagi/operations/parse/parse.py
@@ -207,7 +207,11 @@ async def parse(
                 )
                 else None
             ),
-            imodel=parse_param.imodel or branch.parse_model,
+            imodel=(
+                branch.parse_model
+                if parse_param._is_sentinel(parse_param.imodel)
+                else parse_param.imodel
+            ),
             sender=branch.user,
             recipient=branch.id,
             return_ins_res_message=True,

--- a/tests/operations/test_chat.py
+++ b/tests/operations/test_chat.py
@@ -485,6 +485,63 @@ class TestChatContextParameters:
         assert isinstance(result, str)
 
 
+class TestSuppliedModelSelection:
+    """Which model a turn runs against is decided by whether one was supplied,
+    not by whether it is truthy."""
+
+    @pytest.mark.asyncio
+    async def test_a_supplied_falsy_model_is_used_instead_of_the_branch_model(
+        self, make_mocked_branch_for_chat
+    ):
+        """The parameter bag stores whatever the caller passes, so a model
+        object defining ``__bool__`` as False — an adapter or a subclass
+        wrapping another model — is still a supplied model, and the turn must
+        be invoked against it rather than against the branch default."""
+        branch = make_mocked_branch_for_chat()
+        supplied = _FalsyIModel(branch.chat_model)
+        assert not bool(supplied)
+
+        chat_ctx = ChatParam(
+            guidance=None,
+            context=None,
+            sender="user",
+            recipient=branch.id,
+            response_format=None,
+            progression=None,
+            tool_schemas=[],
+            images=[],
+            image_detail="auto",
+            plain_content="",
+            include_token_usage_to_model=False,
+            imodel=supplied,
+            imodel_kw={},
+        )
+
+        await chat(branch, "Test", chat_ctx, return_ins_res_message=False)
+
+        assert supplied.invoked, "the supplied model was discarded for the branch default"
+
+
+class _FalsyIModel:
+    """Delegates to a real model but reports False in a boolean context, as an
+    adapter or a wrapping subclass may legitimately do. Records whether the
+    turn was actually invoked against it."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.invoked = False
+
+    def __bool__(self) -> bool:
+        return False
+
+    async def invoke(self, **kw):
+        self.invoked = True
+        return await self._inner.invoke(**kw)
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
 # ============================================================================
 # Fixtures
 # ============================================================================

--- a/tests/operations/test_lndl_middle.py
+++ b/tests/operations/test_lndl_middle.py
@@ -38,6 +38,14 @@ class AnswerModel(BaseModel):
     answer: str
 
 
+class _FalsyModel(SimpleNamespace):
+    """A model stand-in that is False in a boolean context, as an adapter or a
+    wrapping subclass may legitimately be."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
 class TwoFieldModel(BaseModel):
     answer: str
     detail: str
@@ -257,6 +265,23 @@ class TestRunRoundChatDispatch:
                 branch, "hi", ChatParam(imodel=SimpleNamespace(is_cli=True))
             )
         assert result == "cli text"
+        fake.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_supplied_model_that_is_falsy_still_overrides_the_branch(self):
+        """Whether a model was supplied is decided by sentinel status, not by
+        truthiness. The parameter bag stores whatever the caller passes, so a
+        model object defining ``__bool__`` as False — an adapter or a subclass
+        wrapping another model — is still a supplied model and must select the
+        transport, rather than being discarded for the branch default."""
+        branch = SimpleNamespace(chat_model=SimpleNamespace(is_cli=True))
+        supplied = _FalsyModel(is_cli=False)
+        assert not bool(supplied)
+
+        fake = AsyncMock(return_value="api text")
+        with patch("lionagi.operations.communicate.communicate.communicate", new=fake):
+            result = await _run_round_chat(branch, "hi", ChatParam(imodel=supplied))
+        assert result == "api text"
         fake.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/operations/test_lndl_middle.py
+++ b/tests/operations/test_lndl_middle.py
@@ -233,6 +233,33 @@ class TestRunRoundChatDispatch:
         fake.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_per_call_api_model_overrides_a_cli_branch(self):
+        """A model supplied on the chat param overrides the branch default for
+        this call, so an API model must take the non-streaming path even when
+        the branch's own chat_model is CLI-backed."""
+        branch = SimpleNamespace(chat_model=SimpleNamespace(is_cli=True))
+        fake = AsyncMock(return_value="api text")
+        with patch("lionagi.operations.communicate.communicate.communicate", new=fake):
+            result = await _run_round_chat(
+                branch, "hi", ChatParam(imodel=SimpleNamespace(is_cli=False))
+            )
+        assert result == "api text"
+        fake.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_per_call_cli_model_overrides_an_api_branch(self):
+        """The inverse override: a CLI model on the chat param takes the
+        streaming path even though the branch's chat_model is an API model."""
+        branch = SimpleNamespace(chat_model=SimpleNamespace(is_cli=False))
+        fake = AsyncMock(return_value="cli text")
+        with patch("lionagi.operations.run.run.run_and_collect", new=fake):
+            result = await _run_round_chat(
+                branch, "hi", ChatParam(imodel=SimpleNamespace(is_cli=True))
+            )
+        assert result == "cli text"
+        fake.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_real_scripted_branch_round_trips_via_run_and_collect(self):
         """End-to-end sanity check with a real TestBranch (necessarily
         CLI-routed, see class docstring) — confirms the dispatch wiring


### PR DESCRIPTION
A branch on a CLI provider, given a per-call API model through
`ChatParam(imodel=...)`, routed that API model into the CLI streaming path,
which rejected it with `run operation only supports CLI endpoints`. The LNDL
round dispatcher read `branch.chat_model` to choose the transport while the
request itself was issued against the per-call model.

Closes #2403

## Corrected: the siblings were not a correct model to copy

The first version of this change made `_run_round_chat` match its siblings by
adopting `chat_param.imodel or branch.chat_model`, and this description claimed
the surrounding code was consistent and `_run_round_chat` was the lone outlier.
**That was wrong, and review disproved it.**

`ChatParam` inherits a generic parameter bag that stores whatever value the
caller passes for an allowed key, with no runtime type validation. `or` resolves
by truthiness, so a supplied model object that defines `__bool__` as False — an
adapter, or a subclass wrapping another model — is silently discarded in favour
of the branch default, even though it was explicitly supplied. The unsupplied
value is a sentinel, which is *also* falsy, and that coincidence is what made the
idiom look correct: it is right for the unsupplied case and for every ordinary
truthy model, and wrong for the case the parameter bag admits.

So the corrected statement is the inverse of the original one: the siblings were
not a correct target to align with. They carried the same latent defect, and
aligning LNDL with them would have spread it rather than fixed it.

The resolution is now by sentinel status at every site:

```python
branch.chat_model if param._is_sentinel(param.imodel) else param.imodel
```

This is not a new idiom — `run.py` already resolves its own model this way.
Behaviour is unchanged for every truthy model and for the unsupplied sentinel,
and corrected for a supplied falsy one.

## Which call sites are in scope

The sites that read `.imodel` off a parameter bag, all four fixed:

| Site | Bag |
|---|---|
| `lndl_middle/lndl_middle.py` | `ChatParam` |
| `chat/chat.py` | `ChatParam` |
| `operate/operate.py` (transport selection) | `ChatParam` / `RunParam` |
| `parse/parse.py` | `ParseParam` |

Two call sites that look similar are **not** the same shape and are left alone:
the `chat_model` arguments of `prepare_operate_kw` and `prepare_communicate_kw`
are ordinary Python function parameters defaulting to `None`, not bag fields.
There is no sentinel to consult there — the correct discriminator would be
`is None`, which is a different change with a different justification.

## Correction to the issue's failure scenario

The scenario the issue lists **first** — an API branch given a CLI model
selecting `communicate` — is not reachable through `Branch.operate`.
`prepare_operate_kw` derives the param class from the *effective* model, so a
per-call CLI model yields a `RunParam` and the `isinstance` clause routes it
correctly. It gets the right answer by accident of the param class rather than by
consulting the model, but it gets it. Only the inverse direction bites publicly.
Verified by executing `prepare_operate_kw` on both combinations.

The `operate.py` location the issue names had already been changed by #2471, but
to the `or` form, which this change now supersedes.

## Reported, not fixed

`run.py` assigns `branch.chat_model = param.imodel` *before* the `is_cli` guard
raises, so a rejected misroute leaves the branch mutated to the model that was
just rejected. That is a real defect, it is out of scope for this change, and it
is deliberately untouched here — it wants its own change.

## Verification

Two regression tests, each built on a model object whose `__bool__` returns
`False`, and each asserting `not bool(supplied)` inline so it cannot silently
stop exercising the case:

- `test_lndl_middle.py` — a falsy per-call API model must still take the
  non-streaming path on a CLI branch.
- `test_chat.py` — a falsy per-call model must be the one the turn is invoked
  against.

Each was run with **its own** fix reverted and nothing else:

| Run | Result |
|---|---|
| both fixes in place | rc 0, 2 passed |
| LNDL fix reverted alone | rc 1, 1 failed, 1 passed — the LNDL test |
| chat fix reverted alone | rc 1, 1 failed, 1 passed — the chat test |

In each revert-alone run the other test still passed, which is what establishes
each test is bound to its own fix rather than to the pair.

One caveat worth stating plainly: the LNDL test fails *indirectly* when reverted.
The discarded model causes the branch's CLI model to select the streaming path,
which then raises `AttributeError` on the stand-in rather than tripping the
test's own assertion. It discriminates correctly, but it is not a clean assertion
failure.

Affected suites (`test_lndl_middle`, `test_chat`, `test_operate`, `test_parse`,
`test_communicate`): rc 0, 103 passed. The full suite was **not** re-run after
this revision; the previously reported full-suite result no longer describes this
head and should not be read as covering it.
