### PR TITLE
fix(notify): classify a failed terminal notice without storing what it said

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ DESIGN_REVIEW*.txt
 ADR_REVIEW*.txt
 ALL_ADRS_COMPILED.txt
 codex_review_*.md
+.lane-*.md

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -71,6 +71,37 @@ _FAILURE_CLASSES: tuple[tuple[str, tuple[str, ...]], ...] = (
 )
 
 
+_FAILURE_TIMEOUT = "timeout"
+
+# The one allowed set, and the reason it is defined here rather than derived at
+# each use: this field is persisted, so the guarantee that has to hold is about
+# the value that reaches the record, not about what the classifier happens to
+# return today. Every name that can ever be stored appears here -- the classified
+# ones, ``unknown``, and ``timeout``, which is assigned on the exception path and
+# so never passes through the classifier at all.
+_ALLOWED_FAILURE_CLASSES: frozenset[str] = frozenset(
+    {name for name, _ in _FAILURE_CLASSES} | {_FAILURE_UNKNOWN, _FAILURE_TIMEOUT}
+)
+
+
+def _pin_failure_class(value: str | None) -> str | None:
+    """Force a classification into the closed set, at the boundary that stores it.
+
+    ``_classify_failure`` is fail-closed today, and pinning here does not trust
+    that it stays so. A later edit that returns part of the command's output --
+    the change any diagnostics-minded reader is tempted to make -- would
+    otherwise be persisted verbatim and reopen the leak this module exists to
+    close. Placing the check immediately before the record is built means the
+    invariant is enforced where it is needed rather than where it is produced.
+
+    ``None`` is a real value here and passes through: it means the delivery
+    succeeded and there is no failure to name.
+    """
+    if value is None:
+        return None
+    return value if value in _ALLOWED_FAILURE_CLASSES else _FAILURE_UNKNOWN
+
+
 def _classify_failure(text: str) -> str:
     """Map a delivery command's output to one name from the closed set above.
 
@@ -260,15 +291,19 @@ def _deliver(
             "ok": False,
             "exit_code": None,
             "error": type(exc).__name__,
-            "failure_class": (
-                "timeout" if isinstance(exc, subprocess.TimeoutExpired) else _FAILURE_UNKNOWN
+            "failure_class": _pin_failure_class(
+                _FAILURE_TIMEOUT if isinstance(exc, subprocess.TimeoutExpired) else _FAILURE_UNKNOWN
             ),
             "command": program,
         }
     ok = proc.returncode == 0
     # Classified here and not retained: `proc` goes out of scope with the
-    # function, and only the returned name outlives it.
-    failure_class = None if ok else _classify_quietly(f"{proc.stderr or ''}\n{proc.stdout or ''}")
+    # function, and only the returned name outlives it. Pinned on the way into
+    # the record, so what is persisted is a member of the closed set whatever
+    # the classifier returned.
+    failure_class = _pin_failure_class(
+        None if ok else _classify_quietly(f"{proc.stderr or ''}\n{proc.stdout or ''}")
+    )
     outcome = {
         "attempted": True,
         "ok": ok,
@@ -290,8 +325,8 @@ def _deliver(
     return outcome
 
 
-def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
-    """Append one line to the run's own log when a configured delivery failed.
+def _note_delivery_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
+    """Append one line to the run's own log when the notice needs an operator's eye.
 
     The outcome is already on the job record, but that record is only seen by
     someone who thinks to query it. A run whose notice never arrived is
@@ -299,10 +334,18 @@ def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
     Ending it with a stated failure is what lets the log serve as the fallback
     for a notice that did not.
 
-    The line carries the classified reason when there is one. It is a name from
-    a closed set, never anything the command said, so the log stays as free of
-    the command's own text as the job record is -- a log is if anything the
-    easier of the two to read by accident.
+    Two outcomes qualify, and the second is the reason this is not simply a
+    failure note. A delivery that ran, exited zero, and *could not be verified*
+    is recorded as such on the job record, but an operator reading the log or a
+    job listing would otherwise see an ordinary success. A degraded result that
+    only the record knows about is a degraded result nobody acts on, so it gets
+    a line of its own -- distinct in wording from a failure, because the notice
+    probably did arrive and reporting it as failed would be its own lie.
+
+    Every line carries only names from closed sets: the classified reason, or
+    the fixed ``unverified_reason``. Never anything the command said, so the log
+    stays as free of the command's own text as the job record is -- a log is if
+    anything the easier of the two to read by accident.
 
     Best-effort like everything else in this hook: the run has already
     finished, and a log that cannot be appended to must not turn a delivered
@@ -310,19 +353,30 @@ def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
     """
     if not outcome.get("attempted") and not outcome.get("error"):
         return  # nothing was configured; silence is the documented default
+
     if outcome.get("ok"):
