### PR TITLE
feat(studio): show artifacts arriving instead of waiting for the run to end

### DIFF
--- a/apps/studio/frontend/src/components/runs/ExpectedArtifacts.test.ts
+++ b/apps/studio/frontend/src/components/runs/ExpectedArtifacts.test.ts
@@ -1,0 +1,40 @@
+/**
+ * ExpectedArtifacts — source-contract tests (this project has no
+ * @testing-library/react, so component wiring is verified against the source
+ * rather than a live render; see ui/Markdown.test.ts for the same pattern).
+ *
+ * The behaviour under test: a provisional verification is a reading taken while
+ * the run is still going. An artifact that is not on disk yet has not been
+ * missed, it has not been written yet, and the panel must not say otherwise.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(__dirname, "ExpectedArtifacts.tsx"), "utf-8");
+
+describe("ExpectedArtifacts.tsx — provisional readings", () => {
+  it("never calls an artifact missing on a provisional reading", () => {
+    expect(SRC).toMatch(/!verification\?\.provisional &&/);
+  });
+
+  it("keeps MISSING reachable for a recorded verdict", () => {
+    expect(SRC).toMatch(/missingRequired\.has\(entry\.id\) \|\| missingOptional\.has\(entry\.id\)/);
+    expect(SRC).toMatch(/"MISSING"/);
+  });
+
+  it("shows written-so-far progress instead of a contract status while the run is live", () => {
+    expect(SRC).toMatch(/verification\?\.provisional \?/);
+    expect(SRC).toMatch(/\{producedById\.size\} of \{expected\.length\} written/);
+  });
+
+  it("still shows the recorded verdict when there is one", () => {
+    expect(SRC).toMatch(/Verified: \{verification\.status\}/);
+  });
+
+  it("counts progress from what was produced, not from the contract status", () => {
+    // status is "failed" for every incomplete run, so keying the badge off it
+    // would put a red verdict on a run that is simply not finished.
+    expect(SRC).toMatch(/producedById\.size === expected\.length \? "ok" : "pending"/);
+  });
+});

--- a/apps/studio/frontend/src/components/runs/ExpectedArtifacts.tsx
+++ b/apps/studio/frontend/src/components/runs/ExpectedArtifacts.tsx
@@ -34,17 +34,31 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
         <span className="rounded bg-surface-overlay px-1.5 py-0 font-mono text-[length:var(--t-xs)] text-content-muted">
           {expected.length}
         </span>
-        {verification?.status && (
-          <Badge tone={verificationTone(verification.status)}>
-            Verified: {verification.status}
+        {verification?.provisional ? (
+          // Mid-run, a contract status is always "failed" until the last
+          // artifact lands, which says nothing except that the run is not over.
+          // Progress is the thing worth showing while it is still going.
+          <Badge tone={producedById.size === expected.length ? "ok" : "pending"}>
+            {producedById.size} of {expected.length} written
           </Badge>
+        ) : (
+          verification?.status && (
+            <Badge tone={verificationTone(verification.status)}>
+              Verified: {verification.status}
+            </Badge>
+          )
         )}
       </div>
       <div className="rounded border border-edge bg-surface-raised px-3 py-2 shadow-card">
         <ul className="flex flex-col divide-y divide-edge-subtle">
           {expected.map((entry) => {
             const produced = producedById.get(entry.id);
-            const missing = missingRequired.has(entry.id) || missingOptional.has(entry.id);
+            // A provisional reading is taken while the run is still going, so an
+            // artifact that is not on disk yet has not been missed — it has not
+            // been written yet. Only a recorded verdict can call one missing.
+            const missing =
+              !verification?.provisional &&
+              (missingRequired.has(entry.id) || missingOptional.has(entry.id));
             const required = entry.required !== false;
             const statusTone = produced
               ? "ok"

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -46,6 +46,9 @@ export interface ArtifactVerification {
   missing_required: ExpectedArtifact[];
   missing_optional: ExpectedArtifact[];
   produced: ProducedArtifact[];
+  /** A reading taken while the run is still going, rather than the recorded
+   *  verdict it was judged on. Artifacts may still appear. */
+  provisional?: boolean;
 }
 
 // ─── Run types ───────────────────────────────────────────────────────────────

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import math
 import os
 import stat
