### PR TITLE
fix(mcp): projection for profile.list, and a source that no longer outranks the resolver

### DIFF
--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -590,7 +590,7 @@ def _run_roster(verb: Verb, args: dict[str, Any]) -> dict[str, Any]:
         raise OpError("invalid_input", f"cwd {cwd!r} is not a directory")
     try:
         if verb.name == "profile.list":
-            return roster.profile_list(cwd=cwd)
+            return roster.profile_list(cwd=cwd, names=args.get("names"), fields=args.get("fields"))
         return roster.profile_show(args["name"], cwd=cwd)
     except FileNotFoundError as exc:
         # The loader's own miss already names every available profile; re-listing

--- a/lionagi/mcp/roster.py
+++ b/lionagi/mcp/roster.py
@@ -165,6 +165,24 @@ def _placement(name: str) -> dict[str, Any]:
 _PLACEMENT_FIELDS = ("source", "shadowed", "ambiguous")
 
 
+def _record_placement(name: str) -> dict[str, Any]:
+    """The placement a reply carries when it was not asked for anything narrower.
+
+    ``match`` and ``ambiguous`` describe how the resolver arrived at its answer.
+    That is worth having, but a caller reading a reply it did not ask to be
+    reshaped has to find the keys it has always found and no others, so the two
+    are reachable only by naming them in ``fields``.
+    """
+    placement = _placement(name)
+    source = placement["source"]
+    return {
+        "source": None if source is None else {k: v for k, v in source.items() if k != "match"},
+        "shadowed": [
+            {k: v for k, v in entry.items() if k != "match"} for entry in placement["shadowed"]
+        ],
+    }
+
+
 def _resolved_fields() -> tuple[str, ...]:
     """The keys a resolved block carries, asked of the function that builds one.
 
@@ -224,7 +242,7 @@ def _profile_entry(
     entirely — the fields a caller left out cost nothing to leave out.
     """
     if not projected:
-        return {"name": name, **_placement(name), "resolved": config}
+        return {"name": name, **_record_placement(name), "resolved": config}
     entry: dict[str, Any] = {"name": name}
     if selected:
         entry.update({k: v for k, v in _placement(name).items() if k in selected})
