### PR TITLE
feat(cli): a flow that names neither an agent nor a model orchestrates by default

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -52,6 +52,7 @@ __all__ = (
     "resolve_model_spec",
     "resolve_persisted_effort",
     "AgentProfile",
+    "AgentProfileNotFoundError",
     "AmbiguousProfileNameError",
     "build_agent_profile_catalog",
     "build_deadline_preamble",
@@ -383,6 +384,16 @@ class AmbiguousProfileNameError(ValueError):
     """One agents dir declares a name under both '-' and '_' spellings."""
 
 
+class AgentProfileNotFoundError(FileNotFoundError):
+    """No profile of that name exists on the search path.
+
+    A subclass rather than a bare FileNotFoundError so a caller can tell "there
+    is no such profile" from "a profile was found and then could not be read".
+    The two are the same exception type otherwise, and a caller acting on the
+    first would silently swallow the second.
+    """
+
+
 def _name_spellings(name: str) -> tuple[str, ...]:
     """NAME plus its separator spellings, requested spelling first.
 
@@ -592,7 +603,7 @@ def load_agent_profile(name: str) -> AgentProfile:
         return _parse_profile(name, plugin_path.read_text())
 
     if not dirs and not plugin_token:
-        raise FileNotFoundError(
+        raise AgentProfileNotFoundError(
             "No .lionagi/ directory found. Create .lionagi/agents/ in your repo "
             "or ~/.lionagi/agents/ globally."
         )
@@ -603,7 +614,7 @@ def load_agent_profile(name: str) -> AgentProfile:
         msg += f"\n{path} exists but its symlink target is unreadable: {target}"
     if available:
         msg += f"\nAvailable: {', '.join(available)}"
-    raise FileNotFoundError(msg)
+    raise AgentProfileNotFoundError(msg)
 
 
 def _parse_profile_timeout(name: str, raw: Any) -> int | None:

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -35,6 +35,7 @@ from .._logging import hint, warn
 from .._providers import (
     _CLAUDE_PROVIDER_NAMES,
     AgentProfile,
+    AgentProfileNotFoundError,
     build_imodel_from_spec,
     list_agents,
     load_agent_profile,
@@ -617,12 +618,17 @@ async def setup_orchestration(
     if agent_name:
         try:
             orc_profile = load_agent_profile(agent_name)
-        except FileNotFoundError as exc:
+        except AgentProfileNotFoundError as exc:
             if not defaulted_agent:
                 raise
             # The caller never mentioned this profile, so an error naming it as
             # if they had asked for it explains nothing. Say what was assumed
             # and what would satisfy it instead.
+            #
+            # Only the not-found case is translated. The loader reads the file
+            # once it has found one, and a file that disappears between those
+            # two steps raises the same builtin type — reported as a missing
+            # default profile it would send the reader somewhere else entirely.
             raise ConfigurationError(
                 "Naming neither an agent nor a model orchestrates under the "
                 f"{DEFAULT_ORCHESTRATOR_AGENT!r} agent profile, and no such profile "

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -609,12 +609,26 @@ async def setup_orchestration(
     # Only the fully unspecified case defaults. A caller who named either one
     # gets it honoured, and still gets the refusal below if it cannot resolve
     # to a model, because there the caller did choose and we could not comply.
-    if not agent_name and not model_spec:
+    defaulted_agent = not agent_name and not model_spec
+    if defaulted_agent:
         agent_name = DEFAULT_ORCHESTRATOR_AGENT
 
     orc_profile: AgentProfile | None = None
     if agent_name:
-        orc_profile = load_agent_profile(agent_name)
+        try:
+            orc_profile = load_agent_profile(agent_name)
+        except FileNotFoundError as exc:
+            if not defaulted_agent:
+                raise
+            # The caller never mentioned this profile, so an error naming it as
+            # if they had asked for it explains nothing. Say what was assumed
+            # and what would satisfy it instead.
+            raise ConfigurationError(
+                "Naming neither an agent nor a model orchestrates under the "
+                f"{DEFAULT_ORCHESTRATOR_AGENT!r} agent profile, and no such profile "
+                "was found. Create one in .lionagi/agents/ or ~/.lionagi/agents/, "
+                "or name an agent or a model on this call."
+            ) from exc
         if orc_profile.model and not model_spec:
             model_spec = orc_profile.model
         if orc_profile.effort and not effort:

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -79,7 +79,11 @@ __all__ = (
     "role_config",
     "resolve_modes",
     "parse_orchestrator_provider",
+    "DEFAULT_ORCHESTRATOR_AGENT",
 )
+
+#: Profile used when a submit names neither an agent nor a model.
+DEFAULT_ORCHESTRATOR_AGENT = "orchestrator"
 
 
 def parse_orchestrator_provider(model_spec: str) -> tuple[str | None, str | None]:
@@ -599,6 +603,15 @@ async def setup_orchestration(
 
     cache_cancelled_exc_class()
 
+    # Naming no agent and no model is a request to orchestrate, not an
+    # incomplete command: orchestration is what this entry point does, so the
+    # orchestrator profile is the answer rather than a question to ask back.
+    # Only the fully unspecified case defaults. A caller who named either one
+    # gets it honoured, and still gets the refusal below if it cannot resolve
+    # to a model, because there the caller did choose and we could not comply.
+    if not agent_name and not model_spec:
+        agent_name = DEFAULT_ORCHESTRATOR_AGENT
+
     orc_profile: AgentProfile | None = None
     if agent_name:
         orc_profile = load_agent_profile(agent_name)
@@ -612,8 +625,12 @@ async def setup_orchestration(
             fast = True
 
     if not model_spec:
+        # Only reachable when the caller named an agent, since naming nothing
+        # defaults above and naming a model satisfies this outright. So the
+        # caller did choose, and the profile they chose carries no model.
         raise ConfigurationError(
-            "Provide a model spec or use -a/--agent to load a profile with a model."
+            f"Agent profile {agent_name!r} declares no model, and no model spec was given. "
+            "Add a model: line to the profile, or pass a model spec."
         )
 
     from lionagi.casts.catalog import _load_packaged_pack

--- a/tests/cli/orchestrate/test_orchestration_cwd_failfast.py
+++ b/tests/cli/orchestrate/test_orchestration_cwd_failfast.py
@@ -82,6 +82,9 @@ async def test_setup_orchestration_none_cwd_is_unaffected(monkeypatch):
     profile rather than refusing, so that error is no longer reachable here and
     cannot serve as the marker. Stop the call at the first thing built instead,
     which proves the same point: cwd validation let a cwd=None call through.
+
+    The call names a model so that nothing here depends on which agent profiles
+    happen to exist on the machine running the test.
     """
     import lionagi.cli.orchestrate._orchestration as orch_mod
 
@@ -96,7 +99,7 @@ async def test_setup_orchestration_none_cwd_is_unaffected(monkeypatch):
     with pytest.raises(_ReachedBuild):
         await setup_orchestration(
             pattern_name="Flow",
-            model_spec="",
+            model_spec="claude",
             agent_name=None,
             save_dir=None,
             cwd=None,

--- a/tests/cli/orchestrate/test_orchestration_cwd_failfast.py
+++ b/tests/cli/orchestrate/test_orchestration_cwd_failfast.py
@@ -74,9 +74,26 @@ async def test_setup_orchestration_rejects_cwd_that_is_a_file(monkeypatch, tmp_p
 
 @pytest.mark.asyncio
 async def test_setup_orchestration_none_cwd_is_unaffected(monkeypatch):
-    """cwd=None (no --cwd given) must not be rejected by the new check —
-    it must reach the existing 'model spec required' validation instead."""
-    with pytest.raises(ConfigurationError) as exc_info:
+    """cwd=None (no --cwd given) must not be rejected by the cwd check — it
+    must carry on into the rest of setup.
+
+    This used to be shown by falling through to a 'model spec required' error.
+    A call naming neither an agent nor a model now resolves to the orchestrator
+    profile rather than refusing, so that error is no longer reachable here and
+    cannot serve as the marker. Stop the call at the first thing built instead,
+    which proves the same point: cwd validation let a cwd=None call through.
+    """
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    class _ReachedBuild(Exception):
+        pass
+
+    def _stop(*a, **kw):
+        raise _ReachedBuild
+
+    monkeypatch.setattr(orch_mod, "build_imodel_from_spec", _stop)
+
+    with pytest.raises(_ReachedBuild):
         await setup_orchestration(
             pattern_name="Flow",
             model_spec="",
@@ -88,6 +105,3 @@ async def test_setup_orchestration_none_cwd_is_unaffected(monkeypatch):
             effort=None,
             theme=None,
         )
-    # Falls through to the pre-existing "model spec required" error, proving
-    # the cwd check did not short-circuit a legitimate cwd=None call.
-    assert "model spec" in str(exc_info.value).lower()

--- a/tests/cli/orchestrate/test_orchestration_default_agent.py
+++ b/tests/cli/orchestrate/test_orchestration_default_agent.py
@@ -114,6 +114,44 @@ async def test_a_named_agent_with_no_model_still_refuses_and_names_itself(monkey
 
 
 @pytest.mark.asyncio
+async def test_a_missing_orchestrator_profile_says_what_was_assumed(monkeypatch):
+    """The default reaches for a profile the caller never mentioned, so if it is
+    not there the raw loader error names something they did not ask for. Explain
+    the assumption instead."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    def _absent(name, *a, **kw):
+        raise FileNotFoundError(f"Agent profile '{name}' not found")
+
+    monkeypatch.setattr(orch_mod, "load_agent_profile", _absent)
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await _run()
+
+    message = str(exc_info.value)
+    assert DEFAULT_ORCHESTRATOR_AGENT in message
+    assert "name an agent or a model" in message
+
+
+@pytest.mark.asyncio
+async def test_a_named_agent_that_is_missing_still_raises_the_loader_error(monkeypatch):
+    """The explanation above is for the assumption we made. A caller who named
+    the profile themselves gets the loader's own error, which lists what is
+    available."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    def _absent(name, *a, **kw):
+        raise FileNotFoundError(f"Agent profile '{name}' not found")
+
+    monkeypatch.setattr(orch_mod, "load_agent_profile", _absent)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        await _run(agent_name="no-such-agent")
+
+    assert "no-such-agent" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_the_default_does_not_fire_when_a_modelless_agent_was_named(monkeypatch):
     """Guards the interaction between the two behaviours: a modelless named
     agent must reach the refusal, never silently fall through to the default

--- a/tests/cli/orchestrate/test_orchestration_default_agent.py
+++ b/tests/cli/orchestrate/test_orchestration_default_agent.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 import pytest
 
 from lionagi._errors import ConfigurationError
+from lionagi.cli._providers import AgentProfileNotFoundError
 from lionagi.cli.orchestrate._orchestration import (
     DEFAULT_ORCHESTRATOR_AGENT,
     setup_orchestration,
@@ -121,7 +122,7 @@ async def test_a_missing_orchestrator_profile_says_what_was_assumed(monkeypatch)
     import lionagi.cli.orchestrate._orchestration as orch_mod
 
     def _absent(name, *a, **kw):
-        raise FileNotFoundError(f"Agent profile '{name}' not found")
+        raise AgentProfileNotFoundError(f"Agent profile '{name}' not found")
 
     monkeypatch.setattr(orch_mod, "load_agent_profile", _absent)
 
@@ -141,14 +142,34 @@ async def test_a_named_agent_that_is_missing_still_raises_the_loader_error(monke
     import lionagi.cli.orchestrate._orchestration as orch_mod
 
     def _absent(name, *a, **kw):
-        raise FileNotFoundError(f"Agent profile '{name}' not found")
+        raise AgentProfileNotFoundError(f"Agent profile '{name}' not found")
 
     monkeypatch.setattr(orch_mod, "load_agent_profile", _absent)
 
-    with pytest.raises(FileNotFoundError) as exc_info:
+    with pytest.raises(AgentProfileNotFoundError) as exc_info:
         await _run(agent_name="no-such-agent")
 
     assert "no-such-agent" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_a_profile_that_cannot_be_read_is_not_reported_as_a_missing_default(monkeypatch):
+    """The loader finds the file and then reads it, and a file that disappears
+    between those two steps raises the same builtin type as a missing profile.
+    Calling that "no orchestrator profile was found" sends the reader to create
+    a profile that is already there."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    def _found_then_vanished(name, *a, **kw):
+        raise FileNotFoundError(f"[Errno 2] No such file or directory: '{name}.md'")
+
+    monkeypatch.setattr(orch_mod, "load_agent_profile", _found_then_vanished)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        await _run()
+
+    assert not isinstance(exc_info.value, ConfigurationError)
+    assert "No such file or directory" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/cli/orchestrate/test_orchestration_default_agent.py
+++ b/tests/cli/orchestrate/test_orchestration_default_agent.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li o flow` / `li o fanout` (and `li play`, which expands into `li o flow`)
+share `setup_orchestration()`. Naming neither an agent nor a model there is a
+request to orchestrate, not an incomplete command, so it resolves to the
+orchestrator profile instead of refusing.
+
+The refusal survives for the case it was written for: a caller who did name an
+agent, whose profile carries no model.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from lionagi._errors import ConfigurationError
+from lionagi.cli.orchestrate._orchestration import (
+    DEFAULT_ORCHESTRATOR_AGENT,
+    setup_orchestration,
+)
+
+
+class _Reached(Exception):
+    """Raised in place of building an imodel, to stop the call once the
+    agent/model resolution under test has already happened."""
+
+
+@pytest.fixture
+def resolution_probe(monkeypatch, tmp_path):
+    """Capture which profile name setup_orchestration loads, then stop the call
+    before it builds anything. Returns the list of names passed to
+    load_agent_profile."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    loaded: list[str] = []
+
+    def _fake_load_agent_profile(name, *a, **kw):
+        loaded.append(name)
+        return SimpleNamespace(model="claude", effort=None, yolo=False, fast_mode=False)
+
+    def _stop(*a, **kw):
+        raise _Reached
+
+    monkeypatch.setattr(orch_mod, "load_agent_profile", _fake_load_agent_profile)
+    monkeypatch.setattr(orch_mod, "build_imodel_from_spec", _stop)
+    return loaded
+
+
+async def _run(**overrides):
+    kwargs = dict(
+        pattern_name="Fanout",
+        model_spec=None,
+        agent_name=None,
+        save_dir=None,
+        cwd=None,
+        yolo=False,
+        verbose=False,
+        effort=None,
+        theme=None,
+    )
+    kwargs.update(overrides)
+    return await setup_orchestration(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_naming_neither_agent_nor_model_defaults_to_the_orchestrator(resolution_probe):
+    """The bare case is the one the directive is about: no agent, no model."""
+    with pytest.raises(_Reached):
+        await _run()
+
+    assert resolution_probe == [DEFAULT_ORCHESTRATOR_AGENT]
+
+
+@pytest.mark.asyncio
+async def test_a_named_model_is_honoured_and_loads_no_profile(resolution_probe):
+    """Naming compute is still naming compute — the default must not override
+    it, and must not drag a profile in behind it."""
+    with pytest.raises(_Reached):
+        await _run(model_spec="claude")
+
+    assert resolution_probe == []
+
+
+@pytest.mark.asyncio
+async def test_a_named_agent_is_honoured_over_the_default(resolution_probe):
+    with pytest.raises(_Reached):
+        await _run(agent_name="reviewer")
+
+    assert resolution_probe == ["reviewer"]
+
+
+@pytest.mark.asyncio
+async def test_a_named_agent_with_no_model_still_refuses_and_names_itself(monkeypatch):
+    """The refusal is not deleted, it is narrowed. It now fires only where the
+    caller chose an agent we could not resolve to a model, so it says which."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    def _modelless_profile(name, *a, **kw):
+        return SimpleNamespace(model=None, effort=None, yolo=False, fast_mode=False)
+
+    def _boom(*a, **kw):
+        raise AssertionError("must refuse before building an imodel")
+
+    monkeypatch.setattr(orch_mod, "load_agent_profile", _modelless_profile)
+    monkeypatch.setattr(orch_mod, "build_imodel_from_spec", _boom)
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        await _run(agent_name="profile-without-a-model")
+
+    assert "profile-without-a-model" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_the_default_does_not_fire_when_a_modelless_agent_was_named(monkeypatch):
+    """Guards the interaction between the two behaviours: a modelless named
+    agent must reach the refusal, never silently fall through to the default
+    and orchestrate under compute the caller did not ask for."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    loaded: list[str] = []
+
+    def _modelless_profile(name, *a, **kw):
+        loaded.append(name)
+        return SimpleNamespace(model=None, effort=None, yolo=False, fast_mode=False)
+
+    monkeypatch.setattr(orch_mod, "load_agent_profile", _modelless_profile)
+
+    with pytest.raises(ConfigurationError):
+        await _run(agent_name="profile-without-a-model")
+
+    assert loaded == ["profile-without-a-model"]
+    assert DEFAULT_ORCHESTRATOR_AGENT not in loaded


### PR DESCRIPTION
## What

`li o flow`, `li o fanout` and `li play` previously refused a call that named neither an agent nor a model, telling the caller to supply one. Naming nothing is a request to orchestrate, not an incomplete command, so it now resolves to the `orchestrator` profile.

## Where

`setup_orchestration()` in `lionagi/cli/orchestrate/_orchestration.py` is the single setup helper `flow.py` and `fanout.py` both call. Placing the default there means the CLI and the programmatic surface cannot disagree about what a bare invocation means, and it answers the flow-versus-fanout scope question by construction rather than by keeping two behaviours in step.

## What still refuses

Only the fully unspecified case defaults:

| named | behaviour |
| --- | --- |
| neither agent nor model | defaults to the `orchestrator` profile |
| a model | honoured, no profile loaded |
| an agent | honoured, that profile loaded |
| an agent whose profile declares no model | refused |

The last row is the case the original error was written for, and it keeps refusing. The message now names the profile that carries no model instead of restating general usage, because by the time it fires the caller has already chosen.

## Tests

`tests/cli/orchestrate/test_orchestration_default_agent.py` covers each row above, including a guard that a modelless named agent reaches the refusal rather than silently falling through to the default and orchestrating under compute the caller did not ask for.

One assertion in `test_orchestration_cwd_failfast.py` changed. It used the "model spec required" error as its marker for having got past cwd validation, and that error is no longer reachable from a bare call. The test now stops the call at the first thing built, which demonstrates the same property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)