### PR TITLE
fix(orchestrate): a submission naming neither an agent nor a model is admitted

### DIFF
--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -1011,10 +1011,10 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             return 1
         args.model, args.prompt = resolved
 
-        has_model = args.model is not None or args.agent is not None
-        if not has_model:
-            log_error("model or --agent is required")
-            return 1
+        # Naming neither a model nor an agent is not an incomplete command here:
+        # setup_orchestration reads it as a request to orchestrate and resolves
+        # the default orchestrator profile. A prompt is still required, because
+        # nothing downstream can supply one.
         if not args.prompt:
             log_error("prompt is required")
             return 1
@@ -1178,11 +1178,10 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             args.prompt = args.model
             args.model = None
 
-        has_model = args.model is not None or args.agent is not None
-        if not has_model:
-            log_error("model or --agent is required")
-            return 1
-
+        # Naming neither a model nor an agent is not an incomplete command here:
+        # setup_orchestration reads it as a request to orchestrate and resolves
+        # the default orchestrator profile. A prompt is still required, because
+        # nothing downstream can supply one.
         if not args.prompt:
             log_error("prompt is required (positional or via -f spec file)")
             return 1

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -529,7 +529,9 @@ def _has_model_source(kind: str, args: dict[str, Any], prompt: str | None) -> bo
     default is the same kind of claim and gets the same treatment: naming
     neither a model nor an agent is a request to orchestrate, so those commands
     resolve the default orchestrator profile themselves, and that profile is a
-    source this does not read either.
+    source this does not read either. That default answers this question and no
+    other: those commands still require a prompt, which is a separate question
+    with its own check below.
 
     Where the model would sit in the positional bucket does not differ by
     command, though the reason it lands there does. Every one of these commands
@@ -648,6 +650,73 @@ def _refuse_without_model(
     )
 
 
+def _has_prompt_source(kind: str, args: dict[str, Any], prompt: str | None) -> bool:
+    """Whether this submission gives an orchestrating run any way to obtain a prompt.
+
+    Asked only of the kinds whose model question the default orchestrator
+    profile answers for them. For every other kind the positional bucket carries
+    both, so the model check above already refuses a submission carrying
+    neither; here the model is never missing and the prompt can be.
+
+    A prompt reaches these commands by two routes and both are read: ``prompt``
+    and ``prompt_file`` are resolved before this runs, while a prompt passed
+    positionally arrives in ``query`` — where a lone value is the prompt and a
+    second one is the model ahead of it, so any positional at all means a prompt
+    is present.
+
+    Beyond those, each command is taken at its parser's word. Flow also accepts
+    a spec file and a playbook, either of which may carry a ``prompt`` key this
+    does not read, so their presence makes the question the command's to answer.
+    A play is that same command with the playbook required, so it always has
+    one. Fanout takes neither and has only the two routes.
+    """
+    if prompt is not None or args.get("query"):
+        return True
+    if kind == "fanout":
+        return False
+    return bool(args.get("file") or args.get("playbook"))
+
+
+_FLOW_PROMPT_SOURCES = (
+    "pass the prompt in 'prompt' or 'prompt_file', or as the last value of 'query', or "
+    "name a spec with 'file' or a playbook with 'playbook' that carries one"
+)
+
+# What each orchestrating command accepts as a prompt, spelled the way that
+# command accepts it and stated per command for the same reason the model
+# sources are: naming a source the receiving command has no argument for would
+# send the caller into a second refusal from argument validation.
+_PROMPT_SOURCES = {
+    "fanout": "pass the prompt in 'prompt' or 'prompt_file', or as the last value of 'query'",
+    "flow": _FLOW_PROMPT_SOURCES,
+    "play": _FLOW_PROMPT_SOURCES,
+}
+
+
+def _refuse_without_prompt(verb: Verb, args: dict[str, Any], prompt: str | None) -> None:
+    """Refuse a promptless orchestrating submission, naming the fix.
+
+    The same class of refusal as the missing model beside it, for the same
+    reason: the command checks its prompt before either runner is entered, so
+    the run dies without reaching the hook that records an end and the caller
+    holds a handle to a run that will never reach a terminal status or notify.
+
+    A sibling of that check rather than a clause inside it because the two
+    refusals differ in what they can tell the caller. The correction for a
+    missing model names model sources; naming them for a submission that has a
+    model and no prompt would be a correction the caller cannot act on. Keeping
+    them apart also keeps each remediation table answering one question.
+    """
+    kind = verb.job_kind
+    if kind not in _ORCHESTRATING_KINDS or _has_prompt_source(kind, args, prompt):
+        return
+    raise OpError(
+        "invalid_input",
+        f"{verb.name!r} has no prompt and nothing to supply one, so the run would be "
+        f"refused on start and would never reach a terminal status: {_PROMPT_SOURCES[kind]}",
+    )
+
+
 def _resolve_cwd(args: dict[str, Any]) -> str | None:
     """The caller's working directory, resolved the way it will be used.
 
@@ -680,6 +749,7 @@ def _resolve_cwd(args: dict[str, Any]) -> str | None:
 def _run_spawn(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict[str, Any]:
     prompt = _resolve_prompt(args)
     _refuse_without_model(verb, schema, args, prompt)
+    _refuse_without_prompt(verb, args, prompt)
     cwd = _resolve_cwd(args)
     flags = render_argv(schema, args)
     assert verb.job_kind is not None

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -506,6 +506,14 @@ def _resolve_prompt(args: dict[str, Any]) -> str | None:
     return text
 
 
+# The kinds whose command treats naming neither a model nor an agent as a
+# request to orchestrate, and answers it with the default orchestrator profile
+# instead of refusing. Named by kind rather than inferred from the absence of
+# the others, so a spawning command added later is refused as before until it
+# is known to carry the same default.
+_ORCHESTRATING_KINDS = frozenset({"flow", "fanout", "play"})
+
+
 def _has_model_source(kind: str, args: dict[str, Any], prompt: str | None) -> bool:
     """Whether this submission gives the run any way to obtain a model.
 