-        return
-    detail = outcome.get("error") or f"exit code {outcome.get('exit_code')}"
-    failure_class = outcome.get("failure_class")
-    if failure_class:
-        detail = f"{detail} ({failure_class})"
+        if outcome.get("delivery_verified") is not False:
+            return  # delivered, and the exit code is evidence we trust
+        line = (
+            f"\n[notify] WARNING: terminal notice for run {run_id} reported success but "
+            f"could NOT be verified: {outcome.get('unverified_reason')}. "
+            f"The notice may not have been delivered; do not read this run's "
+            f"completion signal as confirmed.\n"
+        )
+    else:
+        detail = outcome.get("error") or f"exit code {outcome.get('exit_code')}"
+        failure_class = outcome.get("failure_class")
+        if failure_class:
+            detail = f"{detail} ({failure_class})"
+        line = (
+            f"\n[notify] terminal notice NOT delivered for run {run_id}: {detail}. "
+            f"This run finished; its completion signal did not.\n"
+        )
+
     try:
         path = config.job_dir(run_id) / "console.log"
         with path.open("a", encoding="utf-8") as fh:
-            fh.write(
-                f"\n[notify] terminal notice NOT delivered for run {run_id}: {detail}. "
-                f"This run finished; its completion signal did not.\n"
-            )
+            fh.write(line)
     except OSError:
         pass
 
@@ -456,7 +510,7 @@ def main(argv: list[str] | None = None) -> int:
         sender=args.sender,
     )
     recorded = jobs.record_notify_delivery(args.run_id, outcome)
-    _note_failure_in_console_log(args.run_id, outcome)
+    _note_delivery_in_console_log(args.run_id, outcome)
     if recorded.refused:
         # The notice was attempted against a durable end; what is missing is the
         # record of how it went. Reported the same way, because a delivery

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -36,10 +36,68 @@ from typing import Any
 # the path because that interpreter is the one lionagi is installed in.
 from . import config, jobs
 
-# A configured notifier's stdout/stderr is free text that can carry a
-# credential the command obtained anywhere, so it is never captured or logged:
-# the child inherits DEVNULL and this hook keeps nothing.
 _DELIVERY_TIMEOUT_S = 30
