### PR TITLE
fix(state): a bare artifact path matches whatever worker produced it

### DIFF
--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -103,6 +103,52 @@ def warn_unknown_artifact_keys(
     return warnings
 
 
+def _resolve_produced(root: str, rel: str) -> str | None:
+    """Return the path an expected artifact was actually produced at, or None.
+
+    An entry naming a directory is matched exactly, so a contract that knows
+    where its artifact lands keeps saying so precisely.
+
+    A bare filename is matched at the root first and then in any immediate
+    subdirectory. In a multi-agent run each worker writes into its own
+    subdirectory, and which worker produces a given artifact is decided when
+    the plan is cast — so the author of a playbook contract cannot name that
+    directory in advance, and requiring one made a bare filename impossible to
+    satisfy. Declaring *what* is expected and knowing *who* produces it are
+    held by different parties; only the first belongs in the contract.
+
+    Subdirectories are searched in sorted order, so a filename produced by more
+    than one worker resolves to the same one on every run rather than to
+    whatever the filesystem happened to list first.
+    """
+    try:
+        direct = _safe_join(root, rel)
+    except ArtifactPathError:
+        return None
+    if os.path.isfile(direct):
+        return direct
+
+    if len(PurePosixPath(rel).parts) != 1:
+        return None
+
+    try:
+        subdirs = sorted(entry.name for entry in os.scandir(root) if entry.is_dir())
+    except OSError:
+        return None
+
+    for sub in subdirs:
+        try:
+            candidate = _safe_join(root, f"{sub}/{rel}")
+        except ArtifactPathError:
+            # A subdirectory whose name is not a legal path segment (a glob
+            # character, say) is skipped rather than failing the whole check:
+            # it is not somewhere we would have written an artifact.
+            continue
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
 def validate_artifact_contract(contract: dict[str, Any] | None) -> None:
     if contract is None:
         return
@@ -205,13 +251,16 @@ def verify_artifact_contract(
     produced: list[ProducedArtifact] = []
 
     for entry in expected:
-        full = _safe_join(root, entry["path"])
-        present = os.path.isfile(full) and os.path.getsize(full) > 0
+        full = _resolve_produced(root, entry["path"])
+        present = full is not None and os.path.getsize(full) > 0
         if present:
             produced.append(
                 {
                     "id": entry["id"],
-                    "path": entry["path"],
+                    # Report where it was found, not only what was asked for: a
+                    # bare filename may have resolved into a worker's own
+                    # subdirectory, and the reader wants the path that exists.
+                    "path": os.path.relpath(full, root),
                     "size": os.path.getsize(full),
                     "present": True,
                 }

--- a/tests/state/test_artifact_verifier.py
+++ b/tests/state/test_artifact_verifier.py
@@ -424,3 +424,158 @@ def test_safe_join_dotdot_rejects(tmp_path):
 def test_safe_join_glob_rejects(tmp_path):
     with pytest.raises(ArtifactPathError, match="glob characters"):
         _safe_join(str(tmp_path), "*.md")
+
+
+# ── A bare filename resolves to whichever worker produced it ──────────────────
+#
+# In a multi-agent run each worker writes into its own subdirectory of the
+# artifacts root, and which worker produces a given artifact is decided when the
+# plan is cast. A playbook contract therefore cannot name that subdirectory in
+# advance, so a bare filename used to be impossible to satisfy: every declared
+# artifact verified as MISSING even when the file was sitting one level down,
+# which in turn rewrote a completed run to failed.
+
+
+def _contract(*entries):
+    return {"expected": list(entries)}
+
+
+def test_bare_filename_found_in_a_worker_subdirectory(tmp_path):
+    (tmp_path / "scribe").mkdir()
+    (tmp_path / "scribe" / "VERDICTS.md").write_text("rows")
+
+    result = verify_artifact_contract(
+        _contract({"id": "verdicts", "path": "VERDICTS.md", "required": True}),
+        artifacts_root=str(tmp_path),
+    )
+    assert result["status"] == "passed"
+    assert result["missing_required"] == []
+    assert result["produced"][0]["id"] == "verdicts"
+
+
+def test_produced_reports_where_the_file_actually_is(tmp_path):
+    # _context_from reads produced["path"] relative to the root, so reporting
+    # the declared name rather than the resolved one would hand it a path that
+    # does not exist.
+    (tmp_path / "planner").mkdir()
+    (tmp_path / "planner" / "SLICES.md").write_text("slices")
+
+    result = verify_artifact_contract(
+        _contract({"id": "slices", "path": "SLICES.md", "required": True}),
+        artifacts_root=str(tmp_path),
+    )
+    entry = result["produced"][0]
+    assert entry["path"] == os.path.join("planner", "SLICES.md")
+    assert (tmp_path / entry["path"]).read_text() == "slices"
+
+
+def test_a_file_at_the_root_still_wins_over_a_subdirectory_copy(tmp_path):
+    (tmp_path / "REPORT.md").write_text("root copy")
+    (tmp_path / "worker").mkdir()
+    (tmp_path / "worker" / "REPORT.md").write_text("subdir copy")
+
+    result = verify_artifact_contract(
+        _contract({"id": "r", "path": "REPORT.md", "required": True}),
+        artifacts_root=str(tmp_path),
+    )
+    assert result["produced"][0]["path"] == "REPORT.md"
+
+
+def test_same_filename_in_two_subdirectories_resolves_deterministically(tmp_path):
+    for name in ("zeta", "alpha", "mid"):
+        (tmp_path / name).mkdir()
+        (tmp_path / name / "OUT.md").write_text(name)
+
+    seen = {
+        verify_artifact_contract(
+            _contract({"id": "o", "path": "OUT.md", "required": True}),
+            artifacts_root=str(tmp_path),
+        )["produced"][0]["path"]
+        for _ in range(5)
+    }
+    assert seen == {os.path.join("alpha", "OUT.md")}
+
+
+def test_a_directory_qualified_path_is_matched_exactly_and_not_searched_elsewhere(tmp_path):
+    # role_default entries name their own directory. That precision must be
+    # honoured: a contract asking for critic/review.md is not satisfied by some
+    # other worker's review.md.
+    (tmp_path / "writer").mkdir()
+    (tmp_path / "writer" / "review.md").write_text("wrong author")
+
+    result = verify_artifact_contract(
+        _contract({"id": "cr", "path": "critic/review.md", "required": True}),
+        artifacts_root=str(tmp_path),
+    )
+    assert result["status"] == "failed"
+    assert [e["id"] for e in result["missing_required"]] == ["cr"]
+
+
+def test_a_nested_bare_filename_is_not_found_two_levels_down(tmp_path):
+    # The search is one level deep on purpose: workers write into their own
+    # directory, not into arbitrary trees, and an unbounded walk would let an
+    # incidental file elsewhere satisfy a contract.
+    deep = tmp_path / "worker" / "nested"
+    deep.mkdir(parents=True)
+    (deep / "DEEP.md").write_text("too far")
+
+    result = verify_artifact_contract(
+        _contract({"id": "d", "path": "DEEP.md", "required": True}),
+        artifacts_root=str(tmp_path),
+    )
+    assert result["status"] == "failed"
+
+
+def test_an_empty_file_in_a_subdirectory_is_still_missing(tmp_path):
+    # A worker that created the file and wrote nothing has not produced it.
+    (tmp_path / "scribe").mkdir()
+    (tmp_path / "scribe" / "EMPTY.md").write_text("")
+
+    result = verify_artifact_contract(
+        _contract({"id": "e", "path": "EMPTY.md", "required": True}),
+        artifacts_root=str(tmp_path),
+    )
+    assert result["status"] == "failed"
+
+
+def test_a_genuinely_absent_artifact_is_still_missing(tmp_path):
+    (tmp_path / "scribe").mkdir()
+    (tmp_path / "scribe" / "SOMETHING_ELSE.md").write_text("x")
+
+    result = verify_artifact_contract(
+        _contract({"id": "gone", "path": "NOT_THERE.md", "required": True}),
+        artifacts_root=str(tmp_path),
+    )
+    assert result["status"] == "failed"
+    assert [e["id"] for e in result["missing_required"]] == ["gone"]
+
+
+def test_the_reported_run_shape_now_passes_end_to_end(tmp_path):
+    # The exact contract and layout that produced a false failure: four
+    # playbook-declared bare filenames, each written by a different worker,
+    # plus one role_default entry that already named its own directory.
+    layout = {
+        "scribe": "VERDICTS.md",
+        "planner": "SLICES.md",
+        "writer": "STALE.md",
+        "advisor": "PARKED.md",
+        "critic": "review.md",
+    }
+    for agent, filename in layout.items():
+        (tmp_path / agent).mkdir()
+        (tmp_path / agent / filename).write_text("content")
+
+    result = verify_artifact_contract(
+        _contract(
+            {"id": "verdicts", "path": "VERDICTS.md", "required": True},
+            {"id": "slices", "path": "SLICES.md", "required": True},
+            {"id": "stale", "path": "STALE.md", "required": False},
+            {"id": "parked", "path": "PARKED.md", "required": False},
+            {"id": "critic__review", "path": "critic/review.md", "required": True},
+        ),
+        artifacts_root=str(tmp_path),
+    )
+    assert result["status"] == "passed"
+    assert result["missing_required"] == []
+    assert result["missing_optional"] == []
+    assert len(result["produced"]) == 5


### PR DESCRIPTION
## The report

A play ran to completion and produced every artifact it had declared. The run was
recorded as `failed`, with the reason "missing required artifact", and the Studio
artifact panel showed all four as MISSING while the files sat on disk.

## What actually happened

`verify_artifact_contract` joined each declared `path` directly under the
artifacts root and asked whether a file was there. In a multi-agent run nothing
is there: each worker writes into its own subdirectory of the root. The four
declared artifacts had been written to `scribe/VERDICTS.md`, `planner/SLICES.md`,
`writer/STALE.md` and `advisor/PARKED.md`; the root itself held zero files.

The declaration cannot name those directories. Which worker produces a given
artifact is decided when the plan is cast, so a contract written before the run
can say *what* is expected but not *who* will produce it. A `role_default` entry
can carry the prefix (`critic/review.md`) precisely because it is attached to the
role; a playbook entry cannot. So every playbook-declared bare filename was
unsatisfiable by construction.

The consequence is not cosmetic. `_runs.py` rewrites a `completed` run to
`failed` when verification fails, so a contract that could never be satisfied
converted a good run into a bad record.

## The change

- A path that names a directory keeps its exact match. A contract asking for
  `critic/review.md` is still not satisfied by some other worker's `review.md`.
- A bare filename is looked for at the root first, then in each immediate
  subdirectory, in sorted order so the answer does not depend on how the
  filesystem happens to list entries.
- The search stops at one level. Workers write into their own directory, and an
  unbounded walk would let an incidental file elsewhere in the tree satisfy a
  contract.
- `produced[].path` now reports where the file was found rather than what was
  asked for. `_context_from` reads that path back off disk, so reporting the
  declared name would have handed it something that does not exist.

Traversal rejection, glob rejection, the empty-file rule and the missing-root
path are all unchanged.

## Evidence

`tests/state/test_artifact_verifier.py` gains 9 tests, including the exact
layout from the reported run (four bare filenames across four worker
directories plus one directory-qualified `role_default` entry).

Counterfactual control, same invocation: with the production change reverted and
the tests left at HEAD, 4 of the 9 fail —

```
FAILED test_bare_filename_found_in_a_worker_subdirectory
FAILED test_produced_reports_where_the_file_actually_is
FAILED test_same_filename_in_two_subdirectories_resolves_deterministically
FAILED test_the_reported_run_shape_now_passes_end_to_end
```

The other 5 assert preserved behaviour (exact match not searched elsewhere, no
two-level descent, zero-byte file absent, genuinely missing file absent, root
file wins over a subdirectory copy) and pass both ways by design.

`tests/state/` green: 821 passed, 7 skipped (asyncpg absent).