@@ -517,21 +525,28 @@ def _has_model_source(kind: str, args: dict[str, Any], prompt: str | None) -> bo
     Answered conservatively: true whenever any source of a model is present,
     false only when none is. A profile, a spec file and a playbook each name one
     in content this does not read, so any of them present makes the question the
-    command's to answer, not this one's.
+    command's to answer, not this one's. The orchestrating commands' implicit
+    default is the same kind of claim and gets the same treatment: naming
+    neither a model nor an agent is a request to orchestrate, so those commands
+    resolve the default orchestrator profile themselves, and that profile is a
+    source this does not read either.
 
-    Where the model would sit in the positional bucket differs by command
-    because the prompt is delivered differently: an agent reads its prompt from
-    a file, so its bucket holds the model alone, while flow and fanout take the
-    prompt as the last positional, so a model is present only when a second
-    token accompanies it.
+    Where the model would sit in the positional bucket does not differ by
+    command, though the reason it lands there does. Every one of these commands
+    reads its positionals as ``[MODEL] PROMPT``, so a lone positional is the
+    prompt and a model is present only when a second value accompanies it.
+    Flow and fanout receive the prompt as that second positional; an agent
+    receives it through ``--prompt-file`` and so leaves the bucket one shorter,
+    which is why the prompt is counted alongside the positionals rather than
+    only within them.
     """
     if args.get("agent") or args.get("resume") or args.get("continue_last"):
         return True
-    query = args.get("query") or []
-    if kind == "agent":
-        return bool(query)
+    if kind in _ORCHESTRATING_KINDS:
+        return True
     if args.get("file") or args.get("playbook"):
         return True
+    query = args.get("query") or []
     bucket = [*query, *([prompt] if prompt is not None else [])]
     return len(bucket) >= 2
 
@@ -548,7 +563,11 @@ _FLOW_MODEL_SOURCES = (
 # from argument validation, so the sources are stated per command rather than
 # once for all of them. A play runs the flow command and takes its arguments.
 _MODEL_SOURCES = {
-    "agent": ("pass a model as the first positional in 'query', or name a profile with 'agent'"),
+    "agent": (
+        "pass a model as the first value of 'query' with the prompt in 'prompt' or as a "
+        "second value — a lone positional is read as the prompt, not as a model — or name "
+        "a profile with 'agent'"
+    ),
     "fanout": (
         "pass a model as the first value of 'query' with the prompt after it — a lone "
         "positional is read as the prompt, not as a model — or name a profile with 'agent'"

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -661,16 +661,29 @@ def _has_prompt_source(kind: str, args: dict[str, Any], prompt: str | None) -> b
     A prompt reaches these commands by two routes and both are read: ``prompt``
     and ``prompt_file`` are resolved before this runs, while a prompt passed
     positionally arrives in ``query`` — where a lone value is the prompt and a
-    second one is the model ahead of it, so any positional at all means a prompt
-    is present.
+    second one is the model ahead of it. A resolved ``prompt`` is appended
+    behind the ``query`` values, so whichever of them comes last is the one the
+    command reads as its prompt.
+
+    That last value is tested for truth rather than for presence, because the
+    command tests it for truth: it assigns the positionals and then refuses on
+    a prompt that is falsy, not on one that is absent. An empty string is
+    present and not true, so a check asking only whether a prompt was passed
+    admits a submission the command refuses on start — the same stranded
+    non-terminal run this refusal exists to prevent, arriving as a value
+    instead of as a gap.
 
     Beyond those, each command is taken at its parser's word. Flow also accepts
     a spec file and a playbook, either of which may carry a ``prompt`` key this
-    does not read, so their presence makes the question the command's to answer.
-    A play is that same command with the playbook required, so it always has
-    one. Fanout takes neither and has only the two routes.
+    does not read, so their presence makes the question the command's to answer
+    — including when a positional is present but empty, since the command reads
+    the file after assigning the positionals and lets it supply the prompt. A
+    play is that same command with the playbook required, so it always has one.
+    Fanout takes neither and has only the two routes.
     """
