### PR TITLE
feat(mcp): report which MCP servers a run gave its workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   opening its record on disk. An empty list and a null say different things: the
   list means the question was settled and the answer was none, which covers both
   a caller disabling MCP for the run and a config that was found and declares no
-  servers. The null means no set was resolved, which is what a caller naming their
-  own config file gets, since this run does not read that file. The field reports
-  what was resolved, which is not a claim that the child's provider then started
-  each server.
+  servers. The null means no set was resolved, which happens three ways: a caller
+  named their own config file, which this run does not read; no config was found
+  at or above the launch directory; or the record predates the field. The field
+  reports what was resolved, which is not a claim that the child's provider then
+  started each server.
 
 ## [0.31.1] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- A run reports which MCP servers it gave its workers. `mcp_config_servers` names
+  them on the submit handle, and `job.status` now carries the whole `mcp_config`
+  group, so a run that has already finished answers the question without anyone
+  opening its record on disk. An empty list and a null say different things: the
+  list means the question was settled and the answer was none, the null means no
+  set was resolved, which is what a caller naming their own config file gets. The
+  field reports what was resolved, which is not a claim that the child's provider
+  then started each server.
+
 ## [0.31.1] - 2026-07-28
 
 ### Upgrading from 0.31.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   them on the submit handle, and `job.status` now carries the whole `mcp_config`
   group, so a run that has already finished answers the question without anyone
   opening its record on disk. An empty list and a null say different things: the
