### PR TITLE
fix(mcp): a spawn that never resolved is no longer reported as still running

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -187,11 +187,19 @@ WAIT_MAX_POLL_SECONDS = 60.0
 
 # How long a spawn may sit unresolved before wait() stops holding its window open.
 # This is a polling decision, not a verdict: nothing here terminalises a run, and
-# the classifier's refusal to resolve such a record stands untouched. It is not a
-# parameter because a caller who wants a different number no longer needs one —
-# every wait entry now carries the spawn phase and the submission time, so the
-# caller can draw its own line from the same two facts this constant is drawn from.
-UNRESOLVED_SPAWN_AFTER_SECONDS = 600.0
+# the classifier's refusal to resolve such a record stands untouched.
+#
+# The number is WAIT_MAX_SECONDS, and that is the whole derivation rather than a
+# coincidence: a spawn that has not resolved in the time one maximum-length wait
+# could span is not going to resolve inside any single caller's window, so holding
+# a window open for it cannot pay off however long the caller waits. Anything
+# shorter would start reporting spawns that a caller could still have waited out.
+#
+# Not a parameter, because a caller wanting a different line no longer needs one —
+# every entry now carries the spawn phase and the submission time, which are the
+# two facts this constant is drawn from, so a caller can draw its own from the same
+# inputs without this function having to guess whose line to hold.
+UNRESOLVED_SPAWN_AFTER_SECONDS = WAIT_MAX_SECONDS
 
 # The terminal hook module, invoked by the CLI's --notify by absolute
 # interpreter path so it runs regardless of PATH in the CLI's environment.
