### PR TITLE
fix(cli): a play awaiting a gate decision is not running

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -648,7 +648,10 @@ async def _detail_show(db: Any, show: dict[str, Any]) -> str:
     if plays:
         lines.append("")
         lines.append(_dim("  -- plays --"))
-        terminal = {"merged", "escalated", "gate_failed", "aborted_after_finish"}
+        # Every terminal play status the lifecycle declares. A play here has
+        # finished and cannot move again without an override, so it reads
+        # [done] even when it finished badly.
+        terminal = {"merged", "escalated", "gate_failed", "blocked", "aborted_after_finish"}
         # Executing right now, which is narrower than "not finished". `gated`
         # and `pending` fall through to [wait] because waiting is what they are
         # doing. This set is also narrower than the default listing's in-flight

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -214,7 +214,14 @@ async def _query_running_plays(
         query += " AND updated_at >= ?"
         params.append(since)
     else:
-        running_statuses = ("running", "running_complete", "gated", "redoing", "prepared")
+        # `gated` is deliberately absent: a play parked on a gate decision is
+        # not in flight. It has stopped, and nothing it does can move it — only
+        # a decision can. Counting it here left every undecided play on the
+        # live view indefinitely, which is the one thing the default view is
+        # supposed to rule out. Such a play is still reachable through
+        # `--since`, through `li monitor <id>`, and through the show detail
+        # view, which marks it as waiting.
+        running_statuses = ("running", "running_complete", "redoing", "prepared")
         placeholders = ",".join("?" * len(running_statuses))
         query += f" AND status IN ({placeholders})"
         params.extend(running_statuses)
@@ -642,12 +649,17 @@ async def _detail_show(db: Any, show: dict[str, Any]) -> str:
         lines.append("")
         lines.append(_dim("  -- plays --"))
         terminal = {"merged", "escalated", "gate_failed", "aborted_after_finish"}
-        active = {"running", "running_complete", "gated", "redoing"}
+        # Executing right now, which is narrower than "not finished". `gated`
+        # and `pending` fall through to [wait] because waiting is what they are
+        # doing. This set is also narrower than the default listing's in-flight
+        # filter, which counts `prepared`: there the question is whether a run
+        # is under way at all, here it is whether this play is the one moving.
+        live = {"running", "running_complete", "redoing"}
         for play in plays:
             pstatus = play.get("status") or "?"
             if pstatus in terminal:
                 marker = _dim("  [done]  ")
-            elif pstatus in active:
+            elif pstatus in live:
                 marker = _green("  [live]  ")
             else:
                 marker = _yellow("  [wait]  ")

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -1950,3 +1950,72 @@ def test_watch_loop_leaves_unrestorable_handlers_alone(monkeypatch: pytest.Monke
     monitor_mod._watch_loop(1, None, since_window=None, entity_type=None, project=None)
 
     assert installed == []
+
+
+# ── Regression: a play awaiting a gate decision is not running ────────────────
+
+
+@pytest.mark.asyncio
+async def test_gated_play_absent_from_default_listing(temp_db_path: Path) -> None:
+    """A play parked on a gate decision has stopped and cannot advance on its
+    own, so the default (no --since) view must not list it as in-flight work.
+    A running play in the same store is the control: the filter still selects
+    real work, it just no longer selects a play waiting to be decided."""
+    async with StateDB() as db:
+        show_id = await _make_show(db)
+        gated_id = await _make_play(db, show_id, status="gated", name="awaiting-gate")
+        running_id = await _make_play(db, show_id, status="running", name="in-flight")
+
+        rows = await _gather_table_rows(db, since=None, entity_type=None, project=None)
+
+    ids = [r["id"] for r in rows]
+    assert running_id[:16] in ids, "a running play must still be listed"
+    assert gated_id[:16] not in ids
+
+
+@pytest.mark.asyncio
+async def test_gated_play_absent_from_play_type_listing(temp_db_path: Path) -> None:
+    """Same exclusion through `--type play`, which reaches the plays query by
+    its own branch in _gather_entities."""
+    async with StateDB() as db:
+        show_id = await _make_show(db)
+        gated_id = await _make_play(db, show_id, status="gated", name="awaiting-gate")
+
+        rows = await _gather_table_rows(db, since=None, entity_type="play", project=None)
+
+    assert gated_id[:16] not in [r["id"] for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_gated_play_still_visible_with_since(temp_db_path: Path) -> None:
+    """--since drops the status filter entirely, which is what keeps an
+    undecided play reachable after it stops counting as running. Guards that
+    escape hatch: if the window query ever grew a status filter of its own, a
+    gated play would become invisible rather than merely not-running."""
+    async with StateDB() as db:
+        show_id = await _make_show(db)
+        gated_id = await _make_play(db, show_id, status="gated", name="awaiting-gate")
+
+        rows = await _gather_table_rows(
+            db, since=time.time() - 3600, entity_type=None, project=None
+        )
+
+    assert gated_id[:16] in [r["id"] for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_show_detail_marks_gated_play_as_waiting(temp_db_path: Path) -> None:
+    """The show detail view splits plays into done/live/wait. A play waiting on
+    a gate decision belongs in wait, not live."""
+    async with StateDB() as db:
+        show_id = await _make_show(db)
+        await _make_play(db, show_id, status="gated", name="awaiting-gate")
+        await _make_play(db, show_id, status="running", name="in-flight")
+
+    output = await _run_detail(show_id)
+
+    gated_line = next(line for line in output.splitlines() if "awaiting-gate" in line)
+    running_line = next(line for line in output.splitlines() if "in-flight" in line)
+    assert "[wait]" in gated_line
+    assert "[live]" not in gated_line
+    assert "[live]" in running_line, "a running play must still be marked live"

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -2019,3 +2019,24 @@ async def test_show_detail_marks_gated_play_as_waiting(temp_db_path: Path) -> No
     assert "[wait]" in gated_line
     assert "[live]" not in gated_line
     assert "[live]" in running_line, "a running play must still be marked live"
+
+
+@pytest.mark.asyncio
+async def test_show_detail_marks_blocked_play_as_done(temp_db_path: Path) -> None:
+    """`blocked` is a terminal play status: the play has finished and cannot
+    move again on its own. The detail view must render it [done], not [wait] —
+    waiting is the one thing a blocked play is not doing. A gated play in the
+    same store is the control for the distinction the marker draws: it is also
+    not executing, but it is genuinely unfinished, so it stays [wait]."""
+    async with StateDB() as db:
+        show_id = await _make_show(db)
+        await _make_play(db, show_id, status="blocked", name="blocked-play")
+        await _make_play(db, show_id, status="gated", name="awaiting-gate")
+
+    output = await _run_detail(show_id)
+
+    blocked_line = next(line for line in output.splitlines() if "blocked-play" in line)
+    gated_line = next(line for line in output.splitlines() if "awaiting-gate" in line)
+    assert "[done]" in blocked_line
+    assert "[wait]" not in blocked_line
+    assert "[wait]" in gated_line, "an undecided play is unfinished, not done"


### PR DESCRIPTION
`li monitor` counted plays with status `gated` as in-flight work. A gated play has stopped and cannot advance on its own — only a gate decision can move it — so every undecided play stayed on the live view indefinitely, which is the one thing the default view exists to rule out.

Reviewing that fix surfaced a second, opposite error in the same view: a `blocked` play, which has finished, was not being marked done.

## What changed

Two status sets in `lionagi/cli/monitor.py` lose `gated`:

- **the default listing's in-flight filter** — an undecided play is no longer reported as running. It stays reachable through `--since` (which drops the status filter entirely), through `li monitor <id>`, and through the show detail view.
- **the show detail view's live-marker set** — such a play now renders `[wait]` rather than `[live]`, which is what it is doing.

The two sets stay distinct rather than being merged into one constant, because they answer different questions. The listing filter asks *is work under way here*, which is why it still counts `prepared`. The detail marker asks the narrower *is this the play that is moving*, and everything else non-terminal already has a correct home in `[wait]`. Merging them would force one question to be answered by the other's set.

The detail view's local set is renamed `active` → `live` so it does not read as the broader, genuinely non-terminal `PLAY_ACTIVE_STATUSES` — to which `gated` does belong.

Separately, the show detail view's **terminal** set gains `blocked`. A blocked play has finished and cannot move again without an override, so it now reads `[done]` rather than falling through to `[wait]`. The set now matches every terminal play status the lifecycle declares, including the ones that finished badly.

## What deliberately did not change

Every other consumer of a play status set asks about **terminality**, not liveness, and a gated play is genuinely not finished — it can still become `merged`:

- `PLAY_ACTIVE_STATUSES` (`lionagi/state/db.py`), and `li kill` through it — dropping `gated` would let a show whose only outstanding child awaits a decision be treated as fully terminal and reaped.
- `li status` classification and `li wait` — dropping it would report an exit class for an undecided play and make `li wait` return early.
- `_REAPABLE_PLAY_STATUSES` in the studio lifecycle sweep already excluded `gated`, with a comment noting that a paused gate is legitimately long-lived.

No data is touched; this is a reporting fix only.

## Tests

Five regression tests in `tests/cli/test_monitor.py`. A `gated` row is covered specifically: absent from the default listing and from `--type play` (with a running play present in the same store as a control), still visible under `--since`, and marked `[wait]` in the show detail view while a running play is marked `[live]`. A fifth test pins the other direction, asserting a `blocked` play renders `[done]` while a `gated` one in the same view renders `[wait]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
