### PR TITLE
fix(cli): let a resumed codex leg replace the profile its first run generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   profile per invocation, so the code refuses to add a second one when the
   caller already asked for a profile of their own. A resumed leg re-spawns from
   its persisted request, which carries the profile the first run generated, and
-  that was being read as a caller's profile. A generated profile is now
-  recognised and replaced, which is also what the resumed leg needs: the first
-  run deleted its profile file on the way out, so the inherited name pointed at
-  nothing. A profile the caller supplied is still refused.
+  that was being read as a caller's profile. A profile named in the generated
+  shape, `lionagi-mcp-` followed by 32 hex characters, is now replaced instead,
+  which is also what the resumed leg needs: the first run deleted its profile
+  file on the way out, so the inherited name pointed at nothing. That shape is
+  reserved. Any other profile name, including another name under the same
+  prefix, is the caller's and is still refused.
 
 ## [0.31.1] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   reports what was resolved, which is not a claim that the child's provider then
   started each server.
 
+### Fixed
+
+- Resuming a codex leg that was given MCP servers with `env` or `http_headers`
+  no longer fails before spawn. Those fields are handed to codex through a
+  generated config profile rather than the command line, and codex takes one
+  profile per invocation, so the code refuses to add a second one when the
+  caller already asked for a profile of their own. A resumed leg re-spawns from
+  its persisted request, which carries the profile the first run generated, and
+  that was being read as a caller's profile. A generated profile is now
+  recognised and replaced, which is also what the resumed leg needs: the first
+  run deleted its profile file on the way out, so the inherited name pointed at
+  nothing. A profile the caller supplied is still refused.
+
 ## [0.31.1] - 2026-07-28
 
 ### Upgrading from 0.31.0

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from collections.abc import Callable, Collection
 from typing import TYPE_CHECKING, Any
 
@@ -962,10 +963,25 @@ def _discover_ambient_codex_mcp_server_names() -> set[str]:
     return {entry["name"] for entry in listed if isinstance(entry, dict) and "name" in entry}
 
 
-# Names under this prefix are generated here and belong to lionagi. It is what
+# Names of this shape are generated here and belong to lionagi. It is what
 # separates a profile this code minted from one the caller asked for, so the
 # minting, the reaping and the caller-profile check all read it from one place.
+#
+# It has to be the NAME that carries this, because the profile a resumed leg
+# arrives with was written by a different process: an in-process record of what
+# this run generated cannot recognise it. So the shape is narrow, a fixed prefix
+# and exactly 32 hex characters, and it is reserved: a caller who names a
+# profile in that exact shape is treated as having named one of ours and has it
+# replaced. Anything else, `lionagi-mcp-custom` included, is the caller's and is
+# refused rather than overwritten.
 _CODEX_MCP_PROFILE_PREFIX = "lionagi-mcp-"
+_GENERATED_CODEX_PROFILE_RE = re.compile(rf"^{re.escape(_CODEX_MCP_PROFILE_PREFIX)}[0-9a-f]{{32}}$")
+
+
+def _is_generated_codex_profile(name: object) -> bool:
+    """Whether *name* is a profile name `_write_codex_mcp_secret_profile` minted."""
+    return isinstance(name, str) and _GENERATED_CODEX_PROFILE_RE.match(name) is not None
+
 
 # Profile files older than this are considered abandoned (the process that
 # wrote them was killed before its `atexit` cleanup ran, e.g. SIGKILL/crash)
