### PR TITLE
fix(cli): li state prune reclaims message rows and previews a measured count

### DIFF
--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -565,12 +565,31 @@ async def _vacuum() -> None:
         await db.vacuum()
 
 
+class _PreviewOnlyError(Exception):
+    """Signals the end of a preview so its transaction unwinds instead of committing.
+
+    A preview has to answer "how many rows would this free", and the only answer
+    that cannot drift from the real one is the real one. The preview therefore
+    runs the prune and then refuses to commit it, carrying the counts out with it.
+    """
+
+    def __init__(self, counts: dict[str, int]) -> None:
+        super().__init__("preview complete")
+        self.counts = counts
+
+
 async def _prune(
     *,
     keep_days: int,
     keep_n: int,
     dry_run: bool,
 ) -> dict[str, int]:
+    """Delete old sessions and the branches, progressions and messages they owned.
+
+    ``dry_run`` runs exactly the same statements and then rolls the transaction
+    back, so the reported counts are measurements of the prune rather than an
+    estimate of it.
+    """
     import time as _time
 
     from lionagi.state.db import StateDB
@@ -579,87 +598,136 @@ async def _prune(
 
     from sqlalchemy import text
 
+    counts = {"sessions": 0, "branches": 0, "messages": 0}
+
     async with StateDB() as db:
-        async with db._read() as conn:
-            rows = (
-                (
-                    await conn.execute(
-                        text(
-                            "SELECT id FROM sessions "
-                            "WHERE id NOT IN ("
-                            "  SELECT id FROM sessions ORDER BY updated_at DESC LIMIT :keep_n"
-                            ") AND (updated_at < :cutoff OR updated_at IS NULL)"
-                        ),
-                        {"keep_n": keep_n, "cutoff": cutoff},
+        try:
+            async with db._tx() as conn:
+                rows = (
+                    (
+                        await conn.execute(
+                            text(
+                                "SELECT id FROM sessions "
+                                "WHERE id NOT IN ("
+                                "  SELECT id FROM sessions ORDER BY updated_at DESC LIMIT :keep_n"
+                                ") AND (updated_at < :cutoff OR updated_at IS NULL)"
+                            ),
+                            {"keep_n": keep_n, "cutoff": cutoff},
+                        )
+                    )
+                    .mappings()
+                    .all()
+                )
+                victim_ids = [r["id"] for r in rows]
+
+                if not victim_ids:
+                    raise _PreviewOnlyError(counts)
+
+                placeholders = ",".join(f":v{i}" for i in range(len(victim_ids)))
+                id_params = {f"v{i}": vid for i, vid in enumerate(victim_ids)}
+
+                branch_count = (
+                    (
+                        await conn.execute(
+                            text(
+                                f"SELECT COUNT(*) AS n FROM branches "  # noqa: S608
+                                f"WHERE session_id IN ({placeholders})"
+                            ),
+                            id_params,
+                        )
+                    )
+                    .mappings()
+                    .first()["n"]
+                )
+
+                # progressions carry no ownership edge back to the session or
+                # branch that made them, so nothing removes them when their
+                # owner goes. They are collected here while the owners are still
+                # readable, and the collection is held in a scratch table rather
+                # than in a parameter list so a large prune does not run into the
+                # bound-parameter ceiling.
+                await conn.execute(text("DROP TABLE IF EXISTS prune_orphan_progressions"))
+                await conn.execute(
+                    text("CREATE TEMPORARY TABLE prune_orphan_progressions (id TEXT PRIMARY KEY)")
+                )
+                await conn.execute(
+                    text(
+                        "INSERT INTO prune_orphan_progressions (id) "  # noqa: S608
+                        f"SELECT progression_id FROM sessions WHERE id IN ({placeholders}) "
+                        "  AND progression_id IS NOT NULL "
+                        "UNION "
+                        f"SELECT progression_id FROM branches WHERE session_id IN ({placeholders})"
+                        "  AND progression_id IS NOT NULL"
+                    ),
+                    id_params,
+                )
+
+                await conn.execute(
+                    text(
+                        f"DELETE FROM sessions WHERE id IN ({placeholders})"  # noqa: S608
+                    ),
+                    id_params,
+                )
+
+                # Branches cascade with their session, so what is still
+                # referenced now is what survives the prune. A progression a
+                # survivor still points at is not an orphan, whoever else
+                # pointed at it.
+                await conn.execute(
+                    text(
+                        "DELETE FROM prune_orphan_progressions WHERE id IN ("
+                        "  SELECT progression_id FROM sessions WHERE progression_id IS NOT NULL"
+                        "  UNION"
+                        "  SELECT progression_id FROM branches WHERE progression_id IS NOT NULL"
+                        ")"
                     )
                 )
-                .mappings()
-                .all()
-            )
-        victim_ids = [r["id"] for r in rows]
 
-        if not victim_ids:
-            return {"sessions": 0, "branches": 0, "messages": 0}
-
-        placeholders = ",".join(f":v{i}" for i in range(len(victim_ids)))
-        id_params = {f"v{i}": vid for i, vid in enumerate(victim_ids)}
-
-        async with db._read() as conn:
-            branch_count = (
-                (
+                # Messages are addressed only through a progression's collection
+                # or through one of the three id columns that name one directly,
+                # so a message no surviving referent mentions is unreachable.
+                # This runs while the orphaned progressions still exist, since
+                # their collections are what says which messages are in play.
+                deleted_messages = (
                     await conn.execute(
                         text(
-                            f"SELECT COUNT(*) AS n FROM branches "  # noqa: S608
-                            f"WHERE session_id IN ({placeholders})"
-                        ),
-                        id_params,
+                            "DELETE FROM messages WHERE id IN ("
+                            "  SELECT value FROM progressions, json_each(progressions.collection)"
+                            "  WHERE progressions.id IN (SELECT id FROM prune_orphan_progressions)"
+                            ") AND id NOT IN ("
+                            "  SELECT value FROM progressions, json_each(progressions.collection)"
+                            "  WHERE progressions.id NOT IN"
+                            "    (SELECT id FROM prune_orphan_progressions)"
+                            ") AND id NOT IN ("
+                            "  SELECT first_msg_id FROM sessions WHERE first_msg_id IS NOT NULL"
+                            "  UNION"
+                            "  SELECT last_msg_id FROM sessions WHERE last_msg_id IS NOT NULL"
+                            "  UNION"
+                            "  SELECT system_msg_id FROM branches WHERE system_msg_id IS NOT NULL"
+                            ")"
+                        )
+                    )
+                ).rowcount
+
+                await conn.execute(
+                    text(
+                        "DELETE FROM progressions "
+                        "WHERE id IN (SELECT id FROM prune_orphan_progressions)"
                     )
                 )
-                .mappings()
-                .first()["n"]
-            )
+                await conn.execute(text("DROP TABLE IF EXISTS prune_orphan_progressions"))
 
-            msgs_before = (
-                (await conn.execute(text("SELECT COUNT(*) AS n FROM messages")))
-                .mappings()
-                .first()["n"]
-            )
+                counts = {
+                    "sessions": len(victim_ids),
+                    "branches": branch_count,
+                    "messages": deleted_messages,
+                }
+                if dry_run:
+                    raise _PreviewOnlyError(counts)
+        except _PreviewOnlyError as preview:
+            return preview.counts
 
-        if dry_run:
-            return {
-                "sessions": len(victim_ids),
-                "branches": branch_count,
-                "messages": 0,  # can't preview without doing the delete
-            }
-
-        async with db._tx() as conn:
-            await conn.execute(
-                text(
-                    f"DELETE FROM sessions WHERE id IN ({placeholders})"  # noqa: S608
-                ),
-                id_params,
-            )
-            await conn.execute(
-                text(
-                    "DELETE FROM messages "
-                    "WHERE id NOT IN ("
-                    "  SELECT value FROM progressions, json_each(progressions.collection)"
-                    ")"
-                )
-            )
-
-        async with db._read() as conn:
-            msgs_after = (
-                (await conn.execute(text("SELECT COUNT(*) AS n FROM messages")))
-                .mappings()
-                .first()["n"]
-            )
-
-        return {
-            "sessions": len(victim_ids),
-            "branches": branch_count,
-            "messages": msgs_before - msgs_after,
-        }
+    return counts
 
 
 async def _doctor(

--- a/tests/cli/test_state_commands.py
+++ b/tests/cli/test_state_commands.py
@@ -295,17 +295,22 @@ async def test_prune_dry_run_does_not_delete(temp_db_path: Path):
 
     result = await _prune(keep_days=30, keep_n=1, dry_run=True)
     assert result["sessions"] >= 1
-    assert result["messages"] == 0  # dry-run never previews messages
 
     async with StateDB() as db:
         assert (await db.get_session(old_sid)) is not None
         assert (await db.get_session(new_sid)) is not None
+        # Nothing the dry run touched was kept: every row is still there.
+        for table in ("sessions", "branches", "messages", "progressions"):
+            row = await db.fetch_one(f"SELECT COUNT(*) AS n FROM {table}")  # noqa: S608
+            assert row["n"] > 0, table
+        row = await db.fetch_one("SELECT COUNT(*) AS n FROM messages")
+        assert row["n"] == 3
 
 
 async def test_prune_deletes_old_sessions_and_cascades_branches(
     temp_db_path: Path,
 ):
-    """Prune deletes old sessions and cascade-drops branches; messages survive if their progression row is not FK-cascaded."""
+    """Prune deletes old sessions, cascade-drops branches, and frees the messages they held."""
     now = time.time()
     old_ts = now - (60 * 86400)
     async with StateDB() as db:
@@ -324,8 +329,7 @@ async def test_prune_deletes_old_sessions_and_cascades_branches(
     assert result["sessions"] == 1
     # branches were cascaded from the deleted session.
     assert result["branches"] == 1
-    # Current behavior: orphan progression keeps msgs alive, sweep no-ops.
-    assert result["messages"] == 0
+    assert result["messages"] == 3
 
     async with StateDB() as db:
         assert (await db.get_session(old_sid)) is None
@@ -375,6 +379,156 @@ async def test_prune_with_nothing_to_delete_returns_zero(temp_db_path: Path):
 
     async with StateDB() as db:
         assert (await db.get_session(sid)) is not None
+
+
+async def test_prune_frees_the_message_rows_the_deleted_session_held(
+    temp_db_path: Path,
+):
+    """Messages a pruned session held are removed along with the progressions that held them.
+
+    Progressions carry no foreign key back to their session, so nothing removes
+    them when their owner goes; the messages they list then stay reachable from
+    a row nothing points at. Both are gone here.
+    """
+    now = time.time()
+    async with StateDB() as db:
+        old_sid, old_msgs = await _seed_session_with_messages(
+            db,
+            n_messages=4,
+            updated_at=now - (60 * 86400),
+        )
+        new_sid, new_msgs = await _seed_session_with_messages(
+            db,
+            n_messages=2,
+            updated_at=now,
+        )
+
+    result = await _prune(keep_days=30, keep_n=1, dry_run=False)
+    assert result["messages"] == 4
+
+    async with StateDB() as db:
+        for mid in old_msgs:
+            row = await db.fetch_one("SELECT COUNT(*) AS n FROM messages WHERE id = ?", (mid,))
+            assert row["n"] == 0, f"message {mid} of the pruned session was left behind"
+        # The surviving session keeps everything it holds.
+        for mid in new_msgs:
+            row = await db.fetch_one("SELECT COUNT(*) AS n FROM messages WHERE id = ?", (mid,))
+            assert row["n"] == 1, f"message {mid} of a surviving session was deleted"
+        # No progression is left pointing at nothing.
+        row = await db.fetch_one(
+            "SELECT COUNT(*) AS n FROM progressions WHERE id NOT IN ("
+            "  SELECT progression_id FROM sessions"
+            "  UNION"
+            "  SELECT progression_id FROM branches"
+            ")"
+        )
+        assert row["n"] == 0
+
+
+async def _seed_prune_fixture_with_shared_and_pinned_messages(db: StateDB) -> tuple[str, str, int]:
+    """Seed one prunable session whose messages are only partly reclaimable.
+
+    Of the victim's four messages, one is also listed in a surviving session's
+    progression and one is named by a surviving session's ``first_msg_id``. Two
+    are therefore freed. Every count that skips one of those two survivor
+    references lands on 3 or 4 instead, so the fixture separates the real answer
+    from the near misses.
+
+    Returns ``(victim_session_id, survivor_session_id, expected_messages_freed)``.
+    """
+    now = time.time()
+    victim_sid, victim_bid = str(uuid.uuid4()), str(uuid.uuid4())
+    victim_spid, victim_bpid = str(uuid.uuid4()), str(uuid.uuid4())
+    keeper_sid, keeper_bid = str(uuid.uuid4()), str(uuid.uuid4())
+    keeper_spid, keeper_bpid = str(uuid.uuid4()), str(uuid.uuid4())
+
+    for pid in (victim_spid, victim_bpid, keeper_spid, keeper_bpid):
+        await db.create_progression(pid)
+    for sid, pid in ((victim_sid, victim_spid), (keeper_sid, keeper_spid)):
+        await db.create_session(
+            {"id": sid, "progression_id": pid, "status": "completed", "started_at": now}
+        )
+    for bid, sid, pid in (
+        (victim_bid, victim_sid, victim_bpid),
+        (keeper_bid, keeper_sid, keeper_bpid),
+    ):
+        await db.create_branch({"id": bid, "session_id": sid, "progression_id": pid})
+
+    victim_msgs = []
+    for i in range(4):
+        mid = str(uuid.uuid4())
+        await db.insert_message(
+            {
+                "id": mid,
+                "created_at": now,
+                "node_metadata": {},
+                "content": {"text": f"victim-{i}"},
+                "role": "user",
+                "sender": "u",
+                "recipient": "x",
+                "channel": "test",
+            }
+        )
+        await db.append_to_progression(victim_bpid, mid)
+        await db.append_to_progression(victim_spid, mid)
+        victim_msgs.append(mid)
+
+    # One of the victim's messages is quoted into a surviving progression, and
+    # another is named directly by a surviving session.
+    await db.append_to_progression(keeper_bpid, victim_msgs[0])
+    await db.execute(
+        "UPDATE sessions SET first_msg_id = ? WHERE id = ?",
+        (victim_msgs[1], keeper_sid),
+    )
+
+    await db.execute(
+        "UPDATE sessions SET updated_at = ? WHERE id = ?",
+        (now - (60 * 86400), victim_sid),
+    )
+    await db.execute("UPDATE sessions SET updated_at = ? WHERE id = ?", (now, keeper_sid))
+    return victim_sid, keeper_sid, 2
+
+
+async def test_dry_run_message_count_is_the_count_the_real_prune_deletes(
+    temp_db_path: Path,
+):
+    """The preview's message count is the real prune's, measured on the same store.
+
+    The preview is the prune, rolled back, so the two cannot be derived
+    separately. This runs both against the same fixture and pins the answer to
+    the number of rows the store actually loses, which is what makes a
+    re-introduced separate estimate visible rather than merely suspicious.
+    """
+    async with StateDB() as db:
+        (
+            victim_sid,
+            keeper_sid,
+            expected,
+        ) = await _seed_prune_fixture_with_shared_and_pinned_messages(db)
+        row = await db.fetch_one("SELECT COUNT(*) AS n FROM messages")
+        before = row["n"]
+
+    preview = await _prune(keep_days=30, keep_n=1, dry_run=True)
+
+    async with StateDB() as db:
+        # The preview committed nothing, so the real prune below sees the same store.
+        row = await db.fetch_one("SELECT COUNT(*) AS n FROM messages")
+        assert row["n"] == before
+        assert (await db.get_session(victim_sid)) is not None
+
+    real = await _prune(keep_days=30, keep_n=1, dry_run=False)
+
+    async with StateDB() as db:
+        row = await db.fetch_one("SELECT COUNT(*) AS n FROM messages")
+        observed = before - row["n"]
+
+    assert preview["messages"] == real["messages"] == observed == expected
+    assert preview["sessions"] == real["sessions"]
+    assert preview["branches"] == real["branches"]
+
+    async with StateDB() as db:
+        assert (await db.get_session(victim_sid)) is None
+        assert (await db.get_session(keeper_sid)) is not None
 
 
 # ── _doctor (li state doctor) ────────────────────────────────────────────────


### PR DESCRIPTION
Closes #2466

## The defects

**`li state prune` did not free message rows.** `progressions` has no foreign key
back to the session or branch that owns it, so deleting a session cascaded its
branches but left the progression rows behind. The message sweep asked whether a
message id appeared in *any* progression collection:

```sql
DELETE FROM messages
WHERE id NOT IN (SELECT value FROM progressions, json_each(progressions.collection))
```

An orphaned progression answers that question on behalf of a session that no
longer exists, so every message it listed stayed — and every prune created more
orphans, making the retained set grow with each run.

**`--dry-run` printed a message count it had not measured.** It returned a
literal `0`, which the CLI rendered as `0 orphan message(s)` — shaped exactly
like a measurement, and the number an operator reads to decide whether to run
the real thing.

## How it was reproduced

At `8516adcf1`, with a temp store: one session updated 60 days ago holding 3
messages across its session and branch progressions, one recent session holding
2, then `_prune(keep_days=30, keep_n=1, ...)`.

```
before: {'sessions': 2, 'branches': 2, 'messages': 5, 'progressions': 4}
DRY-RUN result : {'sessions': 1, 'branches': 1, 'messages': 0}
REAL    result : {'sessions': 1, 'branches': 1, 'messages': 0}
after : {'sessions': 1, 'branches': 1, 'messages': 5, 'progressions': 4}
messages of the DELETED session still present: 3/3
orphaned progression rows left behind        : 2
```

Both defects present: nothing was freed, and the preview's `0` happened to
match the real `0` only because both were wrong. Same script after the change:

```
DRY-RUN result : {'sessions': 1, 'branches': 1, 'messages': 3}
REAL    result : {'sessions': 1, 'branches': 1, 'messages': 3}
after : {'sessions': 1, 'branches': 1, 'messages': 2, 'progressions': 2}
messages of the DELETED session still present: 0/3
orphaned progression rows left behind        : 0
```

## What changed

`_prune` now runs as one transaction that: collects the progressions its victim
sessions and their branches own; deletes the sessions (branches cascade); drops
from that collection any progression a survivor still points at; deletes the
messages those remaining progressions list that no surviving progression,
session `first_msg_id`/`last_msg_id` or branch `system_msg_id` also names; then
deletes the orphaned progressions.

`--dry-run` runs that same transaction and raises out of it so it rolls back,
carrying the counts with it. The preview is the prune, not a model of it.

### Whether messages are meant to outlive their session

Checked before deleting anything: every read path reaches a message either
through a progression's collection (`studio/services/sessions.py`,
`studio/scheduler/coordination.py`, `StateDB.get_branch_messages`) or by an id
taken from `sessions.first_msg_id` / `sessions.last_msg_id` /
`branches.system_msg_id`. A message no surviving referent names is unreachable,
not retained on purpose. All four of those referents are in the delete's guard,
so a message shared with a live session is not touched — which is also what the
second test fixture exercises.

### Choices worth naming

- **Roll the real prune back, rather than compute a preview count separately.**
  A count derived from a second query would have to restate "which references
  survive" in its own terms, which is how the two drift. The cost is that a
  preview takes the write lock and does the delete work before undoing it; on a
  large store that is not free. Correctness of the number an operator acts on
  was judged worth it.
- **Scope the delete to the pruned lineage.** The old sweep was global — it
  would also have removed a message written but not yet appended to any
  progression by a concurrent writer. Scoping to the victims' own progressions
  removes that window and is what makes the message count attributable to the
  prune.
- **Hold the candidate progression ids in a temporary table, not a parameter
  list.** The issue's store would put ~21k ids in an `IN (...)`; a scratch table
  keeps the new statements off the bound-parameter ceiling entirely.

The message sweep still uses `json_each`, so like the code it replaces it is
SQLite-shaped; the Postgres backend would need `json_array_elements_text`. That
is unchanged by this PR, not introduced by it.

## Tests

Both new, in `tests/cli/test_state_commands.py`. Revert-alone means: this change
reverted out of `lionagi/cli/state.py`, tests kept.

| test | revert-alone result |
|---|---|
| `test_prune_frees_the_message_rows_the_deleted_session_held` | FAILS — `assert 0 == 4` |
| `test_dry_run_message_count_is_the_count_the_real_prune_deletes` | FAILS — `assert 0 == 2` |
| `test_prune_deletes_old_sessions_and_cascades_branches` (updated) | FAILS — `assert 0 == 3` |

The second test is built so an independently-derived preview count is visibly
wrong rather than merely suspicious: the victim holds four messages, one of
which is also listed in a surviving session's progression and one of which is
named by a surviving session's `first_msg_id`. Exactly two are freed. A count
that skips either survivor reference lands on 3 or 4, and the test asserts the
preview count, the real count and the store's actual row loss are all the same
number.

Two existing tests asserted the old behaviour (`result["messages"] == 0`) and
were updated to the counts the prune now reports. The dry-run test additionally
asserts the store is untouched afterwards, which is the precondition the
rollback-based preview depends on.

`tests/cli/test_state_commands.py`: 28 tests, rc=0.