-    if prompt is not None or args.get("query"):
+    query = args.get("query") or []
+    last_positional = prompt if prompt is not None else (query[-1] if query else None)
+    if last_positional:
         return True
     if kind == "fanout":
         return False

--- a/tests/cli/orchestrate/test_unspecified_configuration_orchestrates.py
+++ b/tests/cli/orchestrate/test_unspecified_configuration_orchestrates.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`li o flow` / `li o fanout` given neither a model nor an agent.
+
+Setup already reads that as a request to orchestrate and answers it with the
+default orchestrator profile, so the command has no missing argument to report.
+It reported one anyway, ahead of setup, and returned 1 — the run the caller
+asked for was refused by the layer that had nothing to decide.
+
+The prompt is a different matter: nothing downstream can supply one, so a
+submission without it is still refused, with the message it always used.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import lionagi.cli.orchestrate as orch_mod
+from lionagi.cli.main import main
+
+
+def _run_with_flow_mock(argv: list[str]):
+    with patch.object(
+        orch_mod, "_run_flow", AsyncMock(return_value=("flow output", "completed"))
+    ) as run_flow:
+        code = main(argv)
+    return code, run_flow
+
+
+def _run_with_fanout_mock(argv: list[str]):
+    with patch.object(
+        orch_mod, "_run_fanout", AsyncMock(return_value=("fanout output", "completed"))
+    ) as run_fanout:
+        code = main(argv)
+    return code, run_fanout
+
+
+class TestFlow:
+    def test_naming_neither_carries_the_prompt_into_the_flow(self):
+        code, run_flow = _run_with_flow_mock(["o", "flow", "summarize this"])
+        assert code == 0
+        kwargs = run_flow.call_args.kwargs
+        assert kwargs["model_spec"] == ""
+        assert kwargs["agent_name"] is None
+        assert kwargs["prompt"] == "summarize this"
+
+    def test_two_positionals_still_separate_the_model_from_the_prompt(self):
+        """The regression that would matter: admitting the bare form by
+        misreading the pair is worse than refusing the bare form."""
+        code, run_flow = _run_with_flow_mock(
+            ["o", "flow", "claude_code/claude-opus-5", "summarize this"]
+        )
+        assert code == 0
+        kwargs = run_flow.call_args.kwargs
+        assert kwargs["model_spec"] == "claude_code/claude-opus-5"
+        assert kwargs["prompt"] == "summarize this"
+
+    def test_a_named_agent_still_arrives_with_the_prompt(self):
+        code, run_flow = _run_with_flow_mock(["o", "flow", "--agent", "researcher", "do it"])
+        assert code == 0
+        kwargs = run_flow.call_args.kwargs
+        assert kwargs["agent_name"] == "researcher"
+        assert kwargs["prompt"] == "do it"
+
+    def test_no_prompt_is_still_refused(self, capsys):
+        code, run_flow = _run_with_flow_mock(["o", "flow"])
+        assert code == 1
+        assert "prompt is required" in capsys.readouterr().err
+        run_flow.assert_not_called()
+
+
+class TestFanout:
+    def test_naming_neither_carries_the_prompt_into_the_fanout(self):
+        code, run_fanout = _run_with_fanout_mock(["o", "fanout", "summarize this"])
+        assert code == 0
+        kwargs = run_fanout.call_args.kwargs
+        assert kwargs["model_spec"] == ""
+        assert kwargs["agent_name"] is None
+        assert kwargs["prompt"] == "summarize this"
+
+    def test_two_positionals_still_separate_the_model_from_the_prompt(self):
+        code, run_fanout = _run_with_fanout_mock(
+            ["o", "fanout", "claude_code/claude-opus-5", "summarize this"]
+        )
+        assert code == 0
+        kwargs = run_fanout.call_args.kwargs
+        assert kwargs["model_spec"] == "claude_code/claude-opus-5"
+        assert kwargs["prompt"] == "summarize this"
+
+    def test_no_prompt_is_still_refused(self, capsys):
+        code, run_fanout = _run_with_fanout_mock(["o", "fanout"])
+        assert code == 1
+        assert "prompt is required" in capsys.readouterr().err
+        run_fanout.assert_not_called()

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -320,18 +320,18 @@ class TestInProcessContractErrors:
         assert "bogus-top-level-command" in captured.err
         assert captured.out == ""
 
