### PR TITLE
fix(studio): render a markdown artifact as markdown in the file viewer

### DIFF
--- a/apps/studio/frontend/src/components/ui/Markdown.test.ts
+++ b/apps/studio/frontend/src/components/ui/Markdown.test.ts
@@ -72,3 +72,32 @@ describe("Markdown.tsx — file-link resolution wiring", () => {
     expect(SRC).toMatch(/knownFiles: fileContext\.knownFiles/);
   });
 });
+
+describe("Markdown.tsx — the file viewer renders markdown as markdown", () => {
+  it("decides by file extension, accepting .md and .markdown case-insensitively", () => {
+    expect(SRC).toMatch(/const isMarkdown = \/\\\.\(md\|markdown\)\$\/i\.test\(path\)/);
+  });
+
+  it("routes a markdown file through the Markdown renderer rather than a <pre>", () => {
+    expect(SRC).toMatch(/isMarkdown \?/);
+    expect(SRC).toMatch(/<Markdown>\{state\.content\}<\/Markdown>/);
+  });
+
+  it("keeps the verbatim <pre> path for every non-markdown file", () => {
+    // The <pre> must survive as the else-branch: source files, logs and JSON
+    // are read as source, and reflowing them would corrupt what they show.
+    expect(SRC).toMatch(/<pre className="whitespace-pre-wrap break-words font-mono/);
+  });
+
+  it("renders the previewed document WITHOUT a fileContext, so a viewer cannot stack on itself", () => {
+    // <Markdown> with no fileContext prop yields components=undefined, so the
+    // nested render wires no FileRef handlers and mounts no second modal.
+    // A bare <Markdown> tag (no props) is the whole guard — assert it stays bare.
+    expect(SRC).toMatch(/<Markdown>\{state\.content\}<\/Markdown>/);
+    expect(SRC).not.toMatch(/<Markdown[^>]+fileContext/);
+  });
+
+  it("gives a rendered document more width than raw source, since tables need it", () => {
+    expect(SRC).toMatch(/maxWidth=\{isMarkdown \? "max-w-4xl" : "max-w-2xl"\}/);
+  });
+});

--- a/apps/studio/frontend/src/components/ui/Markdown.tsx
+++ b/apps/studio/frontend/src/components/ui/Markdown.tsx
@@ -158,12 +158,17 @@ function FileViewerModal({
     };
   }, [runId, path]);
 
+  // Agents write their reports as markdown, so a .md preview showing raw source
+  // makes the reader parse tables and headings by eye. Render it. Anything else
+  // stays verbatim in a <pre>, where source is the point.
+  const isMarkdown = /\.(md|markdown)$/i.test(path);
+
   return (
     <Modal
       title={path.split("/").pop() ?? path}
       closeLabel="Close file viewer"
       onClose={onClose}
-      maxWidth="max-w-2xl"
+      maxWidth={isMarkdown ? "max-w-4xl" : "max-w-2xl"}
     >
       <div className="max-h-[70vh] overflow-auto p-4">
         {state.status === "loading" && <p className="text-body text-content-muted">Loading…</p>}
@@ -181,9 +186,16 @@ function FileViewerModal({
         )}
         {state.status === "ready" && (
           <>
-            <pre className="whitespace-pre-wrap break-words font-mono text-[length:var(--t-xs)] leading-relaxed text-content-secondary">
-              {state.content}
-            </pre>
+            {isMarkdown ? (
+              // Deliberately rendered without a fileContext: a document being
+              // previewed must not turn its own filename mentions into links
+              // that stack another viewer on top of this one.
+              <Markdown>{state.content}</Markdown>
+            ) : (
+              <pre className="whitespace-pre-wrap break-words font-mono text-[length:var(--t-xs)] leading-relaxed text-content-secondary">
+                {state.content}
+              </pre>
+            )}
             {state.truncated && (
               <p className="mt-2 text-meta text-content-muted">
                 File truncated — showing the first portion only.

--- a/apps/studio/frontend/src/components/ui/Modal.tsx
+++ b/apps/studio/frontend/src/components/ui/Modal.tsx
@@ -9,8 +9,9 @@ export interface ModalProps {
   closeLabel: string;
   onClose: () => void;
   children: ReactNode;
-  /** Width utility for the dialog card. */
-  maxWidth?: "max-w-md" | "max-w-lg" | "max-w-xl" | "max-w-2xl";
+  /** Width utility for the dialog card. Spelled out rather than left open so
+   *  every class the app can produce is literally present for Tailwind to find. */
+  maxWidth?: "max-w-md" | "max-w-lg" | "max-w-xl" | "max-w-2xl" | "max-w-4xl";
   className?: string;
 }
 


### PR DESCRIPTION
## What

Opening a `.md` artifact in the run file viewer showed raw source. Tables rendered as rows of pipe characters and headings as hashes, so the reader parsed by eye the structure the writer had already expressed. Agents write their reports as markdown, so this is the common case rather than an edge one.

Files ending `.md` or `.markdown` now render through the existing `Markdown` component, which already carries `remark-gfm`. Everything else keeps the verbatim `<pre>`, where seeing source exactly as written is the point.

## The recursion this avoids

`FileViewerModal` lives inside `Markdown.tsx`, so the component doing the rendering is the one that owns the viewer. The previewed document is rendered with **no** `fileContext`, which leaves `components` undefined and wires no file-reference handlers. With a `fileContext`, a document mentioning its own sibling filenames would turn them into links that stack a second viewer on top of the first.

A rendered document also gets a wider modal than raw source, since a table needs the width.

## Tests

Five cases added to `Markdown.test.ts`, following the existing source-contract convention in that file. Three of them were checked against the pre-change source to confirm they reject it rather than passing vacuously; the fourth is a regression guard that the `<pre>` branch survives, so it matches both by design.

Full frontend suite: 892 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)