-  list means the question was settled and the answer was none, the null means no
-  set was resolved, which is what a caller naming their own config file gets. The
-  field reports what was resolved, which is not a claim that the child's provider
-  then started each server.
+  list means the question was settled and the answer was none, which covers both
+  a caller disabling MCP for the run and a config that was found and declares no
+  servers. The null means no set was resolved, which is what a caller naming their
+  own config file gets, since this run does not read that file. The field reports
+  what was resolved, which is not a claim that the child's provider then started
+  each server.
 
 ## [0.31.1] - 2026-07-28
 

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1494,6 +1494,9 @@ def submit(
         # case a reader most needs -- a run whose workers got no servers -- read
         # the same as a run where the question was never asked.
         #
+        # Two different things settle it as none: a caller disabling MCP, and a
+        # config that was found and declares no servers. Both report `[]`.
+        #
         # This reports what was RESOLVED. It is not a claim about what the child's
         # provider then managed to start: a server can be in this list and still
         # fail to come up in the child's own session. Distinguishing those needs
@@ -1533,6 +1536,18 @@ def submit(
                     if resolution.reason == "no_mcp_config_found"
                     else resolution.reason
                 )
+                if resolution.reason == "mcp_config_declares_no_servers":
+                    # A config that was found and declares no servers is a
+                    # settled question whose answer is none, so it reports `[]`.
+                    # The resolver returns a null server map for this and for
+                    # finding no config at all, and only its reason tells the two
+                    # apart -- reading the map alone would report "cannot say"
+                    # about a file that said so explicitly. The source is kept for
+                    # the same reason: a reader is owed the name of the file that
+                    # answered, and an empty set beside a null source would send
+                    # them looking for one that was never consulted.
+                    mcp_config_servers = []
+                    mcp_config_source = str(resolution.source) if resolution.source else None
             else:
                 mcp_servers = resolution.servers
                 mcp_config_source = str(resolution.source) if resolution.source else None

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1487,10 +1487,25 @@ def submit(
         mcp_config_source: str | None = None
         mcp_config_reason: str | None = None
         mcp_servers: dict[str, Any] | None = None
+        # Which servers the run gave its workers, by name. Empty list and null are
+        # different answers and neither stands in for the other: `[]` says this run
+        # settled the question and the answer was none, `null` says this run never
+        # resolved a set and cannot speak for one. Collapsing them would make the
+        # case a reader most needs -- a run whose workers got no servers -- read
+        # the same as a run where the question was never asked.
+        #
+        # This reports what was RESOLVED. It is not a claim about what the child's
+        # provider then managed to start: a server can be in this list and still
+        # fail to come up in the child's own session. Distinguishing those needs
+        # the child's startup record, which this does not stand in for. What it
+        # does settle, in one read rather than a dig through the snapshot on disk,
+        # is whether a server a run was supposed to have was ever in its set.
+        mcp_config_servers: list[str] | None = None
         if no_mcp_config:
             # The caller asked for no servers. That is an answer, not an absence, so
             # nothing is resolved and the handle says whose decision it was.
             mcp_config_reason = "mcp_disabled_by_caller"
+            mcp_config_servers = []
         elif mcp_config is not None:
             # The caller named the file, and their flag is already on the line. No
             # snapshot is taken and none is prepended: a second --mcp-config would
@@ -1522,6 +1537,10 @@ def submit(
                 mcp_servers = resolution.servers
                 mcp_config_source = str(resolution.source) if resolution.source else None
                 mcp_config_path = str(d / _MCP_SNAPSHOT_FILENAME)
+                # Sorted so two runs over the same set report the same string and a
+                # reader can compare handles directly; the child reads the snapshot,
+                # never this list, so the order is free to be the readable one.
+                mcp_config_servers = sorted(mcp_servers)
                 options = ["--mcp-config", mcp_config_path, *options]
 
         # Wire the CLI's terminal hook back to the MCP server so we record a reliable
@@ -1590,6 +1609,7 @@ def submit(
         "mcp_config": mcp_config_path,
         "mcp_config_source": mcp_config_source,
         "mcp_config_reason": mcp_config_reason,
+        "mcp_config_servers": mcp_config_servers,
         "submitted_at": _now_iso(),
         "finished_at": None,
         "status": "running",
@@ -1697,6 +1717,7 @@ def submit(
         "mcp_config": mcp_config_path,
         "mcp_config_source": mcp_config_source,
         "mcp_config_reason": mcp_config_reason,
+        "mcp_config_servers": mcp_config_servers,
         "notify_sender": notify_sender,
     }
 
@@ -2192,6 +2213,18 @@ def status(run_id: str) -> dict[str, Any]:
     ``server`` identifies the implementation that answered, so a caller can tell
     which build it is talking to rather than inferring it from behaviour.
 
+    The ``mcp_config*`` fields say what tool surface the run was given, and are the
+    same values the submit handle returned, carried here so a caller investigating
+    a finished run reads them rather than opening the record on disk.
+    ``mcp_config_servers`` names the servers by name. ``[]`` and null are different
+    answers: ``[]`` says the question was settled and the answer was none, null says
+    no set was resolved — either because the caller named their own config file,
+    which this run does not read, or because the record predates the field. It
+    reports what was RESOLVED, which is not a claim that the child's provider then
+    started each one; a server can be listed here and still fail to come up in the
+    child's own session. What it settles is the prior question, whether a server the
+    run was supposed to have was in its set at all.
+
     ``known`` says whether a usable record was obtained, and ``record_state`` says
     what was read to answer that: ``"ok"``, or ``"absent"``, ``"unreadable"`` or
     ``"wrong_shape"`` when it was not. Only ``"absent"`` means the run is unknown.
@@ -2236,6 +2269,10 @@ def status(run_id: str) -> dict[str, Any]:
         "submitted_at": (job or {}).get("submitted_at"),
         "finished_at": (job or {}).get("finished_at"),
         "notify_delivery": (job or {}).get("notify_delivery"),
+        "mcp_config": (job or {}).get("mcp_config"),
+        "mcp_config_source": (job or {}).get("mcp_config_source"),
+        "mcp_config_reason": (job or {}).get("mcp_config_reason"),
+        "mcp_config_servers": (job or {}).get("mcp_config_servers"),
         "run": manifest,
         "log_tail": _tail((job or {}).get("log")),
         "known": job is not None,

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2233,12 +2233,14 @@ def status(run_id: str) -> dict[str, Any]:
     a finished run reads them rather than opening the record on disk.
     ``mcp_config_servers`` names the servers by name. ``[]`` and null are different
     answers: ``[]`` says the question was settled and the answer was none, null says
-    no set was resolved — either because the caller named their own config file,
-    which this run does not read, or because the record predates the field. It
-    reports what was RESOLVED, which is not a claim that the child's provider then
-    started each one; a server can be listed here and still fail to come up in the
-    child's own session. What it settles is the prior question, whether a server the
-    run was supposed to have was in its set at all.
+    no set was resolved. Three things read as null — the caller named their own
+    config file, which this run does not read; no config was found at or above the
+    launch directory; or the record predates the field. ``mcp_config_reason`` names
+    which of the first two, and a record older than the field carries no reason
+    either. It reports what was RESOLVED, which is not a claim that the child's
+    provider then started each one; a server can be listed here and still fail to
+    come up in the child's own session. What it settles is the prior question,
+    whether a server the run was supposed to have was in its set at all.
 
     ``known`` says whether a usable record was obtained, and ``record_state`` says
     what was read to answer that: ``"ok"``, or ``"absent"``, ``"unreadable"`` or

--- a/tests/mcp/test_spawn_reports_its_server_set.py
+++ b/tests/mcp/test_spawn_reports_its_server_set.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A run says which servers it gave its workers, without a read of the snapshot.
+
+The set was already in hand when the snapshot was written and was simply not
+recorded, so a caller asking "did this leg even have the knowledge server" had to
+open the record on disk to find out. These tests pin the reported value in each
+way the question can be answered, and in particular that "none" and "cannot say"
+stay distinguishable — collapsing them would make the one case worth reporting,
+a run whose workers got no servers, read like a run nobody asked about.
+
+Popen is doubled so no real `li` process is spawned.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.mcp import config, jobs
+
+
+@pytest.fixture
+def sandbox(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(config, "li_command", lambda: ["echo"])
+    monkeypatch.setattr(jobs, "_read_lifecycle", lambda run_id: None)
+    return tmp_path
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 4242) -> None:
+        self.pid = pid
+
+
+@pytest.fixture
+def submit_dir(monkeypatch, tmp_path):
+    """A submitting directory with no MCP config above it.
+
+    The search walks to the filesystem root, so an ancestor's real .mcp.json
+    would otherwise decide these tests.
+    """
+    d = tmp_path / "submit"
+    d.mkdir()
+    monkeypatch.chdir(d)
+    return d
+
+
+@pytest.fixture
+def no_spawn(monkeypatch):
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc())
+
+
+def test_a_resolved_set_is_reported_by_name_and_sorted(sandbox, submit_dir, no_spawn):
+    """The names the run resolved, on the handle, without opening the snapshot."""
+    (submit_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"lion": {"command": "li"}, "khive": {"command": "kk"}}})
+    )
+
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    assert handle["mcp_config_servers"] == ["khive", "lion"]
+    # The snapshot on disk is the child's copy and has to agree with what the
+    # handle claims; a handle describing a set the child was not given would be
+    # worse than no handle at all.
+    written = json.loads((sandbox / "jobs" / handle["run_id"] / "mcp-servers.json").read_text())
+    assert sorted(written["mcpServers"]) == handle["mcp_config_servers"]
+
+
+def test_status_carries_the_same_answer_as_the_handle(sandbox, submit_dir, no_spawn):
+    """The point of the change: a finished run answers without a filesystem dig.
+
+    The submit handle is a one-shot. Anyone investigating afterwards -- which is
+    when the question actually gets asked -- reaches for status.
+    """
+    (submit_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"lion": {"command": "li"}, "khive": {"command": "kk"}}})
+    )
+
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+    st = jobs.status(handle["run_id"])
+
+    for field in ("mcp_config", "mcp_config_source", "mcp_config_reason", "mcp_config_servers"):
+        assert st[field] == handle[field], field
+    assert st["mcp_config_servers"] == ["khive", "lion"]
+
+
+def test_caller_asking_for_no_servers_reports_an_empty_set_not_null(sandbox, submit_dir, no_spawn):
+    """`[]` is an answer. The caller settled it and the answer was none."""
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {"lion": {"command": "li"}}}))
+
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir), no_mcp_config=True)
+
+    assert handle["mcp_config_servers"] == []
+    assert handle["mcp_config_reason"] == "mcp_disabled_by_caller"
+    assert jobs.status(handle["run_id"])["mcp_config_servers"] == []
+
+
+def test_a_caller_named_config_reports_null_because_this_run_never_read_it(
+    sandbox, submit_dir, no_spawn, tmp_path
+):
+    """Null is the other answer: no set was resolved, so none can be named.
+
+    The caller's file belongs to the caller and this run does not open it, so
+    reporting names from it would be a claim about a file that may have changed
+    by the time the child reads it.
+    """
+    theirs = tmp_path / "theirs.json"
+    theirs.write_text(json.dumps({"mcpServers": {"whatever": {"command": "w"}}}))
+
+    handle = jobs.submit(
+        "agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir), mcp_config=str(theirs)
+    )
+
+    assert handle["mcp_config_servers"] is None
+    assert handle["mcp_config_reason"] == "mcp_config_named_by_caller"
+
+
+def test_none_and_cannot_say_are_not_the_same_value(sandbox, submit_dir, no_spawn, tmp_path):
+    """The distinction the whole field exists for, asserted directly.
+
+    Two runs, both of which gave their workers no servers this run can vouch
+    for, and they must not report the same thing: one settled the question, the
+    other never asked it.
+    """
+    theirs = tmp_path / "theirs.json"
+    theirs.write_text(json.dumps({"mcpServers": {"whatever": {"command": "w"}}}))
+
+    settled = jobs.submit(
+        "agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir), no_mcp_config=True
+    )
+    unasked = jobs.submit(
+        "agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir), mcp_config=str(theirs)
+    )
+
+    assert settled["mcp_config_servers"] == []
+    assert unasked["mcp_config_servers"] is None
+    assert settled["mcp_config_servers"] != unasked["mcp_config_servers"]
+
+
+def test_no_config_found_reports_null_and_says_where_it_looked(sandbox, submit_dir, no_spawn):
+    """Nothing to resolve is "cannot say", and the reason names the search."""
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    assert handle["mcp_config_servers"] is None
+    assert handle["mcp_config_reason"].startswith("no_mcp_config_found_at_or_above:")
+
+
+def test_a_record_written_before_the_field_existed_reads_as_cannot_say(
+    sandbox, submit_dir, no_spawn
+):
+    """Old records answer null rather than crashing or claiming an empty set.
+
+    A pre-existing record has no key for this. Absent has to mean "cannot say",
+    which is the truth about it -- reading it as `[]` would turn every run that
+    predates the field into a run that reported having no servers.
+    """
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {"lion": {"command": "li"}}}))
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+    run_id = handle["run_id"]
+
+    record_path = sandbox / "jobs" / run_id / "job.json"
+    record = json.loads(record_path.read_text())
+    # Positive control: the key is there to begin with, so its removal is what
+    # the assertion below is reading and not a path that never had it.
+    assert record.pop("mcp_config_servers") == ["lion"]
+    record_path.write_text(json.dumps(record))
+
+    assert jobs.status(run_id)["mcp_config_servers"] is None

