### PR TITLE
fix(mcp): a run whose process is conclusively gone gets an attributable end

### DIFF
--- a/docs/adr/ADR-0107-conclusive-orphan-terminal-reaping.md
+++ b/docs/adr/ADR-0107-conclusive-orphan-terminal-reaping.md
@@ -4,6 +4,10 @@
 - **Kind**: Aspirational (records the target state)
 - **Area**: cli-surface
 - **Date**: 2026-07-27
+- **Amended**: 2026-07-27 — D3, D4, D5, D6 and the verify-by list carry
+  amendment notes marking what changed and why. The amendments settle questions
+  the implementation surfaced: the outcome value, the fifth attribution source,
+  and what a mutation does when it cannot be serialized.
 - **Relations**: extends ADR-0095, ADR-0106
 
 ## Context
@@ -96,7 +100,7 @@ cache, and orphan observer must not overwrite a terminal fact or delivery result
 |---------|----------|
 | How a conclusively gone unreported run becomes terminal | D1: the observer persists an idempotent orphan-reap transition before returning it as terminal |
 | What evidence is conclusive | D2: one positive internal `liveness_conclusion` names conclusive process loss; unknown remains advisory |
-| How the result is represented | D3: `outcome="lost"` and `reason_code="process_gone_without_outcome"` are distinct from reported failure |
+| How the result is represented | D3: `outcome="indeterminate"` and `reason_code="process_gone_without_outcome"` are distinct from reported failure |
 | How the transition is attributed | D4: the sidecar records source, observation time, and bounded evidence |
 | How concurrent writers behave | D5: every sidecar mutation uses one per-run serialization discipline and first terminal fact wins |
 | What wait/list/status mean | D6: all three may trigger the same reap; a reaped run is terminal and contributes to `all_terminal` |
@@ -107,7 +111,8 @@ cache, and orphan observer must not overwrite a terminal fact or delivery result
 
 - Preventing every child crash. Parent reaping or a wrapper may reduce the
   frequency, but cannot cover parent-and-child loss or repair existing records.
-- Automatic retry or resume. `lost` states that no outcome was reported; it does
+- Automatic retry or resume. This outcome states that no result could be
+  established; it does
   not prove that retrying side effects is safe.
 - Closing `spawn_state="preparing"` from elapsed time. No process identity was
   durably acquired, so elapsed time alone is not conclusive.
@@ -198,7 +203,30 @@ meanings for compatibility. The public response additionally exposes
 docstring is corrected in the same change, but no existing emitted value is
 silently redefined.
 
-### D3 — A distinct `lost` outcome and reason
+### D3 — The reserved `indeterminate` outcome and a distinct reason
+
+> **Amended 2026-07-27.** This decision originally mandated a new outcome value,
+> `lost`. It is `indeterminate` instead. Four reasons, in the order they decided
+> it:
+>
+> 1. ADR-0106 D4 already reserves `indeterminate` for a run that ended and whose
+>    result cannot be established. "Process gone without outcome" is that
+>    situation; this producer is what the reservation was for, and is its first
+>    writer.
+> 2. Nothing is lost to callers. Everything that distinguishes this transition
+>    lives in the additive fields this ADR already specifies —
+>    `reason_code="process_gone_without_outcome"` and
+>    `terminal_source="mcp_orphan_reaper"` — which is where the mechanism was
+>    always meant to live.
+> 3. A closed vocabulary widened at an unchanged `contract_version` is a silent
+>    contract change. Keeping the vocabulary closed is worth more than the more
+>    evocative word, and it means `contract_version` does not move.
+> 4. `cancelled` is already one value outside ADR-0106's vocabulary; `lost`
+>    would have been the second. Regularizing `cancelled` is an ADR-0106
+>    amendment item and is out of scope here.
+>
+> Retry semantics carry over unchanged: automatic retry stays reserved to
+> `failed`, and an `indeterminate` run is never automatically retried.
 
 The persisted and returned lifecycle fields are:
 
