### PR TITLE
fix(providers): reject unrepresentable Antigravity deadlines

### DIFF
--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -287,6 +287,11 @@ def format_print_timeout(seconds: int | float) -> str:
 
 def derive_print_timeout(timeout: int | float) -> str:
     """Return an agy Go-duration cap that stays behind lionagi's deadline."""
+    if timeout >= _MAX_GO_DURATION_SECONDS or not math.isfinite(timeout):
+        raise ValueError(
+            f"timeout must be less than {_MAX_GO_DURATION_SECONDS}s so agy's "
+            "print timeout can remain after the caller deadline"
+        )
     # One minute lets lionagi's deadline cancel and preserve its clearer error first.
     return format_print_timeout(timeout + 60)
 

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -768,6 +768,27 @@ async def test_run_derives_gemini_print_timeout_from_caller_timeout():
     assert "timeout" not in captured
 
 
+async def test_run_rejects_gemini_timeout_at_provider_ceiling():
+    """Reject a caller deadline that cannot have a later agy backstop."""
+    from lionagi.providers.google.gemini_code import GeminiCodeRequest
+
+    model, captured = _make_slow_cli_model(chunk_delay=0.0, n_chunks=1)
+    model.endpoint._request_model = GeminiCodeRequest
+    branch = Branch()
+    branch.chat_model = model
+
+    with pytest.raises(ValueError, match="caller deadline"):
+        await _collect(
+            run(
+                branch,
+                "hi",
+                RunParam(imodel_kw={"timeout": (2**63 - 1) // 10**9}),
+            )
+        )
+
+    assert captured == {}
+
+
 async def test_run_preserves_explicit_gemini_print_timeout():
     """An explicit provider cap wins over the timeout-derived default."""
     from lionagi.providers.google.gemini_code import GeminiCodeRequest

--- a/tests/providers/test_gemini_cli_endpoint.py
+++ b/tests/providers/test_gemini_cli_endpoint.py
@@ -120,22 +120,23 @@ class TestCmdArgs:
         ids=["infinite", "astronomically-large", "just-over-go-max"],
     )
     def test_unbounded_caps_stay_parseable_instead_of_raising(self, unbounded):
-        """A cap longer than Go can express clamps rather than breaking.
+        """Clamp configured caps to Go's int64 duration limit."""
+        emitted = format_print_timeout(unbounded)
+        assert emitted.endswith("s")
+        # int() rejects "inf", "1e+300" and every other non-integer
+        # spelling, so this asserts parseability rather than restating the
+        # clamping expression.
+        seconds = int(emitted.removesuffix("s"))
+        assert 0 < seconds <= (2**63 - 1) // 10**9
 
-        A Go duration is int64 nanoseconds, so anything past ~9.2e9 seconds
-        overflows, and a non-finite value cannot be made an integer at all.
-        Both would reach agy as something it cannot parse, which surfaces as
-        agy's own uninformative timeout error -- the failure this path exists
-        to stop producing. Asking for longer than Go can express is asking for
-        as long as possible, so clamping is the honest answer.
-        """
-        for emitted in (format_print_timeout(unbounded), derive_print_timeout(unbounded)):
-            assert emitted.endswith("s")
-            # int() rejects "inf", "1e+300" and every other non-integer
-            # spelling, so this asserts parseability rather than restating the
-            # clamping expression.
-            seconds = int(emitted.removesuffix("s"))
-            assert 0 < seconds <= (2**63 - 1) // 10**9
+    @pytest.mark.parametrize(
+        "caller_timeout",
+        [(2**63 - 1) // 10**9, 1e10, float("inf"), 10**1000],
+        ids=["at-go-max", "over-go-max", "infinite", "huge-integer"],
+    )
+    def test_unrepresentable_caller_timeout_is_rejected(self, caller_timeout):
+        with pytest.raises(ValueError, match="caller deadline"):
+            derive_print_timeout(caller_timeout)
 
     @pytest.mark.parametrize("seconds", [float("-inf"), -1e300, -1, 0, 0.001])
     def test_numeric_caps_have_a_useful_minimum(self, seconds):


### PR DESCRIPTION
## Summary

- Reject caller deadlines at or above Antigravity's maximum representable Go duration before adding the provider-side grace period.
- Reject non-finite and arbitrarily large values with the same deterministic configuration error.
- Preserve the existing clamping behavior for an explicitly configured provider `print_timeout` and preserve its precedence over a derived deadline.

## Why

Deriving the `agy -t` value requires adding a 60-second provider grace period. Near the Go duration ceiling, that result cannot be represented safely and could overflow or fail later with a less actionable error.

Closes #2682

## Reviewer focus

The boundary is intentionally strict: equality with the representable ceiling is rejected because the provider timeout must remain later than the caller deadline after adding its grace period.

## Validation

- `uv run pytest -n0 -q tests/providers/test_gemini_cli_endpoint.py tests/operations/run/test_run.py`
- Boundary coverage includes equality, values above the ceiling, infinity, arbitrarily large integers, and rejection before event creation
- Ruff, pre-commit hooks, and `git diff --check`

## Not covered

This does not change explicit `print_timeout` parsing, lower-bound duration formatting, or sub-nanosecond precision policy.