### PR TITLE
fix(mcp): a run's log keeps the line saying its notice was never delivered

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1179,7 +1179,17 @@ def submit(
     _write_job(record)
 
     try:
-        log_f = open(log_path, "wb")
+        # Append mode, not truncate: every write from the child has to land at
+        # end-of-file rather than at an offset the child carries with it. The
+        # terminal hook appends to this same log while the child is still alive
+        # and still holding this descriptor, so with an offset-carrying
+        # descriptor the child's next write — its final output, or just the
+        # flush the interpreter does on its way out — starts back where the
+        # child left off and overwrites whatever was appended behind its back.
+        # What it overwrites is the one line written only when something went
+        # wrong: the notice that a terminal notice could not be delivered. Each
+        # run gets a directory of its own, so nothing is here to append after.
+        log_f = open(log_path, "ab")
         try:
             proc = subprocess.Popen(  # noqa: S603 — argv is the resolved li_command + CLI flags, no shell
                 argv,

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -181,6 +181,14 @@ def new_run_id() -> str:
 # bound would hang the submission there instead of saying so.
 _RUN_ID_ATTEMPTS = 8
 
+# What a submission writes into its own reserved directory before that directory
+# becomes a job. Named here so the writes and the removal that gives them back
+# cannot drift apart, and so the removal is a fixed list rather than whatever
+# happens to be lying in the directory.
+_PROMPT_FILENAME = "prompt.txt"
+_MCP_SNAPSHOT_FILENAME = "mcp-servers.json"
+_RESERVATION_CONTENTS = (_PROMPT_FILENAME, _MCP_SNAPSHOT_FILENAME)
+
 
 def _reserve_run_dir() -> tuple[str, Path]:
     """Mint a run_id nobody else holds, and return it with its directory.
@@ -213,14 +221,29 @@ def _reserve_run_dir() -> tuple[str, Path]:
 
 
 def _discard_reservation(d: Path) -> None:
-    """Give a reserved directory back, if it is still the empty thing reserved.
+    """Give a reserved directory back, along with what a submission put in it.
 
-    ``rmdir`` refuses a directory with anything in it, and that refusal is the
-    safety here rather than a check taken beforehand: whatever this is asked to
-    remove, a directory holding a run's state survives it. A removal that fails
-    for any other reason leaves a directory nobody claimed, which is worth less
-    than the error that sent us here.
+    A submission that fails partway through writing has already left files
+    behind, so removing only an empty directory would give the reservation back
+    for some failures and not others. The files a submission writes into its own
+    reservation are named here, and only those: they are addressed as fixed
+    names under *d*, never through a path a caller handed in. A caller may name
+    an MCP config that lives anywhere at all, and that file is theirs — it is not
+    part of this reservation whatever it points at, and nothing here can be
+    talked into deleting it.
+
+    ``rmdir`` refuses a directory with anything in it, and that refusal stays the
+    safety here rather than becoming a check taken beforehand: whatever this is
+    asked to remove, a directory holding a run's state survives it — anything not
+    on the short list above stops the removal. A removal that fails for any other
+    reason leaves a directory nobody claimed, which is worth less than the error
+    that sent us here.
     """
+    for name in _RESERVATION_CONTENTS:
+        try:
+            (d / name).unlink()
+        except OSError:
+            pass
     try:
         d.rmdir()
     except OSError:
@@ -1076,12 +1099,18 @@ def submit(
     log_path = d / "console.log"
 
     # Nothing is written into the reserved directory until the whole command line
-    # is assembled, and a submission this function refuses takes the reservation
-    # back on its way out — a run that never started leaves no trace, and an
-    # empty directory here is not nothing: every directory under the jobs root is
+    # is assembled, and a submission that does not become a job takes the
+    # reservation back on its way out — a run that never started leaves no trace,
+    # and a directory here is not nothing: every directory under the jobs root is
     # listed as a job, so one left behind reads back as a job with no kind that
-    # never finishes. The removal is of an empty directory only, so it can never
-    # take a run's own state with it.
+    # never finishes. That holds however far the submission got, so the block
+    # runs to the last write this function makes before the record exists rather
+    # than stopping where the assembly does: a failure at the second of two
+    # writes leaves the same unfinishable job as a failure at the first.
+    #
+    # It ends at the record. Once _write_job has run the directory is a real job
+    # with real state, and correcting it is the business of the marking that
+    # follows, not of a removal.
     try:
         # `flags` may already carry a `--` sentinel, after which every token is a
         # positional. Options this function adds have to go in front of it, or they
@@ -1091,7 +1120,7 @@ def submit(
         prompt_path = None
         if prompt is not None:
             if kind == "agent":
-                prompt_path = d / "prompt.txt"
+                prompt_path = d / _PROMPT_FILENAME
                 options += ["--prompt-file", str(prompt_path)]
             else:
                 # flow/fanout take the prompt as a positional, and a prompt may well
@@ -1166,7 +1195,7 @@ def submit(
             else:
                 mcp_servers = resolution.servers
                 mcp_config_source = str(resolution.source) if resolution.source else None
-                mcp_config_path = str(d / "mcp-servers.json")
+                mcp_config_path = str(d / _MCP_SNAPSHOT_FILENAME)
                 options = ["--mcp-config", mcp_config_path, *options]
 
         # Wire the CLI's terminal hook back to the MCP server so we record a reliable
@@ -1193,14 +1222,21 @@ def submit(
         # Checked before anything is written, because Popen raising this late would
         # leave a job recorded as "running" for a run that never started.
         _reject_oversized_argv(argv, env, kind=kind)
+
+        # The durable writes sit inside this same block rather than under a
+        # handler of their own. One block, because one question is being asked:
+        # did this submission become a job? Everything from here back to the
+        # reservation answers "no" the same way — a full disk on the second write
+        # strands a run exactly as an argv the platform will not carry does — and
+        # a second handler would only invite the two to be given back
+        # differently, which is the state this block exists to prevent.
+        if prompt_path is not None:
+            prompt_path.write_text(prompt)
+        if mcp_servers is not None and mcp_config_path is not None:
+            Path(mcp_config_path).write_text(json.dumps({"mcpServers": mcp_servers}, indent=2))
     except BaseException:
         _discard_reservation(d)
         raise
-
-    if prompt_path is not None:
-        prompt_path.write_text(prompt)
-    if mcp_servers is not None and mcp_config_path is not None:
-        Path(mcp_config_path).write_text(json.dumps({"mcpServers": mcp_servers}, indent=2))
 
     # Persist the record BEFORE spawning, so the child's terminal --notify hook
     # always finds a record to mark. mark_terminal no-ops on a missing record, so

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -174,6 +174,59 @@ def new_run_id() -> str:
     return f"{ts}-{uuid4().hex[:6]}"
 
 
+# How many ids a submission will mint before giving up. An id is a timestamp to
+# the second plus six random hex digits, so a taken one is already unlikely and
+# a run of them is the shape of something else being wrong — a clock pinned to
+# one second, a directory that reports every name as taken. Retrying without a
+# bound would hang the submission there instead of saying so.
+_RUN_ID_ATTEMPTS = 8
+
+
+def _reserve_run_dir() -> tuple[str, Path]:
+    """Mint a run_id nobody else holds, and return it with its directory.
+
+    Minting an id and creating its directory are one step, and the creation is
+    the thing that decides: ``mkdir`` without ``exist_ok`` either creates the
+    directory or says the name is taken, in one operation the filesystem makes
+    indivisible. Checking first and creating second would leave a window for
+    another submission between the two answers, and the id is not random enough
+    to leave that to chance — two submissions in the same second can mint the
+    same six hex digits.
+
+    What a taken name would otherwise cost is a whole run, not a retry: the
+    second submission would write its record over the first's and hand its child
+    a log the first is still writing into, and both runs would answer to one id
+    for the rest of their lives.
+    """
+    for _ in range(_RUN_ID_ATTEMPTS):
+        run_id = new_run_id()
+        d = config.job_dir(run_id)
+        try:
+            d.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
+            continue
+        return run_id, d
+    raise RuntimeError(
+        f"could not reserve a run directory under {config.JOBS_DIR}: "
+        f"{_RUN_ID_ATTEMPTS} freshly minted ids were all already taken"
+    )
+
+
+def _discard_reservation(d: Path) -> None:
+    """Give a reserved directory back, if it is still the empty thing reserved.
+
+    ``rmdir`` refuses a directory with anything in it, and that refusal is the
+    safety here rather than a check taken beforehand: whatever this is asked to
+    remove, a directory holding a run's state survives it. A removal that fails
+    for any other reason leaves a directory nobody claimed, which is worth less
+    than the error that sent us here.
+    """
+    try:
+        d.rmdir()
+    except OSError:
+        pass
+
+
 # --- record I/O ----------------------------------------------------------------
 
 
@@ -1019,126 +1072,131 @@ def submit(
     if kind not in _KIND_ARGV:
         raise ValueError(f"unknown job kind {kind!r}; expected one of {sorted(_KIND_ARGV)}")
 
-    run_id = new_run_id()
-    d = config.job_dir(run_id)
+    run_id, d = _reserve_run_dir()
     log_path = d / "console.log"
 
-    # The whole command line is assembled before anything is created on disk, so a
-    # run that cannot be spawned leaves no trace. Creating the directory first
-    # would leave an empty one behind on a rejection, and that reads back as a job
-    # with no kind that never finishes.
-    # `flags` may already carry a `--` sentinel, after which every token is a
-    # positional. Options this function adds have to go in front of it, or they
-    # arrive as text: appending `--prompt-file` past the sentinel would hand the
-    # agent two words of prompt instead of a file to read.
-    options, positionals = _split_at_sentinel(flags)
-    prompt_path = None
-    if prompt is not None:
-        if kind == "agent":
-            prompt_path = d / "prompt.txt"
-            options += ["--prompt-file", str(prompt_path)]
+    # Nothing is written into the reserved directory until the whole command line
+    # is assembled, and a submission this function refuses takes the reservation
+    # back on its way out — a run that never started leaves no trace, and an
+    # empty directory here is not nothing: every directory under the jobs root is
+    # listed as a job, so one left behind reads back as a job with no kind that
+    # never finishes. The removal is of an empty directory only, so it can never
+    # take a run's own state with it.
+    try:
+        # `flags` may already carry a `--` sentinel, after which every token is a
+        # positional. Options this function adds have to go in front of it, or they
+        # arrive as text: appending `--prompt-file` past the sentinel would hand the
+        # agent two words of prompt instead of a file to read.
+        options, positionals = _split_at_sentinel(flags)
+        prompt_path = None
+        if prompt is not None:
+            if kind == "agent":
+                prompt_path = d / "prompt.txt"
+                options += ["--prompt-file", str(prompt_path)]
+            else:
+                # flow/fanout take the prompt as a positional, and a prompt may well
+                # begin with a dash, so it goes behind a sentinel whether or not the
+                # rendered flags already opened one.
+                if not positionals:
+                    positionals = ["--"]
+                positionals.append(prompt)
+
+        # A run discovers MCP servers from the directory it is told to work in,
+        # which for a detached run is a checkout and not the directory holding this
+        # server's config. Resolve it here, where the submitting directory is still
+        # the one in effect, and hand the resolved set to the child.
+        # Both outcomes are reported on the handle: a run that starts without the
+        # tools its brief assumes should be visible at submit, not deduced later
+        # from its own confused output. An orchestration builds many workers from
+        # the one set its process holds, so leaving the choice to whatever each
+        # provider CLI finds for itself scatters the same question across every
+        # worker and answers it where nobody is looking.
+        #
+        # The servers are read here and written into this run's own directory, and
+        # that copy is what the child is pointed at. Naming the discovered file
+        # instead would leave the run's tool surface tied to a file anyone may edit
+        # between submission and execution — and a run that resumes hours later
+        # would re-read it again, so the same submission could start with a
+        # different set of tools every time. A file only this run writes cannot
+        # change under it, and staying a path keeps the child's existing flag
+        # working. A config that exists but cannot be used fails the submission,
+        # because a child that discovers the problem reports it minutes later and
+        # only in its own log, while the submitter was told the run started.
+        #
+        # A snapshot is taken only when the caller left the choice open. Whether
+        # they did is answered from the values they passed, never by looking through
+        # the tokens for a flag: those tokens are built by the same surface, in a
+        # form (`--flag=value`) chosen so that nothing downstream can take them
+        # apart, so a scan of them reports on spelling rather than on intent.
+        mcp_config_path: str | None = None
+        mcp_config_source: str | None = None
+        mcp_config_reason: str | None = None
+        mcp_servers: dict[str, Any] | None = None
+        if no_mcp_config:
+            # The caller asked for no servers. That is an answer, not an absence, so
+            # nothing is resolved and the handle says whose decision it was.
+            mcp_config_reason = "mcp_disabled_by_caller"
+        elif mcp_config is not None:
+            # The caller named the file, and their flag is already on the line. No
+            # snapshot is taken and none is prepended: a second --mcp-config would
+            # let the parser pick between them, and the handle would go on naming
+            # the one the child did not read. What the child reads is what the
+            # handle reports, and its source is the caller's own path, which this
+            # run does not own and cannot promise will hold still.
+            mcp_config_path = mcp_config
+            mcp_config_source = mcp_config
+            mcp_config_reason = "mcp_config_named_by_caller"
         else:
-            # flow/fanout take the prompt as a positional, and a prompt may well
-            # begin with a dash, so it goes behind a sentinel whether or not the
-            # rendered flags already opened one.
-            if not positionals:
-                positionals = ["--"]
-            positionals.append(prompt)
+            from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
 
-    # A run discovers MCP servers from the directory it is told to work in,
-    # which for a detached run is a checkout and not the directory holding this
-    # server's config. Resolve it here, where the submitting directory is still
-    # the one in effect, and hand the resolved set to the child.
-    # Both outcomes are reported on the handle: a run that starts without the
-    # tools its brief assumes should be visible at submit, not deduced later
-    # from its own confused output. An orchestration builds many workers from
-    # the one set its process holds, so leaving the choice to whatever each
-    # provider CLI finds for itself scatters the same question across every
-    # worker and answers it where nobody is looking.
-    #
-    # The servers are read here and written into this run's own directory, and
-    # that copy is what the child is pointed at. Naming the discovered file
-    # instead would leave the run's tool surface tied to a file anyone may edit
-    # between submission and execution — and a run that resumes hours later
-    # would re-read it again, so the same submission could start with a
-    # different set of tools every time. A file only this run writes cannot
-    # change under it, and staying a path keeps the child's existing flag
-    # working. A config that exists but cannot be used fails the submission,
-    # because a child that discovers the problem reports it minutes later and
-    # only in its own log, while the submitter was told the run started.
-    #
-    # A snapshot is taken only when the caller left the choice open. Whether
-    # they did is answered from the values they passed, never by looking through
-    # the tokens for a flag: those tokens are built by the same surface, in a
-    # form (`--flag=value`) chosen so that nothing downstream can take them
-    # apart, so a scan of them reports on spelling rather than on intent.
-    mcp_config_path: str | None = None
-    mcp_config_source: str | None = None
-    mcp_config_reason: str | None = None
-    mcp_servers: dict[str, Any] | None = None
-    if no_mcp_config:
-        # The caller asked for no servers. That is an answer, not an absence, so
-        # nothing is resolved and the handle says whose decision it was.
-        mcp_config_reason = "mcp_disabled_by_caller"
-    elif mcp_config is not None:
-        # The caller named the file, and their flag is already on the line. No
-        # snapshot is taken and none is prepended: a second --mcp-config would
-        # let the parser pick between them, and the handle would go on naming
-        # the one the child did not read. What the child reads is what the
-        # handle reports, and its source is the caller's own path, which this
-        # run does not own and cannot promise will hold still.
-        mcp_config_path = mcp_config
-        mcp_config_source = mcp_config
-        mcp_config_reason = "mcp_config_named_by_caller"
-    else:
-        from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
-
-        launch_dir = os.getcwd()
-        resolution = resolve_spawn_mcp_servers(launch_dir=launch_dir)
-        if resolution.servers is None:
-            if resolution.reason and resolution.reason.startswith("mcp_config_unusable:"):
-                raise McpConfigError(
-                    f"cannot submit this agent run: the MCP config found at "
-                    f"{resolution.source} cannot be used "
-                    f"({resolution.reason.split(':', 1)[1].strip()})"
+            launch_dir = os.getcwd()
+            resolution = resolve_spawn_mcp_servers(launch_dir=launch_dir)
+            if resolution.servers is None:
+                if resolution.reason and resolution.reason.startswith("mcp_config_unusable:"):
+                    raise McpConfigError(
+                        f"cannot submit this agent run: the MCP config found at "
+                        f"{resolution.source} cannot be used "
+                        f"({resolution.reason.split(':', 1)[1].strip()})"
+                    )
+                mcp_config_reason = (
+                    f"{resolution.reason}_at_or_above:{launch_dir}"
+                    if resolution.reason == "no_mcp_config_found"
+                    else resolution.reason
                 )
-            mcp_config_reason = (
-                f"{resolution.reason}_at_or_above:{launch_dir}"
-                if resolution.reason == "no_mcp_config_found"
-                else resolution.reason
-            )
-        else:
-            mcp_servers = resolution.servers
-            mcp_config_source = str(resolution.source) if resolution.source else None
-            mcp_config_path = str(d / "mcp-servers.json")
-            options = ["--mcp-config", mcp_config_path, *options]
+            else:
+                mcp_servers = resolution.servers
+                mcp_config_source = str(resolution.source) if resolution.source else None
+                mcp_config_path = str(d / "mcp-servers.json")
+                options = ["--mcp-config", mcp_config_path, *options]
 
-    # Wire the CLI's terminal hook back to the MCP server so we record a reliable
-    # finished_at/status (and fire the configured delivery) even across a restart.
-    options = [
-        "--notify",
-        _notify_template(run_id, notify_target, notify_command, notify_sender),
-        *options,
-    ]
+        # Wire the CLI's terminal hook back to the MCP server so we record a reliable
+        # finished_at/status (and fire the configured delivery) even across a restart.
+        options = [
+            "--notify",
+            _notify_template(run_id, notify_target, notify_command, notify_sender),
+            *options,
+        ]
 
-    argv = [*config.li_command(), *_KIND_ARGV[kind], *options, *positionals]
+        argv = [*config.li_command(), *_KIND_ARGV[kind], *options, *positionals]
 
-    # Drop the parent harness marker so the detached child does not inherit an
-    # environment that claims it is running under an interactive harness.
-    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
-    env[config.RUN_ID_ENV_VAR] = run_id
-    # The child carries the run that started it. Every process it goes on to
-    # spawn inherits this, so a live member of the group can later be asked
-    # what it belongs to instead of being guessed at from when it started.
-    env[config.JOB_MARKER_ENV_VAR] = run_id
+        # Drop the parent harness marker so the detached child does not inherit an
+        # environment that claims it is running under an interactive harness.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env[config.RUN_ID_ENV_VAR] = run_id
+        # The child carries the run that started it. Every process it goes on to
+        # spawn inherits this, so a live member of the group can later be asked
+        # what it belongs to instead of being guessed at from when it started.
+        env[config.JOB_MARKER_ENV_VAR] = run_id
 
-    # Only "agent" hands the instruction over in a file; flow and fanout take it
-    # as a positional, so a long one has to fit in the process argument vector.
-    # Checked before anything is written, because Popen raising this late would
-    # leave a job recorded as "running" for a run that never started.
-    _reject_oversized_argv(argv, env, kind=kind)
+        # Only "agent" hands the instruction over in a file; flow and fanout take it
+        # as a positional, so a long one has to fit in the process argument vector.
+        # Checked before anything is written, because Popen raising this late would
+        # leave a job recorded as "running" for a run that never started.
+        _reject_oversized_argv(argv, env, kind=kind)
+    except BaseException:
+        _discard_reservation(d)
+        raise
 
-    d.mkdir(parents=True, exist_ok=True)
     if prompt_path is not None:
         prompt_path.write_text(prompt)
     if mcp_servers is not None and mcp_config_path is not None:
@@ -1187,8 +1245,11 @@ def submit(
         # flush the interpreter does on its way out — starts back where the
         # child left off and overwrites whatever was appended behind its back.
         # What it overwrites is the one line written only when something went
-        # wrong: the notice that a terminal notice could not be delivered. Each
-        # run gets a directory of its own, so nothing is here to append after.
+        # wrong: the notice that a terminal notice could not be delivered.
+        #
+        # There is nothing here to append after: the directory this log sits in
+        # was created for this run and no other, by a creation that fails rather
+        # than accepts a name already taken.
         log_f = open(log_path, "ab")
         try:
             proc = subprocess.Popen(  # noqa: S603 — argv is the resolved li_command + CLI flags, no shell

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -9,12 +9,14 @@ on the argv/env the engine builds and on the on-disk job records it reads back.
 from __future__ import annotations
 
 import builtins
+import errno
 import os
 import signal
 from pathlib import Path
 
 import pytest
 
+from lionagi.cli import _mcp_resolve
 from lionagi.mcp import config, jobs
 
 
@@ -2816,3 +2818,107 @@ def test_a_submission_that_is_refused_leaves_no_directory_behind(sandbox, monkey
 
     assert not (config.JOBS_DIR / "20260101T000000-dddddd").exists()
     assert jobs.list_jobs() == []
+
+
+def test_a_submission_that_fails_between_its_writes_leaves_no_job_behind(sandbox, monkeypatch):
+    """A submission that gets partway through writing is still not a job.
+
+    The refusal above happens before anything is written, so an empty directory
+    is all it leaves. A submission that writes its prompt and then fails to write
+    its MCP snapshot leaves a directory with a file in it, and giving that back
+    takes more than a removal that only works on an empty one. Both leave the
+    same thing behind for an operator: a listed job with no kind that never
+    finishes, which is why the listing is what this asserts on.
+    """
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc(4242))
+    monkeypatch.setattr(
+        _mcp_resolve,
+        "resolve_spawn_mcp_servers",
+        lambda launch_dir: _mcp_resolve.McpResolution(
+            servers={"a-server": {"command": "true"}},
+            reason=None,
+            source=Path("/somewhere/.mcp.json"),
+            searched_from=Path("/somewhere"),
+        ),
+    )
+
+    # Positive control: the same call, unobstructed. Without it a change that
+    # refused every submission of this shape would read as this test passing.
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-eeeeee")
+    control = jobs.submit("agent", [], prompt="x", label="control")["run_id"]
+    assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
+
+    # Now fail the second of the two writes. The first has already landed, so
+    # what is left behind is a directory that is not empty.
+    prompt_was_already_written: list[bool] = []
+    real_write_text = Path.write_text
+
+    def refuse_the_snapshot(self, *args, **kwargs):
+        if self.name == "mcp-servers.json":
+            prompt_was_already_written.append((self.parent / "prompt.txt").exists())
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", refuse_the_snapshot)
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-ffffff")
+
+    with pytest.raises(OSError):
+        jobs.submit("agent", [], prompt="x", label="interrupted")
+
+    # The failure landed after the first write, not before it — otherwise this
+    # would be the empty-directory case the test above already covers.
+    assert prompt_was_already_written == [True]
+    assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
+
+
+def test_discarding_a_reservation_removes_what_the_submission_wrote(sandbox):
+    """Both of the names a submission writes come back with the directory."""
+    d = config.JOBS_DIR / "20260101T000000-111111"
+    d.mkdir(parents=True)
+    (d / "prompt.txt").write_text("x")
+    (d / "mcp-servers.json").write_text("{}")
+
+    jobs._discard_reservation(d)
+
+    assert not d.exists()
+
+
+def test_a_failed_submission_does_not_delete_the_config_its_caller_named(
+    sandbox, tmp_path, monkeypatch
+):
+    """A caller's own MCP config is theirs, wherever they keep it.
+
+    Being named by a submission that failed does not make a file part of the
+    directory being given back, and the file a caller names is not under it.
+    """
+    callers_own_config = tmp_path / "elsewhere" / ".mcp.json"
+    callers_own_config.parent.mkdir()
+    callers_own_config.write_text('{"mcpServers": {}}')
+
+    def refuse(self, *args, **kwargs):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-333333")
+    monkeypatch.setattr(Path, "write_text", refuse)
+
+    with pytest.raises(OSError):
+        jobs.submit("agent", [], prompt="x", mcp_config=str(callers_own_config))
+
+    assert callers_own_config.read_text() == '{"mcpServers": {}}'
+    assert jobs.list_jobs() == []
+
+
+def test_discarding_a_reservation_refuses_a_directory_holding_anything_else(sandbox):
+    """The refusal is the safeguard, and nothing is checked ahead of it.
+
+    A directory with a run's own state in it survives being handed to this, so
+    the removal cannot cost a real job whatever sends us there.
+    """
+    d = config.JOBS_DIR / "20260101T000000-222222"
+    d.mkdir(parents=True)
+    (d / "prompt.txt").write_text("x")
+    (d / "console.log").write_bytes(b"a run wrote this\n")
+
+    jobs._discard_reservation(d)
+
+    assert (d / "console.log").read_bytes() == b"a run wrote this\n"

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -2733,3 +2733,86 @@ def test_status_still_reports_the_whole_delivery_outcome(sandbox):
     assert st["notify_delivery"] == _EXITED_NONZERO
     # and the collapsed form stays out of status: one field, one meaning
     assert "notify_delivery_state" not in st
+
+
+def _popen_that_writes_the_runs_own_line(runs_written: list):
+    """A stand-in child that writes one line down the descriptor it was handed.
+
+    The descriptor is what a collision is felt through — two runs holding a
+    writable handle to one file — so the double has to use it rather than only
+    record it.
+    """
+
+    def fake_popen(argv, **kw):
+        line = kw["env"][config.RUN_ID_ENV_VAR]
+        kw["stdout"].write(f"{line} wrote this\n".encode())
+        runs_written.append(line)
+        return _FakeProc()
+
+    return fake_popen
+
+
+def test_a_second_submission_never_lands_on_a_running_runs_directory(sandbox, monkeypatch):
+    """An id already taken costs a retry, not the run that holds it.
+
+    A run id is a timestamp to the second plus six random hex digits, so two
+    submissions in one second can mint the same one. What that used to mean was
+    not a collision of names but a collision of runs: the second wrote its record
+    over the first's and its child wrote into the first's log, and afterwards
+    nothing could tell the two apart or say what the first one had been.
+
+    Asserted on what an operator can see — two ids, two directories, each log
+    holding only its own run's output and each record naming only its own run.
+    How the retry gets there is this function's business and is not asserted.
+    """
+    written: list[str] = []
+    monkeypatch.setattr(jobs.subprocess, "Popen", _popen_that_writes_the_runs_own_line(written))
+
+    # Positive control first: ordinary submissions, ids that differ on their own.
+    # Without it, a change that refused every second submission — or handed every
+    # one of them a fresh id it never used — would read as this test passing.
+    minted = iter(["20260101T000000-aaaaaa", "20260101T000000-bbbbbb"])
+    monkeypatch.setattr(jobs, "new_run_id", lambda: next(minted))
+    first = jobs.submit("agent", [], label="first")["run_id"]
+    second = jobs.submit("agent", [], label="second")["run_id"]
+
+    assert first != second
+    for rid, label in ((first, "first"), (second, "second")):
+        assert (config.JOBS_DIR / rid).is_dir()
+        assert (config.JOBS_DIR / rid / "console.log").read_text() == f"{rid} wrote this\n"
+        assert jobs._read_job(rid)["label"] == label
+
+    # Now the collision: the next submission mints an id that is already taken
+    # before it mints one that is not.
+    minted = iter(["20260101T000000-bbbbbb", "20260101T000000-cccccc"])
+    monkeypatch.setattr(jobs, "new_run_id", lambda: next(minted))
+    third = jobs.submit("agent", [], label="third")["run_id"]
+
+    assert third not in (first, second)
+    assert (config.JOBS_DIR / third / "console.log").read_text() == f"{third} wrote this\n"
+    assert jobs._read_job(third)["label"] == "third"
+    # The run whose id was taken is untouched: its log holds its own line alone
+    # and its record still says whose it is.
+    assert (config.JOBS_DIR / second / "console.log").read_text() == f"{second} wrote this\n"
+    assert jobs._read_job(second)["label"] == "second"
+    assert written == [first, second, third]
+
+
+def test_a_submission_that_is_refused_leaves_no_directory_behind(sandbox, monkeypatch):
+    """The reservation is taken back when the submission does not happen.
+
+    Every directory under the jobs root is a job to the listing, so one left
+    behind by a rejected submission is a job with no kind that never finishes.
+    """
+
+    def refuse(argv, env, *, kind):
+        raise ValueError("argv is too long for this platform")
+
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-dddddd")
+    monkeypatch.setattr(jobs, "_reject_oversized_argv", refuse)
+
+    with pytest.raises(ValueError):
+        jobs.submit("agent", [], prompt="x")
+
+    assert not (config.JOBS_DIR / "20260101T000000-dddddd").exists()
+    assert jobs.list_jobs() == []

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -12,6 +12,9 @@ no real command is spawned.
 from __future__ import annotations
 
 import json
+import sys
+import time
+from pathlib import Path
 
 import pytest
 
@@ -535,3 +538,89 @@ def test_the_delivery_commands_own_output_is_still_never_kept(job, monkeypatch):
     assert seen["stderr"] is _notify_hook.subprocess.DEVNULL
     outcome = jobs._read_job(job)["notify_delivery"]
     assert set(outcome) == {"attempted", "ok", "exit_code", "error", "command"}
+
+
+# The run whose log this is, standing in for the CLI: it writes ordinary output,
+# fires its --notify template the way the CLI does (shlex-split, ``{status}``
+# replaced), and then writes more output before exiting. That last part is the
+# whole point — the hook appends to a log whose writer is still running and
+# still holding the descriptor it was spawned with.
+_LI_SHIM_THAT_KEEPS_WRITING = """\
+import shlex, subprocess, sys
+
+argv = sys.argv[1:]
+template = argv[argv.index("--notify") + 1]
+
+sys.stdout.write("ordinary output before the notice\\n")
+subprocess.run(
+    [tok.replace("{status}", "completed") for tok in shlex.split(template)],
+    check=False,
+)
+sys.stdout.write("ordinary final output\\n")
+"""
+
+
+def test_the_failure_notice_survives_the_runs_own_remaining_output(monkeypatch, tmp_path):
+    """The appended notice must not be overwritten by the run that is still writing.
+
+    The hook appends to the log while the run that owns it is alive, so the two
+    write to one file through different descriptors. A run whose descriptor
+    carries its own offset writes its next line back over whatever was appended
+    behind it, and the notice — the only trace of a notice that never arrived —
+    goes with it, on a log that was perfectly writable.
+
+    End to end through ``submit`` because that is where the descriptor is
+    opened: the mode it is opened in is the behaviour under test, and a test
+    that opened its own would assert about itself.
+    """
+    # A lionagi home of this test's own, for this process and for every process
+    # it starts: the hook runs in one of those and derives its own job directory
+    # from the environment, so patching the constant here alone would leave the
+    # two halves of this test writing to two different directories.
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "mcp" / "jobs")
+    # The run is launched by absolute script path, so it imports whichever
+    # lionagi its interpreter resolves — which is this checkout only when the
+    # installed distribution happens to point here.
+    monkeypatch.setenv("PYTHONPATH", str(Path(__file__).resolve().parents[2]))
+    # A real delivery that really fails: the outcome the code builds from an
+    # exit code of its own, not one handed to it.
+    monkeypatch.setenv("LIONAGI_MCP_NOTIFY_COMMAND", json.dumps(["/bin/sh", "-c", "exit 1"]))
+    shim = tmp_path / "li_shim.py"
+    shim.write_text(_LI_SHIM_THAT_KEEPS_WRITING)
+    monkeypatch.setattr(config, "li_command", lambda: [sys.executable, str(shim)])
+
+    handle = jobs.submit("agent", [], no_mcp_config=True)
+    _wait_for_run_to_finish(handle["run_id"])
+
+    log = _console_log(handle["run_id"])
+    # Positive control: the run itself wrote, and wrote last, so a missing
+    # notice cannot be read as a probe that never ran the hook at all.
+    assert "ordinary output before the notice" in log
+    assert "ordinary final output" in log
+    assert jobs._read_job(handle["run_id"])["notify_delivery"] == {
+        "attempted": True,
+        "ok": False,
+        "exit_code": 1,
+        "error": None,
+        "command": "/bin/sh",
+    }
+    assert "[notify]" in log
+    assert "NOT delivered" in log
+
+
+def _wait_for_run_to_finish(run_id: str, timeout: float = 60.0) -> None:
+    """Wait until the run's last write has landed.
+
+    The run is spawned detached, so there is nothing to wait on here. Waiting
+    for its final line rather than for the delivery record is what makes the
+    read that follows deterministic: that line is written after the hook has
+    already run, so once it is on disk both writers are done and what the log
+    holds is what it will hold.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if "ordinary final output" in _console_log(run_id):
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"the run never finished writing. log:\n{_console_log(run_id)}")


### PR DESCRIPTION
Closes #2649.

A run's log is opened with `"wb"` and that descriptor is handed to the child as
stdout. `"wb"` is not `O_APPEND`, so the descriptor carries its own offset.

The terminal hook runs as a separate process while the child is still alive. It
opens the same path with `"a"` and writes at end-of-file. The child's next write
— its final output, or just the flush the interpreter performs on its way out —
resumes at the child's own offset, which is behind that append, and writes over
it.

The line that gets overwritten is the one written only when something went
wrong: the notice that a terminal notice could not be delivered. So a run whose
completion signal never arrived looks, in its own log, exactly like one still
working.

## The mechanism, established rather than assumed

Four arms, differing one variable at a time, each recording the same real
delivery failure (a command that genuinely exits 1):

| child's descriptor when the hook appends | line in the log |
| --- | --- |
| flushed and **closed** before the hook runs | present |
| open at EOF, child writes once more after | **lost** |
| open at EOF, child writes nothing after | present |
| open, nothing flushed yet | **lost** |

The first and third arms are the positive controls: the line does appear, in the
same harness with the same hook invocation, so "no line" elsewhere is not a probe
that failed to fire. The third also separates *holding* the descriptor (harmless)
from *writing through it after the append* (fatal), so the two halves of the
discriminator never differ in two things at once.

The losing arms leave the mechanism's signature in the file — a truncated
remnant of the appended text, its first bytes covered by the child's shorter
write:

```text
ordinary final output
ice NOT delivered for run …: exit code 1. This run finished; its completion signal did not.
```

## The change

`open(log_path, "ab")`. With `O_APPEND` every write from the child lands at
end-of-file regardless of the offset it carries, so it can no longer overwrite
something appended behind its back. Each run gets a directory of its own, so
nothing is lost by not truncating.

The fix is on the writer rather than in the hook because the hook has no defence
available: anything it appends can be overwritten by a writer whose descriptor
tracks an offset, and nothing it does to the file changes that. The hook module
is unchanged.

The `except OSError: pass` in the hook is deliberately untouched. A log that
genuinely cannot be appended to still loses the line rather than turning a
delivered outcome into a crash. What changed is the other side of that boundary:
a *writable* log no longer loses it.

## Test

One test, end to end through `submit()`, because `submit()` is where the
descriptor is opened and the open mode is the behaviour under test — a test
opening its own descriptor would be asserting about itself. The delivery command
really exits 1, so the outcome is one the code built rather than one the test
constructed.

Its positive control is the run's own output: the test asserts both the ordinary
lines are present, so a missing notice cannot be read as a harness that never
fired the hook, and asserts the exact delivery record so the failure it reacts to
is the one that occurred.

Restoring `"wb"` reddens it with the remnant visible in the assertion message;
deleting the hook's append reddens it with the line simply absent.

## Not established

The reproduction is on this code in a redirected home, not a re-run of the
original observation. Whether other writers reach a job's log by a differently
spelled path was not proven — the search found the two above.
