### PR TITLE
fix(ln): refuse non-finite floats where durable JSON reaches the filesystem

### DIFF
--- a/lionagi/cli/_mcp_resolve.py
+++ b/lionagi/cli/_mcp_resolve.py
@@ -80,6 +80,22 @@ def discover_mcp_config(start: str | Path) -> Path | None:
     return None
 
 
+def _reject_json_constant(token: str) -> Any:
+    """Refuse ``NaN``/``Infinity``/``-Infinity``, which json.loads accepts by default.
+
+    Those three are a Python extension, not JSON. Accepting one here turns it
+    into a Python float that the snapshot handed to the child re-emits as the
+    same non-standard token, so a config nothing else could parse propagates
+    into a file the child's own reader has to parse. Refusing at the read names
+    the config the operator actually wrote, and does it before anything is
+    spawned; a refusal at the write would name a file this code generated.
+    """
+    raise ValueError(
+        f"{token} is not JSON: it is a Python extension the standard library "
+        "accepts on read, and no other reader of this config has to"
+    )
+
+
 def _read_servers(path: Path) -> dict[str, Any]:
     """Parse ``{"mcpServers": {...}}`` from *path*; raises ValueError on any
     shape this cannot hand to a provider."""
@@ -88,8 +104,10 @@ def _read_servers(path: Path) -> dict[str, Any]:
     except OSError as exc:
         raise McpConfigError(f"could not read {path}: {exc}") from exc
     try:
-        data = json.loads(raw)
+        data = json.loads(raw, parse_constant=_reject_json_constant)
     except json.JSONDecodeError as exc:
+        raise McpConfigError(f"{path} is not valid JSON: {exc}") from exc
+    except ValueError as exc:
         raise McpConfigError(f"{path} is not valid JSON: {exc}") from exc
     if not isinstance(data, dict):
         raise McpConfigError(f"{path} must contain a JSON object, got {type(data).__name__}")

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 from lionagi._paths import RUNS_ROOT, ensure_lionagi_dir
 from lionagi.cli._util import AmbiguousIdError, mark_run_allocated
 from lionagi.libs.path_safety import validate_path_component
+from lionagi.ln._json_dump import raise_if_non_finite
 from lionagi.ln._utils import now_utc
 from lionagi.providers._provider_errors import ProviderError
 from lionagi.utils import LIONAGI_HOME
@@ -83,7 +84,12 @@ def _atomic_write_json(path: Path, payload: dict) -> None:
     The temp file is uniquely named and lives in the destination directory
     (os.replace is only atomic within a filesystem), so concurrent writers
     of the same target cannot corrupt each other's in-progress write.
