### PR TITLE
fix(orchestrate): distinguish output-only artifact paths

### DIFF
--- a/lionagi/cli/orchestrate/_common.py
+++ b/lionagi/cli/orchestrate/_common.py
@@ -60,21 +60,14 @@ def _format_result_json(
 # ── Default worker system prompt (shared by flow + fanout) ────────────────
 
 
-def worker_artifact_section(artifact_dir: str | Path | None) -> str:
-    """Describe where a worker's output files belong.
+def worker_artifact_section(
+    artifact_dir: str | Path | None,
+    *,
+    workspace_assigned: bool = True,
+) -> str:
+    """Describe a worker's artifact destination.
 
-    ``artifact_dir`` MUST be the worker's working directory. The file-editing
-    tool a CLI worker runs under applies a narrower policy than the surrounding
-    sandbox and refuses absolute paths outside the working directory, so naming
-    any other directory would convert an invented destination into a refused
-    one. Callers derive the value from the cwd they actually launch the worker
-    with rather than recomputing it, and this function rejects a relative path
-    — a relative name would be resolved against whatever cwd the worker happens
-    to have, which is the ambiguity the directive exists to remove.
-
-    With no directory (the import-time default, before any run exists) the text
-    falls back to describing the working directory itself, so the prompt stays
-    coherent and still promises nothing about the caller's instruction.
+    Wording distinguishes assigned CLI workspaces from output-only paths.
     """
     if artifact_dir is None:
         return _ARTIFACT_SECTION_NO_DIR
@@ -83,25 +76,35 @@ def worker_artifact_section(artifact_dir: str | Path | None) -> str:
         raise ValueError(
             f"worker artifact directory must be an absolute path, got {artifact_dir!r}"
         )
-    return _ARTIFACT_SECTION_WITH_DIR.format(artifact_dir=path)
+    template = _ARTIFACT_SECTION_WITH_DIR if workspace_assigned else _ARTIFACT_SECTION_OUTPUT_ONLY
+    return template.format(artifact_dir=path)
 
 
 _ARTIFACT_DIR_LINE = re.compile(r"^ARTIFACT DIRECTORY: .*$", re.MULTILINE)
 
 
-def retarget_artifact_section(system_text: str, artifact_dir: str | Path) -> str:
-    """Point an inherited artifact directive at *artifact_dir*.
+def retarget_artifact_section(
+    system_text: str,
+    artifact_dir: str | Path,
+    *,
+    workspace_assigned: bool = True,
+) -> str:
+    """Point an inherited artifact directive at a new destination.
 
-    A reactively spawned worker clones its emitter's branch and so inherits a
-    prompt naming the emitter's directory, while being launched in one of its
-    own. Rewriting the directive keeps the named directory equal to the cwd,
-    which is the only reason it is writable. A prompt with no directive at all
-    gets the section appended.
+    Existing standard guidance is replaced so its workspace claim stays true.
     """
-    section = worker_artifact_section(artifact_dir)
+    section = worker_artifact_section(
+        artifact_dir,
+        workspace_assigned=workspace_assigned,
+    )
+    for pattern in _GENERATED_ARTIFACT_SECTIONS:
+        if pattern.search(system_text):
+            return pattern.sub(lambda _match: section, system_text, count=1)
     if _ARTIFACT_DIR_LINE.search(system_text):
         return _ARTIFACT_DIR_LINE.sub(
-            f"ARTIFACT DIRECTORY: {Path(artifact_dir)}", system_text, count=1
+            lambda _match: f"ARTIFACT DIRECTORY: {Path(artifact_dir)}",
+            system_text,
+            count=1,
         )
     return f"{system_text}\n\n{section}" if system_text else section
 
@@ -135,6 +138,16 @@ and do not infer a destination that is not named here or in your instruction. \
 Reference upstream artifacts only by paths you were given.\
 """
 
+_ARTIFACT_SECTION_OUTPUT_ONLY = """\
+ARTIFACT DIRECTORY: {artifact_dir}
+
+Write every output file there using absolute paths. This is the artifact \
+destination recorded for the task, not an assigned working directory; access \
+remains subject to the provider's tool policy. Do not place output anywhere \
+else, and do not infer a destination that is not named here or in your \
+instruction. Reference upstream artifacts only by paths you were given.\
+"""
+
 _ARTIFACT_SECTION_NO_DIR = """\
 ARTIFACT DIRECTORY: your working directory.
 
@@ -145,6 +158,23 @@ succeed. Do not place output anywhere else, and do not infer a destination \
 that is not named here or in your instruction. Reference upstream artifacts \
 only by paths you were given.\
 """
+
+
+def _artifact_section_pattern(template: str) -> re.Pattern[str]:
+    """Match one generated artifact-section template.
+
+    The directory may vary, but all surrounding harness text must match.
+    """
+    escaped = re.escape(template)
+    escaped = escaped.replace(re.escape("{artifact_dir}"), r"[^\r\n]+")
+    return re.compile(escaped)
+
+
+_GENERATED_ARTIFACT_SECTIONS = (
+    _artifact_section_pattern(_ARTIFACT_SECTION_WITH_DIR),
+    _artifact_section_pattern(_ARTIFACT_SECTION_OUTPUT_ONLY),
+    _artifact_section_pattern(_ARTIFACT_SECTION_NO_DIR),
+)
 
 _BARE_WORKER_BODY = """\
 You are a specialist worker agent in a DAG pipeline. \

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -99,12 +99,15 @@ def _leg_artifact_entries(node_id: str, role_defaults: dict | None) -> list[dict
     return entries
 
 
-def _retarget_spawn_prompt(branch, artifact_dir) -> None:
-    """Rewrite a spawned clone's artifact directive to name its own directory.
+def _retarget_spawn_prompt(
+    branch,
+    artifact_dir,
+    *,
+    workspace_assigned: bool = True,
+) -> None:
+    """Rewrite a spawned clone's artifact directive.
 
-    Best-effort: a prompt that cannot be rewritten is warned about rather than
-    raised, since a stale directive is a worse outcome for the spawned node
-    alone, while an exception here would abort the whole run.
+    Provider-aware wording avoids claiming an unassigned working directory.
     """
     msgs = getattr(branch, "msgs", None)
     if msgs is None:
@@ -117,7 +120,11 @@ def _retarget_spawn_prompt(branch, artifact_dir) -> None:
     if not isinstance(current, str):
         _warn(f"spawned worker prompt not retargeted to {artifact_dir}: prompt is not text")
         return
-    updated = retarget_artifact_section(current, artifact_dir)
+    updated = retarget_artifact_section(
+        current,
+        artifact_dir,
+        workspace_assigned=workspace_assigned,
+    )
     if updated != current:
         msgs.set_system(msgs.create_system(system=updated))
 
@@ -1252,15 +1259,9 @@ async def _execute_dag(
         return f"{req.instruction}\n\n{note}"
 
     def _spawn_branch_setup(operation: Any, branch: Any) -> None:
-        """Give a spawned node its own artifact directory.
+        """Assign a spawned node its artifact destination.
 
-        Every spawned node gets the directory recorded on the run roster and its
-        inherited prompt retargeted at it. Only the workspace move is specific
-        to a CLI provider: `Branch.clone` carries the emitter's `repo` kwarg
-        over, and a non-CLI model has no such kwarg to move. The prompt it
-        inherited names the emitter's directory either way, and being absent
-        from the roster is not a provider-specific outcome — so neither of those
-        may be skipped for a non-CLI worker.
+        CLI branches receive it as a workspace; other providers get output-only wording.
         """
         spawn_id = operation.metadata.get("spawn_id") if operation is not None else None
         if not spawn_id:
@@ -1268,13 +1269,17 @@ async def _execute_dag(
         artifact_dir = env.run.agent_artifact_dir(spawn_id)
         artifact_dir.mkdir(parents=True, exist_ok=True)
         env.worker_artifact_dirs[spawn_id] = artifact_dir
-        # The clone inherits the emitter's prompt, which names the emitter's
-        # directory. Retarget it, or the spawned worker is pointed at a
-        # directory that is no longer its own.
-        _retarget_spawn_prompt(branch, artifact_dir)
-
         chat_model = getattr(branch, "chat_model", None)
-        if chat_model is None or not getattr(chat_model, "is_cli", False):
+        is_cli = bool(chat_model and getattr(chat_model, "is_cli", False))
+        # The clone inherits the emitter's prompt. Retarget its destination and
+        # only describe that destination as a workspace when one is assigned.
+        _retarget_spawn_prompt(
+            branch,
+            artifact_dir,
+            workspace_assigned=is_cli,
+        )
+
+        if not is_cli:
             return
         kwargs = chat_model.endpoint.config.kwargs
         kwargs["repo"] = artifact_dir

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import pytest
 
 from lionagi.casts.emission import TaskAssignment
+from lionagi.cli.orchestrate._common import bare_worker_system
 from lionagi.cli.orchestrate.flow import (
     _build_dag,
     _DagState,
@@ -584,7 +585,7 @@ async def test_execute_dag_reactive_wires_spawn_branch_setup_for_cli_workspace(t
             is_cli=False,
             endpoint=SimpleNamespace(config=SimpleNamespace(kwargs={})),
         ),
-        msgs=_FakeMsgs("ARTIFACT DIRECTORY: /somewhere/else/emitter"),
+        msgs=_FakeMsgs(bare_worker_system(artifact_dir="/somewhere/else/emitter")),
     )
     spawn_branch_setup(non_cli_op, non_cli_branch)
 
@@ -593,7 +594,10 @@ async def test_execute_dag_reactive_wires_spawn_branch_setup_for_cli_workspace(t
     assert "repo" not in non_cli_branch.chat_model.endpoint.config.kwargs
     # … but it is on the roster and its prompt names its own directory.
     assert env.worker_artifact_dirs["spawn-2"] == non_cli_dir
-    assert non_cli_branch.msgs.system_text == f"ARTIFACT DIRECTORY: {non_cli_dir}"
+    assert f"ARTIFACT DIRECTORY: {non_cli_dir}" in non_cli_branch.msgs.system_text
+    assert "/somewhere/else/emitter" not in non_cli_branch.msgs.system_text
+    assert "not an assigned working directory" in non_cli_branch.msgs.system_text
+    assert "It is your working directory" not in non_cli_branch.msgs.system_text
 
 
 @pytest.mark.asyncio

--- a/tests/cli/orchestrate/test_worker_artifact_directive.py
+++ b/tests/cli/orchestrate/test_worker_artifact_directive.py
@@ -70,6 +70,43 @@ def test_retarget_appends_when_no_directive_is_present():
     assert "ARTIFACT DIRECTORY: /tmp/run-x/a" in out
 
 
+def test_retarget_without_workspace_uses_truthful_output_only_guidance():
+    inherited = bare_worker_system(artifact_dir="/tmp/run-x/artifacts/emitter")
+
+    retargeted = retarget_artifact_section(
+        inherited,
+        "/tmp/run-x/artifacts/spawned",
+        workspace_assigned=False,
+    )
+
+    assert "ARTIFACT DIRECTORY: /tmp/run-x/artifacts/spawned" in retargeted
+    assert "/tmp/run-x/artifacts/emitter" not in retargeted
+    assert "not an assigned working directory" in retargeted
+    assert "It is your working directory" not in retargeted
+    assert "SESSION PERSISTENCE" in retargeted
+
+
+def test_retarget_preserves_profile_authored_policy_around_a_directive():
+    inherited = """\
+ARTIFACT DIRECTORY: /tmp/run-x/artifacts/emitter
+
+Write every output file there after first obeying this policy:
+NEVER disclose secrets.
+Reference upstream artifacts only by paths you were given.
+
+Remain concise."""
+
+    retargeted = retarget_artifact_section(
+        inherited,
+        "/tmp/run-x/artifacts/spawned",
+    )
+
+    assert "ARTIFACT DIRECTORY: /tmp/run-x/artifacts/spawned" in retargeted
+    assert "/tmp/run-x/artifacts/emitter" not in retargeted
+    assert "NEVER disclose secrets." in retargeted
+    assert "Remain concise." in retargeted
+
+
 # ── build_worker_branch names exactly the directory it launches the worker in ──
 
 


### PR DESCRIPTION
## Summary

- keep the existing working-directory guarantee for CLI-backed spawned branches
- describe non-CLI artifact paths as output destinations rather than assigned working directories
- replace only exact harness-generated artifact sections and preserve profile-authored policy text
- continue registering every spawned worker's artifact directory without adding a non-CLI `repo` assignment

## Validation

- `uv run pytest -n0 -q tests/cli/orchestrate/test_worker_artifact_directive.py tests/cli/orchestrate/test_flow_phases.py` (51 passed)
- Ruff and pre-commit checks

Closes #2652