### PR TITLE
perf(ci): run coverage on pushes only, so it is off the pull-request path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,8 +190,14 @@ jobs:
 
     # Coverage runs on 3.10, and only on pushes — never on a pull request.
     #
-    # Instrumentation costs about 4 minutes on this suite: measured on one run,
-    # the 3.10 test step took 619s with coverage while 3.11 took 366s without it.
+    # Instrumentation is the slowest thing on the pull-request path. Measured on
+    # the same interpreter, so the comparison is not confounded by Python
+    # version: the 3.10 test step took 488-645s across six instrumented runs,
+    # and 412s uninstrumented. The uninstrumented 3.10 figure lands inside the
+    # 391-517s range the four uninstrumented interpreters occupy among
+    # themselves, which is where it should land if instrumentation is what
+    # separated it from them.
+    #
     # Since ci-gate hard-gates on `test`, that time sat directly on the path a
     # pull request has to clear before it can merge, and the 3.10 leg is kept in
     # the reduced pull-request matrix, so every pull request paid it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,21 +190,16 @@ jobs:
 
     # Coverage runs on 3.10, and only on pushes — never on a pull request.
     #
-    # Instrumentation is the slowest thing on the pull-request path. Measured on
-    # the same interpreter, so the comparison is not confounded by Python
-    # version: the 3.10 test step took 488-645s across six instrumented runs,
-    # and 412s uninstrumented. The uninstrumented 3.10 figure lands inside the
-    # 391-517s range the four uninstrumented interpreters occupy among
-    # themselves, which is where it should land if instrumentation is what
-    # separated it from them.
-    #
-    # Since ci-gate hard-gates on `test`, that time sat directly on the path a
-    # pull request has to clear before it can merge, and the 3.10 leg is kept in
-    # the reduced pull-request matrix, so every pull request paid it.
+    # Running the suite under coverage instrumentation is materially slower than
+    # running it plain. The 3.10 leg is kept in the reduced pull-request matrix
+    # and ci-gate hard-gates on `test`, so before this split that extra time sat
+    # directly on the path every pull request had to clear before it could merge.
     #
     # Coverage is a report rather than a gate, so pushes to a long-lived branch
     # are a sufficient place to produce it. Pull requests run the same tests on
-    # the same interpreters, uninstrumented.
+    # the same interpreters, uninstrumented — no test is skipped on a pull
+    # request, the 3.10 leg is switched from the instrumented command to the
+    # plain one.
     - name: Run tests with coverage
       if: matrix.python-version == '3.10' && github.event_name != 'pull_request'
       run: scripts/ci.sh test-python-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PRs: oldest + newest only (60% faster). Full matrix on main/develop pushes.
+        # PRs: oldest + newest only. Full matrix on main/develop pushes. This
+        # saves runner minutes rather than wall-clock time, because the legs run
+        # in parallel and the ones dropped were not the slowest.
         python-version: ${{ fromJSON((github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.python-matrix == 'endpoints')) && '["3.10","3.14"]' || '["3.10","3.11","3.12","3.13","3.14"]') }}
     # Force every `uv` call (venv, sync, run) onto the matrix interpreter; the
     # repo's .python-version (3.10) otherwise pins all legs to 3.10.
@@ -186,18 +188,26 @@ jobs:
         uv venv
         uv sync --all-extras
 
-    # Coverage runs on 3.10 only (present in both the PR and the full matrix);
-    # other versions run without coverage instrumentation — 5-10x faster.
-    # Codecov is uploaded only from the coverage run.
+    # Coverage runs on 3.10, and only on pushes — never on a pull request.
+    #
+    # Instrumentation costs about 4 minutes on this suite: measured on one run,
+    # the 3.10 test step took 619s with coverage while 3.11 took 366s without it.
+    # Since ci-gate hard-gates on `test`, that time sat directly on the path a
+    # pull request has to clear before it can merge, and the 3.10 leg is kept in
+    # the reduced pull-request matrix, so every pull request paid it.
+    #
+    # Coverage is a report rather than a gate, so pushes to a long-lived branch
+    # are a sufficient place to produce it. Pull requests run the same tests on
+    # the same interpreters, uninstrumented.
     - name: Run tests with coverage
-      if: matrix.python-version == '3.10'
+      if: matrix.python-version == '3.10' && github.event_name != 'pull_request'
       run: scripts/ci.sh test-python-cov
       env:
         MAXFAIL: 25
         PYTEST_RSS_LOG: ${{ github.workspace }}/.pytest-rss
 
     - name: Run tests
-      if: matrix.python-version != '3.10'
+      if: matrix.python-version != '3.10' || github.event_name == 'pull_request'
       run: scripts/ci.sh test-python
       env:
         MAXFAIL: 0
@@ -236,7 +246,7 @@ jobs:
         fi
 
     - name: Upload coverage reports to Codecov
-      if: matrix.python-version == '3.10'
+      if: matrix.python-version == '3.10' && github.event_name != 'pull_request'
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## What this changes

Coverage instrumentation now runs on pushes only. Pull requests run the same tests on the same interpreters, uninstrumented.

## Why

The 3.10 test step is the slowest thing on the pull-request path, and `ci-gate` hard-gates on `test`, so that time sits directly on the path a pull request must clear before it can merge. The reduced pull-request matrix keeps 3.10 and 3.14, and 3.10 is the instrumented leg, so every pull request paid it.

Measured on the **same interpreter**, so the comparison is not confounded by Python version:

| 3.10 test step | observations |
|---|---|
| with coverage | 488, 607, 619, 628, 632, 645 s |
| without coverage | 412 s |

The uninstrumented 3.10 figure lands inside the 391-517 s range the four uninstrumented interpreters occupy among themselves, which is where it should land if instrumentation is what separated it from them.

The uninstrumented observation is a single run, against six instrumented ones. It comes from this branch's own CI, which is the first time 3.10 has run without instrumentation.

## Effect

This branch's own CI run completed in **8 minutes**. Recent runs on the default branch took about 11.

## Conditions

Every matrix leg still runs exactly one of the two test steps:

| event | interpreter | coverage | plain |
|---|---|---|---|
| push | 3.10 | yes | no |
| push | 3.11-3.14 | no | yes |
| pull_request | 3.10 | no | yes |
| pull_request | 3.14 | no | yes |

Confirmed on this branch's own run: the 3.10 job shows `Run tests with coverage` skipped and `Run tests` succeeded.

## Trade-off

Codecov no longer receives a pull-request upload, so patch-coverage feedback on a pull request goes away. Coverage on the default branch is unaffected. Branch protection requires only `ci-gate`, which does not consume a Codecov status.

## Verification note

This branch's CI exercises the pull-request path only. The push path is not exercised until merge, so the `test (3.10)` step list on the first push run should be checked to confirm coverage still runs there.