### PR TITLE
fix(studio): hold declarative command args to their own field's contract

### DIFF
--- a/lionagi/studio/services/schedule_declaration.py
+++ b/lionagi/studio/services/schedule_declaration.py
@@ -493,12 +493,22 @@ def _resolve_command_target(target: CommandTarget) -> dict[str, Any]:
     from lionagi.studio.scheduler.subprocess import (
         _validate_action_command,
         _validate_command_allowlisted,
-        _validate_extra_args,
     )
+    from lionagi.studio.services.schedules import _svc_validate_command_args
 
     _validate_action_command(target.executable)
     _validate_command_allowlisted(target.executable)
-    _validate_extra_args(target.args)
+    # These args are persisted as ``action_command_args``, so they are held to
+    # that field's contract and not to ``action_extra_args``'. A command launch
+    # spawns the executable directly and never accepts action_extra_args at all,
+    # so the leading-'-' rejection that field carries does not apply here: a
+    # literal ``--repo`` is author-written, which is the point of a command
+    # runner. Flag safety for a ``{{var}}`` element is enforced against the
+    # rendered value at fire time, where a trigger-supplied value could actually
+    # inject one. Calling the same check the imperative create path calls is
+    # deliberate — the two used different validators for this one field, and
+    # nothing failed when they diverged.
+    _svc_validate_command_args(list(target.args))
     return {"kind": "command", "executable": target.executable, "args": list(target.args)}
 
 

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -1235,3 +1235,200 @@ async def test_dry_run_plan_never_writes(temp_db_path, agent_profile):
         assert [(e.qualified_name, e.action) for e in plan] == [("demo/nightly", "CREATE")]
         rows = await db.list_schedules()
         assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Command-target args: both create paths write action_command_args, so both
