### PR TITLE
fix(protocols): Pile and Progression are iterables, not iterators

### DIFF
--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -204,6 +204,10 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
       removing a not-yet-visited item raises ``KeyError`` at that step
       (fail-loud) instead of silently yielding a stale object. ``keys`` /
       ``values`` / ``items`` return fully materialized snapshots.
+    - A Pile is iterable but is NOT itself an iterator, matching ``list`` and
+      ``dict``. Traversal position lives in the object ``iter(pile)`` returns,
+      so concurrent readers each get their own cursor and a copied Pile never
+      inherits a partially consumed one.
     - The exclusion boundary is CROSS-THREAD, not cross-task. On the event
       loop's own thread, a sync call made by a different task while an async
       operation is mid-await re-enters the RLock (thread-owned) and proceeds.
@@ -426,11 +430,11 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         for key in order:
             yield self.collections[key]
 
-    def __next__(self) -> T:
-        try:
-            return next(iter(self))
-        except StopIteration:
-            raise StopIteration("End of pile") from None
+    # A Pile is iterable but deliberately NOT an iterator: traversal state lives
+    # in the object returned by ``iter(self)``, never on the container. Two
+    # traversals of the same Pile are therefore independent, and a Pile has no
+    # cursor for copying, pickling or concurrent readers to disagree about.
+    # ``next(pile)`` raises TypeError; use ``it = iter(pile)`` and ``next(it)``.
 
     @synchronized
     def __getitem__(self, key: ID.Ref | ID.RefSeq | int | slice) -> Any | list | T:
@@ -677,11 +681,9 @@ class Pile(Element, Collective[T], Generic[T], Adaptable, AsyncAdaptable):
         for key in order:
             yield self.collections[key]
 
-    async def __anext__(self) -> T:
-        try:
-            return await anext(self.AsyncPileIterator(self))
-        except StopAsyncIteration:
-            raise StopAsyncIteration("End of pile") from None
+    # Async mirror of the sync contract: a Pile is async-iterable but not an
+    # async iterator. ``anext(pile)`` raises TypeError; use ``async for`` or
+    # hold ``Pile.AsyncPileIterator(pile)``, which is a real async iterator.
 
     @synchronized
     def filter(self, predicate: Callable[[T], bool]) -> Pile[T]:

--- a/lionagi/protocols/generic/progression.py
+++ b/lionagi/protocols/generic/progression.py
@@ -118,11 +118,9 @@ class Progression(Element, Ordering[T], Generic[T]):
     def __iter__(self):
         return iter(self.order)
 
-    def __next__(self) -> UUID:
-        try:
-            return next(iter(self.order))
-        except StopIteration:
-            raise StopIteration("No more items in the progression") from None
+    # Iterable, but deliberately not an iterator: the cursor belongs to the
+    # object ``iter(self)`` hands back, so two traversals never share position.
+    # ``next(progression)`` raises TypeError; use ``next(iter(progression))``.
 
     def __list__(self) -> list[UUID]:
         return list(self.order)

