### PR TITLE
fix(operations): a caller with no dependencies can say so

### DIFF
--- a/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
+++ b/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
@@ -183,8 +183,9 @@ Exact node and builder semantics:
 - `node_id` on builder methods is a human reference stored as
   `metadata["reference_id"]`; it does not replace the generated element UUID.
 - `add_operation()` adds `depends_on` edges only for dependency ids already known to that builder.
-  With no explicit dependency, it links every current head to the new node using a `"sequential"`
-  label. A supplied branch is normalized through `ID.get_id()`.
+  With `depends_on` omitted or `None`, it links every current head to the new node using a
+  `"sequential"` label; an explicit empty list adds no incoming edge at all. A supplied branch is
+  normalized through `ID.get_id()`.
 - `inherit_context=True` with dependencies records one `primary_dependency`, always the first
   `depends_on` entry. This metadata controls conversation-message inheritance under D3.
 - `expand_from_result()` raises `OperationError` when the source is unknown. Model items are dumped

--- a/docs/adr/ADR-0033-operation-graph-orchestration-boundary.md
+++ b/docs/adr/ADR-0033-operation-graph-orchestration-boundary.md
@@ -25,14 +25,16 @@ injection would exceed capacity, introduce a cycle, or require a branch clone. T
 initial graph therefore arrives complete; live mutation passes through one locked
 admission path.
 
-**P3 — Two graph builders currently disagree about an omitted dependency list.**
-The role-task builders add only declared dependency or aggregation edges.
+**P3 — Two graph builders answer an omitted dependency list differently.** The
+role-task builders add only declared dependency or aggregation edges.
 `OperationGraphBuilder.add_operation()` instead links a new operation after all
-current heads when `depends_on` is falsey. The CLI uses that incremental builder,
-so nominal fan-out and dependency-free DAG roots can be serialized accidentally.
+current heads when `depends_on` is `None`, which is chaining shorthand for a
+caller building a linear sequence. A caller of the incremental builder that wants
+a fan-out worker or a second DAG root must therefore say so, by passing an empty
+list; a caller that omits the argument gets a chain.
 `lionagi/orchestration/patterns.py`, `lionagi/operations/builder.py`,
-`lionagi/cli/orchestrate/flow.py`, and `lionagi/cli/orchestrate/fanout.py` contain
-the divergence.
+`lionagi/cli/orchestrate/flow.py`, and `lionagi/cli/orchestrate/fanout.py` hold
+the two conventions.
 
 **P4 — Model-emitted work is a request, not execution authority.** A
 `SpawnRequest` can name an operation and assignee, but it must not reach arbitrary
@@ -56,7 +58,7 @@ equivalent to a completed child and does not necessarily fail the parent.
 | Concern | Decision |
 |---------|----------|
 | Shared execution boundary | D1: `Session.flow()` delegates every operation graph to the common dependency-aware or reactive executor. |
-| Initial graph topology | D2: callers own initial topology; the two builder semantics and their current divergence remain explicit. |
+| Initial graph topology | D2: callers own initial topology; the two builder surfaces keep different defaults, and each default is recorded explicitly. |
 | Planned and live work | D3: `TaskAssignment` and `SpawnRequest` are typed requests, with role routing before locked executor admission. |
 | Dependencies, branches, and concurrency | D4: the kernel owns waits, context propagation, branch allocation, edge conditions, and capacity. |
 | Lifecycle and result observation | D5: `op_id` is lifecycle identity; progress translation is opt-in today; result and rejection payloads are stable. |
@@ -176,7 +178,7 @@ operations. Keeping execution immediately below that facade gives every surface
 the same branch and signal context while leaving initial plan construction outside
 the kernel.
 
-### D2 — Caller-owned initial topology, with the shipped builder divergence recorded
+### D2 — Caller-owned initial topology, with both builder conventions recorded
 
 Initial graph design remains outside the kernel. The two shipped construction
 surfaces are not semantically interchangeable.