@@ -285,7 +303,7 @@ def profile_show(name: str, *, cwd: str | None = None) -> dict[str, Any]:
         return {
             "cwd": os.getcwd(),
             "name": name,
-            **_placement(name),
+            **_record_placement(name),
             "resolved": profile_config(profile),
             # Frontmatter keys the loader recognised no runtime meaning for,
             # by name only: enough to see that a profile declares something

--- a/lionagi/mcp/roster.py
+++ b/lionagi/mcp/roster.py
@@ -88,11 +88,27 @@ def _placement(name: str) -> dict[str, Any]:
     walked in the same order and narrowed by the same spelling rule, so the file
     named here is the file that was read and everything after it is a file this
     name really does displace.
+
+    ``match`` says how the source was reached, because the two ways are not
+    equally solid. ``exact`` means a file spelled the way the caller spelled it.
+    ``separator_fallback`` means no such file exists and the other separator
+    spelling answered instead — still what a run would read, but reached by a
+    substitution the caller did not ask for, which is worth knowing before
+    editing the file it names.
+
+    ``ambiguous`` is the case that has no source at all. A directory declaring a
+    name under both separator spellings, with neither spelled as asked, is one
+    the resolver refuses rather than ranks: it raises instead of picking a
+    winner. Those files are listed here, unordered, and the walk stops there —
+    ranking them would name a file as runnable that a submitted run rejects, and
+    listing what lies past the refusal would describe files no request reaches.
     """
     from lionagi._paths import find_lionagi_dirs
     from lionagi.cli._providers import _profile_path_candidates, _resolve_plugin_profile_path
 
     found: list[dict[str, str]] = []
+    ambiguous: list[dict[str, str]] = []
+    refused = False
     if "/" not in name:
         for d in find_lionagi_dirs():
             # Every candidate in the root, not just the winning one: the two
@@ -110,25 +126,142 @@ def _placement(name: str) -> dict[str, Any]:
             for path in _profile_path_candidates(d / "agents", name):
                 if path.is_file():
                     declared.setdefault(path.stem, []).append(path)
-            # No file spelled as asked: the fallback spellings are what is left
-            # to report, and a directory holding more than one of those is the
-            # ambiguity the resolver refuses rather than ranks.
-            resolving = declared.get(name) or [p for paths in declared.values() for p in paths]
-            found.extend({"path": str(path), "scope": _scope(d)} for path in resolving)
-    plugin_path = _resolve_plugin_profile_path(name)
-    if plugin_path is not None:
-        found.append({"path": str(plugin_path), "scope": "plugin"})
-    return {"source": found[0] if found else None, "shadowed": found[1:]}
+            if name in declared:
+                found.extend(
+                    {"path": str(path), "scope": _scope(d), "match": "exact"}
+                    for path in declared[name]
+                )
+                continue
+            if len(declared) > 1:
+                ambiguous.extend(
+                    {"path": str(path), "scope": _scope(d)}
+                    for paths in declared.values()
+                    for path in paths
+                )
+                # Reached only when nothing earlier resolved: this is where the
+                # resolver raises, so there is nothing further for a request to
+                # find. With a source already in hand the walk never gets here
+                # at all, and these files are simply out of reach either way.
+                if not found:
+                    refused = True
+                    break
+                continue
+            found.extend(
+                {"path": str(path), "scope": _scope(d), "match": "separator_fallback"}
+                for paths in declared.values()
+                for path in paths
+            )
+    if not refused:
+        plugin_path = _resolve_plugin_profile_path(name)
+        if plugin_path is not None:
+            found.append({"path": str(plugin_path), "scope": "plugin", "match": "exact"})
+    return {
+        "source": found[0] if found else None,
+        "shadowed": found[1:],
+        "ambiguous": ambiguous,
+    }
 
 
-def profile_list(*, cwd: str | None = None) -> dict[str, Any]:
-    """Every profile name ``agent.submit`` would accept here, and what each resolves to."""
+_PLACEMENT_FIELDS = ("source", "shadowed", "ambiguous")
+
+
+def _resolved_fields() -> tuple[str, ...]:
+    """The keys a resolved block carries, asked of the function that builds one.
+
+    Naming them here as a second list would let the two drift, and the drift
+    would surface as a projection that silently refuses a field the unprojected
+    reply still returns.
+    """
+    from lionagi.cli._providers import AgentProfile, profile_config
+
+    return tuple(profile_config(AgentProfile(name="")))
+
+
+def _parse_fields(fields: list[str]) -> tuple[set[str], tuple[str, ...] | None]:
+    """Split a requested field list into per-profile keys and resolved sub-keys.
+
+    An unrecognised field is refused by name rather than dropped: a caller who
+    misspells one would otherwise read the missing key as a profile that does
+    not declare it, which is a different and wrong answer.
+    """
+    resolved_fields = _resolved_fields()
+    keys: set[str] = set()
+    sub: list[str] = []
+    whole_resolved = False
+    for field in fields:
+        if field in _PLACEMENT_FIELDS:
+            keys.add(field)
+        elif field == "resolved":
+            whole_resolved = True
+        elif field.startswith("resolved.") and field[len("resolved.") :] in resolved_fields:
+            sub.append(field[len("resolved.") :])
+        elif field != "name":
+            known = ", ".join(
+                (
+                    "name",
+                    *_PLACEMENT_FIELDS,
+                    "resolved",
+                    *(f"resolved.{f}" for f in resolved_fields),
+                )
+            )
+            raise ValueError(f"unknown profile field {field!r}; known fields are: {known}")
+    if whole_resolved:
+        return keys, resolved_fields
+    return keys, tuple(sub) if sub else None
+
+
+def _profile_entry(
+    name: str,
+    config: dict[str, Any],
+    selected: set[str],
+    resolved_fields: tuple[str, ...] | None,
+    *,
+    projected: bool,
+) -> dict[str, Any]:
+    """One row of the list, either whole or narrowed to the fields asked for.
+
+    A row asked for neither placement nor configuration skips the placement walk
+    entirely — the fields a caller left out cost nothing to leave out.
+    """
+    if not projected:
+        return {"name": name, **_placement(name), "resolved": config}
+    entry: dict[str, Any] = {"name": name}
+    if selected:
+        entry.update({k: v for k, v in _placement(name).items() if k in selected})
+    if resolved_fields is not None:
+        entry["resolved"] = {k: config[k] for k in resolved_fields}
+    return entry
+
+
+def profile_list(
+    *,
+    cwd: str | None = None,
+    names: list[str] | None = None,
+    fields: list[str] | None = None,
+) -> dict[str, Any]:
+    """Every profile name ``agent.submit`` would accept here, and what each resolves to.
+
+    ``names`` and ``fields`` narrow the reply rather than the work: the roster is
+    resolved the same way either way, and what changes is how much of it comes
+    back. Both matter because the reply is the cost — a caller that wanted one
+    profile has already paid for the whole roster by the time it could filter
+    one out of it. Given neither, the reply is exactly what it has always been.
+
+    ``name`` is always present on a projected profile even when ``fields`` does
+    not ask for it. It is the only key that says which profile a row is about,
+    and rows that cannot be told apart are not a smaller answer but an unusable
+    one.
+    """
     from lionagi.cli._providers import build_agent_profile_catalog
 
+    selected, resolved_fields = (set(), None) if fields is None else _parse_fields(fields)
     with _resolving_under(cwd):
         catalog = build_agent_profile_catalog()
+        if names is not None:
+            wanted = set(names)
+            catalog = {name: config for name, config in catalog.items() if name in wanted}
         profiles = [
-            {"name": name, **_placement(name), "resolved": config}
+            _profile_entry(name, config, selected, resolved_fields, projected=fields is not None)
             for name, config in sorted(catalog.items())
         ]
         return {

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -366,8 +366,9 @@ _PROFILE_LIST_SCHEMA = _own(
                 "Return only these keys per profile: 'source', 'shadowed', 'ambiguous', "
                 "'resolved' for the whole configuration block, or 'resolved.<key>' for "
                 "one of its fields ('resolved.model', 'resolved.effort', ...). 'name' is "
-                "always returned. An unrecognised field is an error rather than an empty "
-                "one. Omit it for the full record."
+                "always returned. A placement field asked for by name also says how the "
+                "resolver reached each file it lists. An unrecognised field is an error "
+                "rather than an empty one. Omit it for the full record."
             ),
         },
     }

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -366,9 +366,15 @@ _PROFILE_LIST_SCHEMA = _own(
                 "Return only these keys per profile: 'source', 'shadowed', 'ambiguous', "
                 "'resolved' for the whole configuration block, or 'resolved.<key>' for "
                 "one of its fields ('resolved.model', 'resolved.effort', ...). 'name' is "
-                "always returned. A placement field asked for by name also says how the "
-                "resolver reached each file it lists. An unrecognised field is an error "
-                "rather than an empty one. Omit it for the full record."
+                "always returned. An unrecognised field is an error rather than an empty "
+                "one. Omit it and every profile comes back as 'name', 'source', "
+                "'shadowed' and the whole 'resolved' block, with each placed file given "
+                "as a path and a scope and nothing else. Naming a placement field returns "
+                "more of it than that, not less: 'source' and 'shadowed' entries then also "
+                "carry 'match', which says whether the resolver found the spelling asked "
+                "for or substituted the other separator, and 'ambiguous' — the files a "
+                "name is refused over rather than ranked between — is reachable only by "
+                "asking for it here."
             ),
         },
     }

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -346,7 +346,32 @@ _ROSTER_CWD = {
     ),
 }
 
-_PROFILE_LIST_SCHEMA = _own({"cwd": _ROSTER_CWD})
+_PROFILE_LIST_SCHEMA = _own(
+    {
+        "cwd": _ROSTER_CWD,
+        "names": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Answer for these profile names only, matched exactly as the roster "
+                "spells them. A name nothing declares is simply absent from the reply, "
+                "so asking for three and reading back two says which one is missing. "
+                "Omit it for the whole roster."
+            ),
+        },
+        "fields": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Return only these keys per profile: 'source', 'shadowed', 'ambiguous', "
+                "'resolved' for the whole configuration block, or 'resolved.<key>' for "
+                "one of its fields ('resolved.model', 'resolved.effort', ...). 'name' is "
+                "always returned. An unrecognised field is an error rather than an empty "
+                "one. Omit it for the full record."
+            ),
+        },
+    }
+)
 
 _PROFILE_SHOW_SCHEMA = _own(
     {

--- a/tests/mcp/test_roster.py
+++ b/tests/mcp/test_roster.py
@@ -16,6 +16,7 @@ moved before any resolution happens.
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 
 import pytest
@@ -123,9 +124,7 @@ def test_a_name_in_both_roots_resolves_to_the_project_one(roots):
     # Whole-file precedence, not a field merge: the global file's effort is
     # displaced, not inherited.
     assert shown["resolved"]["effort"] is None
-    assert shown["shadowed"] == [
-        {"path": str(roots.glob / "reviewer.md"), "scope": "global", "match": "exact"}
-    ]
+    assert shown["shadowed"] == [{"path": str(roots.glob / "reviewer.md"), "scope": "global"}]
 
 
 def test_the_two_layouts_in_one_root_shadow_each_other_too(roots):
@@ -145,7 +144,7 @@ def test_the_two_layouts_in_one_root_shadow_each_other_too(roots):
 
     assert shown["source"]["path"] == str(directory_layout)
     assert shown["resolved"]["model"] == "directory-model"
-    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project", "match": "exact"}]
+    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project"}]
 
 
 def test_a_same_root_loser_is_listed_before_a_further_root(roots):
@@ -205,7 +204,7 @@ def test_a_displaced_layout_is_still_shadowed_beside_the_other_spelling(roots):
     shown = op("profile.show", {"name": "postmortem-lead"})["result"]
 
     assert shown["source"]["path"] == str(directory_layout)
-    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project", "match": "exact"}]
+    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project"}]
     assert op("profile.show", {"name": "postmortem_lead"})["result"]["source"]["path"] == str(
         underscore
     )
@@ -310,24 +309,26 @@ def test_an_unknown_parameter_is_refused_by_name(roots):
 # ── the spelling fallback, and where it has nothing to say ───────────────────
 
 
-def test_a_source_reached_by_the_other_separator_says_so(roots):
-    """The same file in ``source``, but reached two different ways.
+def test_a_file_reached_by_the_other_separator_says_so(roots):
+    """Two files under one name, reached two different ways.
 
-    Asked for by its own spelling it is a file that matched. Asked for by the
-    other separator it is what the fallback produced — the run still reads it,
-    but the caller's spelling names nothing on disk, and a reply that describes
-    both cases identically hides which one it is looking at.
+    The project file is spelled the way the name is spelled. The global one is
+    reached only because the separators stand in for each other, and it is still
+    selectable under its own spelling — so a caller deciding which file to edit
+    is looking at a weaker claim there than in the project root. A reply that
+    describes both entries identically hides which one is which.
     """
-    write_profile(roots.proj, "postmortem_lead", "---\nmodel: m\n---\nbody\n")
+    exact = write_profile(roots.proj, "postmortem-lead", "---\nmodel: m\n---\nbody\n")
+    other_spelling = write_profile(roots.glob, "postmortem_lead", "---\nmodel: g\n---\nbody\n")
 
-    asked_as_written = op("profile.show", {"name": "postmortem_lead"})["result"]
-    assert asked_as_written["source"]["match"] == "exact"
+    entry = op("profile.list", {"names": ["postmortem-lead"], "fields": ["source", "shadowed"]})[
+        "result"
+    ]["profiles"][0]
 
-    asked_with_the_other_separator = op("profile.show", {"name": "postmortem-lead"})["result"]
-    assert asked_with_the_other_separator["source"]["path"] == str(
-        roots.proj / "postmortem_lead.md"
-    )
-    assert asked_with_the_other_separator["source"]["match"] == "separator_fallback"
+    assert entry["source"] == {"path": str(exact), "scope": "project", "match": "exact"}
+    assert entry["shadowed"] == [
+        {"path": str(other_spelling), "scope": "global", "match": "separator_fallback"}
+    ]
 
 
 def test_two_spellings_in_one_root_are_reported_as_ambiguous_not_as_shadowed(roots):
@@ -343,11 +344,14 @@ def test_two_spellings_in_one_root_are_reported_as_ambiguous_not_as_shadowed(roo
     underscores = write_profile(roots.glob, "post_mortem_lead", "---\nmodel: under\n---\nbody\n")
     hyphens = write_profile(roots.glob, "post-mortem-lead", "---\nmodel: hyphen\n---\nbody\n")
 
-    shown = op("profile.show", {"name": "post-mortem_lead"})["result"]
+    listed = op(
+        "profile.list",
+        {"names": ["post-mortem_lead"], "fields": ["source", "shadowed", "ambiguous"]},
+    )["result"]["profiles"]
 
-    assert shown["source"] == {"path": str(exact), "scope": "project", "match": "exact"}
-    assert shown["shadowed"] == []
-    assert sorted(entry["path"] for entry in shown["ambiguous"]) == sorted(
+    assert listed[0]["source"] == {"path": str(exact), "scope": "project", "match": "exact"}
+    assert listed[0]["shadowed"] == []
+    assert sorted(entry["path"] for entry in listed[0]["ambiguous"]) == sorted(
         [str(underscores), str(hyphens)]
     )
     # Both really are selectable, which is why neither is displaced.
@@ -386,17 +390,49 @@ def test_placement_names_no_source_where_the_loader_refuses_to_choose(roots):
 
 
 def test_the_unprojected_list_is_what_it_has_always_been(roots):
-    """Asking for nothing in particular still answers with the full record.
+    """The whole reply to a call that asked for nothing, against the shape on record.
 
-    The projection is an addition, so every caller that never learned about it
-    has to keep reading the same keys in the same shape.
+    The projection is an addition, so a caller that never learned about it has
+    to keep reading the same keys — including inside ``source`` and each
+    ``shadowed`` entry, which is where a key added to the placement walk would
+    otherwise arrive unannounced. Compared whole rather than key by key: a
+    subset check passes on a reply carrying anything extra, which is exactly the
+    change it is here to catch.
     """
-    write_profile(roots.proj, "builder", "---\nmodel: anthropic/claude\n---\nbody\n")
+    write_profile(roots.glob, "reviewer", "---\nmodel: global-model\n---\nglobal\n")
+    write_profile(roots.proj, "reviewer", "---\nmodel: project-model\n---\nproject\n")
 
-    entry = op("profile.list")["result"]["profiles"][0]
+    result = op("profile.list")["result"]
+    # Through a JSON round trip, because that is how a caller receives it.
+    assert json.loads(json.dumps(result)) == result
 
-    assert set(entry) == {"name", "source", "shadowed", "ambiguous", "resolved"}
-    assert entry["resolved"] == profile_config(load_agent_profile("builder"))
+    assert set(result) == {"cwd", "roots", "profiles", "count"}
+    assert result["count"] == 1
+    assert result["profiles"] == [
+        {
+            "name": "reviewer",
+            "source": {"path": str(roots.proj / "reviewer.md"), "scope": "project"},
+            "shadowed": [{"path": str(roots.glob / "reviewer.md"), "scope": "global"}],
+            "resolved": profile_config(load_agent_profile("reviewer")),
+        }
+    ]
+
+
+def test_showing_one_profile_is_what_it_has_always_been_too(roots):
+    """``profile.show`` takes no projection at all, so it carries the same record.
+
+    Placement detail reaches a caller of the list only by being named in
+    ``fields``; there is nothing to name here, so there is nothing extra to
+    return.
+    """
+    write_profile(roots.glob, "reviewer", "---\nmodel: global-model\n---\nglobal\n")
+    write_profile(roots.proj, "reviewer", "---\nmodel: project-model\n---\nproject\n")
+
+    shown = op("profile.show", {"name": "reviewer"})["result"]
+
+    assert set(shown) == {"cwd", "name", "source", "shadowed", "resolved", "declared_extra_keys"}
+    assert shown["source"] == {"path": str(roots.proj / "reviewer.md"), "scope": "project"}
+    assert shown["shadowed"] == [{"path": str(roots.glob / "reviewer.md"), "scope": "global"}]
 
 
 def test_names_answers_for_the_profiles_asked_for_and_no_others(roots):

--- a/tests/mcp/test_roster.py
+++ b/tests/mcp/test_roster.py
@@ -501,6 +501,60 @@ def test_an_unknown_field_is_refused_by_name(roots):
     assert "resolved.model" in result["error"]["message"]
 
 
+def test_the_unprojected_placement_is_narrower_than_the_projected_one(roots):
+    """The same key, two shapes, pinned side by side under one roster.
+
+    Both calls describe the same two files. Omitting ``fields`` gives each of
+    them as a path and a scope; naming ``source`` and ``shadowed`` adds ``match``
+    to both, and ``ambiguous`` exists on the projected reply and nowhere else.
+    Which shape a caller gets is decided by whether they asked, so the two are
+    pinned together rather than apart — that is the part a caller has to be able
+    to predict, and the part the schema text has to describe.
+    """
+    project = write_profile(roots.proj, "reviewer", "---\nmodel: project-model\n---\nproject\n")
+    global_ = write_profile(roots.glob, "reviewer", "---\nmodel: global-model\n---\nglobal\n")
+
+    plain = op("profile.list")["result"]["profiles"][0]
+    asked = op("profile.list", {"fields": ["source", "shadowed", "ambiguous"]})["result"][
+        "profiles"
+    ][0]
+
+    assert plain["source"] == {"path": str(project), "scope": "project"}
+    assert plain["shadowed"] == [{"path": str(global_), "scope": "global"}]
+    assert "ambiguous" not in plain
+
+    assert asked["source"] == {"path": str(project), "scope": "project", "match": "exact"}
+    assert asked["shadowed"] == [
+        {"path": str(global_), "scope": "global", "match": "exact"},
+    ]
+    assert asked["ambiguous"] == []
+
+
+def test_the_fields_description_says_what_omitting_it_returns(roots):
+    """Read from the schema the server serves, against a reply it really produced.
+
+    A caller sizing a call reads this text and nothing else, so it has to name
+    the keys an unprojected reply carries and say that naming a placement field
+    widens that reply rather than narrowing it. Asserting against the served
+    schema rather than against a copy of the string keeps the two from drifting;
+    asserting the key names against a real reply keeps the text from going stale
+    when the reply gains a key.
+    """
+    write_profile(roots.proj, "builder", "---\nmodel: m\n---\nbody\n")
+
+    described = call(help="profile.list")["schema"]["properties"]["fields"]["description"]
+    entry = op("profile.list")["result"]["profiles"][0]
+
+    for key in entry:
+        assert f"'{key}'" in described, key
+    # The two ways a projected placement field is wider than an unprojected one.
+    assert "'match'" in described
+    assert "'ambiguous'" in described
+    # Omitting the parameter returns the narrower placement, so no reading of
+    # this text may promise that omitting it returns more.
+    assert "full record" not in described
+
+
 def test_names_and_fields_narrow_the_same_reply_together(roots):
     write_profile(roots.glob, "archivist", "---\nmodel: a\n---\nbody\n")
     write_profile(roots.proj, "builder", "---\nmodel: b\n---\nbody\n")

--- a/tests/mcp/test_roster.py
+++ b/tests/mcp/test_roster.py
@@ -123,7 +123,9 @@ def test_a_name_in_both_roots_resolves_to_the_project_one(roots):
     # Whole-file precedence, not a field merge: the global file's effort is
     # displaced, not inherited.
     assert shown["resolved"]["effort"] is None
-    assert shown["shadowed"] == [{"path": str(roots.glob / "reviewer.md"), "scope": "global"}]
+    assert shown["shadowed"] == [
+        {"path": str(roots.glob / "reviewer.md"), "scope": "global", "match": "exact"}
+    ]
 
 
 def test_the_two_layouts_in_one_root_shadow_each_other_too(roots):
@@ -143,7 +145,7 @@ def test_the_two_layouts_in_one_root_shadow_each_other_too(roots):
 
     assert shown["source"]["path"] == str(directory_layout)
     assert shown["resolved"]["model"] == "directory-model"
-    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project"}]
+    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project", "match": "exact"}]
 
 
 def test_a_same_root_loser_is_listed_before_a_further_root(roots):
@@ -203,7 +205,7 @@ def test_a_displaced_layout_is_still_shadowed_beside_the_other_spelling(roots):
     shown = op("profile.show", {"name": "postmortem-lead"})["result"]
 
     assert shown["source"]["path"] == str(directory_layout)
-    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project"}]
+    assert shown["shadowed"] == [{"path": str(flat_layout), "scope": "project", "match": "exact"}]
     assert op("profile.show", {"name": "postmortem_lead"})["result"]["source"]["path"] == str(
         underscore
     )
@@ -303,3 +305,172 @@ def test_an_unknown_parameter_is_refused_by_name(roots):
     result = op("profile.list", {"root": "/tmp"})
     assert result["ok"] is False
     assert "root" in result["error"]["message"]
+
+
+# ── the spelling fallback, and where it has nothing to say ───────────────────
+
+
+def test_a_source_reached_by_the_other_separator_says_so(roots):
+    """The same file in ``source``, but reached two different ways.
+
+    Asked for by its own spelling it is a file that matched. Asked for by the
+    other separator it is what the fallback produced — the run still reads it,
+    but the caller's spelling names nothing on disk, and a reply that describes
+    both cases identically hides which one it is looking at.
+    """
+    write_profile(roots.proj, "postmortem_lead", "---\nmodel: m\n---\nbody\n")
+
+    asked_as_written = op("profile.show", {"name": "postmortem_lead"})["result"]
+    assert asked_as_written["source"]["match"] == "exact"
+
+    asked_with_the_other_separator = op("profile.show", {"name": "postmortem-lead"})["result"]
+    assert asked_with_the_other_separator["source"]["path"] == str(
+        roots.proj / "postmortem_lead.md"
+    )
+    assert asked_with_the_other_separator["source"]["match"] == "separator_fallback"
+
+
+def test_two_spellings_in_one_root_are_reported_as_ambiguous_not_as_shadowed(roots):
+    """A root the resolver would refuse contributes no ranking to the answer.
+
+    The project file matches the requested spelling and runs. The two global
+    files spell it the other two ways, and a request that got as far as that
+    root would be refused rather than answered — so neither of them is a file
+    this name displaces, and both are still selectable under their own names.
+    Listing them as shadowed says the opposite of both.
+    """
+    exact = write_profile(roots.proj, "post-mortem_lead", "---\nmodel: exact\n---\nbody\n")
+    underscores = write_profile(roots.glob, "post_mortem_lead", "---\nmodel: under\n---\nbody\n")
+    hyphens = write_profile(roots.glob, "post-mortem-lead", "---\nmodel: hyphen\n---\nbody\n")
+
+    shown = op("profile.show", {"name": "post-mortem_lead"})["result"]
+
+    assert shown["source"] == {"path": str(exact), "scope": "project", "match": "exact"}
+    assert shown["shadowed"] == []
+    assert sorted(entry["path"] for entry in shown["ambiguous"]) == sorted(
+        [str(underscores), str(hyphens)]
+    )
+    # Both really are selectable, which is why neither is displaced.
+    assert (
+        op("profile.show", {"name": "post_mortem_lead"})["result"]["resolved"]["model"] == "under"
+    )
+    assert (
+        op("profile.show", {"name": "post-mortem-lead"})["result"]["resolved"]["model"] == "hyphen"
+    )
+
+
+def test_placement_names_no_source_where_the_loader_refuses_to_choose(roots):
+    """The claim the placement walk must never make, checked against the loader.
+
+    One root, both fallback spellings, and nothing spelled as asked: the loader
+    raises rather than ranking them, so there is no file to call the source. The
+    loader is called here in the same directory as the control — a placement
+    answer is only wrong relative to what a run would actually get.
+    """
+    from lionagi.cli._providers import AmbiguousProfileNameError, load_agent_profile
+    from lionagi.mcp.roster import _placement
+
+    write_profile(roots.proj, "post_mortem_lead", "---\nmodel: under\n---\nbody\n")
+    write_profile(roots.proj, "post-mortem-lead", "---\nmodel: hyphen\n---\nbody\n")
+
+    with pytest.raises(AmbiguousProfileNameError):
+        load_agent_profile("post-mortem_lead")
+
+    placement = _placement("post-mortem_lead")
+    assert placement["source"] is None
+    assert placement["shadowed"] == []
+    assert len(placement["ambiguous"]) == 2
+
+
+# ── asking for less than the whole roster ────────────────────────────────────
+
+
+def test_the_unprojected_list_is_what_it_has_always_been(roots):
+    """Asking for nothing in particular still answers with the full record.
+
+    The projection is an addition, so every caller that never learned about it
+    has to keep reading the same keys in the same shape.
+    """
+    write_profile(roots.proj, "builder", "---\nmodel: anthropic/claude\n---\nbody\n")
+
+    entry = op("profile.list")["result"]["profiles"][0]
+
+    assert set(entry) == {"name", "source", "shadowed", "ambiguous", "resolved"}
+    assert entry["resolved"] == profile_config(load_agent_profile("builder"))
+
+
+def test_names_answers_for_the_profiles_asked_for_and_no_others(roots):
+    write_profile(roots.glob, "archivist", "---\nmodel: a\n---\nbody\n")
+    write_profile(roots.proj, "builder", "---\nmodel: b\n---\nbody\n")
+    write_profile(roots.proj, "critic", "---\nmodel: c\n---\nbody\n")
+
+    result = op("profile.list", {"names": ["builder", "critic"]})["result"]
+
+    assert [p["name"] for p in result["profiles"]] == ["builder", "critic"]
+    assert result["count"] == 2
+    # Narrowed, not reshaped: a named profile carries what it always carried.
+    assert result["profiles"][0]["resolved"]["model"] == "b"
+
+
+def test_a_name_nothing_declares_is_absent_rather_than_an_error(roots):
+    """Which is the answer to 'is there a profile called this'.
+
+    An error would make a caller checking three names unable to ask about all
+    three at once, which is the round trip the parameter exists to save.
+    """
+    write_profile(roots.proj, "builder", "---\nmodel: b\n---\nbody\n")
+
+    result = op("profile.list", {"names": ["builder", "ghost"]})
+    assert result["ok"] is True, result
+    assert [p["name"] for p in result["result"]["profiles"]] == ["builder"]
+
+
+def test_fields_returns_only_what_was_asked_for_plus_the_name(roots):
+    write_profile(roots.proj, "builder", "---\nmodel: anthropic/claude\n---\nbody\n")
+
+    entries = op("profile.list", {"fields": ["resolved.model"]})["result"]["profiles"]
+
+    assert entries == [{"name": "builder", "resolved": {"model": "anthropic/claude"}}]
+
+
+def test_fields_can_ask_for_placement_without_the_configuration(roots):
+    builder = write_profile(roots.proj, "builder", "---\nmodel: m\n---\nbody\n")
+
+    entry = op("profile.list", {"fields": ["source"]})["result"]["profiles"][0]
+
+    assert entry == {
+        "name": "builder",
+        "source": {"path": str(builder), "scope": "project", "match": "exact"},
+    }
+
+
+def test_fields_can_still_ask_for_the_whole_resolved_block(roots):
+    write_profile(roots.proj, "builder", "---\nmodel: m\n---\nbody\n")
+
+    entry = op("profile.list", {"fields": ["resolved"]})["result"]["profiles"][0]
+
+    assert entry["resolved"] == profile_config(load_agent_profile("builder"))
+    assert "source" not in entry
+
+
+def test_an_unknown_field_is_refused_by_name(roots):
+    """Rather than returned empty, which reads as a profile that declares nothing."""
+    write_profile(roots.proj, "builder", "---\nmodel: m\n---\nbody\n")
+
+    result = op("profile.list", {"fields": ["resolved.modle"]})
+
+    assert result["ok"] is False
+    assert result["error"]["kind"] == "invalid_input"
+    assert "resolved.modle" in result["error"]["message"]
+    assert "resolved.model" in result["error"]["message"]
+
+
+def test_names_and_fields_narrow_the_same_reply_together(roots):
+    write_profile(roots.glob, "archivist", "---\nmodel: a\n---\nbody\n")
+    write_profile(roots.proj, "builder", "---\nmodel: b\n---\nbody\n")
+
+    result = op("profile.list", {"names": ["builder"], "fields": ["resolved.model"]})["result"]
+
+    assert result["profiles"] == [{"name": "builder", "resolved": {"model": "b"}}]
+    # The roots are still named: they explain a name that came back missing.
+    assert [r["scope"] for r in result["roots"]] == ["project", "global"]


### PR DESCRIPTION
Two issues on the same roster surface, so one change.

## What was wrong

**`profile.list` had no projection (#2577).** One parameter, one answer: every
profile with its full resolved configuration, source file and shadow list. A
caller asking "is there a profile called `reviewer`, and what model does it run"
paid for the whole roster. Filtering client-side does not help — the cost is the
reply, and it has already been paid by the time a caller can filter it.

**`profile.show` described a fallback guess as a resolved source (#2585).**
`_placement` flattened every separator spelling found in a directory whenever
nothing was spelled as asked, then named the first as `source` and the rest as
`shadowed`.

## Reproduction at the branch point (`8516adcf1`)

Two arms, and they do not both surface the same way.

*Through the verbs.* Project root declares `post-mortem_lead.md`; global root
declares `post_mortem_lead.md` and `post-mortem-lead.md`.
`profile.show(name="post-mortem_lead")` returned the correct project file as
`source` — and both global files as `shadowed`. Neither is shadowed: each
resolves under its own name, and `profile.show` says so when asked directly.
The surface was telling a reader that two selectable profiles cannot be
selected.

*Below the verbs.* One root declaring both `post_mortem_lead.md` and
`post-mortem-lead.md`, asked for as `post-mortem_lead`:

```
load_agent_profile("post-mortem_lead")  -> AmbiguousProfileNameError
_placement("post-mortem_lead")          -> source = .../post_mortem_lead.md
```

The loader refuses to rank the two spellings; the placement walk ranked them.

**That second arm does not reach a caller today, so the report that the verbs
describe an ambiguous file as runnable is not what I observed.**
`profile.show` calls the loader first and fails with the ambiguity error before
`_placement` runs. `profile.list` never asks: its names come from
`list_agents()`, which returns file stems, and a stem always matches itself
exactly. The wrong `source` is real in the function and latent at the surface.
Both are fixed; only the first was observable.

## What changed

`_placement` now mirrors the loader's own three outcomes instead of one:

- a root with a file spelled as asked contributes it with `match: "exact"`
- a root with only the other spelling contributes it with
  `match: "separator_fallback"` — still what a run reads, but reached by a
  substitution the caller did not ask for
- a root declaring more than one spelling with none spelled as asked
  contributes to a new `ambiguous` list, which is unordered and names no
  winner. If nothing resolved earlier, that is where the loader raises, so the
  walk stops there rather than describing files no request reaches.

`profile.list` takes `names` (answer for these profiles only) and `fields`
(return only these keys, including `resolved.<key>` for one field of the
configuration block). Given neither, the reply is exactly what it was.

## Choices worth naming

- **`match` on every placement entry, not one flag beside `source`.** A flag
  would have kept the existing entries untouched, but `source` and `shadowed`
  entries have the same shape, and a shadowed entry reached by fallback is the
  same substitution. Cost: three existing assertions that compared shadow
  entries by whole-dict equality needed the new key.
- **`names` matches roster spelling exactly**, rather than resolving `-`/`_`
  the way the loader does. Tolerant matching would let one requested name match
  two roster entries, which is the ambiguity the other half of this change
  exists to stop reporting. `profile.show` is the verb for the resolution
  question.
- **`name` is always returned under `fields`.** Rows that cannot be told apart
  are not a smaller answer.
- **An unknown field is an error naming the known ones**, not a dropped key: a
  misspelled field returned empty reads as a profile that declares nothing.
- **A requested name nothing declares is absent, not an error**, so a caller can
  ask about three names in one round trip and read back which one is missing.

## Tests, each with its own fix reverted

Twelve new tests in `tests/mcp/test_roster.py`. Suite run:
`pytest tests/mcp tests/cli/test_providers.py --maxfail=200` — 700 passed, rc=0.

Reverting the `_placement` hunk alone: all three placement tests fail, rc=1 —
`test_a_source_reached_by_the_other_separator_says_so`,
`test_two_spellings_in_one_root_are_reported_as_ambiguous_not_as_shadowed`,
`test_placement_names_no_source_where_the_loader_refuses_to_choose`. One
projection test fails with them, because it asserts a projected `source` entry
and that entry now carries `match`; the other six projection tests pass.

Reverting the projection hunk alone (`profile_list`, its schema and its
dispatch): the projection tests fail, rc=1; all three placement tests pass,
rc=0.

Closes #2577
Closes #2585

🤖 Generated with [Claude Code](https://claude.com/claude-code)
