### PR TITLE
fix(streams): resolve parsing and truncation backlog

### DIFF
--- a/lionagi/service/hooks/hooked_event.py
+++ b/lionagi/service/hooks/hooked_event.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+from contextvars import ContextVar
 
 import anyio
 import sniffio
@@ -15,6 +16,8 @@ from lionagi.service.hooks import HookEvent, HookEventTypes
 from ._types import StreamTerminalState
 
 _logger = logging.getLogger(__name__)
+
+_NO_STREAM_CONTEXT = object()
 
 POST_STREAM_TEARDOWN_GRACE = 5.0
 """Seconds a post-stream hook may take when the stream is being closed or cancelled.
@@ -54,7 +57,10 @@ class HookedEvent(Event):
 
     _pre_invoke_hook_event: HookEvent = PrivateAttr(None)
     _post_invoke_hook_event: HookEvent = PrivateAttr(None)
-    _stream_terminal_state: StreamTerminalState | None = PrivateAttr(None)
+    _stream_terminal_state: ContextVar = PrivateAttr(
+        default_factory=lambda: ContextVar("stream_terminal_state", default=_NO_STREAM_CONTEXT)
+    )
+    _last_stream_terminal_state: StreamTerminalState | None = PrivateAttr(None)
 
     @property
     def stream_terminal_state(self) -> StreamTerminalState | None:
@@ -63,7 +69,10 @@ class HookedEvent(Event):
         Set before the post-invocation hook is invoked, so a hook can tell a stream that
         completed from one that failed, was closed by its consumer, or was cancelled.
         """
-        return self._stream_terminal_state
+        state = self._stream_terminal_state.get()
+        if state is _NO_STREAM_CONTEXT:
+            return self._last_stream_terminal_state
+        return state
 
     async def _core_invoke(self):
         """Override in subclasses; return value is stored in ``self.execution.response``."""
@@ -164,7 +173,7 @@ class HookedEvent(Event):
                 )
             await global_hook_logger.alog(h_ev)
 
-        self._stream_terminal_state = None
+        self._last_stream_terminal_state = None
         state = StreamTerminalState.Completed
         try:
             async for chunk in self._core_stream():
@@ -181,31 +190,35 @@ class HookedEvent(Event):
             state = StreamTerminalState.Failed
             raise
         finally:
-            self._stream_terminal_state = state
+            stream_state_token = self._stream_terminal_state.set(state)
             try:
-                await self._run_post_stream_hook(state)
-            except (KeyboardInterrupt, SystemExit):
-                raise
-            except get_cancelled_exc_class():
-                # A cancellation the hook raised at itself was already absorbed where it
-                # could still be attributed. One reaching here was delivered to the
-                # consuming task, so it is honoured -- except on a stream that ended in
-                # cancellation, where re-raising the source leaves the consumer cancelled
-                # anyway and keeps the exception it was handed.
-                if state is not StreamTerminalState.Cancelled:
+                try:
+                    await self._run_post_stream_hook(state)
+                except (KeyboardInterrupt, SystemExit):
                     raise