@@ -1015,10 +1031,10 @@ def _write_codex_mcp_secret_profile(
     # Only a profile the caller asked for is a conflict. A resumed leg re-spawns
     # from its persisted request, and that request carries the profile the first
     # run generated here, whose file that run already deleted on its way out. So
-    # a name under our own prefix is not a second profile to refuse, it is a
-    # spent one to replace.
+    # a name of our own generated shape is not a second profile to refuse, it is
+    # a spent one to replace.
     existing_profile = kwargs.get("profile")
-    if existing_profile and not str(existing_profile).startswith(_CODEX_MCP_PROFILE_PREFIX):
+    if existing_profile and not _is_generated_codex_profile(existing_profile):
         raise ConfigurationError(
             "Cannot forward MCP server secret fields for codex: the request "
             f"already has an explicit profile={existing_profile!r}, and codex "

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -962,6 +962,11 @@ def _discover_ambient_codex_mcp_server_names() -> set[str]:
     return {entry["name"] for entry in listed if isinstance(entry, dict) and "name" in entry}
 
 
+# Names under this prefix are generated here and belong to lionagi. It is what
+# separates a profile this code minted from one the caller asked for, so the
+# minting, the reaping and the caller-profile check all read it from one place.
+_CODEX_MCP_PROFILE_PREFIX = "lionagi-mcp-"
+
 # Profile files older than this are considered abandoned (the process that
 # wrote them was killed before its `atexit` cleanup ran, e.g. SIGKILL/crash)
 # and safe to reap on the next write.
@@ -969,7 +974,7 @@ _STALE_PROFILE_MAX_AGE_SECONDS = 24 * 60 * 60
 
 
 def _reap_stale_codex_mcp_profiles(codex_home: Path) -> None:
-    """Delete `lionagi-mcp-*.config.toml` profile files older than 24h.
+    """Delete generated profile files older than 24h.
 
     `_write_codex_mcp_secret_profile`'s own cleanup is `atexit`-based, so a
     killed-not-terminated process (SIGKILL, crash) leaves its profile file
@@ -979,7 +984,7 @@ def _reap_stale_codex_mcp_profiles(codex_home: Path) -> None:
     import time
 
     cutoff = time.time() - _STALE_PROFILE_MAX_AGE_SECONDS
-    for stale in codex_home.glob("lionagi-mcp-*.config.toml"):
+    for stale in codex_home.glob(f"{_CODEX_MCP_PROFILE_PREFIX}*.config.toml"):
         try:
             if stale.stat().st_mtime < cutoff:
                 stale.unlink(missing_ok=True)
@@ -1007,8 +1012,13 @@ def _write_codex_mcp_secret_profile(
 
     import toml
 
+    # Only a profile the caller asked for is a conflict. A resumed leg re-spawns
+    # from its persisted request, and that request carries the profile the first
+    # run generated here, whose file that run already deleted on its way out. So
+    # a name under our own prefix is not a second profile to refuse, it is a
+    # spent one to replace.
     existing_profile = kwargs.get("profile")
-    if existing_profile:
+    if existing_profile and not str(existing_profile).startswith(_CODEX_MCP_PROFILE_PREFIX):
         raise ConfigurationError(
             "Cannot forward MCP server secret fields for codex: the request "
             f"already has an explicit profile={existing_profile!r}, and codex "
@@ -1020,7 +1030,7 @@ def _write_codex_mcp_secret_profile(
     codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
     codex_home.mkdir(parents=True, exist_ok=True)
     _reap_stale_codex_mcp_profiles(codex_home)
-    profile_name = f"lionagi-mcp-{uuid.uuid4().hex}"
+    profile_name = f"{_CODEX_MCP_PROFILE_PREFIX}{uuid.uuid4().hex}"
     profile_path = codex_home / f"{profile_name}.config.toml"
 
     profile_doc = {"mcp_servers": {name: dict(fields) for name, fields in secret_fields.items()}}

--- a/tests/cli/test_codex_mcp_secret_profile.py
+++ b/tests/cli/test_codex_mcp_secret_profile.py
@@ -77,16 +77,51 @@ def test_a_caller_supplied_profile_still_refuses(codex_home):
     assert not list(codex_home.glob("*.config.toml"))
 
 
-def test_the_prefix_is_the_only_thing_that_distinguishes_the_two(codex_home):
-    """A caller profile that merely resembles ours is still a caller profile.
+@pytest.mark.parametrize(
+    "name",
+    [
+        "lionagi-mcp",  # the prefix without its trailing dash
+        "lionagi-mcp-custom",  # under the prefix but not the generated shape
+        "lionagi-mcp-" + "0" * 31,  # one hex character short
+        "lionagi-mcp-" + "0" * 33,  # one too many
+        "lionagi-mcp-" + "F" * 32,  # uppercase; generated names are lowercase
+        "prefix-lionagi-mcp-" + "0" * 32,  # the shape, but not at the start
+    ],
+)
+def test_a_name_that_resembles_a_generated_one_is_still_the_callers(codex_home, name):
+    """Only the exact generated shape is treated as ours.
 
-    The prefix is a namespace, and the check is a prefix check, so this records
-    where the boundary sits rather than leaving it to be inferred.
+    Recognition has to go by the name, because a resumed request arrives from a
+    different process, so the boundary is worth pinning rather than leaving to
+    be inferred from a prefix test. A caller who picks the exact generated shape,
+    prefix plus 32 lowercase hex, does lose their profile: that shape is
+    reserved, and nothing in the name can distinguish it from one of ours.
     """
-    kwargs = {"profile": "lionagi-mcp"}  # the prefix without its trailing dash
+    kwargs = {"profile": name}
 
-    with pytest.raises(ConfigurationError):
+    with pytest.raises(ConfigurationError) as excinfo:
         _write_codex_mcp_secret_profile(kwargs, SECRET_FIELDS)
+
+    assert name in str(excinfo.value)
+    assert kwargs["profile"] == name
+    assert not list(codex_home.glob("*.config.toml"))
+
+
+def test_a_failed_write_leaves_the_request_alone(codex_home, monkeypatch):
+    """A profile that could not be written must not be named on the request."""
+    original = {"profile": "lionagi-mcp-" + "a" * 32}
+    kwargs = dict(original)
+
+    def boom(*args, **kwargs_):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(os, "open", boom)
+
+    with pytest.raises(OSError):
+        _write_codex_mcp_secret_profile(kwargs, SECRET_FIELDS)
+
+    assert kwargs == original
+    assert not list(codex_home.glob("*.config.toml"))
 
 
 def test_generated_names_match_the_pattern_the_reaper_globs(codex_home):

--- a/tests/cli/test_codex_mcp_secret_profile.py
+++ b/tests/cli/test_codex_mcp_secret_profile.py
@@ -1,0 +1,112 @@
+"""Whose profile is already on the request decides whether forwarding can proceed.
+
+codex takes one `-p` profile per invocation, so forwarding secret-bearing MCP
+server fields through a generated profile has to refuse when the caller asked for
+a profile of their own. A resumed leg re-spawns from its persisted request, and
+that request carries the profile the *first* run generated, so the same guard was
+refusing to let lionagi replace its own profile: every resume of a leg that got
+secret-bearing servers died before spawn.
+"""
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from lionagi._errors import ConfigurationError
+from lionagi.agent.factory import (
+    _CODEX_MCP_PROFILE_PREFIX,
+    _write_codex_mcp_secret_profile,
+)
+
+SECRET_FIELDS = {"khive": {"env": {"KHIVE_TOKEN": "x"}}}
+
+
+@pytest.fixture
+def codex_home(tmp_path, monkeypatch):
+    home = tmp_path / "codex"
+    home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    return home
+
+
+def _written_profile(codex_home: Path) -> Path:
+    files = sorted(codex_home.glob(f"{_CODEX_MCP_PROFILE_PREFIX}*.config.toml"))
+    assert len(files) == 1, f"expected exactly one generated profile, got {files}"
+    return files[0]
+
+
+def test_fresh_request_gets_a_generated_profile(codex_home):
+    kwargs: dict = {}
+    _write_codex_mcp_secret_profile(kwargs, SECRET_FIELDS)
+
+    assert kwargs["profile"].startswith(_CODEX_MCP_PROFILE_PREFIX)
+    written = _written_profile(codex_home)
+    assert written.stem.removesuffix(".config") == kwargs["profile"]
+    assert oct(written.stat().st_mode)[-3:] == "600"
+    assert "KHIVE_TOKEN" in written.read_text()
+
+
+def test_resume_replaces_the_profile_a_previous_run_generated(codex_home):
+    """The persisted request carries the first run's generated profile name.
+
+    Its file is already gone, deleted by that run's own exit cleanup, so keeping
+    the name would point codex at a profile that does not exist. Replacing it is
+    both allowed and required.
+    """
+    stale = f"{_CODEX_MCP_PROFILE_PREFIX}b961dde4c5af46de82922a3b57dfc89d"
+    kwargs = {"profile": stale, "model": "gpt-5.6-terra"}
+
+    _write_codex_mcp_secret_profile(kwargs, SECRET_FIELDS)
+
+    assert kwargs["profile"] != stale
+    assert kwargs["profile"].startswith(_CODEX_MCP_PROFILE_PREFIX)
+    assert kwargs["model"] == "gpt-5.6-terra"
+    assert _written_profile(codex_home).stem.removesuffix(".config") == kwargs["profile"]
+
+
+def test_a_caller_supplied_profile_still_refuses(codex_home):
+    kwargs = {"profile": "my-own-profile"}
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        _write_codex_mcp_secret_profile(kwargs, SECRET_FIELDS)
+
+    assert "my-own-profile" in str(excinfo.value)
+    assert kwargs["profile"] == "my-own-profile"
+    assert not list(codex_home.glob("*.config.toml"))
+
+
+def test_the_prefix_is_the_only_thing_that_distinguishes_the_two(codex_home):
+    """A caller profile that merely resembles ours is still a caller profile.
+
+    The prefix is a namespace, and the check is a prefix check, so this records
+    where the boundary sits rather than leaving it to be inferred.
+    """
+    kwargs = {"profile": "lionagi-mcp"}  # the prefix without its trailing dash
+
+    with pytest.raises(ConfigurationError):
+        _write_codex_mcp_secret_profile(kwargs, SECRET_FIELDS)
+
+
+def test_generated_names_match_the_pattern_the_reaper_globs(codex_home):
+    """Minting and reaping have to agree, or abandoned profiles never get swept."""
+    kwargs: dict = {}
+    _write_codex_mcp_secret_profile(kwargs, SECRET_FIELDS)
+
+    assert re.fullmatch(rf"{re.escape(_CODEX_MCP_PROFILE_PREFIX)}[0-9a-f]{{32}}", kwargs["profile"])
+    assert list(codex_home.glob(f"{_CODEX_MCP_PROFILE_PREFIX}*.config.toml"))
+
+
+def test_stale_generated_profiles_are_reaped_and_live_ones_are_not(codex_home):
+    old = codex_home / f"{_CODEX_MCP_PROFILE_PREFIX}deadbeef.config.toml"
+    old.write_text("")
+    os.utime(old, (0, 0))
+    unrelated = codex_home / "someones-own.config.toml"
+    unrelated.write_text("")
+    os.utime(unrelated, (0, 0))
+
+    _write_codex_mcp_secret_profile({}, SECRET_FIELDS)
+
+    assert not old.exists()
+    assert unrelated.exists(), "the reaper must only touch names it minted"


### PR DESCRIPTION
Resuming a codex agent that was given MCP servers with `env` or `http_headers`
fails before the child spawns:

```
ConfigurationError: Cannot forward MCP server secret fields for codex: the
request already has an explicit profile='lionagi-mcp-b961dde4c5af46de82922a3b57dfc89d',
and codex accepts only one `-p` profile per invocation. Remove the explicit
profile or drop `env`/`http_headers` from the MCP server config.
```

The profile in that message is one lionagi generated. There is nothing for the
caller to remove.

## Why it happens

Server fields that can carry secrets are handed to codex through a generated
config profile under `$CODEX_HOME` rather than on the command line, so the values
stay out of `ps` output and out of serialized request records. codex takes one
`-p` profile per invocation, so `_write_codex_mcp_secret_profile` refuses to add
a second one when the request already names a profile.

A resumed leg re-spawns from its persisted request. `lionagi/cli/agent.py` reads
`cfg = branch.chat_model.endpoint.config.kwargs` on that path, and those kwargs
carry the profile the *first* run generated. The guard could not tell that name
from a profile the caller asked for, so it refused. The failure is deterministic:
every resume of a leg that got secret-bearing servers hits it.

## The fix

A profile named in the shape this function mints, `lionagi-mcp-` followed by 32
lowercase hex characters, is replaced rather than refused. Replacing it is what
the resumed leg needs regardless of the guard: the first run deletes its profile
file on the way out, so the inherited name pointed at a file that no longer
exists. Any other name is the caller's and still refuses, with the same message.

Recognition has to go by the name, and that is worth stating plainly. A resumed
leg arrives carrying a profile written by a different process, so an in-process
record of what this run generated cannot recognise it, and nothing in the string
separates a caller who picks the exact generated shape from lionagi. So that
shape is **reserved**: a caller who names a profile `lionagi-mcp-<32 hex>` will
have it replaced. A near miss is not enough — `lionagi-mcp-custom`, a 31- or
33-character body, and an uppercase body are all the caller's and are refused.
The docstring and the changelog say so rather than leaving it to be found.

The prefix had been spelled out separately in the minting and the reaping glob.
It gets one definition, and the generated shape one regex, so those cannot drift
apart — a reaper that stops matching what the minter writes leaves credential
files on disk indefinitely.

## Tests

`tests/cli/test_codex_mcp_secret_profile.py`, twelve cases: a fresh request gets
a generated 0600 profile; a resumed request replaces the previous run's name and
leaves the rest of the request alone; a caller-supplied profile still raises and
writes nothing; six names that resemble the generated one are still the caller's;
a failed profile write leaves the request untouched; generated names match the
pattern the reaper globs; and the reaper sweeps stale generated files without
touching anyone else's.

Two mutations, each asserted to have reached the file before running:

- reverting the guard to `if existing_profile:` fails the resume case and the
  failed-write case, and leaves the rest green
- loosening the shape check back to a bare prefix test fails four of the
  resembling-name cases

so the suite discriminates the bug this fixes and the looser rule it replaces.

## Unrelated failures seen on the way

`tests/cli/test_mcp_set_reaches_every_cli_provider.py` has two failures that
reproduce on `main` at `df8f6bca6` with this branch's `factory.py` swapped out,
so they are not from this change. They are worth their own look, since one of
them is asserting that a secret stays off the command line. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
