### PR TITLE
test(cli): pin the flow worker to codex so a machine profile cannot pick the provider

### DIFF
--- a/tests/cli/test_mcp_set_reaches_every_cli_provider.py
+++ b/tests/cli/test_mcp_set_reaches_every_cli_provider.py
@@ -380,7 +380,7 @@ async def _codex_worker(flow_run, servers: dict):
 
 @pytest.mark.asyncio
 async def test_the_flow_worker_these_tests_build_is_a_codex_worker(flow_run, codex_home):
-    """Guards the pin the two tests below depend on.
+    """The worker the two cases below build resolves to the codex provider.
 
     Agent profiles live outside the repository, so an unpinned worker makes
     this file's provider a property of the machine running it. Asserting the

--- a/tests/cli/test_mcp_set_reaches_every_cli_provider.py
+++ b/tests/cli/test_mcp_set_reaches_every_cli_provider.py
@@ -27,6 +27,8 @@ import pytest
 
 from lionagi.agent.factory import apply_forwarded_mcp_servers
 
+CODEX_SPEC = "codex/gpt-5.3-codex"
+
 SERVERS = {"khive": {"command": "kkernel", "args": ["serve"]}}
 SECRET = "sk-live-do-not-put-me-on-argv"
 SECRET_SERVERS = {"khive": {"command": "kkernel", "env": {"KHIVE_API_KEY": SECRET}}}
@@ -356,7 +358,7 @@ async def _codex_worker(flow_run, servers: dict):
     (flow_run / ".mcp.json").write_text(json.dumps({"mcpServers": servers}))
     env = await setup_orchestration(
         pattern_name="Fanout",
-        model_spec="codex/gpt-5.3-codex",
+        model_spec=CODEX_SPEC,
         agent_name=None,
         save_dir=None,
         cwd=None,
@@ -365,8 +367,30 @@ async def _codex_worker(flow_run, servers: dict):
         effort=None,
         theme=None,
     )
-    branch, _, _, _ = await build_worker_branch(env, agent_id="w1", role="implementer")
+    # A worker's role resolves through the agent profiles installed on the
+    # machine, and a profile's model beats the run's default spec. Without a
+    # pin, whichever model `implementer` happens to name locally is the one
+    # these codex assertions run against, and the file silently tests another
+    # provider. `model_override` is the only input that wins unconditionally.
+    branch, _, _, _ = await build_worker_branch(
+        env, agent_id="w1", role="implementer", model_override=CODEX_SPEC
+    )
     return env, branch
+
+
+@pytest.mark.asyncio
+async def test_the_flow_worker_these_tests_build_is_a_codex_worker(flow_run, codex_home):
+    """Guards the pin the two tests below depend on.
+
+    Agent profiles live outside the repository, so an unpinned worker makes
+    this file's provider a property of the machine running it. Asserting the
+    provider directly means removing the pin fails here, saying which provider
+    was built, rather than further down on an argv shape that no longer applies.
+    """
+    codex_home.write_config({})
+    _env, branch = await _codex_worker(flow_run, SERVERS)
+
+    assert branch.chat_model.endpoint.config.provider == "codex"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The flow-worker cases in `tests/cli/test_mcp_set_reaches_every_cli_provider.py`
assert on the `-c mcp_servers.*` arguments a codex worker is spawned with, and
on a secret staying off that command line. The worker they build is resolved
from a role alone.

## Why that is not necessarily a codex worker

`build_worker_branch` resolves a role through `resolve_worker_spec`, which reads
the agent profiles installed on the machine. When a profile exists its model
wins over the `model_spec` the run was set up with; only `model_override` beats
it unconditionally.

So the provider these assertions run against is decided outside the repository.
On a machine whose `implementer` profile names a different provider, the file
builds that provider's worker and then asserts codex argv shapes against it.
Both argv cases fail, and they fail in a way that reads as a defect in MCP
server forwarding rather than as the test having built the wrong thing.

A checkout with no local agent profiles resolves the role to the run's default
spec, which is codex, so the file passes there. That is not evidence the
assertions hold. It means the machine supplied no profile.

## The change

The worker carries `model_override`, set to the same spec the run is set up
with, so the provider is a property of the test rather than of the machine.

A new case asserts the resolved provider directly, ahead of the two argv cases.
Without it, removing the pin fails further down on an argv shape that no longer
applies, which does not say what actually went wrong.

## What the discriminator shows, and what it cannot

Removing `model_override` and running the file on a machine whose `implementer`
profile names a non-codex model fails all three cases, the new one first and by
provider name. Restoring it passes all fifteen, with the file hash verified back
to its pre-mutation value.

That discriminator executes anywhere, but it can only falsify on a machine that
has the dependency. Without local agent profiles the unpinned worker resolves to
the run's default spec, which is codex, so all three pass and the mutation shows
nothing. This is inherent rather than a gap in the check: the condition being
removed is a dependency on machine state, and a machine that does not have it
cannot demonstrate its removal.

`tests/cli/` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