--- a/tests/protocols/generic/test_container_iterator_protocol.py
+++ b/tests/protocols/generic/test_container_iterator_protocol.py
@@ -1,0 +1,145 @@
+"""Pile and Progression are iterables, not iterators.
+
+Traversal position belongs to the object ``iter(container)`` returns, never to
+the container. These tests pin that split: the container refuses ``next()``,
+and an iterator taken from it advances, exhausts, and stays independent of any
+other iterator over the same container.
+"""
+
+import copy
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
+
+import pytest
+
+from lionagi.protocols.generic.element import Element
+from lionagi.protocols.generic.pile import Pile
+from lionagi.protocols.generic.progression import Progression
+
+
+@pytest.fixture
+def elements():
+    return [Element() for _ in range(4)]
+
+
+@pytest.fixture
+def pile(elements):
+    return Pile(collections=elements)
+
+
+@pytest.fixture
+def progression(elements):
+    return Progression(order=[e.id for e in elements])
+
+
+# --------------------------------------------------------------------------
+# The container is not an iterator
+# --------------------------------------------------------------------------
+
+
+def test_next_on_pile_raises_type_error(pile):
+    with pytest.raises(TypeError):
+        next(pile)
+
+
+def test_next_on_progression_raises_type_error(progression):
+    with pytest.raises(TypeError):
+        next(progression)
+
+
+@pytest.mark.asyncio
+async def test_anext_on_pile_raises_type_error(pile):
+    with pytest.raises(TypeError):
+        await anext(pile)
+
+
+def test_pile_is_iterable_but_not_iterator(pile):
+    assert isinstance(pile, Iterable)
+    assert not isinstance(pile, Iterator)
+    assert isinstance(pile, AsyncIterable)
+    assert not isinstance(pile, AsyncIterator)
+
+
+def test_progression_is_iterable_but_not_iterator(progression):
+    assert isinstance(progression, Iterable)
+    assert not isinstance(progression, Iterator)
+
+
+def test_iter_returns_a_distinct_object(pile, progression):
+    assert iter(pile) is not pile
+    assert iter(progression) is not progression
+
+
+# --------------------------------------------------------------------------
+# An iterator taken from the container behaves like one
+# --------------------------------------------------------------------------
+
+
+def test_repeated_next_on_pile_iterator_advances(pile, elements):
+    it = iter(pile)
+    assert [next(it) for _ in range(4)] == elements
+    with pytest.raises(StopIteration):
+        next(it)
+
+
+def test_repeated_next_on_progression_iterator_advances(progression, elements):
+    it = iter(progression)
+    assert [next(it) for _ in range(4)] == [e.id for e in elements]
+    with pytest.raises(StopIteration):
+        next(it)
+
+
+def test_two_pile_iterators_are_independent(pile, elements):
+    a, b = iter(pile), iter(pile)
+    assert next(a) is elements[0]
+    assert next(a) is elements[1]
+    # b has its own cursor and still starts at the beginning.
+    assert next(b) is elements[0]
+
+
+def test_two_progression_iterators_are_independent(progression, elements):
+    a, b = iter(progression), iter(progression)
+    next(a)
+    assert next(a) == elements[1].id
+    assert next(b) == elements[0].id
+
+
+def test_copy_does_not_inherit_a_traversal_position(pile, elements):
+    it = iter(pile)
+    next(it)
+    next(it)
+    # The container carries no cursor, so a copy has nothing to resume from.
+    assert list(copy.copy(pile)) == elements
+    assert list(copy.deepcopy(pile)) == [pile.collections[e.id] for e in elements]
+
+
+# --------------------------------------------------------------------------
+# Ordinary traversal is unchanged
+# --------------------------------------------------------------------------
+
+
+def test_for_loop_over_pile(pile, elements):
+    assert [item for item in pile] == elements
+
+
+def test_for_loop_restarts_each_time(pile, elements):
+    assert [item for item in pile] == elements
+    assert [item for item in pile] == elements
+
+
+def test_for_loop_over_progression(progression, elements):
+    assert [key for key in progression] == [e.id for e in elements]
+
+
+@pytest.mark.asyncio
+async def test_async_for_over_pile(pile, elements):
+    collected = [item async for item in pile]
+    assert collected == elements
+
+
+@pytest.mark.asyncio
+async def test_async_pile_iterator_is_a_real_async_iterator(pile, elements):
+    it = Pile.AsyncPileIterator(pile)
+    assert it.__aiter__() is it
+    assert [await anext(it) for _ in range(4)] == elements
+    with pytest.raises(StopAsyncIteration):
+        await anext(it)

--- a/tests/protocols/generic/test_pile_coverage.py
+++ b/tests/protocols/generic/test_pile_coverage.py
@@ -352,17 +352,21 @@ class TestPileAsyncIteration:
         assert len(collected) == 4
 
     @pytest.mark.asyncio
-    async def test_anext_called_directly(self):
+    async def test_pile_is_not_an_async_iterator(self):
         a, b = Element(), Element()
         p = Pile(collections=[a, b])
-        item = await p.__anext__()
-        assert item is a
+        with pytest.raises(TypeError):
+            await anext(p)
 
     @pytest.mark.asyncio
