### PR TITLE
feat(mirror): mirror codex rollouts into StateDB with import provenance

### DIFF
--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -602,19 +602,30 @@ async def mirror_forever(
     *,
     root: Path | None = None,
     codex_root: Path | None = None,
+    source: str = "claude",
     since: str | None = "24h",
     interval: float = 5.0,
     live_window: float = _DEFAULT_LIVE_WINDOW,
 ) -> None:
-    """Tail recent Claude and Codex transcripts into StateDB until ``stop`` is set.
+    """Tail recent transcripts into StateDB until ``stop`` is set.
+
+    ``source`` selects which transcript trees to read ("claude", "codex", or
+    "both") and defaults to claude alone. A caller that scopes ``root`` has
+    scoped the mirror, and must not silently acquire an unscoped codex tree
+    under the home directory; asking for codex is therefore explicit.
 
     Studio's in-process entry point; ``li mirror`` keeps its own loop in ``_run``.
     """
     from lionagi.state.db import StateDB
 
+    if source not in ("both", "claude", "codex"):
+        raise ValueError(f"unknown mirror source: {source!r}")
+    want_claude = source in ("both", "claude")
+    want_codex = source in ("both", "codex")
+
     root = Path(root).expanduser() if root else CLAUDE_PROJECTS_DIR
     codex_root = Path(codex_root).expanduser() if codex_root else CODEX_SESSIONS_DIR
-    if not root.exists() and not codex_root.exists():
+    if not (want_claude and root.exists()) and not (want_codex and codex_root.exists()):
         return
     since_secs = _parse_window(since) if since else None
     states = _load_states()
@@ -629,7 +640,7 @@ async def mirror_forever(
             async with StateDB() as db:
                 while not stop.is_set():
                     try:
-                        if root.exists():
+                        if want_claude and root.exists():
                             await _one_pass(
                                 db,
                                 root,
@@ -639,7 +650,7 @@ async def mirror_forever(
                                 live_window=live_window,
                                 lineage=lineage,
                             )
-                        if codex_root.exists():
+                        if want_codex and codex_root.exists():
                             await _codex_pass(
                                 db,
                                 codex_root,
@@ -669,31 +680,61 @@ async def _run(args: argparse.Namespace) -> int:
 
     from lionagi.state.db import StateDB
 
+    source = getattr(args, "source", "both")
+    want_claude = source in ("both", "claude")
+    want_codex = source in ("both", "codex")
+
     root = Path(args.root).expanduser() if args.root else CLAUDE_PROJECTS_DIR
-    if not root.exists():
+    codex_root = (
+        Path(args.codex_root).expanduser()
+        if getattr(args, "codex_root", None)
+        else CODEX_SESSIONS_DIR
+    )
+    # A requested source whose tree is missing drops out with a warning; only when
+    # nothing requested is readable is there no work to do at all.
+    if want_claude and not root.exists():
         warn(f"no Claude projects directory at {root}")
+        want_claude = False
+    if want_codex and not codex_root.exists():
+        warn(f"no Codex sessions directory at {codex_root}")
+        want_codex = False
+    if not want_claude and not want_codex:
         return 1
 
     since = args.since  # argparse already parsed --since to seconds (or None)
     states = _load_states()
     offsets = {key: st.offset for key, st in states.items()}  # _one_pass new-file seed
     lineage = _Lineage()
+    threads: dict[str, str] = {}
     _seed_lineage(lineage, states)
 
     mode = "catch-up pass" if args.once else f"tailing (every {args.interval:g}s)"
-    hint(f"li mirror: {mode} over {root}")
+    trees = ", ".join(str(p) for p, want in ((root, want_claude), (codex_root, want_codex)) if want)
+    hint(f"li mirror: {mode} over {trees}")
 
     async with StateDB() as db:
         while True:
-            n = await _one_pass(
-                db,
-                root,
-                states,
-                offsets,
-                since=since,
-                live_window=args.live_window,
-                lineage=lineage,
-            )
+            n = 0
+            if want_claude:
+                n += await _one_pass(
+                    db,
+                    root,
+                    states,
+                    offsets,
+                    since=since,
+                    live_window=args.live_window,
+                    lineage=lineage,
+                )
+            if want_codex:
+                n += await _codex_pass(
+                    db,
+                    codex_root,
+                    states,
+                    offsets,
+                    since=since,
+                    live_window=args.live_window,
+                    threads=threads,
+                )
             _save_states(states)
             if n:
                 progress(f"  mirrored {n} new message(s)")

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -107,6 +107,11 @@ class _FileState:
     leaf_uuid: str | None = None  # this file's newest event uuid (lineage index)
     head_checked: bool = False  # whether the file's root parentUuid was examined
     attr_peeked: bool = False  # whether idle project attribution was attempted
+    # Most recent codex turn_context (model/effort/turn_id). Carried across passes
+    # so a message mirrored after a resume is still attributed to the turn that
+    # produced it rather than to nothing.
+    turn: dict[str, str] = field(default_factory=dict)
+    barren_reported: bool = False  # whether "read records, mirrored none" was surfaced
 
 
 @dataclass
@@ -183,8 +188,10 @@ def _resolve_project_for_mirror(cwd: str) -> tuple[str, str]:
 
 
 def _load_states() -> dict[str, _FileState]:
-    # Persist tool_names + leaf_uuid alongside the byte offset so a restart resumes
-    # without losing state that otherwise lives only in process memory.
+    # Persist tool_names, leaf_uuid and the current codex turn alongside the byte
+    # offset so a restart resumes without losing state that otherwise lives only in
+    # process memory. Dropping the turn would leave every message written after a
+    # restart unattributed until the next turn_context happens to arrive.
     try:
         raw = json.loads(_OFFSETS_PATH.read_text())
     except (FileNotFoundError, json.JSONDecodeError):
@@ -199,6 +206,7 @@ def _load_states() -> dict[str, _FileState]:
                 offset=val.get("offset", 0),
                 tool_names=dict(val.get("tool_names") or {}),
                 leaf_uuid=val.get("leaf_uuid"),
+                turn={str(k): str(v) for k, v in (val.get("turn") or {}).items() if v is not None},
             )
     return states
 
@@ -211,6 +219,7 @@ def _save_states(states: dict[str, _FileState]) -> None:
             "session_uid": st.session_uid,
             "tool_names": st.tool_names,
             "leaf_uuid": st.leaf_uuid,
+            "turn": st.turn,
         }
         for key, st in states.items()
     }
@@ -264,11 +273,17 @@ def _since_window(spec: str) -> float:
     return secs
 
 
-def _read_new_events(path: Path, state: _FileState) -> tuple[list[dict[str, Any]], int]:
-    """Read complete JSONL lines past the cursor; return (events, new_offset).
+def _read_new_events(path: Path, state: _FileState) -> tuple[list[dict[str, Any]], int, int]:
+    """Read complete JSONL lines past the cursor; return (events, new_offset, unreadable).
 
     The cursor is NOT advanced here — the caller only commits it after the batch
     is durably mirrored, so a write failure re-reads the same lines next pass.
+
+    ``unreadable`` counts lines that were not JSON, or were JSON but not a record
+    object. It is reported rather than folded into the events count because a line
+    that could not be read is not a line deliberately not mirrored, and a consumer
+    comparing what a file held against what landed needs the difference between a
+    damaged corpus and an uninteresting one.
     """
     size = path.stat().st_size
     if state.offset > size:  # file truncated/rotated — re-read from the top.
