### PR TITLE
fix(mcp): a lock release no longer answers for the failure underneath it

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -558,9 +558,12 @@ def _locked_job(run_id: str) -> Iterator[_GuardedJob]:
         # obvious repair is worse than the problem: by the time a retry ran the
         # runtime may have handed that number to something else, so it would
         # close a file belonging to whatever got it next. What bounds the damage
-        # is not this block but the lock itself — an advisory lock lives with
-        # the open file description, so the worst case lasts as long as this
-        # process and goes when it exits.
+        # is not this block but the lock itself: both of the platform locks this
+        # module takes are held by way of the descriptor rather than recorded
+        # anywhere outside the process, so the worst case lasts as long as this
+        # process and goes when it exits. The two mechanisms are not the same
+        # one and the bound is what they agree on, so the bound is what gets
+        # stated here.
         try:
             with contextlib.suppress(OSError):
                 _unlock_fd(fd)

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -521,7 +521,14 @@ def _locked_job(run_id: str) -> Iterator[_GuardedJob]:
     try:
         _lock_fd(fd)
     except OSError:
-        os.close(fd)
+        # Giving the descriptor back is tidying up after a lock that was not
+        # taken, and tidying up does not get to answer for it. A close that
+        # fails here would leave this function raising out of a context manager
+        # whose whole contract, stated above, is that it yields a state instead
+        # — and it would report the wrong fact besides: the caller needs to know
+        # the section was not entered, not which descriptor could not be closed.
+        with contextlib.suppress(OSError):
+            os.close(fd)
         yield _GuardedJob(None, LOCK_UNAVAILABLE)
         return
     try:
@@ -532,8 +539,24 @@ def _locked_job(run_id: str) -> Iterator[_GuardedJob]:
         if guard.record is not None and guard.record != before:
             _write_job(guard.record)
     finally:
-        _unlock_fd(fd)
-        os.close(fd)
+        # Two releases that both have to happen, neither of them entitled to
+        # speak for the body. The body is where the failures a caller acts on
+        # come from — a refused record, a write that would not serialize — and a
+        # release that fails is worth less than any of them. So a refusal to
+        # release is suppressed, and the close still runs even when the unlock
+        # did not, because a lock left held is a worse outcome than either.
+        #
+        # Only what a refusal looks like, though. An interrupt or an exit
+        # arriving while the release runs is not the release failing, it is
+        # someone asking for the process to stop, and it goes on through — the
+        # nested block is what keeps that from leaking the descriptor on its way
+        # out.
+        try:
+            with contextlib.suppress(OSError):
+                _unlock_fd(fd)
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(fd)
 
 
 def _short_repr(value: Any, limit: int = 60) -> str:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -558,12 +558,11 @@ def _locked_job(run_id: str) -> Iterator[_GuardedJob]:
         # obvious repair is worse than the problem: by the time a retry ran the
         # runtime may have handed that number to something else, so it would
         # close a file belonging to whatever got it next. What bounds the damage
-        # is not this block but the lock itself: both of the platform locks this
-        # module takes are held by way of the descriptor rather than recorded
-        # anywhere outside the process, so the worst case lasts as long as this
-        # process and goes when it exits. The two mechanisms are not the same
-        # one and the bound is what they agree on, so the bound is what gets
-        # stated here.
+        # is not this block but the lock itself: if either platform lock is
+        # still held once cleanup has failed, process exit ends it. That ceiling
+        # is the whole of the claim. The two locks arrive at it by different
+        # routes and neither route is described here, because a description that
+        # fits one of them does not fit the other.
         try:
             with contextlib.suppress(OSError):
                 _unlock_fd(fd)

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -539,18 +539,28 @@ def _locked_job(run_id: str) -> Iterator[_GuardedJob]:
         if guard.record is not None and guard.record != before:
             _write_job(guard.record)
     finally:
-        # Two releases that both have to happen, neither of them entitled to
-        # speak for the body. The body is where the failures a caller acts on
+        # Two releases that both have to be attempted, neither of them entitled
+        # to speak for the body. The body is where the failures a caller acts on
         # come from — a refused record, a write that would not serialize — and a
         # release that fails is worth less than any of them. So a refusal to
-        # release is suppressed, and the close still runs even when the unlock
-        # did not, because a lock left held is a worse outcome than either.
+        # release is suppressed, and the close is still attempted when the
+        # unlock did not happen, because a lock nobody released is a worse
+        # outcome than either.
         #
         # Only what a refusal looks like, though. An interrupt or an exit
         # arriving while the release runs is not the release failing, it is
         # someone asking for the process to stop, and it goes on through — the
