### PR TITLE
fix(studio): distinguish unrecorded artifact verdicts

### DIFF
--- a/apps/studio/frontend/src/components/runs/ExpectedArtifacts.test.ts
+++ b/apps/studio/frontend/src/components/runs/ExpectedArtifacts.test.ts
@@ -1,40 +1,84 @@
-/**
- * ExpectedArtifacts — source-contract tests (this project has no
- * @testing-library/react, so component wiring is verified against the source
- * rather than a live render; see ui/Markdown.test.ts for the same pattern).
- *
- * The behaviour under test: a provisional verification is a reading taken while
- * the run is still going. An artifact that is not on disk yet has not been
- * missed, it has not been written yet, and the panel must not say otherwise.
- */
-import { describe, it, expect } from "vitest";
-import * as fs from "node:fs";
-import * as path from "node:path";
+/** Render tests for live, recorded, and absent artifact-verification states. */
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
 
-const SRC = fs.readFileSync(path.resolve(__dirname, "ExpectedArtifacts.tsx"), "utf-8");
+import ExpectedArtifacts from "./ExpectedArtifacts";
+import type { ArtifactContract, ArtifactVerification } from "@/lib/types";
 
-describe("ExpectedArtifacts.tsx — provisional readings", () => {
-  it("never calls an artifact missing on a provisional reading", () => {
-    expect(SRC).toMatch(/!verification\?\.provisional &&/);
+const CONTRACT: ArtifactContract = {
+  expected: [
+    { id: "report", path: "REPORT.md", required: true },
+    { id: "notes", path: "NOTES.md", required: false },
+  ],
+};
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function renderExpectedArtifacts(verification: ArtifactVerification | null) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(createElement(ExpectedArtifacts, { contract: CONTRACT, verification }));
+  });
+  return container;
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("ExpectedArtifacts", () => {
+  it("shows written progress and keeps unwritten live artifacts pending", () => {
+    const view = renderExpectedArtifacts({
+      status: "failed",
+      checked_at: 10,
+      missing_required: [],
+      missing_optional: [{ id: "notes", path: "NOTES.md", required: false }],
+      produced: [{ id: "report", path: "REPORT.md", size: 5, present: true }],
+      provisional: true,
+    });
+
+    expect(view.textContent).toContain("1 of 2 written");
+    expect(view.textContent).toContain("OK (5 B)");
+    expect(view.textContent).toContain("PENDING");
+    expect(view.textContent).not.toContain("MISSING");
   });
 
-  it("keeps MISSING reachable for a recorded verdict", () => {
-    expect(SRC).toMatch(/missingRequired\.has\(entry\.id\) \|\| missingOptional\.has\(entry\.id\)/);
-    expect(SRC).toMatch(/"MISSING"/);
+  it("shows missing only when a recorded verdict says it is missing", () => {
+    const view = renderExpectedArtifacts({
+      status: "failed",
+      checked_at: 20,
+      missing_required: [{ id: "report", path: "REPORT.md", required: true }],
+      missing_optional: [],
+      produced: [],
+    });
+
+    expect(view.textContent).toContain("Verified: failed");
+    expect(view.textContent).toContain("MISSING");
   });
 
-  it("shows written-so-far progress instead of a contract status while the run is live", () => {
-    expect(SRC).toMatch(/verification\?\.provisional \?/);
-    expect(SRC).toMatch(/\{producedById\.size\} of \{expected\.length\} written/);
+  it("keeps a live null verdict pending", () => {
+    const view = renderExpectedArtifacts(null);
+
+    expect(view.textContent?.match(/PENDING/g)).toHaveLength(2);
+    expect(view.textContent).not.toContain("Verification not recorded");
+    expect(view.textContent).not.toContain("NOT RECORDED");
   });
 
-  it("still shows the recorded verdict when there is one", () => {
-    expect(SRC).toMatch(/Verified: \{verification\.status\}/);
-  });
+  it("renders a terminal null verdict as not recorded instead of pending", () => {
+    const view = renderExpectedArtifacts({ status: "not_recorded" });
 
-  it("counts progress from what was produced, not from the contract status", () => {
-    // status is "failed" for every incomplete run, so keying the badge off it
-    // would put a red verdict on a run that is simply not finished.
-    expect(SRC).toMatch(/producedById\.size === expected\.length \? "ok" : "pending"/);
+    expect(view.textContent).toContain("Verification not recorded");
+    expect(view.textContent?.match(/NOT RECORDED/g)).toHaveLength(2);
+    expect(view.textContent).not.toContain("PENDING");
+    expect(view.textContent).not.toContain("MISSING");
   });
 });

--- a/apps/studio/frontend/src/components/runs/ExpectedArtifacts.tsx
+++ b/apps/studio/frontend/src/components/runs/ExpectedArtifacts.tsx
@@ -23,9 +23,11 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
   const expected = contract?.expected ?? [];
   if (!contract || expected.length === 0) return null;
 
-  const producedById = new Map((verification?.produced ?? []).map((p) => [p.id, p]));
-  const missingRequired = new Set((verification?.missing_required ?? []).map((p) => p.id));
-  const missingOptional = new Set((verification?.missing_optional ?? []).map((p) => p.id));
+  const notRecorded = verification?.status === "not_recorded";
+  const result = verification && !notRecorded ? verification : null;
+  const producedById = new Map((result?.produced ?? []).map((p) => [p.id, p]));
+  const missingRequired = new Set((result?.missing_required ?? []).map((p) => p.id));
+  const missingOptional = new Set((result?.missing_optional ?? []).map((p) => p.id));
 
   return (
     <div id="expected-artifacts" className="scroll-mt-24">
@@ -34,7 +36,9 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
         <span className="rounded bg-surface-overlay px-1.5 py-0 font-mono text-[length:var(--t-xs)] text-content-muted">
           {expected.length}
         </span>
-        {verification?.provisional ? (
+        {notRecorded ? (
+          <Badge tone="default">Verification not recorded</Badge>
+        ) : result?.provisional ? (
           // Mid-run, a contract status is always "failed" until the last
           // artifact lands, which says nothing except that the run is not over.
           // Progress is the thing worth showing while it is still going.
@@ -42,10 +46,8 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
             {producedById.size} of {expected.length} written
           </Badge>
         ) : (
-          verification?.status && (
-            <Badge tone={verificationTone(verification.status)}>
-              Verified: {verification.status}
-            </Badge>
+          result?.status && (
+            <Badge tone={verificationTone(result.status)}>Verified: {result.status}</Badge>
           )
         )}
       </div>
@@ -57,7 +59,7 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
             // artifact that is not on disk yet has not been missed — it has not
             // been written yet. Only a recorded verdict can call one missing.
             const missing =
-              !verification?.provisional &&
+              !result?.provisional &&
               (missingRequired.has(entry.id) || missingOptional.has(entry.id));
             const required = entry.required !== false;
             const statusTone = produced
@@ -71,7 +73,9 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
               ? `OK (${formatBytes(produced.size)})`
               : missing
                 ? "MISSING"
-                : "PENDING";
+                : notRecorded
+                  ? "NOT RECORDED"
+                  : "PENDING";
             return (
               <li
                 key={entry.id}

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -40,7 +40,7 @@ export interface ArtifactContract {
   expected: ExpectedArtifact[];
 }
 
-export interface ArtifactVerification {
+export interface ArtifactVerificationResult {
   status: "passed" | "failed" | "warning" | "skipped";
   checked_at: number;
   missing_required: ExpectedArtifact[];
@@ -50,6 +50,13 @@ export interface ArtifactVerification {
    *  verdict it was judged on. Artifacts may still appear. */
   provisional?: boolean;
 }
+
+export interface ArtifactVerificationNotRecorded {
+  /** The run is terminal, but no verifier verdict was persisted. */
+  status: "not_recorded";
+}
+
+export type ArtifactVerification = ArtifactVerificationResult | ArtifactVerificationNotRecorded;
 
 // ─── Run types ───────────────────────────────────────────────────────────────
 

--- a/lionagi/studio/services/artifact_verification.py
+++ b/lionagi/studio/services/artifact_verification.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Derive the artifact-verification state shown by Studio.
+
+Live progress and terminal verdict absence remain distinct states.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from lionagi.state.artifact_verifier import ArtifactPathError, verify_artifact_contract
+from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
+__all__ = ("provisional_artifact_verification", "resolve_artifact_verification")
+
+
+def provisional_artifact_verification(
+    contract: Any, artifacts_path: str | None
+) -> dict[str, Any] | None:
+    """Read live artifact progress.
+
+    The result is explicitly provisional, never a recorded verdict.
+    """
+    if not artifacts_path:
+        return None
+    if isinstance(contract, str):
+        try:
+            contract = json.loads(contract)
+        except ValueError:
+            return None
+    if not isinstance(contract, dict):
+        return None
+
+    try:
+        result = verify_artifact_contract(contract, artifacts_root=artifacts_path)
+    except ArtifactPathError:
+        return None
+    except OSError:
+        return None
+    return {**result, "provisional": True}
+
+
+def resolve_artifact_verification(
+    stored: Any,
+    *,
+    status: str,
+    contract: Any,
+    artifacts_path: str | None,
+) -> Any:
+    """Resolve the artifact-verification display state.
+
+    Stored verdicts win; terminal verdict absence is represented explicitly.
+    """
+    if stored is not None:
+        return stored
+    if not contract:
+        return None
+    if status == "running":
+        return provisional_artifact_verification(contract, artifacts_path)
+    if status in SESSION_TERMINAL_STATUSES:
+        return {"status": "not_recorded"}
+    return None

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import math
 import os
 import stat
@@ -456,45 +455,6 @@ def _session_liveness(s: dict[str, Any], ps_snapshot: str | None = None) -> bool
     return process_liveness(s, Path(ap) if ap else None, ps_snapshot)
 
 
-def _provisional_verification(contract: Any, artifacts_path: str | None) -> dict[str, Any] | None:
-    """Check a contract against what is on disk right now, for a run whose
-    verification has not been recorded yet.
-
-    Verification is recorded once, when a run finalises. Until then the panel has
-    nothing to read, so every declared artifact shows as pending even after its
-    worker has written it and the viewer is watching the file exist. Answering
-    from the disk costs one stat per declared artifact and makes the panel track
-    the run instead of trailing it.
-
-    The result is marked provisional, because it is a reading taken now rather
-    than the verdict the run was judged on: artifacts may still appear, and this
-    answer is never what decides the run's status.
-    """
-    if not contract or not artifacts_path:
-        return None
-    if isinstance(contract, str):
-        try:
-            contract = json.loads(contract)
-        except ValueError:
-            return None
-    if not isinstance(contract, dict):
-        return None
-
-    from lionagi.state.artifact_verifier import ArtifactPathError, verify_artifact_contract
-
-    try:
-        result = verify_artifact_contract(contract, artifacts_root=artifacts_path)
-    except (ArtifactPathError, OSError):
-        # A contract the run itself will reject, or a root that cannot be read.
-        # Neither is this endpoint's to report: the run's own finalisation says
-        # so, and inventing a status here would put a verdict on the panel that
-        # nothing else agrees with.
-        return None
-    if result is None:
-        return None
-    return {**result, "provisional": True}
-
-
 def _run_row(s: dict[str, Any], now: float, *, process_alive: bool | None = None) -> dict[str, Any]:
     """Canonical Run row shape shared by list and detail routes."""
     from lionagi.state.health import classify_session_health
@@ -665,11 +625,6 @@ async def get_run(
     }
     alive = _session_liveness(detail_session) if detail_session.get("status") == "running" else None
     row = _run_row(detail_session, time.time(), process_alive=alive)
-
-    if row.get("artifact_verification_json") is None:
-        row["artifact_verification_json"] = _provisional_verification(
-            row.get("artifact_contract_json"), artifacts_path
-        )
 
     from . import run_tags
 

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -272,7 +272,25 @@ async def list_sessions(
             "artifacts_path": row["artifacts_path"],
             "source_kind": row["source_kind"] or "live",
             "artifact_contract_json": _parse_json_col(row["artifact_contract_json"]),
-            "artifact_verification_json": _parse_json_col(row["artifact_verification_json"]),
+            # Resolved, not passed through: a terminal session that was contracted
+            # and holds no verdict reports that absence here exactly as the detail
+            # route does. Returning the raw column instead would give the two
+            # routes different answers for the same session, which is the
+            # conflation this state exists to remove.
+            #
+            # artifacts_path is withheld deliberately, and the row does carry one.
+            # Supplying it would enable the live-progress arm, which reads the
+            # artifacts directory per row -- a filesystem walk for every running
+            # session on a paginated list that Studio polls. Withholding it leaves
+            # the two cheap arms intact (a stored verdict still wins, terminal
+            # absence is still named) and declines only the live read, which
+            # belongs to a single-session view.
+            "artifact_verification_json": resolve_artifact_verification(
+                _parse_json_col(row["artifact_verification_json"]),
+                status=row["status"] or "completed",
+                contract=_parse_json_col(row["artifact_contract_json"]),
+                artifacts_path=None,
+            ),
             # ADR-0063: project detection.
             "project": row["project"],
             "project_source": row["project_source"],

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -16,6 +16,7 @@ from lionagi.state.db import DEFAULT_DB_PATH, SESSION_TERMINAL_STATUSES
 from ..registry import studio_route
 from ._db import open_db as _open_db
 from ._io import parse_json_col as _parse_json_col
+from .artifact_verification import resolve_artifact_verification
 
 _DB = str(DEFAULT_DB_PATH)
 
@@ -729,6 +730,16 @@ async def get_session(
     duration_ms = (
         (ended_at - started_at) * 1000 if started_at is not None and ended_at is not None else None
     )
+    status = session_row["status"] or "completed"
+    artifact_contract = _parse_json_col(session_row["artifact_contract_json"])
+    stored_verification = _parse_json_col(session_row["artifact_verification_json"])
+
+    artifact_verification = resolve_artifact_verification(
+        stored_verification,
+        status=status,
+        contract=artifact_contract,
+        artifacts_path=session_row["artifacts_path"],
+    )
 
     return {
         "id": session_row["id"],
@@ -741,10 +752,10 @@ async def get_session(
         "show_topic": session_row["show_topic"],
         "show_play_name": session_row["show_play_name"],
         "artifacts_path": session_row["artifacts_path"],
-        "artifact_contract_json": _parse_json_col(session_row["artifact_contract_json"]),
-        "artifact_verification_json": _parse_json_col(session_row["artifact_verification_json"]),
+        "artifact_contract_json": artifact_contract,
+        "artifact_verification_json": artifact_verification,
         "source_kind": session_row["source_kind"] or "live",
-        "status": session_row["status"] or "completed",
+        "status": status,
         "started_at": started_at,
         "ended_at": ended_at,
         "duration_ms": duration_ms,

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -13,7 +13,7 @@ import pytest
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
 from lionagi.state.claude_mirror import session_db_id  # noqa: E402
-from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.state.db import SESSION_TERMINAL_STATUSES, StateDB  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Shared test data
@@ -56,6 +56,9 @@ async def seed_session(
     status: str = "running",
     started_at=None,
     ended_at=None,
+    artifacts_path: str | None = None,
+    artifact_contract_json: dict | None = None,
+    artifact_verification_json: dict | None = None,
 ) -> str:
     prog_id = f"{session_id}-prog"
     async with StateDB(db_path) as db:
@@ -70,6 +73,9 @@ async def seed_session(
                 "status": status,
                 "started_at": started_at,
                 "ended_at": ended_at,
+                "artifacts_path": artifacts_path,
+                "artifact_contract_json": artifact_contract_json,
+                "artifact_verification_json": artifact_verification_json,
                 "node_metadata": node_metadata,
                 "invocation_kind": "flow",
                 "source_kind": "live",
@@ -286,6 +292,133 @@ async def test_get_session_returns_none_graph_for_null_node_metadata(patched_ses
     assert result["branches"] == []
     assert result["duration_ms"] is None
     assert result["source_kind"] == "live"
+
+
+# ---------------------------------------------------------------------------
+# Artifact verification display state
+# ---------------------------------------------------------------------------
+
+
+ARTIFACT_CONTRACT = {"expected": [{"id": "report", "path": "REPORT.md", "required": True}]}
+
+
+async def test_get_session_returns_live_provisional_artifact_progress(
+    patched_sessions_db, tmp_path
+):
+    svc, db_path = patched_sessions_db
+    (tmp_path / "REPORT.md").write_text("ready")
+    await seed_session(
+        db_path,
+        session_id="sess-live-artifacts",
+        status="running",
+        artifacts_path=str(tmp_path),
+        artifact_contract_json=ARTIFACT_CONTRACT,
+    )
+
+    result = await svc.get_session("sess-live-artifacts")
+
+    assert result is not None
+    verification = result["artifact_verification_json"]
+    assert verification["provisional"] is True
+    assert [item["id"] for item in verification["produced"]] == ["report"]
+
+
+@pytest.mark.parametrize("status", sorted(SESSION_TERMINAL_STATUSES))
+async def test_get_session_reports_terminal_verdict_was_not_recorded_without_artifact_path(
+    patched_sessions_db, status
+):
+    svc, db_path = patched_sessions_db
+    await seed_session(
+        db_path,
+        session_id=f"sess-{status}",
+        status=status,
+        artifacts_path=None,
+        artifact_contract_json=ARTIFACT_CONTRACT,
+        artifact_verification_json=None,
+    )
+
+    result = await svc.get_session(f"sess-{status}")
+
+    assert result is not None
+    assert result["artifact_verification_json"] == {"status": "not_recorded"}
+
+
+async def test_get_session_does_not_synthesize_a_terminal_verdict_from_disk(
+    patched_sessions_db, tmp_path
+):
+    svc, db_path = patched_sessions_db
+    (tmp_path / "REPORT.md").write_text("ready")
+    await seed_session(
+        db_path,
+        session_id="sess-terminal-artifacts",
+        status="completed",
+        artifacts_path=str(tmp_path),
+        artifact_contract_json=ARTIFACT_CONTRACT,
+        artifact_verification_json=None,
+    )
+
+    result = await svc.get_session("sess-terminal-artifacts")
+
+    assert result is not None
+    assert result["artifact_verification_json"] == {"status": "not_recorded"}
+
+
+async def test_get_session_keeps_live_null_verification_pending_without_artifact_path(
+    patched_sessions_db,
+):
+    svc, db_path = patched_sessions_db
+    await seed_session(
+        db_path,
+        session_id="sess-live-no-root",
+        status="running",
+        artifacts_path=None,
+        artifact_contract_json=ARTIFACT_CONTRACT,
+        artifact_verification_json=None,
+    )
+
+    result = await svc.get_session("sess-live-no-root")
+
+    assert result is not None
+    assert result["artifact_verification_json"] is None
+
+
+async def test_get_session_preserves_a_stored_terminal_verdict(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    verdict = {
+        "status": "passed",
+        "checked_at": 42.0,
+        "missing_required": [],
+        "missing_optional": [],
+        "produced": [{"id": "report", "path": "REPORT.md", "size": 5, "present": True}],
+    }
+    await seed_session(
+        db_path,
+        session_id="sess-recorded-verdict",
+        status="completed",
+        artifact_contract_json=ARTIFACT_CONTRACT,
+        artifact_verification_json=verdict,
+    )
+
+    result = await svc.get_session("sess-recorded-verdict")
+
+    assert result is not None
+    assert result["artifact_verification_json"] == verdict
+
+
+async def test_get_session_keeps_verification_null_when_no_contract_exists(patched_sessions_db):
+    svc, db_path = patched_sessions_db
+    await seed_session(
+        db_path,
+        session_id="sess-no-contract",
+        status="completed",
+        artifact_contract_json=None,
+        artifact_verification_json=None,
+    )
+
+    result = await svc.get_session("sess-no-contract")
+
+    assert result is not None
+    assert result["artifact_verification_json"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -636,6 +636,85 @@ async def test_list_sessions_surfaces_status_reason(patched_sessions_db):
     assert row["status_reason_summary"] == "worker exited with code 1"
 
 
+async def test_list_sessions_agrees_with_the_detail_route_on_terminal_absence(
+    patched_sessions_db,
+):
+    """The same session must not report absence one way and null the other."""
+    svc, db_path = patched_sessions_db
+    await seed_session(
+        db_path,
+        session_id="sess-terminal-absent",
+        status="completed",
+        artifacts_path=None,
+        artifact_contract_json=ARTIFACT_CONTRACT,
+        artifact_verification_json=None,
+    )
+
+    rows = await svc.list_sessions()
+    detail = await svc.get_session("sess-terminal-absent")
+
+    assert len(rows) == 1
+    assert rows[0]["artifact_verification_json"] == {"status": "not_recorded"}
+    # Asserted as equality between the two routes rather than against the literal
+    # twice: the defect being closed is a disagreement, so the test fails if
+    # either side moves, not only if the list side does.
+    assert detail is not None
+    assert rows[0]["artifact_verification_json"] == detail["artifact_verification_json"]
+
+
+async def test_list_sessions_preserves_a_stored_verdict(patched_sessions_db):
+    """A recorded verdict is returned as recorded, never re-derived."""
+    svc, db_path = patched_sessions_db
+    stored = {"status": "verified", "produced": [{"id": "report"}]}
+    await seed_session(
+        db_path,
+        session_id="sess-stored",
+        status="completed",
+        artifacts_path=None,
+        artifact_contract_json=ARTIFACT_CONTRACT,
+        artifact_verification_json=stored,
+    )
+
+    rows = await svc.list_sessions()
+
+    assert rows[0]["artifact_verification_json"] == stored
+
+
+async def test_list_sessions_does_not_read_the_artifacts_directory(patched_sessions_db, tmp_path):
+    """The list route declines the live-progress read, and that is deliberate.
+
+    The session is running, holds a contract, names a real artifacts directory,
+    and that directory contains the file the contract requires -- everything the
+    provisional arm needs to report progress. The list route still returns None,
+    because computing it means a filesystem walk per row on a paginated read.
+    Progress belongs to the single-session view, which this same fixture shape is
+    covered for elsewhere.
+
+    This is the test that fails if someone closes the remaining difference by
+    handing the list route its artifacts_path, so the decision has to be made
+    again rather than drifted into.
+    """
+    svc, db_path = patched_sessions_db
+    (tmp_path / "REPORT.md").write_text("ready")
+    await seed_session(
+        db_path,
+        session_id="sess-running-on-disk",
+        status="running",
+        artifacts_path=str(tmp_path),
+        artifact_contract_json=ARTIFACT_CONTRACT,
+        artifact_verification_json=None,
+    )
+
+    rows = await svc.list_sessions()
+
+    assert rows[0]["artifact_verification_json"] is None
+    # The detail route, given the same row, does report the progress -- which is
+    # what makes the None above a scoping decision rather than a lost capability.
+    detail = await svc.get_session("sess-running-on-disk")
+    assert detail is not None
+    assert detail["artifact_verification_json"]["provisional"] is True
+
+
 async def test_list_sessions_orders_by_updated_at_desc(patched_sessions_db):
     svc, db_path = patched_sessions_db
     await seed_session(db_path, session_id="sess-a")

--- a/tests/studio/test_provisional_artifact_verification.py
+++ b/tests/studio/test_provisional_artifact_verification.py
@@ -1,20 +1,14 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Artifact verification is recorded once, when a run finalises. Until then the
-run-detail panel has nothing to read and shows every declared artifact as
-pending, even ones whose file is already on disk and being watched.
-
-The detail route fills that gap by checking the disk itself, and marks the
-answer provisional so nothing mistakes a reading taken mid-run for the verdict
-the run was judged on.
-"""
+"""Tests for live artifact progress before a verdict is recorded."""
 
 from __future__ import annotations
 
 import json
 
-from lionagi.studio.services.runs import _provisional_verification
+import lionagi.studio.services.artifact_verification as verification_mod
+from lionagi.studio.services.artifact_verification import provisional_artifact_verification
 
 CONTRACT = {
     "expected": [
@@ -28,7 +22,7 @@ def test_written_artifacts_are_seen_before_the_run_finishes(tmp_path):
     (tmp_path / "scribe").mkdir()
     (tmp_path / "scribe" / "VERDICTS.md").write_text("rows")
 
-    result = _provisional_verification(CONTRACT, str(tmp_path))
+    result = provisional_artifact_verification(CONTRACT, str(tmp_path))
 
     assert result is not None
     assert result["provisional"] is True
@@ -42,7 +36,7 @@ def test_the_answer_is_always_marked_provisional(tmp_path):
     (tmp_path / "VERDICTS.md").write_text("a")
     (tmp_path / "SLICES.md").write_text("b")
 
-    result = _provisional_verification(CONTRACT, str(tmp_path))
+    result = provisional_artifact_verification(CONTRACT, str(tmp_path))
 
     assert result["status"] == "passed"
     assert result["provisional"] is True
@@ -52,46 +46,55 @@ def test_a_contract_stored_as_json_text_is_read(tmp_path):
     """The column round-trips as text on one backend and as a dict on another."""
     (tmp_path / "VERDICTS.md").write_text("a")
 
-    result = _provisional_verification(json.dumps(CONTRACT), str(tmp_path))
+    result = provisional_artifact_verification(json.dumps(CONTRACT), str(tmp_path))
 
     assert [p["id"] for p in result["produced"]] == ["verdicts"]
 
 
 def test_no_contract_produces_no_reading(tmp_path):
-    assert _provisional_verification(None, str(tmp_path)) is None
-    assert _provisional_verification({}, str(tmp_path)) is None
+    assert provisional_artifact_verification(None, str(tmp_path)) is None
+    assert provisional_artifact_verification({}, str(tmp_path)) is None
 
 
 def test_no_artifacts_path_produces_no_reading():
-    assert _provisional_verification(CONTRACT, None) is None
-    assert _provisional_verification(CONTRACT, "") is None
+    assert provisional_artifact_verification(CONTRACT, None) is None
+    assert provisional_artifact_verification(CONTRACT, "") is None
 
 
 def test_unparseable_contract_text_produces_no_reading(tmp_path):
-    assert _provisional_verification("{not json", str(tmp_path)) is None
+    assert provisional_artifact_verification("{not json", str(tmp_path)) is None
 
 
 def test_a_contract_of_the_wrong_shape_produces_no_reading(tmp_path):
     """A contract the run itself will reject is not this endpoint's to report;
     inventing a status here would put a verdict on the panel that nothing else
     agrees with."""
-    assert _provisional_verification({"expected": "not a list"}, str(tmp_path)) is None
-    assert _provisional_verification(json.dumps([1, 2, 3]), str(tmp_path)) is None
+    assert provisional_artifact_verification({"expected": "not a list"}, str(tmp_path)) is None
+    assert provisional_artifact_verification(json.dumps([1, 2, 3]), str(tmp_path)) is None
 
 
 def test_a_hostile_declared_path_produces_no_reading(tmp_path):
     assert (
-        _provisional_verification(
+        provisional_artifact_verification(
             {"expected": [{"id": "x", "path": "../escape.md"}]}, str(tmp_path)
         )
         is None
     )
 
 
+def test_an_unreadable_artifacts_root_produces_no_reading(tmp_path, monkeypatch):
+    def raise_oserror(*_args, **_kwargs):
+        raise OSError("unreadable")
+
+    monkeypatch.setattr(verification_mod, "verify_artifact_contract", raise_oserror)
+
+    assert provisional_artifact_verification(CONTRACT, str(tmp_path)) is None
+
+
 def test_a_missing_artifacts_root_still_answers(tmp_path):
     """A run whose root does not exist yet has produced nothing, which is a
     reading rather than an error."""
-    result = _provisional_verification(CONTRACT, str(tmp_path / "not-created-yet"))
+    result = provisional_artifact_verification(CONTRACT, str(tmp_path / "not-created-yet"))
 
     assert result is not None
     assert result["produced"] == []


### PR DESCRIPTION
## Summary

- preserve stored artifact-verification verdicts without modification
- synthesize provisional disk progress only while a contracted session is running
- return a distinct `not_recorded` state for every terminal session that has a contract but no stored verdict
- render terminal verdict absence separately from live `PENDING` and recorded `MISSING` states

Both run-detail routes resolve through the same sessions service, and terminal state is never inferred from files that happen to be on disk.

## Validation

- `uv run pytest -n0 -q tests/apps_studio_server/test_sessions_detail.py tests/apps_studio_server/test_runs_detail.py tests/studio/test_provisional_artifact_verification.py` (82 passed)
- `npm test -- src/components/runs/ExpectedArtifacts.test.ts` (4 passed)
- frontend TypeScript, ESLint, and Prettier checks

Closes #2631