-    def test_flow_missing_model_or_agent_is_nonzero(self, capsys):
+    def test_flow_missing_prompt_is_nonzero(self, capsys):
         rc = _run_main(["o", "flow"])
         captured = capsys.readouterr()
         assert rc == 1
-        assert "model or --agent is required" in captured.err
+        assert "prompt is required" in captured.err
         assert captured.out == ""
 
-    def test_fanout_missing_model_or_agent_is_nonzero(self, capsys):
+    def test_fanout_missing_prompt_is_nonzero(self, capsys):
         rc = _run_main(["o", "fanout"])
         captured = capsys.readouterr()
         assert rc == 1
-        assert "model or --agent is required" in captured.err
+        assert "prompt is required" in captured.err
 
     def test_flow_unknown_flag_is_nonzero_and_named(self, capsys):
         rc = _run_main(["o", "flow", "--this-flag-does-not-exist"])

--- a/tests/cli/test_orchestrate_flags_anywhere.py
+++ b/tests/cli/test_orchestrate_flags_anywhere.py
@@ -88,10 +88,15 @@ class TestFlowFlagsAnywhere:
         assert code == 1
         assert "prompt is required" in capsys.readouterr().err
 
-    def test_missing_model_still_errors_clearly(self, capsys):
-        code = main(["o", "flow", "--dry-run", "some prompt"])
-        assert code == 1
-        assert "model or --agent is required" in capsys.readouterr().err
+    def test_naming_neither_a_model_nor_an_agent_orchestrates(self):
+        """Naming neither is a request to orchestrate, not a missing argument:
+        the prompt reaches the flow with both slots empty, and the default
+        orchestrator profile is resolved further in."""
+        code, run_flow = _run_with_flow_mock(["o", "flow", "--dry-run", "some prompt"])
+        assert code == 0
+        assert run_flow.call_args.kwargs["model_spec"] == ""
+        assert run_flow.call_args.kwargs["agent_name"] is None
+        assert run_flow.call_args.kwargs["prompt"] == "some prompt"
 
 
 class TestFanoutFlagsAnywhere:

--- a/tests/mcp/test_admission_without_a_named_model.py
+++ b/tests/mcp/test_admission_without_a_named_model.py
@@ -257,6 +257,52 @@ def test_a_play_naming_only_a_playbook_reaches_the_spawn(spawned, submit_dir):
     assert "--playbook=probe" in spawned.argv, spawned.argv
 
 