@@ -455,6 +456,45 @@ def _session_liveness(s: dict[str, Any], ps_snapshot: str | None = None) -> bool
     return process_liveness(s, Path(ap) if ap else None, ps_snapshot)
 
 
+def _provisional_verification(contract: Any, artifacts_path: str | None) -> dict[str, Any] | None:
+    """Check a contract against what is on disk right now, for a run whose
+    verification has not been recorded yet.
+
+    Verification is recorded once, when a run finalises. Until then the panel has
+    nothing to read, so every declared artifact shows as pending even after its
+    worker has written it and the viewer is watching the file exist. Answering
+    from the disk costs one stat per declared artifact and makes the panel track
+    the run instead of trailing it.
+
+    The result is marked provisional, because it is a reading taken now rather
+    than the verdict the run was judged on: artifacts may still appear, and this
+    answer is never what decides the run's status.
+    """
+    if not contract or not artifacts_path:
+        return None
+    if isinstance(contract, str):
+        try:
+            contract = json.loads(contract)
+        except ValueError:
+            return None
+    if not isinstance(contract, dict):
+        return None
+
+    from lionagi.state.artifact_verifier import ArtifactPathError, verify_artifact_contract
+
+    try:
+        result = verify_artifact_contract(contract, artifacts_root=artifacts_path)
+    except (ArtifactPathError, OSError):
+        # A contract the run itself will reject, or a root that cannot be read.
+        # Neither is this endpoint's to report: the run's own finalisation says
+        # so, and inventing a status here would put a verdict on the panel that
+        # nothing else agrees with.
+        return None
+    if result is None:
+        return None
+    return {**result, "provisional": True}
+
+
 def _run_row(s: dict[str, Any], now: float, *, process_alive: bool | None = None) -> dict[str, Any]:
     """Canonical Run row shape shared by list and detail routes."""
     from lionagi.state.health import classify_session_health
@@ -625,6 +665,11 @@ async def get_run(
     }
     alive = _session_liveness(detail_session) if detail_session.get("status") == "running" else None
     row = _run_row(detail_session, time.time(), process_alive=alive)
+
+    if row.get("artifact_verification_json") is None:
+        row["artifact_verification_json"] = _provisional_verification(
+            row.get("artifact_contract_json"), artifacts_path
+        )
 
     from . import run_tags
 

