### PR TITLE
ci(release): retry buildx setup and verify the image reached the registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,18 +111,11 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
-  # A job of its own, for two reasons. It reads the tag back from the registry
-  # rather than trusting the push step's exit, because those are different claims
-  # and the second is the one a user depends on. And it runs even when the docker
-  # job failed or was cancelled, which is what happened to the two releases that
-  # shipped no image: their only signal was a run-level conclusion that stands for
-  # every job in the run and goes red for unrelated reasons. A named job that
-  # fails says which thing is missing.
-  #
-  # Limit worth knowing: nothing inside a workflow run survives a run-level
-  # cancellation, so a cancelled release run still publishes nothing and reports
-  # nothing. Covering that needs a check outside this workflow, comparing the
-  # published package version against the registry.
+  # Reads the tag back from the registry rather than trusting the push step's
+  # exit, because those are different claims and the second is the one a user
+  # depends on. Its own job so it still runs when the docker job failed or was
+  # cancelled, which is how both missing images happened, and so an absent image
+  # fails something whose name says what is missing.
   verify-image:
     needs: docker
     if: ${{ always() && needs.docker.result != 'skipped' }}
@@ -141,23 +134,33 @@ jobs:
 
         list_tags() {
           local token
-          token="$(curl -sSf "https://ghcr.io/token?scope=repository:${repo}:pull" | jq -r '.token')"
+          token="$(curl -sSf "https://ghcr.io/token?scope=repository:${repo}:pull" | jq -r '.token')" || return 1
           curl -sSf -H "Authorization: Bearer ${token}" \
             "https://ghcr.io/v2/${repo}/tags/list" | jq -r '.tags[]?'
         }
 
+        query_ok=0
+        count=0
+
         # A newly pushed tag can take a moment to appear, so give it a few tries
         # before calling it absent.
         for attempt in 1 2 3 4 5; do
-          tags="$(list_tags || true)"
+          if tags="$(list_tags)"; then
+            query_ok=1
+          else
+            query_ok=0
+            tags=""
+          fi
           count="$(printf '%s\n' "${tags}" | grep -c . || true)"
 
-          # Positive control. An absence only means something if the same query
-          # can return a presence: an empty listing and a missing tag read
-          # identically, so a listing that resolved nothing is an instrument
-          # failure rather than an answer.
-          if [ "${count}" -eq 0 ]; then
-            echo "Attempt ${attempt}: tag listing returned nothing."
+          # Positive control. An absence only means something if the query that
+          # reported it finished and returned some other tag. Both halves are
+          # needed: an empty listing and a missing tag read identically, and a
+          # read that dies partway leaves output behind, so output alone would
+          # let a broken read be reported as a missing image. Status and content
+          # are separate claims and this asks for both.
+          if [ "${query_ok}" -eq 0 ] || [ "${count}" -eq 0 ]; then
+            echo "Attempt ${attempt}: could not list tags for ${repo}."
           elif printf '%s\n' "${tags}" | grep -qxF "${VERSION}"; then
             echo "ghcr.io/${repo}:${VERSION} is present; ${count} tags listed."
             exit 0
@@ -167,7 +170,7 @@ jobs:
           sleep 15
         done
 
-        if [ "${count}" -eq 0 ]; then
+        if [ "${query_ok}" -eq 0 ] || [ "${count}" -eq 0 ]; then
           echo "::error::Could not list tags for ${repo}. This check cannot tell a missing image from a broken read, so it is failing rather than passing."
         else
           echo "::error::ghcr.io/${repo}:${VERSION} is not in the registry. The registry answered with ${count} other tags, so this is the image missing rather than the check failing. Check the docker job for why the push did not land."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,17 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
 
+    # Setting up buildx pulls the BuildKit image from Docker Hub, so this step
+    # depends on a registry outside this project. A transient 502 there is what
+    # cost the 0.31.0 release its image. One retry covers the transient case; a
+    # sustained outage still fails the job, which is the right outcome.
     - name: Set up Docker Buildx
+      id: buildx
+      continue-on-error: true
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+
+    - name: Set up Docker Buildx (second attempt)
+      if: steps.buildx.outcome == 'failure'
       uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
 
     - name: Log in to GitHub Container Registry