--- a/tests/mcp/test_spawn_reports_its_server_set.py
+++ b/tests/mcp/test_spawn_reports_its_server_set.py
@@ -148,6 +148,63 @@ def test_no_config_found_reports_null_and_says_where_it_looked(sandbox, submit_d
     assert handle["mcp_config_reason"].startswith("no_mcp_config_found_at_or_above:")
 
 
+def test_a_config_declaring_no_servers_reports_an_empty_set(sandbox, submit_dir, no_spawn):
+    """The second way an answer of none is reached, and the one that was wrong.
+
+    A config was found and it declares no servers. The question was asked and
+    answered, so it reports `[]`. The resolver returns a null server map both for
+    this and for finding no config at all, and only its reason tells them apart,
+    so reading the map alone reported "cannot say" about a file that had said so
+    explicitly.
+    """
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {}}))
+
+    handle = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    assert handle["mcp_config_servers"] == []
+    assert handle["mcp_config_reason"] == "mcp_config_declares_no_servers"
+    # The file that answered is named, so a reader is not sent looking for a
+    # config that was never consulted.
+    assert handle["mcp_config_source"] == str(submit_dir / ".mcp.json")
+    assert jobs.status(handle["run_id"])["mcp_config_servers"] == []
+
+
+def test_declaring_none_and_finding_no_config_are_different_answers(
+    sandbox, submit_dir, no_spawn, tmp_path
+):
+    """The distinction the fix restores, asserted against its neighbour.
+
+    Both come back from the resolver with a null server map. One of them is a
+    settled answer of none and the other is genuinely nothing to report, and a
+    reader must be able to tell which without knowing the resolver's internals.
+    """
+    (submit_dir / ".mcp.json").write_text(json.dumps({"mcpServers": {}}))
+    declared_none = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    (submit_dir / ".mcp.json").unlink()
+    nothing_found = jobs.submit("agent", ["-m", "x"], prompt="hi", cwd=str(submit_dir))
+
+    assert declared_none["mcp_config_servers"] == []
+    assert nothing_found["mcp_config_servers"] is None
+
+
+@pytest.mark.parametrize("kind", ["flow", "fanout"])
+def test_other_kinds_report_their_server_set_too(sandbox, submit_dir, no_spawn, kind):
+    """Resolution is not agent-only, so neither is the reporting.
+
+    One shared submit path serves every kind. A test that only ever calls `agent`
+    establishes the field for one caller and says nothing about the others.
+    """
+    (submit_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"lion": {"command": "li"}, "khive": {"command": "kk"}}})
+    )
+
+    handle = jobs.submit(kind, ["-m", "x"], prompt="do a thing", cwd=str(submit_dir))
+
+    assert handle["mcp_config_servers"] == ["khive", "lion"]
+    assert jobs.status(handle["run_id"])["mcp_config_servers"] == ["khive", "lion"]
+
+
 def test_a_record_written_before_the_field_existed_reads_as_cannot_say(
     sandbox, submit_dir, no_spawn
 ):