--- a/tests/studio/test_provisional_artifact_verification.py
+++ b/tests/studio/test_provisional_artifact_verification.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Artifact verification is recorded once, when a run finalises. Until then the
+run-detail panel has nothing to read and shows every declared artifact as
+pending, even ones whose file is already on disk and being watched.
+
+The detail route fills that gap by checking the disk itself, and marks the
+answer provisional so nothing mistakes a reading taken mid-run for the verdict
+the run was judged on.
+"""
+
+from __future__ import annotations
+
+import json
+
+from lionagi.studio.services.runs import _provisional_verification
+
+CONTRACT = {
+    "expected": [
+        {"id": "verdicts", "path": "VERDICTS.md", "required": True},
+        {"id": "slices", "path": "SLICES.md", "required": True},
+    ]
+}
+
+
+def test_written_artifacts_are_seen_before_the_run_finishes(tmp_path):
+    (tmp_path / "scribe").mkdir()
+    (tmp_path / "scribe" / "VERDICTS.md").write_text("rows")
+
+    result = _provisional_verification(CONTRACT, str(tmp_path))
+
+    assert result is not None
+    assert result["provisional"] is True
+    assert [p["id"] for p in result["produced"]] == ["verdicts"]
+    assert [e["id"] for e in result["missing_required"]] == ["slices"]
+
+
+def test_the_answer_is_always_marked_provisional(tmp_path):
+    """Without the flag a caller cannot tell this apart from the recorded
+    verdict, and a mid-run reading would be read as a judgement."""
+    (tmp_path / "VERDICTS.md").write_text("a")
+    (tmp_path / "SLICES.md").write_text("b")
+
+    result = _provisional_verification(CONTRACT, str(tmp_path))
+
+    assert result["status"] == "passed"
+    assert result["provisional"] is True
+
+
+def test_a_contract_stored_as_json_text_is_read(tmp_path):
+    """The column round-trips as text on one backend and as a dict on another."""
+    (tmp_path / "VERDICTS.md").write_text("a")
+
+    result = _provisional_verification(json.dumps(CONTRACT), str(tmp_path))
+
+    assert [p["id"] for p in result["produced"]] == ["verdicts"]
+
+
+def test_no_contract_produces_no_reading(tmp_path):
+    assert _provisional_verification(None, str(tmp_path)) is None
+    assert _provisional_verification({}, str(tmp_path)) is None
+
+
+def test_no_artifacts_path_produces_no_reading():
+    assert _provisional_verification(CONTRACT, None) is None
+    assert _provisional_verification(CONTRACT, "") is None
+
+
+def test_unparseable_contract_text_produces_no_reading(tmp_path):
+    assert _provisional_verification("{not json", str(tmp_path)) is None
+
+
+def test_a_contract_of_the_wrong_shape_produces_no_reading(tmp_path):
+    """A contract the run itself will reject is not this endpoint's to report;
+    inventing a status here would put a verdict on the panel that nothing else
+    agrees with."""
+    assert _provisional_verification({"expected": "not a list"}, str(tmp_path)) is None
+    assert _provisional_verification(json.dumps([1, 2, 3]), str(tmp_path)) is None
+
+
+def test_a_hostile_declared_path_produces_no_reading(tmp_path):
+    assert (
+        _provisional_verification(
+            {"expected": [{"id": "x", "path": "../escape.md"}]}, str(tmp_path)
+        )
+        is None
+    )
+
+
+def test_a_missing_artifacts_root_still_answers(tmp_path):
+    """A run whose root does not exist yet has produced nothing, which is a
+    reading rather than an error."""
+    result = _provisional_verification(CONTRACT, str(tmp_path / "not-created-yet"))
+
+    assert result is not None
+    assert result["produced"] == []
+    assert result["provisional"] is True


### PR DESCRIPTION
## The report

Several artifacts of a running play had already been written, and the expected
artifacts panel still showed every one of them as PENDING. Nothing moved while
the run was watched.

## Why

Artifact verification is computed exactly once, in the finalisation path, next to
`ended_at`. Until a run finalises, `artifact_verification_json` is null, so the
panel has nothing to read and falls back to PENDING for every declared entry.
The information was on disk the whole time; nothing was looking.

## The change

The run-detail route checks the disk itself when no verification has been
recorded. It costs one stat per declared artifact, on a single run, and only when
the recorded value is absent — a finalised run keeps reporting the verdict it was
judged on, untouched.

The reading is marked `provisional`, and the panel treats it as what it is:

- An artifact that is not there yet has not been *missed*, it has not been
  *written* yet. It stays PENDING rather than turning red. Only a recorded
  verdict can call an artifact missing.
- The header shows `N of M written` rather than a contract status. Mid-run the
  status is `failed` for every run until its last artifact lands, which says
  nothing except that the run is not over.

A contract the run would itself reject, or a root that cannot be read, produces
no reading at all rather than a fabricated status. Both are for the run's own
finalisation to report, and answering here would put a verdict on the panel that
nothing else agrees with.

No polling, no background task, no new writes to the database.

## Evidence

`tests/studio/test_provisional_artifact_verification.py` — 9 tests: the partial
mid-run state, the provisional flag, a contract stored as JSON text, no contract,
no artifacts root, unparseable text, a wrong-shaped contract, a traversal path,
and a root that does not exist yet.

`ExpectedArtifacts.test.ts` — 5 source-contract tests. Counterfactual control:
3 of the 5 fail against the pre-change component (the two that pass both ways
assert the recorded-verdict path is still reachable, which is the behaviour being
preserved rather than added).

Frontend: 39 files, 892 tests green; `tsc --noEmit` clean.
Python: `tests/studio/` green.
