### PR TITLE
fix(messages): stop dropping generic Message content that exposes an allowed() method

### DIFF
--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -318,17 +318,21 @@ class Message(Node, Sendable):
         return self._chat_msg()
 
     def _chat_msg(self, *, use_render_cache: bool = True) -> dict[str, Any] | None:
-        """Build a provider chat message, reusing the stable content rendering when safe."""
-        try:
-            role_str = self.role.value if isinstance(self.role, MessageRole) else str(self.role)
-            return {
-                "role": role_str,
-                "content": self._render_cached("chat", lambda: self.rendered)
-                if use_render_cache
-                else self.rendered,
-            }
-        except Exception:
-            return None
+        """Build a provider chat message, reusing the stable content rendering
+        when safe.
+
+        A rendering failure propagates rather than degrading to ``None``: a
+        message that reaches a provider with its content missing is
+        indistinguishable from one that never had any, so content that cannot
+        be carried has to fail where it can be seen.
+        """
+        role_str = self.role.value if isinstance(self.role, MessageRole) else str(self.role)
+        return {
+            "role": role_str,
+            "content": self._render_cached("chat", lambda: self.rendered)
+            if use_render_cache
+            else self.rendered,
+        }
 
     def _render_cached(self, variant: str, render: Callable[[], Any]) -> Any:
         """Return a rendering cached by content identity and revision (not
@@ -476,13 +480,20 @@ def _has_untracked_mutable(root: Any) -> bool:
 
 
 def _content_has_untracked_mutable(content: Any) -> bool:
-    """True if any render-input field on `content` carries a value the
-    revision tracker cannot observe in-place mutation of — the cache must
-    not trust its revision counter and should re-render on every call."""
-    allowed = getattr(content, "allowed", None)
-    if not callable(allowed):
-        return False
-    return any(_has_untracked_mutable(getattr(content, name, None)) for name in allowed())
+    """True if any render input on `content` carries a value the revision
+    tracker cannot observe in-place mutation of — the cache must not trust its
+    revision counter and should re-render on every call.
+
+    Only `MessageContent` enumerates its render inputs through `allowed()`.
+    `Message.content` is typed `Any`, so an arbitrary payload may carry an
+    unrelated attribute of that name with its own signature and meaning;
+    calling it would be calling a stranger's method. Such a payload is instead
+    walked directly — it has no tracked revision, so an immutable one stays
+    cacheable and anything else bypasses the cache.
+    """
+    if not isinstance(content, MessageContent):
+        return _has_untracked_mutable(content)
+    return any(_has_untracked_mutable(getattr(content, name, None)) for name in content.allowed())
 
 
 def _copy_rendered(rendered: Any) -> Any:

--- a/tests/protocols/messages/test_message.py
+++ b/tests/protocols/messages/test_message.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+import pytest
+
 from lionagi.protocols.messages.base import (
     MESSAGE_FIELDS,
     MessageField,
@@ -460,3 +462,101 @@ def test_message_content_immutability_via_update():
 
     assert message.content is not original_content
     assert message.content.text == "Updated"
+
+
+class _PayloadWithUnrelatedAllowed:
+    """Generic `Message.content` payload that happens to expose an `allowed`
+    method unrelated to the `MessageContent` field enumerator."""
+
+    def __init__(self, text: str = "still renders"):
+        self.text = text
+
+    def allowed(self, required):
+        return ()
+
+    @property
+    def rendered(self) -> str:
+        return self.text
+
+
+def test_generic_content_with_unrelated_allowed_method_renders():
+    """A payload carrying its own `allowed` method is not mistaken for a
+    field enumerator, and its rendering survives the round trip."""
+    message = RoledMessage(content=_PayloadWithUnrelatedAllowed())
+
+    chat_msg = message.chat_msg
+    assert chat_msg is not None
+    assert chat_msg["content"] == "still renders"
+
+
+def test_generic_content_rendering_is_not_served_stale():
+    """A generic payload has no tracked revision, so its rendering is never
+    served from the cache after the payload changes underneath it."""
+    payload = _PayloadWithUnrelatedAllowed(text="first")
+    message = RoledMessage(content=payload)
+
+    assert message.chat_msg["content"] == "first"
+    payload.text = "second"
+    assert message.chat_msg["content"] == "second"
+
+
+def test_unrenderable_content_raises_rather_than_dropping_the_message():
+    """Content that cannot be rendered fails visibly instead of yielding a
+    message with no content."""
+
+    class _Unrenderable:
+        @property
+        def rendered(self) -> str:
+            raise RuntimeError("cannot render")
+
+    message = RoledMessage(content=_Unrenderable())
+
+    with pytest.raises(RuntimeError, match="cannot render"):
+        _ = message.chat_msg
+
+
+def test_unrenderable_content_surfaces_through_the_manager():
+    """A message that cannot be rendered aborts the conversion instead of
+    leaving a hole in the provider payload."""
+    from lionagi.protocols.messages.manager import MessageManager
+
+    class _Unrenderable:
+        @property
+        def rendered(self) -> str:
+            raise RuntimeError("cannot render")
+
+    manager = MessageManager()
+    manager.add_message(instruction="hello", sender="user", recipient="assistant")
+    manager.messages[manager.progression[0]].content = _Unrenderable()
+
+    with pytest.raises(ValueError):
+        manager.to_chat_msgs()
+
+
+def test_message_content_untracked_mutable_field_still_bypasses_cache():
+    """Guards the precondition the generic-payload change relies on: a
+    `MessageContent` field holding a value the revision tracker cannot watch
+    still re-renders on every call rather than being served from the cache."""
+
+    class _Counter:
+        def __init__(self):
+            self.value = 0
+
+    @dataclass(slots=True)
+    class _ContentWithOpaqueField(MessageContent):
+        counter: Any = None
+
+        @property
+        def rendered(self) -> str:
+            return f"count={self.counter.value}"
+
+        @classmethod
+        def from_dict(cls, data: dict[str, Any]) -> "_ContentWithOpaqueField":
+            return cls(counter=data.get("counter"))
+
+    counter = _Counter()
+    message = RoledMessage(content=_ContentWithOpaqueField(counter=counter))
+
+    assert message.chat_msg["content"] == "count=0"
+    counter.value = 1
+    assert message.chat_msg["content"] == "count=1"


### PR DESCRIPTION
## The defect

`Message.content` is typed `Any`, and the base `Message` is deliberately a generic
envelope. The render-cache safety gate added alongside the untracked-mutable
bypass identified a content object's field enumerator by duck-typing:

```python
allowed = getattr(content, "allowed", None)
if not callable(allowed):
    return False
return any(_has_untracked_mutable(getattr(content, name, None)) for name in allowed())
```

`allowed()` with no arguments is the right call on `MessageContent`. On an
arbitrary payload it is someone else's method. A payload whose `allowed` takes
parameters raised `TypeError`, which propagated up to `_chat_msg`, where a bare
`except Exception: return None` turned it into a message with no content.

The drop was silent in the strong sense: nothing logged, nothing raised, exit
status clean. Worse, `MessageManager.to_chat_msgs` builds its list from
`_chat_msg` per message, so a swallowed failure placed a literal `None` into the
list handed to a provider — and the `try/except` around that comprehension could
never fire, because everything below it had already been caught.

## Reproduction

```python
from lionagi.protocols.messages.message import Message

class Renderable:
    def allowed(self, required):
        return ()

    @property
    def rendered(self):
        return "still renders"

m = Message(content=Renderable())
print("chat_msg =", repr(m.chat_msg))
print("rendered =", repr(m.rendered))
```

Before this change:

```
chat_msg = None
rendered = 'still renders'
```

Note the shape — `rendered` works fine. The content was perfectly renderable; it
was dropped by a gate that had no business calling into it.

## What changed

**1. The field walk no longer calls an arbitrary payload's methods.**
`_content_has_untracked_mutable` gates on `isinstance(content, MessageContent)`
and only enumerates through `allowed()` there.

**2. `_chat_msg` no longer swallows.** Rendering failures propagate.
`to_chat_msgs` then surfaces them as the `ValueError` its existing handler was
always meant to raise, instead of silently emitting a malformed message list.

## Choices between defensible options

**What to do with a generic payload once it is no longer field-walked.** Something
has to decide whether its rendering is cacheable. Three options:

1. `return False` — treat any non-`MessageContent` as cacheable. Smallest diff,
   but wrong: a generic payload has no `_render_revision`, so the cache key is a
   constant `0` and a mutable payload would be rendered once and served forever.
   That trades a silent-drop bug for a silent-staleness bug.
2. `return True` — always bypass for non-`MessageContent`. Correct, but it also
   stops caching `content="a string"` and `content=None`, which are immutable and
   were cacheable before.
3. `return _has_untracked_mutable(content)` — walk the payload itself with the
   same walker already used for fields. **Chosen.** Immutable payloads stay
   cacheable exactly as before; anything the revision tracker cannot observe
   bypasses the cache and re-renders live. No attribute on the payload is ever
   called.

**Whether to make failure visible by raising or by logging.** Chose raising.
A warning does not stop the malformed payload from going out, and the caller
still cannot tell "no content" from "content lost". **This is a behaviour change
on a public property: `Message.chat_msg` can now raise where it previously
returned `None`.** It is the part of this PR most worth pushing back on if you
disagree. No in-repo caller depends on the `None` return — `image_content` and
`to_chat_msgs` are the only consumers, and `operations/chat/_prepare.py` calls
`_render_cached` directly and never went through the swallow.

Also considered and rejected: wrapping in a new `LionError` subclass. The
underlying exception (`TypeError`, a YAML representer error, …) is the more
informative thing to surface, and `to_chat_msgs` already provides a typed error
at the boundary where a caller wants one.

## Tests

Five added to `tests/protocols/messages/test_message.py`. Revert-alone result —
the source change reverted, the new tests run against the pristine tree:

| Test | Revert-alone result |
|---|---|
| `test_generic_content_with_unrelated_allowed_method_renders` | FAIL — `assert None is not None` |
| `test_generic_content_rendering_is_not_served_stale` | FAIL — `TypeError: 'NoneType' object is not subscriptable` |
| `test_unrenderable_content_raises_rather_than_dropping_the_message` | FAIL — `DID NOT RAISE RuntimeError` |
| `test_unrenderable_content_surfaces_through_the_manager` | FAIL — `DID NOT RAISE ValueError` |
| `test_message_content_untracked_mutable_field_still_bypasses_cache` | PASS |

The fifth passes both before and after, and that is intentional — it pins the
*precondition* the fix depends on. Option 3 above is only defensible because the
`MessageContent` field walk still bypasses the cache for an opaque field value.
If that ever quietly stopped working, the generic-payload branch would inherit
the same staleness with nothing noticing, since every other test in the file uses
JSON-safe content.

One honest limit on `test_generic_content_rendering_is_not_served_stale`: it
fails pre-change for the trivial reason (`chat_msg` is `None`), not because it
caught staleness. Its value is prospective — it is the test that fails if the
generic branch is later simplified to option 1.

## Test runs

`tests/agent/ tests/protocols/messages/ tests/operations/` — **rc=0**, no
failures.

A full `tests/` run at this head exits **rc=1** with six failures, all of which
are environment-dependent and unrelated to this change:

- `tests/docs/test_integrations.py::TestLLMProviders::test_ollama_imodel_constructs`
- `tests/tools/test_coding_toolkit.py::test_docling_import_is_available`
- `tests/tools/test_coding_toolkit.py::test_reader_open_real_html_fixture`
- `tests/service/connections/test_match_endpoint.py::TestMatchEndpoint::test_ollama_endpoint`
- `tests/adapters/test_async_postgres_adapter.py::test_async_postgres_to_obj_ensures_table_for_dsn_before_delegating`
- `tests/agent/test_factory.py::test_forward_mcp_populates_claude_code_request_mcp_servers`

The first five reproduce identically with this PR's source change reverted
(missing optional dependencies: `ollama`, `docling`, `asyncpg`), so they are
pre-existing in this environment. The sixth passes in isolation at this head
(rc=0) and passes as part of the `tests/agent/` run above; in the full run it
followed a `[gw11] node down: Not properly terminated` line from the xdist
worker pool, so it appears to be a casualty of that worker loss rather than a
real failure.

That same worker loss suppressed pytest's final count line, so **no total
passed/failed count is claimed for the full run** — only the rc and the named
failures above, which is what the output actually contains.
