### PR TITLE
fix(messages): preserve nullable public projection

### DIFF
--- a/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
+++ b/docs/adr/ADR-0006-conversational-message-envelope-and-ordered-history.md
@@ -314,9 +314,11 @@ Exact history semantics:
   progression in reverse and return `None` on miss.
 - **Raw projection:** `to_chat_msgs(progression=[])` returns an empty list. Otherwise it projects
   the supplied order, or the full manager progression when none/falsy is supplied, through each
-  record's `chat_msg`. An invalid ID is wrapped as `ValueError("One or more messages in the
-  requested progression are invalid.")`. The method does not perform action folding, system
-  folding, transient-field stripping, or empty-content filtering.
+  record's strict internal `_chat_msg`. An invalid ID or projection failure is wrapped as
+  `ValueError("One or more messages in the requested progression are invalid.")`, so manager
+  conversion cannot emit `None` holes even though the public `chat_msg` property is nullable.
+  The method does not perform action folding, system folding, transient-field stripping, or
+  empty-content filtering.
 
 `Branch` remains the operation owner and exposes the records as a facade:
 

--- a/lionagi/protocols/messages/message.py
+++ b/lionagi/protocols/messages/message.py
@@ -314,17 +314,19 @@ class Message(Node, Sendable):
 
     @property
     def chat_msg(self) -> dict[str, Any] | None:
-        """A dictionary representation typically used in chat-based contexts."""
-        return self._chat_msg()
+        """Project this message into a chat payload.
 
-    def _chat_msg(self, *, use_render_cache: bool = True) -> dict[str, Any] | None:
-        """Build a provider chat message, reusing the stable content rendering
-        when safe.
+        Projection failures are contained as ``None`` for compatibility.
+        """
+        try:
+            return self._chat_msg()
+        except Exception:
+            return None
 
-        A rendering failure propagates rather than degrading to ``None``: a
-        message that reaches a provider with its content missing is
-        indistinguishable from one that never had any, so content that cannot
-        be carried has to fail where it can be seen.
+    def _chat_msg(self, *, use_render_cache: bool = True) -> dict[str, Any]:
+        """Build a provider chat message.
+
+        Rendering failures propagate so manager conversion cannot emit holes.
         """
         role_str = self.role.value if isinstance(self.role, MessageRole) else str(self.role)
         return {

--- a/tests/protocols/messages/test_message.py
+++ b/tests/protocols/messages/test_message.py
@@ -500,9 +500,8 @@ def test_generic_content_rendering_is_not_served_stale():
     assert message.chat_msg["content"] == "second"
 
 
-def test_unrenderable_content_raises_rather_than_dropping_the_message():
-    """Content that cannot be rendered fails visibly instead of yielding a
-    message with no content."""
+def test_unrenderable_content_returns_none():
+    """An unrenderable message preserves the nullable public contract."""
 
     class _Unrenderable:
         @property
@@ -511,13 +510,11 @@ def test_unrenderable_content_raises_rather_than_dropping_the_message():
 
     message = RoledMessage(content=_Unrenderable())
 
-    with pytest.raises(RuntimeError, match="cannot render"):
-        _ = message.chat_msg
+    assert message.chat_msg is None
 
 
 def test_unrenderable_content_surfaces_through_the_manager():
-    """A message that cannot be rendered aborts the conversion instead of
-    leaving a hole in the provider payload."""
+    """Manager conversion stays strict despite the nullable public property."""
     from lionagi.protocols.messages.manager import MessageManager
 
     class _Unrenderable:


### PR DESCRIPTION
## Summary

- restore the accepted nullable behavior of the public `Message.chat_msg` projection
- keep the internal manager projection strict so `to_chat_msgs()` cannot emit `None` holes
- retain `ValueError` wrapping for manager lookup or projection failures
- align ADR-0006 with the public/private projection split and return types

## Validation

- `uv run pytest -n0 -q tests/protocols/messages/test_message.py tests/protocols/messages/test_manager_serialization.py tests/operations/test_message_render_cache.py` (69 passed)
- Ruff, Markdown lint, and pre-commit checks

Closes #2612