### PR TITLE
fix(mcp): a run that refuses its own arguments is a refused submit

### DIFF
--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -918,6 +918,17 @@ async def _run_one(entry: Any) -> dict[str, Any]:
             result = _run_machine(verb, schema, args)
     except OpError as exc:
         return _op_error(name, exc, schema)
+    except jobs.SpawnError as exc:
+        # A run that could not start, or that refused its own arguments and died
+        # immediately. The caller asked for a run and does not have one, so this
+        # is their answer rather than an exception that takes the whole batch
+        # down with it. The run_id rides along because a record was written
+        # before the failure and its log holds the cause.
+        return _op_error(
+            name,
+            OpError("invalid_input", str(exc), detail={"run_id": exc.run_id}),
+            schema,
+        )
     except projection.SchemaProjectionError as exc:
         return _op_error(name, OpError("unavailable", str(exc)), None)
     except (ValueError, TypeError, KeyError, OSError) as exc:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -39,6 +39,7 @@ import signal
 import stat
 import subprocess
 import sys
+import time
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -70,6 +71,15 @@ _KIND_ARGV: dict[str, list[str]] = {
 # reported verbatim and classified as a failure, because the failure mode of a
 # stale success list is a timeout or an empty completion read back as a success.
 _SUCCEEDED_STATUSES = frozenset({"completed"})
+
+# How long a just-spawned child is watched for an immediate refusal, and how
+# often it is checked. Two measured startup deaths (an over-long instruction and
+# a malformed artifact contract) both wrote their cause and exited within one
+# second of the spawn, so a three-second window covers that class with room for a
+# slower machine. A healthy run pays the window once, against a submit that goes
+# on to take minutes.
+_EARLY_EXIT_WATCH_SECONDS = 3.0
+_EARLY_EXIT_POLL_SECONDS = 0.05
 
 # Statuses that mean the run was stopped on purpose. Separated from failure
 # because "someone cancelled this" and "this went wrong" call for different
@@ -1224,6 +1234,19 @@ def submit(
     latest["spawn_state"] = "started"
     _write_job(latest)
 
+    # A child that refuses its own arguments dies here, in the first second,
+    # before it is far enough along to be anything the notify hook can report:
+    # the hook runs in the child, so a child that never got past parsing its
+    # instruction has nothing left to run it. Without this the submit returns a
+    # run_id and a live pid for a run that is already dead, and the caller waits
+    # for a notice that cannot come.
+    #
+    # The cause is in the log the whole time. Watch briefly, and if the child is
+    # gone, put it on the record and hand it back to the caller as a refusal.
+    early = _refusal_from_early_exit(proc, run_id, log_path)
+    if early is not None:
+        raise early
+
     # The handle carries the same three lifecycle fields every other
     # status-bearing response does, so a caller never has to classify the status
     # string itself — including in the narrow case where the child reached a
@@ -1245,6 +1268,62 @@ def submit(
         "mcp_config_reason": mcp_config_reason,
         "notify_sender": notify_sender,
     }
+
+
+def _refusal_from_early_exit(
+    proc: subprocess.Popen, run_id: str, log_path: Path
+) -> SpawnError | None:
+    """Watch a just-spawned child briefly and turn an immediate failure into a
+    refused submit, or return None and let the run proceed.
+
+    Anything the child decides about its own arguments — an unparseable spec, a
+    field out of range, an instruction longer than the surface accepts — is
+    decided within the first moment and ends the process. That death happens
+    before the run exists in any sense the terminal hook can report, because the
+    hook is the child; so the record keeps saying "running" against a pid that
+    is already gone, and the caller waits on a notice nothing will ever send.
+    Measured on two such deaths: both wrote their cause and exited inside one
+    second of the spawn.
+
+    Only a NON-ZERO exit is a refusal. A child that exits cleanly in the window
+    did the work and finished; its own terminal path has already recorded that,
+    and rewriting it here would turn a fast success into a failure.
+
+    A live child costs the full window once, which buys back the minutes a
+    director would otherwise spend waiting on a corpse.
+    """
+    deadline = time.monotonic() + _EARLY_EXIT_WATCH_SECONDS
+    while True:
+        code = proc.poll()
+        if code is not None:
+            break
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(_EARLY_EXIT_POLL_SECONDS)
+
+    if code == 0:
+        return None
+
+    # The child wrote why before it went. Prefer that to the exit status, which
+    # only says that something was refused and never which thing.
+    detail = (_tail(str(log_path), limit=1000) or "").strip()
+    reason = f"run refused at startup (exit {code})"
+    if detail:
+        reason = f"{reason}: {detail}"
+
+    record = _read_job(run_id) or {"run_id": run_id}
+    record.update(
+        {
+            "status": "failed",
+            "finished_at": _now_iso(),
+            "reason": reason,
+        }
+    )
+    try:
+        _write_job(record)
+    except OSError:
+        pass
+    return SpawnError(run_id, record, reason)
 
 
 def _record_spawn_failure(run_id: str, exc: Exception) -> SpawnError:

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from lionagi.mcp import jobs
+
+
+@pytest.fixture(autouse=True)
+def short_startup_watch(monkeypatch):
+    """Shorten, but do not disable, submit()'s startup-refusal watch.
+
+    submit() watches a fresh child for a few seconds so a run that dies on its
+    own arguments comes back as a refused submit rather than as a run id. Most
+    tests here spawn a double that never exits, so each one would otherwise sit
+    out the full window.
+
+    Shortened rather than switched off on purpose: at zero the watch would be
+    skipped entirely and every one of these tests would keep passing with the
+    mechanism removed. At a few milliseconds it still runs, and a test that
+    needs the real timing sets its own value.
+    """
+    monkeypatch.setattr(jobs, "_EARLY_EXIT_WATCH_SECONDS", 0.01)

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -36,6 +36,11 @@ class _FakeProc:
     def __init__(self, pid: int = 4242) -> None:
         self.pid = pid
 
+    def poll(self):
+        """Still running. submit() watches a fresh child briefly for a startup
+        refusal, and a double that models a live spawn has to be able to say so."""
+        return None
+
 
 def test_new_run_id_format():
     rid = jobs.new_run_id()

--- a/tests/mcp/test_spawn_mcp_snapshot.py
+++ b/tests/mcp/test_spawn_mcp_snapshot.py
@@ -30,6 +30,11 @@ class _FakeProc:
     def __init__(self, pid: int = 4242) -> None:
         self.pid = pid
 
+    def poll(self):
+        """Still running. submit() watches a fresh child briefly for a startup
+        refusal, and a double that models a live spawn has to be able to say so."""
+        return None
+
 
 @pytest.fixture
 def submit_dir(monkeypatch, tmp_path):

--- a/tests/mcp/test_spawn_mcp_snapshot_flow_fanout.py
+++ b/tests/mcp/test_spawn_mcp_snapshot_flow_fanout.py
@@ -38,6 +38,11 @@ class _FakeProc:
     def __init__(self, pid: int = 4242) -> None:
         self.pid = pid
 
+    def poll(self):
+        """Still running. submit() watches a fresh child briefly for a startup
+        refusal, and a double that models a live spawn has to be able to say so."""
+        return None
+
 
 @pytest.fixture
 def submit_dir(monkeypatch, tmp_path):

--- a/tests/mcp/test_submit_refuses_a_startup_death.py
+++ b/tests/mcp/test_submit_refuses_a_startup_death.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A child that refuses its own arguments dies in the first second, before it is
+far enough along to report anything: the terminal notify hook runs in the child,
+so a child that never got past parsing its instruction has nothing left to run
+it.
+
+Measured, on two real deaths minutes apart, both from the same submit surface:
+
+    run 20260727T193608-efe5e6
+      log: "spec field 'artifacts' is invalid: artifact contract must be a dict, got list"
+    run 20260727T194158-cd9b08
+      log: "spec field 'prompt' exceeds maximum length of 8192 characters"
+
+Two different causes, one identical outward signature — a run_id, a live-looking
+pid, status running, notify_delivery null — and in both cases the cause was
+sitting in the log the whole time and reached nobody. A caller handed the message
+fixes it in seconds; a caller handed a run id waits, and resubmits blind.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from lionagi.mcp import jobs
+
+
+@pytest.fixture
+def job_home(tmp_path, monkeypatch):
+    # The package conftest shortens the watch for tests that fake the spawn.
+    # These spawn real children, so they need a window long enough for a process
+    # to start and exit on a loaded machine.
+    monkeypatch.setattr(jobs, "_EARLY_EXIT_WATCH_SECONDS", 10.0)
+    monkeypatch.setattr(jobs.config, "job_dir", lambda run_id: tmp_path / run_id)
+    return tmp_path
+
+
+def _spawn(script: str, job_home, run_id: str = "test-run"):
+    """Run a real child that behaves like the CLI would, and hand it to the
+    watcher exactly as submit() does."""
+    d = job_home / run_id
+    d.mkdir(parents=True, exist_ok=True)
+    log_path = d / "console.log"
+    with open(log_path, "wb") as log_f:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+        )
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": proc.pid,
+            "kind": "play",
+            "status": "running",
+            "spawn_state": "started",
+            "log": str(log_path),
+            "submitted_at": jobs._now_iso(),
+            "finished_at": None,
+        }
+    )
+    return proc, log_path
+
+
+_DIES_AT_VALIDATION = (
+    "import sys; "
+    "sys.stdout.write(\"error: spec field 'prompt' exceeds maximum length of 8192 characters\\n\"); "
+    "sys.stdout.flush(); "
+    "sys.exit(2)"
+)
+
+
+def test_a_startup_death_becomes_a_refusal_carrying_the_cause(job_home):
+    proc, log_path = _spawn(_DIES_AT_VALIDATION, job_home)
+
+    refusal = jobs._refusal_from_early_exit(proc, "test-run", log_path)
+
+    assert refusal is not None
+    assert "exceeds maximum length of 8192" in str(refusal)
+    assert refusal.run_id == "test-run"
+
+
+def test_the_record_stops_claiming_the_run_is_going(job_home):
+    """The whole failure is a record that reads as running against a dead pid.
+    Both halves have to change: the caller is told, and the record agrees."""
+    proc, log_path = _spawn(_DIES_AT_VALIDATION, job_home)
+
+    jobs._refusal_from_early_exit(proc, "test-run", log_path)
+
+    record = jobs._read_job("test-run")
+    assert record["status"] == "failed"
+    assert record["finished_at"] is not None
+    assert "8192" in record["reason"]
+
+
+def test_the_log_is_kept_rather_than_cleared(job_home):
+    """The cause is evidence. A refusal that deletes it leaves the caller with a
+    message and nothing to go back to."""
+    proc, log_path = _spawn(_DIES_AT_VALIDATION, job_home)
+
+    jobs._refusal_from_early_exit(proc, "test-run", log_path)
+
+    assert "8192" in log_path.read_text()
+
+
+def test_a_different_cause_comes_through_verbatim(job_home):
+    """The second measured death. The watcher must not classify causes, only
+    carry them: it cannot know what the next spec defect will be."""
+    script = (
+        "import sys; "
+        "sys.stdout.write(\"error: spec field 'artifacts' is invalid: "
+        'artifact contract must be a dict, got list\\n"); '
+        "sys.stdout.flush(); "
+        "sys.exit(2)"
+    )
+    proc, log_path = _spawn(script, job_home)
+
+    refusal = jobs._refusal_from_early_exit(proc, "test-run", log_path)
+
+    assert "artifact contract must be a dict, got list" in str(refusal)
+
+
+def test_a_silent_failure_still_refuses(job_home):
+    """A child that dies without explaining itself is still a death. The exit
+    status is a poor cause but it is not nothing."""
+    proc, log_path = _spawn("import sys; sys.exit(3)", job_home)
+
+    refusal = jobs._refusal_from_early_exit(proc, "test-run", log_path)
+
+    assert refusal is not None
+    assert "exit 3" in str(refusal)
+
+
+def test_a_child_that_finishes_cleanly_is_not_a_refusal(job_home):
+    """A fast success is a success. Its own terminal path has already recorded
+    it, and rewriting it here would turn finished work into a failure."""
+    proc, log_path = _spawn("pass", job_home)
+
+    assert jobs._refusal_from_early_exit(proc, "test-run", log_path) is None
+    assert jobs._read_job("test-run")["status"] == "running"
+
+
+def test_a_live_child_is_left_alone(job_home, monkeypatch):
+    """The ordinary case: the run gets past its arguments and keeps going. The
+    watcher gives up at its deadline and reports nothing."""
+    monkeypatch.setattr(jobs, "_EARLY_EXIT_WATCH_SECONDS", 0.3)
+    proc, log_path = _spawn("import time; time.sleep(30)", job_home)
+    try:
+        assert jobs._refusal_from_early_exit(proc, "test-run", log_path) is None
+        assert jobs._read_job("test-run")["status"] == "running"
+    finally:
+        proc.kill()
+        proc.wait()
+
+
+def test_the_watch_is_bounded(job_home, monkeypatch):
+    """A run that outlives the window must not hold the submit open for the
+    length of the run."""
+    monkeypatch.setattr(jobs, "_EARLY_EXIT_WATCH_SECONDS", 0.2)
+    proc, log_path = _spawn("import time; time.sleep(30)", job_home)
+    try:
+        import time as _time
+
+        started = _time.monotonic()
+        jobs._refusal_from_early_exit(proc, "test-run", log_path)
+        elapsed = _time.monotonic() - started
+    finally:
+        proc.kill()
+        proc.wait()
+
+    assert elapsed < 2.0
+
+
+def test_a_death_after_the_window_is_not_this_watchers_business(job_home, monkeypatch):
+    """Deliberately bounded: a run that dies minutes in has a terminal hook to
+    report it. Widening this window to cover that case would hold every submit
+    open for the length of the run."""
+    monkeypatch.setattr(jobs, "_EARLY_EXIT_WATCH_SECONDS", 0.2)
+    proc, log_path = _spawn("import time; time.sleep(2); raise SystemExit(2)", job_home)
+    try:
+        assert jobs._refusal_from_early_exit(proc, "test-run", log_path) is None
+    finally:
+        proc.wait()
+
+
+# ── The same thing through submit(), which is where a caller meets it ─────────
+
+
+def test_submit_refuses_rather_than_handing_back_a_dead_run(tmp_path, monkeypatch):
+    """End to end: the surface a director actually calls. Before this, submit()
+    returned a run_id, a pid and status running for a run that was already
+    gone."""
+    monkeypatch.setattr(jobs, "_EARLY_EXIT_WATCH_SECONDS", 10.0)
+    monkeypatch.setattr(jobs.config, "job_dir", lambda run_id: tmp_path / run_id)
+    monkeypatch.setattr(
+        jobs.config,
+        "li_command",
+        lambda: [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.write(\"error: spec field 'prompt' exceeds maximum "
+            'length of 8192 characters\\n"); sys.exit(2)',
+        ],
+    )
+
+    with pytest.raises(jobs.SpawnError) as exc_info:
+        jobs.submit("play", ["-p", "some-playbook"], no_mcp_config=True)
+
+    assert "8192" in str(exc_info.value)
+    assert exc_info.value.record["status"] == "failed"
+
+
+def test_submit_still_returns_a_handle_for_a_run_that_starts(tmp_path, monkeypatch):
+    """The counterfactual that matters: the refusal must not swallow ordinary
+    submits. A run that gets past its arguments comes back as a handle."""
+    monkeypatch.setattr(jobs, "_EARLY_EXIT_WATCH_SECONDS", 0.2)
+    monkeypatch.setattr(jobs.config, "job_dir", lambda run_id: tmp_path / run_id)
+    monkeypatch.setattr(
+        jobs.config, "li_command", lambda: [sys.executable, "-c", "import time; time.sleep(30)"]
+    )
+
+    handle = jobs.submit("play", ["-p", "some-playbook"], no_mcp_config=True)
+    try:
+        assert handle["status"] == "running"
+        assert handle["spawn_state"] == "started"
+        assert handle["pid"] > 0
+    finally:
+        import os
+        import signal
+
+        os.kill(handle["pid"], signal.SIGKILL)

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -27,6 +27,11 @@ class _FakeProc:
     def __init__(self, pid: int = 4242) -> None:
         self.pid = pid
 
+    def poll(self):
+        """Still running. submit() watches a fresh child briefly for a startup
+        refusal, and a double that models a live spawn has to be able to say so."""
+        return None
+
 
 def _record(rid: str, **fields) -> None:
     base = {


### PR DESCRIPTION
## What happened

Two play submits died at startup within fifteen minutes of each other, from
different causes, and neither told anyone. Both returned a run id, a pid, and
`status: running`. Both were already dead. The director waited.

```
run 20260727T193608-efe5e6
  log: "spec field 'artifacts' is invalid: artifact contract must be a dict, got list"
run 20260727T194158-cd9b08
  log: "spec field 'prompt' exceeds maximum length of 8192 characters"
```

Same outward signature in both cases: `status: exited`, `terminal: false`,
`finished_at: null`, `notify_delivery: null`, `possibly_orphaned: true`,
`alive: false`, `pid_identity: null`. Directory timestamps put both deaths
inside one second of the spawn.

## Why nothing reported it

The terminal notify hook runs *in the child*. A child that never got past
parsing its own instruction has nothing left to run the hook, so it can never
report anything. The submit had already returned a handle by then, and the
record it wrote before spawning still said `running`.

The cause was never missing. It was in the log the whole time, correctly
written. Nothing pointed at it.

## The change

`submit()` watches a fresh child briefly. If it is gone, the record is marked
and the failure is handed back to the caller as a refusal carrying what the
child actually said:

```
run refused at startup (exit 2): error: spec field 'prompt' exceeds maximum
length of 8192 characters
```

A caller handed that message fixes it in seconds. A caller handed a run id
resubmits blind, which is what happened three times in fifteen minutes.

Deliberate limits:

- **Only a non-zero exit refuses.** A child that finishes cleanly inside the
  window did the work; its own terminal path recorded that, and rewriting it
  here would turn a fast success into a failure.
- **The window is bounded** (3s, from two measured sub-second deaths, with room
  for a slower machine). A run that dies minutes in has a terminal hook to
  report it. Widening this to cover that case would hold every submit open for
  the length of the run.
- **The cause is carried, never classified.** The watcher cannot know what the
  next spec defect will be, so it reports the child's own words.
- **The log is kept.** A refusal that cleared its own evidence would leave the
  caller a message and nothing to go back to.
- **The record stays,** marked failed with the reason, rather than being
  deleted. The caller gets the error either way, and deleting would throw away
  the log that explains it.

`dispatch` converts the refusal into an ordinary per-op error carrying the run
id. `SpawnError` is a `RuntimeError` and was not in the caught set, so before
this a spawn failure escaped `request()` entirely and took the whole batch with
it — reachable already, and much more reachable now.

A healthy submit pays the window once, against a run that goes on for minutes.

## Evidence

`tests/mcp/test_submit_refuses_a_startup_death.py` — 11 tests, spawning real
child processes rather than mocking the spawn: both measured causes carried
verbatim, a silent non-zero exit, a clean exit that must not be refused, a live
child left alone, the bound actually holding, a late death correctly ignored,
the record marked, the log preserved, and end to end through `submit()` in both
directions.

The four existing `_FakeProc` doubles gained `poll()` returning `None` — they
model a live spawn, and now have to be able to say so. `tests/mcp/conftest.py`
shortens the watch to 10ms for those tests rather than disabling it, so the
suite does not keep passing with the mechanism removed.

`tests/mcp/`, `tests/state/lifecycle/`, `tests/apps_studio_server/`: green.
