### PR TITLE
fix(cli): one spec-prompt limit, far enough out that no real prompt reaches it

### DIFF
--- a/lionagi/_spec_limits.py
+++ b/lionagi/_spec_limits.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Bounds shared by every surface that validates an orchestration spec.
+
+Deliberately importing nothing. Three modules read from here — the CLI spec
+validator and the two Studio services — and two of those are request-path
+services whose import cost is paid on startup. A constant that arrives with a
+module graph behind it charges every one of them for a number.
+"""
+
+from __future__ import annotations
+
+# How long a spec file's prompt may be, in characters.
+#
+# One number, read by every surface that validates a spec. It used to be written
+# out three times, which meant three chances for them to disagree and no way to
+# raise it in one place.
+#
+# The bound exists for the pathological file, not for the long prompt. An
+# orchestration prompt carries the whole task — the brief, the constraints, the
+# exit criteria — and a real one had already been squeezed to fit the old 8192,
+# which is close enough to normal writing that an ordinary edit could push a
+# working spec over it and kill the run at submit. Set far enough out that no
+# honest spec reaches it, while still refusing a file that is not a prompt.
+MAX_SPEC_PROMPT_CHARS = 256 * 1024

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from lionagi._errors import TimeoutError as LionTimeoutError
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.libs.path_safety import validate_path_component as validate_path_component
 from lionagi.ln.concurrency import is_cancelled, run_async
 
@@ -16,7 +17,6 @@ from .._logging import hint, log_error
 from .._providers import add_common_cli_args
 from .._util import EXIT_CODE_BY_STATUS
 from ._checkpoint import FlowResumeError
-from ._common import MAX_SPEC_PROMPT_CHARS
 from .fanout import FanoutPlanError, _run_fanout
 from .flow import FlowPlanError, _resume_flow, _run_flow
 

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -16,6 +16,7 @@ from .._logging import hint, log_error
 from .._providers import add_common_cli_args
 from .._util import EXIT_CODE_BY_STATUS
 from ._checkpoint import FlowResumeError
+from ._common import MAX_SPEC_PROMPT_CHARS
 from .fanout import FanoutPlanError, _run_fanout
 from .flow import FlowPlanError, _resume_flow, _run_flow
 
@@ -431,8 +432,10 @@ def _validate_spec_fields(spec: dict) -> str | None:
         prompt = spec["prompt"]
         if not isinstance(prompt, str):
             return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
-        if len(prompt) > 8192:
-            return "spec field 'prompt' exceeds maximum length of 8192 characters"
+        if len(prompt) > MAX_SPEC_PROMPT_CHARS:
+            return (
+                f"spec field 'prompt' exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters"
+            )
 
     if "save" in spec:
         save = spec["save"]

--- a/lionagi/cli/orchestrate/_common.py
+++ b/lionagi/cli/orchestrate/_common.py
@@ -12,6 +12,21 @@ from lionagi.ln._utils import now_utc
 from .. import team as _team_module
 from ..team import _locked_team
 
+# How long a spec file's prompt may be, in characters.
+#
+# One number, read by every surface that validates a spec: the CLI, the Studio
+# playbook service, and the Studio schedule service. It used to be written out
+# three times, which meant three chances for them to disagree and no way to
+# raise it in one place.
+#
+# The bound exists for the pathological file, not for the long prompt. An
+# orchestration prompt carries the whole task — the brief, the constraints, the
+# exit criteria — and a real one had already been squeezed to fit the old 8192,
+# which is close enough to normal writing that an ordinary edit could push a
+# working spec over it and kill the run at submit. Set far enough out that no
+# honest spec reaches it, while still refusing a file that is not a prompt.
+MAX_SPEC_PROMPT_CHARS = 256 * 1024
+
 # ── Output formatting ─────────────────────────────────────────────────────
 
 

--- a/lionagi/cli/orchestrate/_common.py
+++ b/lionagi/cli/orchestrate/_common.py
@@ -12,21 +12,6 @@ from lionagi.ln._utils import now_utc
 from .. import team as _team_module
 from ..team import _locked_team
 
-# How long a spec file's prompt may be, in characters.
-#
-# One number, read by every surface that validates a spec: the CLI, the Studio
-# playbook service, and the Studio schedule service. It used to be written out
-# three times, which meant three chances for them to disagree and no way to
-# raise it in one place.
-#
-# The bound exists for the pathological file, not for the long prompt. An
-# orchestration prompt carries the whole task — the brief, the constraints, the
-# exit criteria — and a real one had already been squeezed to fit the old 8192,
-# which is close enough to normal writing that an ordinary edit could push a
-# working spec over it and kill the run at submit. Set far enough out that no
-# honest spec reaches it, while still refusing a file that is not a prompt.
-MAX_SPEC_PROMPT_CHARS = 256 * 1024
-
 # ── Output formatting ─────────────────────────────────────────────────────
 
 

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -10,6 +10,7 @@ import yaml
 from fastapi import Body, HTTPException
 
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
+from lionagi.cli.orchestrate._common import MAX_SPEC_PROMPT_CHARS
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 
 from ..registry import studio_route
@@ -81,8 +82,10 @@ def _check_spec_fields(spec: dict[str, Any]) -> str | None:
         prompt = spec["prompt"]
         if not isinstance(prompt, str):
             return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
-        if len(prompt) > 8192:
-            return "spec field 'prompt' exceeds maximum length of 8192 characters"
+        if len(prompt) > MAX_SPEC_PROMPT_CHARS:
+            return (
+                f"spec field 'prompt' exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters"
+            )
 
     if "save" in spec:
         save = spec["save"]

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -10,7 +10,7 @@ import yaml
 from fastapi import Body, HTTPException
 
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
-from lionagi.cli.orchestrate._common import MAX_SPEC_PROMPT_CHARS
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 
 from ..registry import studio_route

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -18,7 +18,7 @@ from fastapi import HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
-from lionagi.cli.orchestrate._common import MAX_SPEC_PROMPT_CHARS
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 from lionagi.state.db import StateDB, state_db_known_absent
 

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
+from lionagi.cli.orchestrate._common import MAX_SPEC_PROMPT_CHARS
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 from lionagi.state.db import StateDB, state_db_known_absent
 
@@ -374,8 +375,10 @@ def _validate_flow_yaml_spec(yaml_text: str) -> str | None:
         prompt = spec["prompt"]
         if not isinstance(prompt, str):
             return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
-        if len(prompt) > 8192:
-            return "spec field 'prompt' exceeds maximum length of 8192 characters"
+        if len(prompt) > MAX_SPEC_PROMPT_CHARS:
+            return (
+                f"spec field 'prompt' exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters"
+            )
 
     if "save" in spec:
         save = spec["save"]

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -14,6 +14,7 @@ from lionagi.cli.orchestrate import (
     add_orchestrate_subparser,
     run_orchestrate,
 )
+from lionagi.cli.orchestrate._common import MAX_SPEC_PROMPT_CHARS
 
 
 def _parse_flow_args(argv: list[str]) -> argparse.Namespace:
@@ -99,7 +100,7 @@ class TestSpecValidationRejectsBadTypes:
         assert err is not None
 
     def test_prompt_too_long(self):
-        err = _validate_spec_fields({"prompt": "x" * 8193})
+        err = _validate_spec_fields({"prompt": "x" * (MAX_SPEC_PROMPT_CHARS + 1)})
         assert err is not None
         assert "prompt" in err
 
@@ -213,7 +214,7 @@ class TestSpecValidationAcceptsValidFields:
         assert _validate_spec_fields({"prompt": "Do the thing"}) is None
 
     def test_prompt_at_max_length(self):
-        assert _validate_spec_fields({"prompt": "x" * 8192}) is None
+        assert _validate_spec_fields({"prompt": "x" * MAX_SPEC_PROMPT_CHARS}) is None
 
     def test_valid_string_fields(self):
         spec = {

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -9,12 +9,12 @@ from unittest.mock import AsyncMock, patch
 
 import yaml
 
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.cli.orchestrate import (
     _validate_spec_fields,
     add_orchestrate_subparser,
     run_orchestrate,
 )
-from lionagi.cli.orchestrate._common import MAX_SPEC_PROMPT_CHARS
 
 
 def _parse_flow_args(argv: list[str]) -> argparse.Namespace:

--- a/tests/cli/orchestrate/test_spec_prompt_cap.py
+++ b/tests/cli/orchestrate/test_spec_prompt_cap.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 
 import yaml
 
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.cli.orchestrate import _validate_spec_fields
-from lionagi.cli.orchestrate._common import MAX_SPEC_PROMPT_CHARS
 from lionagi.studio.services.playbooks import _check_spec_fields
 from lionagi.studio.services.schedules import _validate_flow_yaml_spec
 

--- a/tests/cli/orchestrate/test_spec_prompt_cap.py
+++ b/tests/cli/orchestrate/test_spec_prompt_cap.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Three surfaces validate a spec's prompt: the CLI, the Studio playbook
+service, and the Studio schedule service. The bound they check against used to
+be written out three times, so there was no single place to raise it and no
+guarantee the three agreed.
+
+The bound is for the pathological file, not the long prompt. An orchestration
+prompt carries the whole task, and at the old 8192 characters a real one had
+already been squeezed to fit — close enough to normal writing that an ordinary
+edit to a working spec could kill the run at submit.
+
+The schedule surface takes YAML text rather than a mapping, so it is called
+through a wrapper here. That difference is the reason the three could drift
+apart unnoticed, which is what these tests are for.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from lionagi.cli.orchestrate import _validate_spec_fields
+from lionagi.cli.orchestrate._common import MAX_SPEC_PROMPT_CHARS
+from lionagi.studio.services.playbooks import _check_spec_fields
+from lionagi.studio.services.schedules import _validate_flow_yaml_spec
+
+
+def _schedule_spec(spec: dict) -> str | None:
+    """Feed the schedule surface the same spec through the shape it accepts."""
+    return _validate_flow_yaml_spec(yaml.safe_dump(spec, width=10**9))
+
+
+ALL_SURFACES = (
+    ("cli", _validate_spec_fields),
+    ("playbook", _check_spec_fields),
+    ("schedule", _schedule_spec),
+)
+
+
+def test_the_bound_is_far_from_anything_a_prompt_reaches():
+    """The old 8192 was reachable by writing. This one is not: a prompt would
+    have to be a file that is not a prompt."""
+    assert MAX_SPEC_PROMPT_CHARS == 256 * 1024
+
+
+def test_a_prompt_that_the_old_cap_refused_is_accepted_everywhere():
+    """The squeeze this fixes: a working playbook cut down to fit 8192."""
+    prompt = "x" * 20000
+
+    for name, validate in ALL_SURFACES:
+        assert validate({"prompt": prompt}) is None, name
+
+
+def test_every_surface_refuses_at_the_same_length():
+    """The point of one constant. Three copies could drift, and a spec accepted
+    by the CLI but refused by a schedule fails at the least useful moment."""
+    over = "x" * (MAX_SPEC_PROMPT_CHARS + 1)
+
+    for name, validate in ALL_SURFACES:
+        error = validate({"prompt": over})
+        assert error is not None, name
+        assert str(MAX_SPEC_PROMPT_CHARS) in error, name
+
+
+def test_a_prompt_exactly_at_the_bound_is_accepted():
+    at = "x" * MAX_SPEC_PROMPT_CHARS
+
+    for name, validate in ALL_SURFACES:
+        assert validate({"prompt": at}) is None, name
+
+
+def test_the_message_names_the_real_number():
+    """A refusal that names a stale number sends the author to trim against a
+    bound that is not the one being enforced."""
+    error = _validate_spec_fields({"prompt": "x" * (MAX_SPEC_PROMPT_CHARS + 1)})
+
+    assert "8192" not in error
+    assert str(MAX_SPEC_PROMPT_CHARS) in error
+
+
+def test_a_non_string_prompt_is_still_refused():
+    """Raising the bound does not loosen the type check that sits above it."""
+    for name, validate in ALL_SURFACES:
+        error = validate({"prompt": 12345})
+        assert error is not None, name
+        assert "string" in error, name


### PR DESCRIPTION
## What

The spec-file prompt length check existed in three copies — the CLI spec validator, the Studio playbook service, and the Studio schedule service — each spelling out `8192` twice, once in the comparison and once in the message. They now read one constant, `MAX_SPEC_PROMPT_CHARS`, raised to 256 KiB.

## Why

Two separate problems, one cause.

**Three copies drift.** There is no place to change the limit, and nothing stops the three from disagreeing. A spec the CLI accepts but a schedule refuses fails at the least useful moment — after it was written, saved, and scheduled.

**8192 is inside the range of ordinary writing.** An orchestration prompt carries the whole task: the brief, the constraints, the exit criteria. A real playbook had already been cut down to fit under the old limit, which means the next ordinary edit to it would have pushed it back over and killed the run at submit time. The failure would land on whoever next improved the prompt, not on whoever wrote the cap.

256 KiB keeps a bound against a file that is not a prompt while putting it far enough out that no honest spec reaches it.

The inline `--prompt` argument stays uncapped. It never had a cap, and this change does not add one.

## Tests

`tests/cli/orchestrate/test_spec_prompt_cap.py` drives all three surfaces through one parametrised list, so a future copy that drifts fails here rather than in production. The schedule surface takes YAML text rather than a mapping, which is exactly the shape difference that let the three fall out of step unnoticed, so it is exercised through that shape.

Covered: a 20000-character prompt the old cap refused is accepted on all three; all three refuse at the same length and name the enforced number; exactly-at-the-bound is accepted; the refusal message no longer names 8192; a non-string prompt is still refused.

Two existing assertions in `test_security_hardening.py` were pinned to the literal `8192` and now read the constant.