### PR TITLE
Revert the deliberately failing probe test

### DIFF
--- a/tests/test_zz_branch_protection_probe.py
+++ b/tests/test_zz_branch_protection_probe.py
@@ -1,5 +1,0 @@
-def test_branch_protection_probe():
-    """Deliberately failing. Throwaway probe branch, never merged."""
-    observed = 1
-    expected = 2
-    assert observed == expected


### PR DESCRIPTION
Removes `tests/test_zz_branch_protection_probe.py`, which was added on a throwaway branch to confirm that a required status check blocks a merge, and which reached main because it does not block an administrator while admin enforcement is off. The test fails by design and has no purpose on main.