+
+    A non-finite float is refused before anything is written: json.dumps would
+    emit the tokens ``NaN``/``Infinity``, which this process reads back happily
+    and every strict reader rejects.
     """
+    raise_if_non_finite(payload)
     fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as fh:

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
+from lionagi.ln._json_dump import raise_if_non_finite
 
 from ._logging import hint, log_error, progress, warn
 
@@ -197,6 +198,13 @@ def _save_states(states: dict[str, _FileState]) -> None:
         }
         for key, st in states.items()
     }
+    # Only the byte offset is this module's own arithmetic. The session uid, the
+    # leaf uuid and the tool-name map are copied out of a transcript another
+    # program wrote, through a json.loads that accepts NaN and Infinity, and none
+    # of them is coerced to str on the way in. So a token no strict reader accepts
+    # can reach this file, and once here it round-trips through the equally
+    # permissive read above and never leaves. Refuse at the write instead.
+    raise_if_non_finite(payload)
     tmp = _OFFSETS_PATH.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload))
     tmp.replace(_OFFSETS_PATH)

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from lionagi._errors import LionError
 from lionagi._paths import RUNS_ROOT
+from lionagi.ln._json_dump import raise_if_non_finite
 
 from .._runs import RunDir
 from .._util import AmbiguousIdError
@@ -155,7 +156,11 @@ class CheckpointWriter:
         self._seq += 1
         self.path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self.path.with_name(f"checkpoint.{self._seq}.tmp")
-        payload = json.dumps(self.to_dict(), default=str)
+        state = self.to_dict()
+        # A non-finite float would be written as the token NaN/Infinity, which
+        # Python reads back and strict readers reject; refuse it at the write.
+        raise_if_non_finite(state, default=str)
+        payload = json.dumps(state, default=str)
         tmp.write_text(payload)
         os.replace(tmp, self.path)
 

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -27,6 +27,7 @@ from lionagi._errors import ConfigurationError
 from lionagi.agent import AgentSpec, create_agent
 from lionagi.agent.factory import register_profile_injection
 from lionagi.ln import Unset
+from lionagi.ln._json_dump import raise_if_non_finite
 from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
@@ -1297,6 +1298,19 @@ def _emit_worker_artifact_report(entries: list[dict]) -> None:
         )
 
 
+def _write_branch_snapshot(snap_path: Path, branch: Any) -> None:
+    """Serialize *branch* to *snap_path* so `li agent -r` can resume it.
+
+    A non-finite float is refused before the file is touched: json.dumps writes
+    it as the token ``NaN``/``Infinity``, which the writing process reads back
+    happily and every strict reader rejects, so the corruption would only
+    surface at whatever boundary consumes the snapshot next.
+    """
+    snapshot = branch.to_dict()
+    raise_if_non_finite(snapshot, default=str)
+    snap_path.write_text(json.dumps(snapshot, default=str))
+
+
 def finalize_orchestration(
     env: OrchestrationEnv,
     *,
@@ -1331,8 +1345,7 @@ def finalize_orchestration(
 
         # Snapshot failure must not abort finalize; only `li agent -r` is affected.
         try:
-            snap_path = env.run.branch_path(str(branch.id))
-            snap_path.write_text(json.dumps(branch.to_dict(), default=str))
+            _write_branch_snapshot(env.run.branch_path(str(branch.id)), branch)
         except Exception as exc:  # noqa: BLE001
             log.warning(
                 "finalize: branch snapshot write failed for %s: %s",

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 
 from lionagi._paths import ensure_lionagi_dir
 from lionagi.cli._util import AmbiguousIdError
+from lionagi.ln._json_dump import raise_if_non_finite
 from lionagi.ln._utils import now_utc
 from lionagi.utils import LIONAGI_HOME
 
@@ -90,6 +91,10 @@ def _locked_team(team_id: str, *, create_path: Path | None = None):
             raw = fp.read()
             data = json.loads(raw) if raw.strip() else {}
             yield data
+            # Checked before the file is truncated, so a payload json.dumps
+            # would write as the token NaN/Infinity — read back only by Python,
+            # rejected by every strict reader — leaves the previous file intact.
+            raise_if_non_finite(data, default=str)
             fp.seek(0)
             fp.truncate()
             fp.write(json.dumps(data, indent=2, default=str))

--- a/lionagi/engines/coding.py
+++ b/lionagi/engines/coding.py
@@ -19,6 +19,7 @@ from typing import Any
 from pydantic import Field
 
 from lionagi.casts.emission import Verdict
+from lionagi.ln._json_dump import raise_if_non_finite
 from lionagi.ln.concurrency import run_sync
 from lionagi.tools._subprocess import _SHELL_CONTROL, _subprocess_sync
 
@@ -368,6 +369,11 @@ class CodingRun(ChainRun):
         """Render each CodeResultRecorded as a ResultRecorded input dict for hypothesis ingestion."""
         seeds: list[dict[str, Any]] = []
         for k in self.events_of(CodeResultRecorded):
+            # The measurements are the likeliest place for a division by zero to
+            # surface, and they are serialized into a string that lands inside a
+            # durable artifact — a NaN token there breaks the nested document
+            # for every reader but Python's own.
+            raise_if_non_finite(k.measurements, default=str)
             seeds.append(
                 {
                     "experiment_ref": k.experiment_ref,
@@ -394,6 +400,7 @@ class CodingRun(ChainRun):
             "hypothesis_seeds": self.to_hypothesis_seeds(),
         }
         results_path = d / "results.json"
+        raise_if_non_finite(payload, default=str)
         results_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
         md = _render_report(self, report)
         report_path = d / "report.md"

--- a/lionagi/engines/hypothesis.py
+++ b/lionagi/engines/hypothesis.py
@@ -14,6 +14,7 @@ from typing import Any, Literal
 from pydantic import Field
 
 from lionagi.casts.emission import Finding, Gap, Verdict
+from lionagi.ln._json_dump import raise_if_non_finite
 
 from .engine import ChainEvent, ChainRun, Engine, EngineEvent, EngineRun, role_profile_route
 
@@ -570,6 +571,10 @@ class HypothesisRun(ChainRun):
             "filing_queue": filing_queue(self),
         }
         chains_path = d / "chains.json"
+        # json.dumps writes a non-finite float as the token NaN/Infinity, which
+        # only Python reads back; refuse rather than emit an artifact that
+        # strict readers reject long after the run that produced it.
+        raise_if_non_finite(payload, default=str)
         chains_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
         trail = render_evidence(self)
         md = f"{report.strip()}\n\n---\n\n{trail}\n" if report.strip() else f"{trail}\n"

--- a/lionagi/ln/__init__.py
+++ b/lionagi/ln/__init__.py
@@ -15,6 +15,7 @@ from ._json_dump import (
     json_dumps,
     json_lines_iter,
     make_options,
+    raise_if_non_finite,
 )
 from ._lazy_init import LazyInit, lazy_import
 from ._list_call import lcall
@@ -113,6 +114,7 @@ __all__ = (
     "make_options",
     "json_dumpb",
     "json_lines_iter",
+    "raise_if_non_finite",
     "lcall",
     "to_list",
     "acreate_path",

--- a/lionagi/ln/_json_dump.py
+++ b/lionagi/ln/_json_dump.py
@@ -28,6 +28,7 @@ __all__ = [
     "json_dumpb",
     "json_dumps",
     "json_lines_iter",
+    "raise_if_non_finite",
 ]
 
 # Types orjson serializes natively; routed through default() only when passthrough is requested.
@@ -327,6 +328,41 @@ def _locate_non_finite(
     return _locate_non_finite(converted, default, opt, path)
 
 
+def raise_if_non_finite(
+    obj: Any,
+    *,
+    default: Callable[[Any], Any] | None = None,
+    options: int = 0,
+) -> None:
+    """Raise ValueError naming the path of the first non-finite float in *obj*.
+
+    For callers that persist a payload through a serializer other than
+    json_dumpb -- notably the standard library's ``json``, which writes inf,
+    -inf and nan as the tokens ``Infinity``/``NaN``. Python reads those tokens
+    back, so the writer never notices; every strict parser rejects them, so the
+    file breaks at whatever boundary reads it next. Check before writing and the
+    refusal names the offending field instead.
+
+    ``default`` should be the conversion the writer itself applies to values it
+    cannot encode (``str`` for a stdlib ``json.dumps(..., default=str)``);
+    omitted, the orjson default is used. The walk mirrors orjson, which is a
+    superset of what the stdlib traverses: it descends into dataclass fields and
+    Enum values, where the stdlib would have handed the whole object to
+    ``default``. A non-finite float hidden in one of those is therefore refused
+    even though the stdlib would have written it as part of a string.
+    """
+    if default is None:
+        default = _cached_default(False, False, False, False, False, 2048)
+    found = _locate_non_finite(obj, default, options)
+    if found is not None:
+        raise ValueError(
+            f"cannot serialize non-finite float at {found}: JSON has no "
+            "representation for inf, -inf or nan, and writing it records "
+            "something no reader can recover -- a null indistinguishable from a "
+            "real one, or the tokens NaN and Infinity that strict parsers reject"
+        )
+
+
 def _dumpb(
     obj: Any, default: Callable[[Any], Any], opt: int, check_non_finite: bool = False
 ) -> bytes:
@@ -347,13 +383,7 @@ def _dumpb(
     # provably clean and the walk is skipped. This only pays off once the caller has
     # already opted into the check; as a gate on every dump it costs more than it saves.
     if check_non_finite and b"null" in out:
-        found = _locate_non_finite(obj, default, opt)
-        if found is not None:
-            raise ValueError(
-                f"cannot serialize non-finite float at {found}: JSON has no "
-                "representation for inf, -inf or nan, and writing it would "
-                "silently record null in its place"
-            )
+        raise_if_non_finite(obj, default=default, options=opt)
     return out
 
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -368,10 +368,19 @@ def _write_job(record: dict[str, Any]) -> None:
     try:
         tmp.write_text(json.dumps(record, indent=2))
         os.replace(tmp, d / "job.json")
-    except OSError:
+    except BaseException:
         # Do not leave the staging file behind: a run whose writes keep failing
         # would otherwise accumulate orphans in its job dir. The original error
         # still propagates.
+        #
+        # Every exception, not the errno family alone, because the caller that
+        # gives a reservation back on a failed publication catches every one and
+        # then removes the directory with rmdir — which refuses a directory
+        # holding anything at all. A staging file left by an interrupt would
+        # therefore survive as the one thing standing between that cleanup and
+        # an empty directory, and the run would be stranded by the file written
+        # to make its record atomic. The two have to answer for the same set of
+        # failures or the narrower one decides the outcome.
         tmp.unlink(missing_ok=True)
         raise
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1387,14 +1387,17 @@ def submit(
     log_path = d / "console.log"
 
     # Nothing is written into the reserved directory until the whole command line
-    # is assembled, and a submission that does not become a job takes the
-    # reservation back on its way out — a run that never started leaves no trace,
-    # and a directory here is not nothing: every directory under the jobs root is
-    # listed as a job, so one left behind reads back as a job with no kind that
-    # never finishes. That holds however far the submission got, so the block
-    # runs to the last write this function makes before the record exists rather
-    # than stopping where the assembly does: a failure at the second of two
-    # writes leaves the same unfinishable job as a failure at the first.
+    # is assembled, and a submission that does not become a job gives the
+    # reservation back on its way out. A directory here is not nothing: every
+    # directory under the jobs root is listed as a job, so one left behind reads
+    # back as a job with no kind that never finishes. What that give-back does
+    # and does not promise is _discard_reservation's to say rather than this
+    # block's, exception included — a removal the filesystem refuses leaves the
+    # directory standing, and insisting past a refusal is worse than accepting
+    # it. What this block decides is the reach: it runs to the last write this
+    # function makes before the record exists rather than stopping where the
+    # assembly does, so a failure at the second of two writes gives the
+    # reservation back the same way a failure at the first does.
     #
     # It ends at the record. Once _write_job has run the directory is a real job
     # with real state, and correcting it is the business of the marking that

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1532,7 +1532,17 @@ def submit(
         "spawn_state": "preparing",
         "log": str(log_path),
     }
-    _write_job(record)
+    try:
+        _write_job(record)
+    except BaseException:
+        # The record is what makes a reservation a job, so a publication that
+        # never landed leaves the prepared files behind with nothing claiming
+        # them — the same stranded directory every earlier failure here gives
+        # back, reached one step later. This is the last point where giving it
+        # back is the right answer: past this line the run exists, and a failure
+        # is marked on the record rather than erased along with it.
+        _discard_reservation(d)
+        raise
 
     try:
         # Append mode, not truncate: every write from the child has to land at

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -45,6 +45,8 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from lionagi.ln._json_dump import raise_if_non_finite
+
 from . import config
 
 # li subcommand for each job kind. "orchestrate" is the canonical parser name
@@ -186,6 +188,14 @@ def _write_job(record: dict[str, Any]) -> None:
     # write in submit() and the terminal hook) never collide on the temp itself.
     # This makes each publish all-or-nothing; it does not serialize two writers,
     # so a read-modify-write pair can still lose an update (last replace wins).
+    # Checked before the temp file is opened, so a refused record leaves neither a
+    # staging file nor a published one. json.dumps would write a non-finite float
+    # as the bare token NaN or Infinity, which only Python reads back: every
+    # reader of this record that is not Python — and every strict parser — would
+    # fail on it long after the run that wrote it. The start time already has a
+    # representation for "unreadable" and it is null, so nothing here encodes a
+    # sentinel that this refuses.
+    raise_if_non_finite(record)
     d = config.job_dir(record["run_id"])
     d.mkdir(parents=True, exist_ok=True)
     tmp = d / f".job.json.{os.getpid()}.{uuid4().hex[:8]}.tmp"
@@ -198,6 +208,21 @@ def _write_job(record: dict[str, Any]) -> None:
         # still propagates.
         tmp.unlink(missing_ok=True)
         raise
+
+
+def _write_mcp_server_snapshot(path: Path, servers: dict[str, Any]) -> None:
+    """Write the ``{"mcpServers": ...}`` file the spawned child is pointed at.
+
+    A server entry is arbitrary nested JSON — whatever the resolved config held —
+    so this is an open-shaped payload despite the closed-looking name. Config
+    resolution already refuses the non-standard constants on the way in, which is
+    where a failure names the config an operator actually wrote. Refusing again
+    here binds the guarantee to the file rather than to today's single source of
+    the map, so it holds for any later path that fills *servers* without going
+    through a config read.
+    """
+    raise_if_non_finite({"mcpServers": servers})
+    path.write_text(json.dumps({"mcpServers": servers}, indent=2))
 
 
 def _short_repr(value: Any, limit: int = 60) -> str:
@@ -1142,7 +1167,7 @@ def submit(
     if prompt_path is not None:
         prompt_path.write_text(prompt)
     if mcp_servers is not None and mcp_config_path is not None:
-        Path(mcp_config_path).write_text(json.dumps({"mcpServers": mcp_servers}, indent=2))
+        _write_mcp_server_snapshot(Path(mcp_config_path), mcp_servers)
 
     # Persist the record BEFORE spawning, so the child's terminal --notify hook
     # always finds a record to mark. mark_terminal no-ops on a missing record, so

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -381,7 +381,19 @@ def _write_job(record: dict[str, Any]) -> None:
         # an empty directory, and the run would be stranded by the file written
         # to make its record atomic. The two have to answer for the same set of
         # failures or the narrower one decides the outcome.
-        tmp.unlink(missing_ok=True)
+        #
+        # The removal cannot be allowed to raise in place of what sent us here.
+        # Widening the catch is what makes that reachable: an interrupt used to
+        # pass straight through, and now it arrives inside a handler whose own
+        # failure would replace it, so a caller waiting on a KeyboardInterrupt
+        # would be handed a PermissionError from the tidying instead. This is the
+        # rule _discard_reservation already states for the same situation — a
+        # removal that fails leaves a file nobody claimed, which is worth less
+        # than the error that sent us here — and it is applied here rather than
+        # invented, because a second answer to one question is how the narrower
+        # handler came to decide for the wider one in the first place.
+        with contextlib.suppress(BaseException):
+            tmp.unlink(missing_ok=True)
         raise
 
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -382,17 +382,22 @@ def _write_job(record: dict[str, Any]) -> None:
         # to make its record atomic. The two have to answer for the same set of
         # failures or the narrower one decides the outcome.
         #
-        # The removal cannot be allowed to raise in place of what sent us here.
-        # Widening the catch is what makes that reachable: an interrupt used to
-        # pass straight through, and now it arrives inside a handler whose own
-        # failure would replace it, so a caller waiting on a KeyboardInterrupt
-        # would be handed a PermissionError from the tidying instead. This is the
-        # rule _discard_reservation already states for the same situation — a
-        # removal that fails leaves a file nobody claimed, which is worth less
-        # than the error that sent us here — and it is applied here rather than
-        # invented, because a second answer to one question is how the narrower
-        # handler came to decide for the wider one in the first place.
-        with contextlib.suppress(BaseException):
+        # A removal that fails does not get to answer in place of what sent us
+        # here. Widening the catch is what makes that reachable: an interrupt
+        # used to pass straight through, and now it arrives inside a handler
+        # whose own failure would replace it, so a caller waiting on a
+        # KeyboardInterrupt would be handed a PermissionError from the tidying
+        # instead. The rule is _discard_reservation's, not a new one — a removal
+        # that fails leaves a file nobody claimed, which is worth less than the
+        # error that sent us here — and the domain it suppresses is the same one:
+        # OSError, what a filesystem refusal actually looks like.
+        #
+        # Deliberately not everything. An interrupt or an exit arriving WHILE the
+        # removal runs is not this removal failing, it is someone asking for the
+        # process to stop, and swallowing it would answer a cancellation with
+        # whatever the run happened to be failing at already. A refusal to delete
+        # is worth less than the original error; a request to stop is not.
+        with contextlib.suppress(OSError):
             tmp.unlink(missing_ok=True)
         raise
 

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -64,8 +64,24 @@ async def _write_branch_snapshot(branch: Branch, snapshot_dir: str | Path) -> No
     )
     tmp_fp = anyio.Path(str(fp) + ".tmp")
     async with await anyio.open_file(tmp_fp, "w") as f:
-        await f.write(json_dumps(branch.to_dict()))
+        # A non-finite float would be written as `null`, which no reader can
+        # tell apart from a genuine null once the snapshot is on disk.
+        await f.write(json_dumps(branch.to_dict(), check_non_finite=True))
     await anyio.to_thread.run_sync(partial(os.replace, str(tmp_fp), str(fp)))
+
+
+async def _append_chunk(buffer_path, chunk) -> None:
+    """Append one streamed chunk to the live JSONL buffer.
+
+    The buffer is replayed after the run, so a non-finite float is refused here
+    rather than written as `null` — by replay time nothing distinguishes it from
+    a value that was genuinely null.
+    """
+    # Serialized before the file is opened, so a refused chunk does not leave an
+    # empty buffer behind for a run that never wrote one.
+    line = json_dumps(chunk.to_dict(), check_non_finite=True) + "\n"
+    async with await anyio.open_file(buffer_path, "a") as f:
+        await f.write(line)
 
 
 async def _stream_with_deadline(model, api_call, deadline: float | None):
@@ -457,8 +473,7 @@ async def run(
 
             async def _persist_chunk(chunk):
                 if hasattr(chunk, "to_dict"):
-                    async with await anyio.open_file(bfp, "a") as f:
-                        await f.write(json_dumps(chunk.to_dict()) + "\n")
+                    await _append_chunk(bfp, chunk)
                 if prev_stream_func is not None:
                     from lionagi.ln import is_coro_func
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -2894,6 +2894,45 @@ def test_a_submission_that_fails_between_its_writes_leaves_no_job_behind(sandbox
     assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
 
 
+def test_a_submission_whose_record_never_publishes_leaves_no_job_behind(sandbox, monkeypatch):
+    """The record is the last thing that can strand a reservation.
+
+    The two writes above it are covered; the write that publishes the record is
+    the one that decides whether any of it was a job at all. When it fails there
+    is no record to mark and no child to mark it, so what is left is the same
+    directory with no kind that never finishes — reached one step later than the
+    other failures, and given back the same way.
+    """
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc(4242))
+
+    # Positive control: the same call, unobstructed. Without it a change that
+    # refused every submission of this shape would read as this test passing.
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-aaabbb")
+    control = jobs.submit("agent", [], prompt="x", label="control")["run_id"]
+    assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
+
+    # The prompt has already been written by the time the record is published,
+    # so this is the non-empty directory case, not the empty one.
+    prompt_was_already_written: list[bool] = []
+    real_replace = os.replace
+
+    def refuse_to_publish(src, dst, *args, **kwargs):
+        if str(dst).endswith("job.json"):
+            prompt_was_already_written.append((Path(dst).parent / "prompt.txt").exists())
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", refuse_to_publish)
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-cccddd")
+
+    with pytest.raises(OSError):
+        jobs.submit("agent", [], prompt="x", label="unpublished")
+
+    assert prompt_was_already_written == [True]
+    assert not (config.JOBS_DIR / "20260101T000000-cccddd").exists()
+    assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
+
+
 def test_discarding_a_reservation_removes_what_the_submission_wrote(sandbox):
     """Both of the names a submission writes come back with the directory."""
     d = config.JOBS_DIR / "20260101T000000-111111"

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3002,6 +3002,39 @@ def test_a_failed_cleanup_does_not_answer_in_place_of_the_failure_that_caused_it
         jobs.submit("agent", [], prompt="x", label="interrupted")
 
 
+def test_an_interrupt_arriving_during_cleanup_is_not_swallowed_by_it(sandbox, monkeypatch):
+    """Being asked to stop is not the same as a removal being refused.
+
+    The removal is allowed to fail without answering in place of the failure
+    underneath it, but only for the failures a filesystem actually produces. An
+    interrupt arriving while it runs is nobody's removal failing — it is a
+    request for the process to stop, and answering that with whatever the run
+    was already failing at loses the request entirely.
+    """
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc(4242))
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-888bbb")
+
+    real_replace = os.replace
+    real_unlink = Path.unlink
+
+    def fail_the_publication(src, dst, *args, **kwargs):
+        if str(dst).endswith("job.json"):
+            raise ValueError("publication failed")
+        return real_replace(src, dst, *args, **kwargs)
+
+    def interrupt_during_removal(self, *args, **kwargs):
+        if self.name.startswith(".job.json.") and self.name.endswith(".tmp"):
+            raise KeyboardInterrupt
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", fail_the_publication)
+    monkeypatch.setattr(Path, "unlink", interrupt_during_removal)
+
+    # The interrupt, not the ValueError it arrived on top of.
+    with pytest.raises(KeyboardInterrupt):
+        jobs.submit("agent", [], prompt="x", label="interrupted-while-tidying")
+
+
 def test_discarding_a_reservation_removes_what_the_submission_wrote(sandbox):
     """Both of the names a submission writes come back with the directory."""
     d = config.JOBS_DIR / "20260101T000000-111111"

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -9,6 +9,8 @@ on the argv/env the engine builds and on the on-disk job records it reads back.
 from __future__ import annotations
 
 import builtins
+import json
+import math
 import os
 import signal
 from pathlib import Path
@@ -267,7 +269,17 @@ def _live_process(monkeypatch, created: float = _SPAWNED_AT):
 
 
 def _identity_record(pid: int = 4242, pgid: int = 7777, created: float = _SPAWNED_AT, **extra):
-    """A job record carrying the process identity submit() now writes."""
+    """A job record carrying the process identity submit() now writes.
+
+    Some of these deliberately carry a start time that cannot act as one, to ask
+    what a *reader* does with it — and among those are the non-finite floats the
+    writer now refuses, because json.dumps would put the bare token NaN or
+    Infinity on disk. A reader still has to survive one: records written before
+    that refusal existed are on disk already, and the job store is shared with
+    whatever else writes into it. So a record the writer will not produce is
+    published directly here, and every record the writer *can* produce still goes
+    through it, which is what keeps this fixture's shape the production shape.
+    """
     rec = {
         "run_id": jobs.new_run_id(),
         "pid": pid,
@@ -278,7 +290,12 @@ def _identity_record(pid: int = 4242, pgid: int = 7777, created: float = _SPAWNE
         "log": None,
     }
     rec.update(extra)
-    jobs._write_job(rec)
+    if isinstance(created, float) and not math.isfinite(created):
+        d = config.job_dir(rec["run_id"])
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "job.json").write_text(json.dumps(rec, indent=2))
+    else:
+        jobs._write_job(rec)
     return rec["run_id"]
 
 

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -2933,6 +2933,39 @@ def test_a_submission_whose_record_never_publishes_leaves_no_job_behind(sandbox,
     assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
 
 
+def test_an_interrupted_publication_leaves_nothing_that_blocks_the_cleanup(sandbox, monkeypatch):
+    """An interrupt is one of the failures the reservation is given back for.
+
+    Giving it back ends in an rmdir, which refuses a directory holding anything
+    at all — so the staging file the record write uses to be atomic is the one
+    thing able to defeat the cleanup that runs because that write failed. The
+    two have to answer for the same set of failures, which is why this asserts
+    on an exception outside the errno family.
+    """
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc(4242))
+
+    # Positive control: the same call, unobstructed.
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-eee111")
+    control = jobs.submit("agent", [], prompt="x", label="control")["run_id"]
+    assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
+
+    real_replace = os.replace
+
+    def interrupt_the_publication(src, dst, *args, **kwargs):
+        if str(dst).endswith("job.json"):
+            raise KeyboardInterrupt
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", interrupt_the_publication)
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-fff222")
+
+    with pytest.raises(KeyboardInterrupt):
+        jobs.submit("agent", [], prompt="x", label="interrupted")
+
+    assert not (config.JOBS_DIR / "20260101T000000-fff222").exists()
+    assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
+
+
 def test_discarding_a_reservation_removes_what_the_submission_wrote(sandbox):
     """Both of the names a submission writes come back with the directory."""
     d = config.JOBS_DIR / "20260101T000000-111111"

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -2966,6 +2966,42 @@ def test_an_interrupted_publication_leaves_nothing_that_blocks_the_cleanup(sandb
     assert [(j["run_id"], j["kind"]) for j in jobs.list_jobs()] == [(control, "agent")]
 
 
+def test_a_failed_cleanup_does_not_answer_in_place_of_the_failure_that_caused_it(
+    sandbox, monkeypatch
+):
+    """Tidying up after a failure never becomes the failure a caller is told about.
+
+    The staging removal runs inside a handler that catches everything, so its own
+    error would otherwise take the place of the one that sent us there: a caller
+    waiting on an interrupt would be handed whatever the tidying refused with. The
+    file may then survive, which is the same trade the reservation give-back
+    already makes — a removal that fails leaves something nobody claimed, and that
+    is worth less than the error underneath it.
+    """
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc(4242))
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-777aaa")
+
+    real_replace = os.replace
+    real_unlink = Path.unlink
+
+    def interrupt_the_publication(src, dst, *args, **kwargs):
+        if str(dst).endswith("job.json"):
+            raise KeyboardInterrupt
+        return real_replace(src, dst, *args, **kwargs)
+
+    def refuse_to_remove(self, *args, **kwargs):
+        if self.name.startswith(".job.json.") and self.name.endswith(".tmp"):
+            raise PermissionError(errno.EACCES, "cleanup denied")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", interrupt_the_publication)
+    monkeypatch.setattr(Path, "unlink", refuse_to_remove)
+
+    # The interrupt, not the PermissionError the tidying raised.
+    with pytest.raises(KeyboardInterrupt):
+        jobs.submit("agent", [], prompt="x", label="interrupted")
+
+
 def test_discarding_a_reservation_removes_what_the_submission_wrote(sandbox):
     """Both of the names a submission writes come back with the directory."""
     d = config.JOBS_DIR / "20260101T000000-111111"

--- a/tests/test_durable_json_non_finite.py
+++ b/tests/test_durable_json_non_finite.py
@@ -16,6 +16,7 @@ back unchanged. Without it a writer that refused everything would pass.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -140,6 +141,122 @@ async def test_run_branch_snapshot_refuses_non_finite(tmp_path):
     good = _Branch({"payload": CONTROL})
     await _write_branch_snapshot(good, tmp_path)
     _assert_control_roundtrip(tmp_path / f"{good.id}.json")
+
+
+def test_job_record_refuses_non_finite(tmp_path, monkeypatch):
+    """``job.json`` is an open-shaped durable record like the rest.
+
+    ``pid_create_time`` is the field that would carry one: it holds a process
+    start time, and a start time that could not be read is recorded as ``null``,
+    never as a non-finite float. So nothing here encodes a sentinel the refusal
+    would destroy, and a NaN reaching this file is damage rather than meaning.
+    """
+    from lionagi.mcp import config, jobs
+
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    run_id = jobs.new_run_id()
+    target = config.job_dir(run_id) / "job.json"
+
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.pid_create_time"):
+        jobs._write_job({"run_id": run_id, "pid": 4242, "pid_create_time": float("nan")})
+    assert not target.exists()
+    # And no staging file was left behind by the refusal either.
+    assert not list(config.job_dir(run_id).glob(".job.json.*.tmp"))
+
+    jobs._write_job({"run_id": run_id, "pid": 4242, "pid_create_time": None, "payload": CONTROL})
+    _assert_control_roundtrip(target)
+    assert json.loads(target.read_text())["pid_create_time"] is None
+
+
+@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"])
+def test_mcp_config_read_refuses_non_standard_json_constants(tmp_path, token):
+    """The three tokens cannot enter the resolved server map at all.
+
+    ``json.loads`` accepts them by default — they are a Python extension, not
+    JSON — so a config carrying one would otherwise resolve to a Python float and
+    be re-emitted into the snapshot the child is handed. The refusal names the
+    file an operator wrote, and happens before anything is spawned.
+    """
+    from lionagi.cli._mcp_resolve import McpConfigError, resolve_spawn_mcp_servers
+
+    (tmp_path / ".mcp.json").write_text(
+        f'{{"mcpServers": {{"x": {{"command": "y", "timeout": {token}}}}}}}'
+    )
+
+    resolution = resolve_spawn_mcp_servers(launch_dir=tmp_path)
+    assert resolution.servers is None
+    assert resolution.reason.startswith("mcp_config_unusable:")
+    assert token in resolution.reason
+
+    with pytest.raises(McpConfigError, match="not valid JSON"):
+        resolve_spawn_mcp_servers(tmp_path / ".mcp.json", launch_dir=tmp_path)
+
+    # Control: the same config with a finite timeout resolves and keeps its value.
+    (tmp_path / ".mcp.json").write_text(
+        '{"mcpServers": {"x": {"command": "y", "timeout": 1.5, "retries": null}}}'
+    )
+    ok = resolve_spawn_mcp_servers(launch_dir=tmp_path)
+    assert ok.servers == {"x": {"command": "y", "timeout": 1.5, "retries": None}}
+
+
+def test_mcp_server_snapshot_refuses_non_finite(tmp_path):
+    """And the write refuses too, for a server map that reached it some other way."""
+    from lionagi.mcp.jobs import _write_mcp_server_snapshot
+
+    target = tmp_path / "mcp-servers.json"
+
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.mcpServers\.x\.timeout"):
+        _write_mcp_server_snapshot(target, {"x": {"command": "y", "timeout": float("inf")}})
+    assert not target.exists()
+
+    _write_mcp_server_snapshot(target, {"payload": CONTROL})
+    assert json.loads(target.read_text())["mcpServers"]["payload"] == CONTROL
+
+
+def test_mirror_offsets_refuse_non_finite(tmp_path, monkeypatch):
+    """The transcript cursor file is not the closed shape its fields suggest.
+
+    The offset is this module's own arithmetic, but the tool-name map comes out
+    of a transcript another program wrote and is never coerced to ``str``.
+    """
+    from lionagi.cli import mirror
+
+    target = tmp_path / "offsets.json"
+    monkeypatch.setattr(mirror, "_OFFSETS_PATH", target)
+
+    bad = mirror._FileState(session_uid="s", offset=12, tool_names={"t1": float("nan")})
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.f\.tool_names\.t1"):
+        mirror._save_states({"f": bad})
+    assert not target.exists()
+
+    good = mirror._FileState(session_uid="s", offset=12, tool_names={"t1": "Read"})
+    mirror._save_states({"f": good})
+    assert json.loads(target.read_text())["f"] == {
+        "offset": 12,
+        "session_uid": "s",
+        "tool_names": {"t1": "Read"},
+        "leaf_uuid": None,
+    }
+
+
+def test_hypothesis_chains_export_refuses_non_finite(tmp_path):
+    """The chains artifact reaches the guard before ``chains.json`` is created."""
+    from lionagi.engines.hypothesis import HypothesisEngine, HypothesisRun
+
+    run = HypothesisRun(HypothesisEngine())
+    run.root = "r"
+    run.agents_made = float("inf")
+
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.agents_made"):
+        run.export(tmp_path)
+    assert not (tmp_path / "chains.json").exists()
+
+    run.agents_made = 3
+    paths = run.export(tmp_path)
+    written = json.loads(Path(paths["chains"]).read_text())
+    assert written["agents_made"] == 3
+    assert written["root"] == "r"
+    assert written["events"] == [] and written["open_questions"] == []
 
 
 async def test_stream_buffer_chunk_refuses_non_finite(tmp_path):

--- a/tests/test_durable_json_non_finite.py
+++ b/tests/test_durable_json_non_finite.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Every durable JSON file lionagi writes refuses a non-finite float.
+
+A NaN or an Infinity has no JSON representation. The stdlib writes the tokens
+``NaN``/``Infinity``, which Python itself reads back, so the file looks fine to
+the process that produced it and breaks for every strict reader; orjson writes
+``null``, which nothing can tell apart from a value that was genuinely null.
+Either way the loss is durable and invisible where it is created, so each writer
+refuses at the write and names the offending field path.
+
+Each test carries its own positive control: the same writer, a payload holding a
+legitimate ``None`` and ordinary floats, which must still be written and read
+back unchanged. Without it a writer that refused everything would pass.
+"""
+
+import json
+
+import pytest
+
+CONTROL = {"finite": 1.5, "negative": -0.25, "zero": 0.0, "absent": None}
+
+
+def _assert_control_roundtrip(path):
+    """The control payload survived the write byte-for-value."""
+    loaded = json.loads(path.read_text())
+    assert loaded["payload"] == CONTROL
+
+
+def test_run_manifest_writer_refuses_non_finite(tmp_path):
+    from lionagi.cli._runs import _atomic_write_json
+
+    target = tmp_path / "run.json"
+
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.usage\.cost"):
+        _atomic_write_json(target, {"usage": {"cost": float("inf")}})
+    assert not target.exists()
+
+    _atomic_write_json(target, {"payload": CONTROL})
+    _assert_control_roundtrip(target)
+
+
+def test_orchestration_branch_snapshot_refuses_non_finite(tmp_path):
+    from lionagi.cli.orchestrate._orchestration import _write_branch_snapshot
+
+    class _Branch:
+        def __init__(self, dict_):
+            self._dict = dict_
+
+        def to_dict(self):
+            return self._dict
+
+    target = tmp_path / "branch.json"
+
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.metrics\.latency"):
+        _write_branch_snapshot(target, _Branch({"metrics": {"latency": float("nan")}}))
+    assert not target.exists()
+
+    _write_branch_snapshot(target, _Branch({"payload": CONTROL}))
+    _assert_control_roundtrip(target)
+
+
+async def test_flow_checkpoint_refuses_non_finite(tmp_path):
+    from lionagi.cli.orchestrate._checkpoint import CheckpointWriter
+
+    def _writer(ops):
+        return CheckpointWriter(
+            path=tmp_path / "checkpoint.json",
+            session_id="s",
+            prompt="p",
+            plan=[],
+            config={},
+            ops=ops,
+        )
+
+    bad = _writer({"a": {"agent_id": "a", "status": "done", "response": {"score": float("-inf")}}})
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.ops\.a\.response\.score"):
+        await bad.flush()
+    assert not (tmp_path / "checkpoint.json").exists()
+
+    good = _writer({"a": {"agent_id": "a", "status": "done", "response": CONTROL}})
+    await good.flush()
+    written = json.loads((tmp_path / "checkpoint.json").read_text())
+    assert written["ops"]["a"]["response"] == CONTROL
+
+
+def test_team_inbox_refuses_non_finite(tmp_path):
+    from lionagi.cli.team import _locked_team
+
+    target = tmp_path / "team.json"
+
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.messages\[0\]\.weight"):
+        with _locked_team("t", create_path=target) as data:
+            data["messages"] = [{"weight": float("nan")}]
+    # The lock is released and the file left as it was, not truncated.
+    assert target.read_text() == ""
+
+    with _locked_team("t", create_path=target) as data:
+        data["payload"] = CONTROL
+    _assert_control_roundtrip(target)
+
+
+def test_coding_measurements_refuse_non_finite():
+    from lionagi.engines.coding import CodeResultRecorded, CodingRun
+
+    class _Run(CodingRun):
+        def __init__(self, measurements):  # bypass the Engine wiring
+            self.store = {
+                CodeResultRecorded: [
+                    CodeResultRecorded(eid="K1", passed=True, measurements=measurements)
+                ]
+            }
+
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.pass_rate"):
+        _Run({"pass_rate": float("nan")}).to_hypothesis_seeds()
+
+    seeds = _Run(dict(CONTROL)).to_hypothesis_seeds()
+    assert json.loads(seeds[0]["measurements"]) == CONTROL
+
+
+async def test_run_branch_snapshot_refuses_non_finite(tmp_path):
+    from uuid import uuid4
+
+    from lionagi.operations.run.run import _write_branch_snapshot
+
+    class _Branch:
+        def __init__(self, dict_):
+            self.id = uuid4()
+            self._dict = dict_
+
+        def to_dict(self):
+            return self._dict
+
+    bad = _Branch({"usage": {"cost": float("inf")}})
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.usage\.cost"):
+        await _write_branch_snapshot(bad, tmp_path)
+    assert not (tmp_path / f"{bad.id}.json").exists()
+
+    good = _Branch({"payload": CONTROL})
+    await _write_branch_snapshot(good, tmp_path)
+    _assert_control_roundtrip(tmp_path / f"{good.id}.json")
+
+
+async def test_stream_buffer_chunk_refuses_non_finite(tmp_path):
+    from lionagi.operations.run.run import _append_chunk
+
+    class _Chunk:
+        def __init__(self, dict_):
+            self._dict = dict_
+
+        def to_dict(self):
+            return self._dict
+
+    target = tmp_path / "b.jsonl"
+
+    with pytest.raises(ValueError, match=r"non-finite float at \$\.usage\.tokens_per_s"):
+        await _append_chunk(target, _Chunk({"usage": {"tokens_per_s": float("nan")}}))
+    assert not target.exists()
+
+    await _append_chunk(target, _Chunk({"payload": CONTROL}))
+    assert json.loads(target.read_text())["payload"] == CONTROL


