### PR TITLE
ci: supersede a PR's own in-flight runs instead of queueing beside them

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # A new push to a PR supersedes its own earlier run; pushes to a branch and
+  # manual runs are never cancelled, because those results are a record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   run-benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # A new push to a PR supersedes its own earlier run; pushes to a branch and
+  # manual runs are never cancelled, because those results are a record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+concurrency:
+  # A new push to a PR supersedes its own earlier run; pushes to a branch and
+  # manual runs are never cancelled, because those results are a record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/marketplace-lint.yml
+++ b/.github/workflows/marketplace-lint.yml
@@ -10,6 +10,12 @@ on:
       - 'scripts/ci.sh'
       - 'tests/marketplace_lint.py'
 
+concurrency:
+  # A new push to a PR supersedes its own earlier run; pushes to a branch and
+  # manual runs are never cancelled, because those results are a record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # A new push to a PR supersedes its own earlier run; pushes to a branch and
+  # manual runs are never cancelled, because those results are a record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pyright:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `concurrency` group to the five PR-triggered workflows: `ci`, `benchmarks`, `codeql`, `marketplace-lint`, `typecheck`.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why

None of the five had one. Every push to a branch started a fresh run while all earlier runs for that same branch kept occupying runners through to completion, so a branch pushed to repeatedly multiplies its own cost rather than replacing it. `ci` alone is 14 jobs, and `benchmarks` runs paired baseline/current A/B suites.

Three workflows in the repo already use this pattern (`docs-deploy`, `studio-vercel-deploy`, `studio-post-deploy-smoke`); this brings the PR-gating ones in line.

## Scope of the cancellation

Grouped per workflow **and** per ref, so no workflow cancels another and no PR cancels a different PR.

Cancellation is deliberately limited to `pull_request` events. A push to `main`/`develop` and a manual `workflow_dispatch` both evaluate the expression to `false` and always run to completion: those results are a record of a specific commit, not a preview of the next one. Only a PR's own superseded run is discarded, and it is stale by definition — its head is no longer the branch head.

## Verification

All five files parse as YAML, and each carries the intended group and cancellation expression:

```
ci: ok                group=${{ github.workflow }}-${{ github.ref }}  cancel=${{ github.event_name == 'pull_request' }}
benchmarks: ok        (same)
codeql: ok            (same)
marketplace-lint: ok  (same)
typecheck: ok         (same)
```

No workflow logic, job, step, or trigger is changed — the insertion is a top-level key above `jobs:` in each file.