### PR TITLE
fix(agent): refuse an MCP server set named for an Antigravity-backed provider

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -53,6 +53,7 @@ async def create_agent(
     chat_model: Any = None,
     log_config: Any = None,
     resolved_mcp_servers: dict[str, Any] | None | UnsetType = Unset,
+    resolved_mcp_explicit: bool = False,
 ) -> Branch:
     """Create a fully wired Branch from AgentSpec: settings → hooks → prompt → model → tools.
 
@@ -60,7 +61,8 @@ async def create_agent(
     its own — it is handed to the CLI request verbatim and suppresses the
     discovery this factory would otherwise do from the agent's own working
     directory. ``None`` means "hand nothing over"; leaving it unset keeps the
-    discovery behaviour.
+    discovery behaviour. ``resolved_mcp_explicit`` says that set was named by
+    the caller rather than found near its launch directory.
     """
     spec = config
 
@@ -164,6 +166,7 @@ async def create_agent(
         spec,
         trust_project_settings=trust_project_settings,
         resolved_servers=resolved_mcp_servers,
+        resolved_servers_explicit=resolved_mcp_explicit,
     )
     _wire_external_hooks(branch, spec)
 
@@ -608,6 +611,7 @@ async def _load_mcp(
 
 
 _MCP_FORWARDING_PROVIDERS = frozenset({*_CLAUDE_PROVIDER_NAMES, "codex"})
+_ANTIGRAVITY_PROVIDER_NAMES = frozenset({"gemini-cli", "gemini_cli", "gemini-code", "gemini_code"})
 
 
 def provider_accepts_forwarded_mcp(provider: str | None) -> bool:
@@ -759,6 +763,7 @@ def _forward_mcp_to_cli_request(
     *,
     trust_project_settings: bool = False,
     resolved_servers: dict[str, Any] | None | UnsetType = Unset,
+    resolved_servers_explicit: bool = False,
 ) -> None:
     """Forward an MCP server set into the CLI provider's own request.
 
@@ -770,6 +775,10 @@ def _forward_mcp_to_cli_request(
     config file is looked for: a caller that already resolved a set is saying
     which servers this agent gets, and discovering a second one from the
     agent's working directory would silently replace it.
+
+    ``resolved_servers_explicit`` says the handed-over set was named by the
+    caller rather than discovered near the launch directory. Both arrive here as
+    the same dict, so only the caller can tell them apart.
     """
     caller_resolved = resolved_servers is not Unset
     mcp_path = (
@@ -786,6 +795,18 @@ def _forward_mcp_to_cli_request(
     provider = getattr(branch.chat_model.endpoint.config, "provider", None)
 
     if not provider_accepts_forwarded_mcp(provider):
+        # Refusing is only right when someone asked for these servers by name.
+        # A set the caller merely discovered near the launch directory is not an
+        # ask, and an empty set is the opposite of one, so neither can turn a
+        # working spawn into a hard failure.
+        named_explicitly = bool(spec.mcp_config_path) or resolved_servers_explicit
+        asked_for_servers = bool(resolved_servers) if caller_resolved else has_config
+        if named_explicitly and asked_for_servers and provider in _ANTIGRAVITY_PROVIDER_NAMES:
+            raise ConfigurationError(
+                f"The {provider!r} provider runs the Antigravity CLI (`agy`), "
+                "which does not support MCP servers; the explicitly supplied "
+                "MCP configuration cannot be forwarded."
+            )
         if has_config:
             import logging
 

--- a/lionagi/cli/_mcp_resolve.py
+++ b/lionagi/cli/_mcp_resolve.py
@@ -59,6 +59,11 @@ class McpResolution:
     reason: str | None
     source: Path | None
     searched_from: Path
+    # True only when the caller named the config file. A set found by walking up
+    # from the launch directory reads identically once resolved, so consumers
+    # that must tell "someone asked for these servers" from "these were lying
+    # around" cannot recover the difference from ``servers`` or ``source``.
+    explicit: bool = False
 
     @property
     def ok(self) -> bool:
@@ -145,7 +150,7 @@ def resolve_spawn_mcp_servers(
             path = (searched_from / path).resolve()
         if not path.is_file():
             raise McpConfigError(f"--mcp-config {str(explicit)!r} is not a readable file ({path})")
-        return McpResolution(_read_servers(path), None, path, searched_from)
+        return McpResolution(_read_servers(path), None, path, searched_from, explicit=True)
 
     found = discover_mcp_config(searched_from)
     if found is None:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -572,6 +572,7 @@ async def _run_agent(
                 log_config=DataLoggerConfig(auto_save_on_exit=False),
                 load_settings=False,
                 resolved_mcp_servers=mcp_resolution.servers,
+                resolved_mcp_explicit=mcp_resolution.explicit,
             )
             # The hand-over happened inside create_agent, so the request it
             # produced is the only honest source for what this leg is getting.

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -7,6 +7,7 @@ import json
 
 import pytest
 
+from lionagi._errors import ConfigurationError
 from lionagi.agent.factory import create_agent
 from lionagi.agent.spec import AgentSpec
 from lionagi.session.branch import Branch
@@ -1247,26 +1248,18 @@ async def test_forward_mcp_codex_none_allowlist_is_still_a_noop(tmp_path, monkey
     assert "config_overrides" not in branch.chat_model.endpoint.config.kwargs
 
 
-async def test_forward_mcp_gemini_provider_warns_and_noops(tmp_path, caplog):
-    import logging
-
+@pytest.mark.parametrize(
+    "provider",
+    ["gemini-cli", "gemini_cli", "gemini-code", "gemini_code"],
+)
+async def test_forward_mcp_gemini_provider_rejects_explicit_config(tmp_path, provider):
     mcp_path = _write_mcp_config(tmp_path, {"khive": {"command": "kkernel"}})
 
-    config = AgentSpec.compose("reviewer", model="gemini_code/gemini-3.5-flash")
+    config = AgentSpec.compose("reviewer", model=f"{provider}/gemini-3.5-flash")
     config.mcp_config_path = mcp_path
 
-    with caplog.at_level(logging.WARNING, logger="lionagi.agent.factory"):
-        branch = await create_agent(config, load_settings=False)
-
-    assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs
-    messages = [rec.getMessage() for rec in caplog.records if "no MCP passthrough" in rec.message]
-    assert len(messages) == 1
-    # This function sees one branch's provider. Sibling branches in the same
-    # run resolve their own, so the text must not claim the run.
-    assert "gemini_code" in messages[0]
-    assert "this branch" in messages[0]
-    assert "this run" not in messages[0]
-    assert str(branch.id) in messages[0]
+    with pytest.raises(ConfigurationError, match="Antigravity.*does not support MCP"):
+        await create_agent(config, load_settings=False)
 
 
 async def test_forward_mcp_gated_by_trust_project_settings_for_project_scope(tmp_path, monkeypatch):

--- a/tests/cli/test_mcp_forwarding_predicate.py
+++ b/tests/cli/test_mcp_forwarding_predicate.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from lionagi._errors import ConfigurationError
 from lionagi.agent.factory import (
     _forward_mcp_to_cli_request,
     provider_accepts_forwarded_mcp,
@@ -79,6 +80,12 @@ def _capture_warnings(fn):
 def test_predicate_matches_what_the_forwarder_does(provider, mcp_config):
     """The predicate is true exactly when the request comes back carrying servers."""
     branch = _fake_branch(provider)
+    if provider == "gemini-cli":
+        with pytest.raises(ConfigurationError, match="Antigravity.*does not support MCP"):
+            _forward_mcp_to_cli_request(branch, _fake_spec(mcp_config))
+        assert provider_accepts_forwarded_mcp(provider) is False
+        return
+
     _forward_mcp_to_cli_request(branch, _fake_spec(mcp_config))
 
     kwargs = branch.chat_model.endpoint.config.kwargs
@@ -87,6 +94,59 @@ def test_predicate_matches_what_the_forwarder_does(provider, mcp_config):
     )
 
     assert request_carries_servers is provider_accepts_forwarded_mcp(provider)
+
+
+def _antigravity_spec():
+    """A spec that named no config of its own — the CLI hands the set over."""
+    return SimpleNamespace(
+        mcp_config_path=None,
+        mcp_servers=None,
+        cwd=None,
+        profile=SimpleNamespace(role=SimpleNamespace(name="reviewer")),
+    )
+
+
+@pytest.mark.parametrize(
+    ("resolved", "explicit", "case"),
+    [
+        ({"khive": {"command": "kkernel"}}, False, "discovered near the launch directory"),
+        ({}, False, "handed an empty set, which is a refusal"),
+        ({}, True, "named a config that declares no servers"),
+        (None, False, "handed nothing at all"),
+    ],
+)
+def test_antigravity_refusal_needs_servers_someone_asked_for(resolved, explicit, case):
+    """Refusing to spawn is only right when a caller named servers by name.
+
+    Every one of these arrives as the same handed-over dict a named config
+    produces, so a guard that keys on "a set was handed over" turns working
+    spawns into hard failures: the CLI hands over what it found near the
+    submitting directory on every leg, and an orchestrator opting out of MCP
+    hands over an empty set.
+    """
+    branch = _fake_branch("gemini-cli")
+
+    _forward_mcp_to_cli_request(
+        branch,
+        _antigravity_spec(),
+        resolved_servers=resolved,
+        resolved_servers_explicit=explicit,
+    )
+
+    assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs, case
+
+
+def test_antigravity_refusal_fires_for_a_named_server_set():
+    """The counterpart: naming servers this provider cannot reach is an error."""
+    branch = _fake_branch("gemini-cli")
+
+    with pytest.raises(ConfigurationError, match="Antigravity.*does not support MCP"):
+        _forward_mcp_to_cli_request(
+            branch,
+            _antigravity_spec(),
+            resolved_servers={"khive": {"command": "kkernel"}},
+            resolved_servers_explicit=True,
+        )
 
 
 def test_forwarding_providers_are_the_two_cli_transports():


### PR DESCRIPTION
## What this is

An investigation that concluded "do not implement", plus the fix for the failure
mode that conclusion leaves behind.

## Finding

`provider_accepts_forwarded_mcp()` excludes every Gemini provider spelling, so a
Gemini leg receives no MCP servers. The obvious reading is that a third
forwarding arm was never written beside the Claude and Codex ones.

That reading is wrong. `lionagi/providers/google/gemini_code.py` spawns the
Antigravity CLI (`agy`), not Google's `gemini` CLI, for all four aliases. `agy`
has no `mcp` subcommand and no option that defines a server set, so there is
nothing to forward into. Google's CLI does support per-invocation server
definitions through an isolated `GEMINI_CLI_HOME` — verified end to end, the CLI
lists only the injected server from an isolated directory — but that mechanism is
inert for a subprocess that is not Google's CLI.

So the capability set is left alone. Adding the aliases to it would produce a
forwarding path that resolves, logs, and delivers nothing.

## What changes

The failure mode, not the capability.

Today a caller who names a config file and gets one of these providers has the
config silently dropped. That is the same shape as a permission table silently
dropping `--yolo`: the request succeeds and the capability is gone. Naming
servers for an Antigravity-backed provider now raises `ConfigurationError` and
says why.

The refusal has to fire only for servers someone actually asked for. Two cases
reach the factory as the same handed-over dict:

- the CLI resolving the nearest `.mcp.json` above the submitting directory, which
  happens on essentially every leg, and
- an orchestrator handing over an empty set to opt out of MCP deliberately.

Neither is a request for servers, and refusing either would turn working spawns
into hard failures — the second with a message about configuration the caller
never supplied. The distinction is not recoverable downstream, so `McpResolution`
now records whether the config file was named by the caller, and the factory
refuses only for a non-empty, caller-named set.

## Tests

`tests/cli/test_mcp_forwarding_predicate.py` covers both directions: four cases
that must still spawn (discovered set, empty set, named-but-declares-no-servers,
nothing handed over) and one that must refuse. `tests/agent/test_factory.py`
asserts the refusal for all four aliases through `create_agent`.

Both arms matter. A guard that fires on everything and a guard that fires on
nothing pass the same one-sided test.

## Verification

```
105 passed in 2.77s
```

covering `tests/cli/test_mcp_forwarding_predicate.py`, `tests/agent/test_factory.py`,
`tests/cli/test_mcp_set_reaches_every_cli_provider.py` and
`tests/cli/test_agent_mcp_scope_messages.py`. `ruff check` and `ruff format` clean;
pre-commit passed on commit.

The broader `tests/cli` run in this checkout also hits `ModuleNotFoundError` for
`fastapi` and `croniter` in the schedule and orchestrate suites — a `uv sync`
without `--all-extras`, not a regression from this change. CI installs extras and
covers those.