### PR TITLE
fix(mcp): the job listing says which running rows never started

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2942,6 +2942,16 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
     live run hiding in a listing somebody has learned to discount is the failure
     this field exists to prevent.
 
+    It is reported as the record carries it, which means null is not one answer.
+    A row whose ``record_state`` is not ``"ok"`` never had a record to read a
+    phase from. A row whose ``record_state`` is ``"ok"`` and whose spawn state is
+    null is a record that parsed and does not name a phase — one written before
+    the field existed, or one carrying something unrecognisable in it. So null
+    reads as "no phase this listing can vouch for", never as "never attempted";
+    the phase that means never-attempted says ``"preparing"`` and says it
+    explicitly. Normalising the value is a change to what ``status`` reports and
+    belongs with it rather than here, where it would make the two disagree.
+
     The directory read itself is different, and is allowed to fail. A listing has
     no field in which to say it could not be read, so answering the empty list
     would say "there are no jobs at all" about a directory nobody could look in.

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2929,6 +2929,19 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
     unknown status. That is a per-run failure, and one damaged record must not cost
     the caller the runs beside it.
 
+    ``spawn_state`` rides along for the same reason those three do, and it is the
+    one that decides what ``running`` means. A record whose spawn was never
+    attempted, or whose result was never written, stays ``running`` on purpose:
+    resolving it would take a bound that cannot tell a loaded machine from a dead
+    spawn, so ``status`` deliberately makes no claim about its fate. That refusal
+    is right, and it is also why the distinction has to be visible here. This
+    listing is what a caller reads to answer "what is in flight right now", and
+    without the spawn state a run that never started is indistinguishable in it
+    from one doing work — same word, two facts. A count that can hold a run that
+    never began is one a caller cannot use as evidence in either direction, so the
+    live run hiding in a listing somebody has learned to discount is the failure
+    this field exists to prevent.
+
     The directory read itself is different, and is allowed to fail. A listing has
     no field in which to say it could not be read, so answering the empty list
     would say "there are no jobs at all" about a directory nobody could look in.
@@ -2956,6 +2969,7 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
                 "terminal": st["terminal"],
                 "outcome": st["outcome"],
                 "reason_code": st["reason_code"],
+                "spawn_state": st["spawn_state"],
                 "submitted_at": st["submitted_at"],
                 "finished_at": st["finished_at"],
                 "terminal_source": st["terminal_source"],

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2946,8 +2946,10 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
     A row whose ``record_state`` is not ``"ok"`` never had a record to read a
     phase from. A row whose ``record_state`` is ``"ok"`` and whose spawn state is
     null is a record that parsed and does not name a phase — one written before
-    the field existed, or one carrying something unrecognisable in it. So null
-    reads as "no phase this listing can vouch for", never as "never attempted";
+    the field existed. A record that names a phase this code does not recognise
+    is listed with that phase verbatim, not as null: the value is reported as the
+    record carries it. So null reads as "no phase this listing can vouch for",
+    never as "never attempted";
     the phase that means never-attempted says ``"preparing"`` and says it
     explicitly. Normalising the value is a change to what ``status`` reports and
     belongs with it rather than here, where it would make the two disagree.

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3251,9 +3251,11 @@ def test_the_listing_says_which_running_rows_never_started(sandbox, monkeypatch)
 def test_a_row_that_names_no_spawn_phase_is_not_read_as_never_started(sandbox, monkeypatch):
     """Null is "no phase this listing can vouch for", not "never attempted".
 
-    A record written before the field existed, and a record carrying something
-    unrecognisable in it, both report null. Neither may be mistaken for the
-    phase that genuinely means never-attempted, which names itself.
+    A record written before the field existed reports null. A record carrying a
+    phase this code does not recognise reports that value verbatim, because the
+    listing repeats what the record says rather than judging it. Neither may be
+    mistaken for the phase that genuinely means never-attempted, which names
+    itself.
     """
     _live_process(monkeypatch)
     legacy = jobs.new_run_id()

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3246,3 +3246,39 @@ def test_the_listing_says_which_running_rows_never_started(sandbox, monkeypatch)
     # And the field that separates them is present without a per-run status call.
     assert listed[never_started]["spawn_state"] == "preparing"
     assert listed[working]["spawn_state"] == "started"
