### PR TITLE
fix(cli): the show detail view reads the play lifecycle instead of restating it

### DIFF
--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -636,6 +636,8 @@ async def _detail_invocation(db: Any, inv: dict[str, Any]) -> str:
 
 
 async def _detail_show(db: Any, show: dict[str, Any]) -> str:
+    from lionagi.state.db import PLAY_ACTIVE_STATUSES, PLAY_TERMINAL_STATUSES
+
     lines: list[str] = []
     lines.append(_bold(f"SHOW  {show['id']}"))
     lines.append(f"  topic:   {show.get('topic') or '-'}")
@@ -650,8 +652,12 @@ async def _detail_show(db: Any, show: dict[str, Any]) -> str:
         lines.append(_dim("  -- plays --"))
         # Every terminal play status the lifecycle declares. A play here has
         # finished and cannot move again without an override, so it reads
-        # [done] even when it finished badly.
-        terminal = {"merged", "escalated", "gate_failed", "blocked", "aborted_after_finish"}
+        # [done] even when it finished badly. Read from the lifecycle
+        # vocabulary rather than restated as a literal here: the policy owns
+        # which statuses are terminal, and a copy of it in this view goes
+        # stale silently — the day the policy grows a terminal status this
+        # view keeps calling a finished play [wait].
+        terminal = PLAY_TERMINAL_STATUSES
         # Executing right now, which is narrower than "not finished". `gated`
         # and `pending` fall through to [wait] because waiting is what they are
         # doing. This set is also narrower than the default listing's in-flight
@@ -664,8 +670,18 @@ async def _detail_show(db: Any, show: dict[str, Any]) -> str:
                 marker = _dim("  [done]  ")
             elif pstatus in live:
                 marker = _green("  [live]  ")
-            else:
+            elif pstatus in PLAY_ACTIVE_STATUSES:
                 marker = _yellow("  [wait]  ")
