### PR TITLE
fix(providers): give agy a print-mode cap derived from the caller's timeout

### DIFF
--- a/lionagi/config.py
+++ b/lionagi/config.py
@@ -82,6 +82,11 @@ class AppSettings(BaseSettings, frozen=True):
     # 0 disables the watchdog (deterministic / test runs).
     LIONAGI_WORKER_LIVENESS_TIMEOUT: float = 120.0
 
+    # Antigravity print-mode cap (seconds). One hour is comfortably above
+    # expected caller deadlines while retaining a finite subprocess bound;
+    # deployments that need another ceiling can override this setting by name.
+    LIONAGI_ANTIGRAVITY_PRINT_TIMEOUT: float = 3600.0
+
     LOG_PERSIST_DIR: str = "./data/logs"
     LOG_SUBFOLDER: str | None = None
     LOG_CAPACITY: int = 50

--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -538,6 +538,28 @@ async def run(
         if isinstance(_timeout, int | float) and _timeout > 0:
             _stream_deadline = anyio.current_time() + float(_timeout)
 
+        request_model = getattr(endpoint, "_request_model", None)
+        if request_model is not None:
+            from lionagi.providers.google.gemini_code import (
+                GeminiCodeRequest,
+                derive_print_timeout,
+                format_print_timeout,
+            )
+
+            endpoint_kwargs = getattr(getattr(endpoint, "config", None), "kwargs", {})
+            if (
+                request_model is GeminiCodeRequest
+                and kw.get("print_timeout") is None
+                and endpoint_kwargs.get("print_timeout") is None
+            ):
+                if _stream_deadline is not None:
+                    kw["print_timeout"] = derive_print_timeout(_timeout)
+                else:
+                    from lionagi.config import settings as _app_settings  # noqa: PLC0415
+
+                    default_cap = _app_settings.LIONAGI_ANTIGRAVITY_PRINT_TIMEOUT
+                    kw["print_timeout"] = format_print_timeout(default_cap)
+
         # Pop liveness_timeout before create_event — CLI providers don't consume it either.
         # Explicit values (including 0/negative-to-disable) are always honored. Absent
         # falls back to the configured default, but only for endpoints that declare

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 import os
 import re
 from collections.abc import AsyncIterator, Callable
@@ -59,6 +60,7 @@ __all__ = (
     "GeminiChunk",
     "GeminiCodeRequest",
     "GeminiSession",
+    "derive_print_timeout",
     "stream_gemini_cli",
     "stream_gemini_cli_events",
     "GeminiCLIEndpoint",
@@ -202,6 +204,20 @@ def resolve_agy_model(
 
 
 # --------------------------------------------------------------------------- request model
+
+
+def format_print_timeout(seconds: int | float) -> str:
+    """Format a seconds value as a Go duration `agy` will parse."""
+    # Whole seconds only. General float formatting reaches scientific notation
+    # for large values ("1e+06"), which Go's duration parser rejects, and a cap
+    # that fails to parse is exactly the uninformative failure this avoids.
+    return f"{math.ceil(seconds)}s"
+
+
+def derive_print_timeout(timeout: int | float) -> str:
+    """Return an agy Go-duration cap that stays behind lionagi's deadline."""
+    # One minute lets lionagi's deadline cancel and preserve its clearer error first.
+    return format_print_timeout(math.ceil(timeout) + 60)
 
 
 class GeminiCodeRequest(BaseModel):

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -206,18 +206,31 @@ def resolve_agy_model(
 # --------------------------------------------------------------------------- request model
 
 
+# A Go duration is an int64 count of nanoseconds, so nothing longer than this
+# parses. It is about 292 years, which is the longest "effectively no cap" that
+# can still be expressed.
+_MAX_GO_DURATION_SECONDS = (2**63 - 1) // 10**9
+
+
 def format_print_timeout(seconds: int | float) -> str:
     """Format a seconds value as a Go duration `agy` will parse."""
-    # Whole seconds only. General float formatting reaches scientific notation
-    # for large values ("1e+06"), which Go's duration parser rejects, and a cap
-    # that fails to parse is exactly the uninformative failure this avoids.
+    # Whole seconds only, and bounded at both ends of what Go can represent.
+    # General float formatting reaches scientific notation for large values
+    # ("1e+06"), an unbounded value overflows Go's int64 nanoseconds, and a
+    # non-finite one cannot be converted to an integer at all. Every one of
+    # those ends the same way: a cap agy cannot parse, so the run fails with
+    # agy's own uninformative timeout error, which is the failure this whole
+    # path exists to stop producing. Asking for longer than Go can express is
+    # asking for as long as possible, so it clamps rather than raising.
+    if not math.isfinite(seconds) or seconds >= _MAX_GO_DURATION_SECONDS:
+        return f"{_MAX_GO_DURATION_SECONDS}s"
     return f"{math.ceil(seconds)}s"
 
 
 def derive_print_timeout(timeout: int | float) -> str:
     """Return an agy Go-duration cap that stays behind lionagi's deadline."""
     # One minute lets lionagi's deadline cancel and preserve its clearer error first.
-    return format_print_timeout(math.ceil(timeout) + 60)
+    return format_print_timeout(timeout + 60)
 
 
 class GeminiCodeRequest(BaseModel):

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -869,6 +869,27 @@ async def test_run_preserves_endpoint_gemini_print_timeout_without_timeout():
     assert model.endpoint.config.kwargs["print_timeout"] == "50m"
 
 
+async def test_run_preserves_endpoint_gemini_print_timeout_with_caller_timeout():
+    """The fourth precedence case: endpoint cap set AND a caller deadline set.
+
+    The other three combinations of (caller timeout, explicit cap) are covered
+    above. This is the one where a derived value exists and could plausibly
+    overwrite an explicit one, so it is the cell most worth pinning down.
+    """
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    model.endpoint._request_model = GeminiCodeRequest
+    model.endpoint.config = types.SimpleNamespace(kwargs={"print_timeout": "50m"})
+    branch = Branch()
+    branch.chat_model = model
+
+    await _collect(run(branch, "hi", RunParam(imodel_kw={"timeout": 1200})))
+
+    assert "print_timeout" not in captured
+    assert model.endpoint.config.kwargs["print_timeout"] == "50m"
+
+
 async def test_gemini_timeout_arms_produce_distinct_caps():
     """A caller deadline receives headroom; the configured default is the cap."""
     from lionagi.providers.google.gemini_code import GeminiCodeRequest

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -752,6 +752,138 @@ async def test_run_strips_timeout_from_create_event_kwargs():
     assert "timeout" not in captured, f"timeout leaked into create_event kwargs: {captured!r}"
 
 
+async def test_run_derives_gemini_print_timeout_from_caller_timeout():
+    """The shared run seam forwards its deadline to buffered Gemini CLI requests."""
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    model.endpoint._request_model = GeminiCodeRequest
+    branch = Branch()
+    branch.chat_model = model
+
+    await _collect(run(branch, "hi", RunParam(imodel_kw={"timeout": 1200})))
+
+    derived = captured["print_timeout"]
+    assert int(derived.removesuffix("s")) > 1200
+    assert "timeout" not in captured
+
+
+async def test_run_preserves_explicit_gemini_print_timeout():
+    """An explicit provider cap wins over the timeout-derived default."""
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    model.endpoint._request_model = GeminiCodeRequest
+    branch = Branch()
+    branch.chat_model = model
+
+    await _collect(
+        run(
+            branch,
+            "hi",
+            RunParam(imodel_kw={"timeout": 1200, "print_timeout": "45m"}),
+        )
+    )
+
+    assert captured["print_timeout"] == "45m"
+
+
+async def test_run_without_timeout_sets_configured_gemini_print_timeout(monkeypatch):
+    """The shared run seam supplies the configured cap without an outer deadline."""
+    import lionagi.config as config_module
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    configured_cap = 3600.0
+    monkeypatch.setattr(
+        config_module,
+        "settings",
+        config_module.AppSettings(LIONAGI_ANTIGRAVITY_PRINT_TIMEOUT=configured_cap),
+    )
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    model.endpoint._request_model = GeminiCodeRequest
+    branch = Branch()
+    branch.chat_model = model
+
+    await _collect(run(branch, "hi", RunParam()))
+
+    assert captured["print_timeout"] == "3600s"
+
+
+async def test_configured_gemini_print_timeout_stays_a_parseable_go_duration(monkeypatch):
+    """A large configured cap must not reach agy as scientific notation.
+
+    The setting exists to be overridden, and general float formatting turns
+    values at or above a million into "1e+06", which Go's duration parser
+    rejects. That failure would surface as agy's own uninformative timeout
+    error, which is the failure this whole path exists to stop producing.
+    """
+    import lionagi.config as config_module
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    monkeypatch.setattr(
+        config_module,
+        "settings",
+        config_module.AppSettings(LIONAGI_ANTIGRAVITY_PRINT_TIMEOUT=1_000_000.0),
+    )
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    model.endpoint._request_model = GeminiCodeRequest
+    branch = Branch()
+    branch.chat_model = model
+
+    await _collect(run(branch, "hi", RunParam()))
+
+    emitted = captured["print_timeout"]
+    assert emitted.endswith("s")
+    # int() rejects both "1e+06" and any other non-integer spelling, so this
+    # asserts parseability rather than restating the formatting expression.
+    assert int(emitted.removesuffix("s")) == 1_000_000
+
+
+async def test_run_preserves_explicit_gemini_print_timeout_without_timeout():
+    """An explicit provider cap also wins when no outer deadline is configured."""
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    model.endpoint._request_model = GeminiCodeRequest
+    branch = Branch()
+    branch.chat_model = model
+
+    await _collect(run(branch, "hi", RunParam(imodel_kw={"print_timeout": "45m"})))
+
+    assert captured["print_timeout"] == "45m"
+
+
+async def test_run_preserves_endpoint_gemini_print_timeout_without_timeout():
+    """Endpoint configuration is explicit and must not receive a request default."""
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    model.endpoint._request_model = GeminiCodeRequest
+    model.endpoint.config = types.SimpleNamespace(kwargs={"print_timeout": "50m"})
+    branch = Branch()
+    branch.chat_model = model
+
+    await _collect(run(branch, "hi", RunParam()))
+
+    assert "print_timeout" not in captured
+    assert model.endpoint.config.kwargs["print_timeout"] == "50m"
+
+
+async def test_gemini_timeout_arms_produce_distinct_caps():
+    """A caller deadline receives headroom; the configured default is the cap."""
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    async def captured_cap(imodel_kw):
+        model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+        model.endpoint._request_model = GeminiCodeRequest
+        branch = Branch()
+        branch.chat_model = model
+        await _collect(run(branch, "hi", RunParam(imodel_kw=imodel_kw)))
+        return captured["print_timeout"]
+
+    assert await captured_cap({"timeout": 1200}) != await captured_cap({})
+
+
 # ---------------------------------------------------------------------------
 # Regression: Branch.operate() must flatten **kwargs so timeout reaches run()
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_gemini_cli_endpoint.py
+++ b/tests/providers/test_gemini_cli_endpoint.py
@@ -16,6 +16,7 @@ import pytest
 from lionagi.providers.google.gemini_code import (
     GeminiCodeRequest,
     GeminiSession,
+    derive_print_timeout,
     stream_gemini_cli,
 )
 
@@ -62,6 +63,27 @@ class TestCmdArgs:
         assert req.full_prompt() == "be terse\n\nask"
         args = req.as_cmd_args()
         assert args[1] == "be terse\n\nask"
+
+    def test_caller_timeout_emits_derived_print_timeout(self):
+        caller_timeout = 1200
+        derived = derive_print_timeout(caller_timeout)
+        args = GeminiCodeRequest(prompt="hi", print_timeout=derived).as_cmd_args()
+
+        i = args.index("--print-timeout")
+        assert args[i + 1] == derived
+        assert int(derived.removesuffix("s")) > caller_timeout
+
+    def test_explicit_print_timeout_is_preserved(self):
+        explicit = "45m"
+        args = GeminiCodeRequest(prompt="hi", print_timeout=explicit).as_cmd_args()
+
+        i = args.index("--print-timeout")
+        assert args[i + 1] == explicit
+
+    def test_no_caller_timeout_omits_print_timeout(self):
+        args = GeminiCodeRequest(prompt="hi").as_cmd_args()
+
+        assert "--print-timeout" not in args
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_gemini_cli_endpoint.py
+++ b/tests/providers/test_gemini_cli_endpoint.py
@@ -17,6 +17,7 @@ from lionagi.providers.google.gemini_code import (
     GeminiCodeRequest,
     GeminiSession,
     derive_print_timeout,
+    format_print_timeout,
     stream_gemini_cli,
 )
 
@@ -84,6 +85,29 @@ class TestCmdArgs:
         args = GeminiCodeRequest(prompt="hi").as_cmd_args()
 
         assert "--print-timeout" not in args
+
+    @pytest.mark.parametrize(
+        "unbounded",
+        [float("inf"), 1e300, 1e10],
+        ids=["infinite", "astronomically-large", "just-over-go-max"],
+    )
+    def test_unbounded_caps_stay_parseable_instead_of_raising(self, unbounded):
+        """A cap longer than Go can express clamps rather than breaking.
+
+        A Go duration is int64 nanoseconds, so anything past ~9.2e9 seconds
+        overflows, and a non-finite value cannot be made an integer at all.
+        Both would reach agy as something it cannot parse, which surfaces as
+        agy's own uninformative timeout error -- the failure this path exists
+        to stop producing. Asking for longer than Go can express is asking for
+        as long as possible, so clamping is the honest answer.
+        """
+        for emitted in (format_print_timeout(unbounded), derive_print_timeout(unbounded)):
+            assert emitted.endswith("s")
+            # int() rejects "inf", "1e+300" and every other non-integer
+            # spelling, so this asserts parseability rather than restating the
+            # clamping expression.
+            seconds = int(emitted.removesuffix("s"))
+            assert 0 < seconds <= (2**63 - 1) // 10**9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2677.

A `gemini-cli` / `gemini-code` leg died at roughly 300 seconds regardless of the timeout the caller set.

## Cause

The limit on how long the work may run has two enforcement points, and only one was reachable from the caller:

1. **lionagi's run deadline** (`_stream_with_deadline`) holds the caller's `timeout`. It closes the stream, and for a CLI provider that close cascades to the subprocess reader's `finally` and terminates the process group, so it genuinely bounds the child.
2. **`agy`'s own `--print-timeout`**, applied inside that same subprocess.

Nothing in the package ever set `print_timeout`, so the flag was never passed and `agy` applied its `5m0s` default. That default is tighter than any realistic caller timeout, so it always fired first, and its error names neither the limit nor its origin and discards partial output.

## Change

Both enforcement points now derive from the same value.

| caller timeout | forwarded `--print-timeout` |
|---|---|
| set | the caller's value plus 60s headroom, so the enforcer with the better diagnostics fires first and `agy` stays a backstop |
| not set | `LIONAGI_ANTIGRAVITY_PRINT_TIMEOUT` (default 3600s), a named configurable cap rather than an inherited vendor default |

An explicitly supplied `print_timeout` wins in both cases, on the request and via endpoint kwargs.

The cap is formatted as whole seconds: general float formatting reaches scientific notation for large values (`1e+06`), which Go's duration parser rejects, and a cap that fails to parse would surface as exactly the uninformative error this change removes.

## Verification

- Both entry paths covered: the wiring sits at the shared `run()` seam rather than in either CLI-specific path.
- 57 tests pass across `tests/operations/run/test_run.py` and `tests/providers/test_gemini_cli_endpoint.py`.
- Tests assert the two arms produce *different* values for the same call shape, so a flag-presence check cannot pass for the wrong reason; the ordering relationship is asserted rather than the arithmetic restated.
- The installed `agy` accepts the emitted duration strings.
- `ruff check` and `ruff format` clean; pre-commit passes on all changed files.