-        # nested block is what keeps that from leaking the descriptor on its way
-        # out.
+        # nested block is what keeps the close attempt on its way out.
+        #
+        # Attempted is the honest word for the close, and the reason it is not
+        # stronger is that nothing here can make it stronger. Whether a close
+        # that fails released the descriptor anyway is unspecified, and the
+        # obvious repair is worse than the problem: by the time a retry ran the
+        # runtime may have handed that number to something else, so it would
+        # close a file belonging to whatever got it next. What bounds the damage
+        # is not this block but the lock itself — an advisory lock lives with
+        # the open file description, so the worst case lasts as long as this
+        # process and goes when it exits.
         try:
             with contextlib.suppress(OSError):
                 _unlock_fd(fd)

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3086,3 +3086,111 @@ def test_discarding_a_reservation_refuses_a_directory_holding_anything_else(sand
     jobs._discard_reservation(d)
 
     assert (d / "console.log").read_bytes() == b"a run wrote this\n"
+
+
+def test_a_lock_that_cannot_be_taken_says_so_even_when_the_descriptor_will_not_close(
+    sandbox, monkeypatch
+):
+    """Failing to acquire the lock is a state, and tidying up cannot turn it into a raise.
+
+    Failing to create the lock file and failing to acquire it are the same fact —
+    this section was not entered — and both are reported as a state rather than
+    escaping a context manager whose contract is that it yields. Handing the
+    descriptor back is tidying up after that fact, so a close that refuses must
+    not become the answer: it is worth less than the fact underneath it, and it
+    would leave every caller of this receiving an exception where the contract
+    promises a state.
+    """
+    run_id = "20260101T000000-aaa111"
+    (config.JOBS_DIR / run_id).mkdir(parents=True)
+
+    taken = {}
+    real_close = os.close
+
+    def refuse_the_lock(fd):
+        taken["fd"] = fd
+        raise OSError(errno.EAGAIN, "Resource temporarily unavailable")
+
+    def refuse_to_close(fd):
+        if fd == taken.get("fd"):
+            real_close(fd)
+            raise OSError(errno.EBADF, "Bad file descriptor")
+        return real_close(fd)
+
+    monkeypatch.setattr(jobs, "_lock_fd", refuse_the_lock)
+    monkeypatch.setattr(os, "close", refuse_to_close)
+
+    with jobs._locked_job(run_id) as guard:
+        assert guard.record is None
+        assert guard.state == jobs.LOCK_UNAVAILABLE
+
+
+def test_releasing_the_lock_does_not_answer_in_place_of_what_the_body_raised(sandbox, monkeypatch):
+    """The body is where the failures a caller acts on come from.
+
+    A record that will not serialize, a write the filesystem refuses — those
+    reach a caller through this section, and a release that fails on the way out
+    is worth less than any of them. The release also runs on every exit, so an
+    unguarded one puts itself in front of every failure the section can produce
+    rather than in front of some rare one.
+    """
+    run_id = "20260101T000000-bbb222"
+    (config.JOBS_DIR / run_id).mkdir(parents=True)
+    jobs._write_job({"run_id": run_id, "kind": "agent", "status": "running"})
+
+    def refuse_to_release(fd):
+        raise OSError(errno.EBADF, "Bad file descriptor")
+
+    monkeypatch.setattr(jobs, "_unlock_fd", refuse_to_release)
+
+    # The body's ValueError, not the release's OSError.
+    with pytest.raises(ValueError, match="what the caller needs to see"):
+        with jobs._locked_job(run_id) as guard:
+            assert guard.record is not None
+            raise ValueError("what the caller needs to see")
+
+
+def test_an_interrupt_arriving_during_release_is_not_swallowed_and_still_closes(
+    sandbox, monkeypatch
+):
+    """Being asked to stop is not a release refusing, and neither costs the descriptor.
+
+    The release is allowed to fail without answering for the body, but only for
+    what a filesystem refusal looks like. An interrupt delivered while it runs is
+    a request for the process to stop, and cleanup that absorbs it loses the
+    request entirely. The descriptor is closed on that way out too — a lock left
+    held is a worse outcome than either failure, and it is the one that outlives
+    the process that hit it.
+    """
+    run_id = "20260101T000000-ccc333"
+    (config.JOBS_DIR / run_id).mkdir(parents=True)
+    jobs._write_job({"run_id": run_id, "kind": "agent", "status": "running"})
+
+    taken = {}
+    closed = []
+    real_lock = jobs._lock_fd
+    real_close = os.close
+
+    def remember_the_fd(fd):
+        taken["fd"] = fd
+        return real_lock(fd)
+
+    def stop_during_release(fd):
+        raise KeyboardInterrupt
+
+    def record_close(fd):
+        if fd == taken.get("fd"):
+            closed.append(fd)
+        return real_close(fd)
+
+    monkeypatch.setattr(jobs, "_lock_fd", remember_the_fd)
+    monkeypatch.setattr(jobs, "_unlock_fd", stop_during_release)
+    monkeypatch.setattr(os, "close", record_close)
+
+    # The interrupt, not the ValueError it arrived on top of.
+    with pytest.raises(KeyboardInterrupt):
+        with jobs._locked_job(run_id) as guard:
+            assert guard.record is not None
+            raise ValueError("the failure the interrupt arrived during")
+
+    assert closed == [taken["fd"]]

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3161,10 +3161,10 @@ def test_an_interrupt_arriving_during_release_is_not_swallowed_and_still_closes(
     request entirely.
 
     The close is still attempted on that way out, which is what this asserts: a
-    lock nobody released is worse than either failure, and it stays held for the
-    rest of this process's life: the lock is held by way of the descriptor on
-    every platform this module locks on, so it goes when the process exits and
-    not before. Attempted is
+    lock nobody released is worse than either failure, and process exit is the
+    only thing that puts a ceiling on how long it stays held. A ceiling is not a
+    schedule — the close attempted right here takes the lock down earlier every
+    time it succeeds, which is the whole reason for attempting it. Attempted is
     all that can be asserted, here or anywhere: a close that raises may or may
     not have released the descriptor, and there is no second call that could
     settle it safely.

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3162,8 +3162,9 @@ def test_an_interrupt_arriving_during_release_is_not_swallowed_and_still_closes(
 
     The close is still attempted on that way out, which is what this asserts: a
     lock nobody released is worse than either failure, and it stays held for the
-    rest of this process's life — an advisory lock lives with the open file
-    description, so it goes when the process exits and not before. Attempted is
+    rest of this process's life: the lock is held by way of the descriptor on
+    every platform this module locks on, so it goes when the process exits and
+    not before. Attempted is
     all that can be asserted, here or anywhere: a close that raises may or may
     not have released the descriptor, and there is no second call that could
     settle it safely.

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3153,14 +3153,20 @@ def test_releasing_the_lock_does_not_answer_in_place_of_what_the_body_raised(san
 def test_an_interrupt_arriving_during_release_is_not_swallowed_and_still_closes(
     sandbox, monkeypatch
 ):
-    """Being asked to stop is not a release refusing, and neither costs the descriptor.
+    """Being asked to stop is not a release refusing, and the close is tried anyway.
 
     The release is allowed to fail without answering for the body, but only for
     what a filesystem refusal looks like. An interrupt delivered while it runs is
     a request for the process to stop, and cleanup that absorbs it loses the
-    request entirely. The descriptor is closed on that way out too — a lock left
-    held is a worse outcome than either failure, and it is the one that outlives
-    the process that hit it.
+    request entirely.
+
+    The close is still attempted on that way out, which is what this asserts: a
+    lock nobody released is worse than either failure, and it stays held for the
+    rest of this process's life — an advisory lock lives with the open file
+    description, so it goes when the process exits and not before. Attempted is
+    all that can be asserted, here or anywhere: a close that raises may or may
+    not have released the descriptor, and there is no second call that could
+    settle it safely.
     """
     run_id = "20260101T000000-ccc333"
     (config.JOBS_DIR / run_id).mkdir(parents=True)


### PR DESCRIPTION
Closes #2663.

`_locked_job()` guards the read-modify-write cycle for one run's record. Two
cleanup boundaries in it could each answer in place of the failure they existed
to tidy up after.

**Handing back a descriptor whose lock could not be taken.** After acquiring an
fd and failing to lock it, the `os.close(fd)` that releases the descriptor was
unguarded. A close that raises turns a state this function promises to yield
into an exception escaping it — and the contract is stated in the function's own
docstring: failing to create the lock file and failing to acquire it are the
same fact, this section was not entered, and both are reported as a state rather
than one of them escaping a context manager whose contract is that it yields. It
also reports the wrong fact: a caller needs to know the section was not entered,
not which descriptor could not be closed.

**The finalizer.** `_unlock_fd(fd)` followed by `os.close(fd)` runs on every exit
from a successfully locked section, so an unguarded failure there sits in front
of *every* failure the section can produce rather than some rare one. The body is
where the failures a caller acts on come from — a record that will not
serialize, a write the filesystem refuses — and a release that fails on the way
out is worth less than any of them. A failing unlock also skipped the close,
leaving the descriptor open.

Both now suppress what a filesystem refusal actually looks like and nothing
wider, which is the rule this module already states elsewhere. A cancellation
delivered *while* a release runs is a request for the process to stop rather
than a release failing, so it goes on through; the close still runs on that way
out, because a lock left held outlives the process that hit it.

### Tests

Three added, each verified to fail against the unfixed code and to discriminate
under mutation. Selection was by node id rather than by keyword after `-k lock`
was found to also match `..._blocks_the_cleanup`.

| Mutation | Tests that redden |
|---|---|
| un-guard the failed-lock close | the failed-lock test, alone |
| revert the finalizer to the bare two calls | the body-failure test and the cancellation test |
| widen the unlock's suppression to `BaseException` | the cancellation test, alone |

The last row is the one worth keeping: it is what stops the cure for the second
defect from becoming "swallow anything the finalizer raises". Each mutation was
checked to have actually applied before its result was read — an edit that
matches nothing leaves every test passing, which reads identically to a test
that does not discriminate.

`tests/mcp/ tests/test_durable_json_non_finite.py`: 761 passed.


---

### Correction to an earlier commit message in this branch

The first commit's message says a lock left held "outlives the process that hit
it". That is wrong and the later commits in this branch correct it. `flock` and
`msvcrt.locking` are both released when the descriptor closes or the process
ends, so process exit is a ceiling on how long an unreleased lock can be held,
not a floor — and a close that succeeds takes it down sooner.

The commit message is left as written rather than rewritten, so this note is
here for anyone reading the branch's individual commits. The squash message
carries the corrected statement.
