### PR TITLE
docs(state): what a skipped schedule_run can mean, and why its prefix does not bound it

### DIFF
--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -173,12 +173,26 @@ class ShowReasons:
 class ScheduleReasons:
     """ADR-0070 schedule-fire outcomes.
 
-    Three of these describe a fire that did not happen, and they are the whole
-    set -- a reader deciding what a skipped schedule_run can mean does not have
-    to go looking for a fourth. They are written down here because the
-    alternative is inferring the range from whatever a store happens to hold,
-    and a store is silent about a branch nothing has taken yet while that
-    silence reads as impossibility.
+    Three names here begin with ``schedule.skipped.``, and those three are
+    exactly that prefix -- but **the prefix is not the set of reasons a skipped
+    ``schedule_run`` can carry, and reading it as one is the mistake this
+    docstring exists to prevent.** Two other codes in this same class land on
+    rows whose status is ``skipped``: ``DEFERRED_CAPACITY`` and
+    ``BUDGET_EXHAUSTED``, neither of which carries the prefix. A third comes
+    from a different class entirely -- the task-admission path stamps a
+    ``schedule_run`` to ``skipped`` with the admission decision's own code,
+    falling back to ``RunReasons.SKIPPED_WAITER_CAP_EXCEEDED``.
+
+    So no enumeration here can be closed: that admission writer takes its code
+    from a decision object rather than from a literal, and the only bound
+    anywhere in the system is ``VALID_REASON_CODES``, which is the union across
+    every reason class in this module. A consumer filtering skipped rows by the
+    ``schedule.skipped.`` prefix will silently drop capacity deferrals, budget
+    exhaustion and admission rejections -- and silently is the operative word,
+    because the filter returns rows and looks like it worked.
+
+    What follows describes the three prefixed codes and is not a claim about
+    what else a skipped row may hold.
 
     ``SKIPPED_OVERLAP`` is stamped when a fire arrives while the previous run of
     the same schedule is still going.
@@ -206,6 +220,14 @@ class ScheduleReasons:
     code, so in practice it means "skipped, and the writer gave no reason". A
     consumer that treats it as evidence a precondition was checked and failed is
     reading a fallback as a finding.
+
+    One property of ``DEFERRED_CAPACITY`` belongs with these, since it is the
+    same kind of trap: those rows are **sampled, not one-per-event**. The
+    scheduler counts every deferral but writes a row only for the first and
+    every tenth after it, so that sustained saturation does not flood
+    ``schedule_runs``. Counting deferred-capacity rows therefore undercounts
+    deferrals, by up to that factor, and the row's own timestamp is the sampled
+    deferral's rather than the first one's.
     """
 
     QUEUED_CREATED = "schedule.queued.created"

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -171,7 +171,42 @@ class ShowReasons:
 
 
 class ScheduleReasons:
-    """ADR-0070 schedule-fire outcomes."""
+    """ADR-0070 schedule-fire outcomes.
+
+    Three of these describe a fire that did not happen, and they are the whole
+    set -- a reader deciding what a skipped schedule_run can mean does not have
+    to go looking for a fourth. They are written down here because the
+    alternative is inferring the range from whatever a store happens to hold,
+    and a store is silent about a branch nothing has taken yet while that
+    silence reads as impossibility.
+
+    ``SKIPPED_OVERLAP`` is stamped when a fire arrives while the previous run of
+    the same schedule is still going.
+
+    ``SKIPPED_MISSED_FIRE`` is stamped for a fire whose due instant passed while
+    the scheduler was not running, on a schedule whose missed-fire policy is not
+    to run it late. Two properties of it surprise readers, and both are
+    properties of *when the check runs* rather than of the code:
+
+    - Detection is **once per process start**, not continuous. The missed-fire
+      sweep runs in the tick loop's preamble, before the loop begins, and never
+      again for the life of the process. So a scheduler that stops and restarts
+      records its missed fires, and a scheduler that stalls while still running
+      records nothing at all -- the second case leaves no row here and no
+      failing health check either.
+    - Consequently the timestamp on such a row is bounded by time-to-restart,
+      not by the tick interval. It is closer to a restart timestamp than to a
+      detection latency, and reading it as "how long the miss took to notice"
+      overstates what it measures. A row's lateness and a fired row's lateness
+      are set by different clocks and are not comparable.
+
+    ``SKIPPED_PRECONDITION`` is the odd one and the one worth reading twice: no
+    code path evaluates a precondition and stamps it. It is the DEFAULT reason
+    attached to a ``schedule_run`` that moves to ``skipped`` without an explicit
+    code, so in practice it means "skipped, and the writer gave no reason". A
+    consumer that treats it as evidence a precondition was checked and failed is
+    reading a fallback as a finding.
+    """
 
     QUEUED_CREATED = "schedule.queued.created"
     FIRED_DUE = "schedule.fired.due"

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -223,11 +223,17 @@ class ScheduleReasons:
 
     One property of ``DEFERRED_CAPACITY`` belongs with these, since it is the
     same kind of trap: those rows are **sampled, not one-per-event**. The