-                _logger.warning(
-                    "Post-stream teardown was cancelled while the stream was ending "
-                    "(%s); the stream's own ending is preserved",
-                    state.value,
-                )
-            except BaseException as _teardown_exc:
-                _logger.warning(
-                    "Post-stream teardown failed while the stream was ending (%s): %s",
-                    state.value,
-                    _teardown_exc,
-                    exc_info=True,
-                )
+                except get_cancelled_exc_class():
+                    # A cancellation the hook raised at itself was already absorbed where it
+                    # could still be attributed. One reaching here was delivered to the
+                    # consuming task, so it is honoured -- except on a stream that ended in
+                    # cancellation, where re-raising the source leaves the consumer cancelled
+                    # anyway and keeps the exception it was handed.
+                    if state is not StreamTerminalState.Cancelled:
+                        raise
+                    _logger.warning(
+                        "Post-stream teardown was cancelled while the stream was ending "
+                        "(%s); the stream's own ending is preserved",
+                        state.value,
+                    )
+                except BaseException as _teardown_exc:
+                    _logger.warning(
+                        "Post-stream teardown failed while the stream was ending (%s): %s",
+                        state.value,
+                        _teardown_exc,
+                        exc_info=True,
+                    )
+            finally:
+                self._last_stream_terminal_state = state
+                self._stream_terminal_state.reset(stream_state_token)
 
     async def _run_post_stream_hook(self, state: StreamTerminalState) -> None:
         """Invoke and log the post-invocation hook for a stream that ended in ``state``.

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -873,7 +873,7 @@ class Branch(Element, Relational):
                 image_detail=image_detail or "auto",
                 plain_content=plain_content or "",
                 include_token_usage_to_model=include_token_usage_to_model,
-                imodel=imodel or self.chat_model,
+                imodel=self.chat_model if ChatParam._is_sentinel(imodel) else imodel,
                 imodel_kw=kwargs,
                 turn_origin=_turn_origin,
             ),

--- a/tests/operations/test_parse.py
+++ b/tests/operations/test_parse.py
@@ -239,6 +239,34 @@ class TestAdvancedFeatures:
     """P1: Advanced features and parameters."""
 
     @pytest.mark.asyncio
+    async def test_parse_repair_uses_supplied_falsy_model(self, make_mocked_branch_for_parse):
+        """A false-valued model override still handles the repair turn."""
+        branch = make_mocked_branch_for_parse()
+
+        class FalsyModel:
+            def __init__(self, inner):
+                self.inner = inner
+                self.invoked = False
+
+            def __bool__(self):
+                return False
+
+            async def invoke(self, **kwargs):
+                self.invoked = True
+                return await self.inner.invoke(**kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self.inner, name)
+
+        supplied = FalsyModel(branch.chat_model)
+        parse_param = ParseParam(response_format=OutputModel, imodel=supplied)
+
+        result = await _parse(branch, "invalid json needing repair", parse_param)
+
+        assert isinstance(result, OutputModel)
+        assert supplied.invoked
+
+    @pytest.mark.asyncio
     async def test_parse_return_res_message_success(self, make_mocked_branch_for_parse):
         """Test return_res_message returns tuple on direct validation."""
         branch = make_mocked_branch_for_parse()

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -4,6 +4,7 @@
 """Tests for lionagi.service.hooks.hooked_event — HookedEvent._invoke() and _stream()."""
 
 import asyncio
+import contextvars
 import gc
 import logging
 from types import SimpleNamespace
@@ -454,6 +455,81 @@ async def test_stream_terminal_state_is_completed_on_exhaustion():
     assert chunks == ["chunk1", "chunk2"]
     assert seen == [StreamTerminalState.Completed]
     assert h.stream_terminal_state is StreamTerminalState.Completed
+
+
+@pytest.mark.asyncio
+async def test_concurrent_stream_hooks_see_their_own_terminal_state():
+    """Each concurrent stream's hook observes how that stream ended."""
+    current_stream = contextvars.ContextVar("current_stream")
+    first_hook_started = asyncio.Event()
+    release_first_hook = asyncio.Event()
+    seen: dict[str, StreamTerminalState | None] = {}
+
+    class ConcurrentStream(HookedEvent):
+        async def _core_stream(self):
+            if current_stream.get() == "first":
+                raise ValueError("first stream failed")
+            yield "second stream completed"
+
+    class RecordingPostHook:
+        execution = SimpleNamespace(status=EventStatus.COMPLETED, error=None)
+        _should_exit = False
+        _exit_cause = None
+
+        async def invoke(self):
+            stream = current_stream.get()
+            if stream == "first":
+                first_hook_started.set()
+                await release_first_hook.wait()
+            seen[stream] = event.stream_terminal_state
+
+    event = ConcurrentStream()
+    event._post_invoke_hook_event = RecordingPostHook()
+
+    async def consume(stream: str):
+        current_stream.set(stream)
+        return [chunk async for chunk in event._stream()]
+
+    first = asyncio.create_task(consume("first"))
+    await first_hook_started.wait()
+    assert await consume("second") == ["second stream completed"]
+    release_first_hook.set()
+    with pytest.raises(ValueError, match="first stream failed"):
+        await first
+
+    assert seen == {
+        "first": StreamTerminalState.Failed,
+        "second": StreamTerminalState.Completed,
+    }
+    assert event.stream_terminal_state is StreamTerminalState.Failed
+
+
+@pytest.mark.asyncio
+async def test_public_stream_retains_terminal_state_for_parent_after_context_reset():
+    """The parent keeps seeing the completed state after child invocation cleanup."""
+    event = SimpleHooked()
+
+    async def consume():
+        return [chunk async for chunk in event.stream()]
+
+    assert await asyncio.create_task(consume()) == ["chunk1", "chunk2"]
+    assert event.stream_terminal_state is StreamTerminalState.Completed
+
+
+@pytest.mark.asyncio
+async def test_public_stream_can_be_advanced_from_different_task_contexts():
+    """A timeout task may advance each chunk without corrupting normal exhaustion."""
+    event = SimpleHooked()
+    stream = event.stream()
+
+    assert await asyncio.wait_for(anext(stream), 1) == "chunk1"
+    assert await asyncio.wait_for(anext(stream), 1) == "chunk2"
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(stream), 1)
+
+    assert event.status is EventStatus.COMPLETED
+    assert event.execution.error is None
+    assert event.stream_terminal_state is StreamTerminalState.Completed
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -416,10 +416,11 @@ def _truncation_advice(doc: str) -> tuple[list[str], list[str]]:
 
 
 async def test_docstring_recovery_advice_is_executable(tmp_path):
