### PR TITLE
fix(cli): a resolved MCP server set reaches every CLI provider that can carry one

### DIFF
--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -593,6 +593,16 @@ propertyNames) deny by default for executor-signaling tools instead of admitting
   `mcp_config` would raise `ValidationError` on the very next turn. An explicit
   `spec.mcp_servers=[]` with no resolvable config file still forwards `{}` (forcing zero MCP
   servers) rather than leaving the CLI to fall back to its own discovery.
+- `apply_forwarded_mcp_servers()` — the transport application itself, on a plain kwargs dict:
+  `_forward_mcp_to_cli_request` resolves a config file and filters it, then delegates here, and
+  so do the three CLI spawn paths that resolve a set of their own (`build_chat_model` for a
+  plain `li agent` leg, the resume path in `cli/agent.py`, and `_hand_mcp_servers` for every
+  flow/fanout worker). One function so that "can this provider be given a set?" has one answer
+  — `provider_accepts_forwarded_mcp` — instead of each site re-deriving it from a provider
+  name. Codex takes the set as `-c mcp_servers.<name>.<field>` overrides, with `env` and
+  `http_headers` (possible secrets) routed to a 0600 profile file instead of argv. `exclusive`
+  says the set is the whole set: the Claude lane adds `strict_mcp_config`, codex disables every
+  server it would otherwise load by name, since `-c mcp_servers={}` merges rather than replaces.
 - Mutating `chat_model.endpoint.config.kwargs` in place would corrupt any other Branch sharing
   the same iModel instance (Branch keeps a caller-supplied chat_model by reference, not copy).
   The fix copies chat_model before mutating, sharing `share_session`/`share_executor` with the

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from typing import TYPE_CHECKING, Any
 
 from lionagi._errors import ConfigurationError
 from lionagi.ln import Unset
 from lionagi.ln.concurrency import is_coro_func
 from lionagi.ln.types import UnsetType
+from lionagi.service.providers import _CLAUDE_PROVIDER_NAMES
 from lionagi.session.branch import Branch
 
 from .spec import AgentSpec
