### PR TITLE
fix(service): complete the CLI provider permission tables and guard them at import

### DIFF
--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -179,22 +179,55 @@ del _overlap
 # ── Per-provider yolo kwargs ──────────────────────────────────────────────
 
 PROVIDER_YOLO_KWARGS: dict[str, dict] = {
+    "claude-code": {"permission_mode": "bypassPermissions"},
     "claude_code": {"permission_mode": "bypassPermissions"},
     "claude": {"permission_mode": "bypassPermissions"},
     "codex": {"full_auto": True, "skip_git_repo_check": True},
+    "gemini-cli": {"yolo": True},
+    "gemini_cli": {"yolo": True},
     "gemini_code": {"yolo": True},
     "gemini-code": {"yolo": True},
     "pi": {"no_tools": False},
 }
 
 PROVIDER_BYPASS_KWARGS: dict[str, dict] = {
+    "claude-code": {"permission_mode": "bypassPermissions"},
     "claude_code": {"permission_mode": "bypassPermissions"},
     "claude": {"permission_mode": "bypassPermissions"},
     "codex": {"bypass_approvals": True, "skip_git_repo_check": True},
+    "gemini-cli": {"yolo": True},
+    "gemini_cli": {"yolo": True},
     "gemini_code": {"yolo": True},
     "gemini-code": {"yolo": True},
     "pi": {"no_tools": False},
 }
+
+
+def _validate_provider_permission_tables(
+    cli_providers: set[str] | frozenset[str],
+    yolo_kwargs: dict[str, dict],
+    bypass_kwargs: dict[str, dict],
+) -> None:
+    """Raise when a CLI provider is absent from a permission capability table."""
+    missing = {
+        "PROVIDER_YOLO_KWARGS": sorted(cli_providers - yolo_kwargs.keys()),
+        "PROVIDER_BYPASS_KWARGS": sorted(cli_providers - bypass_kwargs.keys()),
+    }
+    missing = {table: providers for table, providers in missing.items() if providers}
+    if missing:
+        details = "; ".join(
+            f"{table} missing {providers!r}" for table, providers in missing.items()
+        )
+        raise RuntimeError(f"Provider permission table incomplete: {details}")
+
+
+# Missing entries silently downgrade execution permissions, so capability table
+# drift must fail at import rather than at the first tool call.
+_validate_provider_permission_tables(
+    CLI_PROVIDERS,
+    PROVIDER_YOLO_KWARGS,
+    PROVIDER_BYPASS_KWARGS,
+)
 
 # fast_mode: route codex via OpenAI priority tier (lower latency, same effort)
 # No-op for providers that don't support service_tier.

--- a/tests/service/test_providers.py
+++ b/tests/service/test_providers.py
@@ -1,0 +1,37 @@
+import pytest
+
+from lionagi.service.providers import (
+    CLI_PROVIDERS,
+    PROVIDER_BYPASS_KWARGS,
+    PROVIDER_YOLO_KWARGS,
+    _validate_provider_permission_tables,
+)
+
+
+def test_cli_providers_have_permission_table_entries():
+    assert CLI_PROVIDERS <= PROVIDER_YOLO_KWARGS.keys()
+    assert CLI_PROVIDERS <= PROVIDER_BYPASS_KWARGS.keys()
+
+
+def test_provider_permission_table_validation_names_missing_provider():
+    with pytest.raises(RuntimeError) as exc_info:
+        _validate_provider_permission_tables(
+            {"covered", "missing-provider"},
+            {"covered": {}},
+            {"covered": {}, "missing-provider": {}},
+        )
+    assert "missing-provider" in str(exc_info.value)
+    assert "PROVIDER_YOLO_KWARGS" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("alias", "sibling"),
+    [
+        ("claude-code", "claude_code"),
+        ("gemini-cli", "gemini_code"),
+        ("gemini_cli", "gemini_code"),
+    ],
+)
+def test_permission_aliases_match_provider_family(alias, sibling):
+    assert PROVIDER_YOLO_KWARGS[alias] == PROVIDER_YOLO_KWARGS[sibling]
+    assert PROVIDER_BYPASS_KWARGS[alias] == PROVIDER_BYPASS_KWARGS[sibling]


### PR DESCRIPTION
The per-provider yolo and bypass capability tables in `lionagi/service/providers.py`
are keyed by provider spelling and were maintained by hand, so they had drifted
from `CLI_PROVIDERS`: `claude-code`, `gemini-cli` and `gemini_cli` were absent
from both tables.

Every consumer reads these tables with a default of an empty dict
(`lionagi/cli/agent.py`, `lionagi/agent/factory.py`, and two sites in
`lionagi/cli/_providers.py`), so a provider missing from a table did not raise.
It silently lost the permissions the caller asked for.

The visible effect: a run launched with `--yolo` reached the CLI with permissions
unset, had its tool call auto-denied, and reported an error advising the user to
re-run with yolo, which was already set. The advice came from the same path that
had discarded the flag.

## Changes

- Add the three missing spellings to both tables, each mapping to the same kwargs
  its existing provider-family sibling already uses.
- Add `_validate_provider_permission_tables`, a pure completeness check called at
  import, which raises when any `CLI_PROVIDERS` member is absent from either table
  and names both the table and the missing providers. This follows the module's
  existing precedent of failing closed at import on a provider-classification
  conflict.

The values genuinely differ per provider family, so the tables stay explicit
rather than becoming comprehensions over `CLI_PROVIDERS`. The validator supplies
the safety without pretending the values are uniform.

## Tests

`tests/service/test_providers.py`:

- completeness asserted over the live objects rather than a hardcoded list, so it
  detects the next drift rather than restating this fix;
- the validator is called directly with crafted missing-key inputs to prove it
  raises and names the offender;
- alias parity: each previously-missing spelling resolves to the same kwargs as
  its sibling.

154 tests pass across the new file and the existing provider, CLI and factory
suites. Ruff format and lint pass.
