### PR TITLE
fix(hooks): run the post-invocation hook however a stream ends

### DIFF
--- a/lionagi/protocols/generic/event.py
+++ b/lionagi/protocols/generic/event.py
@@ -299,7 +299,12 @@ class Event(Element):
         raise NotImplementedError("Override _invoke() in subclass.")
 
     async def stream(self):
-        """Streaming variant of invoke(). Same outcome contract."""
+        """Streaming variant of invoke(). Same outcome contract.
+
+        A consumer that stops before the stream is exhausted should close it, with
+        ``aclose()`` or ``contextlib.aclosing``, so the teardown below runs at that
+        point rather than whenever the interpreter finalizes the abandoned generator.
+        """
         if self.execution.status in self._TERMINAL_STATUSES:
             return
 

--- a/lionagi/protocols/generic/event.py
+++ b/lionagi/protocols/generic/event.py
@@ -307,8 +307,12 @@ class Event(Element):
         start = ln.now_utc().timestamp()
 
         try:
-            async for chunk in self._stream():
-                yield chunk
+            # aclosing, not a bare `async for`: a consumer that stops early closes this
+            # generator, and the inner one has to be closed with it so its teardown runs
+            # now rather than whenever the interpreter finalizes it.
+            async with contextlib.aclosing(self._stream()) as source:
+                async for chunk in source:
+                    yield chunk
             self.status = EventStatus.COMPLETED
         except Exception as e:
             self.status = EventStatus.FAILED

--- a/lionagi/service/hooks/__init__.py
+++ b/lionagi/service/hooks/__init__.py
@@ -1,7 +1,12 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-from ._types import AssociatedEventInfo, HookDict, HookEventTypes
+from ._types import (
+    AssociatedEventInfo,
+    HookDict,
+    HookEventTypes,
+    StreamTerminalState,
+)
 from .hook_event import HookEvent
 from .hook_registry import HookRegistry
 from .hooked_event import HookedEvent, global_hook_logger
@@ -14,4 +19,5 @@ __all__ = (
     "HookRegistry",
     "global_hook_logger",
     "HookedEvent",
+    "StreamTerminalState",
 )

--- a/lionagi/service/hooks/_types.py
+++ b/lionagi/service/hooks/_types.py
@@ -18,6 +18,7 @@ __all__ = (
     "HookDict",
     "StreamHandlers",
     "AssociatedEventInfo",
+    "StreamTerminalState",
 )
 
 
@@ -25,6 +26,22 @@ class HookEventTypes(str, Enum):
     PreEventCreate = "pre_event_create"
     PreInvocation = "pre_invocation"
     PostInvocation = "post_invocation"
+
+
+class StreamTerminalState(str, Enum):
+    """How a hooked stream ended, as seen by its post-invocation hook."""
+
+    Completed = "completed"
+    """The source stream was consumed to exhaustion."""
+
+    Failed = "failed"
+    """The source stream raised; the exception still propagates to the caller."""
+
+    Closed = "closed"
+    """The consumer stopped early, so the stream was closed before exhaustion."""
+
+    Cancelled = "cancelled"
+    """The consuming task was cancelled, including by an enclosing timeout."""
 
 
 ALLOWED_HOOKS_TYPES = HookEventTypes.allowed()

--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -109,6 +109,13 @@ class HookedEvent(Event):
         early-stopping consumer, or cancellation — and ``stream_terminal_state`` says
         which of those it was. Whatever ended the stream still propagates unchanged;
         post-hook failures are logged, never raised.
+
+        A consumer that stops early is responsible for closing the stream, with
+        ``aclose()`` or ``contextlib.aclosing``. A bare ``break`` does not close the
+        generator it was iterating, so teardown is deferred to whenever the interpreter
+        finalizes the abandoned generator — it still runs, and still reports the closed
+        state, but not at a point the consumer picked, and during interpreter or loop
+        shutdown the grace bound below can cut it short.
         """
         if h_ev := self._pre_invoke_hook_event:
             await h_ev.invoke()

--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import logging
 
 import anyio
@@ -110,6 +111,21 @@ class HookedEvent(Event):
         which of those it was. Whatever ended the stream still propagates unchanged;
         post-hook failures are logged, never raised.
 
+        Guaranteed: the caller receives the very same exception object the stream ended
+        with, not a replacement, no matter how the teardown fails — an ordinary
+        exception, a cancellation the hook raises at itself, or a failure in the hook's
+        own logging. A stream that ended normally still ends normally.
+
+        Deliberately not guaranteed: a cancellation actually delivered to the consuming
+        task while the teardown is running is not swallowed. It reaches the caller in
+        place of whatever the stream ended with, because a task that was cancelled from
+        outside must not come back believing it was not. On a stream that was itself
+        ended by cancellation the source is re-raised instead, since the consumer stays
+        cancelled either way. Off asyncio the two kinds of cancellation cannot be told
+        apart at all and both propagate. ``KeyboardInterrupt`` and ``SystemExit`` raised
+        inside the teardown also propagate — they are process-level directives rather
+        than hook failures.
+
         A consumer that stops early is responsible for closing the stream, with
         ``aclose()`` or ``contextlib.aclosing``. A bare ``break`` does not close the
         generator it was iterating, so teardown is deferred to whenever the interpreter
@@ -147,7 +163,30 @@ class HookedEvent(Event):
             raise
         finally:
             self._stream_terminal_state = state
-            await self._run_post_stream_hook(state)
+            try:
+                await self._run_post_stream_hook(state)
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except get_cancelled_exc_class():
+                # A cancellation the hook raised at itself was already absorbed where it
+                # could still be attributed. One reaching here was delivered to the
+                # consuming task, so it is honoured -- except on a stream that ended in
+                # cancellation, where re-raising the source leaves the consumer cancelled
+                # anyway and keeps the exception it was handed.
+                if state is not StreamTerminalState.Cancelled:
+                    raise
+                _logger.warning(
+                    "Post-stream teardown was cancelled while the stream was ending "
+                    "(%s); the stream's own ending is preserved",
+                    state.value,
+                )
+            except BaseException as _teardown_exc:
+                _logger.warning(
+                    "Post-stream teardown failed while the stream was ending (%s): %s",
+                    state.value,
+                    _teardown_exc,
+                    exc_info=True,
+                )
 
     async def _run_post_stream_hook(self, state: StreamTerminalState) -> None:
         """Invoke and log the post-invocation hook for a stream that ended in ``state``.
