### PR TITLE
fix(cli,scheduler): four independent fixes across kill identity, admission order, and team artifact contracts

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -64,7 +64,7 @@ def _cmdline_is_lionagi(cmdline: list[str], expected_cmd: str) -> bool:
         return True
     # Shebang-launched console scripts: argv[0] is the Python interpreter and
     # argv[1] is the script path (e.g. .venv/bin/li).
-    if exe.startswith("python") and len(cmdline) >= 2:
+    if exe.lower().startswith("python") and len(cmdline) >= 2:
         if os.path.basename(cmdline[1]) == "li":
             return True
     for flag, mod in zip(cmdline, cmdline[1:], strict=False):

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -882,6 +882,10 @@ async def _execute_dag(
     spawn doesn't overwrite `spawned` with `[]` and lose reconstructed work."""
     assignments = plan_result.assignments
     agent_ids = plan_result.agent_ids
+    role_by_worker = {
+        agent_id: assignment.assignee
+        for agent_id, assignment in zip(agent_ids, assignments, strict=True)
+    }
 
     reactive = dag_state.reactive
     spawn_roles = dag_state.spawn_roles
@@ -1157,6 +1161,25 @@ async def _execute_dag(
         env.messenger.on("done", _team_coordinator.on_done)
         env.messenger.on("finished", _team_coordinator.on_finished)
 
+    def _artifact_defaults_for_assignee(assignee: str | None) -> dict | None:
+        role = role_by_worker.get(assignee, assignee)
+        return dag_state.role_artifact_defaults.get(role) if role else None
+
+    def _decorate_team_round_artifacts(operation: Any) -> None:
+        """Tell a stamped team round about the contract its result will register."""
+        assignee = operation.metadata.get("assignee")
+        spawn_id = operation.metadata.get("spawn_id")
+        if not spawn_id:
+            return
+        leg_expected = _leg_artifact_entries(spawn_id, _artifact_defaults_for_assignee(assignee))
+        artifact_note = _artifact_directive(env.run, spawn_id, leg_expected)
+        params = operation.parameters
+        if not isinstance(params, dict):
+            raise TypeError("team round operation parameters must be a dictionary")
+        context = params.setdefault("context", [])
+        context.append({"artifact_instructions": artifact_note})
+        env.expect_worker(spawn_id)
+
     def _on_team_op_complete(node: Any) -> None:
         """ReactiveExecutor.on_op_complete callback: race-free inject() for
         team wakeup rounds. Called for every completed node."""
@@ -1190,6 +1213,7 @@ async def _execute_dag(
             return
         injected = []
         for op in new_ops:
+            _decorate_team_round_artifacts(op)
             if executor.inject(op, independent=True):
                 injected.append(op)
             else:
@@ -1474,10 +1498,10 @@ async def _execute_dag(
 
         # Record the spawned node's role-declared artifacts in the session
         # contract, namespaced under its own subdir — required entries stay
-        # enforceable, not just observability, since decorate_instruction
-        # already told the spawned node its dir + REQUIRED files before it ran.
+        # enforceable, not just observability, since the node received its
+        # artifact directive before it was injected.
         if assignee:
-            role_defaults = dag_state.role_artifact_defaults.get(assignee)
+            role_defaults = _artifact_defaults_for_assignee(assignee)
             spawned_contract_entries.extend(_leg_artifact_entries(sid, role_defaults))
 
     ctx_lp = getattr(env, "_live_persist", None)

--- a/lionagi/studio/scheduler/worker.py
+++ b/lionagi/studio/scheduler/worker.py
@@ -51,6 +51,7 @@ from lionagi.studio.scheduler.admit import (
     AdmissionDecision,
     WorkerCaps,
     admit,
+    declared_max_duration_seconds,
     normalize_action_args,
     notify_request,
 )
@@ -338,7 +339,8 @@ async def claim_and_execute(
     D4 match rule: row R is claimable iff its capability tokens are a subset
     of *advertised_capabilities* AND its execution_target is in
     *execution_targets* (NULL/empty target = claimable by anyone). Candidates
-    are then ordered by affinity match, ties broken by ``queued_at``.
+    Static duration rejections are handled first, then remaining candidates
+    are ordered by affinity match, ties broken by ``queued_at``.
 
     ADR-0071 D3: each candidate is routed through
     ``lionagi.studio.scheduler.admit.admit()``, which folds in the
@@ -408,11 +410,19 @@ async def claim_and_execute(
             if len(page) < _CLAIM_PAGE_SIZE:
                 break  # queue exhausted
 
-    # Stable sort: preserves the SQL's queued_at ASC order among equal
-    # affinity scores, only reordering across different scores.
-    candidates.sort(key=lambda item: -capabilities.affinity_score(item[1], advertised))
-    # `limit` caps claim attempts, applied after affinity reordering so it
-    # never truncates before affinity gets a chance to reorder.
+    # Static duration-invalid rows must be terminalized before waiter-cap
+    # decisions: otherwise an affinity-preferred valid row can count an older
+    # invalid row as a waiter and be rejected before that invalid row is
+    # removed. Within each duration class, preserve affinity-first ordering
+    # and the SQL's queued_at order for ties.
+    def candidate_order(item: tuple[Any, list[str]]) -> tuple[bool, int]:
+        row, required = item
+        max_duration = declared_max_duration_seconds(normalize_action_args(row["action_args"]))
+        duration_valid = max_duration is None or max_duration < lease_ttl
+        return duration_valid, -capabilities.affinity_score(required, advertised)
+
+    candidates.sort(key=candidate_order)
+    # `limit` caps claim attempts, applied after duration/affinity reordering.
     candidates = candidates[:limit]
 
     # `running_keys` seeds admit()'s pass-local `claimed_keys`: a key claimed

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -266,7 +266,10 @@ class TestSpecValidationAcceptsValidFields:
 
 class TestSavePathContainment:
     def test_save_path_rejects_escape(self, tmp_path, caplog):
-        escape_path = str(Path.home().parent / "li_sec_test_escape_dir")
+        allowed_roots = (Path.cwd().resolve(), Path.home().resolve())
+        escape = Path(Path.cwd().anchor).resolve() / "li_sec_test_escape_dir"
+        assert all(not escape.is_relative_to(root) for root in allowed_roots)
+        escape_path = str(escape)
         spec_file = tmp_path / "spec.yaml"
         spec_file.write_text(
             yaml.dump({"model": "claude/opus", "prompt": "task", "save": escape_path})

--- a/tests/cli/orchestrate/test_team_lifecycle_wiring.py
+++ b/tests/cli/orchestrate/test_team_lifecycle_wiring.py
@@ -612,6 +612,94 @@ async def test_execute_dag_real_executor_wakes_alice_before_task_group_closes(tm
     assert round_result["response"] == "all clear now"
 
 
+async def test_execute_dag_team_round_communicates_matching_required_artifact_contract(tmp_path):
+    """A team wakeup stamped as a spawned round must receive the same
+    per-round artifact directive that its finalize-time contract registers.
+
+    The worker name deliberately differs from its role so both sides must
+    resolve the planned worker-to-role assignment rather than accidentally
+    relying on those names being equal.
+    """
+    team_id = "e2e-real-team-artifacts"
+    _make_team(team_id, ["orchestrator", "alice"])
+
+    env = _make_env(tmp_path)
+    env.team_data = {"id": team_id, "name": "e2e", "members": ["orchestrator", "alice"]}
+    env.messenger = _FakeMessenger()
+    # A false-y live-persist context exercises the append-only in-memory
+    # contract path without installing message-persistence hooks on the stub.
+    env._live_persist = {}
+
+    calls: list[dict] = []
+
+    async def alice_operate(**kw):
+        calls.append(kw)
+        if len(calls) == 1:
+            with team._locked_team(team_id) as data:
+                data["messages"].append(
+                    {
+                        "id": "m1",
+                        "from": "orchestrator",
+                        "to": ["alice"],
+                        "content": "please publish the report",
+                        "kind": "message",
+                        "read_by": {},
+                        "timestamp": "2026-01-01T00:00:00",
+                    }
+                )
+            team.post_done_signal(team_id, worker="alice", summary="first pass done")
+            return "first pass done"
+        team.post_done_signal(team_id, worker="alice", summary="report published")
+        return "report published"
+
+    alice_branch = _build_stub_branch(alice_operate)
+    session = Session()
+    session.default_branch = alice_branch
+    env.session = session
+
+    graph = Graph()
+    node = Operation(operation="operate", parameters={"instruction": "do the work"})
+    node.branch_id = alice_branch.id
+    graph.add_node(node)
+    env.builder.get_graph = lambda: graph
+
+    plan_result, dag_state = _plan_and_dag_real(
+        node, "alice", worker_branches={"alice": alice_branch}, messenger_bound={"alice": True}
+    )
+    dag_state.role_artifact_defaults = {
+        "researcher": {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+    }
+
+    await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0, team_max_rounds=1)
+
+    assert len(calls) == 2
+    round_context = calls[1]["context"]
+    artifact_context = [
+        entry["artifact_instructions"]
+        for entry in round_context
+        if "artifact_instructions" in entry
+    ]
+    round_dir = env.run.agent_artifact_dir("alice-round1")
+    assert artifact_context == [
+        f"Your artifact directory: {round_dir}/ — write output files here. "
+        "REQUIRED: write report.md in that directory — the run is marked failed "
+        "if it is missing at completion."
+    ]
+    assert "alice-round1" in env.expected_worker_ids
+
+    contract = env._live_persist["artifact_contract"]
+    assert contract == {
+        "expected": [
+            {
+                "id": "alice-round1__report",
+                "path": "alice-round1/report.md",
+                "required": True,
+                "source": "role_default",
+            }
+        ]
+    }
+
+
 async def test_execute_dag_real_executor_respects_team_max_rounds_bound(tmp_path):
     """Alice leaves new mail every turn; team_max_rounds=1 caps it at one
     injected round against the real executor."""

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -475,6 +475,19 @@ def test_identity_accepts_shebang_launched_li(monkeypatch: pytest.MonkeyPatch):
     assert _check_pid_identity(42, "lionagi") == "ours"
 
 
+def test_identity_accepts_macos_framework_python_launcher(monkeypatch: pytest.MonkeyPatch):
+    _mock_psutil(
+        monkeypatch,
+        cmdline=[
+            "/opt/homebrew/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/"
+            "Contents/MacOS/Python",
+            "/opt/.venv/bin/li",
+            "agent",
+        ],
+    )
+    assert _check_pid_identity(42, "lionagi") == "ours"
+
+
 def test_identity_rejects_foreign_script_with_li_in_path(monkeypatch: pytest.MonkeyPatch):
     """A non-lionagi script whose path contains 'li' must not be accepted."""
     _mock_psutil(

--- a/tests/studio/services/test_worker_admission.py
+++ b/tests/studio/services/test_worker_admission.py
@@ -185,6 +185,50 @@ async def test_concurrency_block_holds_across_a_fresh_pass_via_db_state(db: Stat
     assert (await _status_of(db, waiter_2))["status"] == "queued"
 
 
+async def test_duration_invalid_waiter_does_not_consume_cap_after_affinity_sort(
+    db: StateDB,
+) -> None:
+    holder_id = await _submit(db)
+    result = await transition(
+        db,
+        TransitionRequest(
+            entity_type="schedule_run",
+            entity_id=holder_id,
+            from_state="queued",
+            to_state="running",
+            reason=StateReason(code=RunReasons.STARTED_OK, summary="held"),
+            actor=Actor(type="system", id="test-holder"),
+            idempotency_key=f"claim:{holder_id}",
+        ),
+        patch={"leased_by": "test-holder", "lease_expires_at": None, "lease_attempts": 1},
+    )
+    assert result.applied is True
+
+    invalid_id = await _submit(
+        db,
+        args={"admission": {"max_duration_seconds": 120}},
+    )
+    valid_id = await _submit(
+        db,
+        required_capabilities=["gpu-exclusive", "warmed-cache"],
+    )
+
+    claimed = await claim_and_execute(
+        db,
+        worker_id="w1",
+        execute=_never_completes_execute,
+        advertised_capabilities=["gpu-exclusive", "warmed-cache"],
+        lease_ttl=60,
+        waiter_cap_multiplier=1,
+    )
+
+    assert claimed == 0
+    invalid_row = await _status_of(db, invalid_id)
+    assert invalid_row["status"] == "skipped"
+    assert invalid_row["status_reason_code"] == RunReasons.SKIPPED_DURATION_EXCEEDS_LEASE
+    assert (await _status_of(db, valid_id))["status"] == "queued"
+
+
 # ── 2. Claim-time rejection surfaces observably ──────────────────────────
 
 


### PR DESCRIPTION
Four small, independent fixes, each with its own test. They are grouped because each is
a handful of lines; every commit stands alone and can be dropped without affecting the
others.

## `fix(cli): recognize macOS Python launchers`

`_cmdline_is_lionagi` matched `exe.startswith("python")` case-sensitively. macOS framework
builds present argv[0] as `.../Python.app/Contents/MacOS/Python`, capital P, so a
shebang-launched `li` started by a framework interpreter was not recognized as ours and
`li kill` declined to act on its own process. One `.lower()`, plus a test pinning the real
Homebrew framework path.

## `fix(scheduler): reject invalid waiters before cap checks`

Claim-time candidates were sorted by affinity alone. A row whose declared
`max_duration_seconds` exceeds the lease can never run and is destined to be terminalized,
but until it is, it still counts as a waiter against the cap. So an affinity-preferred
valid row could be rejected by a cap consumed by a row that was already invalid.

Candidates now sort duration-valid first, then by affinity, preserving `queued_at` order
for ties within each class. The test builds exactly that arrangement and asserts the
invalid row ends `skipped` with `SKIPPED_DURATION_EXCEEDS_LEASE` while the valid row stays
`queued` rather than being wrongly rejected.

## `fix(cli): communicate team round artifact contracts` (closes #2355)

Team wakeup rounds were injected without being told the artifact contract their result
would be registered against, so the session recorded required entries the node was never
informed of. Injected rounds now receive the artifact directive before injection, and the
worker is registered as expected.

This also corrects a lookup that was silently wrong: `role_artifact_defaults` is keyed by
**role**, but the call site passed `assignee`, which is an agent id. For team-mode workers
that lookup always returned `None`. A `role_by_worker` map built from the plan's
assignments resolves the id to its role first.

## `test(cli): make save-path escape deterministic`

`TestSavePathContainment` built its supposedly-out-of-bounds path as
`Path.home().parent / ...`, which is not reliably outside the allowed roots and on some
layouts sits inside one. The test would then pass without exercising containment at all.
It now derives the path from the filesystem anchor and asserts it is outside every allowed
root before using it, so the test fails if its own premise stops holding.

## Verification

`pytest tests/cli/test_kill.py tests/studio/services/test_worker_admission.py
tests/cli/orchestrate/test_team_lifecycle_wiring.py tests/cli/orchestrate/test_security_hardening.py`
— 162 passed on CPython 3.10.15. The full matrix is CI's to confirm.

Each change was also checked against `main` by reverse-applying its patch: all four are
absent from `main`, and both underlying defects are still present there
(`startswith("python")` at `kill.py:67`; no duration-class ordering in `worker.py`).