### PR DESCRIPTION
Partially addresses #2664.

#2664 raises two separable things. This does the second one only.

- **Whether the orchestration server belongs in a worker's set at all** is a
  behaviour change with arguments both ways, and the issue itself says it
  should be decided rather than assumed. Not touched here.
- **Whether the resolved set is reportable** needs no such decision. It is
  purely additive, and it is what a caller needs first: before asking why a
  worker could not reach a server, you want to know whether that server was
  ever in the run's set.

## What changes

`mcp_config_servers` names the resolved servers, sorted, on the submit handle.

`job.status` carries the whole `mcp_config` group. It previously reported none
of it, so the values existed only on the submit handle, which is a one-shot.
The question gets asked afterwards, while looking into a run that has already
finished, and until now answering it meant opening the run's record on disk.

An empty list and a null are deliberately different answers:

| value | meaning | when |
|---|---|---|
| `["khive", "lion"]` | this run resolved these | a config was found and snapshotted |
| `[]` | settled, and the answer was none | the caller disabled MCP for the run, or a config was found and declares no servers |
| `null` | no set was resolved, so none can be named | the caller named their own config file, or no config was found at or above the launch directory, or the record predates the field |

Collapsing those would make the case most worth reporting, a run whose workers
got no servers, read exactly like a run where nobody asked.

`mcp_config_reason` separates the causes within each value, except for a record
older than the field, which carries no reason either.

The second `[]` case keeps its `mcp_config_source`, so a reader is told which
file answered rather than being left with an empty set beside a null source and
sent looking for a config that was never consulted.

## What it does not claim

The field reports what was **resolved**. It is not a claim that the child's
provider then started each server: one can be listed here and still fail to
come up in the child's own session. Telling those apart needs the child's own
startup record, which this does not stand in for and does not provide.

## Tests

Eleven test functions, twelve cases with the parametrized kinds. They cover
each answer, that `[]` and `null` are not equal, that the two paths returning a
null server map from the resolver report differently, that `status` agrees with
the handle, that flow and fanout report the same as agent, and that a record
written before the field existed reads as `null` rather than as an empty set.
The last one asserts the key is present before removing it, so it reads a
removal rather than a path that never had the key.

Verified the tests discriminate by mutation: removing the branch that reports
`[]` for a config declaring no servers fails exactly the two tests that exist
for it, with the mutation confirmed applied in the file before the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
