### PR TITLE
fix(mcp): a notice that could not be delivered shows up where callers wait

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -698,7 +698,10 @@ list), and `notify_seat` fills the `{target}` placeholder. The environment
 variables `LIONAGI_MCP_NOTIFY_COMMAND` and `LIONAGI_MCP_NOTIFY_TARGET` set a
 process-wide default. Delivery outcome is recorded on the job and surfaced in
 `job.status` (`notify_delivery`), so a notice that failed to send is visible
-rather than silently lost.
+rather than silently lost. `job.list` carries the same outcome collapsed to one
+word in `notify_delivery_state` — `delivered`, `failed`, or `none` when no
+notifier was configured — so a run whose notice never went out is spotted while
+scanning runs, not only when one is looked up.
 
 ---
 

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -131,7 +131,11 @@ def _delivery_env(sender: str) -> dict[str, str] | None:
 
 
 def _deliver(
-    argv: list[str], payload: dict[str, str], env: dict[str, str] | None = None
+    argv: list[str],
+    payload: dict[str, str],
+    env: dict[str, str] | None = None,
+    *,
+    program: str | None = None,
 ) -> dict[str, Any]:
     """Run the delivery command best-effort; return its outcome for the record.
 
@@ -140,6 +144,13 @@ def _deliver(
     fail silently would cost the detached-spawn pattern its reliability. Only
     the exit code is kept: the command's stdout/stderr is free text that can
     carry a credential, so it goes to DEVNULL and is never captured.
+
+    *program* is recorded alongside it so the record names which notifier this
+    was. It is the program token of the configured argv template, before any run
+    field is substituted into it — operator configuration, which whoever wrote it
+    can already read, and not something the command produced at runtime. That is
+    the whole difference: it says *what* failed without keeping a byte of what
+    the command said, which stays discarded.
     """
     try:
         proc = subprocess.run(  # noqa: S603 — argv is the operator-configured delivery command, no shell
@@ -153,13 +164,23 @@ def _deliver(
             env=env,
         )
     except (OSError, subprocess.SubprocessError) as exc:
-        # never fail the run's terminal path; record the failure instead
-        return {"attempted": True, "ok": False, "exit_code": None, "error": type(exc).__name__}
+        # never fail the run's terminal path; record the failure instead.
+        # The exception *type* names how the delivery came apart — never started,
+        # or ran past the timeout — and the exception's message is left out: it
+        # is the one string here whose content this hook does not choose.
+        return {
+            "attempted": True,
+            "ok": False,
+            "exit_code": None,
+            "error": type(exc).__name__,
+            "command": program,
+        }
     return {
         "attempted": True,
         "ok": proc.returncode == 0,
         "exit_code": proc.returncode,
         "error": None,
+        "command": program,
     }
 
 
@@ -218,6 +239,10 @@ def main(argv: list[str] | None = None) -> int:
         args.command or os.environ.get("LIONAGI_MCP_NOTIFY_COMMAND"),
         cwd=(job or {}).get("cwd"),
     )
+    # Taken before the sender check below can drop the template: a notifier
+    # refused for want of a sender is one an operator most wants named, and the
+    # program token is the only part of it that survives the refusal.
+    program = template[0] if template else None
     if template and not sender and any("{sender}" in tok for tok in template):
         # The command asks who the notice is from and there is no answer. An
         # empty string is not one: it puts a blank where an identity belongs,
@@ -235,12 +260,22 @@ def main(argv: list[str] | None = None) -> int:
             "target": target,
             "sender": sender,
         }
-        outcome = _deliver(_substitute(template, fields), fields, _delivery_env(sender))
+        outcome = _deliver(
+            _substitute(template, fields), fields, _delivery_env(sender), program=program
+        )
     elif unusable:
         # Configured but unusable. Recorded as a failure so job_status shows a
         # notifier that cannot deliver, rather than the silence of one that was