-    async def test_anext_stop_async_iteration(self):
-        p = Pile(collections=[])
+    async def test_async_iterator_yields_then_stops(self):
+        a, b = Element(), Element()
+        p = Pile(collections=[a, b])
+        it = Pile.AsyncPileIterator(p)
+        assert await anext(it) is a
+        assert await anext(it) is b
         with pytest.raises(StopAsyncIteration):
-            await p.__anext__()
+            await anext(it)
 
     @pytest.mark.asyncio
     async def test_async_context_manager(self):

--- a/tests/protocols/generic/test_pile_filter.py
+++ b/tests/protocols/generic/test_pile_filter.py
@@ -172,13 +172,19 @@ class TestMisc:
             assert isinstance(uuid, UUID)
             assert isinstance(item, Item)
 
-    def test_next_raises_on_empty(self):
+    def test_pile_is_not_an_iterator(self, pile_3):
+        # A Pile is iterable, not an iterator: next() on the container itself
+        # is a TypeError rather than a traversal that silently never advances.
+        with pytest.raises(TypeError):
+            next(pile_3)
+
+    def test_iter_raises_on_empty(self):
         p = Pile()
         with pytest.raises(StopIteration):
-            next(p)
+            next(iter(p))
 
-    def test_next_returns_first(self, pile_3, three_items):
-        first = next(pile_3)
+    def test_iter_returns_first(self, pile_3, three_items):
+        first = next(iter(pile_3))
         assert first == three_items[0]
 
     def test_append_alias_for_update(self, pile_3):

--- a/tests/protocols/generic/test_progression.py
+++ b/tests/protocols/generic/test_progression.py
@@ -115,14 +115,21 @@ def test_iter(sample_progression, sample_elements):
         assert prog_item == element.id
 
 
-def test_next(sample_progression, sample_elements):
-    assert next(sample_progression) == sample_elements[0].id
+def test_progression_is_not_an_iterator(sample_progression):
+    # Iterable, not an iterator: next() on the container itself is a TypeError
+    # rather than a call that keeps returning the first id forever.
+    with pytest.raises(TypeError):
+        next(sample_progression)
+
+
+def test_next_over_iter(sample_progression, sample_elements):
+    assert next(iter(sample_progression)) == sample_elements[0].id
 
 
 def test_next_empty():
     empty_prog = Progression()
     with pytest.raises(StopIteration):
-        next(empty_prog)
+        next(iter(empty_prog))
 
 
 def test_direct_order_mutation_keeps_contains_accurate():


### PR DESCRIPTION
Closes #2478

## The defect

`Pile` and `Progression` defined `__next__` while `__iter__` returned a fresh
iterator on every call. Each `__next__` built a new iterator internally and
pulled one item from it, so repeated `next()` returned the first element
forever instead of advancing.

## Reproduction at the head this branch forks from

```python
from lionagi.protocols.generic.pile import Pile
from lionagi.protocols.graph.node import Node

p = Pile(collections=[Node(content=f"n{i}") for i in range(4)])
[next(p).content for _ in range(3)]
```

Observed:

```
pile next x3: ['n0', 'n0', 'n0']
prog next x3 all equal first: [True, True, True]
pile anext x3: ['n0', 'n0', 'n0']
isinstance(p, Iterator): True
isinstance(prog, Iterator): True
```

Two things the issue did not mention, both observed while reproducing:

- **`Pile.__anext__` has the same defect.** It built a fresh `AsyncPileIterator`
  per call, so `await pile.__anext__()` also returned the first item forever.
  This PR fixes it too.
- **`isinstance(p, Iterator)` was `True`.** `collections.abc.Iterator` is a
  structural check — `__iter__` plus `__next__` is all it tests. So the false
  iterator claim propagated into any code that dispatches on that check, which
  would treat a `Pile` as a single-consumption stream safe to drain. That is a
  consequence beyond the "never advances" symptom.

## The choice

The issue lays out two coherent directions. This PR takes **removal**: drop
`Pile.__next__`, `Pile.__anext__`, and `Progression.__next__`, leaving
`__iter__` / `__aiter__` and `Pile.AsyncPileIterator` untouched.

**What callers actually do.** Grepping every `next(` and `anext(` call in
`lionagi/` and `tests/`:

