### PR TITLE
fix(studio): space execution-graph nodes by their real height

### DIFF
--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -9,7 +9,14 @@ import ReactFlow, {
   useNodesState,
   useEdgesState,
 } from "reactflow";
-import type { Connection, Edge, Node, NodeMouseHandler, EdgeMouseHandler } from "reactflow";
+import type {
+  Connection,
+  Edge,
+  Node,
+  NodeMouseHandler,
+  EdgeMouseHandler,
+  ReactFlowInstance,
+} from "reactflow";
 import "reactflow/dist/style.css";
 
 import StepNodeComponent from "./StepNode";
@@ -160,6 +167,10 @@ export default function WorkerCanvas({
   compact = false,
 }: WorkerCanvasProps) {
   const initialised = useRef(false);
+  // Captured via onInit rather than useReactFlow(): this component renders its
+  // own <ReactFlow> and sits outside any ReactFlowProvider, so the hook has no
+  // context to read.
+  const flowRef = useRef<ReactFlowInstance | null>(null);
 
   const initialFlowNodes = useMemo(() => toFlowNodes(graph.nodes), [graph.nodes]);
   const initialFlowEdges = useMemo(() => toFlowEdges(graph.edges), [graph.edges]);
@@ -174,6 +185,22 @@ export default function WorkerCanvas({
     setNodes(ln);
     setEdges(le);
     initialised.current = true;
+
+    // ReactFlow's `fitView` prop fits once, when the flow initialises. At that
+    // moment `nodes` is still the empty array this component starts with, since
+    // the layout above only reaches state in an effect — after the first
+    // render. So the declarative fit lands on an empty graph and never runs
+    // again, leaving the viewport at its default while the real graph is laid
+    // out somewhere off-screen. Small graphs happen to fall inside that default
+    // viewport and look fine, which is why this reads as a large-graph bug.
+    //
+    // Fit explicitly once the nodes exist. rAF defers to after React has
+    // committed them, so ReactFlow measures a populated graph.
+    if (ln.length === 0) return;
+    const frame = requestAnimationFrame(() => {
+      flowRef.current?.fitView({ padding: 0.3 });
+    });
+    return () => cancelAnimationFrame(frame);
   }, [initialFlowNodes, initialFlowEdges, setNodes, setEdges]);
 
   // Apply execution status to nodes. nodeStatuses (live signal-derived, keyed
@@ -357,6 +384,9 @@ export default function WorkerCanvas({
           nodesDraggable={true}
           nodesConnectable={editable}
           elementsSelectable={true}
+          onInit={(instance) => {
+            flowRef.current = instance;
+          }}
           fitView
           fitViewOptions={{ padding: 0.3 }}
           proOptions={{ hideAttribution: true }}

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -9,14 +9,7 @@ import ReactFlow, {
   useNodesState,
   useEdgesState,
 } from "reactflow";
-import type {
-  Connection,
-  Edge,
-  Node,
-  NodeMouseHandler,
-  EdgeMouseHandler,
-  ReactFlowInstance,
-} from "reactflow";
+import type { Connection, Edge, Node, NodeMouseHandler, EdgeMouseHandler } from "reactflow";
 import "reactflow/dist/style.css";
 
 import StepNodeComponent from "./StepNode";
@@ -167,10 +160,6 @@ export default function WorkerCanvas({
   compact = false,
 }: WorkerCanvasProps) {
   const initialised = useRef(false);
-  // Captured via onInit rather than useReactFlow(): this component renders its
-  // own <ReactFlow> and sits outside any ReactFlowProvider, so the hook has no
-  // context to read.
-  const flowRef = useRef<ReactFlowInstance | null>(null);
 
   const initialFlowNodes = useMemo(() => toFlowNodes(graph.nodes), [graph.nodes]);
   const initialFlowEdges = useMemo(() => toFlowEdges(graph.edges), [graph.edges]);
@@ -185,22 +174,6 @@ export default function WorkerCanvas({
     setNodes(ln);
     setEdges(le);
     initialised.current = true;
-
-    // ReactFlow's `fitView` prop fits once, when the flow initialises. At that
-    // moment `nodes` is still the empty array this component starts with, since
-    // the layout above only reaches state in an effect — after the first
-    // render. So the declarative fit lands on an empty graph and never runs
-    // again, leaving the viewport at its default while the real graph is laid
-    // out somewhere off-screen. Small graphs happen to fall inside that default
-    // viewport and look fine, which is why this reads as a large-graph bug.
-    //
-    // Fit explicitly once the nodes exist. rAF defers to after React has
-    // committed them, so ReactFlow measures a populated graph.
-    if (ln.length === 0) return;
-    const frame = requestAnimationFrame(() => {
-      flowRef.current?.fitView({ padding: 0.3 });
-    });
-    return () => cancelAnimationFrame(frame);
   }, [initialFlowNodes, initialFlowEdges, setNodes, setEdges]);
 
   // Apply execution status to nodes. nodeStatuses (live signal-derived, keyed
@@ -384,9 +357,6 @@ export default function WorkerCanvas({
           nodesDraggable={true}
           nodesConnectable={editable}
           elementsSelectable={true}
-          onInit={(instance) => {
-            flowRef.current = instance;
-          }}
           fitView
           fitViewOptions={{ padding: 0.3 }}
           proOptions={{ hideAttribution: true }}

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -1,0 +1,121 @@
+/**
+ * StepNode is not a fixed-height box: it grows a row at a time as a run fills
+ * in the role, the assignment, and the duration/calls line. dagre is told a
+ * height up front, so if that height is a constant it is right for one moment
+ * of a node's life and wrong afterwards, and the nodes crowd.
+ *
+ * getLayoutedElements is exercised through dagre here rather than mocked, so
+ * these assert the property that matters (laid-out boxes do not overlap)
+ * instead of the arithmetic that happens to produce it.
+ */
+import { describe, it, expect } from "vitest";
+import type { Node, Edge } from "reactflow";
+import { estimateNodeHeight, getLayoutedElements } from "./useLayout";
+
+const bare = (id: string): Node => ({
+  id,
+  position: { x: 0, y: 0 },
+  data: { label: id },
+});
+
+const full = (id: string): Node => ({
+  id,
+  position: { x: 0, y: 0 },
+  data: {
+    label: id,
+    role: "investigator",
+    assignment: "codex/gpt-5.6-terra",
+    durationSeconds: 147.5,
+    toolCallCount: 20,
+  },
+});
+
+describe("estimateNodeHeight", () => {
+  it("gives a node carrying no optional rows the base height", () => {
+    expect(estimateNodeHeight(bare("a"))).toBe(40);
+  });
+
+  it("grows as each row is filled in, so a fully populated node is much taller", () => {
+    expect(estimateNodeHeight(full("a"))).toBeGreaterThan(estimateNodeHeight(bare("a")));
+    // The gap is the whole bug: a single constant cannot describe both.
+    expect(estimateNodeHeight(full("a")) - estimateNodeHeight(bare("a"))).toBeGreaterThan(40);
+  });
+
+  it("counts each row independently rather than treating any one as a proxy", () => {
+    const roleOnly = { ...bare("a"), data: { label: "a", role: "critic" } };
+    const roleAndModel = {
+      ...bare("a"),
+      data: { label: "a", role: "critic", assignment: "codex/gpt-5.6-terra" },
+    };
+    expect(estimateNodeHeight(roleAndModel)).toBeGreaterThan(estimateNodeHeight(roleOnly));
+    expect(estimateNodeHeight(roleOnly)).toBeGreaterThan(estimateNodeHeight(bare("a")));
+  });
+
+  it("does not count a zero/absent stats row", () => {
+    const zeroed = {
+      ...bare("a"),
+      data: { label: "a", errorCount: 0, toolCallCount: 0 },
+    };
+    expect(estimateNodeHeight(zeroed)).toBe(estimateNodeHeight(bare("a")));
+  });
+
+  it("survives a node with no data at all", () => {
+    const noData = { id: "a", position: { x: 0, y: 0 } } as unknown as Node;
+    expect(() => estimateNodeHeight(noData)).not.toThrow();
+    expect(estimateNodeHeight(noData)).toBe(40);
+  });
+});
+
+describe("getLayoutedElements — populated nodes do not overlap", () => {
+  // Siblings off one parent share a dagre rank, so they are stacked along the
+  // cross axis. That is exactly where an under-reserved height shows up.
+  const parent = "root";
+  const siblings = ["s1", "s2", "s3", "s4", "s5"];
+  const edges: Edge[] = siblings.map((s) => ({ id: `${parent}-${s}`, source: parent, target: s }));
+
+  function verticalGaps(nodes: Node[]): number[] {
+    const laid = siblings
+      .map((id) => nodes.find((n) => n.id === id))
+      .filter((n): n is Node => Boolean(n))
+      .sort((a, b) => a.position.y - b.position.y);
+    const gaps: number[] = [];
+    for (let i = 1; i < laid.length; i++) {
+      const prev = laid[i - 1];
+      const cur = laid[i];
+      gaps.push(cur.position.y - (prev.position.y + estimateNodeHeight(prev)));
+    }
+    return gaps;
+  }
+
+  it("leaves a positive gap between fully populated siblings", () => {
+    const input = [full(parent), ...siblings.map(full)];
+    const { nodes } = getLayoutedElements(input, edges, "LR");
+    for (const gap of verticalGaps(nodes)) {
+      expect(gap).toBeGreaterThan(0);
+    }
+  });
+
+  it("leaves a positive gap between bare siblings too", () => {
+    const input = [bare(parent), ...siblings.map(bare)];
+    const { nodes } = getLayoutedElements(input, edges, "LR");
+    for (const gap of verticalGaps(nodes)) {
+      expect(gap).toBeGreaterThan(0);
+    }
+  });
+
+  it("spaces populated siblings further apart than bare ones, since they are taller", () => {
+    const populated = getLayoutedElements([full(parent), ...siblings.map(full)], edges, "LR");
+    const plain = getLayoutedElements([bare(parent), ...siblings.map(bare)], edges, "LR");
+    const span = (nodes: Node[]) => {
+      const ys = siblings.map((id) => nodes.find((n) => n.id === id)!.position.y);
+      return Math.max(...ys) - Math.min(...ys);
+    };
+    expect(span(populated.nodes)).toBeGreaterThan(span(plain.nodes));
+  });
+
+  it("keeps every node it was given", () => {
+    const input = [full(parent), ...siblings.map(full)];
+    const { nodes } = getLayoutedElements(input, edges, "LR");
+    expect(nodes.map((n) => n.id).sort()).toEqual([parent, ...siblings].sort());
+  });
+});

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -3,7 +3,43 @@ import dagre from "dagre";
 import type { Node, Edge } from "reactflow";
 
 const NODE_WIDTH = 210;
-const NODE_HEIGHT = 64;
+
+// StepNode grows a row at a time as a run fills its data in: the role badge,
+// the assignment (the model it ran on), then the duration/calls line. A single
+// constant height therefore describes the node at exactly one moment of its
+// life. Feeding dagre that constant once the other rows exist makes it reserve
+// less vertical room than the node occupies, and the boxes crowd into each
+// other — worst on a graph where every node has been assigned, which is any
+// graph worth looking at.
+//
+// These track StepNode's own padding and per-row heights. They are estimates:
+// exact only matters to the extent that ranks stay clear of each other, and
+// over-reserving is harmless where under-reserving overlaps.
+const NODE_BASE_HEIGHT = 40; // vertical padding + the label row
+const ROW_ROLE = 22;
+const ROW_ASSIGNMENT = 17;
+const ROW_STATS = 19;
+
+export function estimateNodeHeight(node: Node): number {
+  const data = (node.data ?? {}) as {
+    role?: unknown;
+    assignment?: unknown;
+    durationSeconds?: number | null;
+    errorCount?: number | null;
+    toolCallCount?: number | null;
+  };
+  let height = NODE_BASE_HEIGHT;
+  if (data.role) height += ROW_ROLE;
+  if (data.assignment) height += ROW_ASSIGNMENT;
+  if (
+    (data.durationSeconds != null && data.durationSeconds >= 0) ||
+    (data.errorCount ?? 0) > 0 ||
+    (data.toolCallCount ?? 0) > 0
+  ) {
+    height += ROW_STATS;
+  }
+  return height;
+}
 
 export function getLayoutedElements(
   nodes: Node[],
@@ -21,7 +57,7 @@ export function getLayoutedElements(
   });
 
   for (const node of nodes) {
-    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+    g.setNode(node.id, { width: NODE_WIDTH, height: estimateNodeHeight(node) });
   }
   for (const edge of edges) {
     g.setEdge(edge.source, edge.target);
@@ -31,11 +67,13 @@ export function getLayoutedElements(
 
   const layoutedNodes = nodes.map((node) => {
     const pos = g.node(node.id);
+    // dagre reports a centre, so each node is offset by its OWN height. Using a
+    // shared constant here would re-introduce the overlap from the other side.
     return {
       ...node,
       position: {
         x: pos.x - NODE_WIDTH / 2,
-        y: pos.y - NODE_HEIGHT / 2,
+        y: pos.y - estimateNodeHeight(node) / 2,
       },
     };
   });


### PR DESCRIPTION
## The report

The execution graph renders correctly when the orchestrator first emits its plan,
then degrades once agent names attach to the nodes.

## What is wrong

`getLayoutedElements` hands dagre a constant `height: 64` for every node. The
node itself is not a constant height: `StepNode` grows a role badge, an
assignment line and a statistics row as the run progresses, going from about
40px to about 98px. Dagre packs ranks against the number it was given, so as
soon as those rows populate the boxes are taller than the space reserved for
them and they collide. That is exactly the reported sequence: correct at plan
time, wrong once assignments land.

## The change

`estimateNodeHeight` reads the same fields `StepNode` renders and adds the row
height for each one that is present. That estimate is used both when the node is
registered with dagre and when dagre's centre coordinate is converted back to a
top-left position, so the two stay consistent.

The estimates over-reserve slightly rather than under-reserve; in a
left-to-right graph that costs a little vertical space and never costs an
overlap.

## What was dropped after review

An earlier commit here also added an explicit `fitView` call, on the reading
that the declarative `fitView` prop fits an empty graph at init and never runs
again. That reading is wrong for the pinned `reactflow@11.11.4`:
`fitView` returns early over zero nodes without setting `fitViewOnInitDone`
(`@reactflow/core/dist/esm/index.mjs:1494-1524`), and `updateNodeDimensions`
retries the initial fit on every dimension update while that flag is unset
(`:3849-3899`). So the flow is fitted once the real nodes arrive, without help.
The explicit call was redundant and would have re-run on every new graph
identity, discarding a pan or zoom the viewer had chosen. It is reverted;
`WorkerCanvas.tsx` is unchanged from main.

## Evidence

`useLayout.test.ts` adds 9 tests that exercise dagre for real rather than
mocking it, and assert that sibling boxes do not overlap at their estimated
heights.

Measured against `origin/main` (`92167c4ec`), same graph, bare nodes versus
nodes carrying role, assignment and stats:

| | bare | populated |
| --- | --- | --- |
| constant 64px (main) | 400px span | 400px span |
| estimated height (here) | 304px | 536px |

The control result is that the layout on main does not respond to node content
at all: identical 400px spans either way.

Of the nine tests, exactly one discriminates behaviourally against that control:
the span assertion, which compares bare against populated. Seven require
`estimateNodeHeight`, which does not exist on main, so against the control they
fail by absence rather than by behaviour. The ninth asserts that layout returns
every node it was given, and passes against either implementation; it is a
preservation guard, not evidence for this change.

An earlier version of this description said "8 of 9 fail", which read as if eight
were behavioural evidence. They are not.

Frontend suite: 39 files, 896 tests, green.
