### PR TITLE
fix(agent): reject unsupported explicit MCP configurations

### DIFF
--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -614,6 +614,12 @@ _MCP_FORWARDING_PROVIDERS = frozenset({*_CLAUDE_PROVIDER_NAMES, "codex"})
 _ANTIGRAVITY_PROVIDER_NAMES = frozenset({"gemini-cli", "gemini_cli", "gemini-code", "gemini_code"})
 
 
+def _canonical_provider(provider: str | None) -> str:
+    """Fold a provider string the way endpoint resolution does, so a spelling that
+    resolves to an endpoint is never one these predicates fail to recognise."""
+    return provider.strip().lower() if isinstance(provider, str) else ""
+
+
 def provider_accepts_forwarded_mcp(provider: str | None) -> bool:
     """Whether a provider's request can carry an MCP server set resolved by the caller.
 
@@ -628,7 +634,7 @@ def provider_accepts_forwarded_mcp(provider: str | None) -> bool:
     handed anything over — for that, read ``request_carries_forwarded_mcp`` off
     the request the spawn produced.
     """
-    return provider in _MCP_FORWARDING_PROVIDERS
+    return _canonical_provider(provider) in _MCP_FORWARDING_PROVIDERS
 
 
 def _reject_unforwardable_explicit_mcp(
@@ -638,7 +644,11 @@ def _reject_unforwardable_explicit_mcp(
     asked_for_servers: bool,
 ) -> None:
     """Reject an explicit MCP server set that Antigravity cannot receive."""
-    if named_explicitly and asked_for_servers and provider in _ANTIGRAVITY_PROVIDER_NAMES:
+    if (
+        named_explicitly
+        and asked_for_servers
+        and _canonical_provider(provider) in _ANTIGRAVITY_PROVIDER_NAMES
+    ):
         raise ConfigurationError(
             f"The {provider!r} provider runs the Antigravity CLI (`agy`), "
             "which does not support MCP servers; the explicitly supplied "

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -631,6 +631,21 @@ def provider_accepts_forwarded_mcp(provider: str | None) -> bool:
     return provider in _MCP_FORWARDING_PROVIDERS
 
 
+def _reject_unforwardable_explicit_mcp(
+    provider: str | None,
+    *,
+    named_explicitly: bool,
+    asked_for_servers: bool,
+) -> None:
+    """Reject an explicit MCP server set that Antigravity cannot receive."""
+    if named_explicitly and asked_for_servers and provider in _ANTIGRAVITY_PROVIDER_NAMES:
+        raise ConfigurationError(
+            f"The {provider!r} provider runs the Antigravity CLI (`agy`), "
+            "which does not support MCP servers; the explicitly supplied "
+            "MCP configuration cannot be forwarded."
+        )
+
+
 def request_kwargs_carry_forwarded_mcp(kwargs: dict[str, Any] | None) -> bool:
     """Whether CLI request kwargs actually carry a forwarded MCP server set.
 
@@ -801,12 +816,11 @@ def _forward_mcp_to_cli_request(
         # working spawn into a hard failure.
         named_explicitly = bool(spec.mcp_config_path) or resolved_servers_explicit
         asked_for_servers = bool(resolved_servers) if caller_resolved else has_config
-        if named_explicitly and asked_for_servers and provider in _ANTIGRAVITY_PROVIDER_NAMES:
-            raise ConfigurationError(
-                f"The {provider!r} provider runs the Antigravity CLI (`agy`), "
-                "which does not support MCP servers; the explicitly supplied "
-                "MCP configuration cannot be forwarded."
-            )
+        _reject_unforwardable_explicit_mcp(
+            provider,
+            named_explicitly=named_explicitly,
+            asked_for_servers=asked_for_servers,
+        )
         if has_config:
             import logging
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -496,6 +496,14 @@ async def _run_agent(
             "or use --resume / --continue-last to reopen an existing one."
         )
 
+    from lionagi.agent.factory import _reject_unforwardable_explicit_mcp
+
+    _reject_unforwardable_explicit_mcp(
+        provider,
+        named_explicitly=mcp_resolution.explicit,
+        asked_for_servers=bool(mcp_resolution.servers),
+    )
+
     if branch is None:
         # Codex blocks tool calls until file access is enabled. Surface this
         # even without verbose output; CLI or profile approval flags suppress it.

--- a/tests/cli/test_agent_preset_mcp_handover.py
+++ b/tests/cli/test_agent_preset_mcp_handover.py
@@ -187,6 +187,29 @@ async def test_direct_antigravity_leg_rejects_a_named_nonempty_mcp_set(spawn, tm
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["GEMINI-CLI", "Gemini_Code", "gemini-Cli", " gemini-cli "])
+async def test_a_provider_spelling_that_resolves_is_a_spelling_the_guard_recognises(
+    spawn, tmp_path, provider
+):
+    """Endpoint resolution case-folds the provider, so the guard must too.
+
+    A spelling that differs only in case still resolves to the Antigravity CLI and
+    still runs, so matching the exact lowercase spellings would let the very
+    omission this rejection exists to prevent through under a capitalised name.
+    """
+    from lionagi.cli.agent import _run_agent
+
+    named = _write_mcp_config(tmp_path / "named", {"named": {"command": "server"}})
+
+    with pytest.raises(ConfigurationError, match="Antigravity.*does not support MCP"):
+        await _run_agent(
+            f"{provider}/gemini-3.5-flash",
+            "go",
+            mcp_config=str(named),
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider", ANTIGRAVITY_PROVIDERS)
 async def test_resumed_antigravity_leg_rejects_a_named_nonempty_mcp_set(
     spawn, tmp_path, monkeypatch, provider

--- a/tests/cli/test_agent_preset_mcp_handover.py
+++ b/tests/cli/test_agent_preset_mcp_handover.py
@@ -1,15 +1,9 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""A coding-preset leg must be handed the MCP servers resolved at submission.
+"""Test submission-time MCP handoff and refusal across single-agent CLI paths.
 
-The whole point of resolving the server set from the submitting directory is
-that a leg pointed at a checkout without a config of its own still gets the
-servers its instructions assume. The coding preset builds its agent through
-the factory, which resolves an MCP config of its own unless it is handed one,
-so these spawn with a config that exists only where the command was submitted
-and assert the leg's request carries exactly that set — for both CLI
-transports, since they carry it in different places.
+Caller-named sets must fail when the chosen provider cannot forward them.
 """
 
 from __future__ import annotations
@@ -23,17 +17,13 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from lionagi._errors import ConfigurationError
 from lionagi.cli._logging import _HINT_LOGGER_NAME, _WARN_LOGGER_NAME
 
 
 @contextlib.contextmanager
 def _capture_cli_messages():
-    """Collect what the spawn tells its caller.
-
-    Handlers go on the CLI's own channels rather than through caplog: those
-    loggers stop propagating once CLI logging is configured, and whether that
-    has happened depends on what else ran in the session.
-    """
+    """Collect CLI hints and warnings without relying on log propagation."""
     messages: list[str] = []
 
     class _Collect(logging.Handler):
@@ -56,6 +46,7 @@ def _capture_cli_messages():
 
 SUBMITTED = {"khive": {"command": "kkernel", "args": ["serve"]}}
 NEARBY = {"decoy": {"command": "not-the-submitted-server"}}
+ANTIGRAVITY_PROVIDERS = ("gemini-cli", "gemini_cli", "gemini-code", "gemini_code")
 
 
 def _write_mcp_config(directory: Path, servers: dict) -> Path:
@@ -160,6 +151,99 @@ def _forwarded_servers(branch) -> dict:
             servers.setdefault(name, {})[field] = value
         return servers
     return kwargs.get("mcp_servers") or {}
+
+
+def _write_cli_branch(directory: Path, provider: str) -> tuple[str, Path]:
+    """Persist a CLI-backed branch for a resume-path test."""
+    from lionagi import Branch, iModel
+
+    branch = Branch(
+        chat_model=iModel(
+            provider=provider,
+            endpoint="query_cli",
+            model="gemini-3.5-flash",
+            api_key="dummy",
+        )
+    )
+    branch_id = str(branch.id)
+    path = directory / f"{branch_id}.json"
+    path.write_text(json.dumps(branch.to_dict()))
+    return branch_id, path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ANTIGRAVITY_PROVIDERS)
+async def test_direct_antigravity_leg_rejects_a_named_nonempty_mcp_set(spawn, tmp_path, provider):
+    from lionagi.cli.agent import _run_agent
+
+    named = _write_mcp_config(tmp_path / "named", {"named": {"command": "server"}})
+
+    with pytest.raises(ConfigurationError, match="Antigravity.*does not support MCP"):
+        await _run_agent(
+            f"{provider}/gemini-3.5-flash",
+            "go",
+            mcp_config=str(named),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ANTIGRAVITY_PROVIDERS)
+async def test_resumed_antigravity_leg_rejects_a_named_nonempty_mcp_set(
+    spawn, tmp_path, monkeypatch, provider
+):
+    import lionagi.cli.agent as agent_mod
+
+    branch_id, branch_path = _write_cli_branch(tmp_path, provider)
+    monkeypatch.setattr(agent_mod, "find_branch", lambda _bid: ("run-x", branch_path))
+    named = _write_mcp_config(tmp_path / "named", {"named": {"command": "server"}})
+
+    with pytest.raises(ConfigurationError, match="Antigravity.*does not support MCP"):
+        await agent_mod._run_agent(
+            None,
+            "go",
+            resume=branch_id,
+            mcp_config=str(named),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ANTIGRAVITY_PROVIDERS)
+@pytest.mark.parametrize("resumed", [False, True], ids=["direct", "resumed"])
+@pytest.mark.parametrize(
+    "config_case",
+    ["discovered", "explicit-empty", "disabled"],
+)
+async def test_antigravity_leg_keeps_non_requested_mcp_sets_non_failing(
+    spawn,
+    tmp_path,
+    monkeypatch,
+    provider,
+    resumed,
+    config_case,
+):
+    import lionagi.cli.agent as agent_mod
+
+    model = f"{provider}/gemini-3.5-flash"
+    kwargs = {}
+    if resumed:
+        branch_id, branch_path = _write_cli_branch(tmp_path, provider)
+        monkeypatch.setattr(agent_mod, "find_branch", lambda _bid: ("run-x", branch_path))
+        model = None
+        kwargs["resume"] = branch_id
+
+    if config_case == "explicit-empty":
+        kwargs["mcp_config"] = str(_write_mcp_config(tmp_path / "empty", {}))
+    elif config_case == "disabled":
+        kwargs["no_mcp_config"] = True
+
+    result, _provider, _branch_id, status, _session_id = await agent_mod._run_agent(
+        model,
+        "go",
+        **kwargs,
+    )
+
+    assert result == "done"
+    assert status == "completed"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_mcp_set_reaches_every_cli_provider.py
+++ b/tests/cli/test_mcp_set_reaches_every_cli_provider.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from lionagi._errors import ConfigurationError
 from lionagi.agent.factory import apply_forwarded_mcp_servers
 
 CODEX_SPEC = "codex/gpt-5.3-codex"
@@ -304,23 +305,18 @@ async def test_resumed_leg_keeps_codex_secret_fields_off_the_command_line(
 
 
 @pytest.mark.asyncio
-async def test_resumed_leg_on_a_provider_without_a_transport_is_told_so(
-    monkeypatch, tmp_path, caplog
-):
+async def test_resumed_antigravity_leg_rejects_an_explicit_server_set(monkeypatch, tmp_path):
     from lionagi.cli.agent import _run_agent
 
     branch_id = _wire_resume_stubs(monkeypatch, tmp_path, "gemini_code", "gemini-3.5-flash")
 
-    with caplog.at_level(logging.WARNING, logger=WARN_LOGGER):
+    with pytest.raises(ConfigurationError, match="Antigravity.*does not support MCP"):
         await _run_agent(
             None,
             "follow up",
             resume=branch_id,
             mcp_config=_mcp_config_file(tmp_path, SERVERS),
         )
-
-    assert "not carried" in caplog.text
-    assert "gemini_code" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Centralize the rejection rule for an explicit, non-empty MCP server set sent to an Antigravity provider.
- Apply the rule after provider resolution for both new and resumed CLI branches, while retaining the factory guard for direct factory callers.
- Cover every accepted Antigravity provider spelling and preserve non-failing behavior for discovered, explicitly empty, and disabled MCP configurations.

## Why

`agy` has no MCP transport. Some direct and resumed paths could previously accept an explicitly requested server set and silently omit it.

Closes #2680

## Reviewer focus

The core invariant is deliberately narrow: reject only when the set was named explicitly, is non-empty, and the resolved provider is Antigravity. The CLI-entry guard protects resumed paths; the factory guard protects callers that bypass the CLI entry point.

## Validation

- `uv run pytest -n0 -q tests/cli/test_agent_preset_mcp_handover.py tests/cli/test_mcp_set_reaches_every_cli_provider.py`
- Coverage pins the CLI-entry guard, factory fallback, explicitness check, non-empty check, and Antigravity provider scope
- Ruff, pre-commit hooks, and `git diff --check`

## Not covered

This does not add MCP support to `agy` or change orchestration worker inheritance and provider-selection policy.