### PR TITLE
fix(providers): validate the agy print-mode cap before it reaches argv

### DIFF
--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -12,6 +12,7 @@ import math
 import os
 import re
 from collections.abc import AsyncIterator, Callable
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Literal
 
@@ -210,6 +211,61 @@ def resolve_agy_model(
 # parses. It is about 292 years, which is the longest "effectively no cap" that
 # can still be expressed.
 _MAX_GO_DURATION_SECONDS = (2**63 - 1) // 10**9
+_MAX_GO_DURATION_NANOSECONDS = 2**63 - 1
+_MIN_USEFUL_PRINT_TIMEOUT_NANOSECONDS = 10**9
+# The digit classes are spelled `[0-9]` rather than `\d` on purpose. Go's
+# duration grammar is ASCII decimal digits only, while Python's `\d` matches
+# every Unicode decimal digit, so `\d` would accept an Arabic-Indic or
+# fullwidth spelling here and hand it to a parser that rejects it.
+_GO_DURATION_PART = re.compile(
+    r"(?P<number>(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+))"
+    r"(?P<unit>ns|us|µs|μs|ms|s|m|h)"
+)
+_GO_DURATION_UNIT_NANOSECONDS = {
+    "ns": 1,
+    "us": 1_000,
+    "µs": 1_000,
+    "μs": 1_000,
+    "ms": 1_000_000,
+    "s": 1_000_000_000,
+    "m": 60_000_000_000,
+    "h": 3_600_000_000_000,
+}
+
+
+def _validate_print_timeout(value: str) -> str:
+    """Reject a print cap that Go cannot parse or that expires too quickly."""
+    if not isinstance(value, str) or not value:
+        raise ValueError("print_timeout must be a Go duration of at least 1s")
+
+    unsigned = value
+    sign = 1
+    if unsigned[0] in "+-":
+        sign = -1 if unsigned[0] == "-" else 1
+        unsigned = unsigned[1:]
+
+    position = 0
+    nanoseconds = Decimal(0)
+    try:
+        while position < len(unsigned):
+            part = _GO_DURATION_PART.match(unsigned, position)
+            if part is None:
+                raise ValueError
+            nanoseconds += Decimal(part["number"]) * _GO_DURATION_UNIT_NANOSECONDS[part["unit"]]
+            position = part.end()
+    except (InvalidOperation, ValueError):
+        raise ValueError("print_timeout must be a parseable Go duration of at least 1s") from None
+
+    nanoseconds *= sign
+    if (
+        position == 0
+        or nanoseconds < _MIN_USEFUL_PRINT_TIMEOUT_NANOSECONDS
+        or nanoseconds > _MAX_GO_DURATION_NANOSECONDS
+    ):
+        raise ValueError(
+            "print_timeout must be a parseable Go duration between 1s and 9223372036854775807ns"
+        )
+    return value
 
 
 def format_print_timeout(seconds: int | float) -> str:
@@ -222,9 +278,11 @@ def format_print_timeout(seconds: int | float) -> str:
     # agy's own uninformative timeout error, which is the failure this whole
     # path exists to stop producing. Asking for longer than Go can express is
     # asking for as long as possible, so it clamps rather than raising.
-    if not math.isfinite(seconds) or seconds >= _MAX_GO_DURATION_SECONDS:
+    if math.isnan(seconds) or seconds == math.inf or seconds >= _MAX_GO_DURATION_SECONDS:
         return f"{_MAX_GO_DURATION_SECONDS}s"
-    return f"{math.ceil(seconds)}s"
+    if seconds == -math.inf:
+        return "1s"
+    return f"{max(1, math.ceil(seconds))}s"
 
 
 def derive_print_timeout(timeout: int | float) -> str:
@@ -341,7 +399,7 @@ class GeminiCodeRequest(BaseModel):
         elif self.continue_recent:
             args.append("--continue")
         if self.print_timeout:
-            args += ["--print-timeout", self.print_timeout]
+            args += ["--print-timeout", _validate_print_timeout(self.print_timeout)]
         return args
 
 

--- a/tests/providers/test_gemini_cli_endpoint.py
+++ b/tests/providers/test_gemini_cli_endpoint.py
@@ -141,6 +141,12 @@ class TestCmdArgs:
     def test_numeric_caps_have_a_useful_minimum(self, seconds):
         emitted = format_print_timeout(seconds)
 
+        # Whatever the numeric paths emit has to survive the same guard an
+        # explicitly supplied value passes through. Asserting the number alone
+        # would not notice a dropped unit suffix, because int("1") is also 1.
+        args = GeminiCodeRequest(prompt="hi", print_timeout=emitted).as_cmd_args()
+        assert args[args.index("--print-timeout") + 1] == emitted
+        assert emitted.endswith("s")
         assert int(emitted.removesuffix("s")) >= 1
 
 

--- a/tests/providers/test_gemini_cli_endpoint.py
+++ b/tests/providers/test_gemini_cli_endpoint.py
@@ -81,6 +81,34 @@ class TestCmdArgs:
         i = args.index("--print-timeout")
         assert args[i + 1] == explicit
 
+    @pytest.mark.parametrize(
+        "explicit",
+        [
+            "not-a-duration",
+            "0s",
+            "-1s",
+            "999ms",
+            "9223372036854775808ns",
+            # Digits outside ASCII: a duration grammar of ASCII decimal digits
+            # does not accept these, so letting them through would send agy a
+            # value it cannot parse.
+            "١h",
+            "１h",
+        ],
+    )
+    def test_explicit_print_timeout_rejects_unusable_go_durations(self, explicit):
+        request = GeminiCodeRequest(prompt="hi", print_timeout=explicit)
+
+        with pytest.raises(ValueError, match="print_timeout"):
+            request.as_cmd_args()
+
+    def test_endpoint_config_print_timeout_is_checked_at_argv_boundary(self):
+        endpoint_kwargs = {"print_timeout": "0s"}
+        request = GeminiCodeRequest(prompt="hi", **endpoint_kwargs)
+
+        with pytest.raises(ValueError, match="print_timeout"):
+            request.as_cmd_args()
+
     def test_no_caller_timeout_omits_print_timeout(self):
         args = GeminiCodeRequest(prompt="hi").as_cmd_args()
 
@@ -108,6 +136,12 @@ class TestCmdArgs:
             # clamping expression.
             seconds = int(emitted.removesuffix("s"))
             assert 0 < seconds <= (2**63 - 1) // 10**9
+
+    @pytest.mark.parametrize("seconds", [float("-inf"), -1e300, -1, 0, 0.001])
+    def test_numeric_caps_have_a_useful_minimum(self, seconds):
+        emitted = format_print_timeout(seconds)
+
+        assert int(emitted.removesuffix("s")) >= 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was wrong

An explicitly supplied `print_timeout` was appended to the `agy` command line unchecked. A value the duration parser cannot read reached the CLI, and the run died with agy's own timeout error, which names neither the limit nor where it came from. That is the exact failure the cap exists to prevent, so a malformed cap defeated the feature while appearing to configure it.

Three paths produce this value. Two of them (derived from the caller's timeout, and the configured default) went through the numeric formatter, which guarded the upper end. The third, an explicit caller or endpoint-config string, is the one precedence deliberately prefers, and it had no validator at all: `print_timeout="banana"` reached argv as `banana`.

## What changed

**Validation moved to the single point where the value becomes argv.** Both request keyword arguments and endpoint configuration pass through `as_cmd_args()`, so the producers do not each grow their own check that then has to agree with the others. The validator accepts the signed compound duration syntax and unit spellings, computes the nanosecond value with exact decimal arithmetic, and rejects:

- strings it cannot parse
- values below one second
- values past the signed int64 nanosecond range

**The numeric formatter now floors at one second.** It previously emitted zero and negative durations for zero, negative and fractional inputs, all of which are immediate deadlines. Its existing upper clamp for very large and non-finite values is unchanged.

**Digit matching is ASCII-only.** The duration grammar is ASCII decimal digits, while Python's `\d` matches every Unicode decimal digit. Without the restriction, `١h` and `１h` passed validation and were handed to a parser that rejects them, which is the failure mode this change exists to close.

## Behaviour change worth noting

Sub-second explicit values such as `500ms` were previously accepted and now raise. They parse, but they cap every run at under a second, so they configure a failure rather than a limit. One second is the chosen floor because the computed contract emits whole seconds and a sub-second deadline is effectively immediate for a buffered CLI operation.

Precedence is unchanged: an explicit cap still wins over a computed one, and valid explicit values are passed through byte for byte. Invalid explicit values are rejected loudly at argv construction rather than normalised, because silently rewriting an explicit duration preserves neither the caller's intent nor any way to diagnose it.

## Agreement with the reference parser

The accepted unit table was checked against the reference implementation's source rather than its prose documentation, because the documentation names only one of the two microsecond spellings and says nothing about the other. The source accepts both, and this validator accepts exactly the same eight units: `ns`, `us`, `µs` (U+00B5), `μs` (U+03BC), `ms`, `s`, `m`, `h`.

One deliberate divergence, at the very top of the range. The reference parser truncates a sub-nanosecond fraction to zero before its overflow check, so `9223372036854775807.9ns` parses there. This validator computes exactly and rejects it as over the signed int64 bound. The divergence is confined to values within one nanosecond of a 292-year cap and is in the safe direction: it fails at this boundary with a message naming the field, rather than being accepted here and failing somewhere else.

## Tests

`tests/providers/test_gemini_cli_endpoint.py`, `tests/operations/run/test_run.py`: 74 passed.

- `test_explicit_print_timeout_rejects_unusable_go_durations` fails if malformed, non-positive, sub-second, overflowing, or non-ASCII-digit request values reach argv.
- `test_endpoint_config_print_timeout_is_checked_at_argv_boundary` fails if the endpoint-config arm bypasses the common guard.
- `test_numeric_caps_have_a_useful_minimum` feeds what the numeric paths emit back through the same guard an explicit value passes, so a dropped unit suffix fails it. Asserting the number alone did not do that, because `int("1")` clears a `>= 1` assertion just as well as `int("1s".removesuffix("s"))`.
- Existing precedence, caller-derived, configured-default, upper-clamp and omitted-cap tests are retained and still pass.