@@ -171,12 +210,12 @@ class HookedEvent(Event):
             StreamTerminalState.Cancelled,
         )
         if not unwinding:
-            await self._invoke_post_stream_hook(h_ev)
+            await self._invoke_post_stream_hook_isolated(h_ev)
             return
 
         with anyio.CancelScope(shield=True):
             with move_on_after(POST_STREAM_TEARDOWN_GRACE) as scope:
-                await self._invoke_post_stream_hook(h_ev)
+                await self._invoke_post_stream_hook_isolated(h_ev)
             if scope.cancelled_caught:
                 _logger.warning(
                     "Post-stream hook did not finish within %ss while the stream was "
@@ -184,6 +223,38 @@ class HookedEvent(Event):
                     POST_STREAM_TEARDOWN_GRACE,
                     state.value,
                 )
+
+    async def _invoke_post_stream_hook_isolated(self, h_ev: HookEvent) -> None:
+        """Run the post-hook in a child task, so a cancellation it raises is attributable.
+
+        Within one task a cancellation raised by the awaited code and one delivered to
+        the task at that await are the same exception arriving at the same place, and
+        cannot be told apart -- shielding does not help, since a direct ``Task.cancel()``
+        reaches a shielded await anyway. Running the hook in a child task separates them:
+        if a cancellation surfaces here and the child has finished, it came out of the
+        hook and must not replace the stream's own ending; if the child is still running,
+        the cancellation was delivered to the consuming task and is the consumer's, so
+        the hook is cancelled with it and the cancellation propagates.
+
+        Off asyncio there is no task to branch into, so the hook runs inline and the two
+        are indistinguishable; a cancellation then propagates.
+        """
+        try:
+            child = asyncio.ensure_future(self._invoke_post_stream_hook(h_ev))
+        except RuntimeError:
+            await self._invoke_post_stream_hook(h_ev)
+            return
+
+        try:
+            await asyncio.shield(child)
+        except get_cancelled_exc_class():
+            if child.done():
+                _logger.warning(
+                    "Post-stream hook cancelled itself (data already sent)",
+                )
+                return
+            child.cancel()
+            raise
 
     async def _invoke_post_stream_hook(self, h_ev: HookEvent) -> None:
         try:

--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 
 import anyio
+import sniffio
 from pydantic import PrivateAttr
 
 from lionagi.ln.concurrency import get_cancelled_exc_class, move_on_after
@@ -20,6 +21,24 @@ POST_STREAM_TEARDOWN_GRACE = 5.0
 
 Teardown on those paths runs shielded so it is not cut short by the cancellation that
 caused it, but it must not stall the unwind either, so it is bounded by this grace.
+"""
+
+POST_STREAM_HOOK_STOP_GRACE = 1.0
+"""Seconds a post-stream hook is given to stop after it has been cancelled.
+
+A hook that swallows its own cancellation cannot be waited on forever, so once this
+expires its task is abandoned: reported at WARNING and left running, rather than
+dropped on the floor for the interpreter to complain about later.
+"""
+
+_abandoned_post_stream_hooks: set = set()
+"""Post-stream hook tasks that did not stop when cancelled.
+
+Held for the life of the process so a hook that outlived its cancellation is not
+destroyed mid-await while the program is still running; each entry drops out on its own
+if the hook ever finishes. At interpreter shutdown a still-pending one is released and
+CPython reports it as destroyed while pending, which by then is an accurate description
+of it.
 """
 
 global_hook_logger = DataLogger(
@@ -225,36 +244,94 @@ class HookedEvent(Event):
                 )
 
     async def _invoke_post_stream_hook_isolated(self, h_ev: HookEvent) -> None:
-        """Run the post-hook in a child task, so a cancellation it raises is attributable.
+        """Run the post-hook so a cancellation it raises cannot pass for the consumer's.
 
         Within one task a cancellation raised by the awaited code and one delivered to
-        the task at that await are the same exception arriving at the same place, and
-        cannot be told apart -- shielding does not help, since a direct ``Task.cancel()``
-        reaches a shielded await anyway. Running the hook in a child task separates them:
-        if a cancellation surfaces here and the child has finished, it came out of the
-        hook and must not replace the stream's own ending; if the child is still running,
-        the cancellation was delivered to the consuming task and is the consumer's, so
-        the hook is cancelled with it and the cancellation propagates.
+        the task at that await are the same exception arriving at the same place.
+        Shielding does not separate them, since a direct ``Task.cancel()`` reaches a
+        shielded await anyway, and neither does asking afterwards whether the hook has
+        finished: a hook finishing and a cancellation being delivered can be queued in
+        the same loop turn, so that answer is a sample of a race, not a provenance.
 
-        Off asyncio there is no task to branch into, so the hook runs inline and the two
-        are indistinguishable; a cancellation then propagates.
+        The collision is therefore removed rather than resolved. The hook runs in a child
+        task that CAPTURES whatever ends it and RETURNS it instead of raising it, so that
+        task can never end cancelled because of something the hook did. A cancellation
+        surfacing at the await below then has exactly one possible origin -- delivery to
+        this task -- and is honoured: the hook's task is cancelled, given
+        ``POST_STREAM_HOOK_STOP_GRACE`` seconds to stop, and the cancellation propagates.
+        A hook that will not stop within that grace is abandoned: it is reported at
+        WARNING and left running, held so that it is not destroyed mid-await while the
+        program is still going.
+
+        A cancellation the hook raised at itself comes back as a returned value and is
+        logged; anything else the hook ended with is re-raised for the caller to record,
+        which keeps ``KeyboardInterrupt`` and ``SystemExit`` propagating.
+
+        The backend is decided before any asyncio object exists, because an asyncio task
+        or future is not awaitable on another backend and constructing one there fails at
+        the await rather than at the construction. Off asyncio the hook runs inline: the
+        two kinds of cancellation are genuinely indistinguishable there and both
+        propagate.
         """
         try:
-            child = asyncio.ensure_future(self._invoke_post_stream_hook(h_ev))
-        except RuntimeError:
+            backend = sniffio.current_async_library()
+        except sniffio.AsyncLibraryNotFoundError:
+            backend = None
+        if backend != "asyncio":
             await self._invoke_post_stream_hook(h_ev)
             return
 
+        child = asyncio.get_running_loop().create_task(self._capture_post_stream_hook(h_ev))
         try:
-            await asyncio.shield(child)
+            hook_ended_with = await asyncio.shield(child)
         except get_cancelled_exc_class():
-            if child.done():
-                _logger.warning(
-                    "Post-stream hook cancelled itself (data already sent)",
-                )
-                return
-            child.cancel()
+            await self._stop_post_stream_hook(child)
             raise
+
+        if hook_ended_with is None:
+            return
+        if isinstance(hook_ended_with, get_cancelled_exc_class()):
+            _logger.warning(
+                "Post-stream hook cancelled itself (data already sent)",
+            )
+            return
+        raise hook_ended_with
+
+    async def _capture_post_stream_hook(self, h_ev: HookEvent) -> BaseException | None:
+        """Run the post-hook and return whatever ended it instead of raising it.
+
+        Returning the outcome is what makes this task's own ending unambiguous: it can
+        complete, but it cannot end cancelled because of what the hook did.
+        """
+        try:
+            await self._invoke_post_stream_hook(h_ev)
+        except BaseException as e:
+            return e
+        return None
+
+    async def _stop_post_stream_hook(self, child: asyncio.Task) -> None:
+        """Cancel the hook's task and wait a bounded time for it to actually stop.
+
+        Runs shielded, so the cancellation that got us here does not cut the wait short,
+        and abandons the task with a warning if the hook outlasts the grace.
+        """
+        if child.done():
+            return
+
+        child.cancel()
+        with anyio.CancelScope(shield=True):
+            try:
+                with move_on_after(POST_STREAM_HOOK_STOP_GRACE):
+                    await asyncio.shield(child)
+            finally:
+                if not child.done():
+                    _abandoned_post_stream_hooks.add(child)
+                    child.add_done_callback(_abandoned_post_stream_hooks.discard)
+                    _logger.warning(
+                        "Post-stream hook did not stop within %ss of being cancelled; "
+                        "it is left running and is not waited on again",
+                        POST_STREAM_HOOK_STOP_GRACE,
+                    )
 
     async def _invoke_post_stream_hook(self, h_ev: HookEvent) -> None:
         try:

--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -3,12 +3,23 @@
 
 import logging
 
+import anyio
 from pydantic import PrivateAttr
 
+from lionagi.ln.concurrency import get_cancelled_exc_class, move_on_after
 from lionagi.protocols.types import DataLogger, Event, EventStatus
 from lionagi.service.hooks import HookEvent, HookEventTypes
 
+from ._types import StreamTerminalState
+
 _logger = logging.getLogger(__name__)
+
+POST_STREAM_TEARDOWN_GRACE = 5.0
+"""Seconds a post-stream hook may take when the stream is being closed or cancelled.
+
+Teardown on those paths runs shielded so it is not cut short by the cancellation that
+caused it, but it must not stall the unwind either, so it is bounded by this grace.
+"""
 
 global_hook_logger = DataLogger(
     persist_dir="./data/logs",
@@ -23,6 +34,16 @@ class HookedEvent(Event):
 
     _pre_invoke_hook_event: HookEvent = PrivateAttr(None)
     _post_invoke_hook_event: HookEvent = PrivateAttr(None)
+    _stream_terminal_state: StreamTerminalState | None = PrivateAttr(None)
+
+    @property
+    def stream_terminal_state(self) -> StreamTerminalState | None:
+        """How the current ``_stream()`` run ended, or None while it is still running.
+
+        Set before the post-invocation hook is invoked, so a hook can tell a stream that
+        completed from one that failed, was closed by its consumer, or was cancelled.
+        """
+        return self._stream_terminal_state
 
     async def _core_invoke(self):
         """Override in subclasses; return value is stored in ``self.execution.response``."""
@@ -82,7 +103,13 @@ class HookedEvent(Event):
         return response
 
     async def _stream(self):
-        """Run pre-hook, yield chunks from ``_core_stream()``, run post-hook (post failures only logged)."""
+        """Run pre-hook, yield chunks from ``_core_stream()``, run post-hook.
+
+        The post-hook runs however the stream ends — exhaustion, a source error, an
+        early-stopping consumer, or cancellation — and ``stream_terminal_state`` says
+        which of those it was. Whatever ended the stream still propagates unchanged;
+        post-hook failures are logged, never raised.
+        """
         if h_ev := self._pre_invoke_hook_event:
             await h_ev.invoke()
             if h_ev.execution.status in (EventStatus.FAILED, EventStatus.CANCELLED):
@@ -95,32 +122,81 @@ class HookedEvent(Event):
                 )
             await global_hook_logger.alog(h_ev)
 