### PR DESCRIPTION
Closes #2646.

Durable JSON that lands on the filesystem was written with a bare `json.dumps`, so a non-finite float serialized as the tokens `NaN` / `Infinity` rather than being refused at the write. Python's own `json.load` accepts those by default, so the process that wrote the file reads it back happily; every strict reader rejects them. The corruption is invisible where it is created and surfaces at a boundary, later and to someone else.

## Enumeration first

The issue named two writers and said explicitly they were not claimed to be the complete set. They were not. Nine durable filesystem writers carry open-shaped payloads:

| Writer | Lands in |
| --- | --- |
| the run manifest's atomic writer | `run.json`, artifact index |
| the orchestration finalize snapshot | `branches/{id}.json` |
| the flow checkpoint | `checkpoint.json` |
| the team inbox | `teams/{id}.json` |
| the coding engine's results | `results.json`, plus a nested JSON string inside it |
| the hypothesis engine's chains | `chains.json` |
| the live branch snapshot | `branches/{id}.json` |
| the stream buffer | `stream/{id}.buffer.jsonl` |

Eight are fixed here. The checkpoint, the team inbox and the two engine artifact writers persist exactly the kind of computed number — a rate, a duration, a ratio — that goes non-finite on a division by zero.

Three more durable writers were found and deliberately left alone because their payloads are closed-shape and no float can reach them: the last-branch pointer, the transcript offsets, and the server config handed to a child process. Guarding those would buy nothing and cost a traversal per write. A fourth, the pile's JSONL dump, is already guarded upstream because its records round-trip through a checked serializer.

