### PR TITLE
fix(deps): floor datamodel-code-generator at the patched release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,9 @@ rich = [
 ]
 
 schema = [
-    "datamodel-code-generator>=0.31.2",
+    # Advisories through 0.63.0 affect the generator's own parsing path, which is
+    # exactly what the schema fallback invokes, so floor the patched release.
+    "datamodel-code-generator>=0.64.0",
 ]
 
 pandas = [

--- a/uv.lock
+++ b/uv.lock
@@ -1382,22 +1382,22 @@ wheels = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.56.1"
+version = "0.71.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
-    { name = "black" },
+    { name = "black", marker = "sys_platform != 'emscripten'" },
     { name = "genson" },
     { name = "inflect" },
-    { name = "isort" },
+    { name = "isort", marker = "sys_platform != 'emscripten'" },
     { name = "jinja2" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/9c/5379be8daf9ff2fbbb9a7efcf68c037b089e5b76f360c4f9ca730916e2ee/datamodel_code_generator-0.56.1.tar.gz", hash = "sha256:697abd90cc4eb2c65f130be79a83a24746c3f2d0e15e6eb9dbf17b96784449be", size = 840372, upload-time = "2026-04-16T17:09:53.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/f5/f4ce23d99503b147c9ec514dc995a96d3b4d2a3284252ad665f875a3145d/datamodel_code_generator-0.71.0.tar.gz", hash = "sha256:d27cd7a0d10f9b2db74a41db7f3e050c226da9cf0afb4916a7ab56275ebacbf2", size = 1684916, upload-time = "2026-07-24T15:32:04.334Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/cd/4a4a13f55069d88d8405aa325874b04c1b1dbc830f0d66c0e56cbd16aa12/datamodel_code_generator-0.56.1-py3-none-any.whl", hash = "sha256:cb2adc18a301f1a2cfcd56672037218eeaff0573669861c2b371eefe86753874", size = 256845, upload-time = "2026-04-16T17:09:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4d/556cb290170f41b97ce50fd872e10a266f141d7a38352bb3071e4ae61f41/datamodel_code_generator-0.71.0-py3-none-any.whl", hash = "sha256:680b68338d59e98a0559eeb54d8e5ca33c35b3ec0bef922ec2cc783f2cb28e9a", size = 452379, upload-time = "2026-07-24T15:32:02.467Z" },
 ]
 
 [[package]]
@@ -3258,7 +3258,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.10.0" },
     { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.27.0" },
     { name = "croniter", marker = "extra == 'studio'", specifier = ">=1.4" },
-    { name = "datamodel-code-generator", marker = "extra == 'schema'", specifier = ">=0.31.2" },
+    { name = "datamodel-code-generator", marker = "extra == 'schema'", specifier = ">=0.64.0" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.171.0" },
     { name = "docling", marker = "extra == 'reader'", specifier = ">=2.91.0" },
     { name = "fastapi", marker = "extra == 'studio'", specifier = ">=0.115" },


### PR DESCRIPTION
## Summary

Floors the `schema` extra at `datamodel-code-generator>=0.64.0` (was `>=0.31.2`) and relocks, moving the resolved version 0.56.1 -> 0.71.0.

## Why

Every open dependency alert on the default branch — 11 of them, 10 high and 1 low — is the same package. The affected ranges cover the generator's own parsing path, which is exactly the code `lionagi/libs/schema/load_pydantic_model_from_schema.py` invokes as its JSON-schema fallback. 0.64.0 is the first release past every affected range.

This follows the pattern the `mcp` extra already uses in the same file: floor the patched release at the extra rather than carrying a transitive pin.

## Verification

- `uv lock` changes exactly one package block; no packages added or removed.
- `uv run pytest tests/libs/schema/` — exit 0, no F/E markers, 200 tests, unchanged against 0.71.0.

## Not covered, deliberately

The frontend `npm audit` reports 7 high findings. All 7 are one transitive package (`brace-expansion` via `minimatch`), reached only through devDependencies (eslint and its plugins); none is in the runtime dependency set, so none ships in the built bundle. **There is no compatible fix today**, and both available routes were tried and reverted:

- Overriding `brace-expansion` to the patched `5.0.8` clears the audit but **breaks lint** (exit 2, crash inside `@eslint/config-array`), because eslint 9 pins `minimatch@3`, which requires `brace-expansion@^1`.
- Upgrading to `eslint@10` drops the count to 5 but still breaks lint, in `eslint-plugin-react`'s version detection. The latest published `eslint-plugin-react` (7.37.5) declares a peer of `eslint: ... || ^9.7`, and `eslint-plugin-jsx-a11y` caps at `^9` — no released version supports eslint 10.

Tracking this separately so the eslint-toolchain upgrade is done as its own change rather than smuggled into a dependency floor. The frontend lockfile is untouched here.