-        async for chunk in self._core_stream():
-            yield chunk
+        self._stream_terminal_state = None
+        state = StreamTerminalState.Completed
+        try:
+            async for chunk in self._core_stream():
+                yield chunk
+        except GeneratorExit:
+            # Raised at the yield above when the consumer stops early and the generator
+            # is closed. Teardown may await, but must not yield, and must not stall.
+            state = StreamTerminalState.Closed
+            raise
+        except get_cancelled_exc_class():
+            state = StreamTerminalState.Cancelled
+            raise
+        except BaseException:
+            state = StreamTerminalState.Failed
+            raise
+        finally:
+            self._stream_terminal_state = state
+            await self._run_post_stream_hook(state)
 
-        # Post-stream hook failure: data already sent, must not reraise — log at WARNING only.
-        # HookRegistry.post_invocation() records a handler's raised exception on the
-        # HookEvent (status FAILED/CANCELLED/ABORTED) rather than re-raising it out of
-        # invoke(), so the failure must be detected via status, not a try/except.
-        if h_ev := self._post_invoke_hook_event:
-            try:
-                await h_ev.invoke()
-                if h_ev.execution.status in (
-                    EventStatus.FAILED,
-                    EventStatus.CANCELLED,
-                    EventStatus.ABORTED,
-                ):
-                    _logger.warning(
-                        "Post-stream hook failed (data already sent): %s",
-                        h_ev.execution.error,
-                    )
-            except Exception as _hook_exc:
+    async def _run_post_stream_hook(self, state: StreamTerminalState) -> None:
+        """Invoke and log the post-invocation hook for a stream that ended in ``state``.
+
+        Post-stream hook failure: data already sent, must not reraise — log at WARNING
+        only. HookRegistry.post_invocation() records a handler's raised exception on the
+        HookEvent (status FAILED/CANCELLED/ABORTED) rather than re-raising it out of
+        invoke(), so the failure must be detected via status, not a try/except.
+        """
+        h_ev = self._post_invoke_hook_event
+        if not h_ev:
+            return
+
+        # On the close and cancel paths the teardown is running inside an unwind that is
+        # already cancelling: an unshielded await would be cancelled before the hook
+        # could run, and would replace the exception in flight with a fresh one. Shield
+        # it so the hook actually runs, and bound it so a slow hook cannot hold the
+        # unwind open.
+        unwinding = state in (
+            StreamTerminalState.Closed,
+            StreamTerminalState.Cancelled,
+        )
+        if not unwinding:
+            await self._invoke_post_stream_hook(h_ev)
+            return
+
+        with anyio.CancelScope(shield=True):
+            with move_on_after(POST_STREAM_TEARDOWN_GRACE) as scope:
+                await self._invoke_post_stream_hook(h_ev)
+            if scope.cancelled_caught:
+                _logger.warning(
+                    "Post-stream hook did not finish within %ss while the stream was "
+                    "being torn down (%s)",
+                    POST_STREAM_TEARDOWN_GRACE,
+                    state.value,
+                )
+
+    async def _invoke_post_stream_hook(self, h_ev: HookEvent) -> None:
+        try:
+            await h_ev.invoke()
+            if h_ev.execution.status in (
+                EventStatus.FAILED,
+                EventStatus.CANCELLED,
+                EventStatus.ABORTED,
+            ):
                 _logger.warning(
                     "Post-stream hook failed (data already sent): %s",
-                    _hook_exc,
-                    exc_info=True,
+                    h_ev.execution.error,
                 )