The ninth open-shaped writer, the job record, is **not** fixed here. Adding the guard reddens five existing tests that construct non-finite start-time values, and settling that is a question about the pid-identity contract rather than about serialization. It is recorded as an open finding rather than papered over.

## The remedy

The detection already existed on the SQL side of this category: a walk that mirrors the encoder's own traversal and returns the *path* of the first offending value. Nothing new was written to detect anything. One function, `raise_if_non_finite`, lifts that raise out of the private dump helper so a caller serializing with something else can use it. There is one detector and one message.

Writers already on the fast serializer got `check_non_finite=True` — no new code path. The stdlib writers got `raise_if_non_finite` immediately before the dump.

Two extractions, purely for testability and with no behaviour change: the branch-snapshot write and the stream-chunk append are now named functions. The chunk append also serializes before opening the file, so a refused chunk no longer leaves a zero-byte buffer behind.

## Why the stdlib writers kept the stdlib

Switching them to the fast serializer would have changed the bytes for every value they write, not only the non-finite ones. Three concrete differences for the shapes these writers actually persist: the stdlib escapes non-ASCII to `\uXXXX` while the other emits raw UTF-8, and these files carry arbitrary user text; four of the writers pass `default=str` and rely on it to stringify whatever turns up, where the other's default hook raises instead; and the stdlib coerces non-string dict keys where the other refuses them without an option set.