-    scheduler counts every deferral but writes a row only for the first and
-    every tenth after it, so that sustained saturation does not flood
-    ``schedule_runs``. Counting deferred-capacity rows therefore undercounts
-    deferrals, by up to that factor, and the row's own timestamp is the sampled
-    deferral's rather than the first one's.
+    scheduler counts every deferral and records only the first, then one every
+    N deferrals after that, so sustained saturation does not flood
+    ``schedule_runs``.
+
+    N is a constant in the scheduler module and this docstring deliberately does
+    not repeat its value. Prose here cannot be kept honest about a number
+    defined somewhere else: it would read as current long after the number
+    changed, and nothing would fail. What holds for any N above one is the part
+    worth relying on -- counting these rows undercounts deferrals, and a row's
+    timestamp is the sampled deferral's rather than the first one's in that
+    stretch.
     """
 
     QUEUED_CREATED = "schedule.queued.created"

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -78,6 +78,29 @@ class TestReasonNamespace:
         assert ShowReasons.BLOCKED_NO_READY_PLAYS in VALID_REASON_CODES
         assert ScheduleReasons.FIRED_DUE in VALID_REASON_CODES
 
+    def test_schedule_skipped_set_is_closed_at_three(self):
+        """Keep the enumeration in the class docstring honest.
+
+        A reader deciding what a skipped schedule_run can mean is told there are
+        exactly three answers. That claim is prose, so it goes stale silently the
+        moment a fourth code is added, and the reader who trusted it treats an
+        unseen value as impossible. Deriving the set by prefix here means the
+        addition reds this test instead, and whoever adds the code updates the
+        enumeration a consumer is actually reading.
+        """
+        skipped = {
+            value
+            for name, value in vars(ScheduleReasons).items()
+            if not name.startswith("_")
+            and isinstance(value, str)
+            and value.startswith("schedule.skipped.")
+        }
+        assert skipped == {
+            ScheduleReasons.SKIPPED_PRECONDITION,
+            ScheduleReasons.SKIPPED_OVERLAP,
+            ScheduleReasons.SKIPPED_MISSED_FIRE,
+        }
+
 
 class TestValidators:
     def test_validate_reason_code_accepts_legal(self):

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -78,28 +78,51 @@ class TestReasonNamespace:
         assert ShowReasons.BLOCKED_NO_READY_PLAYS in VALID_REASON_CODES
         assert ScheduleReasons.FIRED_DUE in VALID_REASON_CODES
 
-    def test_schedule_skipped_set_is_closed_at_three(self):
-        """Keep the enumeration in the class docstring honest.
+    def test_schedule_skipped_prefix_holds_exactly_three_codes(self):
+        """Pin the ``schedule.skipped.`` namespace, and only that.
 
-        A reader deciding what a skipped schedule_run can mean is told there are
-        exactly three answers. That claim is prose, so it goes stale silently the
-        moment a fourth code is added, and the reader who trusted it treats an
-        unseen value as impossible. Deriving the set by prefix here means the
-        addition reds this test instead, and whoever adds the code updates the
-        enumeration a consumer is actually reading.
+        This guards a claim about the PREFIX. It is deliberately not a claim
+        about which reasons a skipped ``schedule_run`` can carry -- see the
+        companion test below for why that set cannot be closed here.
         """