+
+
+def test_a_row_that_names_no_spawn_phase_is_not_read_as_never_started(sandbox, monkeypatch):
+    """Null is "no phase this listing can vouch for", not "never attempted".
+
+    A record written before the field existed, and a record carrying something
+    unrecognisable in it, both report null. Neither may be mistaken for the
+    phase that genuinely means never-attempted, which names itself.
+    """
+    _live_process(monkeypatch)
+    legacy = jobs.new_run_id()
+    jobs._write_job(
+        {"run_id": legacy, "pid": None, "kind": "agent", "status": "running", "log": None}
+    )
+    junk = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": junk,
+            "pid": None,
+            "kind": "agent",
+            "status": "running",
+            "spawn_state": "starting?",
+            "log": None,
+        }
+    )
+
+    listed = {j["run_id"]: j for j in jobs.list_jobs()}
+    # A record with no phase in it says so, and says nothing more.
+    assert listed[legacy]["spawn_state"] is None
+    assert listed[legacy]["record_state"] == "ok"
+    # An unrecognised value is passed through rather than laundered into a known
+    # phase, so a caller can see that the record says something it should not.
+    assert listed[junk]["spawn_state"] == "starting?"
+    # Neither is the value that means never-attempted.
+    assert listed[legacy]["spawn_state"] != "preparing"
+    assert listed[junk]["spawn_state"] != "preparing"

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3201,3 +3201,48 @@ def test_an_interrupt_arriving_during_release_is_not_swallowed_and_still_closes(
             raise ValueError("the failure the interrupt arrived during")
 
     assert closed == [taken["fd"]]
+
+
+def test_the_listing_says_which_running_rows_never_started(sandbox, monkeypatch):
+    """`running` is two different facts, and the listing has to tell them apart.
+
+    A record whose spawn was never attempted stays `running` on purpose — the
+    classifier refuses to resolve it by a bound that cannot tell a loaded machine
+    from a dead spawn. That refusal is right and it is exactly why the listing
+    must carry the spawn state: this is the surface a caller reads to answer what
+    is in flight, and a run that never began must not be counted there as one
+    doing work.
+    """
+    _live_process(monkeypatch)
+    never_started = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": never_started,
+            "pid": None,
+            "kind": "agent",
+            "status": "running",
+            "spawn_state": "preparing",
+            "log": None,
+        }
+    )
+    working = jobs.new_run_id()
+    jobs._write_job(
+        {
+            "run_id": working,
+            "pid": 4242,
+            "pid_create_time": _SPAWNED_AT,
+            "kind": "agent",
+            "status": "running",
+            "spawn_state": "started",
+            "log": None,
+        }
+    )
+
+    listed = {j["run_id"]: j for j in jobs.list_jobs()}
+    assert set(listed) == {never_started, working}
+
+    # Both wear the same word, which is what makes the listing alone misleading.
+    assert listed[never_started]["status"] == listed[working]["status"] == "running"
+    # And the field that separates them is present without a per-run status call.
+    assert listed[never_started]["spawn_state"] == "preparing"
+    assert listed[working]["spawn_state"] == "started"


### PR DESCRIPTION
## What a caller could not see

`list_jobs` is the surface a caller reads to answer "what is in flight right now". It projected a subset of what `status` computes, and the spawn state was not in it.

A record whose spawn was never attempted, or whose result was never written, stays `running`. That is deliberate: resolving it would take a bound that cannot tell a loaded machine from a dead spawn, so the classifier makes no claim about its fate and leaves the row non-terminal. The row reads exactly like a run doing work.

So the listing carried two different facts under one word, and separating them took a per-run `status` call for every row.

## Why it matters past one stale row

A count that can hold a run that never began is one a caller cannot use as evidence in either direction.

Over-counting what is live reads as the safe direction — a caller waits longer, or holds off on a restart. The unsafe direction follows from the same defect: once a listing is known to hold phantoms, a genuinely live run hiding in it is discounted too.

## What this does

`spawn_state` is carried in each listing entry, alongside the fields already there for the same reason: the delivery state of a run's notice, the source of its end, and the state of the record read. Each of those is in the listing because it changes what a row means and a caller polling this surface should not have to open the record to find out.

Nothing is filtered or terminalised. The classifier's refusal to resolve a pre-spawn record by a timeout is untouched and remains correct — a state a caller can see is better than one guessed from a bound.

## Test

One added. It writes two records that both read as `running` — one never spawned, one with a live process — and asserts the listing shows the same status for both and separates them on `spawn_state` without a per-run status call.

Mutation-checked: removing the field from the projection makes it fail. Full `tests/mcp` suite passes; ruff clean.