### PR TITLE
fix(orchestrate): distinguish initial API artifact paths

### DIFF
--- a/lionagi/cli/orchestrate/_common.py
+++ b/lionagi/cli/orchestrate/_common.py
@@ -109,10 +109,20 @@ def retarget_artifact_section(
     return f"{system_text}\n\n{section}" if system_text else section
 
 
-def bare_worker_system(*, grant_spawn: bool = False, artifact_dir: str | Path | None = None) -> str:
+def bare_worker_system(
+    *,
+    grant_spawn: bool = False,
+    artifact_dir: str | Path | None = None,
+    workspace_assigned: bool = True,
+) -> str:
     from lionagi.session.prompts import LION_SYSTEM_MESSAGE
 
-    body = _BARE_WORKER_BODY.format(artifact_section=worker_artifact_section(artifact_dir))
+    body = _BARE_WORKER_BODY.format(
+        artifact_section=worker_artifact_section(
+            artifact_dir,
+            workspace_assigned=workspace_assigned,
+        )
+    )
     if grant_spawn:
         body = body.replace(_LEAF_EXECUTOR_LINE, _SPAWN_AFFORDANCE)
     return LION_SYSTEM_MESSAGE.strip() + "\n\n" + body

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -865,21 +865,17 @@ async def build_worker_branch(
         fast=w_fast,
     )
     _hand_mcp_servers(w_imodel, getattr(env, "mcp_servers", None), label=agent_id)
+    is_cli = bool(getattr(w_imodel, "is_cli", False))
     artifact_dir = env.run.agent_artifact_dir(agent_id)
     artifact_dir.mkdir(parents=True, exist_ok=True)
-    w_imodel.endpoint.config.kwargs["repo"] = artifact_dir
-    # The directory named in the worker's system prompt must be the one the
-    # worker can actually write. The file-editing tool refuses absolute paths
-    # outside the working directory, so only the cwd qualifies — read it back
-    # from the kwargs the worker is launched with rather than reusing the
-    # local, so a later change to how the cwd is chosen cannot leave the
-    # prompt naming a path the worker will be refused.
-    worker_cwd = Path(w_imodel.endpoint.config.kwargs["repo"])
-    env.worker_artifact_dirs[agent_id] = worker_cwd
-    project_root = str(Path(env.cwd).resolve()) if env.cwd else str(Path.cwd().resolve())
-    w_imodel.endpoint.config.kwargs.setdefault("add_dir", [])
-    if project_root not in w_imodel.endpoint.config.kwargs["add_dir"]:
-        w_imodel.endpoint.config.kwargs["add_dir"].append(project_root)
+    if is_cli:
+        w_imodel.endpoint.config.kwargs["repo"] = artifact_dir
+    env.worker_artifact_dirs[agent_id] = artifact_dir
+    if is_cli:
+        project_root = str(Path(env.cwd).resolve()) if env.cwd else str(Path.cwd().resolve())
+        w_imodel.endpoint.config.kwargs.setdefault("add_dir", [])
+        if project_root not in w_imodel.endpoint.config.kwargs["add_dir"]:
+            w_imodel.endpoint.config.kwargs["add_dir"].append(project_root)
 
     if explicit_name is not None:
         env.register_name(explicit_name)
@@ -892,9 +888,7 @@ async def build_worker_branch(
     # is assembled so the coordination section names the right channel.
     exchange = getattr(env, "exchange", None)
     messenger = getattr(env, "messenger", None)
-    messenger_bound = (
-        exchange is not None and messenger is not None and not getattr(w_imodel, "is_cli", False)
-    )
+    messenger_bound = exchange is not None and messenger is not None and not is_cli
 
     resolved_modes = [] if env.bare else resolve_modes(role, modes, env.pack)
     team_section = team_worker_system(
@@ -909,19 +903,26 @@ async def build_worker_branch(
     # verbatim path only when it authored a body — one that just sets a model
     # or an effort has no body to run, and leaves the role composing as usual.
     #
-    # An authored body is prose the harness did not write, so it carries no
-    # artifact directive of its own — and if it does carry one, the directory it
-    # names is whatever its author typed, not the directory this worker was
-    # launched in. Both cases are handled by retargeting: the section is
-    # appended when absent and rewritten when present, so every verbatim prompt
-    # ends up naming the cwd the worker can actually write.
+    # Retarget authored prompts so they name this worker's artifact destination.
     verbatim_system: str | None = None
     if system_prompt_override is not None:
-        verbatim_system = retarget_artifact_section(system_prompt_override, worker_cwd)
+        verbatim_system = retarget_artifact_section(
+            system_prompt_override,
+            artifact_dir,
+            workspace_assigned=is_cli,
+        )
     elif not env.bare and w_profile and w_profile.raw_body:
-        verbatim_system = retarget_artifact_section(w_profile.system_prompt, worker_cwd)
+        verbatim_system = retarget_artifact_section(
+            w_profile.system_prompt,
+            artifact_dir,
+            workspace_assigned=is_cli,
+        )
     elif env.bare or not _is_casts_role(role):
-        verbatim_system = bare_worker_system(grant_spawn=grant_spawn, artifact_dir=worker_cwd)
+        verbatim_system = bare_worker_system(
+            grant_spawn=grant_spawn,
+            artifact_dir=artifact_dir,
+            workspace_assigned=is_cli,
+        )
 
     log_config = DataLoggerConfig(auto_save_on_exit=False)
     if verbatim_system is None:
@@ -931,7 +932,10 @@ async def build_worker_branch(
         # sees `bare_worker_system`, so the artifact directive is appended here
         # too — otherwise the default (non-`--bare`) worker, which is the
         # common case, would still be told nothing about where output belongs.
-        artifact_section = worker_artifact_section(worker_cwd)
+        artifact_section = worker_artifact_section(
+            artifact_dir,
+            workspace_assigned=is_cli,
+        )
         composed_extra = (
             f"{artifact_section}\n\n{team_section}" if team_section else artifact_section
         )

--- a/tests/cli/orchestrate/test_worker_artifact_directive.py
+++ b/tests/cli/orchestrate/test_worker_artifact_directive.py
@@ -107,10 +107,19 @@ Remain concise."""
     assert "Remain concise." in retargeted
 
 
-# ── build_worker_branch names exactly the directory it launches the worker in ──
+# ── build_worker_branch names and records each worker's artifact destination ──
 
 
-def _build_worker(tmp_path, *, agent_id, role, bare=True, profile=None):
+def _build_worker(
+    tmp_path,
+    *,
+    agent_id,
+    role,
+    bare=True,
+    profile=None,
+    is_cli=True,
+    system_prompt_override=None,
+):
     """Run `build_worker_branch` with no model, no MCP, and no I/O.
 
     Returns ``(env, imodel, built)`` where ``built`` holds the kwargs the
@@ -131,9 +140,8 @@ def _build_worker(tmp_path, *, agent_id, role, bare=True, profile=None):
             self.config = SimpleNamespace(kwargs={}, provider="claude_code")
 
     class _IModel:
-        is_cli = True
-
         def __init__(self):
+            self.is_cli = is_cli
             self.endpoint = _Endpoint()
 
     imodel = _IModel()
@@ -179,7 +187,14 @@ def _build_worker(tmp_path, *, agent_id, role, bare=True, profile=None):
             lambda env, role, override: ("claude_code/sonnet", profile, None),
         )
         mp.setattr(orch, "team_worker_system", lambda *a, **k: "")
-        asyncio.run(orch.build_worker_branch(env, agent_id=agent_id, role=role))
+        asyncio.run(
+            orch.build_worker_branch(
+                env,
+                agent_id=agent_id,
+                role=role,
+                system_prompt_override=system_prompt_override,
+            )
+        )
     finally:
         mp.undo()
 
@@ -258,6 +273,60 @@ def test_a_profile_body_naming_another_directory_is_retargeted(tmp_path):
     repo = imodel.endpoint.config.kwargs["repo"]
     assert f"ARTIFACT DIRECTORY: {repo}" in built["system"]
     assert "/somewhere/the/author/chose" not in built["system"]
+
+
+@pytest.mark.parametrize(
+    ("bare", "profile", "system_prompt_override", "prompt_key"),
+    [
+        (True, None, None, "system"),
+        (False, None, None, "spec"),
+        (
+            False,
+            SimpleNamespace(
+                raw_body=True,
+                system_prompt="A profile-authored API worker.",
+                effort=None,
+                yolo=False,
+                fast_mode=False,
+                khive_injection=None,
+            ),
+            None,
+            "system",
+        ),
+        (False, None, "An explicitly configured API worker.", "system"),
+    ],
+)
+def test_initial_api_worker_paths_use_output_only_artifact_guidance(
+    tmp_path,
+    bare,
+    profile,
+    system_prompt_override,
+    prompt_key,
+):
+    """Ensure every initial API prompt treats its artifact path as output-only.
+
+    CLI-only endpoint settings must remain absent.
+    """
+    env, imodel, built = _build_worker(
+        tmp_path,
+        agent_id="api-worker",
+        role="researcher",
+        bare=bare,
+        profile=profile,
+        is_cli=False,
+        system_prompt_override=system_prompt_override,
+    )
+
+    prompt = built[prompt_key]
+    if prompt_key == "spec":
+        prompt = prompt.extra_prompt
+    artifact_dir = tmp_path / "artifacts" / "api-worker"
+    assert f"ARTIFACT DIRECTORY: {artifact_dir}" in prompt
+    assert "not an assigned working directory" in prompt
+    assert "It is your working directory" not in prompt
+    assert "repo" not in imodel.endpoint.config.kwargs
+    assert "add_dir" not in imodel.endpoint.config.kwargs
+    assert env.worker_artifact_dirs["api-worker"] == artifact_dir
 
 
 def test_a_reactively_spawned_branch_stops_naming_the_emitters_directory(tmp_path):


### PR DESCRIPTION
## Summary

- classify each initial worker once as CLI-backed or API-backed
- keep the CLI-only `repo` and `add_dir` endpoint settings off API models
- render output-only artifact guidance for API workers across bare, casts-role, profile-authored, and explicit-prompt paths

## Root cause

Initial workers unconditionally received CLI workspace settings and every prompt-construction path used the default workspace wording. API-backed workers have no subprocess working-directory contract, so their prompts described the recorded artifact destination as a workspace that was never assigned.

## Impact

Initial API workers are now told to use the recorded artifact path as an output destination without claiming it is their working directory. CLI worker behavior is unchanged.

## Verification

- `uv run pytest tests/cli/orchestrate/test_worker_artifact_directive.py tests/cli/orchestrate/test_flow_phases.py -q` — 55 passed
- independent review exercised 118 directly relevant tests — passed
- focused Ruff and pre-commit hooks — passed
- full `uv run pytest` — 16,523 passed, 8 skipped, 3 unrelated local failures:
  - the mirror-tail isolation test passed immediately with `-n0`
  - two Docling checks consistently fail while loading a malformed local SciPy Mach-O binary, before reaching project code

Fixes #2712