### PR TITLE
fix(mcp): a stale-fingerprint refusal names the playbook the call resolved

### DIFF
--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -215,7 +215,13 @@ def schema_fingerprint(schema: dict[str, Any]) -> str:
     return hashlib.sha256(body.encode()).hexdigest()[:16]
 
 
-def _describe_fingerprint(entry: dict[str, Any], verb: Verb, schema: dict[str, Any]) -> None:
+def _describe_fingerprint(
+    entry: dict[str, Any],
+    verb: Verb,
+    schema: dict[str, Any],
+    *,
+    playbook: str | None = None,
+) -> None:
     """Say what a fingerprint-gated verb's ops have to carry.
 
     A playbook-aware verb is projected again once a playbook is named, so its
@@ -223,11 +229,16 @@ def _describe_fingerprint(entry: dict[str, Any], verb: Verb, schema: dict[str, A
     argument-free schema is a real call and its fingerprint is quoted; when the
     verb requires a playbook there is no such call, so quoting anything would
     hand the caller a string that is guaranteed to be refused.
+
+    Naming the playbook resolves that argument, so the schema is a real one and
+    its fingerprint is quoted. Both help surfaces route through here rather than
+    each deciding: the catalog withheld the unusable value while targeted help
+    returned it, which is one contract answered two ways by two callers.
     """
     varies = ["playbook"] if verb.playbook_aware else []
     if varies:
         entry["schema_fingerprint_varies_with"] = varies
-    if any(name in verb.requires for name in varies):
+    if playbook is None and any(name in verb.requires for name in varies):
         return
     entry["schema_fingerprint"] = schema_fingerprint(schema)
 