-    """The commands the oversized-output advice names must match what the guard allows.
+    """The oversized-output advice must name remedies that run and reduce output.
 
     Every command listed as a supported remedy is run here and must succeed;
-    every command listed as unavailable is run here and must be refused by the
+    its stdout must be at most a tenth of the unremedied command's output.
+    Every command listed as unavailable is run here and must be refused by the
     guard. Neither list is compared against expected prose — both are read out
     of the docstring — so rewording the advice keeps this green, while moving a
     command between the lists, or changing the guard so a listed remedy stops
@@ -435,7 +436,8 @@ async def test_docstring_recovery_advice_is_executable(tmp_path):
     # run inside tmp_path. A remedy using an unknown placeholder is a failure,
     # not a silent skip.
     payload = tmp_path / "payload.txt"
-    payload.write_text("line\n" * 200)
+    large_payload = "line\n" * 40_000
+    payload.write_text(large_payload)
     writer = tmp_path / "writer.py"
     writer.write_text(
         "import sys\n"
@@ -443,6 +445,10 @@ async def test_docstring_recovery_advice_is_executable(tmp_path):
         "open(out, 'w').write('generated\\n')\n"
     )
     fixtures = {"FILE": str(payload), "PROG": f"{sys.executable} {writer}"}
+    baseline = await tool.handle_request(BashRequest(command=f"cat {payload}"))
+    assert baseline.return_code == 0
+    assert "truncated" in baseline.stdout.lower()
+    baseline_bytes = len(baseline.stdout.encode())
 
     def runnable(template: str) -> str:
         used = set(re.findall(r"\b[A-Z]{2,}\b", template))
@@ -452,10 +458,18 @@ async def test_docstring_recovery_advice_is_executable(tmp_path):
         return template
 
     for template in offered:
+        payload.write_text(large_payload)
         resp = await tool.handle_request(BashRequest(command=runnable(template)))
         assert resp.return_code == 0, f"advised remedy {template!r} does not run: {resp.stderr}"
+        remedy_bytes = len(resp.stdout.encode())
+        max_remedy_bytes = baseline_bytes // 10
+        assert remedy_bytes <= max_remedy_bytes, (
+            f"advised remedy {template!r} did not materially reduce stdout: "
+            f"{remedy_bytes} bytes exceeds {max_remedy_bytes}"
+        )
 
     for template in ruled_out:
+        payload.write_text(large_payload)
         command = runnable(template)
         resp = await tool.handle_request(BashRequest(command=command))
         assert resp.return_code == -1, (


### PR DESCRIPTION
## Summary

- isolate terminal state for concurrent streams while preserving the last state for parent observers
- preserve explicitly supplied false-valued chat models during parse repair
- require documented truncation remedies to materially reduce output

Closes #2651
Closes #2611
Closes #2647

## Deferred items, since resolved

This branch originally deferred two issues as needing a design decision. Both
were settled separately before this merged, so nothing is outstanding:

- #2652 was fixed by #2709 on the respawn path and by #2713 on the initial-worker
  path. Endpoint `repo` and `add_dir` kwargs are CLI-only, so they are set only
  for CLI-backed workers and the prompt wording follows from that.
- #2612 was fixed by #2707. The nullable projection does not conflict with the
  accepted ADR: ADR-0006 specifies that any exception during the chat projection
  is contained and returns `None`, so restoring that behaviour is what the ADR
  requires. The strict path callers depend on is a separate method and is
  unaffected.

## Verification

Each fix has a discriminating red-before-green regression. The rebased focused
stream, parse, message, and Bash suites pass, as do changed-file Ruff/format and
pre-commit checks.