### PR TITLE
fix(cli): record the profile a run used, not the one it was asked for

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -471,6 +471,20 @@ class OrchestrationEnv:
     builder: OperationGraphBuilder
 
     orc_profile: AgentProfile | None
+
+    # The name of the profile above, carried separately so anything recording
+    # the run can name it. Deliberately not defaulted: a construction site that
+    # cannot say which profile the run used has to say so out loud rather than
+    # record a null the reader will mistake for "no profile".
+    orc_profile_name: str | None
+    """Which agent profile this run actually orchestrated under.
+
+    Not necessarily the one the caller named, because a caller who named
+    neither an agent nor a model named none, and the run resolves one on their
+    behalf — this is the one it resolved and loaded. ``None`` means no profile
+    was used at all, which is the caller who named only a model.
+    """
+
     default_model_spec: str
 
     bare: bool
@@ -716,6 +730,9 @@ async def setup_orchestration(
         orc_branch=orc_branch,
         builder=builder,
         orc_profile=orc_profile,
+        # Read off the loaded profile rather than off `agent_name`, so the
+        # recorded name cannot name a profile other than the one loaded.
+        orc_profile_name=orc_profile.name if orc_profile is not None else None,
         default_model_spec=model_spec,
         bare=bare,
         effort=effort,

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -124,7 +124,10 @@ async def _run_fanout(
         env,
         invocation_kind="fanout",
         playbook_name=playbook_name,
-        agent_name=agent_name,
+        # The profile the run resolved, not the one this call named: a call that
+        # named neither an agent nor a model named none, and recording that
+        # `agent_name` would leave the record unable to say what it ran under.
+        agent_name=env.orc_profile_name,
         artifacts_path=str(env.run.artifact_root),
         invocation_id=invocation_id,
         model=_orc_model,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1829,7 +1829,10 @@ async def _run_flow(
         env,
         invocation_kind=_invocation_kind,
         playbook_name=playbook_name,
-        agent_name=agent_name,
+        # The profile the run resolved, not the one this call named: a call that
+        # named neither an agent nor a model named none, and recording that
+        # `agent_name` would leave the record unable to say what it ran under.
+        agent_name=env.orc_profile_name,
         artifacts_path=str(env.run.artifact_root),
         invocation_id=invocation_id,
         model=_orc_model,

--- a/tests/cli/orchestrate/test_fanout_artifacts.py
+++ b/tests/cli/orchestrate/test_fanout_artifacts.py
@@ -37,6 +37,7 @@ def _fanout_env(tmp_path) -> tuple[OrchestrationEnv, RunDir, Session]:
         orc_branch=orchestrator,
         builder=OperationGraphBuilder(),
         orc_profile=None,
+        orc_profile_name=None,
         default_model_spec="codex/model",
         bare=False,
         effort=None,

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -61,6 +61,7 @@ def _minimal_real_env() -> OrchestrationEnv:
         orc_branch=orc_branch,
         builder=MagicMock(),
         orc_profile=None,
+        orc_profile_name=None,
         default_model_spec="claude",
         bare=False,
         effort=None,

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -852,6 +852,7 @@ async def test_reactive_spawn_required_artifact_persistence_matrix(
         orc_branch=orc_branch,
         builder=MagicMock(),
         orc_profile=None,
+        orc_profile_name=None,
         default_model_spec="claude",
         bare=False,
         effort=None,

--- a/tests/cli/orchestrate/test_flow_terminal_notify.py
+++ b/tests/cli/orchestrate/test_flow_terminal_notify.py
@@ -63,6 +63,7 @@ def _make_env(tmp_path: Path) -> OrchestrationEnv:
         orc_branch=orc_branch,
         builder=MagicMock(),
         orc_profile=None,
+        orc_profile_name=None,
         default_model_spec="claude",
         bare=False,
         effort=None,

--- a/tests/cli/orchestrate/test_help_coordinator.py
+++ b/tests/cli/orchestrate/test_help_coordinator.py
@@ -42,6 +42,7 @@ def _make_env(tmp_path):
         orc_branch=SimpleNamespace(),
         builder=SimpleNamespace(),
         orc_profile=None,
+        orc_profile_name=None,
         default_model_spec="openai/gpt-4o-mini",
         bare=True,
         effort=None,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -51,6 +51,7 @@ def _minimal_env(orc_branch: Branch | None = None) -> OrchestrationEnv:
         orc_branch=orc_branch,
         builder=MagicMock(),
         orc_profile=None,
+        orc_profile_name=None,
         default_model_spec="claude",
         bare=False,
         effort=None,

--- a/tests/cli/orchestrate/test_messenger_wiring.py
+++ b/tests/cli/orchestrate/test_messenger_wiring.py
@@ -81,6 +81,7 @@ def _make_env(
         orc_branch=SimpleNamespace(),
         builder=SimpleNamespace(),
         orc_profile=None,
+        orc_profile_name=None,
         default_model_spec="openai/gpt-4o-mini",
         bare=True,
         effort=None,

--- a/tests/cli/orchestrate/test_orchestration_default_agent.py
+++ b/tests/cli/orchestrate/test_orchestration_default_agent.py
@@ -8,16 +8,26 @@ orchestrator profile instead of refusing.
 
 The refusal survives for the case it was written for: a caller who did name an
 agent, whose profile carries no model.
+
+Because that resolution happens inside `setup_orchestration`, the record of the
+run has to be told about it: a defaulted run orchestrates under a profile its
+caller never named, and a record that repeats the caller's own (empty) argument
+cannot tell such a run from one that used no profile at all. The second half of
+this module follows the resolved name out to what lands on disk.
 """
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from lionagi._errors import ConfigurationError
-from lionagi.cli._providers import AgentProfileNotFoundError
+from lionagi.cli._providers import AgentProfile, AgentProfileNotFoundError
+from lionagi.cli._runs import RunDir
 from lionagi.cli.orchestrate._orchestration import (
     DEFAULT_ORCHESTRATOR_AGENT,
     setup_orchestration,
@@ -192,3 +202,218 @@ async def test_the_default_does_not_fire_when_a_modelless_agent_was_named(monkey
 
     assert loaded == ["profile-without-a-model"]
     assert DEFAULT_ORCHESTRATOR_AGENT not in loaded
+
+
+# ── The resolved name has to leave the function ───────────────────────────────
+
+
+@pytest.fixture
+def completing_setup(monkeypatch, tmp_path):
+    """Let `setup_orchestration` run to its return without building a provider,
+    a branch or a session, so the env it hands back can be inspected.
+
+    Only profile resolution is left live — that is what these tests are about.
+    """
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    def _profile(name, *a, **kw):
+        return AgentProfile(name=name, system_prompt="be an orchestrator", model="claude")
+
+    imodel = MagicMock()
+    imodel.endpoint.config.provider = "claude_code"
+    imodel.endpoint.config.kwargs = {}
+
+    def _allocate(save_dir=None, run_id=None):
+        run = RunDir(
+            run_id="setup-run",
+            state_root=tmp_path / "state",
+            artifact_root=tmp_path / "artifacts",
+        )
+        run.ensure_state_dirs()
+        return run
+
+    monkeypatch.setattr(orch_mod, "load_agent_profile", _profile)
+    monkeypatch.setattr(orch_mod, "build_imodel_from_spec", lambda *a, **kw: imodel)
+    monkeypatch.setattr(orch_mod, "allocate_run", _allocate)
+    monkeypatch.setattr(orch_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(orch_mod, "Branch", MagicMock())
+    monkeypatch.setattr(orch_mod, "Session", MagicMock())
+    monkeypatch.setattr(orch_mod, "OperationGraphBuilder", MagicMock())
+    monkeypatch.setattr(orch_mod, "register_profile_injection", lambda *a, **kw: None)
+    monkeypatch.setattr(orch_mod, "create_agent", AsyncMock(return_value=MagicMock()))
+
+
+@pytest.mark.asyncio
+async def test_a_defaulted_run_carries_out_the_name_it_resolved(completing_setup):
+    """The caller named nothing, so nothing they passed can name the profile.
+    The env has to, or the run is unattributable from here on."""
+    env = await _run()
+
+    assert env.orc_profile_name == DEFAULT_ORCHESTRATOR_AGENT
+
+
+@pytest.mark.asyncio
+async def test_a_named_agent_carries_out_its_own_name(completing_setup):
+    env = await _run(agent_name="reviewer")
+
+    assert env.orc_profile_name == "reviewer"
+
+
+@pytest.mark.asyncio
+async def test_naming_only_a_model_carries_out_no_name(completing_setup):
+    """No profile was loaded, so there is no name to record. Recording one
+    would claim a profile shaped this run when none did."""
+    env = await _run(model_spec="claude_code/sonnet")
+
+    assert env.orc_profile is None
+    assert env.orc_profile_name is None
+
+
+@pytest.mark.asyncio
+async def test_the_carried_name_is_the_loaded_profiles_own(completing_setup, monkeypatch):
+    """Read off the profile, not off the argument: the two can differ, and it is
+    the profile that shaped the run."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+
+    monkeypatch.setattr(
+        orch_mod,
+        "load_agent_profile",
+        lambda name, *a, **kw: AgentProfile(name="orchestrator", system_prompt="s", model="claude"),
+    )
+
+    env = await _run(agent_name="orchestrator-alias")
+
+    assert env.orc_profile_name == "orchestrator"
+
+
+# ── …and reach the record a later reader has ──────────────────────────────────
+
+
+@pytest.fixture
+def temp_db_path(tmp_path, monkeypatch):
+    """Keep the state DB the persist layer opens inside tmp_path."""
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
+
+
+def _persisting_env(tmp_path, *, orc_profile_name):
+    """An env already past setup_orchestration, with a real run directory so the
+    manifest it writes can be read back off disk."""
+    from lionagi import Branch, Session
+    from lionagi.cli.orchestrate._orchestration import OrchestrationEnv
+    from lionagi.operations.builder import OperationGraphBuilder
+
+    orc_branch = Branch(name="orchestrator")
+    run = RunDir(
+        run_id="record-run",
+        state_root=tmp_path / "run-state",
+        artifact_root=tmp_path / "run-artifacts",
+    )
+    run.ensure_state_dirs()
+    run.ensure_artifact_root()
+    profile = (
+        None
+        if orc_profile_name is None
+        else AgentProfile(name=orc_profile_name, system_prompt="s", model="codex/gpt-5.6-sol")
+    )
+    return OrchestrationEnv(
+        run=run,
+        session=Session(default_branch=orc_branch),
+        orc_branch=orc_branch,
+        builder=OperationGraphBuilder(),
+        orc_profile=profile,
+        orc_profile_name=orc_profile_name,
+        default_model_spec="codex/gpt-5.6-sol",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+
+
+def _manifest(env) -> dict:
+    return json.loads(Path(env.run.manifest_path).read_text())
+
+
+@pytest.mark.asyncio
+async def test_a_bare_fanout_run_names_the_profile_it_used_on_disk(temp_db_path, tmp_path):
+    """`li o fanout` with no agent and no model: the manifest a later reader
+    opens must say which profile the run orchestrated under. `agent_name=None`
+    is passed here on purpose — it is what the bare command line gives."""
+    from lionagi.cli.orchestrate import fanout as fanout_module
+
+    env = _persisting_env(tmp_path, orc_profile_name=DEFAULT_ORCHESTRATOR_AGENT)
+
+    with (
+        patch.object(fanout_module, "setup_orchestration", AsyncMock(return_value=env)),
+        # An empty assignment list is the shortest path from start_live_persist
+        # to a clean terminal status — no worker or DAG machinery runs.
+        patch.object(fanout_module, "plan", AsyncMock(return_value=[])),
+    ):
+        await fanout_module._run_fanout("codex/gpt-5.6-sol", "prompt", agent_name=None)
+
+    assert _manifest(env)["agent_name"] == DEFAULT_ORCHESTRATOR_AGENT
+
+    # The manifest and the session row are two records of the same run, and a
+    # reader may open either. Both have to name the profile.
+    from lionagi.state.db import StateDB
+
+    async with StateDB() as db:
+        row = await db.get_session(str(env.session.id))
+    assert row is not None
+    assert row["agent_name"] == DEFAULT_ORCHESTRATOR_AGENT
+
+
+@pytest.mark.asyncio
+async def test_a_fanout_run_that_named_only_a_model_names_no_profile_on_disk(
+    temp_db_path, tmp_path
+):
+    """No profile was used, so the record must not name one."""
+    from lionagi.cli.orchestrate import fanout as fanout_module
+
+    env = _persisting_env(tmp_path, orc_profile_name=None)
+
+    with (
+        patch.object(fanout_module, "setup_orchestration", AsyncMock(return_value=env)),
+        patch.object(fanout_module, "plan", AsyncMock(return_value=[])),
+    ):
+        await fanout_module._run_fanout("codex/gpt-5.6-sol", "prompt", agent_name=None)
+
+    assert _manifest(env)["agent_name"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_bare_flow_run_names_the_profile_it_used_on_disk(temp_db_path, tmp_path):
+    """The same for `li o flow`, which `li play` also expands into."""
+    from lionagi.cli.orchestrate import flow as flow_module
+
+    env = _persisting_env(tmp_path, orc_profile_name=DEFAULT_ORCHESTRATOR_AGENT)
+
+    with (
+        patch.object(flow_module, "setup_orchestration", AsyncMock(return_value=env)),
+        patch.object(flow_module, "_run_flow_inner", AsyncMock(return_value="ok")),
+    ):
+        await flow_module._run_flow("codex/gpt-5.6-sol", "prompt", agent_name=None)
+
+    assert _manifest(env)["agent_name"] == DEFAULT_ORCHESTRATOR_AGENT
+
+
+@pytest.mark.asyncio
+async def test_a_flow_run_that_named_an_agent_still_names_that_agent_on_disk(
+    temp_db_path, tmp_path
+):
+    """A caller who did name an agent is recorded exactly as before."""
+    from lionagi.cli.orchestrate import flow as flow_module
+
+    env = _persisting_env(tmp_path, orc_profile_name="reviewer")
+
+    with (
+        patch.object(flow_module, "setup_orchestration", AsyncMock(return_value=env)),
+        patch.object(flow_module, "_run_flow_inner", AsyncMock(return_value="ok")),
+    ):
+        await flow_module._run_flow("codex/gpt-5.6-sol", "prompt", agent_name="reviewer")
+
+    assert _manifest(env)["agent_name"] == "reviewer"

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -3945,6 +3945,7 @@ def _persistence_seam_env(tmp_path):
         orc_branch=orc_branch,
         builder=mock.MagicMock(),
         orc_profile=None,
+        orc_profile_name=None,
         default_model_spec="claude",
         bare=False,
         effort=None,


### PR DESCRIPTION
## The defect

`setup_orchestration` resolves the default orchestrator profile when a call names
neither an agent nor a model. That resolution never left the function: it assigned
the name locally, loaded the profile, and returned an environment that did not
carry it. Both persisting call sites passed their own `agent_name` parameter,
which in that case is `None`.

So a bare `li orchestrate fanout` recorded the orchestrator profile's model and
provider alongside a null `agent_name`. The run demonstrably ran under a profile,
and the record could not say which — a later reader cannot tell a defaulted
orchestration from one that ran with no profile at all.

## What changed

`OrchestrationEnv` carries `orc_profile_name`, filled from the loaded
`AgentProfile`'s own `name` field rather than from the argument, so the recorded
name cannot name a profile other than the one that was loaded. `_run_fanout` and
`_run_flow` record that instead of their parameter.

Three cases fall out of one expression, with no special-casing:

| Call | profile loaded | recorded name |
|---|---|---|
| named an agent | that one | that name, exactly as before |
| named neither an agent nor a model | the resolved default | the default's name |
| named only a model | none | none, because none was used |

The field is deliberately not defaulted. A `None` default would let a future
construction site say nothing and silently record a null that reads as "no
profile" — which is the failure being fixed. Requiring it forces each site to
state what the run used; the cost is one keyword at eight existing test
constructions.

Nothing about what `setup_orchestration` does changed. Its resolution logic,
defaulting, error translation and comments are untouched. This is a reporting
change.

## Tests

Eight new tests in the module that already owns the defaulting behaviour, in two
groups: four that the resolved name leaves the function, and four that it reaches
the record a later reader actually has — driving the real `_run_fanout` and
`_run_flow` through the real persist path with a real run directory, then reading
`run.json` back off disk and the `sessions` row back through `StateDB`. A reader
may open either, so both are asserted.

Each new assertion was broken deliberately and confirmed red, including the
session-row assertion, which needed its own break because the manifest assertion
on the same test fails first. Two of the breaks reproduce the original defect
verbatim.

No orchestration was run and no LLM call was made.

## Left alone, deliberately

The artifact-contract gate in `flow.py` still reads `agent_name`, so a defaulted
run does not pick up the default profile's `artifact_defaults`. Switching it to
the resolved profile would change behaviour rather than reporting, so it stays as
it is.