@@ -277,20 +292,24 @@ def _read_new_events(path: Path, state: _FileState) -> tuple[list[dict[str, Any]
         fh.seek(state.offset)
         chunk = fh.read()
     if b"\n" not in chunk:
-        return [], state.offset
+        return [], state.offset, 0
     body, _, _ = chunk.rpartition(b"\n")
     new_offset = state.offset + len(body) + 1
     events = []
+    unreadable = 0
     for raw in body.split(b"\n"):
         if not raw.strip():
             continue
         try:
             obj = json.loads(raw)
         except json.JSONDecodeError:
+            unreadable += 1
             continue
         if isinstance(obj, dict):
             events.append(obj)
-    return events, new_offset
+        else:
+            unreadable += 1
+    return events, new_offset, unreadable
 
 
 _COMMAND_NOISE = ("<command-", "<local-command-")
@@ -390,7 +409,9 @@ def _first_prompt(events: list[dict[str, Any]]) -> str | None:
 async def _mirror_one(db, path: Path, state: _FileState, lineage: _Lineage) -> int:
     from lionagi.state.claude_mirror import mirror_session
 
-    events, new_offset = _read_new_events(path, state)
+    events, new_offset, unreadable = _read_new_events(path, state)
+    if unreadable:
+        warn(f"{path.name}: {unreadable} unreadable line(s) skipped")
     if not events:
         state.offset = new_offset  # advance past blank/malformed-only lines
         return 0
@@ -517,7 +538,7 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
     """Mirror new records from one rollout file; returns messages written."""
     from lionagi.state.codex_mirror import link_session_lineage, mirror_session
 
-    records, new_offset = _read_new_events(path, state)
+    records, new_offset, unreadable = _read_new_events(path, state)
 
     meta: dict[str, Any] | None = None
     if not state.head_checked:
@@ -543,7 +564,7 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
         if thread:
             node_metadata = {"codex": thread}
 
-    written = await mirror_session(
+    written, tally = await mirror_session(
         db,
         rollout_uid=state.session_uid,
         records=records,
@@ -554,6 +575,9 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
         name=state.name,
         status="running",
         node_metadata=node_metadata,
+        source_path=str(path),
+        turn=state.turn,
+        unparseable=unreadable,
     )
     # Advance only after a durable write, so a failed batch is re-read next pass.
     state.offset = new_offset
@@ -565,6 +589,17 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
     if written and not state.created:
         state.created = True
         progress(f"  mirror: {state.name or state.session_uid[:8]} (+{written} msgs)")
+    elif not written and records and not state.barren_reported:
+        # A file the mirror read in full and produced nothing from is a finding, not
+        # a quiet skip: without this it is indistinguishable from a file not yet
+        # reached, and no session row is written to carry the counts either. Measured
+        # cause on the local corpus: 6 of 29,652 rollouts (all 2025-09-01/02) predate
+        # the enveloped record format and match no record type this mirror reads.
+        state.barren_reported = True
+        warn(
+            f"{path.name}: read {sum(tally.seen.values())} record(s), mirrored none "
+            f"(types: {', '.join(sorted(tally.seen)) or 'none'})"
+        )
     return written
 
 

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -19,6 +19,7 @@ from lionagi.ln._json_dump import raise_if_non_finite
 from ._logging import hint, log_error, progress, warn
 
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
+CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
 _OFFSETS_PATH = LIONAGI_HOME / "mirror" / "offsets.json"
 
 # A session whose newest message is within this window counts as live (running);
@@ -66,6 +67,21 @@ def add_mirror_subparser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         metavar="DIR",
         help=f"Claude projects directory (default {CLAUDE_PROJECTS_DIR}).",
+    )
+    p.add_argument(
+        "--codex-root",
+        default=None,
+        metavar="DIR",
+        help=f"Codex sessions directory (default {CODEX_SESSIONS_DIR}).",
+    )
+    p.add_argument(
+        "--source",
+        choices=("both", "claude", "codex"),
+        default="both",
+        help=(
+            "Which transcripts to mirror (default both). A full codex backfill is "
+            "large; pair 'codex' with --since to bound it."
+        ),
     )
     p.add_argument(
         "--live-window",
@@ -453,27 +469,158 @@ async def _one_pass(db, root: Path, states, offsets, *, since, live_window, line
     return total
 
 
+def _peek_codex_meta(path: Path) -> dict[str, Any] | None:
+    """Read a rollout's session_meta (its first line) without consuming the tail."""
+    from lionagi.state.codex_mirror import session_meta
+
+    try:
+        with path.open("rb") as fh:
+            line = fh.readline()
+    except OSError:
+        return None
+    try:
+        rec = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return session_meta(rec) if isinstance(rec, dict) else None
+
+
+def _derive_codex_metadata(state: _FileState, records: list[dict[str, Any]]) -> None:
+    """Fill model and session name from the records seen so far."""
+    if state.model is None:
+        for r in records:
+            if r.get("type") != "turn_context":
+                continue
+            model = (r.get("payload") or {}).get("model")
+            if model:
+                state.model = str(model)
+                break
+    if state.name is None:
+        prompt = _first_codex_prompt(records)
+        if prompt:
+            state.name = prompt[:72]
+
+
+def _first_codex_prompt(records: list[dict[str, Any]]) -> str | None:
+    """First real user turn in a rollout, skipping codex's injected context blocks."""
+    from lionagi.state.codex_mirror import messages_for_record
+
+    for r in records:
+        for m in messages_for_record(r, "probe", {}):
+            text = (m.content or {}).get("instruction") if isinstance(m.content, dict) else None
+            if text:
+                return " ".join(str(text).split())
+    return None
+
+
+async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str, str]) -> int:
+    """Mirror new records from one rollout file; returns messages written."""
+    from lionagi.state.codex_mirror import link_session_lineage, mirror_session
+
+    records, new_offset = _read_new_events(path, state)
+
+    meta: dict[str, Any] | None = None
+    if not state.head_checked:
+        state.head_checked = True
+        meta = _peek_codex_meta(path)
+        if meta:
+            state.session_uid = meta["rollout_uid"] or path.stem
+            if meta.get("cwd"):
+                state.project, state.project_source = _resolve_project_for_mirror(meta["cwd"])
+    if not state.session_uid:
+        state.session_uid = path.stem
+    if not records:
+        state.offset = new_offset
+        return 0
+
+    _derive_codex_metadata(state, records)
+    node_metadata = None
+    if meta:
+        thread = {k: v for k, v in meta.items() if k.endswith("_uid") and v}
+        thread.pop("rollout_uid", None)
+        if meta.get("originator"):
+            thread["originator"] = meta["originator"]
+        if thread:
+            node_metadata = {"codex": thread}
+
+    written = await mirror_session(
+        db,
+        rollout_uid=state.session_uid,
+        records=records,
+        tool_names=state.tool_names,
+        project=state.project,
+        project_source=state.project_source,
+        model=state.model,
+        name=state.name,
+        status="running",
+        node_metadata=node_metadata,
+    )
+    # Advance only after a durable write, so a failed batch is re-read next pass.
+    state.offset = new_offset
+
+    if meta and meta.get("thread_uid"):
+        parent = threads.setdefault(meta["thread_uid"], state.session_uid)
+        if parent != state.session_uid:
+            await link_session_lineage(db, child_uid=state.session_uid, parent_uid=parent)
+    if written and not state.created:
+        state.created = True
+        progress(f"  mirror: {state.name or state.session_uid[:8]} (+{written} msgs)")
+    return written
+
+
+async def _codex_pass(db, root: Path, states, offsets, *, since, live_window, threads) -> int:
+    """One sweep over the codex rollout tree; mirrors new records and reconciles status."""
+    from lionagi.state.codex_mirror import reconcile_session_status
+
+    now = time.time()
+    total = 0
+    seen: set[str] = set()
+    for path in sorted(root.rglob("rollout-*.jsonl")):
+        try:
+            if since is not None and (now - path.stat().st_mtime) > since:
+                continue
+            key = str(path)
+            state = states.get(key)
+            if state is None:
+                state = _FileState(session_uid="", offset=offsets.get(key, 0))
+                states[key] = state
+            total += await _mirror_one_codex(db, path, state, threads)
+            offsets[key] = state.offset
+            if state.session_uid:
+                seen.add(state.session_uid)
+        except FileNotFoundError:
+            continue
+        except Exception as exc:  # one bad rollout must not kill the tail
+            log_error(f"mirror failed for {path.name}: {exc}")
+    for uid in seen:
+        await reconcile_session_status(db, uid, now=now, live_window=live_window)
+    return total
+
+
 async def mirror_forever(
     stop: asyncio.Event,
     *,
     root: Path | None = None,
+    codex_root: Path | None = None,
     since: str | None = "24h",
     interval: float = 5.0,
     live_window: float = _DEFAULT_LIVE_WINDOW,
 ) -> None:
-    """Tail recent Claude transcripts into StateDB until ``stop`` is set.
+    """Tail recent Claude and Codex transcripts into StateDB until ``stop`` is set.
 
     Studio's in-process entry point; ``li mirror`` keeps its own loop in ``_run``.
     """
     from lionagi.state.db import StateDB
 
     root = Path(root).expanduser() if root else CLAUDE_PROJECTS_DIR
-    if not root.exists():
+    codex_root = Path(codex_root).expanduser() if codex_root else CODEX_SESSIONS_DIR
+    if not root.exists() and not codex_root.exists():
         return
     since_secs = _parse_window(since) if since else None
     states = _load_states()
     offsets = {key: st.offset for key, st in states.items()}  # _one_pass new-file seed
     lineage = _Lineage()
+    threads: dict[str, str] = {}
     _seed_lineage(lineage, states)
     # The connection lives inside the supervise loop so a failure to open it (e.g. a
     # locked/half-migrated state.db at studio startup) is retried, not fatal.
@@ -482,18 +629,29 @@ async def mirror_forever(
             async with StateDB() as db:
                 while not stop.is_set():
                     try:
-                        await _one_pass(
-                            db,
-                            root,
-                            states,
-                            offsets,
-                            since=since_secs,
-                            live_window=live_window,
-                            lineage=lineage,
-                        )
+                        if root.exists():
+                            await _one_pass(
+                                db,
+                                root,
+                                states,
+                                offsets,
+                                since=since_secs,
+                                live_window=live_window,
+                                lineage=lineage,
+                            )
+                        if codex_root.exists():
+                            await _codex_pass(
+                                db,
+                                codex_root,
+                                states,
+                                offsets,
+                                since=since_secs,
+                                live_window=live_window,
+                                threads=threads,
+                            )
                         _save_states(states)
                     except Exception:  # a single bad pass must never kill the tail
-                        _log.exception("claude mirror pass failed")
+                        _log.exception("transcript mirror pass failed")
                     try:
                         await asyncio.wait_for(stop.wait(), timeout=interval)
                     except (asyncio.TimeoutError, TimeoutError):

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -592,9 +592,10 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
     elif not written and records and not state.barren_reported:
         # A file the mirror read in full and produced nothing from is a finding, not
         # a quiet skip: without this it is indistinguishable from a file not yet
-        # reached, and no session row is written to carry the counts either. Measured
-        # cause on the local corpus: 6 of 29,652 rollouts (all 2025-09-01/02) predate
-        # the enveloped record format and match no record type this mirror reads.
+        # reached. The durable half is the session row the writer keeps for such a
+        # file; this only surfaces it in the run that saw it. Measured cause on the
+        # local corpus: 6 of 29,652 rollouts (all 2025-09-01/02) predate the
+        # enveloped record format and match no record type this mirror reads.
         state.barren_reported = True
         warn(
             f"{path.name}: read {sum(tally.seen.values())} record(s), mirrored none "

--- a/lionagi/state/_mirror_common.py
+++ b/lionagi/state/_mirror_common.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Shared write-side helpers for the transcript mirrors (Claude Code, Codex).
+
+Both mirrors tail an external tool's transcript into StateDB, so status
+reconciliation and lineage linking are identical once the session id is known.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .db import StateDB
+
+__all__ = ("reconcile_status", "link_lineage")
+
+
+async def reconcile_status(
+    db: StateDB,
+    sid: str,
+    *,
+    now: float,
+    live_window: float,
+    actor: str,
+) -> None:
+    """Align a mirrored session's status with its live/idle state, both directions.
+    Liveness keys off ``last_message_at``, never ``updated_at`` — see docs/internals/runtime.md."""
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES
+    from lionagi.state.reasons import RunReasons
+
+    existing = await db.get_session(sid)
+    if not existing:
+        return
+    live = (now - float(existing.get("last_message_at") or 0.0)) <= live_window
+    desired = "running" if live else "completed"
+    previous = existing.get("status")
+    if previous == desired:
+        return
+
+    previous_terminal = previous in SESSION_TERMINAL_STATUSES
+    if previous_terminal and desired != "running":
+        return
+
+    reactivating = previous_terminal and desired == "running"
+    await db.update_status(
+        "session",
+        sid,
+        new_status=desired,
+        reason_code=RunReasons.STARTED_OK if desired == "running" else RunReasons.COMPLETED_OK,
+        reason_summary=(
+            "mirror session reactivated because transcript resumed within live_window"
+            if reactivating
+            else "mirror session became idle"
+        ),
+        evidence_refs=[{"kind": "session", "id": sid}],
+        source="system",
+        actor=actor,
+        expected_statuses={previous},
+        expected_updated_at=existing.get("updated_at"),
+        override=reactivating,
+        override_actor=actor if reactivating else None,
+        override_justification=(
+            "mirror session terminal reactivation: transcript resumed within live_window"
+            if reactivating
+            else None
+        ),
+    )
+
+
+async def link_lineage(
+    db: StateDB,
+    *,
+    child_sid: str,
+    parent_sid: str,
+    parent_uid: str,
+    parent_event_uuid: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Record that one mirrored session continues another, on the child's node_metadata.
+    Idempotent: the lineage entry is rewritten wholesale rather than appended."""
+    existing = await db.get_session(child_sid)
+    if existing is None:
+        return
+    meta = dict(existing.get("node_metadata") or {})
+    lineage: dict[str, Any] = {
+        "parent_session_id": parent_sid,
+        "parent_session_uid": parent_uid,
+        "parent_event_uuid": parent_event_uuid,
+    }
+    if extra:
+        lineage.update(extra)
+    meta["lineage"] = lineage
+    await db.set_session_provenance(child_sid, node_metadata=meta)

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -294,48 +294,15 @@ async def reconcile_session_status(
 ) -> None:
     """Align a mirrored session's status with its live/idle state, both directions.
     Liveness keys off ``last_message_at``, never ``updated_at`` — see docs/internals/runtime.md."""
-    from lionagi.state.db import SESSION_TERMINAL_STATUSES
-    from lionagi.state.reasons import RunReasons
+    from ._mirror_common import reconcile_status
 
-    existing = await db.get_session(session_db_id(session_uid))
-    if not existing:
-        return
-    live = (now - float(existing.get("last_message_at") or 0.0)) <= live_window
-    desired = "running" if live else "completed"
-    previous = existing.get("status")
-    if previous == desired:
-        return
-
-    previous_terminal = previous in SESSION_TERMINAL_STATUSES
-    if previous_terminal and desired != "running":
-        return
-
-    reactivating = previous_terminal and desired == "running"
-    written = await db.update_status(
-        "session",
+    await reconcile_status(
+        db,
         session_db_id(session_uid),
-        new_status=desired,
-        reason_code=RunReasons.STARTED_OK if desired == "running" else RunReasons.COMPLETED_OK,
-        reason_summary=(
-            "mirror session reactivated because transcript resumed within live_window"
-            if reactivating
-            else "mirror session became idle"
-        ),
-        evidence_refs=[{"kind": "session", "id": session_db_id(session_uid)}],
-        source="system",
+        now=now,
+        live_window=live_window,
         actor="claude-mirror-reconcile",
-        expected_statuses={previous},
-        expected_updated_at=existing.get("updated_at"),
-        override=reactivating,
-        override_actor="claude-mirror-reconcile" if reactivating else None,
-        override_justification=(
-            "mirror session terminal reactivation: transcript resumed within live_window"
-            if reactivating
-            else None
-        ),
     )
-    if not written:
-        return
 
 
 async def link_session_lineage(
@@ -347,14 +314,12 @@ async def link_session_lineage(
 ) -> None:
     """Record that one Claude session continues another (conversation lineage) via
     a ``lineage`` entry on the child's node_metadata. Idempotent; see docs/internals/runtime.md."""
-    child_sid = session_db_id(child_uid)
-    existing = await db.get_session(child_sid)
-    if existing is None:
-        return
-    meta = dict(existing.get("node_metadata") or {})
-    meta["lineage"] = {
-        "parent_session_id": session_db_id(parent_uid),
-        "parent_session_uid": parent_uid,
-        "parent_event_uuid": parent_event_uuid,
-    }
-    await db.set_session_provenance(child_sid, node_metadata=meta)
+    from ._mirror_common import link_lineage
+
+    await link_lineage(
+        db,
+        child_sid=session_db_id(child_uid),
+        parent_sid=session_db_id(parent_uid),
+        parent_uid=parent_uid,
+        parent_event_uuid=parent_event_uuid,
+    )

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -1,12 +1,20 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 """Mirror Codex CLI/app rollouts (~/.codex/sessions/**/rollout-*.jsonl) into StateDB,
-one lionagi message per conversation record, under deterministic ids."""
+one lionagi message per conversation record, under deterministic ids.
+
+Reads the enveloped rollout format, where each line is ``{type, timestamp, payload}``.
+Rollouts written before 2025-09-20 use a flat format with no envelope, and mirror
+nothing; that was measured over the whole local corpus rather than sampled, at 6 files
+out of 29,652, and the caller reports a file it read records from and mirrored none of
+rather than passing over it in silence.
+"""
 
 from __future__ import annotations
 
 import json
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -27,7 +35,22 @@ __all__ = (
     "mirror_session",
     "reconcile_session_status",
     "link_session_lineage",
+    "RecordTally",
+    "turn_context",
+    "SOURCE_KIND",
+    "ID_FIELD",
 )
+
+# Provenance value for a session this mirror wrote, as opposed to one lionagi ran.
+SOURCE_KIND = "imported_codex"
+
+# Which of a rollout's identifiers ``cc_session_id`` holds. A rollout carries three,
+# and the column that stores one of them says nothing about which — so the name is
+# written beside the value rather than left to a future reader to infer.
+ID_FIELD = "codex_rollout_id"
+
+# Where the import provenance lives on a mirrored session's node_metadata.
+_IMPORT_KEY = "codex_import"
 
 # Distinct from the Claude mirror's namespace so the two mirrors can never derive
 # the same StateDB id from the same-looking upstream uid.
@@ -44,6 +67,94 @@ _INJECTED_USER_PREFIXES = ("<recommended_plugins>", "<environment_context>")
 
 # Roles that carry conversation. ``developer`` is the system-instruction channel.
 _MIRRORED_ROLES = frozenset({"user", "assistant"})
+
+# Per-turn model/effort/config. Retained rather than skipped: it is what makes the
+# conversation records interpretable, and without it every mirrored turn is an
+# unattributed quote — "which model, at what effort" is the question a future reader
+# asks when deciding whether a run's output is usable.
+_TURN_CONTEXT_RECORD = "turn_context"
+
+# The turn_context fields carried onto each message. Measured over a whole-corpus
+# stride sample: model and effort are present on every turn_context seen, turn_id on
+# about two thirds (it postdates the older rollouts).
+_TURN_FIELDS = ("model", "effort", "turn_id")
+
+
+@dataclass(frozen=True)
+class RecordTally:
+    """Per-record-type counts from both sides of one file's import.
+
+    Completeness is then a subtraction any consumer can do — ``seen`` minus
+    ``mirrored``, per type — rather than a narrative the importer writes about
+    itself. A self-report goes stale silently when the importer's behaviour
+    changes; two numbers that disagree cannot.
+
+    ``unparseable`` is deliberately its own count and never folded into a type's
+    skip. A line that could not be read is not a line deliberately not mirrored,
+    and rolling the two together makes the subtraction stop discriminating exactly
+    where a corpus is damaged.
+    """
+
+    seen: dict[str, int] = field(default_factory=dict)
+    mirrored: dict[str, int] = field(default_factory=dict)
+    unparseable: int = 0
+
+    def merged(self, other: RecordTally) -> RecordTally:
+        """This tally plus another (successive passes over a growing file)."""
+        seen = dict(self.seen)
+        mirrored = dict(self.mirrored)
+        for key, val in other.seen.items():
+            seen[key] = seen.get(key, 0) + val
+        for key, val in other.mirrored.items():
+            mirrored[key] = mirrored.get(key, 0) + val
+        return RecordTally(seen, mirrored, self.unparseable + other.unparseable)
+
+    def as_provenance(self) -> dict[str, Any]:
+        """The form written to a session row; keys stay stable for consumers."""
+        return {
+            "records_seen": dict(sorted(self.seen.items())),
+            "messages_mirrored": dict(sorted(self.mirrored.items())),
+            "records_unparseable": self.unparseable,
+        }
+
+
+def _import_block(source_path: str | None, tally: RecordTally) -> dict[str, Any]:
+    """The provenance a mirrored session carries: where the row came from, which
+    identifier it was keyed on, and both sides of the record counts."""
+    block: dict[str, Any] = {"id_field": ID_FIELD, **tally.as_provenance()}
+    if source_path:
+        block["source_path"] = source_path
+    return block
+
+
+def _carried_tally(block: Any) -> RecordTally:
+    """The tally already recorded on a session row, for merging with a new batch.
+
+    A block written by an older version, or damaged, reads as an empty tally rather
+    than raising — but an empty tally is not silently equivalent to a complete one,
+    because the counts it merges into still have to match the file.
+    """
+    if not isinstance(block, dict):
+        return RecordTally()
+    seen = block.get("records_seen")
+    mirrored = block.get("messages_mirrored")
+    unparseable = block.get("records_unparseable")
+    return RecordTally(
+        dict(seen) if isinstance(seen, dict) else {},
+        dict(mirrored) if isinstance(mirrored, dict) else {},
+        unparseable if isinstance(unparseable, int) else 0,
+    )
+
+
+def turn_context(record: dict[str, Any]) -> dict[str, Any] | None:
+    """The retained fields of a ``turn_context`` record, or None for other records."""
+    if record.get("type") != _TURN_CONTEXT_RECORD:
+        return None
+    p = record.get("payload")
+    if not isinstance(p, dict):
+        return None
+    out = {k: str(p[k]) for k in _TURN_FIELDS if p.get(k)}
+    return out or None
 
 
 def _det(*parts: str) -> str:
@@ -127,9 +238,15 @@ def messages_for_record(
     record: dict[str, Any],
     rollout_uid: str,
     tool_names: dict[str, str],
+    turn: dict[str, Any] | None = None,
 ) -> list[RoledMessage]:
     """Map one codex rollout record to ordered lionagi messages. ``tool_names`` is
-    read/written in place so a tool output can label its ActionResponse."""
+    read/written in place so a tool output can label its ActionResponse.
+
+    ``turn`` is the most recent ``turn_context`` seen before this record; it is
+    stamped onto every message produced so a mirrored turn stays attributable to
+    the model and effort that produced it.
+    """
     if record.get("type") != _CONVERSATION_RECORD:
         return []
     p = record.get("payload")
@@ -139,6 +256,10 @@ def messages_for_record(
     base = _ts(record.get("timestamp")) or 0.0
     kind = p.get("type")
     pid = str(p.get("id") or "")
+    # Attribution travels with the message, not only with the session: a rollout can
+    # change model or effort mid-thread, so a session-level value would misattribute
+    # every turn before the switch.
+    meta = {"codex_turn": dict(turn)} if turn else {}
     specs: list[tuple[str, Any]] = []
 
     if kind == "message":
@@ -156,7 +277,7 @@ def messages_for_record(
                 (
                     mid,
                     lambda mid, ts, text=text: Instruction(
-                        id=mid, created_at=ts, content={"instruction": text}
+                        id=mid, created_at=ts, content={"instruction": text}, metadata=meta
                     ),
                 )
             )
@@ -166,7 +287,7 @@ def messages_for_record(
                 (
                     mid,
                     lambda mid, ts, text=text: AssistantResponse(
-                        id=mid, created_at=ts, content={"assistant_response": text}
+                        id=mid, created_at=ts, content={"assistant_response": text}, metadata=meta
                     ),
                 )
             )
@@ -182,7 +303,10 @@ def messages_for_record(
             (
                 req_id,
                 lambda mid, ts, fn=fn, args=args: ActionRequest(
-                    id=mid, created_at=ts, content={"function": fn, "arguments": args}
+                    id=mid,
+                    created_at=ts,
+                    content={"function": fn, "arguments": args},
+                    metadata=meta,
                 ),
             )
         )
@@ -205,6 +329,7 @@ def messages_for_record(
                         "action_request_id": req_id,
                         "error": None,
                     },
+                    metadata=meta,
                 ),
             )
         )
@@ -227,21 +352,44 @@ async def mirror_session(
     name: str | None = None,
     status: str = "running",
     node_metadata: dict[str, Any] | None = None,
-) -> int:
-    """Idempotently write a batch of codex records for one rollout; returns msgs written.
-    Live/idle transitions are owned by ``reconcile_session_status``, not this writer."""
+    source_path: str | None = None,
+    turn: dict[str, Any] | None = None,
+    unparseable: int = 0,
+) -> tuple[int, RecordTally]:
+    """Idempotently write a batch of codex records for one rollout.
+
+    Returns the messages written and the tally for this batch. ``turn`` is the
+    turn_context carried in from the previous batch, so attribution survives a
+    file being mirrored across several passes; it is updated in place as records
+    are walked. ``source_path`` is the rollout file this batch came from, stamped
+    into the session's provenance so any row resolves back to its file.
+
+    Live/idle transitions are owned by ``reconcile_session_status``, not this writer.
+    """
     sid = session_db_id(rollout_uid)
     branch_id = _det(rollout_uid, "branch")
     bprog = _det(rollout_uid, "bprog")
     sprog = _det(rollout_uid, "sprog")
 
+    seen: dict[str, int] = {}
+    mirrored: dict[str, int] = {}
     messages: list[RoledMessage] = []
     for rec in records:
-        messages.extend(messages_for_record(rec, rollout_uid, tool_names))
+        rtype = str(rec.get("type") or "<untyped>")
+        seen[rtype] = seen.get(rtype, 0) + 1
+        ctx = turn_context(rec)
+        if ctx is not None and turn is not None:
+            turn.clear()
+            turn.update(ctx)
+        produced = messages_for_record(rec, rollout_uid, tool_names, turn)
+        if produced:
+            mirrored[rtype] = mirrored.get(rtype, 0) + len(produced)
+            messages.extend(produced)
+    tally = RecordTally(seen, mirrored, unparseable)
 
     existing = await db.get_session(sid)
     if existing is None and not messages:
-        return 0
+        return 0, tally
 
     first_ts = min((m.created_at for m in messages), default=None)
     last_ts = max((m.created_at for m in messages), default=None)
@@ -250,6 +398,8 @@ async def mirror_session(
     await db.create_progression(sprog)
     await db.create_progression(bprog)
     if existing is None:
+        meta = dict(node_metadata or {})
+        meta[_IMPORT_KEY] = _import_block(source_path, tally)
         await db.create_session(
             {
                 "id": sid,
@@ -260,11 +410,13 @@ async def mirror_session(
                 "status": status,
                 "invocation_kind": "agent",
                 "agent_name": "codex",
+                "source_kind": SOURCE_KIND,
                 "model": model,
                 "provider": provider,
+                "effort": (turn or {}).get("effort"),
                 "project": project,
                 "project_source": project_source,
-                "node_metadata": node_metadata,
+                "node_metadata": meta,
                 "started_at": first_ts,
                 "updated_at": last_ts,
             }
@@ -272,13 +424,20 @@ async def mirror_session(
     else:
         cc_session_id = rollout_uid if existing.get("cc_session_id") is None else None
         provenance_project = project if project and not existing.get("project") else None
-        if cc_session_id is not None or provenance_project is not None:
-            await db.set_session_provenance(
-                sid,
-                cc_session_id=cc_session_id,
-                project=provenance_project,
-                project_source=project_source if provenance_project is not None else None,
-            )
+        # A file mirrored across several passes accumulates its counts, so the
+        # subtraction a consumer does is against the whole file rather than the
+        # last batch of it.
+        meta = dict(existing.get("node_metadata") or {})
+        meta[_IMPORT_KEY] = _import_block(
+            source_path, _carried_tally(meta.get(_IMPORT_KEY)).merged(tally)
+        )
+        await db.set_session_provenance(
+            sid,
+            cc_session_id=cc_session_id,
+            project=provenance_project,
+            project_source=project_source if provenance_project is not None else None,
+            node_metadata=meta,
+        )
     await db.create_branch(
         {
             "id": branch_id,
@@ -300,7 +459,7 @@ async def mirror_session(
     if messages:
         await db.touch_session_activity(sid, at=last_ts)
 
-    return len(messages)
+    return len(messages), tally
 
 
 async def reconcile_session_status(

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -6,16 +6,19 @@ one lionagi message per conversation record, under deterministic ids.
 Reads the enveloped rollout format, where each line is ``{type, timestamp, payload}``.
 Rollouts written before 2025-09-20 use a flat format with no envelope, and mirror
 nothing; that was measured over the whole local corpus rather than sampled, at 6 files
-out of 29,652, and the caller reports a file it read records from and mirrored none of
-rather than passing over it in silence.
+out of 29,652. Such a file still gets a session row carrying its counts, because a
+rollout that mirrors nothing is the case the per-type count pair exists to expose and
+a row is what there is to subtract against.
 """
 
 from __future__ import annotations
 
 import json
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from lionagi.protocols.messages.action_request import ActionRequest
@@ -192,6 +195,18 @@ def _ts(iso: str | None) -> float | None:
         return datetime.fromisoformat(str(iso).replace("Z", "+00:00")).timestamp()
     except (ValueError, TypeError):
         return None
+
+
+def _source_mtime(source_path: str | None) -> float:
+    """Last-resort time for a rollout carrying no readable record timestamp.
+
+    Only reached when a file is unparseable enough that not one record yielded a
+    time, which is itself a rollout worth having a row for.
+    """
+    try:
+        return Path(source_path).stat().st_mtime  # type: ignore[arg-type]
+    except (OSError, TypeError):
+        return time.time()
 
 
 def _text_blocks(content: Any) -> str:
@@ -412,11 +427,23 @@ async def mirror_session(
     tally = RecordTally(seen, mirrored, unparseable)
 
     existing = await db.get_session(sid)
-    if existing is None and not messages:
+    # A rollout none of whose records mirror still gets a row. That is the case
+    # the count pair exists for: an injection form nobody enumerated, or a legacy
+    # flat file this reader cannot parse, both look like "seen, never mirrored"
+    # from the outside — but only if a row is there to subtract against. Writing
+    # nothing would leave the one shape the accounting was built to expose as the
+    # one shape it cannot see. Only a batch that read nothing at all is skipped.
+    if existing is None and not records and not unparseable:
         return 0, tally
 
-    first_ts = min((m.created_at for m in messages), default=None)
-    last_ts = max((m.created_at for m in messages), default=None)
+    msg_first = min((m.created_at for m in messages), default=None)
+    msg_last = max((m.created_at for m in messages), default=None)
+    # Both time columns are NOT NULL, and a fully filtered rollout has no message
+    # times to take them from, so the records' own timestamps carry the row.
+    rec_ts = [t for t in (_ts(rec.get("timestamp")) for rec in records) if t is not None]
+    floor = min(rec_ts) if rec_ts else _source_mtime(source_path)
+    first_ts = msg_first or floor
+    last_ts = msg_last or (max(rec_ts) if rec_ts else floor)
     created_at = (existing.get("created_at") if existing is not None else None) or first_ts
 
     await db.create_progression(sprog)

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Mirror Codex CLI/app rollouts (~/.codex/sessions/**/rollout-*.jsonl) into StateDB,
+one lionagi message per conversation record, under deterministic ids."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from lionagi.protocols.messages.action_request import ActionRequest
+from lionagi.protocols.messages.action_response import ActionResponse
+from lionagi.protocols.messages.assistant_response import AssistantResponse
+from lionagi.protocols.messages.instruction import Instruction
+
+if TYPE_CHECKING:
+    from lionagi.protocols.messages.message import RoledMessage
+
+    from .db import StateDB
+
+__all__ = (
+    "session_db_id",
+    "session_meta",
+    "messages_for_record",
+    "mirror_session",
+    "reconcile_session_status",
+    "link_session_lineage",
+)
+
+# Distinct from the Claude mirror's namespace so the two mirrors can never derive
+# the same StateDB id from the same-looking upstream uid.
+_NS = uuid.UUID("9c4a7b21-6d8e-4f13-a05c-2e7b9d1f83a4")
+
+# A rollout interleaves the model conversation (``response_item``) with UI
+# telemetry (``event_msg``), which restates the same turns. Only the former is
+# mirrored; mirroring both would double every message.
+_CONVERSATION_RECORD = "response_item"
+
+# Harness-injected context that codex prepends as a user turn. Measured against
+# the local corpus: these two account for every non-prompt user message seen.
+_INJECTED_USER_PREFIXES = ("<recommended_plugins>", "<environment_context>")
+
+# Roles that carry conversation. ``developer`` is the system-instruction channel.
+_MIRRORED_ROLES = frozenset({"user", "assistant"})
+
+
+def _det(*parts: str) -> str:
+    """Deterministic UUID for a logical entity (session/branch/message)."""
+    return str(uuid.uuid5(_NS, "|".join(parts)))
+
+
+def session_db_id(rollout_uid: str) -> str:
+    """StateDB session id for a codex rollout id (stable across runs)."""
+    return _det(rollout_uid, "session")
+
+
+def _ts(iso: str | None) -> float | None:
+    if not iso:
+        return None
+    try:
+        return datetime.fromisoformat(str(iso).replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _text_blocks(content: Any) -> str:
+    """Flatten a codex content array (input_text/output_text blocks) to display text."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return "" if content is None else str(content)
+    parts = []
+    for b in content:
+        if isinstance(b, dict):
+            if b.get("text"):
+                parts.append(str(b["text"]))
+        elif isinstance(b, str):
+            parts.append(b)
+    return "\n".join(p for p in parts if p)
+
+
+def _arguments(raw: Any) -> dict[str, Any]:
+    """Coerce a tool-call argument payload to a dict; codex sends JSON text or a dict."""
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"input": raw}
+        return parsed if isinstance(parsed, dict) else {"value": parsed}
+    return {}
+
+
+def session_meta(record: dict[str, Any]) -> dict[str, Any] | None:
+    """Pull the fields a mirrored session needs out of a ``session_meta`` record.
+
+    ``id`` is the rollout's own identity and is always present; ``session_id`` is
+    the thread it belongs to and is absent on older rollouts.
+    """
+    if record.get("type") != "session_meta":
+        return None
+    p = record.get("payload")
+    if not isinstance(p, dict):
+        return None
+    return {
+        "rollout_uid": str(p.get("id") or ""),
+        "thread_uid": str(p["session_id"]) if p.get("session_id") else None,
+        "parent_thread_uid": str(p["parent_thread_id"]) if p.get("parent_thread_id") else None,
+        "forked_from_uid": str(p["forked_from_id"]) if p.get("forked_from_id") else None,
+        "cwd": str(p["cwd"]) if p.get("cwd") else None,
+        "originator": str(p["originator"]) if p.get("originator") else None,
+        "cli_version": str(p["cli_version"]) if p.get("cli_version") else None,
+        "timestamp": p.get("timestamp"),
+    }
+
+
+def _tool_pair_ids(rollout_uid: str, call_id: str, fallback: str) -> tuple[str, str]:
+    """(request_id, response_id) for a tool exchange, linked by codex's call_id."""
+    key = call_id or fallback
+    return _det(rollout_uid, "toolreq", key), _det(rollout_uid, "toolresp", key)
+
+
+def messages_for_record(
+    record: dict[str, Any],
+    rollout_uid: str,
+    tool_names: dict[str, str],
+) -> list[RoledMessage]:
+    """Map one codex rollout record to ordered lionagi messages. ``tool_names`` is
+    read/written in place so a tool output can label its ActionResponse."""
+    if record.get("type") != _CONVERSATION_RECORD:
+        return []
+    p = record.get("payload")
+    if not isinstance(p, dict):
+        return []
+
+    base = _ts(record.get("timestamp")) or 0.0
+    kind = p.get("type")
+    pid = str(p.get("id") or "")
+    specs: list[tuple[str, Any]] = []
+
+    if kind == "message":
+        role = p.get("role")
+        if role not in _MIRRORED_ROLES:
+            return []  # developer turns are instruction plumbing, not conversation
+        text = _text_blocks(p.get("content")).strip()
+        if not text:
+            return []
+        if role == "user":
+            if text.startswith(_INJECTED_USER_PREFIXES):
+                return []
+            mid = _det(rollout_uid, pid or f"user:{base}", "instr")
+            specs.append(
+                (
+                    mid,
+                    lambda mid, ts, text=text: Instruction(
+                        id=mid, created_at=ts, content={"instruction": text}
+                    ),
+                )
+            )
+        else:
+            mid = _det(rollout_uid, pid or f"asst:{base}", "text")
+            specs.append(
+                (
+                    mid,
+                    lambda mid, ts, text=text: AssistantResponse(
+                        id=mid, created_at=ts, content={"assistant_response": text}
+                    ),
+                )
+            )
+
+    elif kind in ("function_call", "custom_tool_call", "tool_search_call"):
+        call_id = str(p.get("call_id") or "")
+        fn = str(p.get("name") or ("tool_search" if kind == "tool_search_call" else ""))
+        args = _arguments(p.get("arguments") if kind != "custom_tool_call" else p.get("input"))
+        if call_id:
+            tool_names[call_id] = fn
+        req_id, _ = _tool_pair_ids(rollout_uid, call_id, pid)
+        specs.append(
+            (
+                req_id,
+                lambda mid, ts, fn=fn, args=args: ActionRequest(
+                    id=mid, created_at=ts, content={"function": fn, "arguments": args}
+                ),
+            )
+        )
+
+    elif kind in ("function_call_output", "custom_tool_call_output", "tool_search_output"):
+        call_id = str(p.get("call_id") or "")
+        out = p.get("tools") if kind == "tool_search_output" else p.get("output")
+        text = json.dumps(out, default=str) if kind == "tool_search_output" else _text_blocks(out)
+        req_id, resp_id = _tool_pair_ids(rollout_uid, call_id, pid)
+        fn = tool_names.get(call_id, "")
+        specs.append(
+            (
+                resp_id,
+                lambda mid, ts, fn=fn, text=text, req_id=req_id: ActionResponse(
+                    id=mid,
+                    created_at=ts,
+                    content={
+                        "function": fn,
+                        "output": text,
+                        "action_request_id": req_id,
+                        "error": None,
+                    },
+                ),
+            )
+        )
+
+    # reasoning summaries and agent_message routing records carry no display
+    # value in the studio reader — skipped, as thinking blocks are for Claude.
+    return [builder(mid, base + i * 1e-3) for i, (mid, builder) in enumerate(specs)]
+
+
+async def mirror_session(
+    db: StateDB,
+    *,
+    rollout_uid: str,
+    records: list[dict[str, Any]],
+    tool_names: dict[str, str],
+    project: str | None = None,
+    project_source: str | None = None,
+    model: str | None = None,
+    provider: str | None = "openai",
+    name: str | None = None,
+    status: str = "running",
+    node_metadata: dict[str, Any] | None = None,
+) -> int:
+    """Idempotently write a batch of codex records for one rollout; returns msgs written.
+    Live/idle transitions are owned by ``reconcile_session_status``, not this writer."""
+    sid = session_db_id(rollout_uid)
+    branch_id = _det(rollout_uid, "branch")
+    bprog = _det(rollout_uid, "bprog")
+    sprog = _det(rollout_uid, "sprog")
+
+    messages: list[RoledMessage] = []
+    for rec in records:
+        messages.extend(messages_for_record(rec, rollout_uid, tool_names))
+
+    existing = await db.get_session(sid)
+    if existing is None and not messages:
+        return 0
+
+    first_ts = min((m.created_at for m in messages), default=None)
+    last_ts = max((m.created_at for m in messages), default=None)
+    created_at = (existing.get("created_at") if existing is not None else None) or first_ts
+
+    await db.create_progression(sprog)
+    await db.create_progression(bprog)
+    if existing is None:
+        await db.create_session(
+            {
+                "id": sid,
+                "cc_session_id": rollout_uid,
+                "created_at": created_at,
+                "progression_id": sprog,
+                "name": name or "Codex session",
+                "status": status,
+                "invocation_kind": "agent",
+                "agent_name": "codex",
+                "model": model,
+                "provider": provider,
+                "project": project,
+                "project_source": project_source,
+                "node_metadata": node_metadata,
+                "started_at": first_ts,
+                "updated_at": last_ts,
+            }
+        )
+    else:
+        cc_session_id = rollout_uid if existing.get("cc_session_id") is None else None
+        provenance_project = project if project and not existing.get("project") else None
+        if cc_session_id is not None or provenance_project is not None:
+            await db.set_session_provenance(
+                sid,
+                cc_session_id=cc_session_id,
+                project=provenance_project,
+                project_source=project_source if provenance_project is not None else None,
+            )
+    await db.create_branch(
+        {
+            "id": branch_id,
+            "created_at": created_at,
+            "session_id": sid,
+            "progression_id": bprog,
+            "model": model,
+            "provider": provider,
+            "agent_name": "codex",
+        }
+    )
+
+    for m in messages:
+        md = m.to_dict(mode="db")
+        await db.insert_message(md)
+        await db.append_to_progression(bprog, md["id"])
+        await db.append_to_progression(sprog, md["id"])
+
+    if messages:
+        await db.touch_session_activity(sid, at=last_ts)
+
+    return len(messages)
+
+
+async def reconcile_session_status(
+    db: StateDB,
+    rollout_uid: str,
+    *,
+    now: float,
+    live_window: float,
+) -> None:
+    """Align a mirrored codex session's status with its live/idle state."""
+    from ._mirror_common import reconcile_status
+
+    await reconcile_status(
+        db,
+        session_db_id(rollout_uid),
+        now=now,
+        live_window=live_window,
+        actor="codex-mirror-reconcile",
+    )
+
+
+async def link_session_lineage(
+    db: StateDB,
+    *,
+    child_uid: str,
+    parent_uid: str,
+    relation: str = "thread",
+) -> None:
+    """Record that one codex rollout continues another (same thread, fork, or subagent).
+    ``relation`` names which of the three, because the fix differs per kind."""
+    from ._mirror_common import link_lineage
+
+    await link_lineage(
+        db,
+        child_sid=session_db_id(child_uid),
+        parent_sid=session_db_id(parent_uid),
+        parent_uid=parent_uid,
+        parent_event_uuid="",
+        extra={"relation": relation},
+    )

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -61,9 +61,27 @@ _NS = uuid.UUID("9c4a7b21-6d8e-4f13-a05c-2e7b9d1f83a4")
 # mirrored; mirroring both would double every message.
 _CONVERSATION_RECORD = "response_item"
 
-# Harness-injected context that codex prepends as a user turn. Measured against
-# the local corpus: these two account for every non-prompt user message seen.
-_INJECTED_USER_PREFIXES = ("<recommended_plugins>", "<environment_context>")
+# Harness-injected context that codex delivers through the user role: repo
+# instructions, skill definitions, environment and editor blocks, the interruption
+# notice. None of it is something a person typed, and it is not a rare case — a
+# 1,000-file stride over the whole local corpus found 1,433 of 2,427 user messages
+# (59%) to be injection, so without this filter most of the mirrored "prompts"
+# would be machine text.
+#
+# The list is what that census turned up, and is deliberately NOT treated as
+# closed: codex adds forms over time and two of these were found only after a
+# first pass called an earlier, shorter list exhaustive. An uncovered form leaves
+# a mirrored response_item the count pair cannot account for, which is the backstop
+# for the completeness this list cannot promise on its own.
+_INJECTED_USER_PREFIXES = (
+    "<recommended_plugins>",
+    "<environment_context>",
+    "<skill>",
+    "<turn_aborted>",
+    "# AGENTS.md instructions for ",
+    "# Context from my IDE setup:",
+    "# Files mentioned by the user:",
+)
 
 # Roles that carry conversation. ``developer`` is the system-instruction channel.
 _MIRRORED_ROLES = frozenset({"user", "assistant"})
@@ -259,6 +277,12 @@ def messages_for_record(
     # Attribution travels with the message, not only with the session: a rollout can
     # change model or effort mid-thread, so a session-level value would misattribute
     # every turn before the switch.
+    #
+    # No attribution is written when no turn_context has been seen yet, which happens
+    # for a prompt at the head of a resumed rollout — measured at 2 of 12,889 messages
+    # over a live tree. Absent means the file had nothing to attribute to at that
+    # point, not that attribution was lost; inventing one from the following turn
+    # would state something the rollout does not.
     meta = {"codex_turn": dict(turn)} if turn else {}
     specs: list[tuple[str, Any]] = []
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -414,7 +414,7 @@ TransitionRejectedError = _lifecycle_adapters.TransitionRejectedError
 
 
 _INVOCATION_KINDS = frozenset({"agent", "play", "flow", "fanout", "show-play"})
-_SOURCE_KINDS = frozenset({"live", "imported_fs"})
+_SOURCE_KINDS = frozenset({"live", "imported_fs", "imported_codex"})
 
 _SHOW_STATUSES = frozenset({"active", "completed", "aborted", "imported"})
 _PLAY_STATUSES = frozenset(
@@ -857,7 +857,7 @@ class StateDB:
         await self._refuse_newer_schema()
         await self._reconcile_columns()
         if self.dialect == "sqlite":
-            await self._drop_legacy_session_status_check()
+            await self._rebuild_legacy_sessions_table()
             # existing DBs created before flow_yaml was added carry a
             # 4-value CHECK on schedules.action_kind that omits 'flow_yaml'.
             await self._drop_legacy_action_kind_check()
@@ -1044,9 +1044,26 @@ class StateDB:
                 raise
 
     _LEGACY_SESSION_STATUS_CHECK_MARKER = "'running', 'completed', 'failed', 'aborted'"
+    # Present only in a sessions CREATE SQL written before transcript imports had
+    # their own provenance value; its absence beside a source_kind CHECK is what
+    # marks a DB that would reject 'imported_codex'.
+    _NARROW_SOURCE_KIND_MARKER = "'live', 'imported_fs')"
 
-    async def _drop_legacy_session_status_check(self) -> None:
-        """Rebuild sessions table if it carries the legacy 4-value CHECK constraint."""
+    @classmethod
+    def _sessions_rebuild_needed(cls, create_sql: str) -> bool:
+        """Whether a sessions CREATE SQL still carries either legacy CHECK.
+
+        A DB with no source_kind CHECK at all (the column was added by column
+        reconciliation, which cannot attach one) accepts every value already, so
+        only a CHECK that names the narrow set needs widening.
+        """
+        if cls._LEGACY_SESSION_STATUS_CHECK_MARKER in create_sql:
+            return True
+        return cls._NARROW_SOURCE_KIND_MARKER in create_sql
+
+    async def _rebuild_legacy_sessions_table(self) -> None:
+        """Rebuild sessions if it carries either legacy CHECK: the 4-value status
+        vocabulary, or a source_kind that predates the codex-import provenance value."""
         if self.dialect != "sqlite":
             return
         async with self._engine.connect() as conn:
@@ -1062,7 +1079,7 @@ class StateDB:
         if row is None or row["sql"] is None:
             return
         create_sql: str = row["sql"]
-        if self._LEGACY_SESSION_STATUS_CHECK_MARKER not in create_sql:
+        if not self._sessions_rebuild_needed(create_sql):
             return
 
         async with self._engine.connect() as conn:
@@ -1140,7 +1157,8 @@ class StateDB:
                               artifacts_path  TEXT,
                               source_kind     TEXT    DEFAULT 'live' CHECK(
                                                 source_kind IS NULL
-                                                OR source_kind IN ('live', 'imported_fs')
+                                                OR source_kind IN
+                                                  ('live', 'imported_fs', 'imported_codex')
                                               ),
                               status          TEXT,
                               started_at      REAL,
@@ -1191,7 +1209,7 @@ class StateDB:
 
         await self._rebuild_check_constraint(
             "sessions",
-            lambda sql: sql is None or self._LEGACY_SESSION_STATUS_CHECK_MARKER not in sql,
+            lambda sql: sql is None or not self._sessions_rebuild_needed(sql),
             _rebuild,
         )
 
@@ -1204,7 +1222,7 @@ class StateDB:
 
         The old CHECK omits ``'flow_yaml'``; SQLite cannot drop a constraint via
         ALTER TABLE, so we use the rename → CREATE new → INSERT SELECT → DROP
-        old pattern (same as ``_drop_legacy_session_status_check``).
+        old pattern (same as ``_rebuild_legacy_sessions_table``).
         """
         if self.dialect != "sqlite":
             return
@@ -1525,7 +1543,7 @@ class StateDB:
 
         SQLite cannot drop a constraint via ALTER TABLE, so we use the same
         rename → CREATE new → INSERT SELECT → DROP old pattern as
-        ``_drop_legacy_session_status_check`` / ``_drop_legacy_action_kind_check``.
+        ``_rebuild_legacy_sessions_table`` / ``_drop_legacy_action_kind_check``.
         """
         if self.dialect != "sqlite":
             return

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -133,7 +133,7 @@ CREATE TABLE IF NOT EXISTS sessions (
   artifacts_path  TEXT,
   source_kind     TEXT    DEFAULT 'live' CHECK(
                     source_kind IS NULL
-                    OR source_kind IN ('live', 'imported_fs')
+                    OR source_kind IN ('live', 'imported_fs', 'imported_codex')
                   ),
   -- ── Lifecycle (ADR-0057) ─────────────────────
   -- No CHECK constraint: ADR-0057 makes Python the source of truth for

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -181,7 +181,7 @@ sessions = Table(
         "source_kind",
         Text,
         CheckConstraint(
-            "source_kind IS NULL OR source_kind IN ('live','imported_fs')",
+            "source_kind IS NULL OR source_kind IN ('live','imported_fs','imported_codex')",
             name="ck_sessions_source_kind",
         ),
         server_default="live",

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -77,7 +77,12 @@ def _emit_startup_warnings() -> None:
 
 def _start_claude_mirror() -> tuple[asyncio.Event, asyncio.Task] | tuple[None, None]:
     """Start the in-process Claude Code mirror tail if enabled; return (stop, task)."""
-    from .config import MIRROR_CLAUDE_ENABLED, MIRROR_CLAUDE_INTERVAL, MIRROR_CLAUDE_SINCE
+    from .config import (
+        MIRROR_CLAUDE_ENABLED,
+        MIRROR_CLAUDE_INTERVAL,
+        MIRROR_CLAUDE_SINCE,
+        MIRROR_SOURCE,
+    )
 
     if not MIRROR_CLAUDE_ENABLED:
         return None, None
@@ -85,7 +90,12 @@ def _start_claude_mirror() -> tuple[asyncio.Event, asyncio.Task] | tuple[None, N
 
     stop = asyncio.Event()
     task = asyncio.create_task(
-        mirror_forever(stop, since=MIRROR_CLAUDE_SINCE, interval=MIRROR_CLAUDE_INTERVAL),
+        mirror_forever(
+            stop,
+            source=MIRROR_SOURCE,
+            since=MIRROR_CLAUDE_SINCE,
+            interval=MIRROR_CLAUDE_INTERVAL,
+        ),
         name="claude-mirror-tail",
     )
 

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -382,12 +382,19 @@ DISPATCH_RETENTION_DEAD_LETTER_DAYS: int = int(
     os.environ.get("LIONAGI_STUDIO_DISPATCH_RETENTION_DEAD_LETTER_DAYS", "30")
 )
 
-# ── Ambient Claude Code mirror ────────────────────────────────────────────────
-# When on, studio tails ~/.claude/projects in-process so Claude Code sessions show
-# up (and stream live) without a separate `li mirror`. Bounded by the window below,
-# so startup catches up the recent window only and never backfills full history.
+# ── Ambient transcript mirror ─────────────────────────────────────────────────
+# When on, studio tails the local agent transcript trees in-process so those
+# sessions show up (and stream live) without a separate `li mirror`. Bounded by
+# the window below, so startup catches up the recent window only and never
+# backfills full history — which matters most for codex, whose rollout corpus
+# runs to tens of thousands of files.
 MIRROR_CLAUDE_ENABLED: bool = os.environ.get(
     "LIONAGI_STUDIO_MIRROR_CLAUDE", "1"
 ).strip().lower() not in ("0", "false", "no", "off", "")
 MIRROR_CLAUDE_SINCE: str = os.environ.get("LIONAGI_STUDIO_MIRROR_CLAUDE_SINCE", "24h")
 MIRROR_CLAUDE_INTERVAL: float = float(os.environ.get("LIONAGI_STUDIO_MIRROR_CLAUDE_INTERVAL", "5"))
+# Which transcript trees the ambient mirror reads: "both", "claude", or "codex".
+_MIRROR_SOURCE_RAW: str = os.environ.get("LIONAGI_STUDIO_MIRROR_SOURCE", "both").strip().lower()
+MIRROR_SOURCE: str = (
+    _MIRROR_SOURCE_RAW if _MIRROR_SOURCE_RAW in ("both", "claude", "codex") else "both"
+)

--- a/tests/apps_studio_server/test_claude_mirror_tail.py
+++ b/tests/apps_studio_server/test_claude_mirror_tail.py
@@ -117,6 +117,55 @@ def test_mirror_forever_missing_root_is_noop(tmp_path, monkeypatch):
     assert not db_path.exists()
 
 
+def test_scoping_the_claude_root_does_not_reach_the_real_codex_tree(tmp_path, monkeypatch):
+    """A caller that scopes ``root`` must not silently acquire the home codex tree.
+
+    ``codex_root`` defaults to ~/.codex/sessions, so without the explicit source
+    selector a test (or any embedder) that carefully points the mirror at its own
+    directory would still walk the machine's whole codex rollout corpus.
+    """
+    import lionagi.cli.mirror as mirror_mod
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(mirror_mod, "_OFFSETS_PATH", tmp_path / "offsets.json")
+
+    visited: list[str] = []
+
+    async def _spy_codex_pass(db, root, states, offsets, **kw):
+        visited.append(str(root))
+        return 0
+
+    monkeypatch.setattr(mirror_mod, "_codex_pass", _spy_codex_pass)
+
+    root = tmp_path / "claude_projects"
+    _write_transcript(
+        root, "aaaaaaaa-2222-3333-4444-555555555555", cwd=str(tmp_path), base_ts=time.time()
+    )
+
+    async def _run_once(**kwargs) -> None:
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            mirror_mod.mirror_forever(stop, root=root, since=None, interval=0.02, **kwargs)
+        )
+        await asyncio.sleep(0.15)
+        stop.set()
+        await asyncio.wait_for(task, timeout=5)
+
+    run_async(_run_once())
+    assert visited == [], f"default source reached codex roots: {visited}"
+
+    # The codex tree is read only when the caller asks for it, and then it is the
+    # one the caller named — never the home default. The tail polls repeatedly in
+    # the window, so it is the set of roots that is under test, not the count.
+    codex_root = tmp_path / "codex_sessions"
+    codex_root.mkdir()
+    run_async(_run_once(source="both", codex_root=codex_root))
+    assert visited, "explicit source=both never ran a codex pass"
+    assert set(visited) == {str(codex_root)}
+
+
 def test_start_claude_mirror_respects_flag(monkeypatch):
     """_start_claude_mirror no-ops when off, spawns and threads config when on."""
     import lionagi.studio.app as app_mod

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -739,13 +739,13 @@ def test_read_new_events_buffers_partial_line(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\n{"a":2}\n{"a":3')  # last line incomplete
     state = _FileState(session_uid="x")
-    first, new_offset = _read_new_events(path, state)
+    first, new_offset, _ = _read_new_events(path, state)
     assert [e["a"] for e in first] == [1, 2]
     state.offset = new_offset  # caller commits the cursor only after a durable mirror
     # Complete the dangling line; the next read picks up only the new event.
     with path.open("a") as fh:
         fh.write("}\n")
-    second, _ = _read_new_events(path, state)
+    second, _, _ = _read_new_events(path, state)
     assert [e["a"] for e in second] == [3]
 
 
@@ -753,7 +753,7 @@ def test_read_new_events_resets_on_truncation(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\n')
     state = _FileState(session_uid="x", offset=9999)  # offset past EOF
-    out, _ = _read_new_events(path, state)
+    out, _, _ = _read_new_events(path, state)
     assert [e["a"] for e in out] == [1]
 
 
@@ -761,8 +761,11 @@ def test_read_new_events_skips_corrupt_lines(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\nnot json\n{"a":2}\n')
     state = _FileState(session_uid="x")
-    out, _ = _read_new_events(path, state)
+    out, _, unreadable = _read_new_events(path, state)
     assert [e["a"] for e in out] == [1, 2]
+    # The dropped line is reported, not silently absorbed: a damaged transcript
+    # and an uninteresting one must not read the same downstream.
+    assert unreadable == 1
 
 
 def test_read_new_events_skips_non_dict_json_without_losing_followers(tmp_path: Path) -> None:
@@ -772,8 +775,9 @@ def test_read_new_events_skips_non_dict_json_without_losing_followers(tmp_path: 
     path = tmp_path / "t.jsonl"
     path.write_text('[]\n{"a":1}\n42\n{"a":2}\n')
     state = _FileState(session_uid="x")
-    out, _ = _read_new_events(path, state)
+    out, _, unreadable = _read_new_events(path, state)
     assert [e["a"] for e in out] == [1, 2]
+    assert unreadable == 2  # both the bare list and the bare scalar
 
 
 def test_first_prompt_skips_meta_and_command_noise() -> None:
@@ -1120,3 +1124,40 @@ async def test_lineage_resolves_after_restart(
     lineage = child["node_metadata"]["lineage"]
     assert lineage["parent_session_uid"] == a
     assert lineage["parent_event_uuid"] == "a-leaf"
+
+
+async def test_codex_file_that_mirrors_nothing_is_reported_not_skipped(tmp_path, caplog):
+    """A rollout read in full that produces no messages is surfaced, not passed over.
+
+    Without this it is indistinguishable from a file the mirror has not reached:
+    mirror_session writes no session row when a batch yields nothing, so there is
+    no row carrying the counts either. The measured cause on a real corpus is the
+    pre-2025-09-20 flat rollout format, which matches no record type read here.
+    """
+    import logging
+
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.db import StateDB
+
+    path = tmp_path / "rollout-legacy.jsonl"
+    # Flat legacy records: a type at the top level and no payload envelope.
+    path.write_text(
+        '{"id":"x","instructions":"y","timestamp":"2025-09-01T09:34:37Z"}\n'
+        '{"type":"message","role":"user","content":[{"text":"hi"}]}\n'
+        '{"type":"function_call","name":"shell","arguments":"{}"}\n'
+    )
+    state = _FileState(session_uid="")
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        with caplog.at_level(logging.WARNING):
+            written = await _mirror_one_codex(db, path, state, {})
+
+    assert written == 0
+    text = " ".join(r.message for r in caplog.records)
+    assert "rollout-legacy.jsonl" in text
+    assert "mirrored none" in text
+    # The record types it did see are named, so the reason is diagnosable from the
+    # log alone without re-reading the file.
+    assert "function_call" in text and "message" in text
+    # Reported once per file, not on every poll pass.
+    assert state.barren_reported

--- a/tests/state/test_check_rebuild_concurrency.py
+++ b/tests/state/test_check_rebuild_concurrency.py
@@ -38,7 +38,7 @@ _BARRIER_TIMEOUT_SECONDS = 15
 
 def _create_legacy_session_status_db(db_path: Path) -> None:
     """Full current schema, except sessions.status still carries the legacy
-    4-value CHECK constraint that ``_drop_legacy_session_status_check``
+    4-value CHECK constraint that ``_rebuild_legacy_sessions_table``
     rebuilds away. Every column already matches the current schema, so
     ``_reconcile_columns`` is a no-op and the session-status rebuild's own
     write is the first (and only) write transaction ``open()`` performs.

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -203,3 +203,38 @@ def test_tally_merge_is_additive_on_both_sides():
     assert merged.seen == {"x": 3, "y": 3}
     assert merged.mirrored == {"x": 1}
     assert merged.unparseable == 3
+
+
+@pytest.mark.parametrize(
+    "opening",
+    [
+        "<recommended_plugins>",
+        "<environment_context>",
+        "<skill>",
+        "<turn_aborted>",
+        "# AGENTS.md instructions for /some/repo",
+        "# Context from my IDE setup:",
+        "# Files mentioned by the user:",
+    ],
+)
+async def test_harness_injected_user_turns_are_not_mirrored_as_prompts(db, opening):
+    """Codex delivers repo instructions, skills and notices through the user role.
+
+    None was typed by a person, so mirroring them puts machine text in the
+    conversation and, at the top of a file, makes it the first thing a reader sees.
+    """
+    records = [
+        _rec("session_meta", {"id": ROLLOUT_UID, "cwd": "/x"}),
+        _turn("gpt-5.6-terra", "high"),
+        _user(f"{opening}\nbody text here", "inj"),
+        _user("the actual question", "real"),
+    ]
+    written, tally = await _mirror(db, records)
+    assert written == 1
+    # The injected record is still counted as seen, so the difference between what
+    # the file held and what was mirrored stays visible rather than being erased.
+    assert tally.seen["response_item"] == 2
+    assert tally.mirrored["response_item"] == 1
+
+    messages = await db.get_branch_messages(_det(ROLLOUT_UID, "branch"))
+    assert [m["content"]["instruction"] for m in messages] == ["the actual question"]

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the codex rollout mirror: provenance, record accounting, turn attribution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lionagi.state.codex_mirror import (
+    ID_FIELD,
+    SOURCE_KIND,
+    RecordTally,
+    _det,
+    mirror_session,
+    session_db_id,
+    turn_context,
+)
+from lionagi.state.db import StateDB
+
+
+def _rec(rtype: str, payload: dict, ts: str = "2026-07-29T12:00:00Z") -> dict:
+    return {"type": rtype, "timestamp": ts, "payload": payload}
+
+
+def _turn(model: str, effort: str) -> dict:
+    return _rec("turn_context", {"model": model, "effort": effort, "cwd": "/x"})
+
+
+def _user(text: str, pid: str) -> dict:
+    return _rec(
+        "response_item",
+        {"type": "message", "role": "user", "id": pid, "content": [{"text": text}]},
+    )
+
+
+def _assistant(text: str, pid: str) -> dict:
+    return _rec(
+        "response_item",
+        {"type": "message", "role": "assistant", "id": pid, "content": [{"text": text}]},
+    )
+
+
+ROLLOUT_UID = "0199aaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _records() -> list[dict]:
+    """A rollout that switches model mid-thread, and carries records of four types."""
+    return [
+        _rec("session_meta", {"id": ROLLOUT_UID, "cwd": "/x"}),
+        _turn("gpt-5.6-terra", "high"),
+        _user("first question", "m1"),
+        _assistant("first answer", "m2"),
+        _turn("gpt-5.6-sol", "xhigh"),  # the switch
+        _user("second question", "m3"),
+        _assistant("second answer", "m4"),
+        _rec("world_state", {"anything": 1}),
+        # developer turns are instruction plumbing: seen, never mirrored
+        _rec("response_item", {"type": "message", "role": "developer", "content": [{"text": "d"}]}),
+    ]
+
+
+@pytest.fixture
+async def db(tmp_path: Path):
+    state = StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}")
+    async with state:
+        yield state
+
+
+async def _mirror(db, records, *, turn=None, unparseable=0, source_path="/tmp/rollout-x.jsonl"):
+    return await mirror_session(
+        db,
+        rollout_uid=ROLLOUT_UID,
+        records=records,
+        tool_names={},
+        turn=turn if turn is not None else {},
+        unparseable=unparseable,
+        source_path=source_path,
+    )
+
+
+async def test_mirrored_session_carries_codex_import_provenance(db):
+    """The row records that it was imported, from which file, and on which id."""
+    written, tally = await _mirror(db, _records())
+    assert written == 4  # two user turns, two assistant turns
+
+    row = await db.get_session(session_db_id(ROLLOUT_UID))
+    assert row["source_kind"] == SOURCE_KIND
+    assert row["cc_session_id"] == ROLLOUT_UID
+
+    block = (row["node_metadata"] or {})["codex_import"]
+    # A rollout carries three identifiers; the column that stores one of them is
+    # silent about which, so the name travels with the value.
+    assert block["id_field"] == ID_FIELD
+    assert block["source_path"] == "/tmp/rollout-x.jsonl"
+    assert tally.seen == block["records_seen"]
+
+
+async def test_count_pairs_let_a_consumer_subtract_rather_than_trust(db):
+    """Both sides of every record type are recorded, so completeness is arithmetic."""
+    _, tally = await _mirror(db, _records())
+
+    # Source side: what the file held, including the types nothing is mirrored from.
+    assert tally.seen == {
+        "session_meta": 1,
+        "turn_context": 2,
+        "response_item": 5,
+        "world_state": 1,
+    }
+    # DB side: only the four conversation turns produced messages. The developer
+    # response_item is seen and not mirrored, and the difference is visible.
+    assert tally.mirrored == {"response_item": 4}
+    assert tally.seen["response_item"] - tally.mirrored["response_item"] == 1
+    # Types that mirror nothing at all are absent from the DB side, never zeroed
+    # into it, so "seen but produced nothing" and "never seen" stay distinguishable.
+    assert "world_state" not in tally.mirrored
+
+
+async def test_unparseable_is_its_own_number_not_a_skip(db):
+    """A line that could not be read never rolls into a type's deliberate skip."""
+    _, tally = await _mirror(db, _records(), unparseable=3)
+    assert tally.unparseable == 3
+    # It is not attributed to any record type, because it has none — that is the
+    # whole reason it is counted separately.
+    assert sum(tally.seen.values()) == 9
+    assert tally.as_provenance()["records_unparseable"] == 3
+
+    row = await db.get_session(session_db_id(ROLLOUT_UID))
+    assert row["node_metadata"]["codex_import"]["records_unparseable"] == 3
+
+
+async def test_each_message_is_attributed_to_the_turn_that_produced_it(db):
+    """Model and effort travel per message, so a mid-thread switch is not flattened."""
+    await _mirror(db, _records())
+    sid = session_db_id(ROLLOUT_UID)
+    messages = await db.get_branch_messages(_det(ROLLOUT_UID, "branch"))
+    turns = [(m["node_metadata"] or {}).get("codex_turn") for m in messages]
+
+    assert all(t is not None for t in turns), "a mirrored turn must not be an unattributed quote"
+    models = [t["model"] for t in turns]
+    # The first two turns predate the switch, the last two follow it. A session-level
+    # model would report one value for all four and misattribute half of them.
+    assert models == ["gpt-5.6-terra"] * 2 + ["gpt-5.6-sol"] * 2
+    assert [t["effort"] for t in turns] == ["high"] * 2 + ["xhigh"] * 2
+
+
+async def test_turn_attribution_survives_a_split_batch(db):
+    """A file mirrored across two passes keeps attributing to the carried turn.
+
+    The turn_context arrives in the first batch only; without carrying it, every
+    message in the second batch would be written with no attribution at all.
+    """
+    records = _records()
+    carried: dict[str, str] = {}
+    await _mirror(db, records[:4], turn=carried)
+    assert carried == {"model": "gpt-5.6-terra", "effort": "high"}
+
+    await _mirror(db, [_user("later question", "m9")], turn=carried)
+    messages = await db.get_branch_messages(_det(ROLLOUT_UID, "branch"))
+    last = messages[-1]
+    assert (last["node_metadata"] or {})["codex_turn"]["model"] == "gpt-5.6-terra"
+
+
+async def test_successive_passes_accumulate_the_counts(db):
+    """The recorded tally describes the whole file, not the most recent batch."""
+    records = _records()
+    await _mirror(db, records[:4])
+    await _mirror(db, records[4:])
+
+    block = (await db.get_session(session_db_id(ROLLOUT_UID)))["node_metadata"]["codex_import"]
+    assert block["records_seen"] == {
+        "session_meta": 1,
+        "turn_context": 2,
+        "response_item": 5,
+        "world_state": 1,
+    }
+    assert block["messages_mirrored"] == {"response_item": 4}
+
+
+async def test_re_mirroring_the_same_records_writes_no_duplicates(db):
+    """Ids are derived from the rollout, so a re-read is an update, not an insert."""
+    await _mirror(db, _records())
+    before = await db.get_branch_messages(_det(ROLLOUT_UID, "branch"))
+    await _mirror(db, _records())
+    after = await db.get_branch_messages(_det(ROLLOUT_UID, "branch"))
+    assert [m["id"] for m in before] == [m["id"] for m in after]
+
+
+def test_turn_context_reads_only_turn_context_records():
+    assert turn_context(_turn("m", "e")) == {"model": "m", "effort": "e"}
+    assert turn_context(_user("hi", "m1")) is None
+    assert turn_context({"type": "turn_context", "payload": None}) is None
+    # A turn_context carrying none of the retained fields is None rather than {},
+    # so it never clears a good carried attribution with an empty one.
+    assert turn_context(_rec("turn_context", {"cwd": "/x"})) is None
+
+
+def test_tally_merge_is_additive_on_both_sides():
+    a = RecordTally({"x": 1}, {"x": 1}, 1)
+    b = RecordTally({"x": 2, "y": 3}, {}, 2)
+    merged = a.merged(b)
+    assert merged.seen == {"x": 3, "y": 3}
+    assert merged.mirrored == {"x": 1}
+    assert merged.unparseable == 3

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -187,6 +187,91 @@ async def test_re_mirroring_the_same_records_writes_no_duplicates(db):
     assert [m["id"] for m in before] == [m["id"] for m in after]
 
 
+async def test_legacy_flat_rollout_is_recorded_even_though_it_mirrors_nothing(db):
+    """A file this reader cannot parse gets a row, or it leaves no trace at all.
+
+    Pre-2025-09-20 rollouts carry no ``{type, timestamp, payload}`` envelope, so
+    every record falls through as untyped. Skipping the write would make the one
+    outcome the count pair exists to expose the one outcome it cannot see.
+    """
+    flat = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+    written, tally = await _mirror(db, flat)
+    assert written == 0
+
+    row = await db.get_session(session_db_id(ROLLOUT_UID))
+    assert row is not None, "a rollout that mirrors nothing must still be accounted for"
+    assert row["source_kind"] == SOURCE_KIND
+    block = row["node_metadata"]["codex_import"]
+    assert block["records_seen"] == {"<untyped>": 2}
+    assert block["messages_mirrored"] == {}
+    assert block["source_path"] == "/tmp/rollout-x.jsonl"
+    # NOT NULL columns, and there is no message to take a time from.
+    assert row["created_at"] is not None
+
+
+async def test_fully_injected_rollout_is_recorded_with_its_counts(db):
+    """Every user turn filtered is exactly the shape an unenumerated form takes.
+
+    The filter list cannot be closed against a format another program owns, so a
+    future injection prefix will read as a rollout that mirrors nothing. That has
+    to arrive as a row whose seen count exceeds its mirrored count.
+    """
+    records = [
+        _rec("session_meta", {"id": ROLLOUT_UID, "cwd": "/x"}),
+        _turn("gpt-5.6-terra", "high"),
+        _user("<environment_context>\ncwd is /x", "i1"),
+        _user("# AGENTS.md instructions for /x\nbe good", "i2"),
+    ]
+    written, tally = await _mirror(db, records)
+    assert written == 0
+
+    row = await db.get_session(session_db_id(ROLLOUT_UID))
+    assert row is not None
+    block = row["node_metadata"]["codex_import"]
+    # Two response_items read, none mirrored: the subtraction a consumer does
+    # returns 2, and that is the signal.
+    assert block["records_seen"]["response_item"] == 2
+    assert "response_item" not in block["messages_mirrored"]
+    assert row["created_at"] is not None
+    assert await db.get_branch_messages(_det(ROLLOUT_UID, "branch")) == []
+
+
+async def test_a_later_batch_fills_in_a_rollout_that_began_barren(db):
+    """The row written for a barren batch is the same row its real turns land in."""
+    await _mirror(db, [_rec("session_meta", {"id": ROLLOUT_UID, "cwd": "/x"})])
+    sid = session_db_id(ROLLOUT_UID)
+    created_first = (await db.get_session(sid))["created_at"]
+
+    await _mirror(db, [_turn("gpt-5.6-sol", "xhigh"), _user("a real question", "m1")])
+    row = await db.get_session(sid)
+    # Accumulated across both batches rather than replaced by the second.
+    assert row["node_metadata"]["codex_import"]["records_seen"] == {
+        "session_meta": 1,
+        "turn_context": 1,
+        "response_item": 1,
+    }
+    assert row["created_at"] == created_first
+    assert len(await db.get_branch_messages(_det(ROLLOUT_UID, "branch"))) == 1
+
+
+async def test_a_batch_that_read_nothing_writes_no_row(db):
+    """An empty poll on a file is not a rollout; it must not mint a session."""
+    written, tally = await _mirror(db, [])
+    assert written == 0
+    assert tally.seen == {}
+    assert await db.get_session(session_db_id(ROLLOUT_UID)) is None
+
+
+async def test_a_batch_of_only_unreadable_lines_is_recorded(db):
+    """Lines that failed to parse are a finding; the row is where the count lives."""
+    written, _ = await _mirror(db, [], unparseable=4)
+    assert written == 0
+    row = await db.get_session(session_db_id(ROLLOUT_UID))
+    assert row is not None
+    assert row["node_metadata"]["codex_import"]["records_unparseable"] == 4
+    assert row["created_at"] is not None
+
+
 def test_turn_context_reads_only_turn_context_records():
     assert turn_context(_turn("m", "e")) == {"model": "m", "effort": "e"}
     assert turn_context(_user("hi", "m1")) is None

--- a/tests/state/test_engine_schema.py
+++ b/tests/state/test_engine_schema.py
@@ -336,6 +336,42 @@ async def test_metadata_check_constraint_parity_vs_schema_sql(tmp_path, sqlite_m
     assert not drift, f"CHECK enum drift:\n{drift}"
 
 
+async def test_python_enum_sets_match_schema_sql_checks(tmp_path):
+    """The Python vocabularies the writers validate against carry the same values
+    as the CHECK constraints in schema.sql.
+
+    The metadata-parity guard above covers the SQLAlchemy mirror only, so a value
+    added to schema.sql and the mirror alone would be legal in the database and
+    still refused by ``create_session`` — accepted by the store, rejected by the
+    only code that writes to it.
+    """
+    import re
+    import sqlite3
+
+    from lionagi.state.db import _INVOCATION_KINDS, _SCHEMA_PATH, _SOURCE_KINDS
+
+    raw_db = tmp_path / "python_enum_parity.db"
+    schema_text = _SCHEMA_PATH.read_text()
+    lines = [ln for ln in schema_text.splitlines() if not ln.strip().upper().startswith("PRAGMA")]
+    conn = sqlite3.connect(str(raw_db))
+    conn.executescript("\n".join(lines))
+    sessions_sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='sessions'"
+    ).fetchone()[0]
+    conn.close()
+
+    in_re = re.compile(r"(\w+)\s+IN\s*\(([^)]+)\)", re.IGNORECASE)
+    found = {
+        col: frozenset(p.strip().strip("'").strip() for p in vals.split(",") if p.strip())
+        for col, vals in in_re.findall(sessions_sql)
+    }
+
+    expected = {"source_kind": _SOURCE_KINDS, "invocation_kind": _INVOCATION_KINDS}
+    # Fail closed: a column whose CHECK the regex missed must not read as parity.
+    assert set(expected) <= set(found), f"no CHECK parsed for {set(expected) - set(found)}"
+    assert {col: found[col] for col in expected} == expected
+
+
 async def test_metadata_unique_enforcement_present(sqlite_meta_engine):
     """The three natural-key uniqueness rules are enforced (constraint or index)."""
     expected = {

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -1040,7 +1040,7 @@ async def test_dispatched_at_migration_backfills_preexisting_running_rows(tmp_pa
 
 def _create_legacy_session_status_db(db_path: Path) -> None:
     """Create a database whose sessions table still carries the four-value
-    status CHECK that ``_drop_legacy_session_status_check`` rebuilds away."""
+    status CHECK that ``_rebuild_legacy_sessions_table`` rebuilds away."""
     from lionagi.state.db import _SCHEMA_PATH
 
     schema = _SCHEMA_PATH.read_text()
@@ -1093,6 +1093,101 @@ async def test_migrated_db_reports_current_schema_version(tmp_path):
     # ... so the stamp moved with it.
     assert version == SCHEMA_VERSION
     assert _schema_meta_version(db_path) == SCHEMA_VERSION
+
+
+def _create_narrow_source_kind_db(db_path: Path) -> None:
+    """Create a database whose sessions.source_kind CHECK predates transcript
+    imports having their own provenance value."""
+    from lionagi.state.db import _SCHEMA_PATH
+
+    schema = _SCHEMA_PATH.read_text()
+    current = "OR source_kind IN ('live', 'imported_fs', 'imported_codex')"
+    assert current in schema, "widened source_kind CHECK not found in schema.sql"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(schema.replace(current, "OR source_kind IN ('live', 'imported_fs')", 1))
+
+
+def _insert_session(db_path: Path, sid: str, source_kind: str) -> None:
+    """Insert one session, satisfying every constraint except the one under test,
+    so a rejection can only have come from the source_kind CHECK."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("INSERT OR IGNORE INTO progressions (id, created_at) VALUES ('p', 1.0)")
+        conn.execute(
+            "INSERT INTO sessions (id, created_at, updated_at, progression_id, source_kind) "
+            "VALUES (?, ?, ?, 'p', ?)",
+            (sid, 1.0, 1.0, source_kind),
+        )
+
+
+async def test_narrow_source_kind_check_is_widened_for_codex_imports(tmp_path):
+    """A database created before codex transcripts had their own provenance value
+    rejects 'imported_codex' until the sessions rebuild widens its CHECK."""
+    from lionagi.state.db import StateDB
+
+    db_path = tmp_path / "narrow.db"
+    _create_narrow_source_kind_db(db_path)
+
+    # Pre-state: the value the codex mirror writes is refused outright.
+    with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+        _insert_session(db_path, "pre", "imported_codex")
+    # ... and the DB is otherwise usable, so the rebuild has real rows to carry.
+    _insert_session(db_path, "kept", "imported_fs")
+
+    state = StateDB(f"sqlite+aiosqlite:///{db_path}")
+    async with state:
+        pass
+
+    assert "'imported_codex'" in _sessions_create_sql(db_path)
+    _insert_session(db_path, "post", "imported_codex")
+    with sqlite3.connect(db_path) as conn:
+        rows = dict(conn.execute("SELECT id, source_kind FROM sessions").fetchall())
+    assert rows == {"kept": "imported_fs", "post": "imported_codex"}
+
+    # A value outside the vocabulary is still refused, so the rebuild widened the
+    # CHECK rather than dropping it.
+    with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+        _insert_session(db_path, "bogus", "imported_elsewhere")
+
+
+async def test_current_schema_db_is_not_rebuilt(tmp_path):
+    """A database created by this release carries neither legacy CHECK, so opening
+    it leaves the sessions table byte-identical."""
+    from lionagi.state.db import _SCHEMA_PATH, StateDB
+
+    db_path = tmp_path / "current.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_SCHEMA_PATH.read_text())
+    before = _sessions_create_sql(db_path)
+    assert not StateDB._sessions_rebuild_needed(before)
+
+    state = StateDB(f"sqlite+aiosqlite:///{db_path}")
+    async with state:
+        pass
+
+    assert _sessions_create_sql(db_path) == before
+
+
+def test_sessions_rebuild_needed_reads_both_triggers():
+    """Each legacy marker fires on its own, and the widened form fires on neither."""
+    from lionagi.state.db import StateDB
+
+    legacy_status = (
+        "CREATE TABLE sessions (status TEXT CHECK(status IN "
+        "('running', 'completed', 'failed', 'aborted')), "
+        "source_kind TEXT CHECK(source_kind IN "
+        "('live', 'imported_fs', 'imported_codex')))"
+    )
+    narrow_source = (
+        "CREATE TABLE sessions (status TEXT, source_kind TEXT CHECK(source_kind IN "
+        "('live', 'imported_fs')))"
+    )
+    current = (
+        "CREATE TABLE sessions (status TEXT, source_kind TEXT CHECK(source_kind IN "
+        "('live', 'imported_fs', 'imported_codex')))"
+    )
+    assert StateDB._sessions_rebuild_needed(legacy_status)
+    assert StateDB._sessions_rebuild_needed(narrow_source)
+    assert not StateDB._sessions_rebuild_needed(current)
 
 
 def test_schema_sql_seed_version_matches_constant():

--- a/tests/state/test_session_status_vocabulary.py
+++ b/tests/state/test_session_status_vocabulary.py
@@ -183,7 +183,7 @@ async def test_drop_legacy_check_is_idempotent(tmp_path: Path):
     await state1.update_session(s["id"], status="cancelled")
     await state1.close()
 
-    # Second open — _drop_legacy_session_status_check should find no
+    # Second open — _rebuild_legacy_sessions_table should find no
     # marker and return immediately.
     state2 = StateDB(path)
     await state2.open()

--- a/tests/test_durable_json_non_finite.py
+++ b/tests/test_durable_json_non_finite.py
@@ -236,6 +236,10 @@ def test_mirror_offsets_refuse_non_finite(tmp_path, monkeypatch):
         "session_uid": "s",
         "tool_names": {"t1": "Read"},
         "leaf_uuid": None,
+        # Carried so a message mirrored after a restart keeps the attribution of
+        # the turn that produced it; it reaches this file out of a codex rollout,
+        # so it is on the same foreign-data footing as tool_names above.
+        "turn": {},
     }
 
 


### PR DESCRIPTION
Codex sessions run outside lionagi never appeared in studio. This mirrors
`~/.codex/sessions/**/rollout-*.jsonl` into StateDB the way `~/.claude/projects`
is already mirrored, and records enough provenance that a mirrored row can be
told apart from a run lionagi executed.

## Provenance

`sessions.source_kind` gains `imported_codex`. It is added at all four places
that define the vocabulary — `schema.sql`, the inline rebuild DDL, the Python
set the writers validate against, and the SQLAlchemy metadata mirror — and the
existing sessions rebuild now fires on either legacy CHECK, so an existing
database is widened on open rather than accepting the value only in newly
created ones.

The metadata-parity guard covered two of those four sites. Setting the Python
set back to the narrow value leaves the whole state suite green while
`create_session` refuses a value the database accepts, so the guard is extended
to cover the Python vocabularies too, and fails closed when it parses no CHECK
for a column it was asked about.

Each mirrored session records the rollout file it was read from and which of a
rollout's three identifiers `cc_session_id` holds — the column stores one of
them and is otherwise silent about which.

## Completeness is a subtraction, not a claim

Rather than a manifest the importer writes about itself, each session carries
per-record-type count pairs: what the file held, and what became messages. A
consumer subtracts. Lines that could not be read are counted separately and
never folded into a type's deliberate skip, so a damaged transcript and an
uninteresting one do not read the same downstream.

A file read in full that produces no messages is reported with the record types
it did contain, instead of passing silently — otherwise it is indistinguishable
from a file the mirror never reached, and no session row exists to carry the
counts either. Measured cause: 6 of 29,652 rollouts, all from 2025-09-01/02,
predate the enveloped record format.

## Attribution

`turn_context` is retained rather than skipped. Model and effort travel per
message, because a rollout can switch model mid-thread and a session-level
value would misattribute every turn before the switch. The current turn is
persisted with the file cursor so a restart does not leave the next batch
unattributed.

## Injected turns

Codex delivers repo instructions, skill definitions, environment and editor
blocks and the interruption notice through the user role. A 1,000-file stride
over a whole local corpus finds 1,433 of 2,427 user messages (59%) are
injection of that kind, so without filtering, most mirrored "prompts" are
machine text — and at the head of a file it is the first thing a reader sees.
The list is explicitly not treated as closed; an uncovered form leaves a
mirrored record the count pair cannot account for.

## Mirror source is explicit

`mirror_forever` defaulted its codex root to the home directory regardless of
whether the caller had scoped the claude root, so a caller that pointed the
mirror at its own directory still walked the machine's whole rollout corpus.
Which trees are read is now an explicit `source` argument defaulting to claude
alone; studio passes its configured value (`LIONAGI_STUDIO_MIRROR_SOURCE`,
default both), which is where "read everything on this machine" belongs. Daemon
behaviour is unchanged. `li mirror` now honours the `--source` and
`--codex-root` flags it already advertised but ignored.

## Verification

Count pairs were checked against an independent read of ten real rollouts
spanning the corpus, oldest end included: source-side counts match on every
file. End to end through the CLI into an isolated store, 97 sessions and 12,889
messages land as `imported_codex`, with 12,887 carrying turn attribution — the
two without it are one prompt at the head of a resumed rollout, where the file
genuinely carries no turn context yet.

New assertions are mutation-verified: dropping `source_kind`, flattening
attribution to a session-level value, folding the unreadable-line count into
the tally, and removing the barren-file report each turn the corresponding test
red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)