### PR TITLE
fix(mcp): reject excess spawn positionals before submit

### DIFF
--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -481,6 +481,40 @@ def render_argv(schema: dict[str, Any], args: dict[str, Any]) -> list[str]:
 # ── executors ────────────────────────────────────────────────────────────────
 
 
+_POSITIONAL_LIMITS = {
+    "agent": 2,
+    "flow": 2,
+    "fanout": 2,
+    "play": 2,
+}
+
+
+def _refuse_too_many_positionals(
+    verb: Verb,
+    args: dict[str, Any],
+    prompt: str | None,
+) -> None:
+    """Refuse a positional bucket the receiving CLI would reject.
+
+    Admission runs before any job record or child process can be created.
+    """
+    limit = _POSITIONAL_LIMITS.get(verb.job_kind)
+    query = args.get("query") or []
+    prompt_count = int(prompt is not None)
+    effective_count = len(query) + prompt_count
+    if limit is None or effective_count <= limit:
+        return
+    sources = f"{len(query)} in 'query'"
+    if prompt_count:
+        sources += " plus a resolved prompt"
+    raise OpError(
+        "invalid_input",
+        f"{verb.name!r} got {effective_count} positional values ({sources}), but accepts "
+        f"at most {limit}: [MODEL] PROMPT; pass the prompt exactly once, quote a "
+        "multi-word prompt, or use 'prompt' or 'prompt_file' instead",
+    )
+
+
 def _resolve_prompt(args: dict[str, Any]) -> str | None:
     prompt = args.get("prompt")
     prompt_file = args.get("prompt_file")