-        skipped = {
+        prefixed = {
             value
             for name, value in vars(ScheduleReasons).items()
             if not name.startswith("_")
             and isinstance(value, str)
             and value.startswith("schedule.skipped.")
         }
-        assert skipped == {
+        assert prefixed == {
             ScheduleReasons.SKIPPED_PRECONDITION,
             ScheduleReasons.SKIPPED_OVERLAP,
             ScheduleReasons.SKIPPED_MISSED_FIRE,
         }
+
+    def test_skipped_schedule_runs_carry_codes_outside_the_skipped_prefix(self):
+        """Guard the trap, because the prefix reads like the whole answer.
+
+        Filtering skipped ``schedule_run`` rows by the ``schedule.skipped.``
+        prefix loses rows, and loses them quietly: capacity deferrals and budget
+        exhaustion are stamped from this class without the prefix, and the
+        task-admission path stamps a schedule_run from ``RunReasons`` entirely.
+        The class docstring warns about exactly this, and prose goes stale in
+        silence.
+
+        Asserting the negative is the point. If someone renames these into the
+        prefix, or drops the cross-class writer, this test reds and whoever did
+        it has to correct the warning a consumer is relying on.
+        """
+        for code in (ScheduleReasons.DEFERRED_CAPACITY, ScheduleReasons.BUDGET_EXHAUSTED):
+            assert not code.startswith("schedule.skipped."), (
+                f"{code!r} moved into the skipped prefix -- the class docstring's warning "
+                "about prefix filtering is now wrong and must be updated"
+            )
+            assert code in VALID_REASON_CODES
+
+        # A reason from another class reaches a skipped schedule_run, so no
+        # enumeration drawn from ScheduleReasons alone can be complete.
+        assert RunReasons.SKIPPED_WAITER_CAP_EXCEEDED.startswith("run.")
+        assert RunReasons.SKIPPED_WAITER_CAP_EXCEEDED in VALID_REASON_CODES
 
 
 class TestValidators:


### PR DESCRIPTION
## Summary

A consumer deciding what a skipped `schedule_run` can mean had to infer the range from whatever a store happened to hold, and a store is silent about a branch nothing has taken yet while that silence reads as impossibility. This documents that range in `ScheduleReasons`, and the important part is what it does **not** claim.

Three codes in that class begin with `schedule.skipped.`, and those three are exactly that prefix. **The prefix is not the set of reasons a skipped `schedule_run` can carry.** Two other codes in the same class land on rows whose status is `skipped` without carrying the prefix, `schedule.deferred.capacity` and `schedule.budget.exhausted`, and a third comes from a different class entirely: the task-admission path stamps a `schedule_run` to `skipped` with the admission decision's own code, falling back to a `run.*` value.

So no enumeration in that docstring can be closed. The admission writer takes its code from a decision object rather than from a literal, and the only bound anywhere is `VALID_REASON_CODES`, the union across every reason class in the module. A consumer filtering skipped rows by the `schedule.skipped.` prefix drops capacity deferrals, budget exhaustion and admission rejections. It drops them silently, which is the operative word, because the filter returns rows and looks like it worked.

## What else the docstring now says

`SKIPPED_OVERLAP` is stamped when a fire arrives while the previous run of the same schedule is still going.

Two properties of `SKIPPED_MISSED_FIRE` belong to *when the check runs* rather than to the code:

- Detection is once per process start, in the tick loop's preamble, not on every tick. A scheduler that stops and restarts records its missed fires; one that stalls while still running records nothing here and fails no health check either.
- The timestamp is therefore bounded by time-to-restart, not by the tick interval. It is closer to a restart timestamp than to a detection latency, and a skipped row's lateness is not comparable with a fired row's.

`SKIPPED_PRECONDITION` is documented as what it is: no code path evaluates a precondition and stamps it. It is the default reason for a `schedule_run` that reaches `skipped` without an explicit code, so it means the writer gave no reason. Reading it as a failed precondition reads a fallback as a finding.

`DEFERRED_CAPACITY` rows are sampled rather than one per event: the scheduler counts every deferral and records only the first, then one every N deferrals after that.

The docstring names that mechanism and deliberately **does not** restate N, which is a constant in the scheduler module. Prose here cannot be kept honest about a number defined in another module: it would read as current long after the number changed, and nothing would fail. What is kept is what holds for any N above one: counting those rows undercounts deferrals, and a row's timestamp is the sampled deferral's rather than the first one's in that stretch.

## Tests

The guard is split in two, because the two claims are different sizes.

- One pins the `schedule.skipped.` namespace and says in its name that it is a claim about the prefix.
- The other asserts the negative the warning rests on: that the capacity and budget codes sit outside the prefix, and that a `run.*` code reaches a skipped `schedule_run`. Renaming those into the prefix reds the suite instead of quietly making the warning wrong.

Both were mutation-checked: moving `schedule.deferred.capacity` into the `schedule.skipped.` prefix fails both of them, and the file is restored byte-identical afterwards.

`tests/state/test_status_reasons.py` — 58 tests, 0 failures, 0 errors, 0 skips, counts read from the JUnit record rather than from the output tail.

The wider `tests/state/` run shows 873 tests with 4 failures in `test_state_db_url_guards.py`. Those are absent from this change: the identical four fail in a tree without it, on `ModuleNotFoundError: No module named 'fastapi'`, which is a missing local extra rather than a code defect. Local evidence here does not cover any path that needs that extra; CI's matrix is what covers it.