+# must hold it to the same contract
+# ---------------------------------------------------------------------------
+
+
+def _command_manifest(args_yaml: str, cwd: Path) -> str:
+    return f"""
+apiVersion: lionagi.io/v1alpha1
+kind: ScheduleSet
+metadata:
+  name: automation
+  project: demo
+schedules:
+  m:
+    trigger:
+      every: 1h
+    target:
+      kind: command
+      executable: refresh-index
+      args:
+{args_yaml}
+    execution:
+      cwd: {cwd}
+"""
+
+
+def test_declarative_command_target_accepts_author_written_flags(tmp_path, monkeypatch):
+    """A command runner whose args may not start with '-' cannot express a command.
+
+    Nearly every real command line carries a flag, so rejecting them left
+    ``kind: command`` unable to say what it exists to say. The args land in
+    ``action_command_args``, whose contract permits author-written flags; the
+    field that forbids them is ``action_extra_args``, which a command launch
+    never uses.
+    """
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
+    manifest = _command_manifest(
+        '        - "run"\n'
+        '        - "--no-project"\n'
+        '        - "python"\n'
+        '        - "worker.py"\n'
+        '        - "--repo"\n'
+        '        - "owner/name"\n',
+        tmp_path,
+    )
+    resolved = resolve_schedule_set(parse_schedule_set(manifest), tmp_path)
+    assert resolved["m"].db_fields["action_command_args"] == [
+        "run",
+        "--no-project",
+        "python",
+        "worker.py",
+        "--repo",
+        "owner/name",
+    ]
+
+
+def test_every_flag_position_resolves_not_only_the_first(tmp_path, monkeypatch):
+    """The old rejection returned at the first offending element.
+
+    That made the error name one token, so a reader inferred one defect and
+    tried renaming it. Each of these would have been refused in turn, so the
+    test asserts a flag resolves in first, middle and last position rather
+    than trusting a single case.
+    """
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
+    for args in (
+        ['        - "--first"\n', '        - "x"\n'],
+        ['        - "x"\n', '        - "--middle"\n', '        - "y"\n'],
+        ['        - "x"\n', '        - "--last"\n'],
+    ):
+        manifest = _command_manifest("".join(args), tmp_path)
+        resolved = resolve_schedule_set(parse_schedule_set(manifest), tmp_path)
+        got = resolved["m"].db_fields["action_command_args"]
+        assert any(tok.startswith("-") for tok in got), got
+
+
+def test_both_create_paths_hold_command_args_to_the_same_contract(tmp_path, monkeypatch):
+    """The divergence guard, and the test whose absence let the paths drift.
+
+    The declarative resolver and the imperative create service write the same
+    database field. They validated it with different functions, and nothing
+    failed when one of them was the wrong function. This asserts that whatever
+    the declarative path produces, the imperative path's own check accepts —
+    so a future change to either one has to face the other.
+    """
+    from lionagi.studio.services.schedules import _svc_validate_command_args
+
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
+    manifest = _command_manifest(
+        '        - "run"\n        - "--no-project"\n        - "worker.py"\n', tmp_path
+    )
+    resolved = resolve_schedule_set(parse_schedule_set(manifest), tmp_path)
+    _svc_validate_command_args(resolved["m"].db_fields["action_command_args"])
+
+
+def test_declarative_command_target_still_refuses_a_non_allowlisted_executable(
+    tmp_path, monkeypatch
+):
+    """Accepting flags must not have widened the boundary that is real.
+
+    For this kind the security boundary is the executable allow-list, not the
+    shape of the arguments.
+    """
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "something-else")
+    manifest = _command_manifest('        - "--flag"\n', tmp_path)
+    with pytest.raises(ValueError, match="ALLOWLIST"):
+        resolve_schedule_set(parse_schedule_set(manifest), tmp_path)
+
+
+def test_a_templated_arg_rendering_to_a_flag_is_still_refused(tmp_path):
+    """The protection that does apply, kept asserted.
+
+    A literal flag is author-written. A ``{{var}}`` element takes its value
+    from trigger context, which an attacker may influence, so the rendered
+    result is what gets checked — and it is checked where rendering happens.
+    """
+    from lionagi.studio.scheduler.subprocess import _render_command_arg
+
+    assert _render_command_arg("--repo", {}) == "--repo"
+    assert _render_command_arg("{{pr}}", {"pr": "123"}) == "123"
+    with pytest.raises(ValueError, match="would inject a flag"):
+        _render_command_arg("{{pr}}", {"pr": "--oops"})
+
+
+# The distinct argument shapes real scheduled commands take. Each is a command
+# line someone actually wrote and scheduled, reduced to its structure: an
+# interpreter subcommand, a scope flag, flag/value pairs whose values are paths,
+# a valueless boolean flag, a templated value behind a flag, and free-text
+# positionals. Paths and names here are placeholders; the shapes are the point.
+_REAL_COMMAND_ARG_SHAPES = [
+    ["run", "--project", "PROJECT_DIR", "python", "worker.py", "one arg", "another"],
+    [
+        "run",
+        "--project",
+        "PROJECT_DIR",
+        "python",
+        "probe.py",
+        "--config",
+        "probe.json",
+        "--state",
+        "probe_state.json",
+    ],
+    ["run", "--no-project", "python", "health.py", "--json", "--cwd", "PROJECT_DIR"],
+    ["run", "--no-project", "bash", "watch.sh"],
+    [
+        "run",
+        "--no-project",
+        "python",
+        "poll.py",
+        "--pr",
+        "{{pr_number}}",
+        "--repo",
+        "owner/name",
+        "--out",
+        "OUT_DIR",
+    ],
+]
+
+
+@pytest.mark.parametrize("args", _REAL_COMMAND_ARG_SHAPES)
+def test_real_command_shapes_are_expressible_declaratively(args, tmp_path, monkeypatch):
+    """Every shape a scheduled command actually uses must survive the resolver.
+
+    Flags are not an edge case for this kind: all five shapes carry at least
+    one, so a resolver that refuses them can express none of them. The last
+    shape is the mixed case that matters most — an author-written flag whose
+    value is a ``{{var}}`` template, which is exactly the combination the two
+    contracts have to tell apart.
+    """
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
+    args_yaml = "".join(f'        - "{a}"\n' for a in args)
+    resolved = resolve_schedule_set(
+        parse_schedule_set(_command_manifest(args_yaml, tmp_path)), tmp_path
+    )
+    assert resolved["m"].db_fields["action_command_args"] == args
+
+
+@pytest.mark.parametrize("args", _REAL_COMMAND_ARG_SHAPES)
+def test_the_other_fields_validator_would_refuse_every_real_shape(args):
+    """Proof the test above discriminates, and why the field identity matters.
+
+    ``action_extra_args`` and ``action_command_args`` are not two names for one
+    contract: this asserts the stricter one rejects every shape the looser one
+    must accept. That is what makes the accept assertions above meaningful
+    rather than vacuous — they would all fail against the stricter validator.
+
+    If this test ever fails because the strict check stopped rejecting flags,
+    the two contracts have converged and the reason these fields are validated
+    separately no longer holds. Read that before deleting this.
+    """
+    from lionagi.studio.scheduler.subprocess import _validate_extra_args
+
+    with pytest.raises(ValueError, match="starts with '-'"):
+        _validate_extra_args(args)

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -1318,19 +1318,44 @@ def test_both_create_paths_hold_command_args_to_the_same_contract(tmp_path, monk
     """The divergence guard, and the test whose absence let the paths drift.
 
     The declarative resolver and the imperative create service write the same
-    database field. They validated it with different functions, and nothing
-    failed when one of them was the wrong function. This asserts that whatever
-    the declarative path produces, the imperative path's own check accepts —
-    so a future change to either one has to face the other.
-    """
-    from lionagi.studio.services.schedules import _svc_validate_command_args
+    database field, and they validated it with different functions. What has to
+    be asserted is the *delegation*: that the resolver hands this field to the
+    imperative path's own validator rather than to a check of its own.
 
+    Calling that validator on the resolver's output would not assert it. The
+    resolver already calls it, so re-running it on the result passes by
+    construction and would stay green through exactly the regression this test
+    exists to catch: a resolver that substitutes a weaker check and still
+    returns a list. So the validator is replaced with a recorder and the call
+    itself is what gets asserted.
+    """
+    from lionagi.studio.services import schedules as schedules_svc
+
+    seen: list[list[str]] = []
+    real_validator = schedules_svc._svc_validate_command_args
+
+    def _recording_validator(value):
+        seen.append(value)
+        return real_validator(value)
+
+    # The resolver imports this symbol inside the function body, so patching it
+    # on the defining module is what the call actually resolves.
+    monkeypatch.setattr(schedules_svc, "_svc_validate_command_args", _recording_validator)
     monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
     manifest = _command_manifest(
         '        - "run"\n        - "--no-project"\n        - "worker.py"\n', tmp_path
     )
     resolved = resolve_schedule_set(parse_schedule_set(manifest), tmp_path)
-    _svc_validate_command_args(resolved["m"].db_fields["action_command_args"])
+
+    assert seen == [["run", "--no-project", "worker.py"]], (
+        "the resolver did not delegate action_command_args validation to the "
+        f"imperative path's validator; recorded calls: {seen}"
+    )
+    assert resolved["m"].db_fields["action_command_args"] == [
+        "run",
+        "--no-project",
+        "worker.py",
+    ]
 
 
 def test_declarative_command_target_still_refuses_a_non_allowlisted_executable(
@@ -1413,6 +1438,33 @@ def test_real_command_shapes_are_expressible_declaratively(args, tmp_path, monke
         parse_schedule_set(_command_manifest(args_yaml, tmp_path)), tmp_path
     )
     assert resolved["m"].db_fields["action_command_args"] == args
+
+
+def test_a_resolved_manifest_still_refuses_an_injected_flag_at_fire_time(tmp_path, monkeypatch):
+    """Manifest acceptance and fire-time rejection, joined end to end.
+
+    Permitting author-written flags is only safe because a templated element is
+    checked against its rendered value where the argv is built. Asserting
+    ``_render_command_arg`` directly leaves that argument one step short: it
+    does not show the fire path actually routes every element through it. This
+    takes what the resolver persisted, hands it to ``build_argv``, and asserts
+    a trigger-supplied flag is refused there.
+    """
+    from lionagi.studio.scheduler.subprocess import build_argv
+
+    monkeypatch.setenv("LIONAGI_SCHEDULER_COMMAND_ALLOWLIST", "refresh-index")
+    manifest = _command_manifest(
+        '        - "--repo"\n        - "owner/name"\n        - "--pr"\n        - "{{pr_number}}"\n',
+        tmp_path,
+    )
+    resolved = resolve_schedule_set(parse_schedule_set(manifest), tmp_path)
+    schedule = dict(resolved["m"].db_fields)
+
+    argv, _ = build_argv(schedule, {"pr_number": "123"})
+    assert argv == ["refresh-index", "--repo", "owner/name", "--pr", "123"]
+
+    with pytest.raises(ValueError, match="would inject a flag"):
+        build_argv(schedule, {"pr_number": "--oops"})
 
 
 @pytest.mark.parametrize("args", _REAL_COMMAND_ARG_SHAPES)


### PR DESCRIPTION
## The defect

`_resolve_command_target` in `lionagi/studio/services/schedule_declaration.py` validated a
declarative `kind: command` target's `args` with `_validate_extra_args`. That function is the
validator for a **different field**: `action_extra_args`. The values it was checking are persisted
a few lines later as `action_command_args`, and the imperative `li schedule create` path validates
that same destination field with `_svc_validate_command_args`.

So the two paths that write one database column held it to two different contracts, and the
declarative one was holding it to the contract of a field it never writes.

## Why it mattered

`_validate_extra_args` rejects any element beginning with `-`. That rule is correct for what it
was written for: the `agent`, `flow` and `fanout` subcommands accept no extra positionals, so a
flag placed in `action_extra_args` arrives at the spawned `li` process as an unrecognised option
and the run exits at argument parsing.

A `kind: command` target never spawns `li`. It spawns the named executable directly, and the
firing path refuses a command launch outright if `action_extra_args` is set at all. The resolver
was therefore enforcing a rule that protects a path this kind cannot take, and the cost was that
`kind: command` could not express a command line carrying a flag. Nearly every real command line
carries one, so in practice the kind could not express what it exists to express.

Two further details made this hard to diagnose from the error alone:

- The validator returns at the **first** offending element, so the message names one token. A
  reader reasonably infers one bad argument and tries renaming it, when in fact every flag in the
  list would be refused in turn.
- The message names `action_extra_args`, a field the author did not write and cannot see in their
  manifest.

## What changed

`_resolve_command_target` now calls `_svc_validate_command_args`, the validator the imperative
path already applies to this field. Nothing else in the function moved.

Both real protections are unchanged:

- **Templated values.** A `{{var}}` element takes its value from trigger context, so its
  *rendered* result is checked at render time by `_render_command_arg`, which still refuses a
  rendered value that begins with `-`. That is the only point at which a trigger-supplied value
  could inject a flag, and it is where the check belongs. A literal `--repo` written by the
  manifest author is a different thing and is now permitted, which is the point of a generic
  command runner.
- **The executable allow-list.** `_validate_command_allowlisted` still runs, two lines earlier.
  For this kind that is the security boundary, not the shape of the argument list.

One caveat about that second point, since this change leans on it: the allow-list is evaluated in
the process that performs the write, which is not necessarily the process that later fires the
command. That asymmetry is a separate issue, tracked separately, and this change neither widens nor
narrows it.

> **Correction, added after merge.** The paragraph above was written in a way that invites the
> reading that a write-time admission is the only check, so a command admitted in one process
> would fire unchecked in another. That is not the case. `_validate_command_allowlisted` is called
> at four points, and **two** of them run in the firing process: `build_argv`, and again inside
> `spawn_and_wait` five lines above the `create_subprocess_exec` call itself;
> the allow-list is read fresh from the environment on every call rather than cached, specifically
> so a change between write time and fire time is observed. The real defect is coherence and
> observability: admission does not *predict* execution, because the two processes can hold
> different environments, so a schedule can validate and then be refused at fire, or be refused at
> validation while it would have run. Nothing executes unchecked. The original sentences are left
> above rather than rewritten, so the record shows what was withdrawn.

## Tests

`tests/studio/test_schedule_declaration.py`, eight functions and eighteen cases:

- A flag in **first, middle and last** position, because the old rejection short-circuited at the
  first element and a single case would not have shown that.
- The **five distinct argument shapes** real scheduled commands take: a scope flag, flag/value
  pairs whose values are paths, a valueless boolean flag, free-text positionals, and the mixed
  case that matters most, an author-written flag whose value is a `{{var}}` template.
- A companion test asserting the **stricter validator still refuses every one of those five
  shapes**. Without it, the accepting assertions above would pass against a validator that checks
  nothing, and the suite would not discriminate. It is also the place where a future convergence
  of the two contracts would surface, which is why it says so in its docstring rather than just
  asserting.
- **The resolver delegates this field to the imperative path's validator**, which is the guard
  whose absence allowed the divergence in the first place. It asserts the delegation rather than
  the output: it substitutes a recorder for that validator and checks it was called. Calling the
  validator on the resolver's output would not assert anything, because the resolver already calls
  it, so such a test passes by construction and stays green through the regression it exists to
  catch.
- **Manifest acceptance joined to fire-time rejection**, end to end. Permitting author-written
  flags is only safe because a templated element is checked against its rendered value where the
  argv is built, and exercising `_render_command_arg` directly does not show that the fire path
  routes every element through it. This test takes what the resolver persisted, hands it to
  `build_argv`, and asserts a trigger-supplied value rendering to `--oops` is refused there.
- The allow-list refusal still fires for a non-member executable, so accepting flags did not
  widen the boundary that is real.

Both mutation-tested rather than assumed:

- Reverting the one-line fix fails 8 of the 90 tests in the file, including all five real shapes.
- Substituting a *weaker but still list-returning* check in the resolver fails the delegation
  guard. That is the case a green suite would otherwise have accepted, and it is the reason the
  guard asserts the call instead of the result.

A green run on its own would not have established that any of these look at the thing they claim
to.

Acceptance was also checked end to end against a four-member `ScheduleSet` from a downstream
project in which every member carries four flags. Before: all four refused, each error naming
only the first flag. After: all four resolve, with `action_command` and all nine argument
elements intact.

`uv run --extra studio pytest tests/studio/` is green at 896 passed.

## Not covered

- No test spawns a process. Coverage reaches argv construction, which is where the rendering
  decision is made, and stops there. Nothing here executes an allow-listed executable.
- The `poll_interval` gap in the declarative GitHub trigger is unrelated and untouched here: the
  declarative trigger spec exposes `repo` and `filter` only, so a per-repo polling cadence still
  has nowhere to live in a manifest.


