### PR TITLE
feat(monitor): surface khive injection telemetry

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -523,6 +523,10 @@ li monitor --project myproject  # filter sessions by project
 | `-t, --type` | none | One of `session`, `invocation`, `show`, `play` |
 | `-p, --project` | none | Filter sessions by project name |
 
+A session detail view includes a `khive injection` block when an opted-in profile recorded
+non-zero recall, injection, failure, or writeback counters. The block contains aggregate counts,
+not injected source text.
+
 For scripts, use a waiter instead of scraping the watch display:
 
 ```bash

--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -748,6 +748,12 @@ Python dict (Postgres JSON auto-decode) or a raw string (SQLite text storage via
 to 0 — persisted telemetry is untrusted (hand-edited state.db rows, a future writer with a
 different shape), and a malformed count must never crash the monitor.
 
+**`_format_khive_injection_line`** — renders the non-zero aggregate context-injection counters
+stored under `sessions.node_metadata["khive_injection"]`. Orchestration finalize sums the counters
+across its branches; bare `li agent -a <profile>` teardown records the same shape from its branch.
+Only counts are persisted — never the injected source text — and absent, zero, or malformed
+counter sets are omitted from the session drill-in.
+
 **`_format_coordination_line`** — coordination telemetry shape contract. Renders an
 invocation's coordination telemetry (`node_metadata["coordination"]`, written by the scheduler
 engine's finalize path — see `lionagi.studio.services.scheduler_state.flush_run_telemetry`).

--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -751,8 +751,9 @@ different shape), and a malformed count must never crash the monitor.
 **`_format_khive_injection_line`** — renders the non-zero aggregate context-injection counters
 stored under `sessions.node_metadata["khive_injection"]`. Orchestration finalize sums the counters
 across its branches; bare `li agent -a <profile>` teardown records the same shape from its branch.
-Only counts are persisted — never the injected source text — and absent, zero, or malformed
-counter sets are omitted from the session drill-in.
+A top-level resume seeds its totals from the durable session; an in-process timeout resume carries
+the first leg's counters into the final teardown. Only counts are persisted — never the injected
+source text — and absent, zero, or malformed counter sets are omitted from the session drill-in.
 
 **`_format_coordination_line`** — coordination telemetry shape contract. Renders an
 invocation's coordination telemetry (`node_metadata["coordination"]`, written by the scheduler

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -496,8 +496,17 @@ async def _teardown_common(
         update_kwargs["last_msg_id"] = all_msgs[-1]
 
     if extras:
+        session = await db.get_session(session_id) or {}
+        existing_metadata = session.get("node_metadata") or {}
+        if isinstance(existing_metadata, str):
+            try:
+                existing_metadata = json.loads(existing_metadata)
+            except (TypeError, ValueError):
+                existing_metadata = {}
+        if not isinstance(existing_metadata, dict):
+            existing_metadata = {}
         markers = identity_markers or {}
-        update_kwargs["node_metadata"] = json.dumps({**extras, **markers})
+        update_kwargs["node_metadata"] = json.dumps({**existing_metadata, **extras, **markers})
 
     await db.update_session(session_id, **update_kwargs)
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -74,6 +74,45 @@ _IMAGE_MEDIA_TYPES = {
     ".gif": "image/gif",
 }
 
+_KHIVE_INJECTION_COUNTERS = (
+    "recall_turns",
+    "blocks_injected",
+    "failed",
+    "writeback_records",
+    "writeback_failed",
+)
+
+
+def _fold_injection_stats(totals: dict[str, int], stats: object) -> None:
+    """Add one provider-stat snapshot into session totals.
+
+    Unexpected values are ignored so telemetry cannot break teardown.
+    """
+    if not isinstance(stats, dict):
+        return
+    for counter in _KHIVE_INJECTION_COUNTERS:
+        value = stats.get(counter)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            totals[counter] += value
+
+
+async def _seed_injection_stats(live: dict | None, totals: dict[str, int]) -> None:
+    """Seed a top-level resume from its durable session counters.
+
+    Missing or malformed metadata leaves the new invocation at zero.
+    """
+    if not live or live.get("db") is None:
+        return
+    try:
+        session = await live["db"].get_session(live["session_id"])
+        metadata = session.get("node_metadata") if session else None
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
+        if isinstance(metadata, dict):
+            _fold_injection_stats(totals, metadata.get("khive_injection"))
+    except Exception:  # noqa: BLE001
+        return
+
 
 def _load_image_data_uris(paths: list[str]) -> list[str]:
     """Read each --image path and wrap it as a `data:image/...;base64,...` URI —
@@ -364,11 +403,18 @@ async def _run_agent(
     mcp_config: str | None = None,
     no_mcp_config: bool = False,
     _auto_resumed: bool = False,
+    _injection_totals: dict[str, int] | None = None,
 ) -> tuple[str, str, str, str, str | None]:
     """Execute one agent turn; returns (result, provider, branch_id, terminal_status, session_id).
 
     session_id is None whenever live persistence never started.
     """
+    seed_injection_totals = _injection_totals is None
+    _injection_totals = (
+        dict.fromkeys(_KHIVE_INJECTION_COUNTERS, 0)
+        if _injection_totals is None
+        else dict(_injection_totals)
+    )
     effort = normalize_effort(effort)
     # Fail fast before any run is allocated: a nonexistent --cwd must not spawn
     # into a provider-created dir. Forward the tilde-expanded path — providers
@@ -737,6 +783,8 @@ async def _run_agent(
         effort=effort,
         project=project,
     )
+    if seed_injection_totals:
+        await _seed_injection_stats(live, _injection_totals)
 
     # Session-scoped: teardown_agent_persist terminalizes only the session;
     # invocation records are finalized externally and would never fire. Deferred
@@ -860,12 +908,14 @@ async def _run_agent(
             # from a wrapper exception racing a still-live engine session.
             _engine_session_uid = getattr(branch.chat_model.endpoint, "session_id", None)
             registry = getattr(branch, "_context_providers", None)
-            injection_stats = getattr(registry, "stats", None) if registry else None
-            telemetry_kw = (
-                {"extras": {"khive_injection": dict(injection_stats)}}
-                if injection_stats and any(injection_stats.values())
-                else {}
+            injection_stats = getattr(registry, "stats", None) if registry is not None else None
+            _fold_injection_stats(_injection_totals, injection_stats)
+            telemetry_extras = (
+                {"khive_injection": dict(_injection_totals)}
+                if not will_auto_resume and any(_injection_totals.values())
+                else None
             )
+            telemetry_kw = {"extras": telemetry_extras} if telemetry_extras else {}
             effective_status = await teardown_agent_persist(
                 live,
                 status=_terminal_status,
@@ -942,6 +992,7 @@ async def _run_agent(
             mcp_config=mcp_config,
             no_mcp_config=no_mcp_config,
             _auto_resumed=True,
+            _injection_totals=_injection_totals,
         )
 
     return res or "", provider, branch_id, _terminal_status, session_id

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -859,6 +859,13 @@ async def _run_agent(
             # Engine session id, used by teardown to tell a genuine failure
             # from a wrapper exception racing a still-live engine session.
             _engine_session_uid = getattr(branch.chat_model.endpoint, "session_id", None)
+            registry = getattr(branch, "_context_providers", None)
+            injection_stats = getattr(registry, "stats", None) if registry else None
+            telemetry_kw = (
+                {"extras": {"khive_injection": dict(injection_stats)}}
+                if injection_stats and any(injection_stats.values())
+                else {}
+            )
             effective_status = await teardown_agent_persist(
                 live,
                 status=_terminal_status,
@@ -866,6 +873,7 @@ async def _run_agent(
                 cwd=cwd,
                 engine_session_uid=_engine_session_uid,
                 defer_terminal=will_auto_resume,
+                **telemetry_kw,
             )
             if effective_status != _terminal_status:
                 _terminal_status = effective_status

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import signal
 import sys
@@ -578,6 +579,18 @@ def _as_number(value: Any) -> int | float:
     return value if isinstance(value, (int, float)) and not isinstance(value, bool) else 0
 
 
+def _as_counter(value: Any) -> int:
+    """Return a finite, nonnegative integral counter.
+
+    Invalid numeric telemetry is treated as absent.
+    """
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value if value >= 0 else 0
+    if isinstance(value, float) and math.isfinite(value) and value >= 0 and value.is_integer():
+        return int(value)
+    return 0
+
+
 def _format_khive_injection_line(telemetry: dict[str, Any]) -> str | None:
     """Render persisted aggregate injection counters.
 
@@ -590,7 +603,7 @@ def _format_khive_injection_line(telemetry: dict[str, Any]) -> str | None:
         "writeback_records",
         "writeback_failed",
     )
-    counters = {name: _as_number(telemetry.get(name)) for name in counter_names}
+    counters = {name: _as_counter(telemetry.get(name)) for name in counter_names}
     if not any(counters.values()):
         return None
     return " ".join(f"{name}={value}" for name, value in counters.items())

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -501,6 +501,15 @@ async def _detail_session(db: Any, sess: dict[str, Any]) -> str:
     if last_msg:
         lines.append(f"  last_msg:  {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(last_msg))}")
 
+    node_metadata = _parse_json_field(sess.get("node_metadata"))
+    injection = (node_metadata or {}).get("khive_injection")
+    if isinstance(injection, dict):
+        injection_line = _format_khive_injection_line(injection)
+        if injection_line:
+            lines.append("")
+            lines.append(_dim("  -- khive injection --"))
+            lines.append(f"    {injection_line}")
+
     # Completion-trust evidence: surface why the status landed, so trusting
     # it doesn't require a manual git read.
     if sess.get("status") in ("completed", "completed_empty"):
@@ -567,6 +576,24 @@ def _as_number(value: Any) -> int | float:
     """Coerce *value* to a count, treating anything non-numeric as 0 —
     persisted telemetry is untrusted and must never crash the monitor."""
     return value if isinstance(value, (int, float)) and not isinstance(value, bool) else 0
+
+
+def _format_khive_injection_line(telemetry: dict[str, Any]) -> str | None:
+    """Render persisted aggregate injection counters.
+
+    Empty or malformed counter sets are omitted from the session detail.
+    """
+    counter_names = (
+        "recall_turns",
+        "blocks_injected",
+        "failed",
+        "writeback_records",
+        "writeback_failed",
+    )
+    counters = {name: _as_number(telemetry.get(name)) for name in counter_names}
+    if not any(counters.values()):
+        return None
+    return " ".join(f"{name}={value}" for name, value in counters.items())
 
 
 def _format_coordination_line(telemetry: dict[str, Any]) -> str | None:

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import threading
 from pathlib import Path
@@ -610,6 +611,46 @@ async def test_teardown_updates_session_bookmarks_and_status(
     assert s["first_msg_id"] == str(msg_a.id)
     assert s["last_msg_id"] == str(msg_b.id)
     assert s["ended_at"] is not None
+
+
+async def test_teardown_extras_preserve_existing_node_metadata(
+    temp_db_path: Path,
+):
+    """Teardown extras extend the session metadata object.
+
+    Process identity from setup must survive telemetry writes.
+    """
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    async with StateDB() as db:
+        before = await db.get_session(ctx["session_id"])
+    initial_metadata = before["node_metadata"]
+    if isinstance(initial_metadata, str):
+        initial_metadata = json.loads(initial_metadata)
+
+    counters = {
+        "recall_turns": 2,
+        "blocks_injected": 3,
+        "failed": 1,
+        "writeback_records": 5,
+        "writeback_failed": 2,
+    }
+    await _teardown_live_persist(
+        ctx,
+        status="failed",
+        exception=RuntimeError("boom"),
+        extras={"khive_injection": counters},
+    )
+
+    async with StateDB() as db:
+        after = await db.get_session(ctx["session_id"])
+    final_metadata = after["node_metadata"]
+    if isinstance(final_metadata, str):
+        final_metadata = json.loads(final_metadata)
+
+    assert all(final_metadata[key] == value for key, value in initial_metadata.items())
+    assert final_metadata["khive_injection"] == counters
 
 
 async def test_teardown_finalizes_branch_status_and_ended_at(

--- a/tests/cli/test_agent_profile_khive_injection.py
+++ b/tests/cli/test_agent_profile_khive_injection.py
@@ -121,7 +121,10 @@ async def test_bare_li_agent_path_registers_injection_from_profile(monkeypatch, 
     )
     monkeypatch.setattr(agent_mod, "setup_agent_persist", AsyncMock(return_value=None))
 
+    seen = {}
+
     async def fake_teardown(ctx, *, status="completed", **kw):
+        seen["teardown_extras"] = kw.get("extras")
         return status
 
     monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
@@ -136,10 +139,17 @@ async def test_bare_li_agent_path_registers_injection_from_profile(monkeypatch, 
     )
     monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
 
-    seen = {}
-
     async def fake_operate(self, instruction=None, **kw):
         seen["providers"] = list(self.providers.names)
+        self.providers.stats.update(
+            {
+                "recall_turns": 2,
+                "blocks_injected": 3,
+                "failed": 1,
+                "writeback_records": 5,
+                "writeback_failed": 2,
+            }
+        )
         return "ok"
 
     monkeypatch.setattr(Branch, "operate", fake_operate)
@@ -147,6 +157,15 @@ async def test_bare_li_agent_path_registers_injection_from_profile(monkeypatch, 
     await agent_mod._run_agent("codex/model", "do the thing", agent_name="reviewer")
 
     assert seen["providers"] == ["khive_injection:reviewer-recall-v1"]
+    assert seen["teardown_extras"] == {
+        "khive_injection": {
+            "recall_turns": 2,
+            "blocks_injected": 3,
+            "failed": 1,
+            "writeback_records": 5,
+            "writeback_failed": 2,
+        }
+    }
 
 
 @pytest.mark.asyncio
@@ -191,7 +210,10 @@ async def test_bare_li_agent_path_no_injection_when_profile_lacks_optin(monkeypa
     )
     monkeypatch.setattr(agent_mod, "setup_agent_persist", AsyncMock(return_value=None))
 
+    seen = {}
+
     async def fake_teardown(ctx, *, status="completed", **kw):
+        seen["teardown_kwargs"] = kw
         return status
 
     monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
@@ -206,8 +228,6 @@ async def test_bare_li_agent_path_no_injection_when_profile_lacks_optin(monkeypa
     )
     monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
 
-    seen = {}
-
     async def fake_operate(self, instruction=None, **kw):
         seen["providers"] = list(self.providers.names)
         return "ok"
@@ -217,3 +237,4 @@ async def test_bare_li_agent_path_no_injection_when_profile_lacks_optin(monkeypa
     await agent_mod._run_agent("codex/model", "do the thing", agent_name="myprofile")
 
     assert seen["providers"] == []
+    assert "extras" not in seen["teardown_kwargs"]

--- a/tests/cli/test_agent_resume_on_timeout.py
+++ b/tests/cli/test_agent_resume_on_timeout.py
@@ -467,6 +467,7 @@ def _wire_agent_stubs_real_persist(
     tmp_path: Path,
     *,
     operate_side_effect,
+    injection_stats_by_leg: list[dict[str, int]] | None = None,
 ):
     """Like _wire_agent_stubs_real_chat_model, but setup_agent_persist /
     teardown_agent_persist are left untouched (the real StateDB-backed
@@ -481,6 +482,8 @@ def _wire_agent_stubs_real_persist(
     async def fake_operate(self, instruction=None, **kw):
         idx = call_count["n"]
         call_count["n"] += 1
+        if injection_stats_by_leg is not None:
+            self.providers.stats.update(injection_stats_by_leg[idx])
         snapshot_dir = kw.get("snapshot_dir")
         if snapshot_dir is not None:
             Path(snapshot_dir).mkdir(parents=True, exist_ok=True)
@@ -542,7 +545,25 @@ async def test_auto_resume_real_teardown_no_terminal_guard_rejection(
         return "concluded"
 
     call_count = _wire_agent_stubs_real_persist(
-        monkeypatch, tmp_path, operate_side_effect=side_effect
+        monkeypatch,
+        tmp_path,
+        operate_side_effect=side_effect,
+        injection_stats_by_leg=[
+            {
+                "recall_turns": 2,
+                "blocks_injected": 3,
+                "failed": 1,
+                "writeback_records": 0,
+                "writeback_failed": 0,
+            },
+            {
+                "recall_turns": 4,
+                "blocks_injected": 5,
+                "failed": 0,
+                "writeback_records": 6,
+                "writeback_failed": 1,
+            },
+        ],
     )
 
     from lionagi.cli.agent import _run_agent
@@ -569,6 +590,82 @@ async def test_auto_resume_real_teardown_no_terminal_guard_rejection(
     assert s is not None
     assert s["status"] == "completed"
     assert s["ended_at"] is not None
+    node_metadata = s["node_metadata"]
+    if isinstance(node_metadata, str):
+        node_metadata = json.loads(node_metadata)
+    assert {"lion_class", "pid", "pid_create_time"} <= node_metadata.keys()
+    assert node_metadata["khive_injection"] == {
+        "recall_turns": 6,
+        "blocks_injected": 8,
+        "failed": 1,
+        "writeback_records": 6,
+        "writeback_failed": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_manual_resume_accumulates_persisted_injection_stats(
+    monkeypatch,
+    tmp_path,
+    temp_db_path,
+):
+    """A later top-level resume seeds its totals from the durable session.
+
+    The resumed teardown must add new counters instead of replacing history.
+    """
+
+    def side_effect(i):
+        return f"leg-{i}"
+
+    call_count = _wire_agent_stubs_real_persist(
+        monkeypatch,
+        tmp_path,
+        operate_side_effect=side_effect,
+        injection_stats_by_leg=[
+            {
+                "recall_turns": 2,
+                "blocks_injected": 3,
+                "failed": 1,
+                "writeback_records": 5,
+                "writeback_failed": 0,
+            },
+            {
+                "recall_turns": 7,
+                "blocks_injected": 11,
+                "failed": 0,
+                "writeback_records": 13,
+                "writeback_failed": 1,
+            },
+        ],
+    )
+
+    from lionagi.cli.agent import _run_agent
+    from lionagi.state.db import StateDB
+
+    _result, _provider, branch_id, _status, first_session_id = await _run_agent(
+        "claude_code/sonnet",
+        "first",
+    )
+    _result, _provider, _branch_id, _status, resumed_session_id = await _run_agent(
+        "claude_code/sonnet",
+        "second",
+        resume=branch_id,
+    )
+
+    assert call_count["n"] == 2
+    assert resumed_session_id == first_session_id
+    async with StateDB() as db:
+        session = await db.get_session(resumed_session_id)
+    node_metadata = session["node_metadata"]
+    if isinstance(node_metadata, str):
+        node_metadata = json.loads(node_metadata)
+    assert node_metadata["khive_injection"] == {
+        "recall_turns": 9,
+        "blocks_injected": 14,
+        "failed": 1,
+        "writeback_records": 18,
+        "writeback_failed": 1,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import signal
 import sys
 import time
@@ -17,6 +18,7 @@ from lionagi.cli.monitor import (
     _NON_TTY_MAX_COL_WIDTH,
     _cached_detect_project,
     _colour_status,
+    _detail_session,
     _detail_show,
     _elapsed,
     _find_entity,
@@ -1113,6 +1115,58 @@ async def test_run_detail_session(temp_db_path: Path) -> None:
     output = await _run_detail(sid)
     assert "SESSION" in output
     assert "running" in output.lower()
+
+
+@pytest.mark.asyncio
+async def test_run_detail_session_shows_khive_injection_stats(temp_db_path: Path) -> None:
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        await db.update_session(
+            sid,
+            node_metadata=json.dumps(
+                {
+                    "khive_injection": {
+                        "recall_turns": 2,
+                        "blocks_injected": 3,
+                        "failed": 1,
+                        "writeback_records": 5,
+                        "writeback_failed": 2,
+                    }
+                }
+            ),
+        )
+
+    output = await _run_detail(sid)
+
+    assert "khive injection" in output
+    assert "recall_turns=2" in output
+    assert "blocks_injected=3" in output
+    assert "failed=1" in output
+    assert "writeback_records=5" in output
+    assert "writeback_failed=2" in output
+
+
+@pytest.mark.asyncio
+async def test_detail_session_ignores_malformed_khive_injection_stats(
+    temp_db_path: Path,
+) -> None:
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        sess = await db.get_session(sid)
+        assert sess is not None
+        sess["node_metadata"] = json.dumps(
+            {
+                "khive_injection": {
+                    "recall_turns": "many",
+                    "blocks_injected": False,
+                    "failed": None,
+                }
+            }
+        )
+        output = await _detail_session(db, sess)
+
+    assert "SESSION" in output
+    assert "khive injection" not in output
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_monitor.py
+++ b/tests/cli/test_monitor.py
@@ -1170,6 +1170,28 @@ async def test_detail_session_ignores_malformed_khive_injection_stats(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("value", [-1, 0.5, float("nan"), float("inf")])
+async def test_detail_session_ignores_invalid_numeric_injection_stats(
+    temp_db_path: Path,
+    value: float,
+) -> None:
+    async with StateDB() as db:
+        sid = await _make_session(db)
+        sess = await db.get_session(sid)
+        assert sess is not None
+        sess["node_metadata"] = {
+            "khive_injection": {
+                "recall_turns": value,
+                "blocks_injected": 0,
+            }
+        }
+        output = await _detail_session(db, sess)
+
+    assert "SESSION" in output
+    assert "khive injection" not in output
+
+
+@pytest.mark.asyncio
 async def test_run_detail_invocation(temp_db_path: Path) -> None:
     async with StateDB() as db:
         inv_id = await _make_invocation(db, skill="codex-review")


### PR DESCRIPTION
## Summary

- persist bare `li agent -a <profile>` context-injection counters through the existing teardown metadata path
- merge teardown extras into existing session metadata so process identity and other durable fields survive telemetry writes
- accumulate counters across timeout auto-resume legs and later top-level resumes without double-counting
- render the established aggregate counters in `li monitor <session>` when any activity is nonzero
- omit absent, all-zero, boolean, negative, fractional, non-finite, and otherwise malformed telemetry without crashing
- document that only aggregate counts are persisted and displayed, never injected source text

The orchestration aggregation path and persistence schema remain unchanged.

## Validation

- `uv run pytest -q -n0 tests/cli/test_agent_profile_khive_injection.py tests/cli/test_agent_resume_on_timeout.py tests/cli/test_monitor.py tests/cli/test_agent_live_persist.py tests/cli/test_monitor_run.py tests/cli/orchestrate/test_live_persist.py` (passed)
- focused Pyright check (0 errors)
- Ruff, Markdown lint, and pre-commit checks
- real StateDB regressions for metadata preservation, timeout auto-resume, and later manual resume accumulation

Closes #2271