+@pytest.mark.parametrize("verb", ("flow.submit", "fanout.submit"))
+def test_an_orchestrating_submission_whose_prompt_is_empty_never_reaches_the_spawn(spawned, verb):
+    """The command refuses a falsy prompt, not an absent one. An empty string is
+    present and not true, so admitting it here strands the same run a missing
+    prompt would."""
+    answer = call(ops=[spawn_op(verb, {"prompt": "", "no_mcp_config": True})])["ops"][0]
+
+    assert spawned.argv is None, "the submission reached the spawn"
+    assert answer["ok"] is False, answer
+    assert answer["error"]["kind"] == "invalid_input", answer
+    assert "has no prompt and nothing to supply one" in answer["error"]["message"], answer
+
+
+@pytest.mark.parametrize("verb", ("flow.submit", "fanout.submit"))
+@pytest.mark.parametrize("query", ([""], ["claude_code/claude-opus-5", ""]))
+def test_an_orchestrating_submission_whose_last_positional_is_empty_never_reaches_the_spawn(
+    spawned, verb, query
+):
+    """The command reads the last positional as the prompt: a lone one is it,
+    and with two the model comes first. So a model ahead of an empty prompt is
+    refused exactly as a lone empty one is."""
+    answer = call(ops=[spawn_op(verb, {"query": query, "no_mcp_config": True})])["ops"][0]
+
+    assert spawned.argv is None, "the submission reached the spawn"
+    assert answer["ok"] is False, answer
+    assert answer["error"]["kind"] == "invalid_input", answer
+    assert "has no prompt and nothing to supply one" in answer["error"]["message"], answer
+
+
+def test_a_flow_with_an_empty_positional_and_a_spec_file_reaches_the_spawn(spawned, submit_dir):
+    """The spec file may carry a prompt: key, and the command reads it after
+    assigning the positionals. So an empty positional beside a file is still the
+    command's question to answer, and refusing it here would refuse a run that
+    would have started."""
+    spec = submit_dir / "flow.yaml"
+    spec.write_text("prompt: summarize this\n")
+
+    answer = call(
+        ops=[spawn_op("flow.submit", {"query": [""], "file": str(spec), "no_mcp_config": True})]
+    )["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert spawned.argv is not None, "the submission was refused before the spawn"
+    assert _positionals(spawned.argv) == [""]
+
+
 def test_every_kind_the_prompt_check_refuses_has_a_correction_to_offer():
     """The refusal reads its remediation by kind, so a kind admitted into the
     check without one would raise past the caller instead of answering."""

--- a/tests/mcp/test_admission_without_a_named_model.py
+++ b/tests/mcp/test_admission_without_a_named_model.py
@@ -35,13 +35,15 @@ def call(**kwargs):
     return asyncio.run(dispatch.request(**kwargs))
 
 
-def spawn_op(op: str, args: dict) -> dict:
+def spawn_op(op: str, args: dict, playbook: str | None = None) -> dict:
     """A spawn op carrying the fingerprint its verb requires.
 
     Fetched the way a caller has to fetch it, so these tests exercise the
-    round-trip rather than reaching past it.
+    round-trip rather than reaching past it. A playbook varies the schema, so a
+    submission naming one has to fetch its help the same way.
     """
-    return {"op": op, "args": args, "schema_fingerprint": call(help=op)["schema_fingerprint"]}
+    target: Any = {"verb": op, "playbook": playbook} if playbook is not None else op
+    return {"op": op, "args": args, "schema_fingerprint": call(help=target)["schema_fingerprint"]}
 
 
 class _RecordingPopen:
@@ -176,3 +178,86 @@ def test_an_agent_given_a_model_and_a_prompt_as_two_positionals_reaches_the_spaw
 
     assert answer["ok"] is True, answer
     assert _positionals(spawned.argv) == ["claude_code/claude-opus-5", "do it"]
+
+
+# ── the prompt the orchestrating default does not supply ─────────────────────
+
+
+@pytest.fixture
+def submit_dir(monkeypatch, tmp_path):
+    """A submitting directory with no playbooks or spec files above it.
+
+    A playbook name is resolved from the current directory upwards, so an
+    ancestor holding one would otherwise decide what these tests admit.
+    """
+    d = tmp_path / "submit"
+    d.mkdir()
+    monkeypatch.chdir(d)
+    return d
+
+
+@pytest.mark.parametrize("verb", ("flow.submit", "fanout.submit"))
+def test_an_orchestrating_submission_with_no_prompt_never_reaches_the_spawn(spawned, verb):
+    """Naming neither a model nor an agent is a request to orchestrate, and the
+    command answers it with the default orchestrator profile. It has no such
+    answer for a missing prompt: it refuses before either runner is entered,
+    which strands a run the caller already holds a handle to."""
+    answer = call(ops=[spawn_op(verb, {"no_mcp_config": True})])["ops"][0]
+
+    assert spawned.argv is None, "the submission reached the spawn"
+    assert answer["ok"] is False, answer
+    assert answer["error"]["kind"] == "invalid_input", answer
+    message = answer["error"]["message"]
+    assert "has no prompt and nothing to supply one" in message, message
+    # The correction has to be writable from the message, in arguments this
+    # command takes.
+    assert "'prompt'" in message, message
+    assert "'query'" in message, message
+
+
+def test_a_fanout_is_not_offered_the_spec_file_it_has_no_argument_for(spawned):
+    """Fanout takes no spec file and no playbook, so naming either as a way to
+    supply a prompt would send the caller into a second refusal, this time from
+    argument validation."""
+    answer = call(ops=[spawn_op("fanout.submit", {"no_mcp_config": True})])["ops"][0]
+
+    message = answer["error"]["message"]
+    assert "'file'" not in message, message
+    assert "'playbook'" not in message, message
+
+
+def test_a_flow_whose_prompt_is_only_in_a_spec_file_reaches_the_spawn(spawned, submit_dir):
+    """The spec file may carry a prompt: key, and this check does not read the
+    file. The command does, so the question is left to it."""
+    spec = submit_dir / "flow.yaml"
+    spec.write_text("prompt: summarize this\n")
+
+    answer = call(ops=[spawn_op("flow.submit", {"file": str(spec), "no_mcp_config": True})])["ops"][
+        0
+    ]
+
+    assert answer["ok"] is True, answer
+    assert spawned.argv is not None, "the submission was refused before the spawn"
+    assert any(str(spec) in token for token in spawned.argv), spawned.argv
+
+
+def test_a_play_naming_only_a_playbook_reaches_the_spawn(spawned, submit_dir):
+    """A playbook is a flow whose prompt is already written down, so naming one
+    is a complete submission."""
+    books = submit_dir / ".lionagi" / "playbooks"
+    books.mkdir(parents=True)
+    (books / "probe.playbook.yaml").write_text("name: probe\nprompt: summarize this\nnodes:\n")
+
+    answer = call(
+        ops=[spawn_op("play.submit", {"playbook": "probe", "no_mcp_config": True}, "probe")]
+    )["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert spawned.argv is not None, "the submission was refused before the spawn"
+    assert "--playbook=probe" in spawned.argv, spawned.argv
+
+
+def test_every_kind_the_prompt_check_refuses_has_a_correction_to_offer():
+    """The refusal reads its remediation by kind, so a kind admitted into the
+    check without one would raise past the caller instead of answering."""
+    assert set(dispatch._PROMPT_SOURCES) == set(dispatch._ORCHESTRATING_KINDS)

--- a/tests/mcp/test_admission_without_a_named_model.py
+++ b/tests/mcp/test_admission_without_a_named_model.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""What the pre-spawn model check admits, per command.
+
+The check exists to refuse a submission the command would reject in its first
+second, because such a run never reaches the hook that records an end: the job
+stays non-terminal and a caller waiting on it waits forever. So its answer has
+to track what each command actually does with the arguments, not a general idea
+of what a model source looks like.
+
+Two commands disagreed with it.
+
+Flow and fanout read "no model and no agent" as a request to orchestrate and
+answer it with the default orchestrator profile. A submission naming neither is
+therefore complete, and refusing it here refused a run that would have started.
+
+An agent reads its positionals as ``[MODEL] PROMPT``, so a lone positional is
+the prompt. Treating any positional as a model admitted ``query=["do it"]`` with
+no model anywhere, which is exactly the run that dies on start.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import pytest
+
+from lionagi.mcp import dispatch, jobs
+
+
+def call(**kwargs):
+    return asyncio.run(dispatch.request(**kwargs))
+
+
+def spawn_op(op: str, args: dict) -> dict:
+    """A spawn op carrying the fingerprint its verb requires.
+
+    Fetched the way a caller has to fetch it, so these tests exercise the
+    round-trip rather than reaching past it.
+    """
+    return {"op": op, "args": args, "schema_fingerprint": call(help=op)["schema_fingerprint"]}
+
+
+class _RecordingPopen:
+    """Stand in for the spawn, keeping the command line it was handed.
+
+    The pid it reports is this process's own: the code after the spawn reads the
+    child's start time and process group, and a made-up number either fails
+    those reads or names whatever process happens to hold it.
+    """
+
+    def __init__(self) -> None:
+        self.argv: list[str] | None = None
+        self.pid = os.getpid()
+
+    def __call__(self, argv: list[str], *a: Any, **kw: Any) -> Any:
+        self.argv = list(argv)
+        return self
+
+
+@pytest.fixture
+def spawned(monkeypatch, tmp_path):
+    """Nothing is started and nothing is written outside tmp_path."""
+    popen = _RecordingPopen()
+    monkeypatch.setattr(jobs.config, "JOBS_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(jobs.subprocess, "Popen", popen)
+    return popen
+
+
+def _positionals(argv: list[str]) -> list[str]:
+    """Everything after the sentinel: what the command reads as positionals."""
+    return argv[argv.index("--") + 1 :]
+
+
+# ── the orchestrating commands ───────────────────────────────────────────────
+
+
+def test_a_flow_naming_neither_a_model_nor_an_agent_reaches_the_spawn(spawned):
+    answer = call(
+        ops=[spawn_op("flow.submit", {"prompt": "summarize this", "no_mcp_config": True})]
+    )["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert spawned.argv is not None, "the submission was refused before the spawn"
+    # The prompt is the sole positional, and nothing named a model: the run
+    # starts and resolves the default orchestrator profile for itself.
+    assert _positionals(spawned.argv) == ["summarize this"]
+    assert "--agent" not in spawned.argv
+
+
+def test_a_fanout_naming_neither_a_model_nor_an_agent_reaches_the_spawn(spawned):
+    answer = call(
+        ops=[spawn_op("fanout.submit", {"prompt": "summarize this", "no_mcp_config": True})]
+    )["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert spawned.argv is not None, "the submission was refused before the spawn"
+    assert _positionals(spawned.argv) == ["summarize this"]
+    assert "--agent" not in spawned.argv
+
+
+def test_a_flow_naming_a_model_still_puts_it_ahead_of_the_prompt(spawned):
+    """The form that already worked has to keep working: admitting the bare one
+    by collapsing the two positionals into one would be worse than the refusal
+    it replaces."""
+    answer = call(
+        ops=[
+            spawn_op(
+                "flow.submit",
+                {
+                    "query": ["claude_code/claude-opus-5"],
+                    "prompt": "summarize this",
+                    "no_mcp_config": True,
+                },
+            )
+        ]
+    )["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert _positionals(spawned.argv) == ["claude_code/claude-opus-5", "summarize this"]
+
+
+# ── the agent command ────────────────────────────────────────────────────────
+
+
+def test_an_agent_given_one_positional_and_no_model_is_refused(spawned):
+    """The single positional is the prompt, so this submission names no model
+    at all. It used to be admitted and then rejected by the command itself,
+    which is the stranded run this check exists to prevent."""
+    answer = call(ops=[spawn_op("agent.submit", {"query": ["do it"], "no_mcp_config": True})])[
+        "ops"
+    ][0]
+
+    assert answer["ok"] is False, answer
+    assert answer["error"]["kind"] == "invalid_input", answer
+    assert spawned.argv is None, "the submission reached the spawn"
+    message = answer["error"]["message"]
+    # The correction has to be writable from the message, and has to name only
+    # arguments this command takes.
+    assert "a lone positional is read as the prompt, not as a model" in message, message
+    assert "'prompt'" in message, message
+    assert "name a profile with 'agent'" in message, message
+
+
+def test_an_agent_given_a_model_and_a_prompt_reaches_the_spawn(spawned):
+    answer = call(
+        ops=[
+            spawn_op(
+                "agent.submit",
+                {"query": ["claude_code/claude-opus-5"], "prompt": "do it", "no_mcp_config": True},
+            )
+        ]
+    )["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert spawned.argv is not None, "the submission was refused before the spawn"
+    # The model is the whole positional bucket; the prompt travels in a file,
+    # which is why one positional means something different here than it does
+    # to flow and fanout.
+    assert _positionals(spawned.argv) == ["claude_code/claude-opus-5"]
+    assert "--prompt-file" in spawned.argv
+
+
+def test_an_agent_given_a_model_and_a_prompt_as_two_positionals_reaches_the_spawn(spawned):
+    answer = call(
+        ops=[
+            spawn_op(
+                "agent.submit",
+                {"query": ["claude_code/claude-opus-5", "do it"], "no_mcp_config": True},
+            )
+        ]
+    )["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert _positionals(spawned.argv) == ["claude_code/claude-opus-5", "do it"]

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -356,7 +356,7 @@ def test_a_spawn_verb_renders_the_tokens_the_cli_parser_declares(submitted):
 
 
 def test_a_boolean_only_reaches_argv_when_it_differs_from_the_parser_default(submitted):
-    call(ops=[spawn_op("agent.submit", {"query": ["m"], "yolo": False})])
+    call(ops=[spawn_op("agent.submit", {"query": ["m"], "prompt": "do it", "yolo": False})])
     assert "--yolo" not in submitted["flags"]
 
 
@@ -594,8 +594,7 @@ def test_the_fingerprint_is_not_a_claim_that_anyone_read_the_schema(submitted):
     ("op", "args"),
     [
         ("agent.submit", {"prompt": "do it"}),
-        ("flow.submit", {"prompt": "do it"}),
-        ("fanout.submit", {"prompt": "do it"}),
+        ("agent.submit", {"query": ["do it"]}),
     ],
 )
 def test_a_submission_with_no_model_is_refused_instead_of_handed_a_handle(submitted, op, args):
@@ -650,6 +649,17 @@ def _refusal(op: str) -> str:
     return call(ops=[spawn_op(op, {"prompt": "do it"})])["ops"][0]["error"]["message"]
 
 
+def _sources(kind: str) -> str:
+    """The remediation a refusal of this kind would quote.
+
+    Read from the table rather than from a refusal for the orchestrating
+    commands, which answer a submission naming nothing with the default
+    orchestrator profile and so cannot reach this refusal at all. What the text
+    says is still worth holding: it is what a caller of any future refusal reads.
+    """
+    return dispatch._MODEL_SOURCES[kind]
+
+
 def test_the_remediation_names_only_sources_the_verb_it_was_sent_to_accepts(submitted):
     """A fix a caller cannot follow costs them the round-trip it was meant to save.
 
@@ -659,7 +669,7 @@ def test_the_remediation_names_only_sources_the_verb_it_was_sent_to_accepts(subm
     Both halves are asserted together: what each message names, and what the
     receiving schema actually admits.
     """
-    fanout, flow = _refusal("fanout.submit"), _refusal("flow.submit")
+    fanout, flow = _sources("fanout"), _sources("flow")
     assert "'file'" not in fanout and "'playbook'" not in fanout
     assert "'file'" in flow and "'playbook'" in flow
 
@@ -674,16 +684,20 @@ def test_the_remediation_names_only_sources_the_verb_it_was_sent_to_accepts(subm
 def test_the_remediation_says_where_in_the_positionals_the_model_goes(submitted):
     """Where the model sits differs by command, so each message says its own answer.
 
-    An agent's prompt travels separately, leaving its positional bucket for the
-    model alone. Flow and fanout read the last positional as the prompt, so a
-    caller who passes the model on its own has passed a prompt — the message has
-    to say that a second value follows, or it describes a call still missing a model.
+    Every one of these commands reads a lone positional as the prompt, so a
+    caller who passes the model on its own has passed a prompt — each message
+    has to say where the prompt goes instead, or it describes a call still
+    missing a model. The agent's prompt travels separately, so its message names
+    the parameter that carries it as well as the second positional.
     """
-    for op in ("fanout.submit", "flow.submit"):
-        message = _refusal(op)
+    for kind in ("fanout", "flow"):
+        message = _sources(kind)
         assert "with the prompt after it" in message, message
         assert "read as the prompt" in message, message
-    assert "first positional in 'query'" in _refusal("agent.submit")
+    agent = _refusal("agent.submit")
+    assert "first value of 'query'" in agent, agent
+    assert "the prompt in 'prompt' or as a second value" in agent, agent
+    assert "read as the prompt" in agent, agent
 
 
 def test_every_spawning_command_has_its_own_model_sources(submitted):

--- a/tests/mcp/test_privilege_fence.py
+++ b/tests/mcp/test_privilege_fence.py
@@ -197,7 +197,9 @@ def test_a_positional_that_looks_like_a_switch_stays_a_positional(monkeypatch, v
         return {"run_id": "rid"}
 
     monkeypatch.setattr(jobs, "submit", fake_submit)
-    answer = call(ops=[spawn_op("agent.submit", {"query": [value]})])
+    # The prompt travels separately, which is also what leaves the sole
+    # positional free to be the model this command requires.
+    answer = call(ops=[spawn_op("agent.submit", {"query": [value], "prompt": "do it"})])
     assert answer["ops"][0]["ok"] is True
     # Asserted on the rendering rather than on what a parser makes of it: where
     # the sentinel sits is the same on every Python, and it is what decides


### PR DESCRIPTION
Closes #2635. Closes #2623.

Naming neither an agent nor a model when calling an orchestration entry point is a request to orchestrate, not an incomplete command, and `setup_orchestration` already answers it by resolving the default orchestrator profile. Two gates in front of that answer refused the call before it could be given, so the behaviour was unreachable from every caller-facing route.

Measured before the change on this tree: `li orchestrate flow 'summarize this'` and `li orchestrate fanout 'summarize this'` both printed `error: model or --agent is required`. The MCP surface renders argv and dispatches through the same CLI, so it met the same refusal one gate later.

## What changed

- The command bodies for `flow` and `fanout` no longer refuse when both the model and the agent are absent. Prompt validation is untouched: same position, same condition, same messages.
- `_has_model_source` at the MCP boundary answers true for the orchestrating kinds, because after the above they do have a source. That is the same treatment the function already gives a named profile, whose content it does not read either. The kinds are named explicitly rather than inferred from the absence of the others, so a spawning command added later is refused as before until it is known to carry the same default.
- The `agent` branch of that function no longer treats any lone positional as a model. `li agent` reads a single positional as the prompt, so a submission carrying only one passed this check and was then refused by the command itself — the stranded, never-terminal run the check exists to prevent. Its remediation text now says what that command actually accepts.

## Acceptance

The two-positional form is the regression that mattered; a change that admits the bare form by breaking `flow MODEL PROMPT` would be worse than the defect. Asserted on the real `_run_flow` / `_run_fanout` kwargs in both directions.

End to end on the CLI route, run against this branch:

- `li orchestrate flow --dry-run 'Say only the word ok.'` completes rc=0 and plans a DAG.
- `li orchestrate fanout -n 1 'Reply with exactly: ok'` completes rc=0, the worker answers, and the run manifest records `model=codex/gpt-5.6-sol`, `provider=codex` — the default orchestrator profile's own model, with no model named on the call.

One honest gap, not fixed here: the run manifest records `agent_name` as null on that path, because the default is resolved inside `setup_orchestration` and does not travel back to the caller that writes the manifest. The behaviour is right and the record does not say which profile produced it. Tracked separately rather than widened into this change.