@@ -206,26 +234,28 @@ The persisted and returned lifecycle fields are:
 {
   "status": "exited",
   "terminal": true,
-  "outcome": "lost",
+  "outcome": "indeterminate",
   "reason_code": "process_gone_without_outcome",
   "possibly_orphaned": false
 }
 ```
 
-`outcome="lost"` means: the process identity is conclusively gone and no
-authoritative work outcome was reported. It does not mean the work failed. The
-work may have completed its intended effect before dying; the producer has no
-evidence either way.
+`outcome="indeterminate"` here means: the process identity is conclusively gone
+and no authoritative work outcome was reported. It does not mean the work
+failed. The work may have completed its intended effect before dying; the
+producer has no evidence either way.
 
 `outcome="failed"` remains reserved for a reported terminal status classified
 as failure, including a caught spawn failure. Callers may retry `failed` under
-their existing policy. They must not automatically retry `lost`, because an
-unreported external side effect may already have committed.
+their existing policy. They must not automatically retry an `indeterminate`
+run, because an unreported external side effect may already have committed.
 
-`reason_code="process_gone_without_outcome"` names why the result is lost. It is
-not a failure reason and must never be mapped to `_outcome_for`. The status
-`"exited"` remains an open, displayable producer value; callers continue to
-branch on `terminal`, `outcome`, and `reason_code`, not on that string.
+`reason_code="process_gone_without_outcome"` names why the result cannot be
+established, and is what distinguishes this producer's `indeterminate` from any
+other. It is not a failure reason and must never be mapped to `_outcome_for`.
+The status `"exited"` remains an open, displayable producer value; callers
+continue to branch on `terminal`, `outcome`, and `reason_code`, not on that
+string.
 
 ### D4 — Attribution is durable and additive
 
@@ -255,7 +285,17 @@ field when written or next rewritten:
 | child terminal hook | `cli_terminal_hook` |
 | lifecycle end cached by observer | `lifecycle_cache` |
 | producer-caught spawn failure | `spawn_failure` |
+| kill issued through this server | `mcp_kill` |
 | conclusive orphan observer | `mcp_orphan_reaper` |
+
+> **Amended 2026-07-27.** The fifth row is new. The table originally named four
+> writers and omitted the direct kill path, which publishes an end like the
+> other four and was leaving it unattributed — the one thing this decision
+> exists to prevent. No writer inside the D5 discipline may publish a terminal
+> fact with a null source. The value is `mcp_kill` because every existing value
+> names the mechanism that made the transition rather than the run's fate, and
+> the kill path sits beside `mcp_orphan_reaper` as the other terminal writer
+> inside this server.
 
 `terminal_evidence` is deliberately bounded. It records the classifier version
 if versioning is introduced and the named finding; it does not copy argv,
@@ -284,7 +324,8 @@ Within the guard:
 - an existing `finished_at` wins and is never replaced;
 - a reported hook or lifecycle end that arrived first keeps its reported
   `status`, `outcome`, and `reason_code`;
-- an orphan reap that arrived first remains `lost`; a later child-hook process
+- an orphan reap that arrived first keeps its `indeterminate`; a later
+  child-hook process
   cannot overwrite it, but its delivery attempt may fill an absent
   `notify_delivery`;
 - notification updates merge only `notify_delivery` and cannot roll terminal
@@ -294,6 +335,44 @@ Within the guard:
 This rule makes concurrent observers idempotent and prevents a late stale write
 from un-terminalising a record.
 
+> **Amended 2026-07-27 — a mutation that cannot be serialized refuses, and says
+> so.** This decision required serialization and said nothing about what happens
+> when serialization cannot be obtained. The implementation's answer was to do
+> nothing silently, and that is the fail-open class this ADR exists to close: a
+> terminal-state write that no-ops still lets its caller announce the end, so a
+> notice goes out asserting completion while the record reads `running`.
+>
+> The contract is therefore: **refuse, stay non-terminal, report.** A mutation
+> that cannot enter the critical section — the lock file cannot be created, or
+> the lock cannot be acquired — writes nothing, leaves the record exactly as it
+> stands, and returns a result that distinguishes "could not be serialized" from
+> "no such record". The two must not collapse into one empty answer: an absent
+> record is a settled fact about the run, an unavailable lock is no answer at
+> all, and only the second one is retried by the next observation.
+>
+> Refusal is loud, through the mechanisms the terminal path already uses for
+> failure: the run's own console log carries the note, and the terminal hook
+> process exits non-zero. Per D7 no delivery is attempted for a terminal record
+> that was not durably published. A kill whose record could not be written
+> reports its own code rather than a plain success — the signal was sent and
+> nothing durable says so, which is a different fact from a kill that was
+> recorded. The absent-record behaviour is unchanged in every case.
+>
+> **Second delivery result: last-writer-wins.** D5 protected terminal fields but
+> did not choose between first- and last-writer-wins for `notify_delivery`
+> alone. The later result is kept. Only one caller owns a given run's notice,
+> and where a second exists — a child hook filling in the notice for an end an
+> observer inferred — the later attempt is the more recent fact about the
+> notice, which is the whole of what the field says.
+>
+> **The window this leaves open, named.** A run that in fact succeeded can be
+> reported `indeterminate` when a reap won the race against a late but healthy
+> terminal hook: the D1 latch keeps the first recorded end, and the reap's end
+> was first. This is the intended trade — the latch is what makes concurrent
+> observers agree — and it is stated here so it is a known edge rather than a
+> surprise. An additive late-report capture, following the fill-absent pattern
+> above, remains available to the owner of this decision; it is not required.
+
 ### D6 — Status, list, and wait share the terminal contract
 
 All three public readers resolve through `status()` and therefore may perform
@@ -301,13 +380,17 @@ D1 once:
 
 | Consumer | Existing branch | Required behavior |
 |----------|-----------------|-------------------|
-| `job.status` | displays and returns lifecycle fields | returns the durable `lost` terminal state and attribution fields |
+| `job.status` | displays and returns lifecycle fields | returns the durable `indeterminate` terminal state and attribution fields |
 | `job.list` | calls `status()` per entry | may reap; includes `terminal`, `outcome`, `reason_code`, `finished_at`, and `terminal_source` |
 | `job.wait` | polls `status()` and computes set fields | returns reaped entries as terminal; they are neither `pending` nor `stopped_without_end` |
 
 `all_terminal` means every valid requested run has a durable terminal end,
-including `outcome="lost"`. It does not mean every run succeeded or reported an
-outcome. A caller determines aggregate success from each entry's `outcome`.
+including `outcome="indeterminate"`. It does not mean every run succeeded or
+reported an outcome. A caller determines aggregate success from each entry's
+`outcome`.
+
+> **Amended 2026-07-27.** The outcome value in this decision follows D3's
+> amendment; nothing else about the reader contract changes.
 
 `stopped_without_end` remains additive compatibility output for inconclusive
 advisory cases only. A positively conclusive orphan is reaped before wait
@@ -370,7 +453,7 @@ because they are old.
 
 | Consumer / contract | Current dependency | Result under this ADR | Same-PR change |
 |---------------------|--------------------|-----------------------|----------------|
-| `job.status` | canonical source of `terminal` and `outcome` | safe after D1-D5; gains `lost`, attribution, and liveness conclusion | implementation and public schema/docs |
+| `job.status` | canonical source of `terminal` and `outcome` | safe after D1-D5; gains this `indeterminate` producer, attribution, and liveness conclusion | implementation and public schema/docs |
 | `job.list` | delegates to `status()` but omits orphan and delivery detail | safe to terminalise; projection must include `terminal_source` so attribution is not hidden | projection and tests |
 | `job.wait` | stops polling advisory orphans but keeps `all_terminal=false` | simplifies to one durable stop condition for conclusive cases | aggregation, compatibility field, and tests |
 | terminal notice / `notify_delivery` | child hook owns both transition and delivery | **breaks if only terminality changes**; dead child cannot notify | D7 observer delivery and failure-path tests |
@@ -378,7 +461,7 @@ because they are old.
 | submit PID attachment | late write rereads to preserve hook terminality | unsafe under an added concurrent observer without D5 | shared mutation discipline and race tests |
 | schedule runs | MCP jobs may wrap flow/play work, but scheduler lifecycle is authoritative in StateDB | no scheduler status is inferred or rewritten; only the MCP sidecar closes | cross-surface test that scheduler-reported ends still win |
 | dispatch/outbox | not used by MCP terminal-hook delivery | unchanged; D7 does not enqueue a Studio-dependent dispatch | no behavior change |
-| external machine consumers | branch on `terminal` and `outcome`, status opaque | must accept additive outcome `lost`; must not treat non-success as automatically retryable | ADR-0106 contract/docs and compatibility test |
+| external machine consumers | branch on `terminal` and `outcome`, status opaque | must accept `indeterminate` from a new producer; must not treat non-success as automatically retryable | ADR-0106 contract/docs and compatibility test |
 
 The notification row is the breaking consumer the design must address. A patch
 that changes `_derive` or `all_terminal` without D7 is incomplete.
@@ -401,7 +484,7 @@ that changes `_derive` or `all_terminal` without D7 is incomplete.
 - Sidecar mutation must gain real concurrency control; atomic replace alone is
   insufficient.
 - A read can now incur one bounded notification attempt after the durable write.
-- `lost` expands the public `outcome` vocabulary. Consumers that incorrectly
+- A new producer of `indeterminate` reaches consumers. Consumers that incorrectly
   treat it as a boolean success/failure must be corrected.
 - The actual process exit time remains unknown. `finished_at` records when loss
   was established.
@@ -411,7 +494,7 @@ that changes `_derive` or `all_terminal` without D7 is incomplete.
 
 | Constraint | Tension | Resolution |
 |------------|---------|------------|
-| distinct terminal outcome | expands a public producer vocabulary | additive `lost`, documented and never mapped to failed |
+| distinct terminal outcome | a value few consumers had seen in practice | the vocabulary is unchanged; `indeterminate` is documented and never mapped to failed |
 | conclusive identity only | OS observations occur at read time | only the positive closed conclusion can write; unknown stays advisory |
 | consumers audit | notification is not repaired by terminality alone | D7 makes it part of the same PR |
 | attributable transition | existing records lack a writer field | additive `terminal_source` plus `finished_at` and bounded evidence |
@@ -473,10 +556,13 @@ whose external effects are unknown. Rejected for this sidecar contract.
 - Terminalise from `not alive`, elapsed time, missing PID, denied access, or a
   negative test against an open finding vocabulary.
 - Return `terminal=true` before the durable transition is published.
-- Map `lost` to `failed`, success, cancellation, or automatic retry.
-- Overwrite an earlier reported terminal end with an inferred lost outcome.
+- Map this producer's `indeterminate` to `failed`, success, cancellation, or
+  automatic retry.
+- Overwrite an earlier reported terminal end with an inferred one.
 - Let notification delivery happen under the sidecar mutation lock or roll
   back terminality.
+- Let a mutation that could not be serialized report as one that succeeded, or
+  let a delivery follow a terminal record that was not durably published.
 - Add secrets, environment contents, prompt text, argv, or log bodies to
   terminal evidence.
 - make scheduler/Studio availability necessary for MCP job correctness.
@@ -492,8 +578,9 @@ whose external effects are unknown. Rejected for this sidecar contract.
    notify-result-vs-reaper interleavings preserve the first terminal fact and
    all non-conflicting fields.
 5. A reaped entry makes `job.wait.all_terminal=true` when every other valid
-   entry is terminal; `outcome` is `lost`.
-6. Mixed running/lost/failed/succeeded waits preserve order and aggregate fields.
+   entry is terminal; `outcome` is `indeterminate`.
+6. Mixed running/indeterminate/failed/succeeded waits preserve order and
+   aggregate fields.
 7. `job.list` and `job.status` expose identical terminal classification and
    attribution for the same run.
 8. A configured notice is attempted by the winning observer; success, refusal,
@@ -501,18 +588,30 @@ whose external effects are unknown. Rejected for this sidecar contract.
    without changing the outcome.
 9. Existing pre-change stranded records are reaped on the next conclusive read;
    inconclusive records are untouched.
-10. Public MCP reference and CLI documentation define `lost`,
+10. Public MCP reference and CLI documentation define this producer's
+    `indeterminate`,
     `process_gone_without_outcome`, `terminal_source`,
     `liveness_conclusion`, and the revised `all_terminal` meaning in the same
-    change. Wherever `lost` is publicly defined, the documentation also states
-    the consumer-facing consequence of D4's `finished_at` semantics: for a lost
-    run `finished_at` is when the end was established, not when the process
-    exited, so any duration derived from it is an upper bound.
+    change. Wherever this outcome is publicly defined, the documentation also states
+    the consumer-facing consequence of D4's `finished_at` semantics: for a run
+    ended this way `finished_at` is when the end was established, not when the
+    process exited, so any duration derived from it is an upper bound.
 11. No test branches on `status == "exited"` to decide terminality.
 12. Fault injection after durable terminal publication but before delivery
-    proves that reconciliation still reads a terminal lost run.
+    proves that reconciliation still reads a terminal `indeterminate` run.
+13. Lock-file creation failure and lock acquisition failure are injected
+    separately; each leaves the record non-terminal, attempts no delivery, and
+    reports the refusal where a caller looks. (Added by the 2026-07-27
+    amendment to D5.)
+14. A kill records `terminal_source="mcp_kill"`, and a kill whose record could
+    not be written reports that rather than a plain success. (Added by the
+    2026-07-27 amendments to D4 and D5.)
 
 ## Notes
+
+ADR-0106's outcome vocabulary carries one pre-existing value, `cancelled`, that
+the vocabulary itself does not list. That drift predates this decision and is
+not resolved here; it is an ADR-0106 amendment item.
 
 `AGENT.md` contains workflow guidance addressed to coding agents. It was treated
 as evidence of repository conventions, not as authority over this decision.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -698,25 +698,25 @@ then report it:
 | Field | Value |
 |-------|-------|
 | `terminal` | `true` |
-| `outcome` | `lost` |
+| `outcome` | `indeterminate` |
 | `reason_code` | `process_gone_without_outcome` |
 | `terminal_source` | `mcp_orphan_reaper` |
 
-`outcome: "lost"` means the process is conclusively gone and **no authoritative
+`outcome: "indeterminate"` means the process is conclusively gone and **no authoritative
 outcome was reported**. It does not mean the work failed: the run may well have
 finished what it was doing before it died, and nothing survived to say either
 way. `failed` stays reserved for a reported terminal status classified as a
 failure, and a caller may retry a `failed` run under its own policy. **Do not
-automatically retry a `lost` run** — an external side effect it never got to
+automatically retry such a run** — an external side effect it never got to
 report may already have committed.
 
 `terminal_source` says what wrote the end: `cli_terminal_hook` (the run's own
 terminal hook), `lifecycle_cache` (an end read back from the lifecycle store),
-`spawn_failure` (the spawn was caught failing), or `mcp_orphan_reaper` (this
-server, from the conclusive observation above). It is null on records written
-before the field existed.
+`spawn_failure` (the spawn was caught failing), `mcp_kill` (the run was killed
+through this server), or `mcp_orphan_reaper` (this server, from the conclusive
+observation above). It is null on records written before the field existed.
 
-For a `lost` run, **`finished_at` is when the loss was established and recorded,
+For a run ended this way, **`finished_at` is when the loss was established and recorded,
 not when the process exited** — nothing surviving can report that instant. Any
 duration derived from it is therefore an **upper bound** on how long the run
 actually ran.
@@ -728,7 +728,7 @@ probe — never does, and such a run stays non-terminal and advisory
 (`possibly_orphaned`), reported by `job.wait` under `stopped_without_end`.
 
 `job.wait`'s **`all_terminal` means every valid requested run has a recorded
-end**, including runs whose outcome is `lost`. It does not mean every run
+end**, including runs whose outcome is `indeterminate`. It does not mean every run
 succeeded or reported an outcome; read each entry's `outcome` for that.
 
 ### Terminal notices

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -673,6 +673,56 @@ its own `status` may lag.
 The verb catalog, the `request` result contract, and a worked submit-and-poll
 example are in the [MCP server reference](reference/mcp-server.md).
 
+### When a run's process is gone and nothing recorded how it came out
+
+A background run normally records its own end: the CLI's terminal hook writes it,
+and a run stopped by `li kill` leaves it in the lifecycle store, which the server
+caches onto the job record. A run whose process dies before either of those
+happens leaves nothing behind at all — no surviving producer can ever write its
+end.
+
+Where an observation *positively establishes* that the run's process is gone —
+the recorded pid holds no process, it disappears between two probes, or a live
+process holds the number and started at a different time, so it is a different
+process — `job.status`, `job.list` and `job.wait` record that end themselves and
+then report it:
+
+| Field | Value |
+|-------|-------|
+| `terminal` | `true` |
+| `outcome` | `lost` |
+| `reason_code` | `process_gone_without_outcome` |
+| `terminal_source` | `mcp_orphan_reaper` |
+
+`outcome: "lost"` means the process is conclusively gone and **no authoritative
+outcome was reported**. It does not mean the work failed: the run may well have
+finished what it was doing before it died, and nothing survived to say either
+way. `failed` stays reserved for a reported terminal status classified as a
+failure, and a caller may retry a `failed` run under its own policy. **Do not
+automatically retry a `lost` run** — an external side effect it never got to
+report may already have committed.
+
+`terminal_source` says what wrote the end: `cli_terminal_hook` (the run's own
+terminal hook), `lifecycle_cache` (an end read back from the lifecycle store),
+`spawn_failure` (the spawn was caught failing), or `mcp_orphan_reaper` (this
+server, from the conclusive observation above). It is null on records written
+before the field existed.
+
+For a `lost` run, **`finished_at` is when the loss was established and recorded,
+not when the process exited** — nothing surviving can report that instant. Any
+duration derived from it is therefore an **upper bound** on how long the run
+actually ran.
+
+`liveness_conclusion` on `job.status` says what the observation established:
+`process_gone`, `alive`, or `unknown`. Only `process_gone` can end a run.
+`unknown` — a pid the OS cannot be asked about, a denied or unreadable identity
+probe — never does, and such a run stays non-terminal and advisory
+(`possibly_orphaned`), reported by `job.wait` under `stopped_without_end`.
+
+`job.wait`'s **`all_terminal` means every valid requested run has a recorded
+end**, including runs whose outcome is `lost`. It does not mean every run
+succeeded or reported an outcome; read each entry's `outcome` for that.
+
 ### Terminal notices
 
 When a background run finishes, the server records its terminal status and, if a

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -314,6 +314,46 @@ can travel together:
 Check each entry's `ok`: the second can fail while the first succeeds, and
 `status` would then be `"partial"`.
 
+## Terminal state of a background run
+
+`job.status`, `job.list` and `job.wait` all resolve through one classification
+path, so no two of them can disagree about the same run. Branch on `terminal`
+and `outcome`; `status` is an open producer vocabulary and is for display.
+
+`outcome` carries one additional value beyond a reported result: **`lost`**,
+paired with `reason_code: "process_gone_without_outcome"`. A run is `lost` when
+an observation positively established that its process is gone — the recorded
+pid held no process, it disappeared between two probes, or a live process holds
+the number and started at a different time — and no authoritative outcome was
+ever reported for it. Nothing survived to write one, so the run is ended here
+rather than left waiting forever.
+
+`lost` is not a failure. The work may have had its intended effect before the
+process died. Consumers must not map it to `failed`, to success, or to
+cancellation, and must not retry it automatically: an unreported external side
+effect may already have committed.
+
+Three fields describe such an end:
+
+| Field | Meaning |
+|-------|---------|
+| `terminal_source` | what wrote the end: `cli_terminal_hook`, `lifecycle_cache`, `spawn_failure`, or `mcp_orphan_reaper`. Null on records written before the field existed. Carried by both `job.status` and `job.list`. |
+| `terminal_evidence` | bounded evidence behind an end nobody reported: the kind, and the named finding. Never argv, environment, logs or payloads. |
+| `liveness_conclusion` | what the observation established: `process_gone`, `alive` or `unknown`. Only `process_gone` can end a run. |
+
+An `unknown` conclusion — a pid the OS cannot be asked about, an identity probe
+that was denied or unreadable — never ends a run. Those stay non-terminal and
+advisory (`possibly_orphaned`), and `job.wait` reports them under
+`stopped_without_end`.
+
+**`finished_at` on a `lost` run is when the end was established and recorded,
+not when the process exited**, which nothing surviving can report. Any duration
+derived from it is an upper bound on how long the run actually ran.
+
+`job.wait`'s **`all_terminal` means every valid requested run has a recorded
+end**, including `lost` ones. It does not mean every run succeeded or reported
+an outcome — read each entry's `outcome` for that.
+
 ## Compatibility
 
 An earlier version of this server advertised one tool per operation. Those flat

--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -320,15 +320,15 @@ Check each entry's `ok`: the second can fail while the first succeeds, and
 path, so no two of them can disagree about the same run. Branch on `terminal`
 and `outcome`; `status` is an open producer vocabulary and is for display.
 
-`outcome` carries one additional value beyond a reported result: **`lost`**,
-paired with `reason_code: "process_gone_without_outcome"`. A run is `lost` when
-an observation positively established that its process is gone — the recorded
+`outcome` is the closed set `succeeded | failed | cancelled | indeterminate`.
+**`indeterminate`** paired with `reason_code: "process_gone_without_outcome"` is
+how a run ends when an observation positively established that its process is gone — the recorded
 pid held no process, it disappeared between two probes, or a live process holds
 the number and started at a different time — and no authoritative outcome was
 ever reported for it. Nothing survived to write one, so the run is ended here
 rather than left waiting forever.
 
-`lost` is not a failure. The work may have had its intended effect before the
+That end is not a failure. The work may have had its intended effect before the
 process died. Consumers must not map it to `failed`, to success, or to
 cancellation, and must not retry it automatically: an unreported external side
 effect may already have committed.
@@ -337,7 +337,7 @@ Three fields describe such an end:
 
 | Field | Meaning |
 |-------|---------|
-| `terminal_source` | what wrote the end: `cli_terminal_hook`, `lifecycle_cache`, `spawn_failure`, or `mcp_orphan_reaper`. Null on records written before the field existed. Carried by both `job.status` and `job.list`. |
+| `terminal_source` | what wrote the end: `cli_terminal_hook`, `lifecycle_cache`, `spawn_failure`, `mcp_kill`, or `mcp_orphan_reaper`. Null on records written before the field existed. Carried by both `job.status` and `job.list`. |
 | `terminal_evidence` | bounded evidence behind an end nobody reported: the kind, and the named finding. Never argv, environment, logs or payloads. |
 | `liveness_conclusion` | what the observation established: `process_gone`, `alive` or `unknown`. Only `process_gone` can end a run. |
 
@@ -346,12 +346,12 @@ that was denied or unreadable — never ends a run. Those stay non-terminal and
 advisory (`possibly_orphaned`), and `job.wait` reports them under
 `stopped_without_end`.
 
-**`finished_at` on a `lost` run is when the end was established and recorded,
+**`finished_at` on a run ended this way is when the end was established and recorded,
 not when the process exited**, which nothing surviving can report. Any duration
 derived from it is an upper bound on how long the run actually ran.
 
 `job.wait`'s **`all_terminal` means every valid requested run has a recorded
-end**, including `lost` ones. It does not mean every run succeeded or reported
+end**, including `indeterminate` ones. It does not mean every run succeeded or reported
 an outcome — read each entry's `outcome` for that.
 
 ## Compatibility

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -217,6 +217,29 @@ def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
         pass
 
 
+def _note_persistence_failure(run_id: str, what: str) -> None:
+    """Append one line to the run's own log when a record could not be written.
+
+    The same fallback as a failed delivery, for the same reason: the record is
+    where a failure would ordinarily be reported, and this is the case where the
+    record is exactly what could not be written. The log is the one place left,
+    and it is the place someone reading a run that stops mid-sentence looks.
+
+    Best-effort in the same way. This runs in the dying process of a run that is
+    already over, and a log that cannot be appended to must not turn a refusal
+    that was handled into a crash.
+    """
+    try:
+        path = config.job_dir(run_id) / "console.log"
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(
+                f"\n[notify] could not record the {what} for run {run_id}: the job "
+                f"record could not be locked. The record was left unchanged.\n"
+            )
+    except OSError:
+        pass
+
+
 def deliver_terminal_notice(
     run_id: str,
     job: dict[str, Any] | None,
@@ -303,18 +326,33 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = ap.parse_args(argv)
 
-    job = jobs.mark_terminal(args.run_id, args.status)
+    terminal = jobs.mark_terminal(args.run_id, args.status)
+    if terminal.refused:
+        # The end is not on disk. A notice sent now would assert a completion
+        # that every reader of the record contradicts, so it is not sent: the
+        # record stays non-terminal and the next observation of this run ends it
+        # the way a run whose hook never ran is ended. The refusal is reported
+        # where the run's own log and this process's exit status are the two
+        # places anything is left to look.
+        _note_persistence_failure(args.run_id, "terminal status")
+        return 1
 
     outcome = deliver_terminal_notice(
         args.run_id,
-        job,
+        terminal.record,
         args.status,
         target=args.target,
         command=args.command,
         sender=args.sender,
     )
-    jobs.record_notify_delivery(args.run_id, outcome)
+    recorded = jobs.record_notify_delivery(args.run_id, outcome)
     _note_failure_in_console_log(args.run_id, outcome)
+    if recorded.refused:
+        # The notice was attempted against a durable end; what is missing is the
+        # record of how it went. Reported the same way, because a delivery
+        # nobody can read back is one an operator has to be told about.
+        _note_persistence_failure(args.run_id, "delivery result")
+        return 1
     return 0
 
 

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -217,26 +217,37 @@ def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
         pass
 
 
-def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(prog="lionagi.mcp._notify_hook")
-    ap.add_argument("--run-id", required=True)
-    ap.add_argument("--status", default="completed")
-    ap.add_argument("--target", default=None, help="value for the {target} placeholder")
-    ap.add_argument("--command", default=None, help="delivery argv override (JSON list)")
-    ap.add_argument(
-        "--sender",
-        default=None,
-        help="value for the {sender} placeholder: who the notice is from",
-    )
-    args = ap.parse_args(argv)
+def deliver_terminal_notice(
+    run_id: str,
+    job: dict[str, Any] | None,
+    status: str,
+    *,
+    target: str | None = None,
+    command: str | None = None,
+    sender: str | None = None,
+) -> dict[str, Any]:
+    """Attempt this run's configured terminal notice and report what came of it.
 
-    job = jobs.mark_terminal(args.run_id, args.status)
+    The whole of the delivery decision lives here: which command is configured,
+    what the run's fields substitute into it, whether a missing sender makes it
+    unusable, and how each of those is recorded. It is written as one function
+    because it has two callers — this hook, running in the run's own dying
+    process, and the job observer that publishes an end for a run whose process
+    never got this far — and a notice sent by the second must be the one the
+    first would have sent. Two resolution paths would mean two answers to
+    "what is configured here", and the run that needs the notice most is the one
+    whose own process is not around to be asked.
 
-    target = args.target or os.environ.get("LIONAGI_MCP_NOTIFY_TARGET") or ""
-    sender = args.sender or os.environ.get("LIONAGI_MCP_NOTIFY_SENDER") or ""
+    Nothing raises: the caller is either a terminal path that has already
+    finished or a read that has already published a durable end, and neither can
+    be failed by a notifier. Every way a delivery does not happen comes back as
+    an outcome describing it.
+    """
+    target = target or os.environ.get("LIONAGI_MCP_NOTIFY_TARGET") or ""
+    sender = sender or os.environ.get("LIONAGI_MCP_NOTIFY_SENDER") or ""
     label = (job or {}).get("label") or (job or {}).get("kind") or "run"
     template, unusable = _resolve_command(
-        args.command or os.environ.get("LIONAGI_MCP_NOTIFY_COMMAND"),
+        command or os.environ.get("LIONAGI_MCP_NOTIFY_COMMAND"),
         cwd=(job or {}).get("cwd"),
     )
     # Taken before the sender check below can drop the template: a notifier
@@ -254,30 +265,54 @@ def main(argv: list[str] | None = None) -> int:
 
     if template:
         fields = {
-            "run_id": args.run_id,
-            "status": args.status,
+            "run_id": run_id,
+            "status": status,
             "label": label,
             "target": target,
             "sender": sender,
         }
-        outcome = _deliver(
+        return _deliver(
             _substitute(template, fields), fields, _delivery_env(sender), program=program
         )
-    elif unusable:
+    if unusable:
         # Configured but unusable. Recorded as a failure so job_status shows a
         # notifier that cannot deliver, rather than the silence of one that was
         # never asked to. ``command`` is None when the configuration never
         # yielded a program to name — an unparseable override has no program in
         # it, and saying so beats inventing one.
-        outcome = {
+        return {
             "attempted": False,
             "ok": False,
             "exit_code": None,
             "error": unusable,
             "command": program,
         }
-    else:
-        outcome = {"attempted": False}  # nothing configured — not a failure
+    return {"attempted": False}  # nothing configured — not a failure
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="lionagi.mcp._notify_hook")
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--status", default="completed")
+    ap.add_argument("--target", default=None, help="value for the {target} placeholder")
+    ap.add_argument("--command", default=None, help="delivery argv override (JSON list)")
+    ap.add_argument(
+        "--sender",
+        default=None,
+        help="value for the {sender} placeholder: who the notice is from",
+    )
+    args = ap.parse_args(argv)
+
+    job = jobs.mark_terminal(args.run_id, args.status)
+
+    outcome = deliver_terminal_notice(
+        args.run_id,
+        job,
+        args.status,
+        target=args.target,
+        command=args.command,
+        sender=args.sender,
+    )
     jobs.record_notify_delivery(args.run_id, outcome)
     _note_failure_in_console_log(args.run_id, outcome)
     return 0

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -19,7 +19,7 @@ keep — a copy of lionagi's status names to tell a finished run from a running 
 or a success from a failure. All of these resolve through one path, ``status()``,
 so no two calls can disagree about the same run at the same moment.
 
-A run's end reaches that path from two writers. The terminal hook the CLI runs
+A run's end reaches that path from three writers. The terminal hook the CLI runs
 on ``--notify`` writes it into this package's own job record. A run stopped by
 ``li kill`` never reaches that hook — the kill transitions the lifecycle row and
 signals the process, and writes nothing here — so when the process is gone and
@@ -27,10 +27,22 @@ the job record shows no end, the state is read from the CLI itself, via
 ``li lifecycle <run_id> --machine``, and cached back onto the job record. A read
 that cannot be made concludes nothing: the run is classified exactly as it would
 have been without it.
+
+The third writer is this module's own orphan observer. A run whose process died
+before the terminal hook ran has no surviving producer at all: nothing will ever
+write its end, and a caller waiting for one waits forever. So when — and only
+when — an observation positively establishes that this run's process is gone,
+``status()`` publishes that end itself, as ``outcome="lost"``, before returning
+it. Every mutation of a job record goes through one per-run lock, and the first
+recorded end wins: a later writer may add what is missing beside it but never
+replaces it, so no two readers of one record can disagree about whether the run
+ended.
 """
 
 from __future__ import annotations
 
+import contextlib
+import copy
 import json
 import math
 import os
@@ -39,13 +51,27 @@ import signal
 import stat
 import subprocess
 import sys
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from . import config
+
+# The per-run mutation lock is taken with the platform's own advisory file lock,
+# the way every other read-modify-write in this repository takes one.
+if sys.platform == "win32":  # pragma: no cover - POSIX is what CI runs
+    _fcntl = None
+    try:
+        import msvcrt as _msvcrt
+    except ImportError:
+        _msvcrt = None
+else:
+    import fcntl as _fcntl
+
+    _msvcrt = None
 
 # li subcommand for each job kind. "orchestrate" is the canonical parser name
 # (the `o` alias also works); flow and fanout live under it.
@@ -83,6 +109,47 @@ _REASON_BY_STATUS = {
     "completed_empty": "no_artifacts",
 }
 _SPAWN_FAILED_REASON = "spawn_failed"
+
+# How a run came out when its process is conclusively gone and nothing
+# authoritative ever said what the work did. It is not a failure: the work may
+# well have had its intended effect before the process died, and no producer
+# survived to say either way. That is exactly why a caller may retry a `failed`
+# run under its own policy and must not automatically retry this one — an
+# external side effect may already have committed.
+OUTCOME_LOST = "lost"
+LOST_REASON = "process_gone_without_outcome"
+
+# The outcomes this module publishes. Consulted only to decide whether an
+# `outcome` already recorded on a job record may be reported back, so a damaged
+# record cannot invent a value a caller would branch on.
+_OUTCOMES = frozenset({"succeeded", "failed", "cancelled", OUTCOME_LOST})
+
+# What made a recorded end. Additive: it answers who wrote the end, which
+# neither `status` (open, and the producer's) nor `reason_code` (why the run
+# came out that way) can answer without becoming two fields at once.
+TERMINAL_SOURCE_HOOK = "cli_terminal_hook"
+TERMINAL_SOURCE_LIFECYCLE = "lifecycle_cache"
+TERMINAL_SOURCE_SPAWN_FAILURE = "spawn_failure"
+TERMINAL_SOURCE_ORPHAN_REAPER = "mcp_orphan_reaper"
+
+# What the orphan observer records as its evidence. Deliberately bounded to the
+# kind and the named finding: nothing about argv, environment, logs, delivery
+# payloads or secrets belongs on a record any caller may read back.
+EVIDENCE_PROCESS_GONE = "process_identity_conclusively_gone"
+
+# The three observations that positively establish that this run's process is
+# gone, and the only findings that admit a terminal transition. A closed
+# positive set, never a test against an inconclusive one: a finding added to the
+# liveness classifier later is not conclusive until it is named here.
+FINDING_PID_ABSENT = "pid_absent"
+FINDING_DISAPPEARED_DURING_PROBE = "disappeared_during_probe"
+FINDING_PID_RECYCLED = "pid_recycled"
+CONCLUSIVE_FINDINGS = frozenset(
+    {FINDING_PID_ABSENT, FINDING_DISAPPEARED_DURING_PROBE, FINDING_PID_RECYCLED}
+)
+
+# The name of the per-run mutation lock, kept beside the record it guards.
+_LOCK_NAME = "job.lock"
 
 # The lifecycle read is a control-plane query against a local store; anything
 # slower than this is treated as unavailable rather than waited on, because it
@@ -198,6 +265,88 @@ def _write_job(record: dict[str, Any]) -> None:
         # still propagates.
         tmp.unlink(missing_ok=True)
         raise
+
+
+def _lock_fd(fd: int) -> None:
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_EX)
+        return
+    if _msvcrt is not None:  # pragma: no cover - POSIX is what CI runs
+        os.lseek(fd, 0, os.SEEK_SET)
+        _msvcrt.locking(fd, _msvcrt.LK_LOCK, 1)
+
+
+def _unlock_fd(fd: int) -> None:
+    if _fcntl is not None:
+        _fcntl.flock(fd, _fcntl.LOCK_UN)
+        return
+    if _msvcrt is not None:  # pragma: no cover - POSIX is what CI runs
+        os.lseek(fd, 0, os.SEEK_SET)
+        _msvcrt.locking(fd, _msvcrt.LK_UNLCK, 1)
+
+
+@dataclass
+class _GuardedJob:
+    """The record a mutation holds while it is inside the per-run lock.
+
+    *record* is the record as it stands right now — reread inside the lock, never
+    a snapshot the caller brought in with it — and is the object to mutate.
+    *state* says what the reread found when it found no record, so a caller can
+    tell a run nobody submitted from a file that is on disk and damaged.
+    """
+
+    record: dict[str, Any] | None
+    state: str
+
+
+@contextlib.contextmanager
+def _locked_job(run_id: str) -> Iterator[_GuardedJob]:
+    """Read-modify-write one run's record inside one per-run critical section.
+
+    ``os.replace`` publishes a record without ever tearing it, but two writers
+    that read, merge and publish in turn still lose one of the two updates: the
+    second one's merge started from bytes the first one has already replaced.
+    The terminal hook, the pid attachment, the lifecycle cache, the delivery
+    result and the orphan observer all do exactly that, and they run in
+    different processes, so the section that has to be exclusive is the whole
+    reread-merge-publish cycle rather than the publish alone.
+
+    The lock is an advisory file lock on a file of its own beside the record —
+    not on the record, which is replaced rather than written in place, so a lock
+    held on it would be a lock on bytes that are already unlinked. It is taken
+    for the whole ``with`` body and the write that follows it, and the record is
+    reread under it, so what a caller merges into is what is on disk now.
+
+    The record is published on exit only if the body changed it, so a mutation
+    that decides to keep what it found — which is what first-writer-wins looks
+    like from inside — touches nothing.
+
+    A run with no directory is a run nothing has recorded, and no lock is
+    created for it: making one would leave an empty job directory that reads
+    back as a damaged record for a run nobody submitted. A lock that cannot be
+    taken for any other reason yields no record either, and every mutation below
+    is written to do nothing without one — an unserialized write is exactly what
+    this exists to prevent.
+    """
+    try:
+        fd = os.open(config.job_dir(run_id) / _LOCK_NAME, os.O_RDWR | os.O_CREAT, 0o600)
+    except FileNotFoundError:
+        yield _GuardedJob(None, "absent")
+        return
+    except OSError:
+        yield _GuardedJob(None, "lock_unavailable")
+        return
+    try:
+        _lock_fd(fd)
+        record, state = _read_job_state(run_id)
+        guard = _GuardedJob(record, state)
+        before = copy.deepcopy(record)
+        yield guard
+        if guard.record is not None and guard.record != before:
+            _write_job(guard.record)
+    finally:
+        _unlock_fd(fd)
+        os.close(fd)
 
 
 def _short_repr(value: Any, limit: int = 60) -> str:
@@ -865,6 +1014,18 @@ def _outcome_for(status: Any) -> str:
     return "failed"
 
 
+def _recorded_outcome(job: dict[str, Any]) -> str | None:
+    """The outcome a writer recorded on this record, if it published one.
+
+    Checked against the vocabulary this module publishes rather than passed
+    through: the record is JSON from disk, and `outcome` is the field callers
+    branch on, so a damaged or hand-edited record must not be able to put a
+    value there that no producer would ever write.
+    """
+    value = job.get("outcome")
+    return value if isinstance(value, str) and value in _OUTCOMES else None
+
+
 def _derive(
     job: dict[str, Any] | None,
     alive: bool,
@@ -877,8 +1038,12 @@ def _derive(
 
     ``terminal`` answers "stop waiting" and comes only from a recorded end — a
     ``finished_at`` written by the terminal hook or by ``kill``, a spawn failure
-    the producer caught and wrote down, or an end recorded in the lifecycle
-    store, which is where a run stopped by ``li kill`` leaves its only trace. It
+    the producer caught and wrote down, an end recorded in the lifecycle store,
+    which is where a run stopped by ``li kill`` leaves its only trace, or the
+    orphan transition this module publishes for a process it found conclusively
+    gone. Every one of those is a durable record read back from disk: this
+    function never turns a live observation into a latch, which is what keeps
+    two readers of one unchanged record from disagreeing. It
     is never inferred from the status string and never from a missing pid:
     between the pre-spawn write and the write that attaches the pid, a perfectly
     healthy child has no pid yet.
@@ -889,8 +1054,9 @@ def _derive(
     existed.
 
     ``outcome`` answers "did the work come out right" and is null whenever
-    ``terminal`` is false — including for a run whose process is gone with no end
-    recorded, which has stopped and is still not terminal.
+    ``terminal`` is false — including for a run whose process is gone and whose
+    loss could not be established conclusively, which has stopped looking alive
+    and is still not terminal.
     """
     if job is None:
         return {
@@ -919,7 +1085,12 @@ def _derive(
         return {
             "status": recorded,
             "terminal": True,
-            "outcome": _outcome_for(recorded),
+            # An outcome the writer of the end recorded wins over one derived
+            # from the status string. A run whose process was found gone with
+            # nothing reported has no status to classify — it never said how it
+            # came out — so its outcome is written down at the transition and
+            # read back here rather than guessed at from `"exited"`.
+            "outcome": _recorded_outcome(job) or _outcome_for(recorded),
             # A reason carried on the record wins: it came from the lifecycle
             # store, which knows why the run ended, while the status-derived one
             # is only what the status alone can say.
@@ -971,6 +1142,12 @@ def _derive(
     # Advisory only. Nothing here terminalises it — liveness is an observation
     # about a pid, which can be reused or denied, and two readers of one
     # unchanged record may see it differently. It stays non-terminal.
+    #
+    # A conclusively gone process does not reach this branch: its end is
+    # published before the record is classified, so it arrives here carrying a
+    # `finished_at` and is answered above. What is left is the observation that
+    # established nothing — an unaskable pid — which is precisely the case that
+    # must stay advisory.
     return {
         "status": "exited",
         "terminal": False,
@@ -1216,13 +1393,24 @@ def submit(
     # the child is certainly the one just spawned; a read that fails leaves it
     # null, which kill() reads as "no identity was captured" rather than as any
     # claim about the process.
-    latest = _read_job(run_id) or record
-    latest["pid"] = proc.pid
+    #
+    # The probes are made before the lock is taken, so a process table that is
+    # slow to answer never holds up another observer's mutation of this record.
+    # The merge itself only ever adds the identity fields and the spawn phase:
+    # a terminal the hook recorded, and any delivery result beside it, are on
+    # the record this reads back and are left exactly as they are.
     _state, created = _process_create_time(proc.pid)
-    latest["pid_create_time"] = created
-    latest["pgid"] = _spawned_pgid(proc.pid)
-    latest["spawn_state"] = "started"
-    _write_job(latest)
+    pgid = _spawned_pgid(proc.pid)
+    latest = record
+    with _locked_job(run_id) as guard:
+        if guard.record is None:
+            guard.record = latest = {**record}
+        else:
+            latest = guard.record
+        latest["pid"] = proc.pid
+        latest["pid_create_time"] = created
+        latest["pgid"] = pgid
+        latest["spawn_state"] = "started"
 
     # The handle carries the same three lifecycle fields every other
     # status-bearing response does, so a caller never has to classify the status
@@ -1256,17 +1444,30 @@ def _record_spawn_failure(run_id: str, exc: Exception) -> SpawnError:
     run was going, which is two answers to one question.
     """
     reason = f"spawn failed: {exc}"
-    record = _read_job(run_id) or {"run_id": run_id}
-    record.update(
-        {
-            "spawn_state": "failed",
-            "status": "failed",
-            "finished_at": _now_iso(),
-            "reason": reason,
-        }
-    )
+    record: dict[str, Any] = {
+        "run_id": run_id,
+        "spawn_state": "failed",
+        "status": "failed",
+        "finished_at": _now_iso(),
+        "reason": reason,
+        "terminal_source": TERMINAL_SOURCE_SPAWN_FAILURE,
+    }
     try:
-        _write_job(record)
+        with _locked_job(run_id) as guard:
+            current = guard.record
+            if current is None:
+                current = {"run_id": run_id}
+                guard.record = current
+            current["spawn_state"] = "failed"
+            current["reason"] = reason
+            # The end itself only if nothing recorded one. There is no child to
+            # have written one here, so this is the same first-writer rule every
+            # other mutation keeps rather than a case anyone expects to hit.
+            if current.get("finished_at") is None:
+                current["status"] = "failed"
+                current["finished_at"] = _now_iso()
+                current["terminal_source"] = TERMINAL_SOURCE_SPAWN_FAILURE
+            record = current
     except OSError:
         # The corrective write can fail on exactly the disk that refused the
         # spawn. The caller still gets the failure and the run_id; what is lost
@@ -1317,22 +1518,36 @@ def _cache_lifecycle_end(
     A failed write is not an error here — the record is a cache, so the next
     observation simply asks again — and the in-memory record is returned either
     way so this call is what the caller classifies.
+
+    The copy is made under the per-run lock and onto the record as it stands
+    there. A record that already carries an end keeps it: the store and the hook
+    are both reporting the same run, and the one that got there first is the one
+    the run's readers have already been given.
     """
     if job is None or lifecycle is None or not lifecycle.get("terminal"):
         return job
     ended = lifecycle.get("ended_at")
-    updated = {
-        **job,
+    fields = {
         "status": lifecycle.get("status", job.get("status")),
         "finished_at": _iso_from_epoch(ended) or _now_iso(),
         "reason_code": lifecycle.get("reason_code"),
-        "terminal_source": "lifecycle",
+        "terminal_source": TERMINAL_SOURCE_LIFECYCLE,
     }
+    updated = {**job, **fields}
+    run_id = job.get("run_id")
+    if not isinstance(run_id, str):
+        return updated
     try:
-        _write_job(updated)
+        with _locked_job(run_id) as guard:
+            current = guard.record
+            if current is None:
+                return updated
+            if current.get("finished_at") is not None:
+                return current
+            current.update(fields)
+            return current
     except OSError:
-        pass
-    return updated
+        return updated
 
 
 def _iso_from_epoch(value: Any) -> str | None:
@@ -1366,7 +1581,51 @@ def _server_identity() -> dict[str, str]:
     return {"version": version, "module": str(Path(__file__).resolve().parent)}
 
 
-def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> tuple[bool, str | None]:
+LivenessConclusion = Literal["alive", "process_gone", "unknown"]
+
+
+@dataclass(frozen=True)
+class ProcessLiveness:
+    """What one observation of a run's recorded process established.
+
+    ``alive`` is the answer callers have always had: whether this run's process
+    is running, used to decide whether waiting can still help.
+
+    ``conclusion`` is the decision surface. ``"process_gone"`` is a *positive*
+    finding that this run's process no longer exists, and it is the only value
+    that may end a run. ``"unknown"`` is a probe that established nothing — an
+    unaskable pid, a denied read — and can never end one. The three values are
+    the whole vocabulary, so a case added later is inconclusive until it is
+    written down as conclusive, which is the opposite of the property a rule
+    phrased as "not one of these inconclusive names" has.
+
+    ``finding`` names which observation produced the conclusion, so the record
+    of a transition says what was seen rather than only what was decided.
+    """
+
+    alive: bool
+    conclusion: LivenessConclusion
+    finding: str
+
+
+# The findings this classifier can reach, and the public ``pid_identity`` each
+# one has always been reported as. The public field keeps its meanings exactly:
+# this table is where the internal finding is translated into it, so neither
+# vocabulary has to be read through the other.
+_PID_IDENTITY_BY_FINDING: dict[str, str | None] = {
+    "unusable_pid": "unusable_pid",
+    FINDING_PID_ABSENT: None,
+    FINDING_DISAPPEARED_DURING_PROBE: "gone",
+    FINDING_PID_RECYCLED: "recycled",
+    "identity_confirmed": "confirmed",
+    "identity_not_recorded": "not_recorded",
+    "identity_unusable": "unusable",
+    "identity_unreadable": "unreadable",
+    "no_record": None,
+}
+
+
+def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> ProcessLiveness:
     """Whether the process *this run* spawned is alive, and what settled it.
 
     A pid number is not an identity. Once the run's process exits and the OS
@@ -1379,15 +1638,24 @@ def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> tuple[
     ``possibly_orphaned``, the field that exists for a process gone with no end
     recorded.
 
-    The second element names what was established, so a caller can tell the
-    readings apart rather than infer them: ``"confirmed"``, ``"recycled"``,
-    ``"gone"`` (the pid held no live process when it was read), ``"unreadable"``
-    (the identity probe errored, so nothing was established and the liveness
-    probe stands), ``"not_recorded"`` (the record captured no start time),
-    ``"unusable"`` (it captured one that no start time can be compared against)
-    and ``"unusable_pid"`` (the record's pid is not a number the OS can be asked
-    about, so no probe was made and the answer is not a finding of death). None
-    when there was no live pid to identify.
+    The finding names what was established, so a caller can tell the readings
+    apart rather than infer them, and the conclusion says which of them may end
+    a run. Three are conclusive, and each is a positive observation of this
+    run's process being gone: ``"pid_absent"`` (the pid was askable and held no
+    live process), ``"disappeared_during_probe"`` (it held one at the liveness
+    probe and none at the creation-time probe) and ``"pid_recycled"`` (a live
+    process holds the number and started at a different time than the one this
+    run recorded, so it is a different process). The rest conclude nothing about
+    death: ``"identity_confirmed"``, ``"identity_not_recorded"`` (the record
+    captured no start time), ``"identity_unusable"`` (it captured one that no
+    start time can be compared against), ``"identity_unreadable"`` (the identity
+    probe errored, so nothing was established and the liveness probe stands),
+    ``"unusable_pid"`` (the record's pid is not a number the OS can be asked
+    about, so no probe was made at all) and ``"no_record"`` (a live pid with no
+    record to identify it against).
+
+    The public ``pid_identity`` values are unchanged and are read off
+    :data:`_PID_IDENTITY_BY_FINDING`; nothing here redefines one.
 
     Two separate questions are settled here in the order their evidence allows.
     Whether the pid holds a live process at all needs only the pid, so it is
@@ -1408,9 +1676,13 @@ def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> tuple[
     """
     asked = _askable_pid(pid)
     if asked is None:
-        return False, "unusable_pid"
+        # No probe was made, so nothing at all was established about the
+        # process. Reported not alive, as it always has been, and inconclusive:
+        # a record this module cannot ask about is the one case that must never
+        # be ended from here.
+        return ProcessLiveness(False, "unknown", "unusable_pid")
     if not _pid_alive(asked):
-        return False, None
+        return ProcessLiveness(False, "process_gone", FINDING_PID_ABSENT)
 
     # Whether that pid still holds a live process is settled here, before the
     # record is consulted, because settling it does not need the record. The
@@ -1421,13 +1693,13 @@ def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> tuple[
     # only where a start time was recorded to compare against.
     state, live_created = _process_create_time(asked)
     if state == "gone":
-        return False, "gone"
+        return ProcessLiveness(False, "process_gone", FINDING_DISAPPEARED_DURING_PROBE)
 
     if job is None:
-        return True, None
+        return ProcessLiveness(True, "alive", "no_record")
     recorded = job.get("pid_create_time")
     if recorded is None:
-        return True, "not_recorded"
+        return ProcessLiveness(True, "alive", "identity_not_recorded")
     # The same three values kill() refuses: a bool is an int to isinstance and
     # arrives as a moment in 1970, a NaN loses every comparison silently, and an
     # unbounded JSON integer fails the conversion that any comparison needs.
@@ -1437,13 +1709,173 @@ def _run_process_liveness(job: dict[str, Any] | None, pid: int | None) -> tuple[
     except (TypeError, ValueError, OverflowError):
         usable = False
     if not usable:
-        return True, "unusable"
+        return ProcessLiveness(True, "alive", "identity_unusable")
 
     if state != "found" or live_created is None:
-        return True, "unreadable"
+        # The identity probe was denied or unreadable. The pid holds a live
+        # process, so the run is treated as running; which process it is stayed
+        # unestablished, so this observation concludes nothing either way.
+        return ProcessLiveness(True, "unknown", "identity_unreadable")
     if _start_time_matches(live_created, spawned_at):
-        return True, "confirmed"
-    return False, "recycled"
+        return ProcessLiveness(True, "alive", "identity_confirmed")
+    return ProcessLiveness(False, "process_gone", FINDING_PID_RECYCLED)
+
+
+@dataclass(frozen=True)
+class ReapResult:
+    """What one attempt to end a conclusively gone run came to.
+
+    ``won_transition`` is true for exactly one caller per run: the one whose
+    guarded write published the end. It is what decides who owns the terminal
+    notice, since the notice must be attempted once and the durable record is
+    the only thing that can say who got there first.
+
+    ``record`` is the record as it stands after the attempt — the transition
+    this call wrote, or the end somebody else had already written — so a loser
+    reports the durable fact rather than its own observation. ``reason`` names
+    why a call did not win, which is diagnostic and never something a caller
+    branches on.
+    """
+
+    won_transition: bool
+    record: dict[str, Any] | None
+    reason: str
+
+
+def reap_orphan(run_id: str, *, finding: str, observed_at: str) -> ReapResult:
+    """Publish the end of a run whose process is conclusively gone.
+
+    Idempotent, and safe to call from every observer at once. The whole check is
+    made inside the per-run lock and against a record reread there, because the
+    caller's observation was taken before the lock was held: between the two, the
+    child's terminal hook, a kill, or another observer can have written the end
+    already, and a merge starting from the caller's copy would erase it.
+
+    Everything below has to hold under the lock. The record exists and is this
+    run's; the spawn got as far as starting a process, so there is a process
+    identity to have lost — a spawn still preparing acquired none, and a spawn
+    that failed already ended; nothing has recorded an end; and *finding* is one
+    of the three observations that positively establish that this run's process
+    is gone. Membership in that closed set is the whole admission rule: nothing
+    here reads a liveness field, an elapsed time, or the absence of a
+    disqualifying value.
+
+    The winner writes the end, the outcome, the reason, and the attribution in
+    one publication, so no reader ever sees a half-made transition.
+    ``finished_at`` is *observed_at*: the moment the loss was established and
+    recorded, not the unknown moment the process actually exited, which nothing
+    surviving can report.
+
+    Notification is not attempted here. It runs after this returns, outside the
+    lock, so a delivery command can never hold the record of every other run's
+    observer — and it is the winner's to attempt, which is what the returned
+    ``won_transition`` says.
+    """
+    if finding not in CONCLUSIVE_FINDINGS:
+        # Refused before the lock is taken: a finding that establishes nothing
+        # has no transition to serialize.
+        return ReapResult(False, None, "finding_is_not_conclusive")
+
+    with _locked_job(run_id) as guard:
+        job = guard.record
+        if job is None:
+            return ReapResult(False, None, f"no_usable_record:{guard.state}")
+        if job.get("run_id") != run_id:
+            return ReapResult(False, job, "record_names_another_run")
+        if job.get("spawn_state") != "started":
+            return ReapResult(False, job, "spawn_state_is_not_started")
+        if job.get("finished_at") is not None:
+            return ReapResult(False, job, "already_ended")
+        job.update(
+            {
+                "status": "exited",
+                "outcome": OUTCOME_LOST,
+                "reason_code": LOST_REASON,
+                "finished_at": observed_at,
+                "terminal_source": TERMINAL_SOURCE_ORPHAN_REAPER,
+                "terminal_evidence": {"kind": EVIDENCE_PROCESS_GONE, "finding": finding},
+            }
+        )
+        return ReapResult(True, job, "reaped")
+
+
+def _admits_orphan_reap(job: dict[str, Any] | None, liveness: ProcessLiveness) -> bool:
+    """Whether this observation is one that may end the run.
+
+    Only a positive ``process_gone`` conclusion, and only for a run that started
+    a process and has no end recorded. The record checks are made again inside
+    the lock, where they are the ones that count; this is the cheap gate that
+    keeps an ordinary poll of a healthy or already-ended run from opening a lock
+    file at all.
+    """
+    if job is None or liveness.conclusion != "process_gone":
+        return False
+    return job.get("spawn_state") == "started" and not _record_is_terminal(job)
+
+
+def _deliver_reap_notice(run_id: str, record: dict[str, Any]) -> dict[str, Any] | None:
+    """Attempt the terminal notice the run's own process never got to send.
+
+    The dead child was the owner of both the end and its delivery, so an
+    observer that publishes the end and stops there leaves a notice-only caller
+    asleep forever — the terminality would be repaired and the wake-up would
+    not. The winner of the transition therefore attempts the same configured
+    delivery the hook would have, through the hook's own resolution, so a
+    per-run override and the project/global settings mean here exactly what they
+    mean there and there is only one place a notifier is configured.
+
+    Best-effort and after the fact. The end is already durable when this runs,
+    so nothing here can change how the run came out: a refusal, a non-zero exit
+    or a timeout is recorded as a delivery failure, and a delivery that never
+    gets to record anything leaves ``notify_delivery`` absent, which is what a
+    crash between the two writes looks like from outside.
+
+    The guard is total for the same reason: this is called from a read path, and
+    a notifier that comes apart in a way the hook does not classify must not
+    turn a status read of an already-ended run into a failed call. What is lost
+    is the delivery result, which is the same thing the crash gap loses.
+    """
+    from ._notify_hook import deliver_terminal_notice
+
+    try:
+        outcome = deliver_terminal_notice(
+            run_id,
+            record,
+            record.get("status") or "exited",
+            target=record.get("notify_target"),
+            command=record.get("notify_command"),
+            sender=record.get("notify_sender"),
+        )
+    except Exception:  # noqa: BLE001 — the end is published; delivery may not undo it
+        return None
+    return record_notify_delivery(run_id, outcome)
+
+
+def _reap_if_conclusively_gone(
+    run_id: str, job: dict[str, Any] | None, liveness: ProcessLiveness
+) -> dict[str, Any] | None:
+    """Turn a conclusive observation into a durable end, then report the record.
+
+    This is the one place a read is allowed to write. What it returns is always
+    a record read back from the transition rather than the observation that
+    caused it, so the terminal answer a caller receives is one an unchanged
+    record already contains — the next reader of those same bytes reaches it
+    without observing anything at all.
+    """
+    if not _admits_orphan_reap(job, liveness):
+        return job
+    try:
+        result = reap_orphan(run_id, finding=liveness.finding, observed_at=_now_iso())
+    except OSError:
+        # The transition could not be published. The run is classified exactly
+        # as it was before this call, which is the advisory state it has always
+        # had, and the next observation tries again.
+        return job
+    if result.record is None:
+        return job
+    if not result.won_transition:
+        return result.record
+    return _deliver_reap_notice(run_id, result.record) or result.record
 
 
 def status(run_id: str) -> dict[str, Any]:
@@ -1472,8 +1904,20 @@ def status(run_id: str) -> dict[str, Any]:
     different things to do next. A record written without a start time still
     reports a process that has exited as not alive; what it cannot report is
     whether a live process at that pid is this run's.
-    ``possibly_orphaned`` flags a run whose process is gone with no end recorded;
-    it is advisory and never makes the run terminal.
+    ``liveness_conclusion`` is what that observation established:
+    ``"process_gone"`` positively identifies this run's process as gone,
+    ``"alive"`` that it is running, and ``"unknown"`` that the probe settled
+    neither. Only ``"process_gone"`` can end a run, and it does so by writing the
+    end down before this call returns it — so a caller reading ``terminal`` here
+    is reading a durable fact rather than this observation.
+    ``terminal_source`` says what wrote that end (``"cli_terminal_hook"``,
+    ``"lifecycle_cache"``, ``"spawn_failure"``, ``"mcp_orphan_reaper"``, or null
+    on a record written before the field existed), and ``terminal_evidence``
+    carries the bounded evidence behind an end nobody reported.
+    ``possibly_orphaned`` flags a run whose process is gone with no end recorded
+    and whose loss was not established conclusively — an unaskable pid, or a
+    transition that could not be published; it is advisory and never makes the
+    run terminal.
     ``notify_delivery`` reports whether the terminal notice was delivered.
     ``server`` identifies the implementation that answered, so a caller can tell
     which build it is talking to rather than inferring it from behaviour.
@@ -1488,12 +1932,18 @@ def status(run_id: str) -> dict[str, Any]:
     job, record_state = _read_job_state(run_id)
     manifest = _read_run_manifest(run_id)
     pid = job.get("pid") if job else None
-    alive, pid_identity = _run_process_liveness(job, pid)
+    liveness = _run_process_liveness(job, pid)
+    alive = liveness.alive
 
     lifecycle = None
     if _needs_lifecycle_read(job, alive):
         lifecycle = _read_lifecycle(run_id)
         job = _cache_lifecycle_end(job, lifecycle)
+
+    # The lifecycle store gets asked first, because an end it recorded is an end
+    # somebody reported and is the better answer: reaping is for a run that no
+    # writer survived to speak for.
+    job = _reap_if_conclusively_gone(run_id, job, liveness)
 
     derived = _derive(job, alive, lifecycle)
 
@@ -1507,8 +1957,11 @@ def status(run_id: str) -> dict[str, Any]:
         "reason_code": derived["reason_code"],
         "spawn_state": derived["spawn_state"],
         "possibly_orphaned": derived["possibly_orphaned"],
+        "terminal_source": (job or {}).get("terminal_source"),
+        "terminal_evidence": (job or {}).get("terminal_evidence"),
         "alive": alive,
-        "pid_identity": pid_identity,
+        "pid_identity": _PID_IDENTITY_BY_FINDING.get(liveness.finding),
+        "liveness_conclusion": liveness.conclusion,
         "pid": pid,
         "submitted_at": (job or {}).get("submitted_at"),
         "finished_at": (job or {}).get("finished_at"),
@@ -1592,13 +2045,25 @@ def _mark_killed(job: dict[str, Any]) -> None:
     the way it says, and what was signalled here is work that outlived that end
     — overwriting ``completed`` with ``killed`` would replace how the run came
     out with how its stragglers were cleaned up.
+
+    Which end that is, is decided under the per-run lock against the record as
+    it stands there rather than against the copy the kill decision was made
+    from: the signal takes time, and an end can be recorded while it is being
+    sent. The kill still happened either way — this write is the record of it,
+    not the act.
     """
-    if _record_is_terminal(job):
-        job["group_reaped_at"] = _now_iso()
-    else:
-        job["status"] = "killed"
-        job["finished_at"] = _now_iso()
-    _write_job(job)
+    run_id = job.get("run_id")
+    if not isinstance(run_id, str):
+        return
+    with _locked_job(run_id) as guard:
+        current = guard.record
+        if current is None:
+            return
+        if _record_is_terminal(current):
+            current["group_reaped_at"] = _now_iso()
+        else:
+            current["status"] = "killed"
+            current["finished_at"] = _now_iso()
 
 
 def _signal_group(
@@ -2110,6 +2575,13 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
     reads that as a run still going. A notice that could not be delivered has to
     be visible where the waiting is done, not only on the record.
 
+    ``terminal_source`` travels with the end for the same reason: a run this
+    server ended on its own behalf, because its process was found gone with
+    nothing reported, is a different fact from one whose own process reported an
+    end, and a listing that showed only the outcome would hide which of the two
+    a row is. Every entry resolves through ``status``, so a conclusively gone
+    run is ended here exactly as it would be by a direct status read.
+
     An entry whose record could not be used is listed with the state of that read
     in ``record_state``, the same field ``status`` reports, so a damaged record is
     visible here as a damaged record rather than as a job with no kind and an
@@ -2145,6 +2617,7 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
                 "reason_code": st["reason_code"],
                 "submitted_at": st["submitted_at"],
                 "finished_at": st["finished_at"],
+                "terminal_source": st["terminal_source"],
                 "record_state": st["record_state"],
                 "notify_delivery_state": _notify_delivery_state(st["notify_delivery"]),
             }
@@ -2245,13 +2718,22 @@ async def wait(
 
     A run whose process is gone with no end recorded meets that same criterion:
     it has stopped, and both writers of an end are past it, so the window is not
-    held open for it either. Such ids are named in ``stopped_without_end`` — not
-    in ``pending``, which is what is still worth waiting for, and not as a per-id
-    ``error``, because observing them succeeded. Nothing about the record itself
-    changes: the entry stays non-terminal with a null outcome, and a run that
-    does get an end written afterwards is classified terminal by the next
-    observation as it always was. ``all_terminal`` therefore stays false while any
-    id is here, because a run that stopped without recording an end is not a
+    held open for it either. Where that loss is established conclusively, the
+    observation ends the run — durably, with ``outcome="lost"`` — so the entry
+    comes back terminal like any other and is neither pending nor named below.
+    ``all_terminal`` covers it: the field means every requested run has a
+    recorded end, not that every run succeeded, and a caller reads each entry's
+    ``outcome`` to tell those apart.
+
+    What is left in ``stopped_without_end`` is the id whose loss could not be
+    established — a record whose pid the OS cannot even be asked about — which
+    has stopped looking alive and may still be running for all this can tell.
+    Such ids are not in ``pending``, which is what is still worth waiting for,
+    and not a per-id ``error``, because observing them succeeded. Nothing about
+    the record itself changes: the entry stays non-terminal with a null outcome,
+    and a run that does get an end written afterwards is classified terminal by
+    the next observation as it always was. ``all_terminal`` therefore stays false
+    while any id is here, because a run this cannot account for is not a
     completed one.
 
     Because such an id resolves nothing by waiting, a caller looping until
@@ -2326,25 +2808,44 @@ def mark_terminal(run_id: str, cli_status: str) -> dict[str, Any] | None:
     ``aborted``, ``completed_empty`` — into a false success. The hook fires only
     on a genuine terminal, so the incoming status is trusted as-is and
     ``finished_at`` marks the record terminal.
+
+    The first recorded end wins. A record that already carries one — a kill, an
+    end cached from the lifecycle store, or an observer's orphan transition
+    published while this hook was starting up — keeps it, and this call reports
+    what is there instead of replacing it. The hook's own delivery attempt still
+    goes ahead on the record it read back, so a run whose end was inferred can
+    still have its notice filled in by the child that turned out to be alive
+    enough to send one.
     """
-    job = _read_job(run_id)
-    if job is None:
-        return None
-    job["status"] = cli_status
-    job["cli_status"] = cli_status
-    job["finished_at"] = _now_iso()
-    _write_job(job)
-    return job
+    with _locked_job(run_id) as guard:
+        job = guard.record
+        if job is None or job.get("finished_at") is not None:
+            return job
+        job["status"] = cli_status
+        job["cli_status"] = cli_status
+        job["finished_at"] = _now_iso()
+        job["terminal_source"] = TERMINAL_SOURCE_HOOK
+        return job
 
 
-def record_notify_delivery(run_id: str, outcome: dict[str, Any]) -> None:
+def record_notify_delivery(run_id: str, outcome: dict[str, Any]) -> dict[str, Any] | None:
     """Record whether the terminal notice was delivered (called by the notify hook).
 
     Surfaced by ``status`` so a completion notice that failed to send is visible
     rather than silently lost — the detached-spawn pattern relies on that signal.
+
+    Merges the delivery result and nothing else: it is written under the same
+    per-run lock as every other mutation, so it cannot carry a stale copy of the
+    lifecycle fields back over an end recorded while the notice was being sent.
+    A delivery outcome never changes how the run came out — a notice that failed
+    to send is a fact about the notice.
+
+    Returns the record as it stands afterwards, so a caller that has to report
+    the delivery alongside the run does not have to read it again.
     """
-    job = _read_job(run_id)
-    if job is None:
-        return
-    job["notify_delivery"] = outcome
-    _write_job(job)
+    with _locked_job(run_id) as guard:
+        job = guard.record
+        if job is None:
+            return None
+        job["notify_delivery"] = outcome
+        return job

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -32,11 +32,13 @@ The third writer is this module's own orphan observer. A run whose process died
 before the terminal hook ran has no surviving producer at all: nothing will ever
 write its end, and a caller waiting for one waits forever. So when — and only
 when — an observation positively establishes that this run's process is gone,
-``status()`` publishes that end itself, as ``outcome="lost"``, before returning
-it. Every mutation of a job record goes through one per-run lock, and the first
-recorded end wins: a later writer may add what is missing beside it but never
-replaces it, so no two readers of one record can disagree about whether the run
-ended.
+``status()`` publishes that end itself, as ``outcome="indeterminate"``, before
+returning it. Every mutation of a job record goes through one per-run lock, and
+the first recorded end wins: a later writer may add what is missing beside it but
+never replaces it, so no two readers of one record can disagree about whether the
+run ended. A mutation that cannot take that lock records nothing and says so —
+the record stays non-terminal and the next observation retries it, rather than a
+terminal fact being announced that no reader can find.
 """
 
 from __future__ import annotations
@@ -116,13 +118,20 @@ _SPAWN_FAILED_REASON = "spawn_failed"
 # survived to say either way. That is exactly why a caller may retry a `failed`
 # run under its own policy and must not automatically retry this one — an
 # external side effect may already have committed.
-OUTCOME_LOST = "lost"
+#
+# The value is the one the closed outcome vocabulary already reserves for a run
+# that ended and whose result cannot be established, rather than a new word for
+# this producer. Widening a closed vocabulary without moving the contract
+# version would be a silent contract change; what makes this transition
+# recognisable is the reason code and the terminal source beside it, which is
+# where the mechanism was always meant to live.
+OUTCOME_INDETERMINATE = "indeterminate"
 LOST_REASON = "process_gone_without_outcome"
 
 # The outcomes this module publishes. Consulted only to decide whether an
 # `outcome` already recorded on a job record may be reported back, so a damaged
 # record cannot invent a value a caller would branch on.
-_OUTCOMES = frozenset({"succeeded", "failed", "cancelled", OUTCOME_LOST})
+_OUTCOMES = frozenset({"succeeded", "failed", "cancelled", OUTCOME_INDETERMINATE})
 
 # What made a recorded end. Additive: it answers who wrote the end, which
 # neither `status` (open, and the producer's) nor `reason_code` (why the run
@@ -131,6 +140,15 @@ TERMINAL_SOURCE_HOOK = "cli_terminal_hook"
 TERMINAL_SOURCE_LIFECYCLE = "lifecycle_cache"
 TERMINAL_SOURCE_SPAWN_FAILURE = "spawn_failure"
 TERMINAL_SOURCE_ORPHAN_REAPER = "mcp_orphan_reaper"
+# The kill path is the fifth writer of an end. Like the four above, the value
+# names the mechanism that made the transition rather than the run's fate.
+TERMINAL_SOURCE_KILL = "mcp_kill"
+
+# Why a guarded mutation has no record to work on. Only the first means the run
+# is unknown; the last means the write was refused rather than attempted, so the
+# record is untouched and the operation is the caller's to retry or report.
+RECORD_ABSENT = "absent"
+LOCK_UNAVAILABLE = "lock_unavailable"
 
 # What the orphan observer records as its evidence. Deliberately bounded to the
 # kind and the named finding: nothing about argv, environment, logs, delivery
@@ -191,6 +209,11 @@ KILL_RECORD_WRONG_SHAPE = "job_record_wrong_shape"
 KILL_RECORD_FOREIGN_RUN = "job_record_names_another_run"
 KILL_NO_PID = "no_pid_on_record"
 KILL_SIGNALLED = "signalled"
+# The signal went out and the record of it could not be written, because the
+# record could not be serialized. Its own code, and not one of the refusals
+# above: those say nothing was signalled, while this says something was and the
+# durable trace of it is missing, which the caller may want to retry for.
+KILL_NOT_RECORDED = "kill_not_recorded"
 KILL_PROCESS_GONE = "process_gone"
 KILL_PERMISSION_DENIED = "permission_denied"
 # The record carries neither identity field, so the pid on it cannot be told
@@ -299,6 +322,30 @@ class _GuardedJob:
     state: str
 
 
+@dataclass(frozen=True)
+class WriteResult:
+    """What one guarded mutation came to, said in a way a caller can act on.
+
+    *record* is the record as it stands after the attempt, or None when there
+    was no usable one to work on. *state* says which of those it is, so the two
+    reasons a mutation comes back empty stay apart: a run nothing recorded, and
+    a write that was refused because its critical section could not be entered.
+
+    The distinction is the point. A caller told only "no record" has to guess,
+    and the guess that costs something is treating a refused write as a
+    completed one — announcing an end that is not on disk. ``refused`` names
+    that single case so nobody has to compare strings to find it.
+    """
+
+    record: dict[str, Any] | None
+    state: str
+
+    @property
+    def refused(self) -> bool:
+        """The mutation was not attempted: the record could not be serialized."""
+        return self.state == LOCK_UNAVAILABLE
+
+
 @contextlib.contextmanager
 def _locked_job(run_id: str) -> Iterator[_GuardedJob]:
     """Read-modify-write one run's record inside one per-run critical section.
@@ -327,17 +374,30 @@ def _locked_job(run_id: str) -> Iterator[_GuardedJob]:
     taken for any other reason yields no record either, and every mutation below
     is written to do nothing without one — an unserialized write is exactly what
     this exists to prevent.
+
+    Those two are reported as different states, and the difference is the whole
+    point of reporting them. An absent record is a settled answer about the run;
+    an unavailable lock is no answer at all, and a caller that treats it as one
+    publishes a fact it never wrote. Failing to create the lock file and failing
+    to acquire the lock are the same fact — this section was not entered — so
+    they yield the same state rather than one of them escaping as an exception
+    from a context manager whose contract is that it yields.
     """
     try:
         fd = os.open(config.job_dir(run_id) / _LOCK_NAME, os.O_RDWR | os.O_CREAT, 0o600)
     except FileNotFoundError:
-        yield _GuardedJob(None, "absent")
+        yield _GuardedJob(None, RECORD_ABSENT)
         return
     except OSError:
-        yield _GuardedJob(None, "lock_unavailable")
+        yield _GuardedJob(None, LOCK_UNAVAILABLE)
         return
     try:
         _lock_fd(fd)
+    except OSError:
+        os.close(fd)
+        yield _GuardedJob(None, LOCK_UNAVAILABLE)
+        return
+    try:
         record, state = _read_job_state(run_id)
         guard = _GuardedJob(record, state)
         before = copy.deepcopy(record)
@@ -1789,7 +1849,7 @@ def reap_orphan(run_id: str, *, finding: str, observed_at: str) -> ReapResult:
         job.update(
             {
                 "status": "exited",
-                "outcome": OUTCOME_LOST,
+                "outcome": OUTCOME_INDETERMINATE,
                 "reason_code": LOST_REASON,
                 "finished_at": observed_at,
                 "terminal_source": TERMINAL_SOURCE_ORPHAN_REAPER,
@@ -1848,7 +1908,11 @@ def _deliver_reap_notice(run_id: str, record: dict[str, Any]) -> dict[str, Any] 
         )
     except Exception:  # noqa: BLE001 — the end is published; delivery may not undo it
         return None
-    return record_notify_delivery(run_id, outcome)
+    # A result that could not be recorded reads back the same way a crash
+    # between the two writes does: the end is durable and the delivery outcome
+    # is absent. Nothing here can be failed by that — this is a read path, and
+    # the end it reports is already published.
+    return record_notify_delivery(run_id, outcome).record
 
 
 def _reap_if_conclusively_gone(
@@ -2038,7 +2102,7 @@ def _kill_result(
     }
 
 
-def _mark_killed(job: dict[str, Any]) -> None:
+def _mark_killed(job: dict[str, Any]) -> WriteResult:
     """Record the kill on the job record.
 
     A record that already carries an end keeps it. The run really did finish
@@ -2050,20 +2114,24 @@ def _mark_killed(job: dict[str, Any]) -> None:
     it stands there rather than against the copy the kill decision was made
     from: the signal takes time, and an end can be recorded while it is being
     sent. The kill still happened either way — this write is the record of it,
-    not the act.
+    not the act. What the caller is told is whether the record was made: a kill
+    nothing recorded leaves a run that reads as running to everyone who asks,
+    and that is a different thing to report than a kill that was recorded.
     """
     run_id = job.get("run_id")
     if not isinstance(run_id, str):
-        return
+        return WriteResult(None, "no_run_id_on_record")
     with _locked_job(run_id) as guard:
         current = guard.record
         if current is None:
-            return
+            return WriteResult(None, guard.state)
         if _record_is_terminal(current):
             current["group_reaped_at"] = _now_iso()
         else:
             current["status"] = "killed"
             current["finished_at"] = _now_iso()
+            current["terminal_source"] = TERMINAL_SOURCE_KILL
+        return WriteResult(current, guard.state)
 
 
 def _signal_group(
@@ -2095,7 +2163,20 @@ def _signal_group(
             pid=pid,
             pgid=pgid,
         )
-    _mark_killed(job)
+    written = _mark_killed(job)
+    if written.refused:
+        # The signal went out and nothing durable says so. Reported as its own
+        # code rather than as a plain success: a caller that reads `killed=True`
+        # and then finds the run still recorded as running has been told two
+        # things, and only one of them is on disk.
+        return _kill_result(
+            run_id,
+            killed=True,
+            reason="signalled, but the kill could not be recorded: the run record could not be locked",
+            reason_code=KILL_NOT_RECORDED,
+            pid=pid,
+            pgid=pgid,
+        )
     return _kill_result(
         run_id, killed=True, reason=None, reason_code=reason_code, pid=pid, pgid=pgid
     )
@@ -2719,8 +2800,8 @@ async def wait(
     A run whose process is gone with no end recorded meets that same criterion:
     it has stopped, and both writers of an end are past it, so the window is not
     held open for it either. Where that loss is established conclusively, the
-    observation ends the run — durably, with ``outcome="lost"`` — so the entry
-    comes back terminal like any other and is neither pending nor named below.
+    observation ends the run — durably, with ``outcome="indeterminate"`` — so the
+    entry comes back terminal like any other and is neither pending nor named below.
     ``all_terminal`` covers it: the field means every requested run has a
     recorded end, not that every run succeeded, and a caller reads each entry's
     ``outcome`` to tell those apart.
@@ -2798,7 +2879,7 @@ async def wait(
     }
 
 
-def mark_terminal(run_id: str, cli_status: str) -> dict[str, Any] | None:
+def mark_terminal(run_id: str, cli_status: str) -> WriteResult:
     """Record a terminal status for *run_id* (called by the CLI notify hook).
 
     The CLI's terminal status string is authoritative and recorded verbatim. An
@@ -2816,19 +2897,24 @@ def mark_terminal(run_id: str, cli_status: str) -> dict[str, Any] | None:
     goes ahead on the record it read back, so a run whose end was inferred can
     still have its notice filled in by the child that turned out to be alive
     enough to send one.
+
+    A record this could not serialize is reported as refused rather than as no
+    record. The end is not on disk in that case, and the caller's next act is to
+    announce one — so the two have to be told apart here or the announcement
+    goes out for a record that still reads as running.
     """
     with _locked_job(run_id) as guard:
         job = guard.record
         if job is None or job.get("finished_at") is not None:
-            return job
+            return WriteResult(job, guard.state)
         job["status"] = cli_status
         job["cli_status"] = cli_status
         job["finished_at"] = _now_iso()
         job["terminal_source"] = TERMINAL_SOURCE_HOOK
-        return job
+        return WriteResult(job, guard.state)
 
 
-def record_notify_delivery(run_id: str, outcome: dict[str, Any]) -> dict[str, Any] | None:
+def record_notify_delivery(run_id: str, outcome: dict[str, Any]) -> WriteResult:
     """Record whether the terminal notice was delivered (called by the notify hook).
 
     Surfaced by ``status`` so a completion notice that failed to send is visible
@@ -2840,12 +2926,19 @@ def record_notify_delivery(run_id: str, outcome: dict[str, Any]) -> dict[str, An
     A delivery outcome never changes how the run came out — a notice that failed
     to send is a fact about the notice.
 
+    The last delivery result recorded is the one kept. Only one caller attempts
+    a given run's notice, and where a second one exists — a child hook filling in
+    the notice for an end an observer inferred — the later attempt is the more
+    recent fact about the notice, which is the whole of what this field says.
+
     Returns the record as it stands afterwards, so a caller that has to report
-    the delivery alongside the run does not have to read it again.
+    the delivery alongside the run does not have to read it again, and reports a
+    refused write as refused: a delivery whose result was never recorded is not
+    a delivery anyone can read back.
     """
     with _locked_job(run_id) as guard:
         job = guard.record
         if job is None:
-            return None
+            return WriteResult(None, guard.state)
         job["notify_delivery"] = outcome
-        return job
+        return WriteResult(job, guard.state)

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -2221,7 +2221,7 @@ def test_mark_terminal_and_list(sandbox, monkeypatch):
     monkeypatch.setattr(jobs.subprocess, "Popen", lambda *a, **k: _FakeProc(4242))
     rid = jobs.submit("agent", [], prompt="x")["run_id"]
 
-    job = jobs.mark_terminal(rid, "failed")
+    job = jobs.mark_terminal(rid, "failed").record
     assert job["status"] == "failed" and job["finished_at"]
     assert job["cli_status"] == "failed"
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -158,13 +158,19 @@ def test_status_running_then_terminal(sandbox, monkeypatch):
     _live_process(monkeypatch)
     assert jobs.status(rid)["status"] == "running"
 
-    # pid gone, no terminal record captured -> exited
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
-    assert jobs.status(rid)["status"] == "exited"
-
-    # authoritative terminal recorded by the notify hook
+    # authoritative terminal recorded by the notify hook, which runs while the
+    # run's own process is still there to run it
     jobs.mark_terminal(rid, "completed")
-    assert jobs.status(rid)["status"] == "completed"
+    st = jobs.status(rid)
+    assert st["status"] == "completed"
+    assert st["terminal"] is True and st["outcome"] == "succeeded"
+
+    # the process going away afterwards adds nothing and takes nothing away:
+    # the end is on the record, and that is what every reader answers from
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    st = jobs.status(rid)
+    assert st["status"] == "completed"
+    assert st["terminal"] is True and st["outcome"] == "succeeded"
 
 
 def test_pid_alive_reaps_zombie_child():

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -315,12 +315,14 @@ def test_a_lifecycle_read_that_fails_leaves_the_run_where_it_was(home, monkeypat
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
 
     st = jobs.status(run_id)
+    # The read established nothing, so nothing it could have said is on the
+    # record: the end this run gets is the observer's own, attributed to it and
+    # carrying no status, reason or time from a store that never answered.
     assert st["status"] == "exited"
-    assert st["terminal"] is False
-    assert st["outcome"] is None
-    assert st["possibly_orphaned"] is True
-    # Nothing was cached, so a later read that succeeds is still free to answer.
-    assert jobs._read_job(run_id)["finished_at"] is None
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["reason_code"] == jobs.LOST_REASON
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
+    assert st["possibly_orphaned"] is False
 
 
 def test_a_lifecycle_read_that_times_out_leaves_the_run_where_it_was(home, monkeypatch):
@@ -346,8 +348,10 @@ def test_a_lifecycle_read_that_times_out_leaves_the_run_where_it_was(home, monke
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
 
     st = jobs.status(run_id)
-    assert st["terminal"] is False
-    assert st["possibly_orphaned"] is True
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER, (
+        "a read that learned nothing must not be credited with the end"
+    )
 
 
 def test_an_unavailable_lifecycle_answer_is_not_read_as_no_record(home, monkeypatch):
@@ -394,8 +398,10 @@ def test_an_unavailable_lifecycle_answer_is_not_read_as_no_record(home, monkeypa
 
     assert jobs._read_lifecycle(run_id) is None
     st = jobs.status(run_id)
-    assert st["terminal"] is False
-    assert st["possibly_orphaned"] is True
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER, (
+        "a read that learned nothing must not be credited with the end"
+    )
 
 
 def test_output_that_defeats_the_parser_is_a_read_that_learned_nothing(home, monkeypatch):
@@ -432,9 +438,10 @@ def test_output_that_defeats_the_parser_is_a_read_that_learned_nothing(home, mon
 
     assert jobs._read_lifecycle(run_id) is None
     st = jobs.status(run_id)
-    assert st["terminal"] is False
-    assert st["possibly_orphaned"] is True
-    assert jobs._read_job(run_id)["finished_at"] is None, "nothing was concluded and none cached"
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER, (
+        "a read that learned nothing must not be credited with the end"
+    )
 
 
 def test_a_spawn_failure_nobody_anticipated_is_also_a_read_that_learned_nothing(home, monkeypatch):
@@ -472,8 +479,10 @@ def test_a_spawn_failure_nobody_anticipated_is_also_a_read_that_learned_nothing(
 
     assert jobs._read_lifecycle(run_id) is None
     st = jobs.status(run_id)
-    assert st["terminal"] is False
-    assert st["possibly_orphaned"] is True
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER, (
+        "a read that learned nothing must not be credited with the end"
+    )
 
 
 def test_a_healthy_running_job_is_never_asked_about(home, monkeypatch):

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -319,7 +319,7 @@ def test_a_lifecycle_read_that_fails_leaves_the_run_where_it_was(home, monkeypat
     # record: the end this run gets is the observer's own, attributed to it and
     # carrying no status, reason or time from a store that never answered.
     assert st["status"] == "exited"
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["reason_code"] == jobs.LOST_REASON
     assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
     assert st["possibly_orphaned"] is False
@@ -348,7 +348,7 @@ def test_a_lifecycle_read_that_times_out_leaves_the_run_where_it_was(home, monke
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
 
     st = jobs.status(run_id)
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER, (
         "a read that learned nothing must not be credited with the end"
     )
@@ -398,7 +398,7 @@ def test_an_unavailable_lifecycle_answer_is_not_read_as_no_record(home, monkeypa
 
     assert jobs._read_lifecycle(run_id) is None
     st = jobs.status(run_id)
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER, (
         "a read that learned nothing must not be credited with the end"
     )
@@ -438,7 +438,7 @@ def test_output_that_defeats_the_parser_is_a_read_that_learned_nothing(home, mon
 
     assert jobs._read_lifecycle(run_id) is None
     st = jobs.status(run_id)
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER, (
         "a read that learned nothing must not be credited with the end"
     )
@@ -479,7 +479,7 @@ def test_a_spawn_failure_nobody_anticipated_is_also_a_read_that_learned_nothing(
 
     assert jobs._read_lifecycle(run_id) is None
     st = jobs.status(run_id)
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER, (
         "a read that learned nothing must not be credited with the end"
     )

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -342,8 +342,8 @@ def test_unknown_run_id_is_noop(monkeypatch, tmp_path):
     calls: list = []
     monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: calls.append(a))
     _no_settings_notifier(monkeypatch)
-    # No job record on disk: mark_terminal returns None, delivery still resolves
-    # to nothing, and the hook exits cleanly.
+    # No job record on disk: mark_terminal reports an absent record, delivery
+    # still resolves to nothing, and the hook exits cleanly.
     rc = _notify_hook.main(["--run-id", "nope", "--status", "completed"])
     assert rc == 0
     assert calls == []

--- a/tests/mcp/test_orphan_reaping.py
+++ b/tests/mcp/test_orphan_reaping.py
@@ -113,7 +113,7 @@ def test_each_conclusive_finding_writes_one_terminal_transition(
 
     first = jobs.status(rid)
     assert first["terminal"] is True
-    assert first["outcome"] == jobs.OUTCOME_LOST
+    assert first["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert first["reason_code"] == jobs.LOST_REASON
     assert first["liveness_conclusion"] == "process_gone"
     assert first["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
@@ -124,7 +124,7 @@ def test_each_conclusive_finding_writes_one_terminal_transition(
 
     on_disk = jobs._read_job(rid)
     assert on_disk["finished_at"] == first["finished_at"] is not None
-    assert on_disk["outcome"] == jobs.OUTCOME_LOST
+    assert on_disk["outcome"] == jobs.OUTCOME_INDETERMINATE
 
     # The second reader answers from the record alone. It is given the opposite
     # observation — a live, confirmed process at that pid — and must still
@@ -135,7 +135,7 @@ def test_each_conclusive_finding_writes_one_terminal_transition(
     second = jobs.status(rid)
     assert second["alive"] is True
     assert second["terminal"] is True
-    assert second["outcome"] == jobs.OUTCOME_LOST
+    assert second["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert second["finished_at"] == first["finished_at"]
     assert len(no_delivery) == 1
 
@@ -259,7 +259,7 @@ def test_two_observers_produce_one_transition_and_one_notice(sandbox, monkeypatc
 
     assert len(results) == 2
     assert all(r["terminal"] is True for r in results)
-    assert all(r["outcome"] == jobs.OUTCOME_LOST for r in results)
+    assert all(r["outcome"] == jobs.OUTCOME_INDETERMINATE for r in results)
     # One transition: both readers report the same recorded moment.
     assert results[0]["finished_at"] == results[1]["finished_at"]
     assert len(no_delivery) == 1
@@ -341,7 +341,7 @@ def test_the_pid_attachment_cannot_roll_back_a_reaped_end(sandbox, monkeypatch, 
     rid = _stranded(pid_create_time=None, pgid=None, spawn_state="started")
 
     reaped = jobs.status(rid)
-    assert reaped["outcome"] == jobs.OUTCOME_LOST
+    assert reaped["outcome"] == jobs.OUTCOME_INDETERMINATE
 
     with jobs._locked_job(rid) as guard:
         guard.record["pid"] = 4242
@@ -352,7 +352,7 @@ def test_the_pid_attachment_cannot_roll_back_a_reaped_end(sandbox, monkeypatch, 
     after = jobs._read_job(rid)
     assert after["pid"] == 4242
     assert after["finished_at"] == reaped["finished_at"]
-    assert after["outcome"] == jobs.OUTCOME_LOST
+    assert after["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert after["notify_delivery"]["ok"] is True
 
 
@@ -373,9 +373,9 @@ def test_a_delivery_result_never_rolls_terminal_fields_backward(sandbox, monkeyp
 
     after = jobs._read_job(rid)
     assert after["finished_at"] == reaped["finished_at"]
-    assert after["outcome"] == jobs.OUTCOME_LOST
+    assert after["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert after["notify_delivery"]["exit_code"] == 7
-    assert jobs.status(rid)["outcome"] == jobs.OUTCOME_LOST
+    assert jobs.status(rid)["outcome"] == jobs.OUTCOME_INDETERMINATE
 
 
 def test_a_hook_arriving_after_a_reap_keeps_the_recorded_end(sandbox, monkeypatch, no_delivery):
@@ -390,11 +390,12 @@ def test_a_hook_arriving_after_a_reap_keeps_the_recorded_end(sandbox, monkeypatc
     rid = _stranded()
     reaped = jobs.status(rid)
 
-    assert jobs.mark_terminal(rid, "completed")["finished_at"] == reaped["finished_at"]
+    kept = jobs.mark_terminal(rid, "completed").record
+    assert kept["finished_at"] == reaped["finished_at"]
 
     st = jobs.status(rid)
     assert st["status"] == "exited"
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
 
 
@@ -418,7 +419,7 @@ def test_list_and_status_classify_and_attribute_a_reaped_run_identically(
 
     row = next(r for r in rows if r["run_id"] == rid)
     assert row["terminal"] == st["terminal"] is True
-    assert row["outcome"] == st["outcome"] == jobs.OUTCOME_LOST
+    assert row["outcome"] == st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert row["reason_code"] == st["reason_code"] == jobs.LOST_REASON
     assert row["finished_at"] == st["finished_at"]
     assert row["terminal_source"] == st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
@@ -455,7 +456,7 @@ def test_every_delivery_outcome_is_visible_and_none_of_them_changes_the_run(
     st = jobs.status(rid)
 
     assert st["notify_delivery"] == outcome
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["terminal"] is True
 
 
@@ -479,7 +480,7 @@ def test_a_delivery_that_comes_apart_leaves_a_terminal_run_to_be_reconciled(sand
     st = jobs.status(rid)
 
     assert st["terminal"] is True
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["notify_delivery"] is None
 
     on_disk = jobs._read_job(rid)
@@ -549,7 +550,147 @@ def test_a_record_written_before_any_of_this_is_reaped_on_its_next_read(
 
     st = jobs.status(rid)
 
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
     assert st["submitted_at"] == "2026-01-01T00:00:00+00:00"
     assert len(no_delivery) == 1
+
+
+# --- a mutation that cannot be serialized refuses, loudly ----------------------
+
+
+def _lock_file_cannot_be_created(monkeypatch) -> None:
+    """Make creating the per-run lock file fail, and only that."""
+    real_open = jobs.os.open
+
+    def _refuse(path, *args, **kwargs):
+        if str(path).endswith(jobs._LOCK_NAME):
+            raise PermissionError(13, "permission denied")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(jobs.os, "open", _refuse)
+
+
+def _lock_cannot_be_acquired(monkeypatch) -> None:
+    """Make the lock file open and the lock itself unobtainable."""
+
+    def _refuse(fd):
+        raise OSError(11, "resource temporarily unavailable")
+
+    monkeypatch.setattr(jobs, "_lock_fd", _refuse)
+
+
+def _console(rid: str) -> str:
+    path = config.job_dir(rid) / "console.log"
+    return path.read_text() if path.exists() else ""
+
+
+@pytest.mark.parametrize(
+    "break_the_lock",
+    [_lock_file_cannot_be_created, _lock_cannot_be_acquired],
+    ids=["lock_file_cannot_be_created", "lock_cannot_be_acquired"],
+)
+def test_a_terminal_write_that_cannot_be_serialized_sends_no_notice(
+    sandbox, monkeypatch, no_delivery, break_the_lock
+):
+    """No lock, no terminal record, no notice — and the refusal is visible.
+
+    The two ways the critical section is not entered are exercised separately
+    because they fail at different lines and only one of them was ever
+    classified. Either way the record must be left as it stands: a notice sent
+    here would assert an end that every reader of the record contradicts, which
+    is worse than the missing write it would be papering over, because the
+    missing write is at least still missing on the next observation.
+    """
+    rid = _stranded()
+    break_the_lock(monkeypatch)
+
+    rc = _notify_hook.main(["--run-id", rid, "--status", "completed"])
+
+    assert rc != 0
+    assert no_delivery == []
+    on_disk = jobs._read_job(rid)
+    assert on_disk["finished_at"] is None
+    assert on_disk["status"] == "running"
+    assert "could not record the terminal status" in _console(rid)
+
+
+def test_a_delivery_result_that_cannot_be_recorded_is_reported(sandbox, monkeypatch, no_delivery):
+    """The notice went out against a durable end; its result did not land.
+
+    A different case from the one above and reported the same way: the end is
+    on disk, so the notice was owed and was attempted, and what is missing is
+    the record of how it went. A hook that exits 0 here would say the run's
+    completion signal is accounted for when nothing on disk accounts for it.
+    """
+    rid = _stranded()
+    real_lock = jobs._lock_fd
+    taken: list[int] = []
+
+    def _refuse_after_the_first(fd):
+        taken.append(fd)
+        if len(taken) > 1:
+            raise OSError(11, "resource temporarily unavailable")
+        real_lock(fd)
+
+    monkeypatch.setattr(jobs, "_lock_fd", _refuse_after_the_first)
+
+    rc = _notify_hook.main(["--run-id", rid, "--status", "completed"])
+
+    assert rc != 0
+    assert no_delivery == [rid]
+    assert jobs._read_job(rid).get("notify_delivery") is None
+    assert "could not record the delivery result" in _console(rid)
+
+
+def test_an_absent_record_is_unchanged_by_any_of_this(sandbox, monkeypatch, no_delivery):
+    """A run nobody submitted still resolves its notice and still exits 0.
+
+    The refusal above is about a write that could not be attempted. A run with
+    no record is a settled answer, not a refused write, and it keeps the
+    behaviour it had: whatever is configured is resolved and the hook reports
+    no failure of its own.
+    """
+    rc = _notify_hook.main(["--run-id", "no-such-run", "--status", "completed"])
+
+    assert rc == 0
+    assert no_delivery == ["no-such-run"]
+
+
+def test_a_kill_that_cannot_be_recorded_says_so(sandbox, monkeypatch):
+    """The signal went out and nothing durable says it did.
+
+    The kill is not undone by the failure to record it — it already happened —
+    so `killed` stays true and the code carries the part that did not. Reported
+    rather than swallowed: a caller that reads a success and then finds the run
+    still recorded as running has no way to tell which of the two to believe.
+    """
+    rid = _stranded()
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(jobs.os, "killpg", lambda pgid, sig: signalled.append((pgid, sig)))
+    _lock_cannot_be_acquired(monkeypatch)
+
+    result = jobs._signal_group(rid, jobs._read_job(rid), 4242, 4242, 15, jobs.KILL_SIGNALLED)
+
+    assert signalled == [(4242, 15)]
+    assert result["killed"] is True
+    assert result["reason_code"] == jobs.KILL_NOT_RECORDED
+    assert jobs._read_job(rid)["finished_at"] is None
+
+
+def test_a_recorded_kill_names_the_kill_as_what_ended_the_run(sandbox, monkeypatch):
+    """The fifth writer of an end attributes it like the other four.
+
+    No writer inside the serialization discipline may publish a terminal fact
+    without saying what made it; an unattributed end is exactly what the
+    attribution field exists to prevent.
+    """
+    rid = _stranded()
+    monkeypatch.setattr(jobs.os, "killpg", lambda pgid, sig: None)
+
+    result = jobs._signal_group(rid, jobs._read_job(rid), 4242, 4242, 15, jobs.KILL_SIGNALLED)
+
+    assert result["reason_code"] == jobs.KILL_SIGNALLED
+    on_disk = jobs._read_job(rid)
+    assert on_disk["status"] == "killed"
+    assert on_disk["terminal_source"] == jobs.TERMINAL_SOURCE_KILL

--- a/tests/mcp/test_orphan_reaping.py
+++ b/tests/mcp/test_orphan_reaping.py
@@ -1,0 +1,555 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A run whose process is conclusively gone gets one attributable end.
+
+No test here spawns a long-running child or signals a process it did not start:
+the liveness probes are doubled, so the observations under test are the ones
+this module classifies rather than ones the machine happens to produce. The
+concurrency tests do use the real per-run lock, in threads, because the property
+being checked is that the lock serializes — a doubled lock would prove nothing.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from lionagi.mcp import _notify_hook, config, jobs
+
+_SPAWNED_AT = 1_700_000_000.0
+
+
+@pytest.fixture
+def sandbox(monkeypatch, tmp_path):
+    """Point job/run state at a tmp dir so tests never touch the real ~/.lionagi."""
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(config, "li_command", lambda: ["echo"])
+    monkeypatch.setattr(jobs, "_read_lifecycle", lambda run_id: None)
+    return tmp_path
+
+
+@pytest.fixture
+def no_delivery(monkeypatch):
+    """Record every delivery attempt and make none of them run a command.
+
+    Returned as the list of run ids a notice was attempted for, so a test can
+    assert that exactly one was made — or that none was.
+    """
+    attempts: list[str] = []
+
+    def _fake(run_id, job, status, **kw):
+        attempts.append(run_id)
+        return {"attempted": True, "ok": True, "exit_code": 0, "error": None, "command": "notify"}
+
+    monkeypatch.setattr(_notify_hook, "deliver_terminal_notice", _fake)
+    return attempts
+
+
+def _record(rid: str, **fields: Any) -> str:
+    base: dict[str, Any] = {
+        "run_id": rid,
+        "pid": 4242,
+        "pid_create_time": _SPAWNED_AT,
+        "pgid": 4242,
+        "kind": "agent",
+        "label": "a-label",
+        "status": "running",
+        "spawn_state": "started",
+        "submitted_at": "2026-07-25T00:00:00+00:00",
+        "finished_at": None,
+        "log": None,
+    }
+    base.update(fields)
+    jobs._write_job(base)
+    return rid
+
+
+def _stranded(**fields: Any) -> str:
+    return _record(jobs.new_run_id(), **fields)
+
+
+def _pid_absent(monkeypatch) -> None:
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+
+
+def _disappeared_during_probe(monkeypatch) -> None:
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("gone", None))
+
+
+def _pid_recycled(monkeypatch) -> None:
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT + 5000))
+
+
+_CONCLUSIVE = {
+    jobs.FINDING_PID_ABSENT: _pid_absent,
+    jobs.FINDING_DISAPPEARED_DURING_PROBE: _disappeared_during_probe,
+    jobs.FINDING_PID_RECYCLED: _pid_recycled,
+}
+
+
+# --- verify-by 1: each positive finding writes exactly one transition ----------
+
+
+@pytest.mark.parametrize("finding", sorted(_CONCLUSIVE))
+def test_each_conclusive_finding_writes_one_terminal_transition(
+    sandbox, monkeypatch, no_delivery, finding
+):
+    """Three observations, one contract, and one transition each.
+
+    Each of these positively establishes that the process this run recorded is
+    gone: the pid held nothing when it was asked, it emptied between the two
+    probes, or a live process holds the number and is demonstrably a different
+    one. Each ends the run once — the second read of the same record returns
+    what the first one wrote, without observing anything, which is the property
+    that keeps two readers from disagreeing.
+    """
+    _CONCLUSIVE[finding](monkeypatch)
+    rid = _stranded()
+
+    first = jobs.status(rid)
+    assert first["terminal"] is True
+    assert first["outcome"] == jobs.OUTCOME_LOST
+    assert first["reason_code"] == jobs.LOST_REASON
+    assert first["liveness_conclusion"] == "process_gone"
+    assert first["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
+    assert first["terminal_evidence"] == {
+        "kind": jobs.EVIDENCE_PROCESS_GONE,
+        "finding": finding,
+    }
+
+    on_disk = jobs._read_job(rid)
+    assert on_disk["finished_at"] == first["finished_at"] is not None
+    assert on_disk["outcome"] == jobs.OUTCOME_LOST
+
+    # The second reader answers from the record alone. It is given the opposite
+    # observation — a live, confirmed process at that pid — and must still
+    # report the end, because a latch that a later observation could move is not
+    # one two readers can agree on.
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("found", _SPAWNED_AT))
+    second = jobs.status(rid)
+    assert second["alive"] is True
+    assert second["terminal"] is True
+    assert second["outcome"] == jobs.OUTCOME_LOST
+    assert second["finished_at"] == first["finished_at"]
+    assert len(no_delivery) == 1
+
+
+# --- verify-by 2: nothing inconclusive ends a run -----------------------------
+
+
+def _unusable_pid(monkeypatch) -> dict[str, Any]:
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    return {"pid": "4242"}
+
+
+def _access_denied(monkeypatch) -> dict[str, Any]:
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("unknown", None))
+    return {}
+
+
+def _creation_time_unreadable(monkeypatch) -> dict[str, Any]:
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(jobs, "_process_create_time", lambda pid: ("unknown", None))
+    return {"pid_create_time": None}
+
+
+def _preparing(monkeypatch) -> dict[str, Any]:
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    return {"pid": None, "pid_create_time": None, "pgid": None, "spawn_state": "preparing"}
+
+
+@pytest.mark.parametrize(
+    "setup",
+    [_unusable_pid, _access_denied, _creation_time_unreadable, _preparing],
+    ids=["unusable_pid", "access_denied", "creation_time_unreadable", "preparing"],
+)
+def test_an_observation_that_establishes_nothing_never_ends_a_run(
+    sandbox, monkeypatch, no_delivery, setup
+):
+    """The four inconclusive shapes stay where they were, and wake nobody.
+
+    None of these is evidence that this run's process is gone. A pid the OS
+    cannot be asked about was never probed; a denied or unreadable identity read
+    is a measurement that did not come off; a spawn still preparing never
+    acquired a process identity to lose. Ending a run on any of them would latch
+    a claim the observation does not support, and — since the end owns the
+    notice — would also send a completion notice for a run that may be running.
+    """
+    fields = setup(monkeypatch)
+    rid = _stranded(**fields)
+
+    st = jobs.status(rid)
+
+    assert st["liveness_conclusion"] != "process_gone"
+    assert st["terminal"] is False
+    assert st["outcome"] is None
+    assert st["finished_at"] is None
+    assert st["terminal_source"] is None
+    assert jobs._read_job(rid)["finished_at"] is None
+    assert no_delivery == []
+
+
+def test_a_finding_outside_the_conclusive_set_is_refused_at_the_primitive(sandbox, no_delivery):
+    """The admission rule is membership in the positive set, and nothing else.
+
+    Called directly with a finding that names a real inconclusive observation,
+    the guarded operation refuses it. That is the property that survives someone
+    adding a value to the liveness vocabulary later: a new finding is not
+    conclusive until it is written down as conclusive.
+    """
+    rid = _stranded()
+
+    result = jobs.reap_orphan(
+        rid, finding="identity_unreadable", observed_at="2026-07-27T00:00:00+00:00"
+    )
+
+    assert result.won_transition is False
+    assert jobs._read_job(rid)["finished_at"] is None
+    assert no_delivery == []
+
+
+# --- verify-by 3 and 4: interleavings ------------------------------------------
+
+
+def _hold_lock(rid: str):
+    """Hold the real per-run lock, so a mutation under test genuinely blocks."""
+    return jobs._locked_job(rid)
+
+
+def _run_blocked(fn) -> tuple[threading.Thread, list[Any]]:
+    """Start *fn* in a thread and hand back the thread and where it will answer."""
+    out: list[Any] = []
+    t = threading.Thread(target=lambda: out.append(fn()), daemon=True)
+    t.start()
+    return t, out
+
+
+def test_two_observers_produce_one_transition_and_one_notice(sandbox, monkeypatch, no_delivery):
+    """Two readers racing on one stranded run end it once between them.
+
+    The interleaving is forced rather than hoped for: the test takes the run's
+    own mutation lock first, so both observers reach their guarded write and
+    stop there, with both of them holding a snapshot that says the run has not
+    ended. Releasing the lock lets them proceed one after the other, which is
+    exactly the double transition the guard has to prevent — the loser rereads
+    inside the lock, finds the end, and returns it instead of writing a second
+    one. The notice belongs to whoever won, so one attempt is made, not two.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    with _hold_lock(rid):
+        threads = [_run_blocked(lambda: jobs.status(rid)) for _ in range(2)]
+        for t, _ in threads:
+            t.join(timeout=0.5)
+            assert t.is_alive(), "an observer that did not block took no lock to be serialized by"
+
+    results = []
+    for t, out in threads:
+        t.join(timeout=10)
+        assert not t.is_alive()
+        results.extend(out)
+
+    assert len(results) == 2
+    assert all(r["terminal"] is True for r in results)
+    assert all(r["outcome"] == jobs.OUTCOME_LOST for r in results)
+    # One transition: both readers report the same recorded moment.
+    assert results[0]["finished_at"] == results[1]["finished_at"]
+    assert len(no_delivery) == 1
+
+
+def test_a_hook_end_that_lands_first_survives_the_reaper(sandbox, monkeypatch, no_delivery):
+    """The reaper holds a stale snapshot and must not write over a reported end.
+
+    The observer reads the record, concludes the process is gone, and reaches
+    its guarded write — where the test is holding the lock. The hook's end is
+    recorded inside that same lock, under the observer's feet. What the observer
+    then does is the whole question: rereading is what makes it report the
+    reported end, and merging its own snapshot would replace how the run came
+    out with a guess about it.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    with _hold_lock(rid) as guard:
+        thread, out = _run_blocked(lambda: jobs.status(rid))
+        thread.join(timeout=0.5)
+        assert thread.is_alive()
+        guard.record["status"] = "completed"
+        guard.record["finished_at"] = "2026-07-27T00:00:00+00:00"
+        guard.record["terminal_source"] = jobs.TERMINAL_SOURCE_HOOK
+
+    thread.join(timeout=10)
+    st = out[0]
+
+    assert st["status"] == "completed"
+    assert st["terminal"] is True
+    assert st["outcome"] == "succeeded"
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_HOOK
+    assert jobs._read_job(rid)["finished_at"] == "2026-07-27T00:00:00+00:00"
+    assert no_delivery == [], "the run reported its own end, so its own hook owns the notice"
+
+
+def test_a_lifecycle_end_cached_first_survives_the_reaper(sandbox, monkeypatch, no_delivery):
+    """The same, for the end a kill leaves in the lifecycle store.
+
+    A cancelled run's only trace is the lifecycle row, and an observer that
+    cached it got there with a reported status and reason. An inferred loss must
+    not overwrite either.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    with _hold_lock(rid) as guard:
+        thread, out = _run_blocked(lambda: jobs.status(rid))
+        thread.join(timeout=0.5)
+        assert thread.is_alive()
+        guard.record.update(
+            {
+                "status": "cancelled",
+                "finished_at": "2026-07-27T00:00:00+00:00",
+                "reason_code": "killed_by_operator",
+                "terminal_source": jobs.TERMINAL_SOURCE_LIFECYCLE,
+            }
+        )
+
+    thread.join(timeout=10)
+    st = out[0]
+
+    assert st["outcome"] == "cancelled"
+    assert st["reason_code"] == "killed_by_operator"
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_LIFECYCLE
+    assert no_delivery == []
+
+
+def test_the_pid_attachment_cannot_roll_back_a_reaped_end(sandbox, monkeypatch, no_delivery):
+    """The submit-side write adds identity fields and touches nothing else.
+
+    It is the one mutation that runs while a run is still being created, so it
+    is also the one most likely to hold a record older than everything else on
+    disk. Reaching the lock after a transition, it must merge its own fields and
+    leave the end and the delivery result exactly as they are.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded(pid_create_time=None, pgid=None, spawn_state="started")
+
+    reaped = jobs.status(rid)
+    assert reaped["outcome"] == jobs.OUTCOME_LOST
+
+    with jobs._locked_job(rid) as guard:
+        guard.record["pid"] = 4242
+        guard.record["pid_create_time"] = _SPAWNED_AT
+        guard.record["pgid"] = 4242
+        guard.record["spawn_state"] = "started"
+
+    after = jobs._read_job(rid)
+    assert after["pid"] == 4242
+    assert after["finished_at"] == reaped["finished_at"]
+    assert after["outcome"] == jobs.OUTCOME_LOST
+    assert after["notify_delivery"]["ok"] is True
+
+
+def test_a_delivery_result_never_rolls_terminal_fields_backward(sandbox, monkeypatch, no_delivery):
+    """A notice result merges itself and carries no stale lifecycle fields.
+
+    The hook writes the delivery outcome after the run has ended, from a process
+    that read the record before it ended. Merging its whole copy back would
+    un-terminalise the run; merging the one field it owns cannot.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+    reaped = jobs.status(rid)
+
+    jobs.record_notify_delivery(
+        rid, {"attempted": True, "ok": False, "exit_code": 7, "error": None}
+    )
+
+    after = jobs._read_job(rid)
+    assert after["finished_at"] == reaped["finished_at"]
+    assert after["outcome"] == jobs.OUTCOME_LOST
+    assert after["notify_delivery"]["exit_code"] == 7
+    assert jobs.status(rid)["outcome"] == jobs.OUTCOME_LOST
+
+
+def test_a_hook_arriving_after_a_reap_keeps_the_recorded_end(sandbox, monkeypatch, no_delivery):
+    """The child's own hook, running late, cannot replace an inferred end.
+
+    Whichever end was recorded first is the one every reader has already been
+    given, so it stays. The hook's arrival is still allowed to add what is
+    missing beside it — which is what makes this a merge rule rather than a
+    refusal to write.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+    reaped = jobs.status(rid)
+
+    assert jobs.mark_terminal(rid, "completed")["finished_at"] == reaped["finished_at"]
+
+    st = jobs.status(rid)
+    assert st["status"] == "exited"
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
+
+
+# --- verify-by 7: list and status agree ---------------------------------------
+
+
+def test_list_and_status_classify_and_attribute_a_reaped_run_identically(
+    sandbox, monkeypatch, no_delivery
+):
+    """Two surfaces, one classification — including who wrote the end.
+
+    The listing is the surface a caller polls, so a row that showed the outcome
+    without the attribution would hide the difference between a run that
+    reported its own end and one this server ended on its behalf.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    rows = jobs.list_jobs()
+    st = jobs.status(rid)
+
+    row = next(r for r in rows if r["run_id"] == rid)
+    assert row["terminal"] == st["terminal"] is True
+    assert row["outcome"] == st["outcome"] == jobs.OUTCOME_LOST
+    assert row["reason_code"] == st["reason_code"] == jobs.LOST_REASON
+    assert row["finished_at"] == st["finished_at"]
+    assert row["terminal_source"] == st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
+    assert len(no_delivery) == 1, "the listing reaped it; the status read found it already ended"
+
+
+# --- verify-by 8 and 12: delivery outcomes and the crash gap -------------------
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        {"attempted": True, "ok": True, "exit_code": 0, "error": None, "command": "notify"},
+        {"attempted": False, "ok": False, "exit_code": None, "error": "refused", "command": None},
+        {"attempted": True, "ok": False, "exit_code": 3, "error": None, "command": "notify"},
+        {
+            "attempted": True,
+            "ok": False,
+            "exit_code": None,
+            "error": "TimeoutExpired",
+            "command": "notify",
+        },
+    ],
+    ids=["delivered", "refused", "nonzero_exit", "timeout"],
+)
+def test_every_delivery_outcome_is_visible_and_none_of_them_changes_the_run(
+    sandbox, monkeypatch, outcome
+):
+    """How the notice went is recorded; how the run came out does not move."""
+    monkeypatch.setattr(_notify_hook, "deliver_terminal_notice", lambda *a, **k: outcome)
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    st = jobs.status(rid)
+
+    assert st["notify_delivery"] == outcome
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["terminal"] is True
+
+
+def test_a_delivery_that_comes_apart_leaves_a_terminal_run_to_be_reconciled(sandbox, monkeypatch):
+    """The fault is injected after the end is durable and before the notice.
+
+    This is the crash gap the design accepts: the transition is published, the
+    delivery does not happen, and nothing records why. What must survive it is
+    the end itself — reconciliation is reading the state, so the state has to
+    say the run is over and how it came out, with the missing notice visible as
+    a missing notice rather than as a run still going.
+    """
+
+    def _crash(*_a, **_k):
+        raise RuntimeError("the notifier came apart in a way nobody classified")
+
+    monkeypatch.setattr(_notify_hook, "deliver_terminal_notice", _crash)
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    st = jobs.status(rid)
+
+    assert st["terminal"] is True
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["notify_delivery"] is None
+
+    on_disk = jobs._read_job(rid)
+    assert on_disk["finished_at"] == st["finished_at"]
+    assert on_disk["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
+
+
+def test_the_notice_is_the_one_the_run_configured(sandbox, monkeypatch):
+    """The observer sends what the dead child would have sent, not its own idea.
+
+    The fields come off the run's own record — its per-submit delivery override,
+    its target and its sender — and go through the hook's resolution, so there
+    is one place a notifier is configured rather than two that can disagree.
+    """
+    seen: dict[str, Any] = {}
+
+    def _capture(run_id, job, status, **kw):
+        seen.update({"run_id": run_id, "status": status, "label": (job or {}).get("label"), **kw})
+        return {"attempted": True, "ok": True, "exit_code": 0, "error": None, "command": "x"}
+
+    monkeypatch.setattr(_notify_hook, "deliver_terminal_notice", _capture)
+    _pid_absent(monkeypatch)
+    rid = _stranded(
+        notify_command='["notify-me", "{status}"]',
+        notify_target="seat",
+        notify_sender="who",
+    )
+
+    jobs.status(rid)
+
+    assert seen["run_id"] == rid
+    assert seen["status"] == "exited"
+    assert seen["label"] == "a-label"
+    assert seen["command"] == '["notify-me", "{status}"]'
+    assert seen["target"] == "seat"
+    assert seen["sender"] == "who"
+
+
+# --- verify-by 9: records written before this existed --------------------------
+
+
+def test_a_record_written_before_any_of_this_is_reaped_on_its_next_read(
+    sandbox, monkeypatch, no_delivery
+):
+    """No migration: a stranded record is closed by the next conclusive read.
+
+    The record here carries none of the fields this change introduces, which is
+    what every record on disk when it ships looks like. It receives the current
+    observation time and the observer's attribution, and nothing about it is
+    rewritten for being old.
+    """
+    _pid_absent(monkeypatch)
+    rid = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "pid": 4242,
+            "pid_create_time": _SPAWNED_AT,
+            "kind": "agent",
+            "status": "running",
+            "spawn_state": "started",
+            "submitted_at": "2026-01-01T00:00:00+00:00",
+            "finished_at": None,
+            "log": None,
+        }
+    )
+
+    st = jobs.status(rid)
+
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
+    assert st["submitted_at"] == "2026-01-01T00:00:00+00:00"
+    assert len(no_delivery) == 1

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -89,17 +89,24 @@ def test_terminal_outcome_from_recorded_end(sandbox, cli_status, outcome, reason
     assert st["reason_code"] == reason_code
 
 
-def test_orphan_is_not_terminal_and_has_no_outcome(sandbox, monkeypatch):
-    """A process gone with no end recorded has stopped and is still not terminal."""
+def test_a_conclusively_gone_process_ends_the_run_as_lost(sandbox, monkeypatch):
+    """A process positively established gone, with nothing reported, is over.
+
+    Nothing survived that could ever write this run's end, so leaving it
+    non-terminal leaves it non-terminal forever. The end is the observer's, and
+    it says so: `lost` is not a failure, and the reason names why there is no
+    result rather than classifying one.
+    """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     rid = jobs.new_run_id()
     _record(rid, pid=999_999)
 
     st = jobs.status(rid)
-    assert st["status"] == "exited"
-    assert st["terminal"] is False
-    assert st["outcome"] is None  # null whenever terminal is false, not just while running
-    assert st["possibly_orphaned"] is True
+    assert st["terminal"] is True
+    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["reason_code"] == jobs.LOST_REASON
+    assert st["possibly_orphaned"] is False
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
 
 
 def test_preparing_record_is_not_a_spawn_failure(sandbox, monkeypatch):
@@ -332,7 +339,9 @@ async def test_wait_does_not_touch_the_run(sandbox, monkeypatch):
 async def test_wait_stops_as_soon_as_every_id_is_terminal(sandbox, monkeypatch):
     """The call returns on the transition, not on the deadline."""
     alive = {"value": True}
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: alive["value"])
+    # Both probes, because a live pid whose creation time cannot be matched is
+    # now a run this module ends rather than one it keeps polling.
+    _live_process(monkeypatch, alive=lambda pid: alive["value"])
     rid = jobs.new_run_id()
     _record(rid, pid=4242)
 
@@ -384,15 +393,16 @@ async def test_a_stopped_run_costs_one_poll_interval_and_no_more(sandbox, monkey
     monkeypatch.setattr(anyio, "sleep", no_sleep)
     res = await jobs.wait([rid], max_wait=600, poll_interval=5)
 
-    assert slept == [5]
+    assert slept == []
     assert res["pending"] == []
-    assert res["stopped_without_end"] == [rid]
+    # The run was ended by the observation itself, so there is nothing left to
+    # wait for and nothing to report under the compatibility field.
+    assert res["stopped_without_end"] == []
     assert res["timed_out"] is False
-    # Stopped is not finished: nothing recorded how this run came out.
-    assert res["all_terminal"] is False
-    assert res["runs"][0]["terminal"] is False
-    assert res["runs"][0]["outcome"] is None
-    assert res["runs"][0]["possibly_orphaned"] is True
+    assert res["all_terminal"] is True
+    assert res["runs"][0]["terminal"] is True
+    assert res["runs"][0]["outcome"] == jobs.OUTCOME_LOST
+    assert res["runs"][0]["possibly_orphaned"] is False
     assert res["runs"][0]["error"] is None
 
 
@@ -404,7 +414,7 @@ async def test_wait_still_waits_for_a_running_id_beside_a_stopped_one(sandbox, m
     extra for the stopped one sitting beside it.
     """
     alive = {"value": True}
-    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: pid == 4242 and alive["value"])
+    _live_process(monkeypatch, alive=lambda pid: pid == 4242 and alive["value"])
     gone = jobs.new_run_id()
     _record(gone, pid=999_999)
     busy = jobs.new_run_id()
@@ -426,11 +436,14 @@ async def test_wait_still_waits_for_a_running_id_beside_a_stopped_one(sandbox, m
 
     assert polls["n"] == 2  # the wait did keep observing the running id
     assert res["pending"] == []
-    assert res["stopped_without_end"] == [gone]
+    assert res["stopped_without_end"] == []
     assert res["timed_out"] is False
-    assert res["all_terminal"] is False  # one id never recorded an end
+    # Both ids have a recorded end, so the aggregate is true — and it is the
+    # per-entry outcomes, in the order they were asked for, that say the two
+    # runs came out differently.
+    assert res["all_terminal"] is True
+    assert [r["outcome"] for r in res["runs"]] == [jobs.OUTCOME_LOST, "succeeded"]
     assert res["runs"][1]["terminal"] is True
-    assert res["runs"][1]["outcome"] == "succeeded"
 
 
 async def test_a_stopped_run_that_later_records_an_end_is_terminal(sandbox, monkeypatch):
@@ -443,9 +456,11 @@ async def test_a_stopped_run_that_later_records_an_end_is_terminal(sandbox, monk
     rid = jobs.new_run_id()
     _record(rid, pid=999_999)
 
-    stopped = await jobs.wait([rid], max_wait=0, poll_interval=1)
-    assert stopped["stopped_without_end"] == [rid]
+    ended = await jobs.wait([rid], max_wait=0, poll_interval=1)
+    assert ended["stopped_without_end"] == []
+    assert ended["runs"][0]["outcome"] == jobs.OUTCOME_LOST
 
+    # A hook arriving afterwards cannot replace an end that is already recorded.
     jobs.mark_terminal(rid, "completed")
     res = await jobs.wait([rid], max_wait=0, poll_interval=1)
 
@@ -453,7 +468,7 @@ async def test_a_stopped_run_that_later_records_an_end_is_terminal(sandbox, monk
     assert res["pending"] == []
     assert res["all_terminal"] is True
     assert res["runs"][0]["terminal"] is True
-    assert res["runs"][0]["outcome"] == "succeeded"
+    assert res["runs"][0]["outcome"] == jobs.OUTCOME_LOST
     assert res["runs"][0]["possibly_orphaned"] is False
 
 
@@ -480,7 +495,8 @@ async def test_wait_snapshot_of_a_stopped_run_is_still_a_snapshot(sandbox, monke
 
     assert slept == []
     assert res["max_wait"] == 0.0
-    assert res["stopped_without_end"] == [rid]
+    assert res["stopped_without_end"] == []
+    assert res["runs"][0]["outcome"] == jobs.OUTCOME_LOST
 
 
 async def test_wait_does_not_hold_the_window_open_for_a_reused_pid(sandbox, monkeypatch):
@@ -499,10 +515,11 @@ async def test_wait_does_not_hold_the_window_open_for_a_reused_pid(sandbox, monk
     res = await jobs.wait([rid], max_wait=0, poll_interval=5)
 
     assert res["pending"] == []
-    assert res["stopped_without_end"] == [rid]
-    assert res["all_terminal"] is False
-    assert res["runs"][0]["possibly_orphaned"] is True
-    assert res["runs"][0]["terminal"] is False
+    assert res["stopped_without_end"] == []
+    assert res["all_terminal"] is True
+    assert res["runs"][0]["possibly_orphaned"] is False
+    assert res["runs"][0]["terminal"] is True
+    assert res["runs"][0]["outcome"] == jobs.OUTCOME_LOST
     assert res["runs"][0]["error"] is None
 
 
@@ -516,7 +533,7 @@ async def test_the_floor_never_outruns_the_window(sandbox, monkeypatch):
     """
     monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
     rid = jobs.new_run_id()
-    _record(rid, pid=999_999)
+    _record(rid, pid="999999")  # unaskable: stopped-looking, never conclusive
 
     import anyio
 
@@ -548,7 +565,7 @@ async def test_every_unresolved_id_is_named_somewhere_in_the_result(sandbox, mon
     running = jobs.new_run_id()
     _record(running, pid=4242)
     stopped = jobs.new_run_id()
-    _record(stopped, pid=999_999)
+    _record(stopped, pid="999999")  # unaskable: stopped-looking, never conclusive
     done = jobs.new_run_id()
     _record(done, pid=999_999)
     jobs.mark_terminal(done, "completed")

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -103,7 +103,7 @@ def test_a_conclusively_gone_process_ends_the_run_as_lost(sandbox, monkeypatch):
 
     st = jobs.status(rid)
     assert st["terminal"] is True
-    assert st["outcome"] == jobs.OUTCOME_LOST
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert st["reason_code"] == jobs.LOST_REASON
     assert st["possibly_orphaned"] is False
     assert st["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
@@ -401,7 +401,7 @@ async def test_a_stopped_run_costs_one_poll_interval_and_no_more(sandbox, monkey
     assert res["timed_out"] is False
     assert res["all_terminal"] is True
     assert res["runs"][0]["terminal"] is True
-    assert res["runs"][0]["outcome"] == jobs.OUTCOME_LOST
+    assert res["runs"][0]["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert res["runs"][0]["possibly_orphaned"] is False
     assert res["runs"][0]["error"] is None
 
@@ -419,6 +419,11 @@ async def test_wait_still_waits_for_a_running_id_beside_a_stopped_one(sandbox, m
     _record(gone, pid=999_999)
     busy = jobs.new_run_id()
     _record(busy, pid=4242)
+    # A run that ended badly, so the aggregate below covers all four outcomes a
+    # wait can carry at once rather than three of them.
+    dud = jobs.new_run_id()
+    _record(dud, pid=999_998)
+    jobs.mark_terminal(dud, "failed")
 
     polls = {"n": 0}
     real_status = jobs.status
@@ -432,18 +437,23 @@ async def test_wait_still_waits_for_a_running_id_beside_a_stopped_one(sandbox, m
         return real_status(run_id)
 
     monkeypatch.setattr(jobs, "status", counting_status)
-    res = await jobs.wait([gone, busy], max_wait=30, poll_interval=0.01)
+    res = await jobs.wait([gone, busy, dud], max_wait=30, poll_interval=0.01)
 
     assert polls["n"] == 2  # the wait did keep observing the running id
     assert res["pending"] == []
     assert res["stopped_without_end"] == []
     assert res["timed_out"] is False
-    # Both ids have a recorded end, so the aggregate is true — and it is the
-    # per-entry outcomes, in the order they were asked for, that say the two
+    # Every id has a recorded end, so the aggregate is true — and it is the
+    # per-entry outcomes, in the order they were asked for, that say the three
     # runs came out differently.
     assert res["all_terminal"] is True
-    assert [r["outcome"] for r in res["runs"]] == [jobs.OUTCOME_LOST, "succeeded"]
+    assert [r["outcome"] for r in res["runs"]] == [
+        jobs.OUTCOME_INDETERMINATE,
+        "succeeded",
+        "failed",
+    ]
     assert res["runs"][1]["terminal"] is True
+    assert res["runs"][2]["terminal"] is True
 
 
 async def test_a_stopped_run_that_later_records_an_end_is_terminal(sandbox, monkeypatch):
@@ -458,7 +468,7 @@ async def test_a_stopped_run_that_later_records_an_end_is_terminal(sandbox, monk
 
     ended = await jobs.wait([rid], max_wait=0, poll_interval=1)
     assert ended["stopped_without_end"] == []
-    assert ended["runs"][0]["outcome"] == jobs.OUTCOME_LOST
+    assert ended["runs"][0]["outcome"] == jobs.OUTCOME_INDETERMINATE
 
     # A hook arriving afterwards cannot replace an end that is already recorded.
     jobs.mark_terminal(rid, "completed")
@@ -468,7 +478,7 @@ async def test_a_stopped_run_that_later_records_an_end_is_terminal(sandbox, monk
     assert res["pending"] == []
     assert res["all_terminal"] is True
     assert res["runs"][0]["terminal"] is True
-    assert res["runs"][0]["outcome"] == jobs.OUTCOME_LOST
+    assert res["runs"][0]["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert res["runs"][0]["possibly_orphaned"] is False
 
 
@@ -496,7 +506,7 @@ async def test_wait_snapshot_of_a_stopped_run_is_still_a_snapshot(sandbox, monke
     assert slept == []
     assert res["max_wait"] == 0.0
     assert res["stopped_without_end"] == []
-    assert res["runs"][0]["outcome"] == jobs.OUTCOME_LOST
+    assert res["runs"][0]["outcome"] == jobs.OUTCOME_INDETERMINATE
 
 
 async def test_wait_does_not_hold_the_window_open_for_a_reused_pid(sandbox, monkeypatch):
@@ -519,7 +529,7 @@ async def test_wait_does_not_hold_the_window_open_for_a_reused_pid(sandbox, monk
     assert res["all_terminal"] is True
     assert res["runs"][0]["possibly_orphaned"] is False
     assert res["runs"][0]["terminal"] is True
-    assert res["runs"][0]["outcome"] == jobs.OUTCOME_LOST
+    assert res["runs"][0]["outcome"] == jobs.OUTCOME_INDETERMINATE
     assert res["runs"][0]["error"] is None
 
 


### PR DESCRIPTION
## Problem

A background run whose process is gone but which never recorded how it came out stayed non-terminal forever. Anyone waiting on it waited indefinitely, and nothing said why.

The old code decided terminality from a negative: not alive. That reads the same for a process that is genuinely gone, a pid the platform will not let us query, an unreadable creation time, and a spawn still being prepared. Only the first of those establishes anything.

## What this implements

The decision recorded in `docs/adr/ADR-0107-conclusive-orphan-terminal-reaping.md`.

- **Positive conclusion only.** `ProcessLiveness` carries a closed `LivenessConclusion` (`alive` / `process_gone` / `unknown`) and a finding. Only the closed positive set `{pid_absent, disappeared_during_probe, pid_recycled}` admits a transition. Access denied, an unusable pid, an unreadable creation time and a spawn in preparation stay non-terminal and attempt no delivery.
- **Write, then derive.** The first reader may cause the transition, but it answers from the record it reads back, never from its own observation. Two readers of unchanged bytes cannot disagree.
- **One writer at a time.** A per-run advisory lock (`job.lock`, beside `job.json`) is held across reread, merge and replace for every sidecar read-modify-write. Concurrent observers produce one transition and at most one notice.
- **`lost` is not `failed`.** A run whose process is gone with nothing recorded reports `outcome: lost`, `reason_code: process_gone_without_outcome`. It is terminal, so waits finish; it is not an error, so nothing auto-retries it.
- **Attribution.** `terminal_source` names which writer ended a run, with bounded `terminal_evidence`.
- **Delivery follows publication.** The notice is attempted by the transition winner, after the end is durable, through the same resolution path the hook uses.

`finished_at` on a lost run is when the end was **established**, not when the process exited, so any duration derived from it is an upper bound. Both the MCP reference and the CLI reference say so.

## Tests

New `tests/mcp/test_orphan_reaping.py` (22), plus updates where the ADR changes a contract a test encoded. The concurrency cases are deterministic rather than raced: the test takes the run's real per-run lock, starts the mutation under test in a thread, asserts the thread is still alive after a bounded join (proof it reached the guard and blocked), performs the winning write inside the same lock, then releases.

Closes #2617