@@ -212,8 +214,9 @@ def build_dag_graph(
 
 | Construction case | Shipped edge semantics |
 |-------------------|------------------------|
-| `OperationGraphBuilder.add_operation(..., depends_on=[...])` | Add `depends_on` edges only for ids already present in `_operations`. Unknown ids are silently ignored. |
-| `OperationGraphBuilder.add_operation(..., depends_on=None or [])` with current heads | Add `sequential` edges from every current head, then make the new node the sole head. |
+| `OperationGraphBuilder.add_operation(..., depends_on=[...])` with a non-empty list | Add `depends_on` edges only for ids already present in `_operations`. Unknown ids are silently ignored. |
+| `OperationGraphBuilder.add_operation(..., depends_on=[])` | Add no incoming edge at all, whatever the current heads are: the node is an independent root of its own fan. |
+| `OperationGraphBuilder.add_operation(..., depends_on=None)`, the default, with current heads | Add `sequential` edges from every current head. |
 | `build_fanout_graph()` worker | Add a worker node with no worker-to-worker edge. |
 | `build_fanout_graph(..., synthesis_role=...)` | Add one synthesis node and an `aggregate` edge from every worker. |
 | `build_dag_graph()` | Convert each one-based `TaskAssignment.depends_on` reference to an index and add only declared `depends_on` edges. |
@@ -229,15 +232,25 @@ def build_dag_graph(
 - An assignment whose role is absent produces no node. Fan-out skips it; DAG
   preserves a `None` placeholder so ordinal references remain aligned.
 - If no assignment maps to a role, each role-task builder raises `ValueError`.
-- The incremental builder's falsey `depends_on` branch means `None` and `[]` are
-  indistinguishable. A caller cannot currently express an independent root after
-  a head exists through `add_operation()`.
+- `add_operation()` reads `depends_on` as three-valued, and its two falsy values
+  are not the same answer. `None`, the default, chains onto the current heads;
+  `[]` states that there are no dependencies and produces an independent root.
+  A caller can therefore express a fan root after a head already exists.
+- Whichever of the three cases applies, the new node becomes the sole current
+  head. An independent root does not preserve the heads it declined to depend on,
+  so a later chaining call attaches to that root alone.
+- `inherit_context=True` needs something to inherit from. With `[]` or `None` no
+  `primary_dependency` is recorded, and the flag has no effect.
 - The executor does not infer or repair intended initial topology. It executes
   the edges it receives.
 
 **Why this way**: initial topology is policy, while dependency waiting is
-mechanism. The divergence is retained as retrospective truth, not endorsed as
-ideal; delta 1 makes independent construction explicit.
+mechanism. Giving the empty list its literal meaning keeps that split intact: a
+caller states the shape it wants, and the kernel is never asked to guess which
+omission meant a chain and which meant a root. The chaining default is retained
+because a linear caller should not have to restate the previous node, but it is
+now one of three answers a caller can give rather than the only one reachable
+through this surface.
 
 ### D3 — Typed planned work, typed live requests, and two-stage authority
 
@@ -504,8 +517,10 @@ lionagi/cli/orchestrate/fanout.py       CLI fan-out construction and presentatio
 - CLI graph code may decorate instructions and metadata before submission and
   correlate reactive children afterward, but accepted live graph mutation remains
   inside `ReactiveExecutor`.
-- CLI use of `OperationGraphBuilder` means it currently participates in D2's
-  topology divergence. That is a recorded defect, not a second executor.
+- CLI use of `OperationGraphBuilder` makes the CLI an author of initial topology
+  under D2. Fan-out workers and DAG roots declare an empty dependency list rather
+  than inheriting the chaining default. That is topology authorship, not a second
+  executor.
 - Direct CLI flow calls do not uniformly install the lifecycle translation
   adapter, so absence of a canonical signal does not prove a node did not run.
 
@@ -522,9 +537,10 @@ entry point.
   exposing task-group or lock internals.
 - Callers must understand that initial topology is authoritative. The kernel does
   not infer “fan-out” from a list of nodes.
-- Correcting the incremental-builder divergence can expose races that accidental
-  serialization previously hid; migration therefore requires topology and
-  concurrency tests together.
+- Work that a chaining default previously serialized now runs concurrently where
+  the caller declared it independent. Any state such legs share is exercised in
+  parallel for the first time, so topology and concurrency have to be tested
+  together rather than separately.
 - Uniform lifecycle emission would increase observer traffic and make
   drain-before-return ordering a compatibility obligation for every caller.
 - Reactive admission is best-effort and non-transactional with parent work. A
@@ -541,7 +557,7 @@ entry point.
 
 | # | Delta | Size | Issue |
 |---|-------|------|-------|
-| 1 | Make sequential linking explicit in `OperationGraphBuilder`, migrate CLI fan-out and dependency-free DAG roots to independent-node construction, and add topology tests proving that no undeclared worker-to-worker edges exist. | M | (filled at issue-open time) |
+| 1 | Make sequential linking explicit in `OperationGraphBuilder`, migrate CLI fan-out and dependency-free DAG roots to independent-node construction, and add topology tests proving that no undeclared worker-to-worker edges exist. | M | delivered — `depends_on` is three-valued, with `[]` an independent root and `None` the chaining default; CLI fan-out workers pass `[]` and CLI DAG nodes pass their resolved dependency list unchanged; builder and CLI topology tests assert that a fan carries no `sequential` edge |
 | 2 | Implement one `TaskAssignment.depends_on` normalizer for pattern and CLI builders, document whether forward ordinal references are accepted, and validate the normalized graph for cycles before execution. | S | #2027 |
 | 3 | Move callback-to-node-signal conversion from `engines` to a neutral flow/session module, expose a named observed-flow facade, and migrate EngineRun, Studio, CLI fan-out, CLI synthesis, and main CLI flow without changing signal ordering or result shape. | M | (filled at issue-open time) |
 | 4 | Parameterize the shared role-task builders with branch, instruction, identity, and artifact decorators, then remove CLI-owned duplicate edge wiring while preserving checkpoint and artifact identities. | M | (filled at issue-open time) |
@@ -568,14 +584,16 @@ reason why the graph was chosen.
 
 This would fix fan-out callers but break the shipped incremental-builder
 convenience where successive operations intentionally form a chain. It lost as an
-unqualified compatibility change. The delta instead requires an explicit API so
-both independent and sequential intent are representable.
+unqualified compatibility change. The shipped answer instead separates the two
+falsy values, so both independent and sequential intent are representable and
+neither is inferred from an omission.
 
 ### Treat every omitted dependency as “after current heads”
 
-This is the current incremental-builder shape and makes simple chain construction
-compact. It lost as the universal rule because a fan-out loop becomes a chain and
-multiple independent DAG roots cannot be represented after the first node.
+This was the incremental builder's universal rule and makes simple chain
+construction compact. It lost as the universal rule because a fan-out loop becomes
+a chain and multiple independent DAG roots cannot be represented after the first
+node. It survives as the meaning of `None` alone.
 
 ### Let emitted `SpawnRequest` call any registered operation
 

--- a/docs/api/flow.md
+++ b/docs/api/flow.md
@@ -66,10 +66,15 @@ Returns the node ID used in `depends_on` lists and result lookups.
 
 `operation` must be the name of a `Branch` method: `"communicate"`, `"operate"`, `"ReAct"`, `"parse"`, etc.
 
-`Builder` is incremental. The first operation has no predecessor. After that,
-omitting `depends_on` (or passing an empty list) attaches the new operation after
-every current head with sequential edges. This is convenient for building a chain,
-but it does **not** create another independent root.
+`Builder` is incremental, and `depends_on` is three-valued:
+
+- a non-empty list — depend on exactly those nodes;
+- `[]` — explicitly no dependencies, so the node is an independent root whatever
+  the current heads are. This is what a fan-out caller wants;
+- `None`, the default — attach the new operation after every current head with
+  sequential edges. Convenient for a chain; it does **not** create another root.
+
+Whichever you pass, the new node becomes the builder's current head.
 
 ### `add_aggregation()`
 
@@ -192,10 +197,11 @@ The executor runs graph roots and newly-ready nodes concurrently, up to
 are satisfied.
 
 Do not confuse executor readiness with Builder shorthand: consecutive
-`add_operation()` calls without `depends_on` are linked sequentially by the builder.
-To express parallel work with this incremental API, expand concurrent children from
-a source node, then aggregate them. If constructing a `Graph` directly, independent
-root nodes are naturally eligible in the same wave.
+`add_operation()` calls that omit `depends_on` are linked sequentially by the
+builder. To express parallel work with this incremental API, pass `depends_on=[]`
+for each independent leg, or expand concurrent children from a source node and
+aggregate them. If constructing a `Graph` directly, independent root nodes are
+naturally eligible in the same wave.
 
 Assigning the same `branch=` controls which conversation executes an operation; it
 does not replace dependency edges. Add explicit edges whenever turns must be ordered

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -129,8 +129,9 @@ print(result["operation_results"][summary])
 
 `Builder` is incremental: after the first node, omitting `depends_on` attaches the
 new operation after the builder's current head or heads. It is chaining shorthand,
-not a way to create a new independent root. Use explicit dependencies or
-`expand_from_result(..., strategy=ExpansionStrategy.CONCURRENT)` for parallel work.
+not a way to create a new independent root. For parallel work, pass
+`depends_on=[]` to declare a node independent, name explicit dependencies, or use
+`expand_from_result(..., strategy=ExpansionStrategy.CONCURRENT)`.
 
 The CLI's `li o flow` uses the same execution kernel but has a model plan the graph
 from a task. `li play NAME` runs a reusable, parameterized flow specification.

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -324,6 +324,9 @@ async def _run_fanout_inner(
         node = _build_worker_operate_node(
             env.builder,
             branch=w_branch,
+            # Explicitly no dependencies: fanout workers are independent, and
+            # the builder chains onto its current heads when this is None.
+            depends_on=[],
             instruction=ta.task,
             context=ctx,
             messenger_bound=messenger_bound,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -550,7 +550,7 @@ async def _build_dag(
         node = _build_worker_operate_node(
             env.builder,
             branch=w_branch,
-            depends_on=dep_nodes or None,
+            depends_on=dep_nodes,
             instruction=instruction,
             context=ctx,
             messenger_bound=messenger_bound,

--- a/lionagi/operations/builder.py
+++ b/lionagi/operations/builder.py
@@ -48,6 +48,23 @@ class OperationGraphBuilder:
         branch=None,
         **parameters,
     ) -> str:
+        """Add an operation node.
+
+        `depends_on` is three-valued, and the two falsy values do NOT mean the
+        same thing:
+
+        - a non-empty list: depend on exactly those nodes (`depends_on` edges).
+        - `[]`: explicitly no dependencies. The node is a root of its own fan
+          and gets no incoming edge, whatever the current heads are. This is
+          what a caller building a FAN wants.
+        - `None` (default): chain onto the current heads with `sequential`
+          edges, so a caller building a LINEAR CHAIN can add steps without
+          restating the previous node.
+
+        Passing `None` for a fan silently serializes it: `sequential` edges are
+        ordinary predecessors at execution time, so every worker waits for the
+        one added before it.
+        """
         node = create_operation(operation=operation, parameters=parameters)
 
         if inherit_context and depends_on:
@@ -63,7 +80,7 @@ class OperationGraphBuilder:
         if branch:
             node.branch_id = ID.get_id(branch)
 
-        if depends_on:
+        if depends_on is not None:
             for dep_id in depends_on:
                 if dep_id in self._operations:
                     edge = Edge(head=dep_id, tail=node.id, label=["depends_on"])

--- a/tests/cli/orchestrate/test_fan_shape.py
+++ b/tests/cli/orchestrate/test_fan_shape.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The two orchestration surfaces must build a fan, not a chain.
+
+A serialized fan runs to completion; it is only slow. So these assert the
+SHAPE of the operation graph — the count of `sequential` edges among worker
+nodes — rather than that a run succeeds.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from collections import Counter
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lionagi.casts.emission import TaskAssignment
+from lionagi.cli.orchestrate import fanout as fanout_mod
+from lionagi.cli.orchestrate._common import _build_worker_operate_node
+from lionagi.cli.orchestrate.flow import _build_dag, _PlanResult
+from lionagi.operations.builder import OperationGraphBuilder
+
+from .test_flow_phases import _FakeBranch, _make_env
+
+
+def _label_counts(builder: OperationGraphBuilder) -> Counter:
+    return Counter(tuple(e.label or []) for e in builder.graph.internal_edges.values())
+
+
+# ── flow.py ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_flow_dag_gives_independent_assignments_no_sequential_edges(tmp_path):
+    """A plan whose assignments declare no dependencies must build five roots.
+
+    The sixth assignment declares dependencies on all five and is the positive
+    control: it keeps its `depends_on` edges, so an assertion here cannot pass
+    because the graph came out empty.
+    """
+    env = _make_env(tmp_path)
+    env.builder = OperationGraphBuilder("flow-fan")
+
+    assignments = [TaskAssignment(task=f"independent {i}", assignee="researcher") for i in range(5)]
+    assignments.append(
+        TaskAssignment(
+            task="synthesize",
+            assignee="implementer",
+            depends_on=["1", "2", "3", "4", "5"],
+        )
+    )
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=[f"researcher-{i}" for i in range(5)] + ["implementer"],
+        dep_indices=[[], [], [], [], [], [0, 1, 2, 3, 4]],
+        pool=[],
+        budget_preambles={},
+    )
+
+    with patch(
+        "lionagi.cli.orchestrate.flow.build_worker_branch",
+        return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
+    ):
+        dag_state = await _build_dag(env, "do stuff", plan_result, reactive_spec="off")
+
+    assert len(dag_state.node_ids) == 6
+
+    counts = _label_counts(env.builder)
+    assert counts[("sequential",)] == 0, "dependency-free assignments were chained"
+    assert counts[("depends_on",)] == 5, "the declared-dependency control lost its edges"
+
+    # The five independent workers have no incoming edge at all.
+    workers = {str(n) for n in dag_state.node_ids[:5]}
+    tails = {str(e.tail) for e in env.builder.graph.internal_edges.values()}
+    assert tails == {str(dag_state.node_ids[5])}
+    assert not (tails & workers)
+
+
+@pytest.mark.asyncio
+async def test_flow_dag_preserves_declared_dependency_chain(tmp_path):
+    """A plan that IS a chain still gets its edges — from `depends_on`, not the fallback."""
+    env = _make_env(tmp_path)
+    env.builder = OperationGraphBuilder("flow-chain")
+
+    assignments = [
+        TaskAssignment(task="a", assignee="researcher"),
+        TaskAssignment(task="b", assignee="implementer", depends_on=["1"]),
+    ]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher", "implementer"],
+        dep_indices=[[], [0]],
+        pool=[],
+        budget_preambles={},
+    )
+
+    with patch(
+        "lionagi.cli.orchestrate.flow.build_worker_branch",
+        return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
+    ):
+        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off")
+
+    counts = _label_counts(env.builder)
+    assert counts[("depends_on",)] == 1
+    assert counts[("sequential",)] == 0
+
+    edge = next(iter(env.builder.graph.internal_edges.values()))
+    assert str(edge.head) == str(dag_state.node_ids[0])
+    assert str(edge.tail) == str(dag_state.node_ids[1])
+
+
+# ── fanout.py ─────────────────────────────────────────────────────────────────
+
+
+def test_fanout_node_construction_builds_a_fan():
+    """The shared node-construction helper, called the way fanout.py calls it."""
+    builder = OperationGraphBuilder("fanout-fan")
+    workers = [
+        _build_worker_operate_node(
+            builder,
+            branch=None,
+            depends_on=[],
+            instruction=f"worker {i}",
+            context=[{"overall_task": "t"}],
+            messenger_bound=False,
+        )
+        for i in range(5)
+    ]
+    # Positive control: the synthesis node fanout.py adds after the workers.
+    synth = builder.add_operation("operate", depends_on=workers, instruction="synthesize")
+
+    counts = _label_counts(builder)
+    assert counts[("sequential",)] == 0
+    assert counts[("depends_on",)] == 5
+
+    tails = {str(e.tail) for e in builder.graph.internal_edges.values()}
+    assert tails == {str(synth)}
+
+
+def _worker_node_call(module) -> ast.Call:
+    """The `_build_worker_operate_node(...)` call in the module's worker loop."""
+    tree = ast.parse(Path(inspect.getsourcefile(module)).read_text())
+    calls = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "_build_worker_operate_node"
+    ]
+    assert len(calls) == 1, f"expected one worker-node call in {module.__name__}"
+    return calls[0]
+
+
+def test_fanout_passes_an_explicit_empty_dependency_list():
+    """fanout.py must say 'no dependencies', not leave it to the chaining default.
+
+    This reads the call site rather than running the (network-bound) fanout
+    loop; the graph shape it produces is covered by the helper test above.
+    """
+    call = _worker_node_call(fanout_mod)
+    kw = {k.arg: k.value for k in call.keywords}
+    assert "depends_on" in kw, "fanout.py omits depends_on, so workers chain"
+    assert isinstance(kw["depends_on"], ast.List)
+    assert kw["depends_on"].elts == []

--- a/tests/operations/test_builder_dependency_semantics.py
+++ b/tests/operations/test_builder_dependency_semantics.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Graph-shape tests for `add_operation`'s three-valued `depends_on`.
+
+These assert the SHAPE of the built graph, not that a run completes: a
+serialized fan completes fine, it is only slow.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from lionagi.operations.builder import ExpansionStrategy, OperationGraphBuilder
+
+
+def _label_counts(builder: OperationGraphBuilder) -> Counter:
+    return Counter(tuple(e.label or []) for e in builder.graph.internal_edges.values())
+
+
+def test_empty_depends_on_builds_a_fan_not_a_chain():
+    """`depends_on=[]` means explicitly-none: no incoming edge, whatever the heads are."""
+    builder = OperationGraphBuilder("fan")
+    workers = [
+        builder.add_operation("operate", depends_on=[], instruction=f"w{i}") for i in range(5)
+    ]
+    # Positive control in the same graph: a sink that DOES declare dependencies
+    # still gets them, so these assertions cannot pass on an empty graph.
+    sink = builder.add_operation("operate", depends_on=workers, instruction="sink")
+
+    counts = _label_counts(builder)
+    assert counts[("sequential",)] == 0
+    assert counts[("depends_on",)] == 5
+
+    incoming = {str(e.tail) for e in builder.graph.internal_edges.values()}
+    assert incoming == {str(sink)}
+
+
+def test_none_depends_on_still_chains_onto_current_heads():
+    """The chaining convention is not removed, only made addressable."""
+    builder = OperationGraphBuilder("chain")
+    first = builder.add_operation("operate", depends_on=None, instruction="one")
+    second = builder.add_operation("operate", depends_on=None, instruction="two")
+
+    counts = _label_counts(builder)
+    assert counts[("sequential",)] == 1
+
+    edge = next(iter(builder.graph.internal_edges.values()))
+    assert str(edge.head) == str(first)
+    assert str(edge.tail) == str(second)
+
+
+def test_default_depends_on_is_none_and_still_chains():
+    """Callers that omit the argument entirely keep the old behaviour."""
+    builder = OperationGraphBuilder("chain")
+    builder.add_operation("operate", instruction="one")
+    builder.add_operation("operate", instruction="two")
+
+    assert _label_counts(builder)[("sequential",)] == 1
+
+
+def test_empty_depends_on_does_not_disturb_the_heads_for_a_later_chainer():
+    """After a fan, an `add_operation(depends_on=None)` chains onto the last node only."""
+    builder = OperationGraphBuilder("mixed")
+    builder.add_operation("operate", depends_on=[], instruction="a")
+    b = builder.add_operation("operate", depends_on=[], instruction="b")
+    builder.add_operation("operate", instruction="chained")
+
+    counts = _label_counts(builder)
+    assert counts[("sequential",)] == 1
+    seq = next(e for e in builder.graph.internal_edges.values() if list(e.label) == ["sequential"])
+    assert str(seq.head) == str(b)
+
+
+def test_expand_from_result_concurrent_fans_from_the_source_only():
+    """The expansion path wires every item from the source; siblings are unrelated."""
+    builder = OperationGraphBuilder("expand")
+    source = builder.add_operation("operate", instruction="root")
+    children = builder.expand_from_result(
+        items=["a", "b", "c", "d", "e"],
+        source_node_id=source,
+        operation="operate",
+        strategy=ExpansionStrategy.CONCURRENT,
+    )
+    sink = builder.add_operation("operate", depends_on=children, instruction="sink")
+
+    counts = _label_counts(builder)
+    assert counts[("sequential",)] == 0
+    assert counts[("expansion", "concurrent")] == 5
+    assert counts[("depends_on",)] == 5
+
+    # Every expansion edge comes from the source, so no child waits on a sibling.
+    heads = {
+        str(e.head) for e in builder.graph.internal_edges.values() if "expansion" in list(e.label)
+    }
+    assert heads == {str(source)}
+    assert str(sink) not in heads
+
+
+def test_inherit_context_with_empty_depends_on_records_no_primary_dependency():
+    """`inherit_context` needs a dependency to inherit from; `[]` supplies none."""
+    builder = OperationGraphBuilder("inherit")
+    node_id = builder.add_operation("operate", depends_on=[], inherit_context=True, instruction="w")
+    node = builder._operations[node_id]
+    assert "primary_dependency" not in node.metadata


### PR DESCRIPTION
Closes #2645.

`OperationGraphBuilder.add_operation` adds a `sequential` edge from the current
heads whenever a node arrives with no declared dependencies. That fallback is
correct for the caller it was written for — a linear chain adding a step without
restating the previous node — but it was *unaddressable*: a caller who means "no
dependencies" had no way to say so, because the empty list is indistinguishable
from unspecified under a truthiness test.

Both orchestration surfaces meant "no dependencies" and got a chain. A fanout of
N workers executed as a chain of N; a flow assignment the planner marked
independent waited on the assignment declared before it.

## The change

`depends_on` becomes three-valued:

| value | meaning | edges |
| --- | --- | --- |
| non-empty list | depend on exactly these | `depends_on` per known id |
| `[]` | explicitly none — a fan root | none |
| `None` (default) | chain onto current heads | `sequential` per head |

`if depends_on:` becomes `if depends_on is not None:`. The fallback is kept: it
is load-bearing for the documented chaining convention, which the docs,
cookbooks, notebooks and two existing tests rely on. `None` behaves exactly as
before, so the change is additive.

`fanout.py` now passes `depends_on=[]`. `flow.py` passes `depends_on=dep_nodes`
rather than `dep_nodes or None` — the `or None` was the only thing converting
"the planner declared no dependencies" into "chain me".

`inherit_context` deliberately keeps its truthiness test: with `depends_on=[]`
there is no dependency to inherit context from.

## What was checked beyond the fix

- No caller in the tree passes `[]` today, so the new meaning is not a behaviour
  change for anyone. Confirmed rather than assumed.
- `expand_from_result` with `ExpansionStrategy.CONCURRENT` does not have the
  defect: it wires every child from the source explicitly and never consults the
  current heads. Established by measurement and by reading.
- All seven `add_operation` call sites were classified as fan, chain, or
  neither. The two Studio sites had already worked around this by clearing
  `_current_heads` directly after each node, so they were unaffected in both
  directions.
- Nothing consumes the `sequential` label for behaviour. It is read only by the
  graph renderer, where it falls into the same generic branch as `depends_on`.

## Tests

Ten new tests across two files, all asserting graph shape rather than run
completion — a serialized fan completes fine, so completion proves nothing here.
Each includes a positive control in the same graph (a node with declared
dependencies whose edges must still be present), so an assertion cannot pass
because the graph is empty.

Both halves of the three-valued argument are independently guarded: reverting
the identity check reddens the fan tests, and deleting the fallback reddens the
chaining tests.

3364 tests were run across every directory containing a builder-touching test.
One failure, `tests/docs/test_integrations.py::TestLLMProviders::test_ollama_imodel_constructs`,
is a missing optional extra in the local environment and reproduces on the
unmodified tree.

## Known limitation

`_run_fanout_inner` was not driven end to end. The fan's graph shape is proved
behaviourally through the shared node-construction helper, and the fact that
`fanout.py` supplies `[]` is proved by a static read of its call site. That
second assertion would not catch a change that keeps `depends_on=[]` and breaks
the fan another way. An existing test already guards that both surfaces route
through the one helper, which is what makes the split sound.


## Documentation

The accepted record described the behaviour this change replaces. It said, under
a heading reading "Shipped edge semantics", that `None` and `[]` are
indistinguishable and that an independent root is not expressible after a head
exists. Both statements are now false, so the documentation is amended in the
same change.

- `docs/adr/ADR-0033-operation-graph-orchestration-boundary.md` — the
  construction-case table gains a row so all three values are stated separately;
  the exact-semantics bullets are rewritten; two facts the old text never stated
  are added, that the new node becomes the sole head in all three cases and that
  `inherit_context` records no `primary_dependency` for either falsy value. The
  context, adapter, and consequence paragraphs that described the old shape as a
  divergence are rewritten as two recorded conventions. Delta 1 is recorded as
  delivered.
- `docs/api/flow.md` — said that passing an empty list attaches the new
  operation after every current head. Replaced with the three-valued list, plus
  `depends_on=[]` in the parallel-work guidance.
- `docs/concepts.md` — the parallel-work remedy list now names the direct route.
- `docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md` —
  "with no explicit dependency" reads two ways for a caller passing `[]`;
  disambiguated to "omitted or `None`" with what `[]` does.

Every statement is anchored to a line in `lionagi/operations/builder.py` that
was read to confirm it. No source changed for this part.