+            else:
+                # Neither terminal, nor executing, nor a status the lifecycle
+                # declares in-flight at all. It is not [wait]: waiting claims
+                # the play will continue and nothing here can support that
+                # claim for a status this view does not know. It is not
+                # [done] either: reading an unknown status as terminal is how
+                # live work gets swept. It gets its own marker so the row
+                # reads as a data problem instead of being sorted into a
+                # bucket that answers a question nobody can answer.
+                marker = _red("  [????]  ")
             pelapsed = _elapsed(play.get("started_at"), play.get("ended_at"))
             pname = _trunc(play.get("name") or play["id"][:12], 24)
             pstatus_col = _colour_status(pstatus)

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -17,6 +17,7 @@ from lionagi.cli.monitor import (
     _NON_TTY_MAX_COL_WIDTH,
     _cached_detect_project,
     _colour_status,
+    _detail_show,
     _elapsed,
     _find_entity,
     _format_coordination_line,
@@ -36,7 +37,11 @@ from lionagi.cli.monitor import (
     _stdout_is_tty,
     _trunc,
 )
-from lionagi.state.db import StateDB
+from lionagi.state.db import (
+    PLAY_ACTIVE_STATUSES,
+    PLAY_TERMINAL_STATUSES,
+    StateDB,
+)
 
 
 class _FakeStdout:
@@ -1189,6 +1194,92 @@ async def test_run_detail_show(temp_db_path: Path) -> None:
     output = await _run_detail(show_id)
     assert "SHOW" in output
     assert "implement-auth" in output
+
+
+# ── Show detail: how a play's status is classified into a marker ──────────────
+
+
+class _PlayRowsDB:
+    """Minimal db stand-in for _detail_show — it only calls fetch_all, to read
+    the show's plays. Rows are supplied directly so a play can carry a status
+    no writer would accept, which is the case the unrecognised marker is for."""
+
+    def __init__(self, plays: list[dict[str, Any]]) -> None:
+        self._plays = plays
+
+    async def fetch_all(self, *_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+        return self._plays
+
+
+_MARKER_PLAY_NAME = "marker-probe"
+
+
+async def _marker_for_status(status: str) -> str:
+    """Render a one-play show and return the marker column of that play's row."""
+    db = _PlayRowsDB(
+        [
+            {
+                "id": "0123456789ab",
+                "name": _MARKER_PLAY_NAME,
+                "status": status,
+                "started_at": None,
+                "ended_at": None,
+            }
+        ]
+    )
+    output = await _detail_show(db, {"id": "show-abc", "topic": "t", "status": "active"})
+    line = next(ln for ln in output.splitlines() if _MARKER_PLAY_NAME in ln)
+    return line[: line.index(_MARKER_PLAY_NAME)]
+
+
+@pytest.fixture
+def _no_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Markers are compared verbatim, so keep ANSI wrapping out of them."""
+    monkeypatch.setattr("lionagi.cli.monitor._IS_TTY", False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", sorted(PLAY_TERMINAL_STATUSES))
+async def test_detail_show_policy_terminal_status_reads_done(_no_tty: None, status: str) -> None:
+    """Driven from the lifecycle terminal set, not a literal list — a status
+    added to the policy is covered here the day it is added."""
+    assert await _marker_for_status(status) == "  [done]  "
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["running", "running_complete", "redoing"])
+async def test_detail_show_executing_status_reads_live(_no_tty: None, status: str) -> None:
+    assert await _marker_for_status(status) == "  [live]  "
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["gated", "pending"])
+async def test_detail_show_active_but_not_executing_reads_wait(_no_tty: None, status: str) -> None:
+    """Active without being the play that is moving — waiting is what it is
+    doing, so [wait] is the honest marker."""
+    assert status in PLAY_ACTIVE_STATUSES
+    assert await _marker_for_status(status) == "  [wait]  "
+
+
+@pytest.mark.asyncio
+async def test_detail_show_unrecognised_status_is_not_wait(_no_tty: None) -> None:
+    status = "no-such-play-status"
+    assert status not in PLAY_TERMINAL_STATUSES
+    assert status not in PLAY_ACTIVE_STATUSES
+    marker = await _marker_for_status(status)
+    assert marker == "  [????]  "
+    assert marker not in ("  [wait]  ", "  [done]  ", "  [live]  ")
+
+
+@pytest.mark.asyncio
+async def test_detail_show_marker_column_width_is_uniform(_no_tty: None) -> None:
+    """All four classifications occupy the same column, so the play names
+    below them stay aligned."""
+    markers = [
+        await _marker_for_status(s) for s in ("merged", "running", "gated", "no-such-play-status")
+    ]
+    assert len(set(markers)) == 4
+    assert {len(m) for m in markers} == {10}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2616.

The show detail view classified each play against a literal set of terminal statuses. The lifecycle policy already declares exactly that set and `lionagi/state/db.py` already exposes it as `PLAY_TERMINAL_STATUSES`, which other consumers read. The two agreed today; they disagreed the day the policy grew `blocked` and this line did not, and a finished play read as waiting on every show containing one.

Restating a vocabulary someone else owns is the defect. The value that went missing was the symptom.

## What changed

- The terminal set is read from `PLAY_TERMINAL_STATUSES` rather than restated.
- The `live` set stays a local literal on purpose: it is narrower than `PLAY_ACTIVE_STATUSES` because `gated` and `pending` are active but not executing, which is what the waiting marker is for. Its comment is untouched.
- A status that is neither terminal, nor executing, nor declared in-flight gets its own marker instead of falling through to waiting. Waiting claims the play will continue and nothing in this view can support that claim for a status it does not know; reading it as terminal is how live work gets swept. It renders as a data problem instead.

A play row with a null or empty status previously rendered as waiting and now renders as unrecognised, which is the same case seen from the other side.

## Scope

Read-side only. Constraining what can be written is not part of this change.

Related: #2619, which asks the broader question. Worth recording there: `plays.status` does carry a `CHECK` constraint today (`ck_plays_status` in `state/schema.sql` and `state/schema_meta.py`) enumerating all eleven declared statuses, so on a database created from the current schema an unrecognised status cannot be introduced through that path. Rows predating the constraint are unaffected by it, which is why the read side still needs an answer.