@@ -100,3 +110,50 @@ jobs:
           ghcr.io/ohdearquant/lion-studio:${{ steps.version.outputs.version }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    # Read the tag back from the registry rather than trusting the push step's
+    # own exit. Two releases shipped no image before anyone noticed, because the
+    # only signal was a run-level conclusion that stands for every job in the run
+    # and goes red for unrelated reasons. This asks the registry the question a
+    # user would ask, over the anonymous path a user would use.
+    - name: Verify the image is in the registry
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        set -euo pipefail
+        repo=ohdearquant/lion-studio
+
+        list_tags() {
+          local token
+          token="$(curl -sSf "https://ghcr.io/token?scope=repository:${repo}:pull" | jq -r '.token')"
+          curl -sSf -H "Authorization: Bearer ${token}" \
+            "https://ghcr.io/v2/${repo}/tags/list" | jq -r '.tags[]?'
+        }
+
+        # A newly pushed tag can take a moment to appear, so give it a few tries
+        # before calling it absent.
+        for attempt in 1 2 3 4 5; do
+          tags="$(list_tags || true)"
+          count="$(printf '%s\n' "${tags}" | grep -c . || true)"
+
+          # Positive control. An absence only means something if the same query
+          # can return a presence: an empty listing and a missing tag read
+          # identically, so a listing that resolved nothing is an instrument
+          # failure rather than an answer.
+          if [ "${count}" -eq 0 ]; then
+            echo "Attempt ${attempt}: tag listing returned nothing."
+          elif printf '%s\n' "${tags}" | grep -qxF "${VERSION}"; then
+            echo "ghcr.io/${repo}:${VERSION} is present; ${count} tags listed."
+            exit 0
+          else
+            echo "Attempt ${attempt}: ${count} tags listed, ${VERSION} not among them."
+          fi
+          sleep 15
+        done
+
+        if [ "${count}" -eq 0 ]; then
+          echo "::error::Could not list tags for ${repo}. This check cannot tell a missing image from a broken read, so it is failing rather than passing."
+        else
+          echo "::error::ghcr.io/${repo}:${VERSION} is not in the registry, although the push step reported success and the registry answered with ${count} other tags."
+        fi
+        exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,11 +111,27 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
-    # Read the tag back from the registry rather than trusting the push step's
-    # own exit. Two releases shipped no image before anyone noticed, because the
-    # only signal was a run-level conclusion that stands for every job in the run
-    # and goes red for unrelated reasons. This asks the registry the question a
-    # user would ask, over the anonymous path a user would use.
+  # A job of its own, for two reasons. It reads the tag back from the registry
+  # rather than trusting the push step's exit, because those are different claims
+  # and the second is the one a user depends on. And it runs even when the docker
+  # job failed or was cancelled, which is what happened to the two releases that
+  # shipped no image: their only signal was a run-level conclusion that stands for
+  # every job in the run and goes red for unrelated reasons. A named job that
+  # fails says which thing is missing.
+  #
+  # Limit worth knowing: nothing inside a workflow run survives a run-level
+  # cancellation, so a cancelled release run still publishes nothing and reports
+  # nothing. Covering that needs a check outside this workflow, comparing the
+  # published package version against the registry.
+  verify-image:
+    needs: docker
+    if: ${{ always() && needs.docker.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
     - name: Verify the image is in the registry
       env:
         VERSION: ${{ steps.version.outputs.version }}
@@ -154,6 +170,6 @@ jobs:
         if [ "${count}" -eq 0 ]; then
           echo "::error::Could not list tags for ${repo}. This check cannot tell a missing image from a broken read, so it is failing rather than passing."
         else
-          echo "::error::ghcr.io/${repo}:${VERSION} is not in the registry, although the push step reported success and the registry answered with ${count} other tags."
+          echo "::error::ghcr.io/${repo}:${VERSION} is not in the registry. The registry answered with ${count} other tags, so this is the image missing rather than the check failing. Check the docker job for why the push did not land."
         fi
         exit 1


### PR DESCRIPTION
Two consecutive releases published no container image, and nobody noticed.

`ghcr.io/ohdearquant/lion-studio:0.30.2` and `:0.31.0` do not exist. `0.30.2`'s
docker job was cancelled; `0.31.0`'s died setting up buildx, on a transient 502
from Docker Hub while pulling the BuildKit image. In both cases the Python
packages published normally, so the only signal that anything was wrong was a
run-level conclusion that stands for all six jobs in the release run and goes red
for unrelated reasons. It is simultaneously too alarming to act on and too coarse
to say what broke.

`0.31.1` built and pushed fine, so this is prevent-recurrence rather than a live
outage.

## What changes

**Buildx setup gets one retry.** It pulls the BuildKit image from Docker Hub,
which is a registry this project does not control, and the failure that happened
was transient. A sustained outage still fails the job, which is the right
outcome.

**A new `verify-image` job reads the tag back from the registry.** The push step
reporting success is not the same claim as the tag existing, and the second claim
is the one a user depends on. The check queries the tag list over the anonymous
path an outside consumer would use.

It is a separate job rather than a step, for a reason worth stating: as a step
inside `docker` it could only run after a push that had already succeeded, and
both failures this exists for happened earlier than that. `needs: docker` with a
condition that fires whenever the docker job actually ran means a cancelled or
failed docker job still gets its image checked, and an absent image fails a job
whose name says what is missing.

## The positive control, which is the part that carries the weight

The check refuses to report an absence unless the same query returned some other
tag.

An empty tag list and a missing tag read identically. A query that can never
return anything, from a wrong repository name or an expired token or a registry
outage, reports a missing image exactly the way a genuine gap does, and it fails
only in the reassuring direction if you treat "not found" as the answer. So a
listing that resolves nothing is reported as an instrument failure and says so,
rather than being reported as a missing image.

**The first version of that control was incomplete in the one direction it exists
for.** `tags="$(list_tags || true)"` discarded the query's exit status but kept
its stdout, so a read that died after emitting a tag left output behind, counted
non-zero, and took the branch that reports the image missing. A transport reset
mid-body or a parser failure after the first tag was enough to invert the answer.
The check now keeps the query's status in its own variable, discards tags from an
unsuccessful read rather than counting them, and routes either half being wrong to
the instrument-failure message.

`list_tags` itself also returned success when its token fetch failed, and the
reason is worth stating correctly because the obvious explanation is the wrong
one. It is not that `local token` on a line of its own swallows the next
assignment's status: measured, `$?` is 1 immediately after the failed assignment.
It is that `list_tags` is called from a condition, `if tags="$(list_tags)"`, and
`set -e` does not apply inside a command whose status is being tested. The failed
assignment therefore did not end the function; execution fell through to the
second `curl`, and the function returned that pipeline's status. `|| return 1`
ends the function where the failure happens.

## Verification

The script was extracted from the workflow and run four ways. Only the retry
sleep was shortened; the control flow and network calls are otherwise unchanged.

| Case | Result |
| --- | --- |
| Live registry, `VERSION=0.31.1` | `0.31.1 is present; 23 tags listed.` exit 0 |
| Live registry, `VERSION=0.31.0` | five attempts, then `0.31.0 is not in the registry`, exit 1 |
| Listing emits one tag then fails (status 22) | `could not list tags`, instrument-failure error, exit 1 |
| Listing succeeds and emits nothing | `could not list tags`, instrument-failure error, exit 1 |

The third case is the one the fix is for, and it was run against the previous
version of this script as a control: given the same failing-but-productive read,
the old code reported `ghcr.io/ohdearquant/lion-studio:0.31.1 is not in the
registry` for a version that is in the registry. So the four results above are not
four ways of passing a check that cannot fail.

## Stated limits

`always()` means this job also runs when the release run itself is cancelled, and
it will report the image absent, because it is. That is the deliberate choice:
silencing the cancelled case would silence exactly how `0.30.2` went missing.

`0.30.2` and `0.31.0` have no image and will not get one unless deliberately
rebuilt. Their release notes now say so and point at `0.31.1`. Whether to
backfill those two images is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