@@ -761,6 +795,7 @@ def _resolve_cwd(args: dict[str, Any]) -> str | None:
 
 def _run_spawn(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict[str, Any]:
     prompt = _resolve_prompt(args)
+    _refuse_too_many_positionals(verb, args, prompt)
     _refuse_without_model(verb, schema, args, prompt)
     _refuse_without_prompt(verb, args, prompt)
     cwd = _resolve_cwd(args)

--- a/tests/mcp/test_admission_too_many_positionals.py
+++ b/tests/mcp/test_admission_too_many_positionals.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Preflight the positional limit shared by MCP spawn commands."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from lionagi.mcp import dispatch, jobs, verbs
+
+
+def call(**kwargs):
+    return asyncio.run(dispatch.request(**kwargs))
+
+
+def spawn_op(op: str, args: dict, *, playbook: str | None = None) -> dict:
+    """Build a spawn op with the schema fingerprint a caller must echo."""
+    target: Any = {"verb": op, "playbook": playbook} if playbook is not None else op
+    return {"op": op, "args": args, "schema_fingerprint": call(help=target)["schema_fingerprint"]}
+
+
+@pytest.fixture
+def submit_dir(monkeypatch, tmp_path):
+    """Provide an isolated playbook for the play submission cases."""
+    monkeypatch.chdir(tmp_path)
+    books = tmp_path / ".lionagi" / "playbooks"
+    books.mkdir(parents=True)
+    (books / "probe.playbook.yaml").write_text("name: probe\nprompt: summarize this\nnodes:\n")
+    return tmp_path
+
+
+@pytest.fixture
+def submitted(monkeypatch):
+    """Capture calls at the job boundary; no process or run record is created."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_submit(kind, flags, **kwargs):
+        calls.append({"kind": kind, "flags": list(flags), **kwargs})
+        return {"run_id": "rid", "status": "running", "terminal": False, "outcome": None}
+
+    monkeypatch.setattr(jobs, "submit", fake_submit)
+    return calls
+
+
+_SPAWN_CASES = (
+    ("agent.submit", "agent", None),
+    ("flow.submit", "flow", None),
+    ("fanout.submit", "fanout", None),
+    ("play.submit", "play", "probe"),
+)
+
+
+def _args(query: list[str], playbook: str | None) -> dict:
+    args: dict[str, Any] = {"query": query, "no_mcp_config": True}
+    if playbook is not None:
+        args["playbook"] = playbook
+    return args
+
+
+def _add_prompt_source(args: dict[str, Any], source: str, submit_dir) -> None:
+    if source == "prompt":
+        args["prompt"] = "review the patch"
+        return
+    prompt_path = submit_dir / "prompt.txt"
+    prompt_path.write_text("review the patch")
+    args["prompt_file"] = str(prompt_path)
+
+
+@pytest.mark.parametrize(("verb", "kind", "playbook"), _SPAWN_CASES)
+def test_three_positionals_are_refused_before_every_affected_spawn(
+    submit_dir, submitted, verb, kind, playbook
+):
+    answer = call(
+        ops=[
+            spawn_op(
+                verb,
+                _args(["claude/opus", "review the patch", "unexpected"], playbook),
+                playbook=playbook,
+            )
+        ]
+    )["ops"][0]
+
+    assert answer["ok"] is False, answer
+    assert answer["error"]["kind"] == "invalid_input", answer
+    message = answer["error"]["message"]
+    assert verb in message
+    assert "3 positional values" in message
+    assert "[MODEL] PROMPT" in message
+    assert "quote a multi-word prompt" in message
+    assert submitted == [], f"{kind} reached jobs.submit"
+
+
+@pytest.mark.parametrize(("verb", "kind", "playbook"), _SPAWN_CASES)
+@pytest.mark.parametrize("source", ("prompt", "prompt_file"))
+def test_server_owned_prompt_counts_toward_every_spawn_limit(
+    submit_dir, submitted, verb, kind, playbook, source
+):
+    args = _args(["claude/opus", "positional prompt"], playbook)
+    _add_prompt_source(args, source, submit_dir)
+
+    answer = call(ops=[spawn_op(verb, args, playbook=playbook)])["ops"][0]
+
+    assert answer["ok"] is False, answer
+    assert answer["error"]["kind"] == "invalid_input", answer
+    message = answer["error"]["message"]
+    assert verb in message
+    assert "3 positional values" in message
+    assert "2 in 'query' plus a resolved prompt" in message
+    assert submitted == [], f"{kind} reached jobs.submit"
+
+
+@pytest.mark.parametrize(("verb", "kind", "playbook"), _SPAWN_CASES)
+def test_two_positionals_still_reach_every_affected_spawn(
+    submit_dir, submitted, verb, kind, playbook
+):
+    answer = call(
+        ops=[
+            spawn_op(
+                verb,
+                _args(["claude/opus", "review the patch"], playbook),
+                playbook=playbook,
+            )
+        ]
+    )["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert submitted[-1]["kind"] == kind
+    assert submitted[-1]["flags"][-3:] == ["--", "claude/opus", "review the patch"]
+
+
+@pytest.mark.parametrize(("verb", "kind", "playbook"), _SPAWN_CASES)
+@pytest.mark.parametrize("source", ("prompt", "prompt_file"))
+def test_one_query_plus_server_owned_prompt_still_reaches_every_spawn(
+    submit_dir, submitted, verb, kind, playbook, source
+):
+    args = _args(["claude/opus"], playbook)
+    _add_prompt_source(args, source, submit_dir)
+
+    answer = call(ops=[spawn_op(verb, args, playbook=playbook)])["ops"][0]
+
+    assert answer["ok"] is True, answer
+    assert submitted[-1]["kind"] == kind
+    assert submitted[-1]["flags"][-2:] == ["--", "claude/opus"]
+    assert submitted[-1]["prompt"] == "review the patch"
+
+
+def test_every_registered_spawn_kind_declares_a_positional_limit():
+    registered = {verb.job_kind for verb in verbs.VERBS.values() if verb.executor == "spawn"}
+    assert registered == set(dispatch._POSITIONAL_LIMITS)

--- a/tests/mcp/test_privilege_fence.py
+++ b/tests/mcp/test_privilege_fence.py
@@ -166,7 +166,7 @@ def test_no_verb_accepts_opaque_argv():
 def test_a_spawn_verb_cannot_be_argued_into_a_different_command(monkeypatch):
     # Every spawn verb's command boundary comes from its job kind, not from any
     # caller-supplied value, so a value that looks like a subcommand lands as a
-    # positional argument of the command that was already chosen.
+    # positional pair of the command that was already chosen.
     seen: dict = {}
 
     def fake_submit(kind, flags, **kwargs):
@@ -174,10 +174,10 @@ def test_a_spawn_verb_cannot_be_argued_into_a_different_command(monkeypatch):
         return {"run_id": "rid"}
 
     monkeypatch.setattr(jobs, "submit", fake_submit)
-    call(ops=[spawn_op("agent.submit", {"query": ["plugin", "trust", "evil"]})])
+    call(ops=[spawn_op("agent.submit", {"query": ["plugin", "trust"]})])
     assert seen["kind"] == "agent"
     assert jobs._KIND_ARGV["agent"] == ["agent"]
-    assert seen["flags"] == ["--", "plugin", "trust", "evil"]
+    assert seen["flags"] == ["--", "plugin", "trust"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- declare the existing `[MODEL] PROMPT` maximum for every registered MCP spawn kind
- resolve `prompt` and `prompt_file` first, then count them in the same effective positional bucket as `query`
- reject an overfull bucket before `jobs.submit`, run-record allocation, or process creation
- preserve valid two-value mixed forms and the `--` command-boundary invariant

The admission table is checked against the registered spawn kinds so a new kind cannot bypass the limit silently.

## Validation

- `uv run pytest -n0 -q tests/mcp/test_admission_too_many_positionals.py tests/mcp/test_privilege_fence.py` (45 passed)
- focused prompt-admission and catalog checks (73 passed)
- Ruff and pre-commit checks

Closes #2618