Byte-compatibility could not be established, so it is not claimed. Keeping the stdlib leaves the output of every one of those writers unchanged character for character, and the only new behaviour is a refusal that would otherwise have been a corrupt file.

## One conservatism, declared

The walk mirrors the fast encoder's traversal, which is a superset of the stdlib's: it descends into dataclass fields and enum values where the stdlib would have handed the whole object to `default=str`. So a non-finite float buried inside a dataclass is now refused even though the stdlib would have written it as part of a string — lossy, but not a parse error. The check is stricter than the writer in that one direction and never the other: nothing the stdlib would write as a bare token escapes the walk. It is documented on the function.

## Two ordering choices

The team inbox is checked *before* truncate, so a refused write leaves the previous inbox intact rather than emptying it.

The orchestration finalize snapshot sits inside an existing catch-and-continue by design, so at that one call site the guard's effect is a warning and no snapshot rather than a raised error. Still better than a corrupt token on disk, but the caller cannot see it, and that is stated rather than implied.

## Tests

Seven tests, one per fixed writer. Each asserts the refusal **names the field path** — `$.usage.cost`, `$.ops.a.response.score`, `$.messages[0].weight` — not merely that an exception was raised. Each carries its positive control in the same test: the same writer, a payload with a legitimate `None` alongside ordinary floats, written and read back equal. Most also assert the target file does not exist after a refusal.

Mutations run to prove they discriminate: neutering the detector reddens the stdlib-writer tests; replacing the located path with a constant while leaving the exception type and prefix intact reddens **all** of them, which is what proves no test would pass against a serializer that refuses everything without saying what it refused; turning off the keyword on the two fast-serializer writers reddens exactly those two.

## Adjacent, out of scope

Several call sites hand-roll a dump into a SQLite text column, bypassing the checked path that closed the SQL side of this category. Same defect class, database destination rather than filesystem, so outside this change — but recorded, because the SQL remedy does not in fact cover them.