@@ -3241,6 +3249,24 @@ async def wait(
     exactly as it always was. ``all_terminal`` stays false while any id is here,
     for the same reason it does for ``stopped_without_end``: a run this cannot
     account for is not a completed one.
+
+    That bucket changes what ``timed_out`` means for the ids in it, and the change
+    is not conservative, so it is stated rather than left to be discovered. These
+    ids leave ``pending``, and ``timed_out`` is ``pending`` being non-empty, so it
+    goes false for them — including for a spawn that is genuinely slow rather than
+    dead, which is exactly the case no bound on the record can tell apart from a
+    dead one. A caller reading ``timed_out`` alone would take such a run for one
+    that is no longer outstanding.
+
+    ``all_terminal`` is the field that does not move: it stays false, because the
+    run has no recorded end. So the reading is the triple, not any one field —
+    ``unresolved_spawn`` non-empty with ``timed_out`` false and ``all_terminal``
+    false says *this is not worth waiting on and it is not finished either, go and
+    look at it*. That is a different instruction from ``timed_out`` true, which
+    says keep waiting, and from ``all_terminal`` true, which says stop. Looking
+    means the two facts each entry now carries, ``spawn_state`` and
+    ``submitted_at``, plus whatever the machine says about the process; this
+    function deliberately does not decide it.
 
     Observing does not touch the run. This function only reads: a wait that
     expires, or whose caller cancels or disconnects, leaves the durable record

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -189,11 +189,23 @@ WAIT_MAX_POLL_SECONDS = 60.0
 # This is a polling decision, not a verdict: nothing here terminalises a run, and
 # the classifier's refusal to resolve such a record stands untouched.
 #
-# The number is WAIT_MAX_SECONDS, and that is the whole derivation rather than a
-# coincidence: a spawn that has not resolved in the time one maximum-length wait
-# could span is not going to resolve inside any single caller's window, so holding
-# a window open for it cannot pay off however long the caller waits. Anything
-# shorter would start reporting spawns that a caller could still have waited out.
+# The number is WAIT_MAX_SECONDS, and it is a defensible default rather than a
+# derivation. The distinction is worth the words, because calling it a derivation
+# tells a later reader the question is closed.
+#
+# What it can be argued from is one property, and only in the backward direction the
+# measurement actually supports: past this line, a caller who had waited since the
+# run was submitted would already have spent a full maximum window, so the bucket
+# never speaks about a spawn nobody could have waited out yet. That is a floor on
+# when this may report, not a claim about whether the spawn will resolve.
+#
+# What it cannot be argued from is the forward direction. A record aged exactly this
+# long may still resolve a second later, and that is true of any threshold whatever,
+# so no value distinguishes itself by "anything shorter would report spawns a caller
+# could still have waited out" — that holds here too. Choosing the longest window
+# this function will honour is a bet that a spawn which has outlived one is likelier
+# stuck than slow. It is a bet, and it is labelled one so that the next person to
+# question the number is questioning a choice rather than arguing with arithmetic.
 #
 # Not a parameter, because a caller wanting a different line no longer needs one —
 # every entry now carries the spawn phase and the submission time, which are the
@@ -3249,6 +3261,19 @@ async def wait(
     exactly as it always was. ``all_terminal`` stays false while any id is here,
     for the same reason it does for ``stopped_without_end``: a run this cannot
     account for is not a completed one.
+
+    One population can never reach this bucket, and it is named here because it
+    looks like an oversight to anyone who notices it. The age is drawn from
+    ``submitted_at``, and a missing or unreadable stamp is read as *no evidence*
+    rather than as evidence of being old — so the records certain to be older than
+    any threshold are exactly the records that can never enter the bucket. That is
+    deliberate twice over. Such a record carries no usable spawn phase either, so
+    the phase test excludes it before the age test is reached; and reading an absent
+    stamp as age would resolve a row by a fact nobody recorded. It also cannot arise
+    from anything this module writes today: ``submitted_at`` and the opening
+    ``spawn_state`` are set in the same record literal and published by one atomic
+    write, so no run this code submits can hold ``"preparing"`` without a stamp. The
+    population is the pre-field one, and it keeps the behaviour it has always had.
 
     That bucket changes what ``timed_out`` means for the ids in it, and the change
     is not conservative, so it is stated rather than left to be discovered. These

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -185,6 +185,14 @@ WAIT_MAX_SECONDS = 600.0
 WAIT_MIN_POLL_SECONDS = 0.05
 WAIT_MAX_POLL_SECONDS = 60.0
 
+# How long a spawn may sit unresolved before wait() stops holding its window open.
+# This is a polling decision, not a verdict: nothing here terminalises a run, and
+# the classifier's refusal to resolve such a record stands untouched. It is not a
+# parameter because a caller who wants a different number no longer needs one —
+# every wait entry now carries the spawn phase and the submission time, so the
+# caller can draw its own line from the same two facts this constant is drawn from.
+UNRESOLVED_SPAWN_AFTER_SECONDS = 600.0
+
 # The terminal hook module, invoked by the CLI's --notify by absolute
 # interpreter path so it runs regardless of PATH in the CLI's environment.
 _NOTIFY_MODULE = "lionagi.mcp._notify_hook"
@@ -3060,6 +3068,27 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
     return out
 
 
+def _unresolved_spawn_age(submitted_at: Any) -> float | None:
+    """Seconds since *submitted_at*, or ``None`` when that cannot be established.
+
+    ``None`` is the answer both for a record naming no submission time — one
+    written before the field existed — and for a timestamp that does not parse.
+    Neither is read as an old row. The bucket this feeds says waiting has stopped
+    being useful, and an unreadable timestamp is no evidence for that; treating it
+    as one would resolve a record by the absence of a fact rather than by a fact.
+    """
+    if not isinstance(submitted_at, str) or not submitted_at.strip():
+        return None
+    try:
+        stamped = datetime.fromisoformat(submitted_at)
+    except ValueError:
+        return None
+    if stamped.tzinfo is None:
+        # A stamp written without an offset is this writer's own UTC.
+        stamped = stamped.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - stamped).total_seconds()
+
+
 def _wait_entry(run_id: Any) -> dict[str, Any]:
     """One observation of *run_id*, resolved through the same path ``status`` uses.
 
@@ -3067,6 +3096,14 @@ def _wait_entry(run_id: Any) -> dict[str, Any]:
     rather than raising, so one bad id never costs the caller the ids beside it.
     Every entry carries the full lifecycle shape, error or not, so a caller reads
     the same keys in both cases.
+
+    ``spawn_state`` and ``submitted_at`` are part of that shape. The listing verb
+    already carries both, and its reasoning applies here with more force: this is
+    the surface a caller polls to decide whether to keep waiting, and without the
+    spawn phase a run that never started is indistinguishable in it from one doing
+    work. Reading them here is what lets a caller — or the bucketing below — tell
+    those apart without asking the classifier to resolve what it correctly refuses
+    to resolve.
 
     An id with no record is ``not_found``; an id whose record is present and
     unusable is ``record_unusable``, and says which way it is unusable. They are
@@ -3083,6 +3120,8 @@ def _wait_entry(run_id: Any) -> dict[str, Any]:
         "outcome": None,
         "reason_code": None,
         "possibly_orphaned": False,
+        "spawn_state": None,
+        "submitted_at": None,
         "error": None,
     }
     if not isinstance(run_id, str) or not run_id.strip():
@@ -3109,6 +3148,8 @@ def _wait_entry(run_id: Any) -> dict[str, Any]:
             "outcome": st["outcome"],
             "reason_code": st["reason_code"],
             "possibly_orphaned": st["possibly_orphaned"],
+            "spawn_state": st["spawn_state"],
+            "submitted_at": st["submitted_at"],
         }
     )
     return entry
@@ -3133,9 +3174,10 @@ async def wait(
 
     A bounded observation, not a subscription. It returns one entry per requested
     id, in the order they were requested, plus ``all_terminal``, ``timed_out``,
-    the ids still ``pending`` and the ids ``stopped_without_end`` — never a bare
-    boolean, because mixed outcomes are the normal case and collapsing them forces
-    the follow-up poll this call exists to replace.
+    the ids still ``pending``, the ids ``stopped_without_end`` and the ids whose
+    spawn is ``unresolved_spawn`` — never a bare boolean, because mixed outcomes
+    are the normal case and collapsing them forces the follow-up poll this call
+    exists to replace.
 
     ``max_wait`` is clamped to ``[0, WAIT_MAX_SECONDS]`` and ``poll_interval`` to
     ``[WAIT_MIN_POLL_SECONDS, WAIT_MAX_POLL_SECONDS]``; the effective values are
@@ -3181,6 +3223,25 @@ async def wait(
     can enforce it once for every client, while a documented duty to back off is
     satisfied only by the clients that read it.
 
+    ``unresolved_spawn`` is the third thing waiting cannot fix, and it was
+    previously indistinguishable from the first. A record whose spawn phase is
+    still ``"preparing"`` names a spawn that was never attempted or whose result
+    was never written, and the classifier deliberately makes no claim about its
+    fate, because no bound on the record can tell a loaded machine from a dead
+    spawn. That refusal is right and nothing here disturbs it. But such a record
+    was landing in ``pending``, which set ``timed_out`` for a run that may never
+    have started, so a caller looping until ``all_terminal`` polled it until the
+    window closed and then did so again.
+
+    Past ``unresolved_spawn_after`` — echoed in the result, so the number is read
+    rather than assumed — those ids are reported here instead. This is a decision
+    about whether to hold a window open, not about how the run ended: no outcome
+    is written, ``terminal`` stays false, the durable record is untouched, and a
+    spawn that does resolve afterwards is classified by the next observation
+    exactly as it always was. ``all_terminal`` stays false while any id is here,
+    for the same reason it does for ``stopped_without_end``: a run this cannot
+    account for is not a completed one.
+
     Observing does not touch the run. This function only reads: a wait that
     expires, or whose caller cancels or disconnects, leaves the durable record
     exactly as it was — cancelling an observation is not cancelling the work.
@@ -3197,13 +3258,34 @@ async def wait(
     entries: list[dict[str, Any]] = []
     pending: list[str] = []
     stopped: list[str] = []
+    unresolved: list[str] = []
     waited = False
     while True:
         entries = [_wait_entry(rid) for rid in ordered]
         observed = [e for e in entries if e["error"] is None]
         stopped = [e["run_id"] for e in observed if e["possibly_orphaned"]]
+        # A spawn still in its opening phase past the bound above. Keyed on the
+        # phase equalling `"preparing"` rather than on it differing from it: a
+        # record written before the field existed carries null, which means "no
+        # phase this can vouch for" and never "never attempted", so a not-equal
+        # test would sweep every such record into a bucket that claims the
+        # opposite of what is known about it.
+        unresolved = [
+            e["run_id"]
+            for e in observed
+            if not e["terminal"]
+            and not e["possibly_orphaned"]
+            and e["spawn_state"] == "preparing"
+            and (age := _unresolved_spawn_age(e["submitted_at"])) is not None
+            and age >= UNRESOLVED_SPAWN_AFTER_SECONDS
+        ]
+        unresolved_ids = set(unresolved)
         pending = [
-            e["run_id"] for e in observed if not e["terminal"] and not e["possibly_orphaned"]
+            e["run_id"]
+            for e in observed
+            if not e["terminal"]
+            and not e["possibly_orphaned"]
+            and e["run_id"] not in unresolved_ids
         ]
         remaining = deadline - anyio.current_time()
         if remaining <= 0:
@@ -3211,8 +3293,9 @@ async def wait(
         # Nothing left worth waiting for. Return now unless the only unresolved
         # ids stopped without an end and this call has not waited at all — that
         # is the shape a loop-until-all_terminal caller repeats as fast as it can
-        # ask, so the floor is spent here rather than left to every client.
-        if not pending and (waited or not stopped):
+        # ask, so the floor is spent here rather than left to every client. An
+        # unresolved spawn earns the same floor for the same reason.
+        if not pending and (waited or not (stopped or unresolved)):
             break
         waited = True
         await anyio.sleep(min(eff_poll, remaining))
@@ -3220,10 +3303,12 @@ async def wait(
     errored = any(e["error"] is not None for e in entries)
     return {
         "runs": entries,
-        "all_terminal": not pending and not errored and not stopped,
+        "all_terminal": not pending and not errored and not stopped and not unresolved,
         "timed_out": bool(pending),
         "pending": pending,
         "stopped_without_end": stopped,
+        "unresolved_spawn": unresolved,
+        "unresolved_spawn_after": UNRESOLVED_SPAWN_AFTER_SECONDS,
         "max_wait": eff_max,
         "poll_interval": eff_poll,
         "requested_max_wait": max_wait,

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -689,3 +689,117 @@ def test_a_switch_looking_query_reaches_the_child_as_a_positional(spawned):
     from lionagi.cli import machine
 
     assert not machine.has_machine_flag(argv[1:])
+
+
+# --- an unresolved spawn is not something waiting can fix -----------------------
+
+
+async def test_wait_reports_an_aged_preparing_spawn_as_unresolved_not_pending(sandbox, monkeypatch):
+    """A spawn that never resolved leaves ``pending``, so ``timed_out`` stops lying.
+
+    Such a record was reported as pending with ``timed_out`` set, which is the same
+    shape a live run presents, so a caller waiting for it waited for as long as it
+    kept asking. Nothing about the record changes here: no end is written, it stays
+    non-terminal, and the classifier's refusal to judge the spawn's fate is intact.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = jobs.new_run_id()
+    _record(rid, pid=None, spawn_state="preparing")  # submitted_at defaults to 2026-07-25
+
+    res = await jobs.wait([rid], max_wait=0, poll_interval=1)
+
+    assert res["unresolved_spawn"] == [rid]
+    assert res["pending"] == []
+    assert res["timed_out"] is False
+    assert res["all_terminal"] is False  # a run this cannot account for is not done
+    assert res["unresolved_spawn_after"] == jobs.UNRESOLVED_SPAWN_AFTER_SECONDS
+    assert res["runs"][0]["terminal"] is False
+    assert res["runs"][0]["outcome"] is None
+    assert res["runs"][0]["possibly_orphaned"] is False
+
+
+async def test_wait_keeps_a_freshly_submitted_preparing_spawn_pending(sandbox, monkeypatch):
+    """The guard against a bucket that would swallow every submission.
+
+    ``preparing`` is a legitimate phase for as long as a spawn legitimately takes,
+    and it does advance. A record derived flag with no age in it would report every
+    fresh submit as unresolved, which is why the age is what decides and why this
+    test exists rather than only its aged twin.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = jobs.new_run_id()
+    _record(rid, pid=None, spawn_state="preparing", submitted_at=jobs._now_iso())
+
+    res = await jobs.wait([rid], max_wait=0, poll_interval=1)
+
+    assert res["unresolved_spawn"] == []
+    assert res["pending"] == [rid]
+    assert res["timed_out"] is True
+
+
+async def test_wait_does_not_read_a_null_spawn_phase_as_never_attempted(sandbox, monkeypatch):
+    """Null means "no phase this can vouch for", never "never attempted".
+
+    A record written before the phase field existed carries null, and the phase that
+    does mean never-attempted says ``preparing`` explicitly. So the bucket is keyed
+    on equality with ``preparing`` and not on difference from it; the natural
+    inverted form would sweep every pre-field record into a bucket asserting the
+    opposite of what is known about it.
+
+    Both records here are LIVE, which is what makes the test discriminating rather
+    than merely true. A pid-less record cannot reach the phase test at all — it is
+    excluded one condition earlier as an orphan — so it would pass under the
+    inverted form too and prove nothing. A running process is the case the inversion
+    actually damages: it would report every live run as an unresolved spawn.
+    """
+    _live_process(monkeypatch)
+    no_phase = jobs.new_run_id()
+    _record(no_phase, pid=4242, spawn_state=None)  # written before the field existed
+    started = jobs.new_run_id()
+    _record(started, pid=4242, spawn_state="started")
+
+    res = await jobs.wait([no_phase, started], max_wait=0, poll_interval=1)
+
+    assert res["unresolved_spawn"] == []
+    assert res["pending"] == [no_phase, started]
+    assert res["timed_out"] is True
+    assert res["runs"][0]["spawn_state"] is None
+    assert res["runs"][1]["spawn_state"] == "started"
+
+
+async def test_wait_does_not_collapse_an_orphan_into_an_unresolved_spawn(sandbox, monkeypatch):
+    """The two non-terminal buckets stay distinct, because they are different news.
+
+    ``possibly_orphaned`` presupposes a pid that existed and is now unaskable; an
+    unresolved spawn never acquired one. Collapsing them would give one field two
+    structurally different meanings, and an operator sent to look for a process that
+    was never started is sent to look for nothing.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    orphan = jobs.new_run_id()
+    _record(orphan, pid="999999")  # a pid the OS cannot even be asked about
+
+    res = await jobs.wait([orphan], max_wait=0, poll_interval=1)
+
+    assert res["stopped_without_end"] == [orphan]
+    assert res["unresolved_spawn"] == []
+    assert res["runs"][0]["possibly_orphaned"] is True
+
+
+async def test_wait_and_list_agree_on_the_spawn_phase(sandbox, monkeypatch):
+    """The two observation surfaces report the same phase for the same record.
+
+    Asserted between the surfaces rather than against a literal on each: a literal
+    would let both drift together, and the defect this closes was precisely the two
+    surfaces disagreeing about which facts a caller gets.
+    """
+    monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+    rid = jobs.new_run_id()
+    _record(rid, pid=None, spawn_state="preparing")
+
+    waited = await jobs.wait([rid], max_wait=0, poll_interval=1)
+    listed = [row for row in jobs.list_jobs() if row["run_id"] == rid]
+
+    assert len(listed) == 1
+    assert waited["runs"][0]["spawn_state"] == listed[0]["spawn_state"]
+    assert waited["runs"][0]["submitted_at"] == listed[0]["submitted_at"]

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -807,3 +807,65 @@ async def test_wait_and_list_agree_on_the_spawn_phase(sandbox, monkeypatch):
     assert len(listed) == 1
     assert waited["runs"][0]["spawn_state"] == listed[0]["spawn_state"]
     assert waited["runs"][0]["submitted_at"] == listed[0]["submitted_at"]
+
+
+async def test_a_spawn_that_starts_between_observations_returns_to_pending(sandbox, monkeypatch):
+    """The bucket is a reading of the current record, never a latch.
+
+    This is what makes the bucket safe to put a live-but-slow spawn in: the row
+    leaves it the moment its phase advances, so the cost of a wrong guess is one
+    poll interval rather than a run written off. The claim is asserted across two
+    observations inside ONE wait, not across two calls — two calls would pass even
+    if a latch survived for the length of a call, which is exactly where a cache
+    would sit.
+
+    Both the clock and the sleep are driven rather than waited on. A wall-clock
+    version would either sleep for real or race its own deadline, and a flaky test
+    for a stickiness property is worse than no test: it fails for reasons unrelated
+    to stickiness and gets muted.
+
+    The pid moves with the phase, and it has to: a record claiming ``started`` with
+    no pid is not a running run to the classifier, it is an orphan, so a fixture
+    that only advanced the phase would be asserting a transition into a state it
+    cannot represent. Liveness is answered per-pid rather than by a flat ``False``
+    for the same reason — the source state needs a dead probe and the destination
+    state needs a live one, inside one test.
+    """
+    import anyio
+
+    live_pid = 4242
+    _live_process(monkeypatch, alive=lambda pid: pid == live_pid)
+    rid = jobs.new_run_id()
+    _record(rid, pid=None, spawn_state="preparing")
+
+    # First establish the row really is in the new bucket, so what follows is a
+    # transition OUT of it rather than a row that was never in it. Without this the
+    # test would pass against a build where the bucket never captured anything.
+    before = await jobs.wait([rid], max_wait=0, poll_interval=1)
+    assert before["unresolved_spawn"] == [rid]
+    assert before["pending"] == []
+
+    clock = {"t": 1_000.0}
+    seen: list[str | None] = []
+
+    async def flip_after_the_first_observation(delay):
+        clock["t"] += delay
+        # The phase the loop was looking at when it decided to keep waiting,
+        # captured before this sleep changes anything.
+        seen.append(jobs._wait_entry(rid)["spawn_state"])
+        if len(seen) == 1:
+            _record(rid, pid=live_pid, spawn_state="started")
+
+    monkeypatch.setattr(anyio, "current_time", lambda: clock["t"])
+    monkeypatch.setattr(anyio, "sleep", flip_after_the_first_observation)
+
+    res = await jobs.wait([rid], max_wait=2, poll_interval=1)
+
+    # The two observations the single call actually made, in order.
+    assert seen == ["preparing", "started"]
+    assert res["unresolved_spawn"] == []
+    assert res["pending"] == [rid]
+    # And the triple reads as "keep waiting" again, which is the point: the row is
+    # back to being something waiting can resolve.
+    assert res["timed_out"] is True
+    assert res["all_terminal"] is False

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -708,8 +708,12 @@ async def test_wait_reports_an_aged_preparing_spawn_as_unresolved_not_pending(sa
 
     res = await jobs.wait([rid], max_wait=0, poll_interval=1)
 
+    # Every top-level field that can move for this row class, asserted together.
+    # The derived ones are the point: timed_out is pending being non-empty, so it
+    # cannot be checked by inspecting pending and reasoning about it.
     assert res["unresolved_spawn"] == [rid]
     assert res["pending"] == []
+    assert res["stopped_without_end"] == []
     assert res["timed_out"] is False
     assert res["all_terminal"] is False  # a run this cannot account for is not done
     assert res["unresolved_spawn_after"] == jobs.UNRESOLVED_SPAWN_AFTER_SECONDS


### PR DESCRIPTION
## What was wrong

A job record whose spawn phase is still `preparing` names a spawn that was never attempted, or whose result was never written. The classifier deliberately makes no claim about its fate, because no bound on the record can tell a loaded machine from a dead spawn. That refusal is correct and this change does not touch it.

`wait()` had only two non-terminal buckets, so such a record landed in `pending` and set `timed_out` — the same shape a live run presents. A caller looping until `all_terminal` polled it until the window closed, then did so again. One record had been in that state for five days.

## Why the fix is a propagation, not a new state

The listing verb already carries the spawn phase and the submission time, and its own docstring says why: without the phase, "a run that never started is indistinguishable in it from one doing work — same word, two facts." The wait entry carried neither, while its docstring claimed it carries "the full lifecycle shape."

So the missing thing was an observable, not a verdict. The entry now carries `spawn_state` and `submitted_at`, sourced from the same payload it already read.

## The bucket

Past `unresolved_spawn_after`, echoed in the result so the number is read rather than assumed, those ids are reported in `unresolved_spawn` instead of `pending`. That is a decision about whether to hold a window open, not about how a run ended: no outcome is written, `terminal` stays false, the durable record is untouched, and a spawn that resolves later classifies on the next observation exactly as before. `all_terminal` stays false while any id sits there, for the same reason it does for a run that stopped without an end.

The threshold is a module constant rather than a parameter, because a caller wanting a different line no longer needs one — the two facts it is drawn from are now in every entry.

## The trap inside the fix

Keyed on the phase **equalling** `preparing`, not differing from it. A record written before the field existed carries null, which means "no phase this can vouch for" and never "never attempted". The inverted form would report every live run as an unresolved spawn, which is what one of the tests below pins.

`possibly_orphaned` is deliberately not reused: it presupposes a pid that existed and is now unaskable, while this state never acquired one.

## Compatibility, scoped — the two surfaces do not move together

**The entry dict** is additive: keys added, none removed, and `terminal` / `possibly_orphaned` unchanged for every record.

**The top level is not unchanged, and the change is not conservative.** These ids leave `pending`, and `timed_out` is `pending` being non-empty, so `timed_out` goes **false** for them — including for a spawn that is genuinely slow rather than dead, which is exactly the case no bound on the record can tell apart from a dead one. A caller reading `timed_out` alone would take such a run for one that is no longer outstanding.

`all_terminal` is the field that does not move: it stays false, because the run has no recorded end. So the reading is the triple rather than any single field — `unresolved_spawn` non-empty with `timed_out` false and `all_terminal` false says the run is not worth waiting on and is not finished either. That is distinct from `timed_out` true, which says keep waiting, and from `all_terminal` true, which says stop.

## Tests

Six added, each mutation-checked so the assertion reddens when the change is reverted:

- an aged `preparing` record leaves `pending` for `unresolved_spawn`, with `timed_out` false and `all_terminal` false
- a freshly submitted `preparing` record stays `pending` — the guard against a bucket that would swallow every submission
- two **live** records, one with a null phase and one `started`, stay out of the bucket; live records are used because a pid-less record is excluded one condition earlier and so cannot discriminate on the phase test at all
- an unaskable-pid record stays in `stopped_without_end` and out of the new bucket, pinning that the two are not collapsed
- the wait and listing surfaces agree on the phase and the submission time, asserted between the surfaces rather than against a literal on each
- a record that enters `unresolved_spawn` at one observation and whose phase advances before the next returns to `pending` — asserted across two observations **inside a single call**, since a version that flipped the record between two calls would pass even if the classification latched for the length of a call

`tests/mcp/test_wait_and_spawn.py` is 37 passed, read from the junit record and the process exit code rather than from console output.

Three other files in `tests/mcp` fail in this working environment — `test_stdio_transport.py`, `test_catalog_sufficiency.py`, `test_schedule_verbs.py` — because the `mcp` extra is not installed there (`ModuleNotFoundError: fastmcp`). Running those three files with the failure cap raised gives 45 collected, 7 failures and 8 errors, and the **identical set of 15** at this branch and at the base commit, with nothing appearing only on the branch. That also means this environment exercises none of the MCP wire surface, so the coverage claim for it rests on CI rather than on any local run.