-        # never asked to.
-        outcome = {"attempted": False, "ok": False, "exit_code": None, "error": unusable}
+        # never asked to. ``command`` is None when the configuration never
+        # yielded a program to name — an unparseable override has no program in
+        # it, and saying so beats inventing one.
+        outcome = {
+            "attempted": False,
+            "ok": False,
+            "exit_code": None,
+            "error": unusable,
+            "command": program,
+        }
     else:
         outcome = {"attempted": False}  # nothing configured — not a failure
     jobs.record_notify_delivery(args.run_id, outcome)

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2070,8 +2070,45 @@ def kill(run_id: str, sig: int = signal.SIGTERM) -> dict[str, Any]:
     )
 
 
+def _notify_delivery_state(outcome: Any) -> str:
+    """One word for what became of a run's terminal notice: the listing's shape.
+
+    ``status`` reports the whole ``notify_delivery`` object, which is what someone
+    diagnosing one run needs. The listing is scanned, not read: a caller polling
+    several runs wants to spot the one whose notice failed without decoding a
+    four-field object per row, and a listing that carried the object would make
+    every caller write that decoding itself — including the rule for which
+    combinations count as a failure, which is the part worth having in one place.
+    So the listing carries this collapsed state and leaves the detail to ``status``.
+
+    ``"none"`` covers a run that has not reached a terminal yet and a terminal run
+    with no notifier configured. In both, nobody was waiting on a notice: silence
+    is the documented default and is never a failure. ``"delivered"`` is a notice
+    that went out. ``"failed"`` is every way a *configured* notifier came to
+    nothing — refused before it ran, unable to start, timed out, or exited
+    non-zero — because to a caller waiting on the notice those are one fact.
+
+    The record is JSON on disk, so an ``outcome`` that is not an object is read as
+    no delivery rather than allowed to raise through the listing.
+    """
+    if not isinstance(outcome, dict):
+        return "none"
+    if outcome.get("ok"):
+        return "delivered"
+    if not outcome.get("attempted") and not outcome.get("error"):
+        return "none"
+    return "failed"
+
+
 def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[str, Any]]:
     """Recent jobs, newest first (run_id sorts by timestamp).
+
+    ``notify_delivery_state`` says whether each run's terminal notice was
+    delivered, so a run whose notice failed is distinguishable here from one that
+    is still working. Without it this listing — the surface a caller polls while
+    waiting on several runs — reports a failed notice as no notice, and a caller
+    reads that as a run still going. A notice that could not be delivered has to
+    be visible where the waiting is done, not only on the record.
 
     An entry whose record could not be used is listed with the state of that read
     in ``record_state``, the same field ``status`` reports, so a damaged record is
@@ -2109,6 +2146,7 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
                 "submitted_at": st["submitted_at"],
                 "finished_at": st["finished_at"],
                 "record_state": st["record_state"],
+                "notify_delivery_state": _notify_delivery_state(st["notify_delivery"]),
             }
         )
         if len(out) >= limit:

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -775,3 +775,28 @@ def test_an_unlisted_kind_declaring_no_model_argument_says_so_instead_of_guessin
     assert "declares no argument this check reads as one" in message, message
     assert "per-command model sources" in message, message
     assert submitted == {}
+
+
+def test_job_list_carries_the_delivery_state_out_to_the_caller(monkeypatch, tmp_path):
+    """The verb hands the listing back whole, delivery state included.
+
+    A field the job engine adds and the verb layer then drops is a change that
+    ships and does nothing, so the property is asserted at the surface a caller
+    actually reads rather than one layer in.
+    """
+    from lionagi.mcp import config
+
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {"run_id": rid, "status": "completed", "kind": "agent", "pid": None, "log": None}
+    )
+    jobs.record_notify_delivery(
+        rid, {"attempted": True, "ok": False, "exit_code": 1, "error": None, "command": "notify"}
+    )
+
+    answer = call(ops=[{"op": "job.list", "args": {"limit": 5}}])
+
+    listed = answer["ops"][0]["result"]["jobs"]
+    assert [j["run_id"] for j in listed] == [rid]
+    assert listed[0]["notify_delivery_state"] == "failed"

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -2615,3 +2615,121 @@ def test_an_artifact_whose_metadata_is_refused_does_make_the_listing_unreadable(
 
     assert found == ["kept.txt"]
     assert state == "unreadable"
+
+
+def _terminal_run(outcome, status="completed"):
+    """A finished run carrying *outcome* as its recorded delivery result."""
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "status": status,
+            "kind": "agent",
+            "pid": None,
+            "log": None,
+            "finished_at": "2026-01-01T00:00:00Z" if status == "completed" else None,
+        }
+    )
+    if outcome is not None:
+        jobs.record_notify_delivery(rid, outcome)
+    return rid
+
+
+_DELIVERED = {"attempted": True, "ok": True, "exit_code": 0, "error": None, "command": "notify"}
+_EXITED_NONZERO = {
+    "attempted": True,
+    "ok": False,
+    "exit_code": 1,
+    "error": None,
+    "command": "notify",
+}
+_NEVER_STARTED = {
+    "attempted": True,
+    "ok": False,
+    "exit_code": None,
+    "error": "OSError",
+    "command": "notify",
+}
+_REFUSED_BEFORE_RUNNING = {
+    "attempted": False,
+    "ok": False,
+    "exit_code": None,
+    "error": "delivery_command_is_empty",
+    "command": None,
+}
+_NOTHING_CONFIGURED = {"attempted": False}
+
+
+def test_listing_tells_a_failed_notice_apart_from_a_delivered_one(sandbox):
+    """The listing distinguishes a run whose notice failed from one that is fine.
+
+    This is the surface a caller polls while waiting on several runs. Reporting
+    only the run status there leaves a finished run whose notice never went out
+    looking exactly like a run still working — the failure resolving in the
+    reassuring direction, which is the worst way for it to resolve.
+    """
+    delivered = _terminal_run(_DELIVERED)
+    exited_nonzero = _terminal_run(_EXITED_NONZERO)
+    never_started = _terminal_run(_NEVER_STARTED)
+    refused = _terminal_run(_REFUSED_BEFORE_RUNNING)
+
+    states = {j["run_id"]: j["notify_delivery_state"] for j in jobs.list_jobs()}
+    assert states[delivered] == "delivered"
+    # every way a configured notifier came to nothing reads the same here: to a
+    # caller waiting on the notice they are one fact, and status carries the rest
+    assert states[exited_nonzero] == "failed"
+    assert states[never_started] == "failed"
+    assert states[refused] == "failed"
+
+
+def test_listing_does_not_read_an_absent_notifier_as_a_failure(sandbox):
+    """Silence that was chosen, and a run not yet finished, are not failures.
+
+    Nothing configured is the documented default, so a run that asked for no
+    notice must never appear alongside the ones whose notice was lost.
+    """
+    nothing_configured = _terminal_run(_NOTHING_CONFIGURED)
+    still_running = _terminal_run(None, status="running")
+    delivered = _terminal_run(_DELIVERED)
+    failed = _terminal_run(_EXITED_NONZERO)
+
+    states = {j["run_id"]: j["notify_delivery_state"] for j in jobs.list_jobs()}
+    assert states[nothing_configured] == "none"
+    assert states[still_running] == "none"
+    # the three outcomes a caller branches on are three different words
+    assert len({states[nothing_configured], states[delivered], states[failed]}) == 3
+
+
+def test_listing_reads_a_damaged_delivery_record_as_no_delivery(sandbox):
+    """A record whose delivery field is not an object must not break the listing.
+
+    One damaged record cannot be allowed to cost the caller the runs beside it,
+    and an unreadable field is not evidence that a notice failed.
+    """
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "status": "completed",
+            "kind": "agent",
+            "pid": None,
+            "log": None,
+            "notify_delivery": "delivered!",
+        }
+    )
+
+    assert jobs.list_jobs()[0]["notify_delivery_state"] == "none"
+
+
+def test_status_still_reports_the_whole_delivery_outcome(sandbox):
+    """status is the diagnosis surface and is unchanged: it carries the object.
+
+    The listing's collapsed state is an addition to the listing, not a
+    replacement for what status has always reported.
+    """
+    rid = _terminal_run(_EXITED_NONZERO)
+
+    st = jobs.status(rid)
+    assert st["notify_delivery"] == _EXITED_NONZERO
+    # and the collapsed form stays out of status: one field, one meaning
+    assert "notify_delivery_state" not in st

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -102,6 +102,9 @@ def test_command_override_substitutes_and_delivers(job, monkeypatch):
         "ok": True,
         "exit_code": 0,
         "error": None,
+        # named from the configured template, so the record says which notifier
+        # this was without keeping anything the command itself printed
+        "command": "notify",
     }
 
 
@@ -117,6 +120,7 @@ def test_delivery_failure_is_recorded_not_silent(job, monkeypatch):
         "ok": False,
         "exit_code": 7,
         "error": None,
+        "command": "notify",
     }
 
 
@@ -427,3 +431,107 @@ def test_an_unwritable_log_does_not_break_the_terminal_path(job, monkeypatch):
 
     assert rc == 0
     assert jobs._read_job(job)["notify_delivery"]["ok"] is False
+
+
+def test_the_record_names_which_notifier_failed(job, monkeypatch):
+    """A failed delivery says which notifier it was, without keeping its output.
+
+    The exit code alone says a delivery failed; on a host with more than one
+    notifier configured over time it does not say which. The program name is
+    operator configuration, already readable by whoever wrote it, so naming it
+    costs nothing the command's own output would have cost.
+    """
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(3))
+
+    command = json.dumps(["notify-webhook", "--status", "{status}"])
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert rc == 0
+    outcome = jobs._read_job(job)["notify_delivery"]
+    assert outcome["command"] == "notify-webhook"
+    assert outcome["exit_code"] == 3 and outcome["error"] is None
+
+
+def test_the_named_program_is_the_configured_token_not_the_substituted_one(job, monkeypatch):
+    """The name comes from the template, so no run field can reach the record.
+
+    Substitution puts run fields into the argv that is spawned. Taking the name
+    from the template instead means what lands on the record is exactly the token
+    an operator wrote in their settings, whatever the run was called.
+    """
+    spawned: list = []
+    monkeypatch.setattr(
+        _notify_hook.subprocess,
+        "run",
+        lambda argv, **_k: spawned.append(argv) or _FakeCompleted(1),
+    )
+
+    command = json.dumps(["notify-{status}"])
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert rc == 0
+    assert spawned == [["notify-completed"]]  # the run's field reached the argv
+    assert jobs._read_job(job)["notify_delivery"]["command"] == "notify-{status}"
+
+
+def test_a_notifier_that_never_started_stays_tellable_from_one_that_ran(job, monkeypatch):
+    """Naming the program must not blur the two ways a delivery fails.
+
+    "the notifier is not there" and "the notifier ran and rejected this" send an
+    operator to different places, and the record has always told them apart by
+    which of exit_code / error is filled in. Adding the name leaves that intact.
+    """
+    command = json.dumps(["notify-webhook", "{status}"])
+
+    def _boom(*_a, **_k):
+        raise OSError("no such command")
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", _boom)
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+    never_started = jobs._read_job(job)["notify_delivery"]
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(3))
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+    ran_and_failed = jobs._read_job(job)["notify_delivery"]
+
+    assert never_started["command"] == ran_and_failed["command"] == "notify-webhook"
+    assert never_started["exit_code"] is None and never_started["error"] == "OSError"
+    assert ran_and_failed["exit_code"] == 3 and ran_and_failed["error"] is None
+
+
+def test_a_configuration_with_no_program_in_it_names_none(job, monkeypatch):
+    """An override that never parsed has no program, and none is invented."""
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+    _no_settings_notifier(monkeypatch)
+
+    rc = _notify_hook.main(["--run-id", job, "--status", "completed", "--command", "not json ["])
+
+    assert rc == 0
+    outcome = jobs._read_job(job)["notify_delivery"]
+    assert outcome["error"] == "delivery_command_is_not_valid_json"
+    assert outcome["command"] is None
+
+
+def test_the_delivery_commands_own_output_is_still_never_kept(job, monkeypatch):
+    """Naming the program changes nothing about what the command may say.
+
+    Its stdout and stderr are free text that can carry a credential the command
+    obtained anywhere, so the child inherits DEVNULL and the record holds only
+    fields this hook chose. Asserted here because the name is the boundary: it
+    is configuration, and everything on the far side of it stays discarded.
+    """
+    seen: dict = {}
+
+    def _run(argv, **kwargs):
+        seen.update(kwargs)
+        return _FakeCompleted(4)
+
+    monkeypatch.setattr(_notify_hook.subprocess, "run", _run)
+
+    command = json.dumps(["notify-webhook"])
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert seen["stdout"] is _notify_hook.subprocess.DEVNULL
+    assert seen["stderr"] is _notify_hook.subprocess.DEVNULL
+    outcome = jobs._read_job(job)["notify_delivery"]
+    assert set(outcome) == {"attempted", "ok", "exit_code", "error", "command"}

--- a/tests/mcp/test_notify_sender.py
+++ b/tests/mcp/test_notify_sender.py
@@ -96,6 +96,9 @@ def test_no_delivery_runs_when_the_template_needs_a_sender_and_none_was_given(
     rec = jobs._read_job(rid)
     assert rec["notify_delivery"]["attempted"] is False
     assert rec["notify_delivery"]["error"] == "delivery_command_needs_a_sender_and_none_was_given"
+    # A notifier refused for want of a sender is one an operator wants named:
+    # the template is dropped here, so the program is taken before that happens.
+    assert rec["notify_delivery"]["command"] == "notify"
 
 
 def test_a_template_that_needs_a_sender_delivers_when_one_is_given(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #2622 (first half).

A background run reaching a terminal status runs the configured delivery command, and the outcome is recorded on the job and reported by `job.status`. `job.list` builds each entry from that same `status()` call and then projects a fixed set of keys that omitted the delivery outcome — so the information was computed and dropped one line before the caller saw it.

The listing is the surface a caller polls while waiting on several runs. There a failed notice was indistinguishable from a run still going, and the failure resolved in the reassuring direction: no notice yet reads as still running.

## What changed

- `job.list` entries carry `notify_delivery_state`: `delivered`, `failed`, or `none`. Collapsed to one word because the listing is scanned rather than read, and because carrying the object would make every caller re-implement the rule for which field combinations count as a failure. `job.status` still reports the whole `notify_delivery` object for diagnosis, unchanged.
- A run with no notifier configured, and a run not yet terminal, both read `none`. The absence of a delivery attempt never reads as a failure.
- The delivery record now names the notifier: `command`, the program token of the configured argv template, taken before any run field is substituted into it.

## What deliberately did not change

The issue also asks for the delivery command's stderr to be captured, so a non-zero exit says why. That is declined on the existing reasoning in `_notify_hook.py`: a configured notifier's output is free text that can carry a credential it obtained anywhere, so it goes to DEVNULL and is never kept. The omission is a decision, not a gap. Naming which notifier failed, and keeping "could not start" tellable apart from "ran and exited non-zero", gets the diagnostic value without holding possibly-secret text in a record.

`docs/cli-reference.md` documents the new field in the same change.