@@ -605,35 +606,37 @@ async def _load_mcp(
                 _attach_hooks(tool, spec, tool_name)
 
 
-_MCP_FORWARDING_PROVIDERS = frozenset({"claude_code", "codex"})
+_MCP_FORWARDING_PROVIDERS = frozenset({*_CLAUDE_PROVIDER_NAMES, "codex"})
 
 
 def provider_accepts_forwarded_mcp(provider: str | None) -> bool:
     """Whether a provider's request can carry an MCP server set resolved by the caller.
 
-    One answer for a capability with two transports: claude_code takes the set
-    as a request kwarg, codex takes it as `-c mcp_servers.<name>.<field>`
-    overrides. Both are implemented in ``_forward_mcp_to_cli_request`` below,
+    One answer for a capability with two transports: the Claude CLI takes the
+    set as a request kwarg, codex takes it as `-c mcp_servers.<name>.<field>`
+    overrides. Both are implemented in ``apply_forwarded_mcp_servers`` below,
     which is why the predicate lives here rather than in a second list kept by
-    a caller. It answers what a provider is *capable* of, which is not the same
-    question as whether a given spawn handed anything over — for that, read
-    ``request_carries_forwarded_mcp`` off the request the spawn produced.
+    a caller — every spawn path asks this one function. Each spelling the CLI
+    accepts for the Claude lane counts: which alias a caller typed is not a
+    capability of the provider behind it. It answers what a provider is
+    *capable* of, which is not the same question as whether a given spawn
+    handed anything over — for that, read ``request_carries_forwarded_mcp`` off
+    the request the spawn produced.
     """
     return provider in _MCP_FORWARDING_PROVIDERS
 
 
-def request_carries_forwarded_mcp(branch: Branch) -> bool:
-    """Whether a built CLI request actually carries a forwarded MCP server set.
+def request_kwargs_carry_forwarded_mcp(kwargs: dict[str, Any] | None) -> bool:
+    """Whether CLI request kwargs actually carry a forwarded MCP server set.
 
-    The read counterpart of the writes ``_forward_mcp_to_cli_request`` makes
-    below: the two transports put the set in different places, so a caller that
+    The read counterpart of the writes ``apply_forwarded_mcp_servers`` makes:
+    the two transports put the set in different places, so a caller that
     reports what a leg is getting asks the request that was built rather than
     re-deriving it from the provider name or from what it resolved itself.
     Codex entries that only disable a server by name are not a set being handed
     over, so they do not count.
     """
-    config = getattr(getattr(branch.chat_model, "endpoint", None), "config", None)
-    kwargs = getattr(config, "kwargs", None) or {}
+    kwargs = kwargs or {}
     if kwargs.get("mcp_servers"):
         return True
     overrides = kwargs.get("config_overrides") or {}
@@ -641,6 +644,112 @@ def request_carries_forwarded_mcp(branch: Branch) -> bool:
         key.startswith("mcp_servers.") and not (key.endswith(".enabled") and value is False)
         for key, value in overrides.items()
     )
+
+
+def request_carries_forwarded_mcp(branch: Branch) -> bool:
+    """``request_kwargs_carry_forwarded_mcp`` for a branch's built CLI request."""
+    config = getattr(getattr(branch.chat_model, "endpoint", None), "config", None)
+    return request_kwargs_carry_forwarded_mcp(getattr(config, "kwargs", None))
+
+
+def apply_forwarded_mcp_servers(
+    kwargs: dict[str, Any],
+    servers: dict[str, Any] | None,
+    *,
+    provider: str | None,
+    exclusive: bool = False,
+    allowed_names: Collection[str] | None = None,
+    known_server_names: Collection[str] = (),
+) -> bool:
+    """Write a resolved MCP server set into a CLI request's kwargs.
+
+    Every spawn path that resolves a server set applies it here, so that "can
+    this leg be given a set?" has one answer and one implementation. Returns
+    whether *servers* reached the request: False means this provider has no
+    transport for a caller-resolved set, and the caller is the one who has to
+    say what was lost.
+
+    *exclusive* is the caller stating that *servers* is the whole set rather
+    than an addition to whatever the provider finds for itself. It is what
+    makes an empty set mean "no servers": the Claude CLI needs
+    ``strict_mcp_config``, and codex, which has no wholesale clear, needs each
+    server it would otherwise load disabled by name.
+
+    *allowed_names* is the caller's allowlist when it is wider than the set
+    being forwarded — a name the caller allows but did not itself describe
+    stays enabled rather than being disabled as excluded. *known_server_names*
+    adds names the caller knows the provider may load which ambient discovery
+    would not report. Both only matter under *exclusive*.
+    """
+    if servers is None:
+        return False
+    if not provider_accepts_forwarded_mcp(provider):
+        return False
+
+    if provider in _CLAUDE_PROVIDER_NAMES:
+        kwargs["mcp_servers"] = servers
+        if exclusive:
+            # The handed set alone is merged with whatever the CLI discovers
+            # for itself. The strict flag is what makes it the entire set.
+            kwargs["strict_mcp_config"] = True
+        return True
+
+    # codex: the CLI takes no JSON MCP-config input; each server is forwarded
+    # as `-c mcp_servers.<name>.<field>=<value>` config overrides, which the
+    # request model already serializes onto the command line as TOML. Only
+    # the fields the codex CLI's own McpServerConfig schema understands are
+    # forwarded (verified against the installed codex CLI: `codex mcp list
+    # --json` echoes back exactly this field set); a field outside that set
+    # is a caller mistake, not a value to silently drop, so it's a loud
+    # ConfigurationError. Server shapes lacking both `command` and `url`
+    # aren't a real MCP server transport at all and are skipped outright.
+    overrides = dict(kwargs.get("config_overrides") or {})
+    # `env` and `http_headers` can carry arbitrary secret-bearing literal
+    # values (API keys/tokens, an `Authorization: Bearer ...` header) and
+    # must never land on argv (visible via `ps`, request logs, etc).
+    # `env_http_headers` values are env-var *names*, not secrets -- the
+    # actual header values are resolved by codex from its own environment at
+    # runtime, so those stay on the `-c` override path. Every other
+    # supported field is a name, path, flag, or timeout -- safe as a
+    # `-c` override.
+    secret_fields: dict[str, dict[str, Any]] = {}
+    for server_name, server_cfg in servers.items():
+        if not isinstance(server_cfg, dict) or not ("command" in server_cfg or "url" in server_cfg):
+            continue
+        unsupported = [k for k in server_cfg if k not in _CODEX_MCP_SERVER_FIELDS]
+        if unsupported:
+            raise ConfigurationError(
+                f"MCP server {server_name!r} sets field(s) {unsupported!r} that "
+                "the codex CLI's `-c mcp_servers.<name>.<field>` passthrough "
+                f"does not support. Supported fields: {sorted(_CODEX_MCP_SERVER_FIELDS)!r}."
+            )
+        for field_key in _CODEX_MCP_SERVER_FIELDS:
+            value = server_cfg.get(field_key)
+            if value is None:
+                continue
+            if field_key in _SECRET_CODEX_MCP_FIELDS:
+                secret_fields.setdefault(server_name, {})[field_key] = value
+            else:
+                overrides[f"mcp_servers.{server_name}.{field_key}"] = value
+
+    if exclusive:
+        # codex has no wholesale "clear mcp_servers" override -- `-c
+        # mcp_servers={}` merges onto, rather than replaces, the existing table
+        # (verified against the installed CLI) -- so every server the caller's
+        # set leaves out is disabled by name instead. What codex would load on
+        # its own counts as left out too: an exclusive set enforced only
+        # against names the caller happens to know about leaves every ambient
+        # server enabled, which is the opposite of what it asked for.
+        allowed = set(servers) if allowed_names is None else set(allowed_names)
+        discovered = set(known_server_names) | _discover_ambient_codex_mcp_server_names()
+        for excluded_name in sorted(discovered - allowed):
+            overrides[f"mcp_servers.{excluded_name}.enabled"] = False
+
+    if secret_fields:
+        _write_codex_mcp_secret_profile(kwargs, secret_fields)
+    if overrides:
+        kwargs["config_overrides"] = overrides
+    return True
 
 
 def _forward_mcp_to_cli_request(
@@ -747,69 +856,19 @@ def _forward_mcp_to_cli_request(
     # caller-supplied chat_model by reference, so mutating in place would
     # cross-contaminate other branches sharing the same iModel.
     branch.chat_model = branch.chat_model.copy(share_session=True, share_executor=True)
-    if provider == "claude_code":
-        branch.chat_model.endpoint.config.kwargs["mcp_servers"] = servers
-        return
-
-    # codex: the CLI takes no JSON MCP-config input; each server is forwarded
-    # as `-c mcp_servers.<name>.<field>=<value>` config overrides, which the
-    # request model already serializes onto the command line as TOML. Only
-    # the fields the codex CLI's own McpServerConfig schema understands are
-    # forwarded (verified against the installed codex CLI: `codex mcp list
-    # --json` echoes back exactly this field set); a field outside that set
-    # is a caller mistake, not a value to silently drop, so it's a loud
-    # ConfigurationError. Server shapes lacking both `command` and `url`
-    # aren't a real MCP server transport at all and are skipped outright.
-    overrides = dict(branch.chat_model.endpoint.config.kwargs.get("config_overrides") or {})
-    # `env` and `http_headers` can carry arbitrary secret-bearing literal
-    # values (API keys/tokens, an `Authorization: Bearer ...` header) and
-    # must never land on argv (visible via `ps`, request logs, etc).
-    # `env_http_headers` values are env-var *names*, not secrets -- the
-    # actual header values are resolved by codex from its own environment at
-    # runtime, so those stay on the `-c` override path. Every other
-    # supported field is a name, path, flag, or timeout -- safe as a
-    # `-c` override.
-    secret_fields: dict[str, dict[str, Any]] = {}
-    for server_name, server_cfg in servers.items():
-        if not isinstance(server_cfg, dict) or not ("command" in server_cfg or "url" in server_cfg):
-            continue
-        unsupported = [k for k in server_cfg if k not in _CODEX_MCP_SERVER_FIELDS]
-        if unsupported:
-            raise ConfigurationError(
-                f"MCP server {server_name!r} sets field(s) {unsupported!r} that "
-                "the codex CLI's `-c mcp_servers.<name>.<field>` passthrough "
-                f"does not support. Supported fields: {sorted(_CODEX_MCP_SERVER_FIELDS)!r}."
-            )
-        for field_key in _CODEX_MCP_SERVER_FIELDS:
-            value = server_cfg.get(field_key)
-            if value is None:
-                continue
-            if field_key in _SECRET_CODEX_MCP_FIELDS:
-                secret_fields.setdefault(server_name, {})[field_key] = value
-            else:
-                overrides[f"mcp_servers.{server_name}.{field_key}"] = value
-
-    if spec.mcp_servers is not None:
-        # Explicit allowlist (including an explicit empty one): every
-        # discovered server it excluded must be actively disabled, or codex
-        # keeps loading it from ambient/profile config regardless. codex has
-        # no wholesale "clear mcp_servers" override -- `-c mcp_servers={}`
-        # merges onto, rather than replaces, the existing table (verified
-        # against the installed CLI) -- so each excluded server is disabled
-        # by name instead. "Discovered" must include ambient/profile servers
-        # codex would load on its own, not just the ones lionagi's own MCP
-        # config resolved -- otherwise an allowlist enforced against an empty
-        # `available_servers` (no lionagi MCP config file resolved) is a
-        # no-op, leaving every ambient server enabled.
-        discovered_names = set(available_servers) | _discover_ambient_codex_mcp_server_names()
-        for excluded_name in discovered_names:
-            if excluded_name not in spec.mcp_servers:
-                overrides[f"mcp_servers.{excluded_name}.enabled"] = False
-
-    if secret_fields:
-        _write_codex_mcp_secret_profile(branch, secret_fields)
-    if overrides:
-        branch.chat_model.endpoint.config.kwargs["config_overrides"] = overrides
+    # An explicit allowlist (including an explicit empty one) is the caller
+    # saying which servers this agent gets and no others, so it is applied as
+    # the whole set. It is enforced against the servers this call read as well
+    # as the ones the provider would load on its own; a name the allowlist
+    # permits but the config file did not describe is not an exclusion.
+    apply_forwarded_mcp_servers(
+        branch.chat_model.endpoint.config.kwargs,
+        servers,
+        provider=provider,
+        exclusive=spec.mcp_servers is not None,
+        allowed_names=spec.mcp_servers,
+        known_server_names=tuple(available_servers),
+    )
 
 
 # Fields the codex CLI's MCP server config schema accepts, verified against
@@ -929,7 +988,7 @@ def _reap_stale_codex_mcp_profiles(codex_home: Path) -> None:
 
 
 def _write_codex_mcp_secret_profile(
-    branch: Branch, secret_fields: dict[str, dict[str, Any]]
+    kwargs: dict[str, Any], secret_fields: dict[str, dict[str, Any]]
 ) -> None:
     """Route MCP server fields that may carry secret values (`env`,
     `http_headers`) to codex via a private, on-disk config profile instead
@@ -948,7 +1007,7 @@ def _write_codex_mcp_secret_profile(
 
     import toml
 
-    existing_profile = branch.chat_model.endpoint.config.kwargs.get("profile")
+    existing_profile = kwargs.get("profile")
     if existing_profile:
         raise ConfigurationError(
             "Cannot forward MCP server secret fields for codex: the request "
@@ -973,4 +1032,4 @@ def _write_codex_mcp_secret_profile(
         fh.write(toml.dumps(profile_doc))
     atexit.register(lambda: profile_path.unlink(missing_ok=True))
 
-    branch.chat_model.endpoint.config.kwargs["profile"] = profile_name
+    kwargs["profile"] = profile_name

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -136,11 +136,17 @@ def build_chat_model(
     effort = normalize_effort(effort)
     extra: dict = {}
     if mcp_servers is not None:
-        # Only the Claude CLI lane carries a server set on the request; the
-        # other CLI providers read a user-level config no caller directory
-        # affects, so handing them this here would drop it without a word.
-        if provider in _CLAUDE_PROVIDER_NAMES:
-            extra["mcp_servers"] = mcp_servers
+        from lionagi.agent.factory import apply_forwarded_mcp_servers
+
+        # Whether this provider can be given a set at all is one question with
+        # one answer, and applying it is that answer's implementation — a lane
+        # that carries a set over a different transport (codex, via config
+        # overrides) is a lane this caller must not decide about itself.
+        # An empty set is the caller stating the whole set; a non-empty one is
+        # added to whatever the provider finds for itself.
+        apply_forwarded_mcp_servers(
+            extra, mcp_servers, provider=provider, exclusive=not mcp_servers
+        )
     if bypass:
         extra.update(PROVIDER_BYPASS_KWARGS.get(provider, {}))
     elif yolo:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -527,8 +527,13 @@ async def _run_agent(
         # message waits for the request that call produces (below).
         takes_create_agent_path = preset == "coding" or has_role_key
         if not takes_create_agent_path:
+            from lionagi.agent.factory import request_kwargs_carry_forwarded_mcp
+
+            # Read the request build_chat_model produced: the two transports
+            # put the set in different places, and a provider name is what got
+            # this wrong before.
             built_config = getattr(getattr(chat_model, "endpoint", None), "config", None)
-            forwarded = bool(built_config and "mcp_servers" in built_config.kwargs)
+            forwarded = request_kwargs_carry_forwarded_mcp(getattr(built_config, "kwargs", None))
             _report_mcp_resolution(mcp_resolution, provider=provider, cwd=cwd, forwarded=forwarded)
 
         # Opt-in profile `role:` key switches a plain `-a <profile>` leg onto
@@ -645,13 +650,26 @@ async def _run_agent(
             cfg.update(PROVIDER_FAST_KWARGS.get(provider, {}))
         # A resumed leg re-spawns a CLI child, so it needs the server set handed
         # to it just as a new one does; the persisted branch carries the model,
-        # not the caller's directory.
-        if mcp_resolution.servers is not None and provider in _CLAUDE_PROVIDER_NAMES:
-            cfg["mcp_servers"] = mcp_resolution.servers
+        # not the caller's directory. Which providers can be given a set, and
+        # over which transport, is not this call site's question to answer.
+        from lionagi.agent.factory import (
+            apply_forwarded_mcp_servers,
+            request_kwargs_carry_forwarded_mcp,
+        )
+
+        apply_forwarded_mcp_servers(
+            cfg,
+            mcp_resolution.servers,
+            provider=provider,
+            exclusive=not mcp_resolution.servers,
+        )
         # A resumed leg re-spawns from the persisted request, which is the only
         # thing that decides what it carries — read the answer off it.
         _report_mcp_resolution(
-            mcp_resolution, provider=provider, cwd=cwd, forwarded="mcp_servers" in cfg
+            mcp_resolution,
+            provider=provider,
+            cwd=cwd,
+            forwarded=request_kwargs_carry_forwarded_mcp(cfg),
         )
 
     # Add the profile system prompt for every leg EXCEPT one whose branch carries

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -34,7 +34,6 @@ from lionagi.state import provenance as _provenance
 
 from .._logging import hint, warn
 from .._providers import (
-    _CLAUDE_PROVIDER_NAMES,
     AgentProfile,
     AgentProfileNotFoundError,
     build_imodel_from_spec,
@@ -561,38 +560,47 @@ class OrchestrationEnv:
 
 
 def _hand_mcp_servers(imodel, servers: dict | None, *, label: str) -> None:
-    """Give one branch's model the run's server set, where it can carry one.
+    """Give one worker's model the run's server set, or say it could not be given.
+
+    A caller who named a set for this run gets that set applied to every worker
+    whose provider has a transport for one, and is told about every worker whose
+    provider has none. Which providers those are is not decided here — the
+    request is where the set lands, so the function that writes it is the one
+    that answers whether it landed.
 
     An empty set and no set are different requests. ``{}`` is the caller having
-    asked for no servers, and only a provider that accepts a server set per
-    request can express it: handed ``{}``, the Claude CLI lane is told the whole
-    set is empty rather than being left to find its own. ``None`` is there being
-    nothing to hand over, and the model keeps whatever it would have used.
+    asked for no servers, so it is applied as the whole set rather than as
+    nothing to add. ``None`` is there being nothing to hand over, and the model
+    keeps whatever it would have used.
 
-    The other CLI providers read a user-level config that no caller directory
-    affects, so a set given here would be dropped without a word. That is
-    tolerable for servers the model would mostly have found anyway, but not for
-    a refusal — the caller who asked for none would go on believing they got
-    none, so *label* names the worker whose request could not carry it.
+    *label* names the worker, because a run's workers can resolve different
+    providers and a caller reading the warning needs to know which leg lost
+    what.
     """
     if servers is None:
         return
+    from lionagi.agent.factory import apply_forwarded_mcp_servers
+
     provider = imodel.endpoint.config.provider
-    if provider in _CLAUDE_PROVIDER_NAMES:
-        imodel.endpoint.config.kwargs["mcp_servers"] = servers
-        if not servers:
-            # An empty set alone is merged with whatever the CLI discovers for
-            # itself, which leaves the discovered servers in place. The strict
-            # flag is what makes the handed set the entire set.
-            imodel.endpoint.config.kwargs["strict_mcp_config"] = True
+    applied = apply_forwarded_mcp_servers(
+        imodel.endpoint.config.kwargs,
+        servers,
+        provider=provider,
+        exclusive=not servers,
+    )
+    if applied:
         return
-    if not servers:
-        warn(
-            f"{label}: --no-mcp-config was not applied. The {provider} provider "
-            "takes its MCP servers from its own configuration rather than from "
-            "the request, so this worker keeps the servers that configuration "
-            "gives it."
-        )
+    lost = (
+        "--no-mcp-config was not applied, so this worker keeps the servers that "
+        "configuration gives it"
+        if not servers
+        else f"the {len(servers)} resolved server(s) ({', '.join(sorted(servers))}) "
+        "are not reachable for this worker"
+    )
+    warn(
+        f"{label}: the {provider} provider takes its MCP servers from its own "
+        f"configuration rather than from the request, so {lost}."
+    )
 
 
 async def setup_orchestration(

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,8 +1,11 @@
 """Shared fixtures for CLI tests."""
 
 import logging
+from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
+import toml
 
 # Loggers mutated by lionagi.cli._logging.configure_cli_logging(). Tests that
 # drive main() end-to-end trigger that call, which sets propagate=False and
@@ -33,3 +36,30 @@ def _restore_cli_logging():
         logger.setLevel(level)
         logger.propagate = propagate
         logger.handlers[:] = handlers
+
+
+@dataclass
+class CodexHome:
+    """A private ``$CODEX_HOME`` for a test, plus the ambient server table.
+
+    Anything that hands codex an exclusive server set has to know which servers
+    codex would load on its own, and anything that forwards secret-bearing
+    fields writes a profile file into this directory. Both read the real
+    operator tree unless a test redirects them.
+    """
+
+    path: Path
+
+    def write_config(self, servers: dict) -> None:
+        (self.path / "config.toml").write_text(toml.dumps({"mcp_servers": servers}))
+
+    def profile_files(self) -> list[Path]:
+        return sorted(self.path.glob("lionagi-mcp-*.config.toml"))
+
+
+@pytest.fixture
+def codex_home(monkeypatch, tmp_path) -> CodexHome:
+    home = tmp_path / "codex-home"
+    home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    return CodexHome(home)

--- a/tests/cli/orchestrate/test_no_mcp_config_handoff.py
+++ b/tests/cli/orchestrate/test_no_mcp_config_handoff.py
@@ -108,33 +108,69 @@ async def test_no_config_found_hands_over_nothing_and_says_nothing(tmp_run):
     assert "--strict-mcp-config" not in args
 
 
-def test_refusal_is_reported_when_the_provider_cannot_carry_it(caplog):
-    """A provider whose servers come from its own configuration cannot be told
-    the set is empty. Saying so is the point — the caller passed a flag."""
+def test_refusal_reaches_a_codex_worker_as_a_disabled_server(caplog, codex_home):
+    """codex has no per-request server set and no wholesale clear, so a refusal
+    reaches it as every server it would have loaded, disabled by name."""
     import logging
 
     from lionagi.cli._providers import build_imodel_from_spec
 
+    codex_home.write_config({"khive": {"command": "kkernel"}})
     imodel = build_imodel_from_spec("codex/gpt-5")
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        orch_mod._hand_mcp_servers(imodel, {}, label="reviewer-2")
+
+    assert imodel.endpoint.config.kwargs["config_overrides"] == {"mcp_servers.khive.enabled": False}
+    assert caplog.text == ""
+
+
+def test_a_resolved_set_reaches_a_codex_worker(caplog, codex_home):
+    """The run's set is what the worker gets, over whichever transport its
+    provider has for one."""
+    import logging
+
+    from lionagi.cli._providers import build_imodel_from_spec
+
+    codex_home.write_config({})
+    imodel = build_imodel_from_spec("codex/gpt-5")
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        orch_mod._hand_mcp_servers(imodel, {"khive": {"command": "kkernel"}}, label="reviewer-2")
+
+    assert imodel.endpoint.config.kwargs["config_overrides"] == {
+        "mcp_servers.khive.command": "kkernel"
+    }
+    assert caplog.text == ""
+
+
+def test_refusal_is_reported_when_the_provider_cannot_carry_it(caplog):
+    """A provider with no transport for a caller-resolved set cannot be told the
+    set is empty. Saying so is the point — the caller passed a flag."""
+    import logging
+
+    from lionagi.cli._providers import build_imodel_from_spec
+
+    imodel = build_imodel_from_spec("gemini-cli/gemini-3.5-flash")
+    provider = imodel.endpoint.config.provider
     with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
         orch_mod._hand_mcp_servers(imodel, {}, label="reviewer-2")
 
     assert "mcp_servers" not in imodel.endpoint.config.kwargs
     assert "reviewer-2" in caplog.text
     assert "--no-mcp-config" in caplog.text
-    assert "codex" in caplog.text
+    assert provider in caplog.text
 
 
-def test_a_discovered_server_set_is_still_handed_over_silently(caplog):
-    """The report is for a refusal that could not be applied, not for every
-    provider that reads its own config — a non-empty set stays a no-op there."""
+def test_a_dropped_grant_is_reported_as_well_as_a_dropped_refusal(caplog):
+    """A set the provider cannot carry leaves the worker without servers its
+    instructions assume, which is worth at least as much of a word as a refusal."""
     import logging
 
     from lionagi.cli._providers import build_imodel_from_spec
 
-    imodel = build_imodel_from_spec("codex/gpt-5")
+    imodel = build_imodel_from_spec("gemini-cli/gemini-3.5-flash")
     with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
         orch_mod._hand_mcp_servers(imodel, {"khive": {"command": "kkernel"}}, label="reviewer-2")
 
     assert "mcp_servers" not in imodel.endpoint.config.kwargs
-    assert caplog.text == ""
+    assert "reviewer-2" in caplog.text
+    assert "khive" in caplog.text

--- a/tests/cli/test_mcp_forwarding_predicate.py
+++ b/tests/cli/test_mcp_forwarding_predicate.py
@@ -90,8 +90,12 @@ def test_predicate_matches_what_the_forwarder_does(provider, mcp_config):
 
 
 def test_forwarding_providers_are_the_two_cli_transports():
+    """Two transports, every spelling the CLI accepts for the Claude one: which
+    alias a caller typed is not a capability of the provider behind it, and a
+    `claude/...` leg reaches the same endpoint a `claude_code/...` leg does."""
     accepted = {p for p in KNOWN_PROVIDERS if provider_accepts_forwarded_mcp(p)}
-    assert accepted == {"claude_code", "codex"}
+    assert accepted == {"claude", "claude_code", "codex"}
+    assert {"gemini-cli", "pi", "openai"}.isdisjoint(accepted)
 
 
 def test_unknown_provider_is_not_assumed_to_accept():

--- a/tests/cli/test_mcp_set_reaches_every_cli_provider.py
+++ b/tests/cli/test_mcp_set_reaches_every_cli_provider.py
@@ -1,0 +1,391 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A resolved MCP server set reaches every CLI provider that has a transport for one.
+
+Three spawn shapes build a CLI request — a plain leg, a resumed leg, and a
+flow/fanout worker — and each used to decide for itself whether the set could be
+carried, by asking whether the provider was the Claude CLI. codex carries a set
+too, over config overrides, so a caller who named one got it on one path and
+silently lost it on three. These tests are per spawn shape rather than per
+provider, because the shape is what differed.
+
+The secret-field checks are the reason each shape is checked separately: `env`
+and `http_headers` can hold API keys, and a path that forwards them as `-c`
+overrides puts them in `ps` output and in every serialized request record.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.agent.factory import apply_forwarded_mcp_servers
+
+SERVERS = {"khive": {"command": "kkernel", "args": ["serve"]}}
+SECRET = "sk-live-do-not-put-me-on-argv"
+SECRET_SERVERS = {"khive": {"command": "kkernel", "env": {"KHIVE_API_KEY": SECRET}}}
+
+WARN_LOGGER = "lionagi.cli.warn"
+
+
+async def _cmd_args(imodel) -> list[str]:
+    """The argv the CLI child would be spawned with, off the live request."""
+    api_call = await imodel.create_event(prompt="hi")
+    return api_call.payload["request"].as_cmd_args()
+
+
+def _override_values(kwargs: dict) -> list:
+    return list((kwargs.get("config_overrides") or {}).values())
+
+
+def _assert_secret_is_off_the_wire(kwargs: dict, args: list[str], codex_home) -> None:
+    """The secret reaches the child through a private file, never through argv."""
+    assert all(SECRET not in str(value) for value in _override_values(kwargs))
+    assert all(SECRET not in arg for arg in args)
+
+    profile = codex_home.path / f"{kwargs['profile']}.config.toml"
+    assert profile in codex_home.profile_files()
+    assert SECRET in profile.read_text()
+    assert stat.S_IMODE(profile.stat().st_mode) == 0o600
+    # The child is pointed at the file; the file is how the value gets there.
+    assert args[args.index("-p") + 1] == kwargs["profile"]
+
+
+# ---------------------------------------------------------------------------
+# The transports themselves: what an empty set means to each of them.
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_exclusive_set_is_strict_for_the_claude_transport():
+    kwargs: dict = {}
+    assert apply_forwarded_mcp_servers(kwargs, {}, provider="claude_code", exclusive=True)
+    assert kwargs["mcp_servers"] == {}
+    assert kwargs["strict_mcp_config"] is True
+
+
+def test_an_empty_exclusive_set_disables_by_name_for_the_codex_transport(codex_home):
+    """codex has no wholesale clear: `-c mcp_servers={}` merges onto the existing
+    table rather than replacing it, so each server it would have loaded is
+    disabled by name instead."""
+    codex_home.write_config({"khive": {"command": "kkernel"}, "docs": {"url": "http://x"}})
+    kwargs: dict = {}
+
+    assert apply_forwarded_mcp_servers(kwargs, {}, provider="codex", exclusive=True)
+
+    assert kwargs["config_overrides"] == {
+        "mcp_servers.docs.enabled": False,
+        "mcp_servers.khive.enabled": False,
+    }
+
+
+def test_a_provider_without_a_transport_reports_that_it_carried_nothing():
+    kwargs: dict = {}
+    assert apply_forwarded_mcp_servers(kwargs, SERVERS, provider="gemini_code") is False
+    assert kwargs == {}
+
+
+# ---------------------------------------------------------------------------
+# Site 1 — the plain `li agent` leg (build_chat_model).
+# ---------------------------------------------------------------------------
+
+
+def test_plain_leg_hands_a_codex_request_the_resolved_set(codex_home):
+    from lionagi.cli._providers import build_chat_model
+
+    codex_home.write_config({})
+    model = build_chat_model("codex", "gpt-5.3-codex", False, False, None, mcp_servers=SERVERS)
+
+    assert model.endpoint.config.kwargs["config_overrides"] == {
+        "mcp_servers.khive.command": "kkernel",
+        "mcp_servers.khive.args": ["serve"],
+    }
+
+
+def test_plain_leg_still_hands_a_claude_request_the_resolved_set():
+    from lionagi.cli._providers import build_chat_model
+
+    model = build_chat_model(
+        "claude_code", "claude-opus-4-5", False, False, None, mcp_servers=SERVERS
+    )
+    assert model.endpoint.config.kwargs["mcp_servers"] == SERVERS
+
+
+def test_plain_leg_hands_nothing_to_a_provider_without_a_transport():
+    from lionagi.cli._providers import build_chat_model
+
+    model = build_chat_model(
+        "gemini_code", "gemini-3.5-flash", False, False, None, mcp_servers=SERVERS
+    )
+    # No flags and nothing forwarded leaves a bare spec string, not a request.
+    assert model == "gemini_code/gemini-3.5-flash"
+
+
+@pytest.mark.asyncio
+async def test_plain_leg_keeps_codex_secret_fields_off_the_command_line(codex_home):
+    from lionagi.cli._providers import build_chat_model
+
+    codex_home.write_config({})
+    model = build_chat_model(
+        "codex", "gpt-5.3-codex", False, False, None, mcp_servers=SECRET_SERVERS
+    )
+
+    kwargs = model.endpoint.config.kwargs
+    assert kwargs["config_overrides"] == {"mcp_servers.khive.command": "kkernel"}
+    _assert_secret_is_off_the_wire(kwargs, await _cmd_args(model), codex_home)
+
+
+def test_plain_leg_empty_set_is_the_whole_set_on_both_transports(codex_home):
+    from lionagi.cli._providers import build_chat_model
+
+    codex_home.write_config({"khive": {"command": "kkernel"}})
+
+    codex = build_chat_model("codex", "gpt-5.3-codex", False, False, None, mcp_servers={})
+    assert codex.endpoint.config.kwargs["config_overrides"] == {"mcp_servers.khive.enabled": False}
+
+    claude = build_chat_model("claude_code", "claude-opus-4-5", False, False, None, mcp_servers={})
+    assert claude.endpoint.config.kwargs["mcp_servers"] == {}
+    assert claude.endpoint.config.kwargs["strict_mcp_config"] is True
+
+
+# ---------------------------------------------------------------------------
+# Site 2 — the resumed leg.
+# ---------------------------------------------------------------------------
+
+
+def _wire_resume_stubs(monkeypatch, tmp_path: Path, provider: str, model: str) -> str:
+    """Persist a branch on *provider* and stub every external I/O `_run_agent`
+    does, so what the resumed leg's request ends up carrying is all that is
+    left to observe."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch, iModel
+    from lionagi.service.manager import iModelManager
+
+    branch = Branch(
+        chat_model=iModel(provider=provider, endpoint="query_cli", model=model, api_key="dummy")
+    )
+    branch_path = tmp_path / f"{branch.id}.json"
+    branch_path.write_text(json.dumps(branch.to_dict()))
+
+    async def fake_operate(self, instruction=None, **kw):
+        return "done"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "find_branch", lambda bid: ("run-x", branch_path))
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    async def fake_setup(*a, **kw):
+        return None
+
+    async def fake_teardown(ctx, **kw):
+        return kw.get("status", "completed")
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id="r",
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    return str(branch.id)
+
+
+def _mcp_config_file(tmp_path: Path, servers: dict) -> str:
+    path = tmp_path / ".mcp.json"
+    path.write_text(json.dumps({"mcpServers": servers}))
+    return str(path)
+
+
+@pytest.mark.asyncio
+async def test_resumed_codex_leg_gets_the_set_the_resume_command_resolved(
+    monkeypatch, tmp_path, codex_home, caplog
+):
+    """A resumed leg re-spawns a CLI child, so it needs the set as much as a new
+    one does; the persisted branch carries the model, not the caller's directory.
+    Having been given it, the leg is not also told it was not."""
+    from lionagi.cli.agent import _run_agent
+
+    codex_home.write_config({})
+    branch_id = _wire_resume_stubs(monkeypatch, tmp_path, "codex", "gpt-5.3-codex")
+
+    with caplog.at_level(logging.WARNING, logger=WARN_LOGGER):
+        await _run_agent(
+            None,
+            "follow up",
+            resume=branch_id,
+            mcp_config=_mcp_config_file(tmp_path, SERVERS),
+        )
+
+    assert "not carried" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_resumed_leg_request_carries_the_codex_overrides(monkeypatch, tmp_path, codex_home):
+    """Read the built request, not the report: the overrides are what the child
+    is spawned with."""
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+
+    codex_home.write_config({})
+    branch_id = _wire_resume_stubs(monkeypatch, tmp_path, "codex", "gpt-5.3-codex")
+
+    seen: dict = {}
+
+    async def capture(self, instruction=None, **kw):
+        seen["kwargs"] = dict(self.chat_model.endpoint.config.kwargs)
+        seen["args"] = await _cmd_args(self.chat_model)
+        return "done"
+
+    monkeypatch.setattr(Branch, "operate", capture)
+    await agent_mod._run_agent(
+        None,
+        "follow up",
+        resume=branch_id,
+        mcp_config=_mcp_config_file(tmp_path, SERVERS),
+    )
+
+    assert seen["kwargs"]["config_overrides"] == {
+        "mcp_servers.khive.command": "kkernel",
+        "mcp_servers.khive.args": ["serve"],
+    }
+    assert "-c" in seen["args"]
+    assert 'mcp_servers.khive.command="kkernel"' in seen["args"]
+
+
+@pytest.mark.asyncio
+async def test_resumed_leg_keeps_codex_secret_fields_off_the_command_line(
+    monkeypatch, tmp_path, codex_home
+):
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+
+    codex_home.write_config({})
+    branch_id = _wire_resume_stubs(monkeypatch, tmp_path, "codex", "gpt-5.3-codex")
+
+    seen: dict = {}
+
+    async def capture(self, instruction=None, **kw):
+        seen["kwargs"] = dict(self.chat_model.endpoint.config.kwargs)
+        seen["args"] = await _cmd_args(self.chat_model)
+        return "done"
+
+    monkeypatch.setattr(Branch, "operate", capture)
+    await agent_mod._run_agent(
+        None,
+        "follow up",
+        resume=branch_id,
+        mcp_config=_mcp_config_file(tmp_path, SECRET_SERVERS),
+    )
+
+    _assert_secret_is_off_the_wire(seen["kwargs"], seen["args"], codex_home)
+
+
+@pytest.mark.asyncio
+async def test_resumed_leg_on_a_provider_without_a_transport_is_told_so(
+    monkeypatch, tmp_path, caplog
+):
+    from lionagi.cli.agent import _run_agent
+
+    branch_id = _wire_resume_stubs(monkeypatch, tmp_path, "gemini_code", "gemini-3.5-flash")
+
+    with caplog.at_level(logging.WARNING, logger=WARN_LOGGER):
+        await _run_agent(
+            None,
+            "follow up",
+            resume=branch_id,
+            mcp_config=_mcp_config_file(tmp_path, SERVERS),
+        )
+
+    assert "not carried" in caplog.text
+    assert "gemini_code" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Site 3 — the flow / fanout worker.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def flow_run(monkeypatch, tmp_path):
+    """A run launched from a directory whose .mcp.json is the run's server set."""
+    import lionagi.cli.orchestrate._orchestration as orch_mod
+    from lionagi.cli._runs import RunDir
+
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    monkeypatch.chdir(launch_dir)
+
+    def _allocate(save_dir=None, run_id=None):
+        run = RunDir(
+            run_id="test-run",
+            state_root=tmp_path / "state",
+            artifact_root=tmp_path / "artifacts",
+        )
+        run.ensure_state_dirs()
+        run.ensure_artifact_root()
+        return run
+
+    monkeypatch.setattr(orch_mod, "allocate_run", _allocate)
+    return launch_dir
+
+
+async def _codex_worker(flow_run, servers: dict):
+    from lionagi.cli.orchestrate._orchestration import build_worker_branch, setup_orchestration
+
+    (flow_run / ".mcp.json").write_text(json.dumps({"mcpServers": servers}))
+    env = await setup_orchestration(
+        pattern_name="Fanout",
+        model_spec="codex/gpt-5.3-codex",
+        agent_name=None,
+        save_dir=None,
+        cwd=None,
+        yolo=False,
+        verbose=False,
+        effort=None,
+        theme=None,
+    )
+    branch, _, _, _ = await build_worker_branch(env, agent_id="w1", role="implementer")
+    return env, branch
+
+
+@pytest.mark.asyncio
+async def test_a_codex_worker_is_spawned_with_the_runs_server_set(flow_run, codex_home):
+    """The acceptance case: the `-c mcp_servers.*` arguments on the command line
+    a codex worker of a flow run would actually be spawned with."""
+    codex_home.write_config({})
+    _env, branch = await _codex_worker(flow_run, SERVERS)
+
+    args = await _cmd_args(branch.chat_model)
+    forwarded = [args[i + 1] for i, a in enumerate(args) if a == "-c" and i + 1 < len(args)]
+    assert 'mcp_servers.khive.command="kkernel"' in forwarded
+    assert 'mcp_servers.khive.args=["serve"]' in forwarded
+
+
+@pytest.mark.asyncio
+async def test_a_codex_worker_keeps_secret_fields_off_the_command_line(flow_run, codex_home):
+    codex_home.write_config({})
+    _env, branch = await _codex_worker(flow_run, SECRET_SERVERS)
+
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    _assert_secret_is_off_the_wire(kwargs, await _cmd_args(branch.chat_model), codex_home)


### PR DESCRIPTION
Three spawn paths asked whether the target was a Claude provider before handing over a resolved MCP server set. That is the wrong question: it describes one provider rather than the capability being tested, and the codex transport for exactly this has been implemented in `lionagi/agent/factory.py` for some time — `-c mcp_servers.<name>.<field>` overrides, with secret-bearing fields routed to a 0600 profile instead of argv.

So a caller who named a server set for a codex leg had it dropped. Two of the three paths dropped it silently; the third announced a refusal while dropping a grant, which is the more confusing of the two because the message is true about the wrong thing.

The gates now ask whether the provider can carry a set:

- `lionagi/cli/_providers.py` — plain `li agent` legs
- `lionagi/cli/agent.py` — resumed legs
- `lionagi/cli/orchestrate/_orchestration.py` — flow and fanout workers

with the application itself in one shared function rather than restated per call site, so the three paths cannot drift apart again.

Ambient provider configuration is untouched. A provider that genuinely cannot accept a set still says so, and now says so only when that is what happened.

## Evidence

A codex fanout worker's built request carries the overrides, and the secret reaches a 0600 profile rather than the command line. Narrowing the forwarding predicate back to Claude-only — the single line this change widens — produces zero overrides, no profile, and the unreachable warning for both the orchestrator and the worker. Delivery and announcement move together in both directions.

`tests/cli tests/agent tests/mcp`: 3519 passed, 2 skipped.