-            await global_hook_logger.alog(h_ev)
+        except Exception as _hook_exc:
+            _logger.warning(
+                "Post-stream hook failed (data already sent): %s",
+                _hook_exc,
+                exc_info=True,
+            )
+        await global_hook_logger.alog(h_ev)
 
     def create_pre_invoke_hook(
         self,

--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -273,11 +273,7 @@ class HookedEvent(Event):
         two kinds of cancellation are genuinely indistinguishable there and both
         propagate.
         """
-        try:
-            backend = sniffio.current_async_library()
-        except sniffio.AsyncLibraryNotFoundError:
-            backend = None
-        if backend != "asyncio":
+        if sniffio.current_async_library() != "asyncio":
             await self._invoke_post_stream_hook(h_ev)
             return
 

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -4,6 +4,7 @@
 """Tests for lionagi.service.hooks.hooked_event — HookedEvent._invoke() and _stream()."""
 
 import asyncio
+import gc
 from types import SimpleNamespace
 
 import anyio
@@ -443,3 +444,34 @@ async def test_public_stream_closes_the_inner_stream_when_closed_early():
     await stream.aclose()
 
     assert seen == [StreamTerminalState.Closed]
+
+
+@pytest.mark.asyncio
+async def test_bare_break_defers_teardown_to_generator_finalization():
+    """A consumer that breaks without closing does not get teardown at the break.
+
+    ``break`` does not close the generator it was iterating, so nothing raises
+    GeneratorExit at that point and the post-invocation hook has not run yet. The
+    interpreter still finalizes the abandoned generator, and teardown runs then with
+    the closed terminal state -- but at a moment the consumer does not choose. This
+    is why an early-stopping consumer that needs the hook to have run should close
+    the stream itself.
+    """
+    h = SimpleHooked()
+    seen = _recording_post_hook(h)
+
+    stream = h.stream()
+    async for _ in stream:
+        break
+
+    assert seen == [], "teardown must not be attributed to a break that did not close"
+    assert h.stream_terminal_state is None
+
+    del stream
+    gc.collect()
+    with anyio.fail_after(5):
+        while not seen:
+            await anyio.sleep(0.01)
+
+    assert seen == [StreamTerminalState.Closed]
+    assert h.stream_terminal_state is StreamTerminalState.Closed

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -3,11 +3,14 @@
 
 """Tests for lionagi.service.hooks.hooked_event — HookedEvent._invoke() and _stream()."""
 
+import asyncio
 from types import SimpleNamespace
 
+import anyio
 import pytest
 
 from lionagi.protocols.types import EventStatus
+from lionagi.service.hooks._types import StreamTerminalState
 from lionagi.service.hooks.hooked_event import HookedEvent
 
 # ---------------------------------------------------------------------------
@@ -284,3 +287,129 @@ async def test_stream_post_hook_aborted_status_logs_warning(caplog):
 
     assert chunks == ["chunk1", "chunk2"]
     assert any("Post-stream hook failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# HookedEvent._stream() — teardown on every way a stream can end
+# ---------------------------------------------------------------------------
+
+
+class SlowStream(HookedEvent):
+    """Yields one chunk, then waits long enough to be cancelled from outside."""
+
+    async def _core_stream(self):
+        yield "chunk1"
+        await anyio.sleep(30)
+        yield "chunk2"
+
+
+def _recording_post_hook(event: HookedEvent):
+    """A post-hook that records the terminal state visible to it when it runs."""
+    seen: list[StreamTerminalState | None] = []
+
+    class _RecordingHookEvent:
+        def __init__(self):
+            self.execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+            self._should_exit = False
+            self._exit_cause = None
+
+        async def invoke(self):
+            seen.append(event.stream_terminal_state)
+
+    event._post_invoke_hook_event = _RecordingHookEvent()
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_stream_post_hook_runs_when_core_stream_raises():
+    """A source error must not skip teardown, and must reach the caller unchanged."""
+    h = FailingHooked()
+    seen = _recording_post_hook(h)
+
+    with pytest.raises(ValueError, match="core_stream_failed"):
+        async for _ in h._stream():
+            pass
+
+    assert seen == [StreamTerminalState.Failed]
+    assert h.stream_terminal_state is StreamTerminalState.Failed
+
+
+@pytest.mark.asyncio
+async def test_stream_post_hook_runs_when_consumer_breaks_early():
+    """A consumer that stops after the first chunk still gets teardown."""
+    h = SimpleHooked()
+    seen = _recording_post_hook(h)
+
+    stream = h._stream()
+    async for chunk in stream:
+        assert chunk == "chunk1"
+        break
+    await stream.aclose()
+
+    assert seen == [StreamTerminalState.Closed]
+    assert h.stream_terminal_state is StreamTerminalState.Closed
+
+
+@pytest.mark.asyncio
+async def test_stream_post_hook_runs_when_consuming_task_is_cancelled():
+    """Cancellation still propagates, and teardown runs shielded from it."""
+    h = SlowStream()
+    seen = _recording_post_hook(h)
+    first_chunk = asyncio.Event()
+
+    async def consume():
+        async for _ in h._stream():
+            first_chunk.set()
+
+    task = asyncio.create_task(consume())
+    await first_chunk.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task.cancelled()
+    assert seen == [StreamTerminalState.Cancelled]
+    assert h.stream_terminal_state is StreamTerminalState.Cancelled
+
+
+@pytest.mark.asyncio
+async def test_stream_post_hook_runs_when_an_enclosing_timeout_fires():
+    """A timeout around the consumer reaches the stream as cancellation."""
+    h = SlowStream()
+    seen = _recording_post_hook(h)
+
+    with pytest.raises(TimeoutError):
+        with anyio.fail_after(0.05):
+            async for _ in h._stream():
+                pass
+
+    assert seen == [StreamTerminalState.Cancelled]
+    assert h.stream_terminal_state is StreamTerminalState.Cancelled
+
+
+@pytest.mark.asyncio
+async def test_stream_terminal_state_is_completed_on_exhaustion():
+    """The ordinary path keeps reporting itself as a completed stream."""
+    h = SimpleHooked()
+    seen = _recording_post_hook(h)
+
+    chunks = [c async for c in h._stream()]
+
+    assert chunks == ["chunk1", "chunk2"]
+    assert seen == [StreamTerminalState.Completed]
+    assert h.stream_terminal_state is StreamTerminalState.Completed
+
+
+@pytest.mark.asyncio
+async def test_public_stream_closes_the_inner_stream_when_closed_early():
+    """Closing Event.stream() must close the hooked stream it wraps, so teardown
+    happens at the close rather than whenever the interpreter gets around to it."""
+    h = SimpleHooked()
+    seen = _recording_post_hook(h)
+
+    stream = h.stream()
+    async for _ in stream:
+        break
+    await stream.aclose()
+
+    assert seen == [StreamTerminalState.Closed]

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -10,6 +10,7 @@ import anyio
 import pytest
 
 from lionagi.protocols.types import EventStatus
+from lionagi.service.hooks import hooked_event
 from lionagi.service.hooks._types import StreamTerminalState
 from lionagi.service.hooks.hooked_event import HookedEvent
 
@@ -398,6 +399,35 @@ async def test_stream_terminal_state_is_completed_on_exhaustion():
     assert chunks == ["chunk1", "chunk2"]
     assert seen == [StreamTerminalState.Completed]
     assert h.stream_terminal_state is StreamTerminalState.Completed
+
+
+@pytest.mark.asyncio
+async def test_stream_teardown_does_not_block_the_close_indefinitely(monkeypatch, caplog):
+    """Teardown runs on the close path, but a slow hook must not hold the close open."""
+    monkeypatch.setattr(hooked_event, "POST_STREAM_TEARDOWN_GRACE", 0.1)
+
+    class SlowPostHook:
+        execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            await anyio.sleep(30)
+
+    h = SimpleHooked()
+    h._post_invoke_hook_event = SlowPostHook()
+
+    stream = h._stream()
+    async for _ in stream:
+        break
+
+    started = anyio.current_time()
+    with caplog.at_level("WARNING", logger="lionagi.service.hooks.hooked_event"):
+        await stream.aclose()
+    elapsed = anyio.current_time() - started
+
+    assert elapsed < 5, f"close waited {elapsed}s on a hook it should have given up on"
+    assert any("did not finish within" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import gc
+import logging
 from types import SimpleNamespace
 
 import anyio
@@ -669,3 +670,168 @@ async def test_consumer_cancelled_during_teardown_is_still_cancelled():
         await task
 
     assert task.cancelled(), "a consumer cancelled from outside must stay cancelled"
+
+
+@pytest.mark.asyncio
+async def test_consumer_cancelled_as_the_hook_ends_is_still_cancelled():
+    """A cancellation delivered in the same loop turn the hook finishes in still wins.
+
+    The ordering is forced rather than raced. The hook queues the consumer's
+    ``Task.cancel()`` with ``call_soon`` and then raises its own cancellation without
+    awaiting, so the cancel callback is already on the ready queue while the hook is
+    still running, and the hook's task finishes before that callback is drained. Any
+    rule that decides whose cancellation this was by looking at whether the hook has
+    finished reads "the hook's" here, every time, and loses a consumer cancellation
+    that was delivered from outside.
+    """
+    holder: dict = {}
+
+    class SelfCancellingPostHook:
+        execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            asyncio.get_running_loop().call_soon(holder["task"].cancel)
+            raise asyncio.CancelledError("post hook cancelled itself")
+
+    h = SimpleHooked()
+    h._post_invoke_hook_event = SelfCancellingPostHook()
+
+    async def consume():
+        async for _ in h._stream():
+            pass
+
+    task = asyncio.create_task(consume())
+    holder["task"] = task
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task.cancelled(), "a consumer cancelled from outside must stay cancelled"
+
+
+def test_post_hook_runs_on_a_non_asyncio_backend():
+    """The hook must actually run on Trio, not fail on an asyncio object.
+
+    An asyncio task or future is not awaitable under Trio, and creating one there does
+    not fail where it is created -- it fails at the await, far enough away that the
+    teardown guard logs it and the hook never runs at all. So the backend has to be
+    settled before any asyncio object exists.
+    """
+    seen: list[StreamTerminalState | None] = []
+    h = SimpleHooked()
+
+    class _RecordingHookEvent:
+        execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            seen.append(h.stream_terminal_state)
+
+    h._post_invoke_hook_event = _RecordingHookEvent()
+
+    async def main():
+        return [c async for c in h._stream()]
+
+    chunks = anyio.run(main, backend="trio")
+
+    assert chunks == ["chunk1", "chunk2"]
+    assert seen == [StreamTerminalState.Completed]
+
+
+def test_cancellation_during_teardown_propagates_on_a_non_asyncio_backend():
+    """Off asyncio the two cancellations are indistinguishable, so both propagate.
+
+    That is the documented behaviour on such a backend, and it is what must execute:
+    a cancellation delivered while the hook is running reaches the consumer.
+    """
+    started: list[bool] = []
+
+    class BlockingPostHook:
+        execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            started.append(True)
+            await anyio.sleep(30)
+
+    h = SimpleHooked()
+    h._post_invoke_hook_event = BlockingPostHook()
+
+    async def main():
+        with anyio.move_on_after(0.1) as scope:
+            async for _ in h._stream():
+                pass
+        return scope.cancelled_caught
+
+    cancelled_caught = anyio.run(main, backend="trio")
+
+    assert started, "the post hook must have run on this backend"
+    assert cancelled_caught, "the cancellation must reach the consumer, not be swallowed"
+
+
+def test_a_hook_that_will_not_stop_is_reported_not_destroyed_pending():
+    """A hook that swallows its cancellation is abandoned loudly, not silently.
+
+    It cannot be waited on forever, so after the stop grace it is left running -- but
+    reported at WARNING and kept referenced, so the interpreter does not destroy it
+    mid-await and announce that itself.
+    """
+    from lionagi.service.hooks.hooked_event import (
+        POST_STREAM_HOOK_STOP_GRACE,
+        _abandoned_post_stream_hooks,
+    )
+
+    class ResistantPostHook:
+        execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                pass  # refuses the first cancellation
+            await asyncio.sleep(30)
+
+    h = SlowStream()
+    h._post_invoke_hook_event = ResistantPostHook()
+
+    async def main():
+        started = asyncio.Event()
+
+        async def consume():
+            async for _ in h._stream():
+                started.set()
+
+        task = asyncio.create_task(consume())
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    records: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = _Capture()
+    logging.getLogger("asyncio").addHandler(handler)
+    logging.getLogger(hooked_event.__name__).addHandler(handler)
+    known = set(_abandoned_post_stream_hooks)
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(main())
+    finally:
+        loop.close()
+        logging.getLogger("asyncio").removeHandler(handler)
+        logging.getLogger(hooked_event.__name__).removeHandler(handler)
+
+    gc.collect()
+
+    assert set(_abandoned_post_stream_hooks) - known, "the abandoned hook must be retained"
+    assert any(f"did not stop within {POST_STREAM_HOOK_STOP_GRACE}s" in r for r in records)
+    assert not [r for r in records if "destroyed but it is pending" in r], records

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -9,7 +9,9 @@ from types import SimpleNamespace
 
 import anyio
 import pytest
+from pydantic import PrivateAttr
 
+from lionagi.ln.concurrency import get_cancelled_exc_class
 from lionagi.protocols.types import EventStatus
 from lionagi.service.hooks import hooked_event
 from lionagi.service.hooks._types import StreamTerminalState
@@ -305,6 +307,49 @@ class SlowStream(HookedEvent):
         yield "chunk2"
 
 
+class RaisingStream(HookedEvent):
+    """Yields one chunk, then raises the exception object handed to it.
+
+    Raising a caller-held object is what makes identity assertable: the test can
+    compare what the consumer caught against what the source actually raised.
+    """
+
+    _to_raise: BaseException = PrivateAttr(None)
+
+    async def _core_stream(self):
+        yield "chunk1"
+        raise self._to_raise
+
+
+class CancelCapturingStream(HookedEvent):
+    """Waits to be cancelled from outside, keeping the cancellation it was handed."""
+
+    _delivered: list = PrivateAttr(default_factory=list)
+
+    async def _core_stream(self):
+        yield "chunk1"
+        try:
+            await anyio.sleep(30)
+        except get_cancelled_exc_class() as e:
+            self._delivered.append(e)
+            raise
+        yield "chunk2"
+
+
+def _post_hook_raising(exc: BaseException):
+    """A post-hook that raises ``exc`` out of invoke()."""
+
+    class _RaisingHookEvent:
+        execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            raise exc
+
+    return _RaisingHookEvent()
+
+
 def _recording_post_hook(event: HookedEvent):
     """A post-hook that records the terminal state visible to it when it runs."""
     seen: list[StreamTerminalState | None] = []
@@ -324,14 +369,22 @@ def _recording_post_hook(event: HookedEvent):
 
 @pytest.mark.asyncio
 async def test_stream_post_hook_runs_when_core_stream_raises():
-    """A source error must not skip teardown, and must reach the caller unchanged."""
-    h = FailingHooked()
+    """A source error must not skip teardown, and must reach the caller unchanged.
+
+    Unchanged means the same object: a teardown that replaced it with an equivalent
+    one would still satisfy a type-and-message check while losing the original
+    traceback and any state the caller attached to it.
+    """
+    source = ValueError("core_stream_failed")
+    h = RaisingStream()
+    h._to_raise = source
     seen = _recording_post_hook(h)
 
-    with pytest.raises(ValueError, match="core_stream_failed"):
+    with pytest.raises(ValueError) as caught:
         async for _ in h._stream():
             pass
 
+    assert caught.value is source
     assert seen == [StreamTerminalState.Failed]
     assert h.stream_terminal_state is StreamTerminalState.Failed
 
@@ -474,4 +527,145 @@ async def test_bare_break_defers_teardown_to_generator_finalization():
             await anyio.sleep(0.01)
 
     assert seen == [StreamTerminalState.Closed]
+
+
+# ---------------------------------------------------------------------------
+# HookedEvent._stream() — a failing teardown must not replace the ending it
+# was there to record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hook_exc",
+    [
+        pytest.param(asyncio.CancelledError("post hook cancelled itself"), id="cancelled"),
+        pytest.param(RuntimeError("post hook exploded"), id="ordinary"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_source_error_survives_a_failing_teardown(hook_exc):
+    """A source error reaches the caller as the same object, whatever the hook does.
+
+    A cancellation is the interesting half: it is a BaseException, so a teardown
+    guard written against Exception lets it out of the finally and the caller gets
+    the hook's cancellation instead of the failure that ended the stream.
+    """
+    source = ValueError("core_stream_failed")
+    h = RaisingStream()
+    h._to_raise = source
+    h._post_invoke_hook_event = _post_hook_raising(hook_exc)
+
+    with pytest.raises(ValueError) as caught:
+        async for _ in h._stream():
+            pass
+
+    assert caught.value is source
+    assert h.stream_terminal_state is StreamTerminalState.Failed
+
+
+@pytest.mark.parametrize(
+    "hook_exc",
+    [
+        pytest.param(asyncio.CancelledError("post hook cancelled itself"), id="cancelled"),
+        pytest.param(RuntimeError("post hook exploded"), id="ordinary"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_normal_completion_survives_a_failing_teardown(hook_exc):
+    """A stream that ended normally still ends normally when its teardown fails."""
+    h = SimpleHooked()
+    h._post_invoke_hook_event = _post_hook_raising(hook_exc)
+
+    chunks = [c async for c in h._stream()]
+
+    assert chunks == ["chunk1", "chunk2"]
+    assert h.stream_terminal_state is StreamTerminalState.Completed
+
+
+@pytest.mark.parametrize(
+    "hook_exc",
+    [
+        pytest.param(asyncio.CancelledError("post hook cancelled itself"), id="cancelled"),
+        pytest.param(RuntimeError("post hook exploded"), id="ordinary"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_early_close_survives_a_failing_teardown(hook_exc):
+    """aclose() on an early-stopped stream returns, it does not raise the hook's failure."""
+    h = SimpleHooked()
+    h._post_invoke_hook_event = _post_hook_raising(hook_exc)
+
+    stream = h._stream()
+    async for _ in stream:
+        break
+    await stream.aclose()
+
     assert h.stream_terminal_state is StreamTerminalState.Closed
+
+
+@pytest.mark.asyncio
+async def test_outer_cancellation_survives_a_failing_teardown():
+    """A cancelled consumer gets back the cancellation it was handed, not the hook's.
+
+    Identity is checked inside the consuming coroutine: asyncio re-wraps a task's
+    cancellation at the task boundary, so awaiting the task cannot see it.
+    """
+    h = CancelCapturingStream()
+    h._post_invoke_hook_event = _post_hook_raising(
+        asyncio.CancelledError("post hook cancelled itself")
+    )
+    first_chunk = asyncio.Event()
+    caught: list[BaseException] = []
+
+    async def consume():
+        try:
+            async for _ in h._stream():
+                first_chunk.set()
+        except asyncio.CancelledError as e:
+            caught.append(e)
+            raise
+
+    task = asyncio.create_task(consume())
+    await first_chunk.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task.cancelled()
+    assert caught and caught[0] is h._delivered[0]
+    assert h.stream_terminal_state is StreamTerminalState.Cancelled
+
+
+@pytest.mark.asyncio
+async def test_consumer_cancelled_during_teardown_is_still_cancelled():
+    """The cancellation the fix could swallow: one delivered while teardown awaits.
+
+    The stream itself ended normally, so nothing is in flight to protect, and the
+    cancellation belongs to the consuming task. Swallowing it here would leave a
+    task that was cancelled from outside running on as if it never had been.
+    """
+    hook_running = asyncio.Event()
+
+    class BlockingPostHook:
+        execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            hook_running.set()
+            await anyio.sleep(30)
+
+    h = SimpleHooked()
+    h._post_invoke_hook_event = BlockingPostHook()
+
+    async def consume():
+        async for _ in h._stream():
+            pass
+
+    task = asyncio.create_task(consume())
+    await hook_running.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert task.cancelled(), "a consumer cancelled from outside must stay cancelled"


### PR DESCRIPTION
The post-invocation hook on a streaming event only ran when the stream was exhausted normally. Every other way a stream can end skipped it. Closes #2477.

## What was wrong

`HookedEvent._stream()` yielded chunks from `_core_stream()` and then invoked the post-invocation hook after the loop. Anything that left that loop early -- a source error, a consumer that stopped before the last chunk, a cancellation from an enclosing timeout -- left the hook unrun. A hook is where per-call accounting, quota release and logging live, so a stream that failed or was abandoned silently skipped all of it.

At the parent commit, with a source that yields one chunk and then raises:

```
source error      -> post-hook ran: []
early stop + close-> post-hook ran: []
```

After the change, the same script:

```
source error      -> post-hook ran: [StreamTerminalState.Failed]  state: Failed
early stop + close-> post-hook ran: [StreamTerminalState.Closed]  state: Closed
```

## What changed

- `_stream()` runs the post-hook from a `finally`, so it runs however the stream ends, and classifies the ending: `Completed`, `Failed`, `Closed` or `Cancelled`. Whatever ended the stream still propagates unchanged.
- `stream_terminal_state` exposes that classification, so a hook can tell a stream that finished from one that was abandoned or cancelled.
- On the close and cancel paths the teardown runs inside an unwind that is already cancelling, so an unshielded await would be cancelled before the hook could run and would replace the exception in flight. It runs shielded, and bounded by `POST_STREAM_TEARDOWN_GRACE` so a slow hook cannot hold the unwind open. A hook that exceeds the grace is logged at warning.
- Post-hook failure on a stream is logged at warning, never raised: the data has already been sent to the consumer.
- `Event.stream()` wraps the inner generator in `contextlib.aclosing`, so closing the public stream closes the hooked one with it and teardown happens at the close rather than whenever the interpreter gets to it.

## Where the boundary is

`break` does not close the generator it was iterating. There is no code inside the generator that can change that, so the last commit makes it a stated contract rather than an implied one: a consumer that stops early closes the stream, with `aclose()` or `contextlib.aclosing`. That is documented on both `Event.stream()` and `HookedEvent._stream()`.

An abandoned stream is not lost -- the interpreter finalizes it and teardown runs then, with the closed state. But it runs at a moment the consumer did not pick, and during loop shutdown the teardown grace can cut its logging short. A test pins both halves: nothing at the break, closed state once the generator is finalized.

## Tests

`tests/service/hooks tests/protocols/generic`: 1170 passed, rc=0.

Reverting `contextlib.aclosing` in `Event.stream()` alone fails `test_public_stream_closes_the_inner_stream_when_closed_early` (1 failed, 26 passed), which is what pins that the public stream closes the hooked one it wraps.

The bare-break test passes against the parent tree as well. It is a characterization test, kept deliberately: it records that a break gives no teardown at the break and that finalization still reaches teardown with the closed state. It is the executable half of the contract the docstrings now state, and it fails if either half stops holding.