- **Production code: zero callers.** Every hit in `lionagi/` is
  `next(<generator expression>, default)` — in `cli/mirror.py`,
  `cli/orchestrate/flow.py`, `cli/casts.py`, `cli/machine.py`, `cli/plugin.py`,
  `state/lifecycle/service.py`, `service/connections/mcp_wrapper.py`,
  `libs/schema/extract_docstring.py`, `ln/_utils.py`, `testing/_legacy.py`.
  Not one is a `Pile` or a `Progression`.
- **Tests: five call sites**, all in `tests/protocols/generic/`, and all of them
  assert the broken behavior. `test_next_returns_first` pinned "next returns the
  first item" — the bug itself, held in place by a green test.
- **Docs: none.**

So the standard objection to removal — that it breaks callers who use `next()`
on a container — resolves to five tests that encode the defect. Note this is
still an API removal for downstream users of the published package, which I
cannot survey and am not claiming is empty; it belongs in release notes.

**Why not keep `__next__` with a real cursor.** The issue already shows this
direction has no clean answer: a shallow copy shares the cursor and resumes the
original's traversal, two threads split one traversal between them, and
resetting in `__getstate__`/`__deepcopy__` produces a third behavior rather than
a resolution. `Pile` in particular documents a two-lock thread-safe and
task-safe contract; bolting unsynchronized mutable traversal state onto it
contradicts that contract directly. It also would not fix the `isinstance`
problem.

**Why not deprecate instead of remove.** A deprecation warning keeps the
silently-wrong result and keeps `isinstance(p, Iterator)` answering `True`. It
is the worst of both: the broken call still repeats, just noisily.

**Why removal is the smaller change.** `list`, `dict` and `set` are iterable
without being iterators for exactly this reason — traversal position belongs to
the iterator, not the collection. After removal `next(pile)` raises Python's own
`TypeError: 'Pile' object is not an iterator`, so the broken call fails loudly
with no custom code. `for x in pile`, `async for x in pile`, `it = iter(pile)`,
and `Pile.AsyncPileIterator` all keep working unchanged.

## Tests

New `tests/protocols/generic/test_container_iterator_protocol.py` (16 tests),
plus five existing tests moved onto the `iter()` path.

**Revert-alone** — source files restored to their pre-change state with the new
tests in place:

- New contract file: `rc=1`, **5 failed / 11 passed**. The five discriminating
  tests are `test_next_on_pile_raises_type_error`,
  `test_next_on_progression_raises_type_error`,
  `test_anext_on_pile_raises_type_error`,
  `test_pile_is_iterable_but_not_iterator`,
  `test_progression_is_iterable_but_not_iterator`.
- Rewritten existing tests: `rc=1`, **3 failed / 130 passed** —
  `test_pile_is_not_an_iterator`, `test_pile_is_not_an_async_iterator`,
  `test_progression_is_not_an_iterator`.

The remaining 11 new tests pass both before and after, deliberately:

- `test_repeated_next_on_*_iterator_advances` — non-regression on the supported
  traversal, which is now the only one.
- `test_two_*_iterators_are_independent` and
  `test_copy_does_not_inherit_a_traversal_position` — these pin precisely the
  properties a container-held cursor would destroy. If a cursor is ever
  reintroduced, these fail. That is their job.
- The `for` / `async for` / `AsyncPileIterator` tests characterize behavior that
  had to survive the removal.

**Results after the change** (local, `pytest --maxfail=200`):

- `tests/protocols/` — `rc=0`, **2032 passed**.
- Full `tests/` — `rc=1`, **11 failed, 15931 passed, 19 skipped**. None of the
  11 involve `Pile` or `Progression` iteration. Re-running that set in
  isolation: 6 pass (wall-clock timing assertions that flake under a loaded
  parallel run, including the `performance`-marked
  `test_pile_scaling_performance`, whose own comment notes its thresholds are
  unreliable under load) and 5 still fail on missing optional extras —
  `No module named 'docling'`, `No module named 'pydapter'`, and
  `ollama is not installed`. I did not run the baseline commit for comparison;
  the attribution rests on those failure modes being unreachable from a change
  that only removes two dunder methods from two container classes.
