### PR TITLE
fix(studio): correct graph and artifact status rendering

### DIFF
--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
@@ -85,9 +85,12 @@ describe("WorkerCanvas.tsx — source contract for the compact MiniMap fix", () 
     expect(src).toMatch(/shouldShowMiniMap\(compact, nodes\.length\)/);
   });
 
-  it("docks the non-compact minimap bottom-right at its explicit size", () => {
+  it("docks the non-compact minimap without forcing compact dimensions", () => {
     expect(shouldShowMiniMap(false, 11)).toBe(true);
-    expect(src).toMatch(/position="bottom-right"/);
-    expect(src).toMatch(/style=\{\{ width: 120, height: 80 \}\}/);
+    const minimap = src.match(/<MiniMap[\s\S]*?\/>/)?.[0];
+    expect(minimap).toBeDefined();
+    expect(minimap).toMatch(/position="bottom-right"/);
+    expect(minimap).not.toMatch(/\bstyle=/);
+    expect(minimap).not.toMatch(/\b(?:width|height)=/);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -375,7 +375,6 @@ export default function WorkerCanvas({
               nodeColor={() => "var(--edge-strong)"}
               maskColor="rgba(0, 0, 0, 0.5)"
               className="!bg-surface-raised !border-edge"
-              style={{ width: 120, height: 80 }}
             />
           ) : null}
 

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -666,7 +666,7 @@ async def get_run(
     alive = _session_liveness(detail_session) if detail_session.get("status") == "running" else None
     row = _run_row(detail_session, time.time(), process_alive=alive)
 
-    if row.get("artifact_verification_json") is None:
+    if row.get("status") == "running" and row.get("artifact_verification_json") is None:
         row["artifact_verification_json"] = _provisional_verification(
             row.get("artifact_contract_json"), artifacts_path
         )

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -249,6 +249,53 @@ async def test_get_run_passes_artifact_json_fields(patched_runs_svc):
     assert result["artifact_verification_json"] == verification
 
 
+async def test_get_run_synthesizes_provisional_artifacts_for_running_session(
+    patched_runs_svc, tmp_path
+):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    artifact = tmp_path / "report.md"
+    artifact.write_text("ready")
+    contract = {"expected": [{"id": "report", "path": artifact.name, "required": True}]}
+    await seed_session(
+        db_path,
+        session_id=sid,
+        status="running",
+        artifacts_path=str(tmp_path),
+        artifact_contract_json=contract,
+    )
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    verification = result["artifact_verification_json"]
+    assert verification["provisional"] is True
+    assert [entry["id"] for entry in verification["produced"]] == ["report"]
+
+
+@pytest.mark.parametrize("status", ["completed", "failed"])
+async def test_get_run_does_not_synthesize_provisional_artifacts_for_terminal_session(
+    patched_runs_svc, tmp_path, status
+):
+    svc, db_path = patched_runs_svc
+    sid = str(uuid.uuid4())
+    artifact = tmp_path / "report.md"
+    artifact.write_text("ready")
+    contract = {"expected": [{"id": "report", "path": artifact.name, "required": True}]}
+    await seed_session(
+        db_path,
+        session_id=sid,
+        status=status,
+        artifacts_path=str(tmp_path),
+        artifact_contract_json=contract,
+    )
+
+    result = await svc.get_run(sid)
+
+    assert result is not None
+    assert result["artifact_verification_json"] is None
+
+
 # ---------------------------------------------------------------------------
 # Test 7 — graph is populated from node_metadata when present
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Let the full editor minimap use its responsive dimensions instead of the compact `120x80` sizing.
- Synthesize provisional artifact verification only while a run is `running`; terminal runs without a stored verdict now return `null`.

## Why

The full graph editor was inheriting compact minimap sizing, and completed or failed sessions with no persisted verification could be rendered as though verification were still live.

Closes #2519
Closes #2631

## Reviewer focus

The important contracts are the absence of compact inline dimensions on the non-compact minimap and the `running` status gate before provisional verification synthesis.

## Validation

- `uv run pytest -n0 -q tests/apps_studio_server/test_runs_detail.py tests/studio/test_provisional_artifact_verification.py`
- `npm test -- src/components/canvas/WorkerCanvas.test.ts`
- Frontend lint, typecheck, format check, Ruff, pre-commit hooks, and `git diff --check`

## Not covered

This does not redesign the broader graph layout or manufacture persisted verification for terminal runs that never stored one.