### PR TITLE
fix(cli): measure the prompt that runs, not the template it came from

### DIFF
--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -497,6 +497,30 @@ def _interpolate_prompt(template: str, positional: str | None, playbook_args: di
     return re.sub(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}", _sub, template)
 
 
+def _check_assembled_prompt(prompt: str) -> str | None:
+    """Measure the prompt that will run, not the one it was written from.
+
+    A spec's prompt field is checked when the file is read, but that is a
+    template: the caller's positional and the playbook's arguments are
+    substituted into it afterwards, and either can make the result far longer
+    than the text that passed. A caller that names no spec at all skips the
+    file check outright. Both forms arrive here holding the finished text,
+    which is the only version that reaches a run.
+
+    Same bound as the spec field, deliberately: the number exists to refuse a
+    file that is not a prompt, and it sits far enough out that template plus
+    arguments together stay well under it. A second, larger bound here would
+    mean the assembled prompt could pass while the template it came from could
+    not, which is the asymmetry this check is closing.
+    """
+    if len(prompt) > MAX_SPEC_PROMPT_CHARS:
+        return (
+            f"assembled prompt exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} "
+            f"characters (got {len(prompt)})"
+        )
+    return None
+
+
 def _add_mcp_config_args(parser: argparse.ArgumentParser) -> None:
     """Where this run's workers get their MCP servers from.
 
@@ -1019,6 +1043,11 @@ def run_orchestrate(args: argparse.Namespace) -> int:
             log_error("prompt is required")
             return 1
 
+        prompt_err = _check_assembled_prompt(args.prompt)
+        if prompt_err is not None:
+            log_error(prompt_err)
+            return 1
+
         synth = args.with_synthesis
         with_synthesis = synth is not False
         synthesis_model = synth if isinstance(synth, str) else None
@@ -1184,6 +1213,11 @@ def run_orchestrate(args: argparse.Namespace) -> int:
         # nothing downstream can supply one.
         if not args.prompt:
             log_error("prompt is required (positional or via -f spec file)")
+            return 1
+
+        prompt_err = _check_assembled_prompt(args.prompt)
+        if prompt_err is not None:
+            log_error(prompt_err)
             return 1
 
         if args.team_mode is not None and getattr(args, "team_attach", None) is not None:

--- a/tests/cli/orchestrate/test_assembled_prompt_cap.py
+++ b/tests/cli/orchestrate/test_assembled_prompt_cap.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The prompt a run receives is not always the prompt that was measured.
+
+A spec file's prompt is a template. What reaches the run is that template with
+the caller's positional and the playbook's arguments substituted in, and both
+of those arrive after the spec was validated — so a template comfortably under
+the bound can carry a finished prompt of any size. A caller who names no spec
+at all never meets the spec validator in the first place, and `li o fanout`
+has no spec flag to meet it with.
+
+Every test here is built so the template alone passes: an over-length template
+would be refused by the spec check that already existed and would prove
+nothing. Each one carries an under-bound assembly in the same test, because a
+check that refuses everything also turns the over-length cases green.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock, patch
+
+import yaml
+
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
+from lionagi.cli.orchestrate import (
+    add_orchestrate_subparser,
+    inject_playbook_schema_into_parser,
+    run_orchestrate,
+)
+
+# Short enough that the template is never the thing that fails.
+TEMPLATE_BODY = "t" * 1000
+
+
+def _parse_args(subcommand: str, argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="li")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    orch_parsers = add_orchestrate_subparser(subparsers)
+    full_argv = ["o", subcommand, *argv]
+    inject_playbook_schema_into_parser(orch_parsers["flow"], full_argv)
+    return parser.parse_args(full_argv)
+
+
+def _isolate(monkeypatch, tmp_path):
+    """Nothing this suite runs may reach the real ~/.lionagi, and playbook
+    discovery walks up from cwd as well as from home."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+
+def _write_playbook(tmp_path, name: str, spec: dict) -> None:
+    playbooks_dir = tmp_path / ".lionagi" / "playbooks"
+    playbooks_dir.mkdir(parents=True, exist_ok=True)
+    (playbooks_dir / f"{name}.playbook.yaml").write_text(yaml.dump(spec))
+
+
+def _refused(caplog) -> bool:
+    return "assembled prompt exceeds maximum length" in caplog.text
+
+
+class TestFlowSpecInterpolation:
+    """The template passes the spec check; the argument pushes the result past
+    the bound after it."""
+
+    def test_positional_appended_to_a_placeholderless_template_is_refused(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text(yaml.dump({"prompt": TEMPLATE_BODY}))
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("flow", ["-f", str(spec_file), "y" * MAX_SPEC_PROMPT_CHARS])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 1
+        assert _refused(caplog)
+        assert run_flow.call_count == 0
+
+    def test_the_same_template_with_a_short_positional_still_runs(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Positive control for the case above: identical template, ordinary
+        argument. A check that refuses every assembly fails here."""
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text(yaml.dump({"prompt": TEMPLATE_BODY}))
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("flow", ["-f", str(spec_file), "audit the auth service"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        assert not _refused(caplog)
+        assert run_flow.call_args.kwargs["prompt"].endswith("audit the auth service")
+
+    def test_substituted_placeholder_is_refused(self, monkeypatch, tmp_path, caplog):
+        """The other growth path: the positional lands inside {input} rather
+        than being concatenated onto the end."""
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text(yaml.dump({"prompt": f"{TEMPLATE_BODY} Task: {{input}}"}))
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("flow", ["-f", str(spec_file), "y" * MAX_SPEC_PROMPT_CHARS])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 1
+        assert _refused(caplog)
+        assert run_flow.call_count == 0
+
+    def test_a_playbook_argument_can_overflow_the_template_too(self, monkeypatch, tmp_path, caplog):
+        """Growth does not need the positional: a declared playbook argument
+        is substituted into the same template after the same check."""
+        _write_playbook(
+            tmp_path,
+            "audit",
+            {"args": {"scope": {"type": "str", "default": "auth"}}, "prompt": "Scope: {scope}"},
+        )
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("flow", ["-p", "audit", "--scope", "y" * MAX_SPEC_PROMPT_CHARS, "go"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 1
+        assert _refused(caplog)
+        assert run_flow.call_count == 0
+
+    def test_the_same_playbook_with_an_ordinary_argument_still_runs(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Positive control for the playbook-argument case."""
+        _write_playbook(
+            tmp_path,
+            "audit",
+            {"args": {"scope": {"type": "str", "default": "auth"}}, "prompt": "Scope: {scope}"},
+        )
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("flow", ["-p", "audit", "--scope", "billing", "go"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        assert not _refused(caplog)
+        assert run_flow.call_args.kwargs["prompt"] == "Scope: billing"
+
+    def test_the_error_names_the_bound_and_the_length(self, monkeypatch, tmp_path, caplog):
+        """A refusal that does not say how far over it went leaves the caller
+        guessing at what to cut."""
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text(yaml.dump({"prompt": TEMPLATE_BODY}))
+        _isolate(monkeypatch, tmp_path)
+        overflow = "y" * MAX_SPEC_PROMPT_CHARS
+        args = _parse_args("flow", ["-f", str(spec_file), overflow])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ):
+            code = run_orchestrate(args)
+
+        assert code == 1
+        assembled_len = len(TEMPLATE_BODY) + 2 + len(overflow)
+        assert str(MAX_SPEC_PROMPT_CHARS) in caplog.text
+        assert str(assembled_len) in caplog.text
+
+
+class TestNoSpecFile:
+    """Same input, no spec file: before this check the two invocation forms
+    disagreed about whether the same text was bounded."""
+
+    def test_inline_flow_prompt_is_refused(self, monkeypatch, tmp_path, caplog):
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("flow", ["y" * (MAX_SPEC_PROMPT_CHARS + 1)])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 1
+        assert _refused(caplog)
+        assert run_flow.call_count == 0
+
+    def test_an_inline_flow_prompt_at_the_bound_still_runs(self, monkeypatch, tmp_path, caplog):
+        """Positive control, and the boundary: exactly at the bound is allowed,
+        matching what the spec check has always accepted."""
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("flow", ["y" * MAX_SPEC_PROMPT_CHARS])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_flow",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_flow:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        assert not _refused(caplog)
+        assert len(run_flow.call_args.kwargs["prompt"]) == MAX_SPEC_PROMPT_CHARS
+
+
+class TestFanout:
+    """`li o fanout` has no spec flag at all, so its prompt had never met a
+    bound on any path."""
+
+    def test_inline_fanout_prompt_is_refused(self, monkeypatch, tmp_path, caplog):
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("fanout", ["y" * (MAX_SPEC_PROMPT_CHARS + 1)])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_fanout",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_fanout:
+            code = run_orchestrate(args)
+
+        assert code == 1
+        assert _refused(caplog)
+        assert run_fanout.call_count == 0
+
+    def test_an_ordinary_fanout_prompt_still_runs(self, monkeypatch, tmp_path, caplog):
+        """Positive control."""
+        _isolate(monkeypatch, tmp_path)
+        args = _parse_args("fanout", ["review the parser"])
+
+        with patch(
+            "lionagi.cli.orchestrate._run_fanout",
+            AsyncMock(return_value=("done", "completed")),
+        ) as run_fanout:
+            code = run_orchestrate(args)
+
+        assert code == 0
+        assert not _refused(caplog)
+        assert run_fanout.call_args.kwargs["prompt"] == "review the parser"


### PR DESCRIPTION
A spec's `prompt` field is measured against the bound when the file is read. It is a template. The caller's positional argument and the playbook's arguments are substituted into it afterwards, and either can make the result far longer than the text that passed. A caller who names no spec at all skips the file check outright, and `li o fanout` has no spec argument to check in the first place.

So the length that was validated is not the length that runs.

## Where the growth happens

`_interpolate_prompt` has two of them: `{placeholder}` substitution, and the no-placeholder branch that concatenates the positional onto the end of the template outright. Both run after the template has been measured.

## The change

One helper, `_check_assembled_prompt`, called from two places — the fanout branch and the flow branch, each immediately after the point where `args.prompt` becomes final and before it is handed to the runner. That is the last point at which the value is the same on every invocation form, which is why two call sites cover every entry: the scheduler, the MCP verbs and `li play` all spawn the CLI rather than calling the runners directly.

**Added, not moved.** The spec-field check stays. The two answer different questions: one asks whether a file at rest is sane, and is deliberately aligned with the two write-side validators on the Studio services; the other asks whether the text about to run is within bounds. Moving the first would leave a stored template free to be arbitrarily large and fail only when someone ran it.

The same constant bounds both. A larger post-interpolation bound would let an assembled prompt pass that the template it came from could not — the same asymmetry pointing the other way.

The failure names what happened and does not truncate:

```text
assembled prompt exceeds maximum length of 262144 characters (got 263146)
```

It reports the actual length as well as the bound, so a caller knows how much to cut.

## On "unbounded"

The inline path was not unbounded. Every affected surface either is the CLI or spawns it, so `execve` capped them at `ARG_MAX` — 1 MiB on the development host. The defect is that the bound was roughly four times the intended one and arrived as an unnamed `OSError` in the spawning process rather than a message telling the caller what they did. On a platform with a larger `ARG_MAX` the gap was correspondingly wider.

## Tests

Ten tests driving the real argv parser and dispatch with the runners patched. Every over-length case uses a template that passes the pre-existing spec check comfortably and pushes only the *assembly* over — a test whose template were already over-length would pass against the unfixed code and prove nothing.

Four of the ten are positive controls: the same templates with ordinary arguments, plus a prompt sitting exactly at the bound, all of which must still run.

Mutations run to prove the assertions discriminate: deleting either call site reddens only that surface's tests and leaves the other's green, so the two are independently load-bearing; refusing everything reddens all four positive controls; and `>` to `>=` reddens the at-the-bound case alone.

## Known gaps, filed rather than widened here

Flow resume replays a checkpoint prompt without passing through this dispatch. In normal operation that prompt was validated when the run was first submitted, so the gap opens only for a hand-edited checkpoint — a different trust boundary, left alone deliberately.

Two surfaces with the same shape as this defect are noted for separate issues: a scheduled action's prompt is unbounded at rest and is grown by template rendering at fire time, and the single-agent submit path carries its prompt in a file with no bound anywhere.