@@ -256,6 +267,14 @@ def _require_fingerprint(
     pointer that named the verb alone would send a caller who re-fetches to the
     argument-free schema and back into this same refusal.
     """
+    if playbook is None and verb.playbook_aware and "playbook" in verb.requires:
+        # The fingerprint this call would need is the argument-free schema's, and
+        # help does not hand that one out precisely because no successful call
+        # carries it. Complaining about it here would leave the caller with
+        # nothing to fetch. The real defect is the missing playbook, so let
+        # validation say that: it is the error the caller can act on, and no run
+        # starts either way.
+        return
     current = schema_fingerprint(schema)
     if supplied == current:
         return
@@ -1003,9 +1022,9 @@ def _help(target: Any) -> dict[str, Any]:
         schema = verb_schema(verb, playbook=playbook)
     except projection.SchemaProjectionError as exc:
         raise ValueError(f"{resolved!r} has no describable schema: {exc}") from exc
-    answer = {"verb": resolved, "schema": schema}
+    answer: dict[str, Any] = {"verb": resolved, "schema": schema}
     if verb.executor == "spawn":
-        answer["schema_fingerprint"] = schema_fingerprint(schema)
+        _describe_fingerprint(answer, verb, schema, playbook=playbook)
     return answer
 
 

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -232,7 +232,14 @@ def _describe_fingerprint(entry: dict[str, Any], verb: Verb, schema: dict[str, A
     entry["schema_fingerprint"] = schema_fingerprint(schema)
 
 
-def _require_fingerprint(name: str, verb: Verb, schema: dict[str, Any], supplied: Any) -> None:
+def _require_fingerprint(
+    name: str,
+    verb: Verb,
+    schema: dict[str, Any],
+    supplied: Any,
+    *,
+    playbook: str | None = None,
+) -> None:
     """Spawn ops carry the fingerprint targeted help returned for them.
 
     What this establishes is agreement: the schema the caller validated against is
@@ -243,25 +250,33 @@ def _require_fingerprint(name: str, verb: Verb, schema: dict[str, Any], supplied
     inherited from someone who did read the schema.
 
     The refusal carries its own remedy, because a rejection that only says
-    "stale" strands exactly the caller this exists to help.
+    "stale" strands exactly the caller this exists to help. The remedy has to name
+    the playbook the call resolved: a playbook's own arguments are part of the
+    schema, so the fingerprint below is already qualified by it, and a help
+    pointer that named the verb alone would send a caller who re-fetches to the
+    argument-free schema and back into this same refusal.
     """
     current = schema_fingerprint(schema)
     if supplied == current:
         return
-    remedy = {
-        "help": {"verb": name} if verb.playbook_aware else name,
-        "schema_fingerprint": current,
-    }
+    if playbook is not None:
+        source: Any = {"verb": name, "playbook": playbook}
+    elif verb.playbook_aware:
+        source = {"verb": name}
+    else:
+        source = name
+    remedy = {"help": source, "schema_fingerprint": current}
     # Where the key goes is the part a caller gets wrong: put it inside `args`
     # and it is simply not read, so this refusal repeats verbatim and the
     # failure reads as idempotent rather than as a misplaced key. Spelling the
     # whole op is the only form of the instruction that cannot be misread.
     shape = f"{{'op': {name!r}, 'args': {{...}}, 'schema_fingerprint': {current!r}}}"
+    ask = f"help={source!r}"
     if supplied is None:
         raise OpError(
             "stale_schema",
             f"{name!r} needs the schema_fingerprint that help returns for it; ask for "
-            f"help={name!r} and send the fingerprint as a sibling of 'args', not a "
+            f"{ask} and send the fingerprint as a sibling of 'args', not a "
             f"member of it: {shape}",
             remedy,
         )
@@ -269,7 +284,7 @@ def _require_fingerprint(name: str, verb: Verb, schema: dict[str, Any], supplied
         "stale_schema",
         f"{name!r} was called with schema_fingerprint {supplied!r}, which is not the "
         f"current {current!r}; the parameters changed since that schema was read. "
-        f"Re-read help={name!r} and send: {shape}",
+        f"Re-read {ask} and send: {shape}",
         remedy,
     )
 
@@ -1071,7 +1086,13 @@ async def _run_one(entry: Any) -> dict[str, Any]:
         playbook = args.get("playbook") if verb.playbook_aware else None
         schema = verb_schema(verb, playbook=playbook if isinstance(playbook, str) else None)
         if verb.executor == "spawn":
-            _require_fingerprint(name, verb, schema, entry.get("schema_fingerprint"))
+            _require_fingerprint(
+                name,
+                verb,
+                schema,
+                entry.get("schema_fingerprint"),
+                playbook=playbook if isinstance(playbook, str) else None,
+            )
         _validate(schema, args, verb)
         if verb.executor == "spawn":
             result = _run_spawn(verb, schema, args)

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -416,6 +416,87 @@ def test_a_verb_with_no_playbook_stage_refuses_one():
         call(help={"verb": "agent.submit", "playbook": "anything"})
 
 
+@pytest.fixture
+def a_playbook(tmp_path, monkeypatch):
+    """A playbook declaring one argument of its own, resolvable from cwd.
+
+    Project-local rather than in the user's real playbook directory: a run dying
+    between write and cleanup would otherwise leave a fixture behind where a real
+    playbook of the same name could collide with it.
+    """
+    directory = tmp_path / ".lionagi" / "playbooks"
+    directory.mkdir(parents=True)
+    (directory / "remedy-fixture.playbook.yaml").write_text(
+        json.dumps(
+            {
+                "name": "remedy-fixture",
+                "description": "fixture for the fingerprint remedy",
+                "prompt": "act on {subject}",
+                "args": {"subject": {"type": "str", "default": ".", "help": "what to act on"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    return "remedy-fixture"
+
+
+def test_a_refused_playbook_call_is_told_to_ask_help_for_that_playbook(a_playbook, submitted):
+    """The remedy has to name the playbook, or a caller who re-reads it loops.
+
+    A playbook's own arguments are part of the schema, so the fingerprint the
+    refusal quotes is qualified by the playbook. A `help` pointer naming the verb
+    alone sends a caller who re-fetches to the argument-free schema, whose
+    fingerprint this same call then refuses — the remedy would return the caller
+    to the error it is answering.
+    """
+    answer = call(ops=[{"op": "play.submit", "args": {"playbook": a_playbook}}])
+    error = answer["ops"][0]["error"]
+    assert error["kind"] == "stale_schema"
+    assert error["detail"]["help"] == {"verb": "play.submit", "playbook": a_playbook}
+    assert a_playbook in error["message"]
+    # Following the remedy exactly must produce a call this verb accepts, which is
+    # the property the pointer exists for.
+    qualified = call(help={"verb": "play.submit", "playbook": a_playbook})
+    assert error["detail"]["schema_fingerprint"] == qualified["schema_fingerprint"]
+    assert error["detail"]["schema_fingerprint"] != call(help="play.submit").get(
+        "schema_fingerprint"
+    )
+    assert submitted == {}
+
+
+def test_a_stale_playbook_fingerprint_is_told_the_same_qualified_source(a_playbook, submitted):
+    # The base fingerprint is the wrong-schema value a caller most plausibly
+    # arrives with, so it is the one worth pinning on the stale branch.
+    base = call(help="play.submit").get("schema_fingerprint") or "0000000000000000"
+    answer = call(
+        ops=[
+            {
+                "op": "play.submit",
+                "args": {"playbook": a_playbook},
+                "schema_fingerprint": base,
+            }
+        ]
+    )
+    error = answer["ops"][0]["error"]
+    assert error["kind"] == "stale_schema"
+    assert error["detail"]["help"] == {"verb": "play.submit", "playbook": a_playbook}
+    assert submitted == {}
+
+
+def test_a_playbook_aware_call_naming_none_is_pointed_at_the_base_schema(submitted):
+    # `flow.submit` takes a playbook but does not require one, so the
+    # argument-free schema is a real call and its own fingerprint is the right
+    # answer here. Pinned so the qualified case above cannot be satisfied by
+    # always naming a playbook.
+    answer = call(ops=[{"op": "flow.submit", "args": {"query": ["m", "do it"]}}])
+    error = answer["ops"][0]["error"]
+    assert error["kind"] == "stale_schema"
+    assert error["detail"]["help"] == {"verb": "flow.submit"}
+    assert "playbook" not in error["detail"]["help"]
+    assert submitted == {}
+
+
 # ── the long tail runs as a subprocess and returns a versioned envelope ──────
 
 

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -282,8 +282,13 @@ def test_a_flag_a_detached_run_cannot_honour_is_refused_with_its_reason(submitte
 
 
 def test_a_missing_required_parameter_names_itself(submitted):
-    answer = call(ops=[spawn_op("play.submit", {})])
+    # No fingerprint is sent, deliberately: for a verb that requires a playbook and
+    # was given none, the missing playbook is the error the caller can act on, and
+    # the fingerprint gate must not preempt it with a complaint about a value help
+    # declines to hand out.
+    answer = call(ops=[{"op": "play.submit", "args": {}}])
     assert "missing required parameter 'playbook'" in answer["ops"][0]["error"]["message"]
+    assert submitted == {}
 
 
 def test_a_refusal_on_a_synchronous_verb_does_not_blame_a_background_run():
@@ -484,6 +489,50 @@ def test_a_stale_playbook_fingerprint_is_told_the_same_qualified_source(a_playbo
     assert submitted == {}
 
 
+def test_targeted_help_withholds_a_fingerprint_no_successful_call_can_carry():
+    """`play.submit` requires a playbook, so its argument-free fingerprint is dead.
+
+    Every *successful* `play.submit` op names a playbook and therefore resolves a
+    schema that is not the argument-free one. The argument-free fingerprint is
+    accepted only by a call that omits the playbook, which then fails validation —
+    so its sole effect is to buy a round-trip on the way to a different error. The
+    catalog withheld it and targeted help returned it, so one contract had two
+    answers depending on which way you asked.
+
+    Withholding it is not silence — the answer names the parameter the fingerprint
+    varies with, so the caller knows to ask again with a playbook rather than to
+    retry with a stale string.
+    """
+    answer = call(help="play.submit")
+    assert "schema_fingerprint" not in answer
+    assert answer["schema_fingerprint_varies_with"] == ["playbook"]
+    # The catalog says the same thing about the same verb.
+    entry = {e["verb"]: e for e in call(help=True)["verbs"]}["play.submit"]
+    assert "schema_fingerprint" not in entry
+    assert entry["schema_fingerprint_varies_with"] == ["playbook"]
+
+
+def test_targeted_help_quotes_the_fingerprint_once_the_playbook_is_named(a_playbook):
+    # The suppression above must be about the missing argument, not about the verb:
+    # naming the playbook resolves it, so the value is real and is quoted.
+    answer = call(help={"verb": "play.submit", "playbook": a_playbook})
+    assert answer["schema_fingerprint"]
+    assert answer["schema_fingerprint"] != schema_fingerprint_of_base_play_submit()
+
+
+def schema_fingerprint_of_base_play_submit() -> str:
+    return dispatch.schema_fingerprint(dispatch.verb_schema(verbs.VERBS["play.submit"]))
+
+
+def test_an_optional_playbook_still_quotes_its_argument_free_fingerprint():
+    # `flow.submit` takes a playbook without requiring one, so the argument-free
+    # schema is a real call and its fingerprint is usable. Pinned so the
+    # suppression above cannot widen into every playbook-aware verb.
+    answer = call(help="flow.submit")
+    assert answer["schema_fingerprint"]
+    assert answer["schema_fingerprint_varies_with"] == ["playbook"]
+
+
 def test_a_playbook_aware_call_naming_none_is_pointed_at_the_base_schema(submitted):
     # `flow.submit` takes a playbook but does not require one, so the
     # argument-free schema is a real call and its own fingerprint is the right
@@ -494,6 +543,38 @@ def test_a_playbook_aware_call_naming_none_is_pointed_at_the_base_schema(submitt
     assert error["kind"] == "stale_schema"
     assert error["detail"]["help"] == {"verb": "flow.submit"}
     assert "playbook" not in error["detail"]["help"]
+    assert submitted == {}
+
+
+def test_no_refusal_points_at_a_help_call_that_returns_no_fingerprint(submitted):
+    """Every fingerprint refusal's pointer must lead somewhere that answers it.
+
+    A refusal that says "ask help=X" while X withholds the fingerprint is a dead
+    end, and it is the failure the withholding above would introduce if the gate
+    still fired for a verb whose required playbook is missing. So the two are
+    checked against each other rather than separately: follow every reachable
+    pointer and require a fingerprint at the other end.
+    """
+    subjects = [
+        {"op": "agent.submit", "args": {"query": ["m"]}},
+        {"op": "flow.submit", "args": {"query": ["m", "do it"]}},
+        {"op": "fanout.submit", "args": {"query": ["m", "do it"]}},
+        {"op": "play.submit", "args": {}},
+    ]
+    seen = 0
+    for op in subjects:
+        error = call(ops=[op])["ops"][0].get("error") or {}
+        if error.get("kind") != "stale_schema":
+            continue
+        seen += 1
+        pointer = error["detail"]["help"]
+        answer = call(help=pointer)
+        assert "schema_fingerprint" in answer, (
+            f"{op['op']} is refused and told to ask help={pointer!r}, which returns no "
+            "fingerprint — the remedy leads nowhere"
+        )
+        assert answer["schema_fingerprint"] == error["detail"]["schema_fingerprint"]
+    assert seen, "no op was refused for its fingerprint — this check read nothing"
     assert submitted == {}
 
 


### PR DESCRIPTION
## What

A spawn verb's `schema_fingerprint` is a function of the playbook the op names, because the playbook's declared arguments are resolved into the schema. The `stale_schema` refusal already returned the correct value for the resolved schema. The `help` pointer printed beside it named the verb alone.

So a caller who re-read help instead of taking the value fetched the argument-free schema, sent its fingerprint, and received the same refusal. The remedy returned them to the error it was answering.

## Change

`_require_fingerprint` takes the playbook the call resolved and names it in both the returned `detail.help` and the prose instruction. The call site already resolves it one line earlier for `verb_schema`, so nothing new is computed.

A playbook-aware call that named no playbook still points at the base schema, which for `flow.submit` is a real call a caller can make.

## Evidence

Four tests in `tests/mcp/test_dispatch.py`:

- a missing fingerprint on a playbook-bearing `play.submit` asserts `detail.help` names verb and playbook, and that following that pointer returns exactly the fingerprint the refusal quoted
- the same for a *stale* fingerprint, using the base-schema value as the wrong-schema input a caller most plausibly arrives with
- a `flow.submit` control for the no-playbook case, so the qualified assertions cannot be satisfied by always naming a playbook

Discrimination proved by inverting the fix with the tests in place: the two qualified tests fail, the control keeps passing. Source restored byte-identically afterwards.

`tests/mcp/test_dispatch.py` 101 passed. The wider `tests/mcp/` run has 4 pre-existing failures and 8 pre-existing errors on this machine, identical with and without this change, measured in the same worktree and venv at HEAD and with the change applied.