+
+# A configured notifier's stdout/stderr is free text that can carry a credential
+# the command obtained anywhere, so none of it is ever stored. It used to be
+# discarded at the pipe (DEVNULL), which kept that promise and cost the record
+# any way to tell a failure apart: every failed delivery recorded a bare exit
+# code and a null error, so "the notifier binary is missing" and "the notifier
+# refused the message" were the same row.
+#
+# The output is now read into memory, matched against the closed vocabulary
+# below, and dropped. Only the matched name is stored. That keeps the stored
+# field a bounded enum rather than free text, so the invariant holds by
+# construction instead of by a promise to sanitise.
+_FAILURE_UNKNOWN = "unknown"
+# First match wins, so the more specific phrase must precede any broader one it
+# contains. "connection refused" sits above the policy class for exactly that
+# reason, and the policy class deliberately does NOT match a bare "refused":
+# that word appears in network errors far more often than in policy ones, and a
+# needle that broad silently reclassifies them. A refusal phrased in a way none
+# of these anticipate falls to `unknown`, which is the correct direction to be
+# wrong in.
+_FAILURE_CLASSES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("command_not_found", ("command not found", "no such file or directory", "not found")),
+    ("permission_denied", ("permission denied", "operation not permitted", "eacces")),
+    (
+        "connection_failed",
+        ("connection refused", "no route to host", "unreachable", "network is", "dns"),
+    ),
+    ("authentication_failed", ("unauthorized", "authentication failed", "invalid token", "401")),
+    ("refused_by_policy", ("refused by", "blocked by", "denied by policy", "forbidden", "403")),
+    ("target_unknown", ("unknown recipient", "no such actor", "unknown actor", "no such user")),
+    ("invalid_usage", ("usage:", "unrecognized argument", "invalid argument", "unknown option")),
+)
+
+
+def _classify_failure(text: str) -> str:
+    """Map a delivery command's output to one name from the closed set above.
+
+    Fail-closed: anything that does not match is ``unknown``. A fragment of the
+    text is never returned, however diagnostic it looks — the moment an
+    unmatched case is allowed to contribute its own words, the stored field is
+    free text again and the invariant is gone.
+    """
+    lowered = text.lower()
+    for name, needles in _FAILURE_CLASSES:
+        if any(needle in lowered for needle in needles):
+            return name
+    return _FAILURE_UNKNOWN
+
+
+def _classify_quietly(text: str) -> str:
+    """``_classify_failure`` with every escape route closed.
+
+    An exception raised while classifying must not carry the text out with it.
+    Python exceptions routinely embed the value that caused them, so this
+    swallows the exception object entirely rather than logging it or putting
+    its message anywhere near the record.
+    """
+    try:
+        return _classify_failure(text)
+    except Exception:  # noqa: BLE001 — deliberately not logged: the message could embed the text
+        return _FAILURE_UNKNOWN
 
 
 def _resolve_command(
@@ -130,6 +188,29 @@ def _delivery_env(sender: str) -> dict[str, str] | None:
     return env
 
 
+def _unverifiable_reason(argv: list[str]) -> str | None:
+    """Why a zero exit from *argv* would not actually mean delivered.
+
+    Exit code is this hook's only delivery evidence, and for one adapter shape
+    we know that evidence is weak: ``kkernel exec`` returns 0 when *any* op in
+    the request succeeded, so a multi-op notify whose send was refused still
+    exits 0 and records as delivered. ``--strict`` makes a refused op exit 1.
+
+    Scoped to a known adapter shape on purpose. Reading someone else's argv is
+    only defensible where the alternative is recording a lie, and it stops at
+    marking the outcome — the command still runs exactly as configured, because
+    refusing to run what an operator wrote is not this hook's call.
+    """
+    if not argv:
+        return None
+    program = os.path.basename(argv[0])
+    if program != "kkernel" or "exec" not in argv:
+        return None
+    if any(tok == "--strict" for tok in argv):
+        return None
+    return "kkernel_exec_without_strict_exits_zero_on_a_refused_op"
+
+
 def _deliver(
     argv: list[str],
     payload: dict[str, str],
@@ -141,16 +222,18 @@ def _deliver(
 
     The outcome is recorded on the job so a dead completion notice surfaces in
     ``job_status`` instead of vanishing silently — a completion signal that can
-    fail silently would cost the detached-spawn pattern its reliability. Only
-    the exit code is kept: the command's stdout/stderr is free text that can
-    carry a credential, so it goes to DEVNULL and is never captured.
+    fail silently would cost the detached-spawn pattern its reliability.
+
+    The command's stdout/stderr is free text that can carry a credential, so
+    none of it is stored. It is read, matched against the closed vocabulary in
+    ``_FAILURE_CLASSES``, and dropped; only the matched name reaches the record,
+    in ``failure_class``. That is what turns a bare exit code into something
+    actionable while keeping the stored field a bounded enum by construction.
 
     *program* is recorded alongside it so the record names which notifier this
     was. It is the program token of the configured argv template, before any run
     field is substituted into it — operator configuration, which whoever wrote it
-    can already read, and not something the command produced at runtime. That is
-    the whole difference: it says *what* failed without keeping a byte of what
-    the command said, which stays discarded.
+    can already read, and not something the command produced at runtime.
     """
     try:
         proc = subprocess.run(  # noqa: S603 — argv is the operator-configured delivery command, no shell
@@ -158,30 +241,53 @@ def _deliver(
             input=json.dumps(payload),
             text=True,
             timeout=_DELIVERY_TIMEOUT_S,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            capture_output=True,
             check=False,
             env=env,
         )
     except (OSError, subprocess.SubprocessError) as exc:
-        # never fail the run's terminal path; record the failure instead.
-        # The exception *type* names how the delivery came apart — never started,
-        # or ran past the timeout — and the exception's message is left out: it
-        # is the one string here whose content this hook does not choose.
+        # Never fail the run's terminal path; record the failure instead.
+        #
+        # The exception *type* names how the delivery came apart — never
+        # started, or ran past the timeout — and nothing else from the
+        # exception is kept. This matters more than it looks:
+        # subprocess.TimeoutExpired carries the child's captured output on its
+        # own .stdout/.stderr attributes, so logging the exception, or storing
+        # its str(), would put back exactly the free text this function exists
+        # to keep out.
         return {
             "attempted": True,
             "ok": False,
             "exit_code": None,
             "error": type(exc).__name__,
+            "failure_class": (
+                "timeout" if isinstance(exc, subprocess.TimeoutExpired) else _FAILURE_UNKNOWN
+            ),
             "command": program,
         }
-    return {
+    ok = proc.returncode == 0
+    # Classified here and not retained: `proc` goes out of scope with the
+    # function, and only the returned name outlives it.
+    failure_class = None if ok else _classify_quietly(f"{proc.stderr or ''}\n{proc.stdout or ''}")
+    outcome = {
         "attempted": True,
-        "ok": proc.returncode == 0,
+        "ok": ok,
         "exit_code": proc.returncode,
         "error": None,
+        "failure_class": failure_class,
         "command": program,
     }
+    unverifiable = _unverifiable_reason(argv) if ok else None
+    if unverifiable:
+        # Delivered on the only evidence available, and that evidence is known
+        # to be weak for this shape. Recorded as its own state rather than
+        # folded into either "delivered" or "failed": calling it delivered
+        # records a claim this hook cannot support, and calling it failed
+        # reports a failure that probably did not happen.
+        outcome["ok"] = True
+        outcome["delivery_verified"] = False
+        outcome["unverified_reason"] = unverifiable
+    return outcome
 
 
 def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
@@ -193,9 +299,10 @@ def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
     Ending it with a stated failure is what lets the log serve as the fallback
     for a notice that did not.
 
-    Nothing about *why* it failed is available here by design -- the command's
-    output goes to DEVNULL because it is free text that can carry a credential
-    -- so the line reports the exit code and no more.
+    The line carries the classified reason when there is one. It is a name from
+    a closed set, never anything the command said, so the log stays as free of
+    the command's own text as the job record is -- a log is if anything the
+    easier of the two to read by accident.
 
     Best-effort like everything else in this hook: the run has already
     finished, and a log that cannot be appended to must not turn a delivered
@@ -206,6 +313,9 @@ def _note_failure_in_console_log(run_id: str, outcome: dict[str, Any]) -> None:
     if outcome.get("ok"):
         return
     detail = outcome.get("error") or f"exit code {outcome.get('exit_code')}"
+    failure_class = outcome.get("failure_class")
+    if failure_class:
+        detail = f"{detail} ({failure_class})"
     try:
         path = config.job_dir(run_id) / "console.log"
         with path.open("a", encoding="utf-8") as fh:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2894,12 +2894,22 @@ def _notify_delivery_state(outcome: Any) -> str:
     nothing — refused before it ran, unable to start, timed out, or exited
     non-zero — because to a caller waiting on the notice those are one fact.
 
+    ``"delivered_unverified"`` is its own state and not a flavour of either. The
+    delivery ran and exited zero, but for that command shape a zero exit is known
+    not to mean the message was sent. Collapsing it into ``"delivered"`` reports a
+    claim we cannot support, and collapsing it into ``"failed"`` reports a failure
+    that probably did not happen. A caller that treats any non-``"delivered"``
+    state as needing attention gets the right behaviour without knowing this
+    distinction; one that wants the distinction has it.
+
     The record is JSON on disk, so an ``outcome`` that is not an object is read as
     no delivery rather than allowed to raise through the listing.
     """
     if not isinstance(outcome, dict):
         return "none"
     if outcome.get("ok"):
+        if outcome.get("delivery_verified") is False:
+            return "delivered_unverified"
         return "delivered"
     if not outcome.get("attempted") and not outcome.get("error"):
         return "none"

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -2683,6 +2683,15 @@ _REFUSED_BEFORE_RUNNING = {
     "command": None,
 }
 _NOTHING_CONFIGURED = {"attempted": False}
+_DELIVERED_UNVERIFIED = {
+    "attempted": True,
+    "ok": True,
+    "exit_code": 0,
+    "error": None,
+    "command": "kkernel",
+    "delivery_verified": False,
+    "unverified_reason": "kkernel_exec_without_strict_exits_zero_on_a_refused_op",
+}
 
 
 def test_listing_tells_a_failed_notice_apart_from_a_delivered_one(sandbox):
@@ -2705,6 +2714,30 @@ def test_listing_tells_a_failed_notice_apart_from_a_delivered_one(sandbox):
     assert states[exited_nonzero] == "failed"
     assert states[never_started] == "failed"
     assert states[refused] == "failed"
+
+
+def test_listing_does_not_pass_an_unverified_delivery_off_as_delivered(sandbox):
+    """A zero exit that is known not to prove delivery gets its own word.
+
+    This is the whole point of recording the degraded state: an operator scanning
+    the listing sees "delivered" and stops looking. If the one shape we know can
+    exit zero on a refused send is spelled the same as a confirmed delivery, the
+    marker on the record is information nobody ever acts on.
+
+    It is equally not "failed" — the notice probably did arrive, and reporting a
+    failure that did not happen sends someone chasing it.
+    """
+    unverified = _terminal_run(_DELIVERED_UNVERIFIED)
+    delivered = _terminal_run(_DELIVERED)
+    failed = _terminal_run(_EXITED_NONZERO)
+
+    states = {j["run_id"]: j["notify_delivery_state"] for j in jobs.list_jobs()}
+    assert states[unverified] == "delivered_unverified"
+    assert states[unverified] != states[delivered]
+    assert states[unverified] != states[failed]
+    # a caller that treats anything other than "delivered" as needing a look gets
+    # the right behaviour without having to know this state exists
+    assert states[unverified] != "delivered"
 
 
 def test_listing_does_not_read_an_absent_notifier_as_a_failure(sandbox):

--- a/tests/mcp/test_notify_failure_classification.py
+++ b/tests/mcp/test_notify_failure_classification.py
@@ -16,7 +16,7 @@ import sys
 import pytest
 
 from lionagi.mcp._notify_hook import (
-    _FAILURE_CLASSES,
+    _ALLOWED_FAILURE_CLASSES,
     _FAILURE_UNKNOWN,
     _classify_failure,
     _classify_quietly,
@@ -24,7 +24,11 @@ from lionagi.mcp._notify_hook import (
     _unverifiable_reason,
 )
 
-_NAMES = {name for name, _ in _FAILURE_CLASSES} | {_FAILURE_UNKNOWN}
+# Imported, not rebuilt here. A set derived independently in the test drifts from
+# the one the code enforces, and the first thing it misses is whatever name was
+# added last -- "timeout" was exactly that, assigned on the exception path and so
+# absent from any set derived from the classifier table alone.
+_NAMES = _ALLOWED_FAILURE_CLASSES
 
 
 def _py(script: str) -> list[str]:
@@ -207,6 +211,38 @@ def test_the_marker_is_not_applied_to_a_failed_delivery():
     out = _deliver(_py("import sys; sys.exit(1)"), {})
     assert out["ok"] is False
     assert "delivery_verified" not in out
+
+
+def test_a_classifier_that_returns_free_text_cannot_get_it_into_the_record(monkeypatch):
+    """The invariant is pinned where the value is STORED, not where it is produced.
+
+    `_classify_failure` is fail-closed today. This asserts the record does not
+    depend on it staying so: the tempting future edit is to return a fragment of
+    the command's output because it is diagnostic, and that edit must fail a
+    test rather than silently reopen the leak. Monkeypatching the classifier is
+    a stand-in for exactly that edit.
+    """
+
+    monkeypatch.setattr(
+        "lionagi.mcp._notify_hook._classify_failure",
+        lambda text: "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY",
+    )
+    out = _deliver(_py("import sys; sys.stderr.write('anything'); sys.exit(1)"), {})
+
+    assert out["failure_class"] == _FAILURE_UNKNOWN
+    assert out["failure_class"] in _NAMES
+    assert "wJalrXUtn" not in repr(out)
+
+
+def test_the_timeout_name_is_inside_the_allowed_set():
+    """It is assigned on the exception path and never passes through the classifier.
+
+    A pin whose allowed set omits a name the code legitimately stores would
+    rewrite that name to `unknown` and destroy real information, so membership
+    is asserted rather than assumed.
+    """
+    assert "timeout" in _ALLOWED_FAILURE_CLASSES
+    assert _FAILURE_UNKNOWN in _ALLOWED_FAILURE_CLASSES
 
 
 def test_subprocess_is_invoked_without_devnull_so_there_is_something_to_classify():

--- a/tests/mcp/test_notify_failure_classification.py
+++ b/tests/mcp/test_notify_failure_classification.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""What a failed terminal notice records, and what it must never record.
+
+The delivery command's output can carry a credential it obtained anywhere, so
+none of it is stored. Discarding it at the pipe kept that promise and cost the
+record any way to tell one failure from another. These tests pin both halves:
+the failure is classifiable, and the stored field stays a bounded enum.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from lionagi.mcp._notify_hook import (
+    _FAILURE_CLASSES,
+    _FAILURE_UNKNOWN,
+    _classify_failure,
+    _classify_quietly,
+    _deliver,
+    _unverifiable_reason,
+)
+
+_NAMES = {name for name, _ in _FAILURE_CLASSES} | {_FAILURE_UNKNOWN}
+
+
+def _py(script: str) -> list[str]:
+    return [sys.executable, "-c", script]
+
+
+# ---------------------------------------------------------------------------
+# The invariant: the stored field is a bounded enum, not free text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY",
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig",
+        "sending to https://hooks.example.com/services/T00/B00/XXXXXXXXXXXX failed",
+        "psql: password authentication failed for user 'admin' with password hunter2",
+        "",
+        "   \n\t  ",
+        "\x00\x01 binary garbage \xff",
+    ],
+)
+def test_no_input_can_make_the_stored_value_leave_the_closed_set(text):
+    """Fail-closed is the whole design: an unmatched case yields a name, never a fragment.
+
+    The moment an unrecognised failure is allowed to contribute its own words,
+    the field is free text again and the no-secrets invariant is gone. These
+    inputs are chosen to be exactly the ones a helpful implementation would want
+    to quote.
+    """
+    result = _classify_failure(text)
+    assert result in _NAMES
+    # Nothing from the input survives into the stored value.
+    for token in ("wJalrXUtn", "eyJhbGci", "hooks.example.com", "hunter2", "admin"):
+        assert token not in result
+
+
+def test_a_credential_bearing_line_that_also_matches_a_class_still_stores_only_the_name():
+    """Matching a class must not tempt the classifier into returning context."""
+    result = _classify_failure("401 unauthorized: token sk-live-AAAABBBBCCCCDDDD rejected")
+    assert result == "authentication_failed"
+    assert "sk-live" not in result
+
+
+def test_classifier_failure_yields_unknown_and_carries_nothing_out(monkeypatch):
+    """An exception mid-classification must not carry the text out with it.
+
+    Python exceptions routinely embed the value that caused them, so the
+    swallow is deliberate: the exception object is dropped rather than logged.
+    """
+
+    def _explode(text):
+        raise RuntimeError(f"boom while reading {text}")
+
+    monkeypatch.setattr("lionagi.mcp._notify_hook._classify_failure", _explode)
+    out = _classify_quietly("password=hunter2")
+    assert out == _FAILURE_UNKNOWN
+    assert "hunter2" not in out
+
+
+# ---------------------------------------------------------------------------
+# The point of the change: a failure is now classifiable
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_notifier_is_distinguishable_from_a_refused_message():
+    """The two failures that used to record identically."""
+    missing = _deliver(_py("import sys; sys.stderr.write('command not found'); sys.exit(127)"), {})
+    refused = _deliver(_py("import sys; sys.stderr.write('403 forbidden'); sys.exit(1)"), {})
+
+    assert missing["ok"] is False and refused["ok"] is False
+    assert missing["failure_class"] == "command_not_found"
+    assert refused["failure_class"] == "refused_by_policy"
+    assert missing["failure_class"] != refused["failure_class"]
+
+
+def test_a_network_refusal_is_not_read_as_a_policy_refusal():
+    """First match wins, so a broad needle silently reclassifies a narrower case.
+
+    "connection refused" contains "refused". With the policy class matching the
+    bare word and listed first, every connection failure recorded as a policy
+    refusal — a wrong answer that looks exactly as confident as a right one.
+    """
+    assert _classify_failure("connection refused to vault.internal") == "connection_failed"
+    assert _classify_failure("dial tcp: no route to host") == "connection_failed"
+    assert _classify_failure("request refused by the delivery gate") == "refused_by_policy"
+
+
+def test_a_delivery_that_says_nothing_useful_is_unknown_not_a_quote():
+    out = _deliver(_py("import sys; sys.stderr.write('weird internal burble'); sys.exit(9)"), {})
+    assert out["ok"] is False
+    assert out["exit_code"] == 9
+    assert out["failure_class"] == _FAILURE_UNKNOWN
+    assert "burble" not in str(out)
+
+
+def test_a_successful_delivery_records_no_failure_class():
+    out = _deliver(_py("import sys; sys.exit(0)"), {})
+    assert out["ok"] is True
+    assert out["failure_class"] is None
+
+
+def test_the_child_output_never_appears_anywhere_in_the_recorded_outcome():
+    """The outcome dict is what gets persisted; it is the surface that matters."""
+    out = _deliver(
+        _py(
+            "import sys; sys.stdout.write('token=sk-live-SECRETVALUE'); "
+            "sys.stderr.write('connection refused to vault.internal'); sys.exit(1)"
+        ),
+        {},
+    )
+    blob = repr(out)
+    assert out["failure_class"] == "connection_failed"
+    for token in ("sk-live", "SECRETVALUE", "vault.internal"):
+        assert token not in blob
+
+
+def test_a_timeout_is_classified_without_touching_the_exceptions_captured_output():
+    """subprocess.TimeoutExpired carries the child's output on the exception itself.
+
+    Storing str(exc), or logging it, would put back exactly the free text this
+    function exists to keep out.
+    """
+    out = _deliver(
+        _py(
+            "import sys,time; sys.stderr.write('password=hunter2'); sys.stderr.flush(); time.sleep(60)"
+        ),
+        {},
+    )
+    assert out["ok"] is False
+    assert out["error"] == "TimeoutExpired"
+    assert out["failure_class"] == "timeout"
+    assert "hunter2" not in repr(out)
+
+
+# ---------------------------------------------------------------------------
+# Degraded trust: a zero exit that does not mean delivered
+# ---------------------------------------------------------------------------
+
+
+def test_kkernel_exec_without_strict_is_marked_unverified():
+    """Exit code is the only evidence, and for this shape it is known to be weak.
+
+    kkernel exec exits 0 when any op succeeded, so a multi-op notify whose send
+    was refused still exits 0 and would otherwise record as delivered.
+    """
+    assert _unverifiable_reason(["kkernel", "exec", "comm.send(...)"]) is not None
+    assert _unverifiable_reason(["/opt/homebrew/bin/kkernel", "exec", "x"]) is not None
+
+
+def test_strict_clears_the_marker_and_unrelated_commands_are_never_marked():
+    assert _unverifiable_reason(["kkernel", "exec", "--strict", "x"]) is None
+    # Not this hook's business to opine on notifiers it knows nothing about.
+    assert _unverifiable_reason(["curl", "-X", "POST", "https://example.com"]) is None
+    assert _unverifiable_reason(["kkernel", "status"]) is None
+    assert _unverifiable_reason([]) is None
+
+
+def test_an_unverified_delivery_is_its_own_state_not_a_failure():
+    """Neither 'delivered' nor 'failed' is honest here, so it is marked instead."""
+    out = _deliver(["kkernel", "exec", "comm.send(...)"], {}, program="kkernel")
+    if out["exit_code"] is None:
+        pytest.skip("kkernel not installed on this machine")
+    if out["exit_code"] == 0:
+        assert out["ok"] is True, "a run that exited 0 is not reported as failed"
+        assert out["delivery_verified"] is False
+        assert out["unverified_reason"]
+
+
+def test_a_verified_zero_exit_carries_no_unverified_marker():
+    out = _deliver(_py("import sys; sys.exit(0)"), {})
+    assert out["ok"] is True
+    assert "delivery_verified" not in out
+    assert "unverified_reason" not in out
+
+
+def test_the_marker_is_not_applied_to_a_failed_delivery():
+    """A non-zero exit is already a failure; unverified is about a zero exit."""
+    out = _deliver(_py("import sys; sys.exit(1)"), {})
+    assert out["ok"] is False
+    assert "delivery_verified" not in out
+
+
+def test_subprocess_is_invoked_without_devnull_so_there_is_something_to_classify():
+    """Guards the mechanism: capture_output must stay on for any of this to work."""
+    out = _deliver(_py("import sys; sys.stderr.write('permission denied'); sys.exit(13)"), {})
+    assert out["failure_class"] == "permission_denied", (
+        "classification silently degrades to unknown if the output is discarded again"
+    )
+    assert subprocess.DEVNULL is not None  # sanity: the constant still exists

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -46,8 +46,12 @@ def job(monkeypatch, tmp_path):
 
 
 class _FakeCompleted:
-    def __init__(self, returncode: int = 0) -> None:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
         self.returncode = returncode
+        # The hook reads both streams to classify a failure, so a stand-in for a
+        # finished process has to carry them.
+        self.stdout = stdout
+        self.stderr = stderr
 
 
 def _no_settings_notifier(monkeypatch):
@@ -105,6 +109,8 @@ def test_command_override_substitutes_and_delivers(job, monkeypatch):
         "ok": True,
         "exit_code": 0,
         "error": None,
+        # a delivery that succeeded has no failure to classify
+        "failure_class": None,
         # named from the configured template, so the record says which notifier
         # this was without keeping anything the command itself printed
         "command": "notify",
@@ -122,7 +128,10 @@ def test_delivery_failure_is_recorded_not_silent(job, monkeypatch):
         "attempted": True,
         "ok": False,
         "exit_code": 7,
+        # The command said nothing this hook's closed vocabulary recognises, so
+        # the classification is `unknown` rather than a quote of what it said.
         "error": None,
+        "failure_class": "unknown",
         "command": "notify",
     }
 
@@ -519,25 +528,37 @@ def test_the_delivery_commands_own_output_is_still_never_kept(job, monkeypatch):
     """Naming the program changes nothing about what the command may say.
 
     Its stdout and stderr are free text that can carry a credential the command
-    obtained anywhere, so the child inherits DEVNULL and the record holds only
-    fields this hook chose. Asserted here because the name is the boundary: it
-    is configuration, and everything on the far side of it stays discarded.
+    obtained anywhere, so the record holds only fields this hook chose. That
+    invariant is unchanged; what changed is how it is kept. The output used to
+    be discarded at the pipe, which also discarded any way to tell one failure
+    from another, so every failed delivery recorded a bare exit code. It is now
+    read, matched against a closed vocabulary, and dropped — only the matched
+    name is stored.
+
+    So this pins the boundary rather than the mechanism: the stored key set is
+    fixed, and the value in the one new field comes from the closed set. A
+    future change that lets an unmatched failure contribute its own words fails
+    here instead of passing review.
     """
     seen: dict = {}
 
     def _run(argv, **kwargs):
         seen.update(kwargs)
-        return _FakeCompleted(4)
+        return _FakeCompleted(4, stdout="token=sk-live-AAAA", stderr="permission denied for /etc/x")
 
     monkeypatch.setattr(_notify_hook.subprocess, "run", _run)
 
     command = json.dumps(["notify-webhook"])
     _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
 
-    assert seen["stdout"] is _notify_hook.subprocess.DEVNULL
-    assert seen["stderr"] is _notify_hook.subprocess.DEVNULL
     outcome = jobs._read_job(job)["notify_delivery"]
-    assert set(outcome) == {"attempted", "ok", "exit_code", "error", "command"}
+    assert set(outcome) == {"attempted", "ok", "exit_code", "error", "failure_class", "command"}
+    assert outcome["failure_class"] in {n for n, _ in _notify_hook._FAILURE_CLASSES} | {
+        _notify_hook._FAILURE_UNKNOWN
+    }
+    # Nothing the command said survives into the persisted record.
+    for token in ("sk-live", "AAAA", "/etc/x"):
+        assert token not in json.dumps(outcome)
 
 
 # The run whose log this is, standing in for the CLI: it writes ordinary output,
@@ -603,6 +624,7 @@ def test_the_failure_notice_survives_the_runs_own_remaining_output(monkeypatch, 
         "ok": False,
         "exit_code": 1,
         "error": None,
+        "failure_class": "unknown",
         "command": "/bin/sh",
     }
     assert "[notify]" in log

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -420,6 +420,52 @@ def test_successful_delivery_writes_nothing_to_the_log(job, monkeypatch):
     assert _console_log(job) == "work happened\n"
 
 
+def test_an_unverified_delivery_warns_in_the_log_instead_of_passing_silently(job, monkeypatch):
+    """A degraded result only the record knows about is one nobody acts on.
+
+    The command shape here exits zero when its send was refused, so the zero is
+    not evidence. Recording that on the job was half the job: the log is where an
+    operator actually looks, and an ordinary success there means they stop
+    looking. The line has to say the notice is unconfirmed while not claiming a
+    failure that probably did not happen.
+    """
+    config.job_dir(job).mkdir(parents=True, exist_ok=True)
+    (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+
+    command = json.dumps(["kkernel", "exec", "comm.send(to='recipient', content='{status}')"])
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    log = _console_log(job)
+    assert "work happened" in log  # appended, never rewritten
+    assert "WARNING" in log
+    assert "kkernel_exec_without_strict_exits_zero_on_a_refused_op" in log
+    # not reported as a failure: the notice most likely did arrive
+    assert "NOT delivered" not in log
+    # and the record still says the run's delivery did not fail
+    assert jobs._read_job(job)["notify_delivery"]["ok"] is True
+    assert jobs._read_job(job)["notify_delivery"]["delivery_verified"] is False
+
+
+def test_the_same_command_with_strict_is_verified_and_stays_silent(job, monkeypatch):
+    """The control: --strict makes the exit code mean what it says.
+
+    Without this, a test asserting the warning fires proves only that the log can
+    be written to, not that the marker is what decides it.
+    """
+    config.job_dir(job).mkdir(parents=True, exist_ok=True)
+    (config.job_dir(job) / "console.log").write_text("work happened\n", encoding="utf-8")
+    monkeypatch.setattr(_notify_hook.subprocess, "run", lambda *a, **k: _FakeCompleted(0))
+
+    command = json.dumps(
+        ["kkernel", "exec", "--strict", "comm.send(to='recipient', content='{status}')"]
+    )
+    _notify_hook.main(["--run-id", job, "--status", "completed", "--command", command])
+
+    assert _console_log(job) == "work happened\n"
+    assert "delivery_verified" not in jobs._read_job(job)["notify_delivery"]
+
+
 def test_silence_by_choice_writes_nothing_to_the_log(job, monkeypatch):
     """Nothing configured is the documented default, not a delivery failure."""
     config.job_dir(job).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem

A failed terminal notice recorded a bare exit code and a null error. "The notifier binary is missing" and "the notifier refused the message" produced identical rows, so a caller waiting on a completion signal that never arrived had nothing to act on.

## Why the obvious fix is wrong

Capture the command's stderr and store it. That breaks the reason the output was discarded in the first place: a configured notifier's stdout/stderr is free text that can carry a credential the command obtained anywhere, and the delivery outcome is persisted on the job record. Storing it would put operator-command output into durable storage, and sanitising free text is not a guarantee worth resting an invariant on.

The `DEVNULL` here was deliberate and documented, not an oversight.

## Change

The output is read into memory, matched against a closed vocabulary, and dropped. Only the matched name is stored, in a new `failure_class` field.

The stored value is a bounded enum **by construction** rather than by a promise to sanitise. An unmatched failure classifies as `unknown` rather than contributing its own words, however diagnostic they look — the moment an unrecognised case is allowed to quote itself, the field is free text again.

Two details that are load-bearing rather than incidental:

- **The timeout path is explicit.** `subprocess.TimeoutExpired` carries the child's captured output on the exception object itself, so logging the exception or storing its `str()` would restore exactly what this change exists to exclude. Only the exception's class name is kept.
- **Classification failure swallows its exception** rather than logging it, because a Python exception routinely embeds the value that caused it.

## Degraded trust on a zero exit

Exit code is the only delivery evidence available, and for one known adapter shape that evidence is weak: `kkernel exec` returns 0 when *any* op in the request succeeded, so a notify whose send was refused still exits 0 and records as delivered. That shape is now recorded as `ok` with `delivery_verified: false` and a named reason, instead of a plain success.

The command still runs exactly as configured. Reading someone else's argv is scoped to a known shape and stops at marking the outcome — refusing to run what an operator wrote is not this hook's call. A notifier this hook knows nothing about is never marked.

## Tests

`tests/mcp/test_notify_failure_classification.py`. The fail-closed test feeds the classifier the inputs a helpful implementation would most want to quote (an AWS key, a JWT, a webhook URL with a token in its path, a psql line containing a password, binary garbage) and asserts the result stays inside the closed set and contains none of them.

The existing test that pinned `stdout`/`stderr` as `DEVNULL` is **replaced, not removed**. It now pins the invariant that guard existed to protect — fixed key set, enum membership — so widening the field back to free text fails a test rather than passing review.

One bug found by these tests during development: `connection refused` was classified as `refused_by_policy`, because that class carried a bare `refused` needle above `connection_failed` under first-match-wins. Every network failure would have recorded as a policy refusal. Needle narrowed and ordering fixed, with a test pinning the discrimination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)