### PR TITLE
fix(cli): report the dependencies the run has, not the ones it was asked for

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -477,6 +477,46 @@ class _ExecResult:
 # ── Phase 1: build DAG ────────────────────────────────────────────────────────
 
 
+def _deps_from_built_graph(builder, label_by_node: dict[str, str]) -> dict[str, list[str]]:
+    """Read each node's incoming edges out of the graph the executor walks.
+
+    A dependency list re-derived from what the planner declared is a statement
+    about the *input* to the build step, not an observation of its *output*:
+    the builder can add or omit edges, the executor waits on every incoming
+    edge whatever its label, and nothing downstream would notice the two
+    disagreeing. Reading the graph makes the reported structure and the
+    executed one the same object.
+
+    `label_by_node` names the nodes a reader already has a name for — plan
+    steps, by their 1-based ordinal, matching how deps have always been shown.
+    A head outside it is a node that has no plan ordinal because it did not
+    exist at plan time; it is named by the spawn id stamped on it (the same id
+    its own result record carries), falling back to the raw node id so an edge
+    is never dropped for want of a name.
+    """
+    graph = builder.get_graph()
+    nodes = getattr(graph, "internal_nodes", None)
+    mapping = getattr(graph, "node_edge_mapping", None) or {}
+
+    def _name(head_id: str) -> str:
+        known = label_by_node.get(head_id)
+        if known is not None:
+            return known
+        node = nodes.get(head_id) if nodes is not None else None
+        stamped = node.metadata.get("spawn_id") if node is not None else None
+        return stamped or head_id
+
+    deps: dict[str, list[str]] = {}
+    for node_id, slots in mapping.items():
+        names: list[str] = []
+        for head_id in (slots.get("in") or {}).values():
+            name = _name(str(head_id))
+            if name not in names:
+                names.append(name)
+        deps[str(node_id)] = names
+    return deps
+
+
 async def _build_dag(
     env: OrchestrationEnv,
     prompt: str,
@@ -588,8 +628,13 @@ async def _build_dag(
         node_ids.append(node)
 
     known_nodes = set(node_ids)
+    # Observed from the graph just built, not re-derived from the plan that
+    # asked for it — see _deps_from_built_graph.
+    graph_deps = _deps_from_built_graph(
+        env.builder, {str(node_ids[i]): str(i + 1) for i in range(len(assignments))}
+    )
     deps_by_node = {
-        node_ids[i]: [str(j + 1) for j in dep_indices[i]] for i in range(len(assignments))
+        node_ids[i]: graph_deps.get(str(node_ids[i]), []) for i in range(len(assignments))
     }
 
     # Early DAG snapshot for Studio.
@@ -603,7 +648,7 @@ async def _build_dag(
                 "id": agent_ids[i],
                 "agent_id": agent_ids[i],
                 "control": False,
-                "depends_on": [str(j + 1) for j in dep_indices[i]],
+                "depends_on": deps_by_node[node_ids[i]],
             }
             for i in range(len(assignments))
         ],
@@ -1303,6 +1348,13 @@ async def _execute_dag(
     # below without this — makes it loud at teardown. Spawned nodes aren't
     # in node_ids/agent_ids (fixed-size, plan-time only), so checked separately.
     graph_nodes = getattr(env.builder.get_graph(), "internal_nodes", {}) or {}
+    # Re-read the edges now that the run is over: the durable record and the
+    # Studio DAG outlive the terminal, so they get the final graph rather than
+    # the plan-time one. Nodes absent from the graph (never built) keep their
+    # plan-time entry — there is nothing to observe for them.
+    final_deps = _deps_from_built_graph(
+        env.builder, {str(node_ids[i]): str(i + 1) for i in range(len(assignments))}
+    )
     escalated_op_ids = {str(x) for x in dag_result.get("escalated_operations", [])}
     escalated_evidence = [
         {"kind": "escalated_operation", "id": agent_ids[i], "label": assignments[i].assignee}
@@ -1343,7 +1395,7 @@ async def _execute_dag(
                 "agent_id": agent_ids[i],
                 "name": agent_ids[i],
                 "model": worker_models[i],
-                "depends_on": deps_by_node[nid],
+                "depends_on": final_deps.get(str(nid), deps_by_node[nid]),
                 "spawned": False,
                 "response": str(res) if res is not None else "(no response)",
                 "time_ms": t_exec_elapsed * 1000,
@@ -1411,7 +1463,9 @@ async def _execute_dag(
                 "name": assignee or "spawned",
                 "model": spawn_model,
                 "assignee": assignee,
-                "depends_on": [],
+                # A node injected mid-run has real predecessors; read them off
+                # the graph like every other node rather than reporting none.
+                "depends_on": final_deps.get(str(nid), []),
                 "spawned": True,
                 "response": str(res) if res is not None else "(no response)",
                 "time_ms": t_exec_elapsed * 1000,
@@ -2148,10 +2202,21 @@ async def _run_flow_inner(
     for i, ta in enumerate(assignments):
         deps = f" ← {','.join(str(j + 1) for j in dep_indices[i])}" if dep_indices[i] else ""
         dag_lines.append(f"{i + 1}:{ta.assignee}{deps}")
-    progress(f"Plan done ({t_plan:.1f}s): {len(assignments)} assignments — {' | '.join(dag_lines)}")
+    # Says "as declared" because that is all it can say: no node exists yet for
+    # any of these assignments, so this line is the planner's input to the build
+    # and not an observation of the graph that will run.
+    progress(
+        f"Plan done ({t_plan:.1f}s): {len(assignments)} assignments, dependencies as declared "
+        f"by the planner (the run graph is not built yet) — {' | '.join(dag_lines)}"
+    )
 
     if dry_run:
-        lines = [f"Plan ({len(assignments)} assignments):", ""]
+        lines = [
+            f"Plan ({len(assignments)} assignments):",
+            "Dependencies below are the ones the planner declared. A dry run builds no run",
+            "graph, so nothing here has been checked against the structure that would run.",
+            "",
+        ]
         for i, ta in enumerate(assignments):
             deps = (
                 f"  depends_on: {', '.join(str(j + 1) for j in dep_indices[i])}"

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -16,6 +16,7 @@ from lionagi.casts.emission import TaskAssignment
 from lionagi.cli.orchestrate.flow import (
     _build_dag,
     _DagState,
+    _deps_from_built_graph,
     _ExecResult,
     _execute_dag,
     _finalize_flow,
@@ -133,13 +134,35 @@ class _FakeSession:
 
 
 class _FakeBuilder:
+    """Stub that keeps the real builder's edge semantics: an explicit list of
+    dependencies makes exactly those edges, `None` chains onto the current
+    heads. Callers that want a graph disagreeing with the plan can drive that
+    through `add_operation` and read it back off `get_graph()`.
+    """
+
     def __init__(self):
         self._nodes: list[str] = []
         self._ops: list[dict] = []
+        self._mapping: dict[str, dict] = {}
+        self._graph_nodes: dict[str, SimpleNamespace] = {}
+        self._heads: list[str] = []
+        self._edges = 0
 
-    def add_operation(self, op_type, *, branch, depends_on=None, instruction="", context=None):
+    def add_operation(
+        self, op_type, *, branch, depends_on=None, instruction="", context=None, **kwargs
+    ):
         node_id = f"node-{len(self._nodes)}"
         self._nodes.append(node_id)
+        self._mapping[node_id] = {"in": {}, "out": {}}
+        self._graph_nodes[node_id] = SimpleNamespace(id=node_id, metadata={})
+        heads = list(depends_on) if depends_on is not None else list(self._heads)
+        for head_id in heads:
+            if head_id in self._mapping:
+                self._edges += 1
+                edge_id = f"edge-{self._edges}"
+                self._mapping[head_id]["out"][edge_id] = node_id
+                self._mapping[node_id]["in"][edge_id] = head_id
+        self._heads = [node_id]
         self._ops.append(
             {
                 "id": node_id,
@@ -151,7 +174,13 @@ class _FakeBuilder:
         return node_id
 
     def get_graph(self):
-        return SimpleNamespace(nodes=list(self._nodes))
+        return SimpleNamespace(
+            nodes=list(self._nodes),
+            internal_nodes=dict(self._graph_nodes),
+            node_edge_mapping={
+                k: {"in": dict(v["in"]), "out": dict(v["out"])} for k, v in self._mapping.items()
+            },
+        )
 
 
 class _FakeDB:
@@ -242,6 +271,99 @@ async def test_build_dag_deps_by_node_format(tmp_path):
     nid0, nid1 = dag_state.node_ids
     assert dag_state.deps_by_node[nid0] == []
     assert dag_state.deps_by_node[nid1] == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_build_dag_deps_follow_the_built_graph_not_the_declared_plan(tmp_path):
+    """The reported dependencies are the edges that exist, not the ones asked for.
+
+    Four assignments wired so the declared plan and the built graph disagree in
+    both directions: step 2 is built exactly as declared and must still come out
+    right, step 3 loses a declared dependency, step 4 gains one no assignment
+    ever declared. Re-deriving from the plan would give [], ["1"], ["1", "2"], []
+    — three of the four wrong.
+    """
+    from lionagi.cli.orchestrate._common import _build_worker_operate_node as _real_build
+    from lionagi.operations.builder import OperationGraphBuilder
+
+    env = _make_env(tmp_path)
+    env.builder = OperationGraphBuilder()
+
+    assignments = [
+        TaskAssignment(task="a", assignee="researcher"),
+        TaskAssignment(task="b", assignee="architect", depends_on=["1"]),
+        TaskAssignment(task="c", assignee="implementer", depends_on=["1", "2"]),
+        TaskAssignment(task="d", assignee="critic"),
+    ]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher", "architect", "implementer", "critic"],
+        dep_indices=[[], [0], [0, 1], []],
+        pool=[],
+        budget_preambles={},
+    )
+
+    built: list[str] = []
+
+    def _diverging_build(builder, **kwargs):
+        step = len(built)
+        deps = kwargs.pop("depends_on")
+        if step == 2:
+            deps = [built[1]]  # declared on steps 1 and 2; only 2 gets built
+        elif step == 3:
+            deps = [built[0]]  # declared nothing; built onto step 1 anyway
+        node_id = _real_build(builder, depends_on=deps, **kwargs)
+        built.append(node_id)
+        return node_id
+
+    with (
+        patch(
+            "lionagi.cli.orchestrate.flow.build_worker_branch",
+            return_value=(_FakeBranch(), "codex/gpt-5.5", None, False),
+        ),
+        patch("lionagi.cli.orchestrate.flow._build_worker_operate_node", _diverging_build),
+    ):
+        dag_state = await _build_dag(env, "task", plan_result, reactive_spec="off")
+
+    nid0, nid1, nid2, nid3 = dag_state.node_ids
+    assert dag_state.deps_by_node[nid0] == []
+    assert dag_state.deps_by_node[nid1] == ["1"]  # declared and built agree
+    assert dag_state.deps_by_node[nid2] == ["2"]  # the plan says ["1", "2"]
+    assert dag_state.deps_by_node[nid3] == ["1"]  # the plan says []
+
+    # The Studio snapshot is rendered from the same reading, not a second one.
+    assert [op["depends_on"] for op in env._finalize_extras["operations"]] == [
+        [],
+        ["1"],
+        ["2"],
+        ["1"],
+    ]
+
+
+def test_deps_from_built_graph_names_a_head_that_has_no_plan_ordinal():
+    """A node injected after planning is named by its stamped spawn id."""
+    builder = _FakeBuilder()
+    planned = builder.add_operation("operate", branch=None, depends_on=[])
+    injected = builder.add_operation("operate", branch=None, depends_on=[planned])
+    child = builder.add_operation("operate", branch=None, depends_on=[injected])
+    builder._graph_nodes[injected].metadata["spawn_id"] = "spawn-1"
+
+    deps = _deps_from_built_graph(builder, {planned: "1"})
+
+    assert deps[planned] == []
+    assert deps[injected] == ["1"]
+    assert deps[child] == ["spawn-1"]
+
+
+def test_deps_from_built_graph_keeps_an_unnamed_head_rather_than_dropping_it():
+    """No ordinal and no spawn id: report the node id, never an empty list."""
+    builder = _FakeBuilder()
+    unnamed = builder.add_operation("operate", branch=None, depends_on=[])
+    child = builder.add_operation("operate", branch=None, depends_on=[unnamed])
+
+    deps = _deps_from_built_graph(builder, {})
+
+    assert deps[child] == [unnamed]
 
 
 @pytest.mark.asyncio

--- a/tests/cli/orchestrate/test_flow_planning.py
+++ b/tests/cli/orchestrate/test_flow_planning.py
@@ -14,6 +14,7 @@ from lionagi._errors import EmptyOutgoingContentError
 from lionagi.casts.emission import TaskAssignment
 from lionagi.cli._providers import AgentProfile
 from lionagi.cli.orchestrate import _orchestration as orch
+from lionagi.cli.orchestrate import flow as flow_module
 from lionagi.cli.orchestrate.flow import FlowPlanError, _parse_reactive, _run_flow_inner
 
 
@@ -207,6 +208,39 @@ async def test_dry_run_lists_assignments_with_deps(tmp_path):
     assert "researcher" in out and "architect" in out
     assert "depends_on: 1" in out
     assert len(orc.operate_calls) == 1  # no retry needed
+
+
+@pytest.mark.asyncio
+async def test_plan_output_says_the_dependencies_are_only_declared(tmp_path, monkeypatch):
+    """Both plan-time surfaces have to say they describe the plan, not the run.
+
+    Neither can do better: the progress line is printed while the assignments
+    are still only assignments, and a dry run never builds a graph at all. This
+    assertion pins wording rather than behaviour — it is weak on purpose, and
+    its only job is to stop the qualifier being dropped without anyone noticing.
+    """
+    messages: list[str] = []
+    monkeypatch.setattr(flow_module, "progress", messages.append)
+
+    orc = _FakeOrcBranch(
+        [
+            SimpleNamespace(
+                assignments=[
+                    TaskAssignment(task="survey prior art", assignee="researcher"),
+                    TaskAssignment(task="design on 1", assignee="architect", depends_on=["1"]),
+                ]
+            )
+        ]
+    )
+    out = await _run_flow_inner("codex/gpt-5.5", "task", env=_env(tmp_path, orc), dry_run=True)
+
+    plan_done = [m for m in messages if m.startswith("Plan done")]
+    assert len(plan_done) == 1
+    assert "as declared by the planner" in plan_done[0]
+    assert "not built yet" in plan_done[0]
+
+    assert "the planner declared" in out
+    assert "builds no run" in out
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2648

The per-agent result record and the early Studio DAG snapshot both re-derived a
node's dependencies from the planner's declared indices. That describes the input
to the graph build rather than its output. `OperationGraphBuilder.add_operation`
attaches `sequential` edges when `depends_on` is `None` and `depends_on` edges when
it is a list, the executor waits on every incoming edge whatever its label, and
nothing downstream compared the two. A run could wait on an edge the summary never
showed, or show one the run did not have.

Both surfaces now read the incoming edges off the built graph, so the reported
structure and the executed one are the same object. The reading happens twice: once
at the end of the build, feeding the Studio snapshot, and once when results are
collected, feeding the durable record — the record outlives the terminal and should
carry the graph as it finished, not as it started.

A node injected mid-run has no plan ordinal. It is named by the `spawn_id` its own
result record already carries, falling back to the raw node id, so an edge is never
dropped for want of a name. Reactively spawned nodes previously recorded
`"depends_on": []` unconditionally, which asserted "no dependencies" about nodes
that have at least one by definition; they now report their real predecessors.

The two plan-time surfaces have no graph to read — the "Plan done" progress line
prints before any node exists, and `--dry-run` builds no graph at all. Rather than
inventing one, both now say plainly that they describe the plan as declared.

## Tests

`test_build_dag_deps_follow_the_built_graph_not_the_declared_plan` drives four
assignments through the real `OperationGraphBuilder` with the build step patched so
the graph deliberately disagrees with the plan in both directions: one step loses a
declared dependency, another gains one nobody declared, and one is built exactly as
declared as a positive control. A plan-derived rendering gets three of the four
wrong.

Reverting only the graph-reading line and re-running the suite fails exactly that
test (`1 failed, 544 passed`), at the intended assertion, with the positive control
still passing. Restored, the full `tests/cli/orchestrate/` suite is `545 passed`.

Two helper-level tests cover the naming of a head with no plan ordinal and the
refusal to drop an unnameable head. The annotation test pins strings and can only
turn a deleted qualifier into a red test; it is not evidence the wording is right.

Not covered: a genuinely reactive spawn flowing end to end through `_execute_dag`
and emerging with graph-derived dependencies. The naming is covered at the helper
level; the wiring into the spawned record is covered by inspection only.
