### PR TITLE
feat(studio): Operator workspace with a permission-gated runtime

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -2,13 +2,14 @@
 
 Web interface for Lion. The default experience is zero-install: the hosted
 client-side SPA at <https://lion-studio.khive.ai> connects to your local
-daemon at `http://127.0.0.1:8765` — data never leaves your machine. The
-same-origin FastAPI-served build remains available for Docker, source, and
-dev modes.
+daemon at `http://127.0.0.1:8765`. Studio state remains in that local daemon;
+model requests follow the data-handling terms of the provider you use. The
+same-origin FastAPI-served build remains available for Docker, source, and dev
+modes.
 
 ## Project Layout
 
-```
+```text
 apps/studio/
 └── frontend/               Vite + React SPA
     ├── src/                Source (routes, components, lib)
@@ -37,34 +38,88 @@ All variables are optional; defaults are shown.
 ## Running
 
 **Default (hosted UI + local daemon)**:
+
 ```bash
 li studio          # starts the local daemon and opens https://lion-studio.khive.ai;
                    # nothing is built locally (pass --no-open to skip the browser)
 ```
 
 **Self-contained local build (Docker or same-origin serve)**:
+
 ```bash
 li studio --docker # auto-pulls ghcr.io/ohdearquant/lion-studio; UI + API on :8765
 ```
 
 **Dev mode (hot-reload)**:
+
 ```bash
 li studio --dev    # Vite dev server on :3000 + uvicorn on :8765; Vite proxies /api
 ```
 
 **Backend only** (e.g. desktop shell):
+
 ```bash
 li studio --no-frontend
 ```
 
+## Operator quickstart
+
+Operator uses the locally installed Claude Code CLI and its own authenticated
+session by default. The Studio extra does not install or sign in to Claude
+Code.
+
+On a fresh machine:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install "lionagi[studio]"
+
+npm install -g @anthropic-ai/claude-code
+claude --version
+claude auth login
+
+li studio
+```
+
+See [Claude Code setup](https://code.claude.com/docs/en/setup) for other
+supported installation and authentication methods.
+
+In Studio, use the speech-bubble button at the top of the left rail, press
+<kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>J</kbd>, or choose **Toggle Operator** from
+the command palette. The dock can close while a turn runs; closing it does not
+stop the turn.
+
+- Conversation history is stored by the daemon. Reloading the page or reopening
+  the dock restores the selected conversation and its earlier activity.
+- **Stop** requests cancellation of the active turn. It does not undo tool work
+  that already completed.
+- Disk writes, commands, and other gated work pause on a **Permission required**
+  card. **Allow** permits that request; **Deny** blocks it. The engine waits for
+  the decision.
+- Every Operator turn has an **Open run** link into Fleet's Runs view. Run
+  detail also offers **Continue this run** for live or terminal runs that still
+  have a persisted branch. A follow-up submitted while the current leg is
+  still live is queued and starts after that leg reaches a terminal state.
+- The run detail CLI escape hatch is equivalent to:
+
+  ```bash
+  li agent -r '<branch-id>' --prompt '<follow-up instruction>'
+  ```
+
+For permission behavior, resume details, real-provider verification, and the
+CI stub boundary, see the [Studio guide](../../docs/guides/studio.md).
+
 ## Development
 
 **Backend** (auto-reloads):
+
 ```bash
 uv run uvicorn lionagi.studio.app:app --reload --host 127.0.0.1 --port 8765
 ```
 
 **Frontend** (separate terminal):
+
 ```bash
 cd apps/studio/frontend
 npm install
@@ -73,13 +128,35 @@ npm run dev        # http://localhost:5173 — proxies /api → :8765
 
 ## Authentication
 
-When `LIONAGI_STUDIO_AUTH_TOKEN` is unset, all local API routes are open.
+Bare `li studio` and `li studio --dev` mint a launch-scoped bearer, open the UI
+with it in the URL fragment, and require that bearer on `/api/*`. The bootstrap
+script stores the daemon URL and token in that browser tab's `sessionStorage`,
+then immediately removes both values from the address bar. It does not put the
+token in persistent browser storage.
 
-When set, all `/api/*` requests must include:
-```
+`--no-open` intentionally does not print the generated bearer. Restart without
+`--no-open` when you need Operator. API-only `--no-frontend` does not create a
+browser approval credential; it is suitable for integrations, while the
+desktop shell supplies its own credential over a private pipe.
+
+Directly starting uvicorn with no token leaves ordinary local API routes open,
+but Operator turns and approvals fail closed because there is no trusted
+browser-held human credential.
+
+`LIONAGI_STUDIO_AUTH_TOKEN` still protects ordinary API integrations. When it
+is set, all `/api/*` requests must include:
+
+```text
 Authorization: Bearer <token>
 ```
 
+Environment-derived `LIONAGI_STUDIO_AUTH_TOKEN` and
+`LIONAGI_STUDIO_HUMAN_TOKEN` values are not accepted as Operator's human
+approval boundary because process environments can be inspected. If either is
+set, Operator submission and decisions return a fail-closed remediation error.
+`LIONAGI_STUDIO_AUTH_TOKEN` continues to protect ordinary API requests;
+`LIONAGI_STUDIO_HUMAN_TOKEN` alone does not replace API authentication. Unset
+both and restart with `li studio`; setting both does not bypass this rule.
 `/health` remains open regardless.
 
 ## Database
@@ -123,6 +200,7 @@ cargo build --release     # binary only, no signing
 ```
 
 The shell finds the `li` CLI automatically (searches PATH,
-`~/.local/bin/li`, `~/.cargo/bin/li`, `/opt/homebrew/bin/li`), spawns
-`li studio --no-frontend --port <free-port>`, and loads the SPA with
-`window.__STUDIO_API_BASE__` pre-set via Tauri's initialization script API.
+`~/.local/bin/li`, `~/.cargo/bin/li`, `/opt/homebrew/bin/li`), spawns the
+backend on a free loopback port, passes its launch-scoped bearer over a
+one-shot stdin pipe, and loads the SPA with `window.__STUDIO_API_BASE__` and
+`window.__STUDIO_AUTH_TOKEN__` pre-set via Tauri's initialization script API.

--- a/apps/studio/desktop/README.md
+++ b/apps/studio/desktop/README.md
@@ -104,11 +104,12 @@ Navigation sequence:
 
 ### Process management
 
-`li studio --no-frontend --port N` is spawned with `.process_group(0)` (unix),
-making the child the leader of a new process group. On app exit (or window close),
-`BackendHandle::terminate()` sends `SIGTERM` to the group (`kill(-pgid, SIGTERM)`),
-waits 5 s, then `SIGKILL`s the group. This kills `uvicorn` workers and any other
-grandchild processes.
+`li studio --no-frontend --operator-token-stdin --port N` is spawned with
+`.process_group(0)` (unix), making the child the leader of a new process group.
+The shell writes the per-launch token once to the child's piped stdin and closes
+the pipe. On app exit (or window close), `BackendHandle::terminate()` sends
+`SIGTERM` to the group (`kill(-pgid, SIGTERM)`), waits 5 s, then `SIGKILL`s the
+group. This kills `uvicorn` workers and any other grandchild processes.
 
 Backend stdout/stderr are appended to rotating log files in the Tauri log
 directory (`~/Library/Logs/ai.lionagi.studio/studio-backend-{stdout,stderr}.log`).
@@ -145,8 +146,9 @@ Same-Origin Policy — provided CORS is not misconfigured on the backend.
 At startup the shell generates a 32-hex-char token from `/dev/urandom` (16 bytes
 of OS-level CSPRNG entropy).  The token is:
 
-- Passed to the child process as `LIONAGI_STUDIO_AUTH_TOKEN`.  The FastAPI server
-  enforces bearer auth on all API routes when this env var is present.
+- Written once to the child process over a private stdin pipe. The child captures
+  it in process memory before starting FastAPI; it is never placed in argv or the
+  inherited environment.
 - Injected into the SPA via the Tauri initialization script as
   `window.__STUDIO_AUTH_TOKEN__` before any page scripts run.
 - Attached by `lib/api.ts::fetchJson` as `Authorization: Bearer <token>` on every
@@ -160,12 +162,12 @@ A new token is generated for each app launch.  Restarting the app rotates the to
 attempt to connect to `http://127.0.0.1:N/api/...`.  Without the bearer token every
 such request will be rejected with HTTP 401.
 
-**Cannot**: obtain the bearer token from disk — it is never persisted; it lives in
-the child process environment and the Tauri webview JS heap.  Note the limit of this
-model: a malicious process running *as the same user* can ultimately inspect process
-state (e.g. `ps -E` on its own user's processes), so the token raises the bar and
-blocks other-user/local-network access — it does not defend against an attacker
-already running with your privileges.
+**Cannot**: obtain the bearer token from disk, argv, or the child process
+environment. It is never persisted; after the one-shot pipe closes, it remains in
+the daemon's process memory and the Tauri webview JS heap. Note the limit of this
+model: a malicious process running *as the same user* can ultimately inspect another
+process's memory, so the token blocks unauthenticated local/network access but does
+not defend against an attacker already running with your full user privileges.
 
 ### CORS and live streams
 

--- a/apps/studio/desktop/src-tauri/src/backend.rs
+++ b/apps/studio/desktop/src-tauri/src/backend.rs
@@ -23,6 +23,7 @@
 use std::os::unix::process::CommandExt as _;
 
 use crate::port::{find_free_port, find_li_cli};
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -154,24 +155,48 @@ pub fn spawn_backend(app: &AppHandle, auth_token: &str) -> Result<BackendHandle,
     );
 
     let mut cmd = Command::new(&cli);
-    cmd.args(["studio", "--no-frontend", "--port", &port.to_string()])
-        .env("LIONAGI_STUDIO_HOST", "127.0.0.1")
-        .env("LIONAGI_STUDIO_AUTH_TOKEN", auth_token)
-        // The webview loads the SPA from the tauri custom protocol, so API
-        // calls are cross-origin; the backend's default CORS allowlist only
-        // covers localhost dev ports.
-        .env("CORS_ORIGINS", "tauri://localhost")
-        .stdout(log_stdio(app, "stdout"))
-        .stderr(log_stdio(app, "stderr"));
+    cmd.args([
+        "studio",
+        "--no-frontend",
+        "--operator-token-stdin",
+        "--port",
+        &port.to_string(),
+    ])
+    .env("LIONAGI_STUDIO_HOST", "127.0.0.1")
+    .env_remove("LIONAGI_STUDIO_AUTH_TOKEN")
+    .env_remove("LIONAGI_STUDIO_HUMAN_TOKEN")
+    // The webview loads the SPA from the tauri custom protocol, so API
+    // calls are cross-origin; the backend's default CORS allowlist only
+    // covers localhost dev ports.
+    .env("CORS_ORIGINS", "tauri://localhost")
+    // The launch-scoped bearer crosses a one-shot pipe, never argv or the
+    // inherited environment where an approved provider subprocess could
+    // recover it through process inspection.
+    .stdin(Stdio::piped())
+    .stdout(log_stdio(app, "stdout"))
+    .stderr(log_stdio(app, "stderr"));
 
     // On unix, spawn into a new process group so kill(-pgid, sig) reaches
     // the entire subtree (uvicorn workers, etc.).
     #[cfg(unix)]
     cmd.process_group(0);
 
-    let child = cmd
+    let mut child = cmd
         .spawn()
         .map_err(|e: std::io::Error| LaunchError::SpawnFailed(e.to_string()))?;
+    let write_result = child
+        .stdin
+        .take()
+        .ok_or_else(|| LaunchError::SpawnFailed("backend token pipe was unavailable".into()))
+        .and_then(|mut stdin| {
+            writeln!(stdin, "{auth_token}")
+                .map_err(|e| LaunchError::SpawnFailed(format!("backend token pipe failed: {e}")))
+        });
+    if let Err(error) = write_result {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
 
     Ok(BackendHandle {
         port,

--- a/apps/studio/frontend/e2e/operator.spec.ts
+++ b/apps/studio/frontend/e2e/operator.spec.ts
@@ -162,7 +162,9 @@ test("Operator Deny and Allow decisions traverse the real permission route", asy
     exact: true,
   });
   await expect(deniedProposal).toBeVisible({ timeout: 15_000 });
-  await deniedProposal.getByText("Review exact command", { exact: true }).click();
+  // No click to reveal: the command must be on screen before Allow/Deny are reachable,
+  // so asserting it directly is the contract. Re-adding a click here would collapse the
+  // disclosure and assert the opposite of what this test is for.
   await expect(deniedProposal.getByText('"operation": "record_permission_decision"')).toBeVisible();
 
   const deniedResponsePromise = page.waitForResponse(

--- a/apps/studio/frontend/e2e/operator.spec.ts
+++ b/apps/studio/frontend/e2e/operator.spec.ts
@@ -1,0 +1,234 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const E2E_HUMAN_TOKEN = "lionagi-studio-e2e-human-principal";
+
+function authenticatedStudioUrl(): string {
+  const baseURL = process.env.E2E_BASE_URL;
+  if (!baseURL) throw new Error("E2E_BASE_URL was not provided by global setup");
+  const fragment = new URLSearchParams({
+    "studio-api": baseURL,
+    "studio-token": E2E_HUMAN_TOKEN,
+  });
+  return `/#${fragment.toString()}`;
+}
+
+async function selectFreshConversation(page: Page): Promise<void> {
+  const conversationId = await page.evaluate(async () => {
+    const apiBase = sessionStorage.getItem("studio-api");
+    const token = sessionStorage.getItem("studio-token");
+    if (!apiBase || !token) {
+      throw new Error("Studio fragment credentials were not bootstrapped");
+    }
+
+    const response = await fetch(`${apiBase}/api/operator/conversations`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to create an isolated conversation: ${response.status}`);
+    }
+    const payload = (await response.json()) as { conversation?: { id?: unknown } };
+    if (typeof payload.conversation?.id !== "string") {
+      throw new Error("Conversation response did not include an id");
+    }
+    return payload.conversation.id;
+  });
+
+  await page.reload();
+  const switcher = page.getByRole("combobox", {
+    name: "Operator conversation",
+    exact: true,
+  });
+  await expect(switcher.locator(`option[value="${conversationId}"]`)).toHaveCount(1);
+  await switcher.selectOption(conversationId);
+  await expect(page.getByLabel("Instruction")).toBeEnabled();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.route("https://analytics.khive.ai/**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/javascript", body: "" }),
+  );
+});
+
+test("Operator streams, persists, stops, records a run, and resumes it", async ({ page }) => {
+  test.setTimeout(45_000);
+  const discovery = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      response.url().endsWith("/api/operator/conversations"),
+  );
+  await page.goto(authenticatedStudioUrl());
+  expect((await discovery).status()).toBe(200);
+
+  // The daemon survives individual browser contexts and Playwright retries.
+  // Start from an explicit new conversation so the deterministic engine script
+  // is never coupled to history left by a previous attempt.
+  await selectFreshConversation(page);
+  const instruction = page.getByLabel("Instruction");
+  await expect(instruction).toBeVisible();
+  await instruction.fill("Show me the fleet readiness.");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+
+  await expect(page.getByText("Show me the fleet readiness.", { exact: true })).toBeVisible();
+  await expect(page.getByText("Fleet ready.", { exact: true })).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByText("Turn completed", { exact: true })).toBeVisible();
+
+  const openRun = page.locator('a[href*="/fleet?s="]').filter({ hasText: "Open run" });
+  await expect(openRun).toHaveCount(1);
+  const runHref = await openRun.getAttribute("href");
+  expect(runHref).toMatch(/^\/fleet\?s=.+/);
+
+  await page.reload();
+  await expect(page.getByText("Show me the fleet readiness.", { exact: true })).toBeVisible();
+  await expect(page.getByText("Fleet ready.", { exact: true })).toBeVisible();
+
+  await instruction.fill("wait until I stop you");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  const stop = page.getByRole("button", { name: "Stop", exact: true });
+  await expect(stop).toBeVisible();
+  await stop.click();
+  await expect(page.getByText("Turn stopped", { exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await page.goto(runHref!);
+  await expect(page).toHaveURL(/\/fleet\?s=.+/);
+  await expect(page.getByRole("region", { name: "Continue this run" })).toBeVisible();
+
+  const followUp = page.getByLabel("Follow-up instruction");
+  await followUp.fill("Continue with the next check.");
+  const activityPoll = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" && /\/api\/invocations\/[^/?]+$/.test(response.url()),
+  );
+  await page.getByRole("button", { name: "Resume", exact: true }).click();
+  await expect(page.getByText("Follow-up accepted", { exact: true })).toBeVisible({
+    timeout: 15_000,
+  });
+  expect((await activityPoll).status()).toBe(200);
+
+  const activityLink = page.locator('a[href*="invocation="]').filter({ hasText: "View activity" });
+  await expect(activityLink).toHaveCount(1);
+  expect(await activityLink.getAttribute("href")).toMatch(/^\/fleet\?s=.+&invocation=.+/);
+  await activityLink.click();
+  await expect(page).toHaveURL(/\/fleet\?s=.+&invocation=.+/);
+
+  // Acceptance is not enough: the detached CLI leg must reopen the exact
+  // branch, execute, and flow its new durable message back into the run pane.
+  const main = page.getByRole("main", { name: "Main content" });
+  await expect(main.getByText("Continuation complete.", { exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+  await main.getByRole("tab", { name: "Conversation tab 5 of 5", exact: true }).click();
+  await expect(main.getByText("Continue with the next check.", { exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.reload();
+  await expect(main.getByText("Continuation complete.", { exact: true })).toBeVisible({
+    timeout: 20_000,
+  });
+  await main.getByRole("tab", { name: "Conversation tab 5 of 5", exact: true }).click();
+  await expect(main.getByText("Continue with the next check.", { exact: true })).toBeVisible({
+    timeout: 20_000,
+  });
+});
+
+test("Operator Deny and Allow decisions traverse the real permission route", async ({ page }) => {
+  test.setTimeout(45_000);
+  // Exercise the same fragment bootstrap used by `li studio`: the token is
+  // browser-held and the API client must attach it to human-only decisions.
+  const discovery = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      response.url().endsWith("/api/operator/conversations"),
+  );
+  await page.goto(authenticatedStudioUrl());
+  expect((await discovery).status()).toBe(200);
+
+  await selectFreshConversation(page);
+  const instruction = page.getByLabel("Instruction");
+
+  await instruction.fill("Request a gated demo action and wait for me to deny it.");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+
+  const deniedProposal = page.getByRole("region", {
+    name: "Action requiring permission",
+    exact: true,
+  });
+  await expect(deniedProposal).toBeVisible({ timeout: 15_000 });
+  await deniedProposal.getByText("Review exact command", { exact: true }).click();
+  await expect(deniedProposal.getByText('"operation": "record_permission_decision"')).toBeVisible();
+
+  const deniedResponsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      /\/api\/operator\/conversations\/[^/]+\/proposals\/[^/]+\/decision$/.test(response.url()),
+  );
+  await deniedProposal.getByRole("button", { name: "Deny", exact: true }).click();
+  const deniedResponse = await deniedResponsePromise;
+  expect(deniedResponse.status()).toBe(200);
+  expect(deniedResponse.request().postDataJSON()).toMatchObject({ decision: "deny" });
+  await expect(deniedResponse.json()).resolves.toMatchObject({ status: "failed" });
+  await expect(page.getByText("Action cancelled", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Demo action denied. Nothing was changed.", { exact: true }),
+  ).toBeVisible();
+  const completedTurns = page.getByText("Turn completed", { exact: true });
+  await expect(completedTurns).toBeVisible();
+  const completedBeforeAllow = await completedTurns.count();
+
+  await instruction.fill("Request a gated demo action and wait for me to allow it.");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+
+  const proposals = page.getByRole("region", {
+    name: "Action requiring permission",
+    exact: true,
+  });
+  await expect(proposals).toHaveCount(2, { timeout: 15_000 });
+  const allowedProposal = proposals.filter({
+    has: page.getByRole("button", { name: "Allow", exact: true }),
+  });
+  await expect(allowedProposal).toHaveCount(1);
+
+  const allowedResponsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      /\/api\/operator\/conversations\/[^/]+\/proposals\/[^/]+\/decision$/.test(response.url()),
+  );
+  await allowedProposal.getByRole("button", { name: "Allow", exact: true }).click();
+  const allowedResponse = await allowedResponsePromise;
+  expect(allowedResponse.status()).toBe(200);
+  expect(allowedResponse.request().postDataJSON()).toMatchObject({
+    decision: "allow",
+    expectedCommandHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+  });
+  await expect(allowedResponse.json()).resolves.toMatchObject({
+    status: "succeeded",
+    result: { executed: true },
+  });
+  await expect(page.getByText("Approved action completed", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Demo action allowed and completed safely.", { exact: true }),
+  ).toBeVisible();
+  await expect(completedTurns).toHaveCount(completedBeforeAllow + 1);
+
+  // Both decisions and outcomes are durable daemon history, not client-only UI.
+  await page.reload();
+  await expect(
+    page.getByText("Demo action denied. Nothing was changed.", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Demo action allowed and completed safely.", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Action requiring permission", exact: true }),
+  ).toHaveCount(2);
+  await expect(page.getByRole("button", { name: "Allow", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Deny", exact: true })).toHaveCount(0);
+});

--- a/apps/studio/frontend/e2e/smoke.spec.ts
+++ b/apps/studio/frontend/e2e/smoke.spec.ts
@@ -3,6 +3,18 @@ import { test, expect } from "@playwright/test";
 // Must match tests/e2e_studio/fixtures.py -- the seeded schedule name asserted
 // on below is only ever produced by the seeded daemon's fixtures.
 const SMOKE_SCHEDULE_NAME = "e2e-smoke-nightly-report";
+const E2E_HUMAN_TOKEN = "lionagi-studio-e2e-human-principal";
+
+function authenticatedStudioPath(path: string): string {
+  const baseURL = process.env.E2E_BASE_URL;
+  if (!baseURL) throw new Error("E2E_BASE_URL was not provided by global setup");
+  const url = new URL(path, baseURL);
+  url.hash = new URLSearchParams({
+    "studio-api": baseURL,
+    "studio-token": E2E_HUMAN_TOKEN,
+  }).toString();
+  return url.toString();
+}
 
 // index.html loads the analytics script from an external host. A deferred
 // script participates in the window load event, so a slow or unreachable
@@ -23,22 +35,92 @@ test("app boots, root renders, and the page logs no console errors", async ({ pa
   });
   page.on("pageerror", (err) => errors.push(err.message));
 
-  await page.goto("/");
+  await page.goto(authenticatedStudioPath("/"));
   await expect(page.locator("#root")).not.toBeEmpty();
   expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
 });
 
 test("schedules page renders data that only the seeded db could supply", async ({ page }) => {
-  await page.goto("/schedules");
+  await page.goto(authenticatedStudioPath("/schedules"));
   await expect(page.getByText(SMOKE_SCHEDULE_NAME)).toBeVisible();
 });
 
-test("direct URL navigation renders /schedules and /agents, never a blank screen", async ({
-  page,
-}) => {
-  for (const route of ["/schedules", "/agents"]) {
-    await page.goto(route);
-    const rootText = (await page.locator("#root").innerText()).trim();
-    expect(rootText.length, `${route} rendered a blank page`).toBeGreaterThan(0);
+test("retired workspace URLs resolve into their live consolidated spaces", async ({ page }) => {
+  const aliases = [
+    ["/designer", /\/library\?tab=workflow/, "Library catalog"],
+    ["/canvas", /\/library\?tab=workflow/, "Library catalog"],
+    ["/routing", /\/library\?tab=workflow/, "Library catalog"],
+    ["/agents", /\/library\?tab=agent/, "Library catalog"],
+    ["/history", /\/fleet/, "Session list"],
+    ["/outcomes", /\/fleet/, "Session list"],
+    ["/shows", /\/fleet/, "Session list"],
+    ["/mission", /\/$/, "Mission Control"],
+  ] as const;
+
+  for (const [route, destination, landmark] of aliases) {
+    await page.goto(authenticatedStudioPath(route));
+    await expect(page).toHaveURL(destination);
+    if (landmark === "Mission Control") {
+      await expect(page.getByRole("heading", { name: landmark, exact: true })).toBeVisible();
+    } else {
+      await expect(page.getByRole("region", { name: landmark, exact: true })).toBeVisible();
+    }
+    await expect(page.getByText("Not Found", { exact: true })).toHaveCount(0);
   }
+});
+
+test("primary Studio surfaces render without console failures", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(err.message));
+
+  for (const route of ["/", "/fleet", "/designer", "/library", "/schedules", "/system"]) {
+    await page.goto(authenticatedStudioPath(route));
+    await expect(page.locator("#root")).not.toBeEmpty();
+    await expect(page.getByText("Not Found", { exact: true })).toHaveCount(0);
+  }
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+
+test.describe("narrow Studio shell", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("keeps primary actions and Operator inside the viewport", async ({ page }) => {
+    await page.goto(authenticatedStudioPath("/schedules"));
+    const operatorToggle = page.getByRole("button", { name: "Operator (⌘J)", exact: true });
+    if ((await operatorToggle.getAttribute("aria-pressed")) === "true") {
+      await page
+        .getByRole("complementary", { name: "Operator conversation", exact: true })
+        .getByRole("button", { name: "Close Operator", exact: true })
+        .click();
+      await expect(operatorToggle).toHaveAttribute("aria-pressed", "false");
+    }
+    await expect(page.getByText(SMOKE_SCHEDULE_NAME)).toBeVisible();
+    const newSchedule = page.getByRole("button", { name: "+ New schedule", exact: true });
+    await expect(newSchedule).toBeVisible();
+    const scheduleBox = await newSchedule.boundingBox();
+    expect(scheduleBox).not.toBeNull();
+    expect(scheduleBox!.x).toBeGreaterThanOrEqual(0);
+    expect(scheduleBox!.x + scheduleBox!.width).toBeLessThanOrEqual(390);
+
+    await page.goto(authenticatedStudioPath("/library"));
+    await expect(
+      page
+        .getByRole("region", { name: "Item detail", exact: true })
+        .getByText("e2e-smoke-reviewer", { exact: true }),
+    ).toBeVisible();
+
+    if ((await operatorToggle.getAttribute("aria-pressed")) !== "true") {
+      await operatorToggle.click();
+    }
+    await expect(page.getByLabel("Instruction")).toBeVisible();
+    const operator = page.getByRole("complementary", { name: "Operator conversation" });
+    const operatorBox = await operator.boundingBox();
+    expect(operatorBox).not.toBeNull();
+    expect(operatorBox!.x).toBeGreaterThanOrEqual(56);
+    expect(operatorBox!.x + operatorBox!.width).toBeLessThanOrEqual(390);
+  });
 });

--- a/apps/studio/frontend/index.html
+++ b/apps/studio/frontend/index.html
@@ -4,19 +4,111 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lion Studio</title>
-    <script>
+    <script id="studio-connection-bootstrap">
       (function () {
-        var t = localStorage.getItem('theme') || 'dark';
-        document.documentElement.setAttribute('data-theme', t);
-        if (t === 'dark') document.documentElement.classList.add('dark');
-        else document.documentElement.classList.remove('dark');
+        var apiKey = "studio-api";
+        var tokenKey = "studio-token";
+        var alternateTokenKey = "studio-human-token";
+        var params = new URLSearchParams(window.location.hash.slice(1));
+        var hasBootstrap =
+          params.has(apiKey) ||
+          params.has(tokenKey) ||
+          params.has(alternateTokenKey) ||
+          params.has("apiBase") ||
+          params.has("humanToken");
+        var fragmentApi = (params.get(apiKey) || params.get("apiBase") || "").trim();
+        var fragmentToken = (
+          params.get(tokenKey) ||
+          params.get(alternateTokenKey) ||
+          params.get("humanToken") ||
+          ""
+        ).trim();
+        var storedApi = "";
+        var storedToken = "";
+        var fragmentPairValid = false;
+        var storedPairValid = false;
+
+        function isLoopbackHttp(value) {
+          if (!value) return false;
+          try {
+            var parsed = new URL(value);
+            var host = parsed.hostname.toLowerCase();
+            return (
+              parsed.protocol === "http:" &&
+              !parsed.username &&
+              !parsed.password &&
+              (host === "127.0.0.1" || host === "localhost" || host === "::1" || host === "[::1]")
+            );
+          } catch (_) {
+            return false;
+          }
+        }
+
+        fragmentPairValid =
+          Boolean(fragmentApi) && Boolean(fragmentToken) && isLoopbackHttp(fragmentApi);
+
+        try {
+          storedApi = (sessionStorage.getItem(apiKey) || "").trim();
+          storedToken = (
+            sessionStorage.getItem(tokenKey) ||
+            sessionStorage.getItem(alternateTokenKey) ||
+            ""
+          ).trim();
+          storedPairValid = Boolean(storedApi) && Boolean(storedToken) && isLoopbackHttp(storedApi);
+          if (fragmentPairValid) {
+            sessionStorage.setItem(apiKey, fragmentApi);
+            sessionStorage.setItem(tokenKey, fragmentToken);
+          }
+        } catch (_) {
+          // Privacy-restricted browsers may block sessionStorage. The
+          // fragment values still initialize this tab for the current load.
+        }
+
+        // Treat endpoint + credential as one indivisible capability. Never
+        // combine one value from a fragment with the other from storage.
+        if (fragmentPairValid) {
+          window.__STUDIO_API_BASE__ = fragmentApi;
+          window.__STUDIO_AUTH_TOKEN__ = fragmentToken;
+        } else if (storedPairValid) {
+          window.__STUDIO_API_BASE__ = storedApi;
+          window.__STUDIO_AUTH_TOKEN__ = storedToken;
+        }
+
+        if (hasBootstrap) {
+          params.delete(apiKey);
+          params.delete(tokenKey);
+          params.delete(alternateTokenKey);
+          params.delete("apiBase");
+          params.delete("humanToken");
+          var remainingHash = params.toString();
+          var cleanUrl =
+            window.location.pathname +
+            window.location.search +
+            (remainingHash ? "#" + remainingHash : "");
+          window.history.replaceState(window.history.state, document.title, cleanUrl);
+        }
       })();
     </script>
-    <script
-      defer
-      src="https://analytics.khive.ai/script.js"
-      data-website-id="2899c39b-7da3-40b5-bce5-83961982ecc6"
-    ></script>
+    <script>
+      (function () {
+        var t = localStorage.getItem("theme") || "dark";
+        document.documentElement.setAttribute("data-theme", t);
+        if (t === "dark") document.documentElement.classList.add("dark");
+        else document.documentElement.classList.remove("dark");
+      })();
+    </script>
+    <script id="studio-analytics-bootstrap">
+      (function () {
+        // Authenticated Studio tabs are a local control plane. Do not load a
+        // third-party origin into the page that holds its bearer capability.
+        if (window.__STUDIO_AUTH_TOKEN__) return;
+        var analytics = document.createElement("script");
+        analytics.defer = true;
+        analytics.src = "https://analytics.khive.ai/script.js";
+        analytics.setAttribute("data-website-id", "2899c39b-7da3-40b5-bce5-83961982ecc6");
+        document.head.appendChild(analytics);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/studio/frontend/playwright.config.ts
+++ b/apps/studio/frontend/playwright.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 
-// Smoke-only scaffold: the UI is being redesigned in parallel, so this
-// deliberately stays shallow (boot + one API round-trip + direct-nav checks)
-// against a seeded daemon (see e2e/global-setup.ts and tests/e2e_studio/).
+// Browser contracts run against an isolated, seeded daemon (see
+// e2e/global-setup.ts and tests/e2e_studio/). The Operator provider is
+// deterministic here; the real CLI path is covered by the documented local
+// verification pass.
 export default defineConfig({
   testDir: "./e2e",
   timeout: 15_000,

--- a/apps/studio/frontend/src/components/fleet/FleetView.test.ts
+++ b/apps/studio/frontend/src/components/fleet/FleetView.test.ts
@@ -180,13 +180,14 @@ describe("fleet route validateSearch", () => {
 
 // ─── Selection state: detailActive wiring ────────────────────────────────────
 // SplitPane's detailActive determines collapsed-mode routing.
-// Contract: detailActive=true only after explicit narrow-screen selection.
+// Contract: detailActive=true after an explicit row click or a selected-run
+// deep link. Operator links must reveal detail even when the dock collapses
+// the Fleet split pane.
 
 describe("detailActive contract", () => {
-  it("starts false — no explicit narrow selection yet", () => {
-    // Mirrors FleetView: useState(false)
-    let narrowExplicit = false;
-    expect(narrowExplicit).toBe(false);
+  it("starts from whether the URL already identifies a run", () => {
+    expect(Boolean(null)).toBe(false);
+    expect(Boolean("run-from-operator")).toBe(true);
   });
 
   it("becomes true on explicit agent row click", () => {
@@ -275,6 +276,7 @@ describe("selectedRunId validation", () => {
 // ─── Formatter helpers ────────────────────────────────────────────────────────
 
 import { formatElapsed, formatCompactCount } from "./FleetView";
+import { resetDetailScrollPosition } from "./SessionDetail";
 
 describe("formatElapsed", () => {
   it("renders — for null, NaN, Infinity, and negative input", () => {
@@ -315,5 +317,18 @@ describe("formatCompactCount", () => {
     expect(formatCompactCount(1000)).toBe("1k");
     expect(formatCompactCount(5967)).toBe("5.9k");
     expect(formatCompactCount(999999)).toBe("999.9k");
+  });
+});
+
+describe("session detail scroll reset", () => {
+  it("returns every newly selected run to the top of its detail pane", () => {
+    const pane = document.createElement("div");
+    pane.scrollTop = 480;
+    resetDetailScrollPosition(pane);
+    expect(pane.scrollTop).toBe(0);
+
+    const source = fs.readFileSync(path.join(FLEET_DIR, "SessionDetail.tsx"), "utf-8");
+    expect(source).toContain("useLayoutEffect");
+    expect(source).toContain("[runId]");
   });
 });

--- a/apps/studio/frontend/src/components/fleet/FleetView.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.tsx
@@ -434,9 +434,18 @@ export default function FleetView() {
   const search = Route.useSearch();
   const navigate = Route.useNavigate();
   const urlRunId = (search as { s?: string }).s ?? null;
+  const rawInvocationId = (search as { invocation?: unknown }).invocation;
+  const urlInvocationId =
+    typeof rawInvocationId === "string"
+      ? rawInvocationId
+      : Array.isArray(rawInvocationId) && typeof rawInvocationId[0] === "string"
+        ? rawInvocationId[0]
+        : null;
 
-  // Whether the user has explicitly selected a row on narrow screens
-  const [narrowExplicit, setNarrowExplicit] = useState(false);
+  // A deep link is already an explicit selection. This matters when the
+  // Operator dock narrows Fleet below the split-pane breakpoint: opening a run
+  // must reveal its detail instead of landing back on the master list.
+  const [narrowExplicit, setNarrowExplicit] = useState(() => Boolean(urlRunId));
   const [histFilter, setHistFilter] = useState<HistFilter>("all");
 
   // History pagination. The 3s poll covers page 1 (200 runs); older pages are
@@ -495,24 +504,39 @@ export default function FleetView() {
   // Derive effective selection: URL param first, else auto-select first row.
   // We track whether we've done the auto-select with a ref to avoid loops.
   const autoSelectedRef = useRef<string | null>(null);
-  const allAgentIds = state.orgUnits.flatMap((u) => u.agents.map((a) => a.id));
+  const allAgents = state.orgUnits.flatMap((u) => u.agents);
+  const allAgentIds = allAgents.map((agent) => agent.id);
+  const invocationRunId = urlInvocationId
+    ? (allAgents.find((agent) => agent.invocation_id === urlInvocationId)?.id ??
+      historyRows.find((row) => row.invocation_id === urlInvocationId)?.id ??
+      null)
+    : null;
+  const requestedRunId = urlRunId ?? invocationRunId;
   const urlIdValid =
-    urlRunId != null &&
-    (allAgentIds.includes(urlRunId) || historyRows.some((r) => r.id === urlRunId));
+    requestedRunId != null &&
+    (allAgentIds.includes(requestedRunId) || historyRows.some((r) => r.id === requestedRunId));
+
+  useEffect(() => {
+    if (!urlRunId && invocationRunId) {
+      void navigate({
+        search: { ...search, s: invocationRunId },
+        replace: true,
+      });
+    }
+  }, [invocationRunId, navigate, search, urlRunId]);
 
   // Auto-select first row when data arrives and nothing is selected
   useEffect(() => {
-    if (state.orgUnits.length === 0) return;
-    const first = firstAgentId(state.orgUnits);
+    const first = firstAgentId(state.orgUnits) ?? historyRows[0]?.id ?? null;
     if (!first) return;
     if (urlRunId) return; // URL already has a selection
     if (autoSelectedRef.current === first) return;
     autoSelectedRef.current = first;
     void navigate({ search: { s: first }, replace: true });
-  }, [state.orgUnits, urlRunId, navigate]);
+  }, [state.orgUnits, historyRows, urlRunId, navigate]);
 
   // Resolved selected id: validated URL param, fallback to first (pre-auto-select)
-  const selectedRunId: string | null = urlIdValid ? urlRunId : null;
+  const selectedRunId: string | null = urlIdValid ? requestedRunId : null;
 
   const handleSelectAgent = useCallback(
     (id: string) => {
@@ -529,20 +553,18 @@ export default function FleetView() {
   const master = (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-edge px-4 py-3">
-        <div className="flex items-center gap-3">
-          <h1 className="text-[length:var(--t-md)] font-semibold text-content-primary">
-            {t("page.title")}
-          </h1>
+      <div className="flex items-start justify-between gap-3 border-b border-edge px-4 py-3">
+        <div className="min-w-0">
+          <h1 className="text-page-title font-semibold text-content-primary">{t("page.title")}</h1>
+          <p className="mt-0.5 truncate text-body text-content-muted">{t("page.subtitle")}</p>
+        </div>
+        <div className="shrink-0 pt-0.5">
           <FleetStaleBadge
             dataState={state.dataState}
             lastUpdatedMs={state.lastUpdatedMs}
             errorMessage={state.errorMessage}
           />
         </div>
-        <span className="font-data text-[length:var(--t-xs)] text-content-muted">
-          {t("page.subtitle")}
-        </span>
       </div>
 
       {/* Counts strip */}
@@ -610,7 +632,7 @@ export default function FleetView() {
       master={master}
       detail={detail}
       defaultMasterWidth={400}
-      detailActive={narrowExplicit}
+      detailActive={narrowExplicit || Boolean(invocationRunId)}
       ariaLabelMaster={t("split.master")}
       ariaLabelDetail={t("split.detail")}
     />

--- a/apps/studio/frontend/src/components/fleet/SessionDetail.tsx
+++ b/apps/studio/frontend/src/components/fleet/SessionDetail.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef } from "react";
 import { useTranslations } from "use-intl";
 import RunDetail from "@/components/history/RunDetail";
 
@@ -7,15 +8,44 @@ interface Props {
   showBack?: boolean;
 }
 
+export function resetDetailScrollPosition(element: HTMLElement | null): void {
+  if (element) element.scrollTop = 0;
+}
+
 export default function SessionDetail({ runId, onBack, showBack = false }: Props) {
   const t = useTranslations("fleet");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    resetDetailScrollPosition(scrollRef.current);
+  }, [runId]);
 
   if (!runId) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <span className="font-data text-[length:var(--t-sm)] text-content-muted">
-          {t("detail.hint")}
-        </span>
+      <div className="flex h-full items-center justify-center px-8 py-12 text-center">
+        <div className="max-w-xs">
+          <div className="mx-auto grid size-11 place-items-center rounded-lg border border-edge bg-surface-raised text-content-muted">
+            <svg
+              width="22"
+              height="22"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="8" />
+              <path d="M12 8v4l3 2" />
+            </svg>
+          </div>
+          <h2 className="mt-4 text-label font-semibold text-content-primary">
+            {t("detail.title")}
+          </h2>
+          <p className="mt-1.5 text-body leading-relaxed text-content-muted">{t("detail.hint")}</p>
+          <p className="mt-3 font-data text-meta text-content-muted">{t("empty.hint")}</p>
+        </div>
       </div>
     );
   }
@@ -52,7 +82,7 @@ export default function SessionDetail({ runId, onBack, showBack = false }: Props
 
       {/* Full run detail — same pane History renders, so Fleet selection shows
           the conversation, DAG, files, and signal events instead of bare meta. */}
-      <div className="flex-1 overflow-y-auto">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto">
         <RunDetail id={runId} />
       </div>
     </div>

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -57,6 +57,7 @@ export interface RecentRow {
   id: string;
   name: string;
   status: string;
+  invocation_id: string | null;
   status_reason_code?: string | null;
   status_reason_summary?: string | null;
   endedAtSec: number | null;
@@ -225,6 +226,7 @@ export function terminalRecentRows(runs: RunSummary[]): RecentRow[] {
       id: r.run_id,
       name: r.playbook_name ?? r.agent_name ?? r.run_id.slice(-12),
       status: r.status,
+      invocation_id: r.invocation_id ?? null,
       status_reason_code: r.status_reason_code,
       status_reason_summary: r.status_reason_summary,
       endedAtSec: r.ended_at ?? r.started_at ?? null,

--- a/apps/studio/frontend/src/components/history/ResumeRun.test.tsx
+++ b/apps/studio/frontend/src/components/history/ResumeRun.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import enMessages from "@/messages/en.json";
+import type { SessionBranch } from "@/lib/api";
+
+const resumeRunMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  resumeRun: resumeRunMock,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, search }: { children?: React.ReactNode; search?: Record<string, string> }) => (
+    <a href={`/fleet?${new URLSearchParams(search).toString()}`}>{children}</a>
+  ),
+}));
+
+const { default: ResumeRun, resumeCommand, shellQuote } = await import("./ResumeRun");
+
+function branch(id: string, name: string): SessionBranch {
+  return {
+    id,
+    name,
+    created_at: 1,
+    messages: [],
+    model: "claude/sonnet",
+  };
+}
+
+describe("ResumeRun helpers", () => {
+  it("builds a shell-safe copy escape hatch", () => {
+    expect(shellQuote("reviewer's branch")).toBe("'reviewer'\\''s branch'");
+    expect(resumeCommand("branch-1", "check 'again'")).toBe(
+      "li agent -r 'branch-1' --prompt 'check '\\''again'\\'''",
+    );
+    expect(resumeCommand(null, "")).toBe("li agent -r <branch-id> --prompt 'follow-up'");
+  });
+});
+
+describe("ResumeRun component", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    resumeRunMock.mockReset();
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function mount(branches: SessionBranch[], onResumed = vi.fn()) {
+    await act(async () => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <ResumeRun runId="run-1" branches={branches} onResumed={onResumed} />
+        </IntlProvider>,
+      );
+    });
+    return onResumed;
+  }
+
+  it("requires an explicit branch for a multi-branch run and always shows CLI fallback", async () => {
+    await mount([branch("branch-a", "Research"), branch("branch-b", "Review")]);
+
+    expect(container.querySelector("select")).not.toBeNull();
+    expect(container.textContent).toContain("CLI escape hatch");
+    expect(container.querySelector("code")?.textContent).toContain("<branch-id>");
+    const resume = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Resume"),
+    );
+    expect(resume?.disabled).toBe(true);
+  });
+
+  it("posts the selected branch and keeps a linked accepted state", async () => {
+    const onResumed = vi.fn();
+    resumeRunMock.mockResolvedValue({
+      run_id: "run-1",
+      branch_id: "branch-b",
+      invocation_id: "invocation-2",
+    });
+    await mount([branch("branch-a", "Research"), branch("branch-b", "Review")], onResumed);
+
+    const select = container.querySelector("select")!;
+    const textarea = container.querySelector("textarea")!;
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set?.call(
+        select,
+        "branch-b",
+      );
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set?.call(
+        textarea,
+        "Review the final patch",
+      );
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const resume = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Resume"),
+    )!;
+    await act(async () => {
+      resume.click();
+    });
+
+    expect(resumeRunMock).toHaveBeenCalledWith("run-1", {
+      instruction: "Review the final patch",
+      branch_id: "branch-b",
+    });
+    expect(onResumed).toHaveBeenCalled();
+    expect(container.textContent).toContain("Follow-up accepted");
+    expect(container.textContent).toContain("invocation-2");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "/fleet?s=run-1&invocation=invocation-2",
+    );
+  });
+});

--- a/apps/studio/frontend/src/components/history/ResumeRun.tsx
+++ b/apps/studio/frontend/src/components/history/ResumeRun.tsx
@@ -1,0 +1,220 @@
+import { useRef, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+import { ApiError, resumeRun, type SessionBranch } from "@/lib/api";
+import type { RunResumeResponse } from "@/lib/types";
+import Button from "@/components/ui/Button";
+import { IconArrowRight, IconCheck, IconCopy, IconLaunch } from "@/components/ui/icons";
+
+interface Props {
+  runId: string;
+  branches: SessionBranch[];
+  onResumed: (result: RunResumeResponse) => void | Promise<void>;
+}
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function resumeCommand(branchId: string | null, instruction: string): string {
+  const branch = branchId ? shellQuote(branchId) : "<branch-id>";
+  const followUp = shellQuote(instruction.trim() || "follow-up");
+  return `li agent -r ${branch} --prompt ${followUp}`;
+}
+
+export default function ResumeRun({ runId, branches, onResumed }: Props) {
+  const t = useTranslations("runResume");
+  const initialBranch = branches.length === 1 ? (branches[0]?.id ?? "") : "";
+  const [instruction, setInstruction] = useState("");
+  const [branchId, setBranchId] = useState(initialBranch);
+  const [showBranchSelector, setShowBranchSelector] = useState(branches.length > 1);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<RunResumeResponse | null>(null);
+  const [copied, setCopied] = useState(false);
+  const branchSelectRef = useRef<HTMLSelectElement>(null);
+
+  const selectedBranch = branches.find((branch) => branch.id === branchId) ?? null;
+  const command = resumeCommand(selectedBranch?.id ?? null, instruction);
+  const canResume = Boolean(instruction.trim()) && branches.length > 0 && Boolean(selectedBranch);
+
+  async function handleSubmit() {
+    if (!instruction.trim()) {
+      setError(t("instructionRequired"));
+      return;
+    }
+    if (branches.length === 0) {
+      setError(t("noBranches"));
+      return;
+    }
+    if (!selectedBranch) {
+      setShowBranchSelector(true);
+      setError(t("chooseBranch"));
+      requestAnimationFrame(() => branchSelectRef.current?.focus());
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    setResult(null);
+    try {
+      const accepted = await resumeRun(runId, {
+        instruction: instruction.trim(),
+        branch_id: selectedBranch.id,
+      });
+      setResult(accepted);
+      setInstruction("");
+      await onResumed(accepted);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : t("failed");
+      if (
+        (caught instanceof ApiError && caught.status === 409 && /branch_id/i.test(message)) ||
+        /branch_id is required/i.test(message)
+      ) {
+        setShowBranchSelector(true);
+        setError(t("chooseBranch"));
+        requestAnimationFrame(() => branchSelectRef.current?.focus());
+      } else {
+        setError(message);
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function copyCommand() {
+    if (!selectedBranch) return;
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setError(t("copyFailed"));
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby={`resume-run-${runId}`}
+      className="rounded-lg border border-edge bg-surface-raised p-3 shadow-[var(--shadow-raised-soft)]"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded border border-edge bg-surface-overlay text-accent">
+          <IconLaunch size={15} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 id={`resume-run-${runId}`} className="text-label font-semibold text-content-primary">
+            {t("title")}
+          </h3>
+          <p className="mt-0.5 text-body leading-relaxed text-content-muted">{t("description")}</p>
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {(showBranchSelector || branches.length > 1) && (
+          <label className="grid gap-1 text-meta font-medium text-content-secondary">
+            <span>{t("branch")}</span>
+            <select
+              ref={branchSelectRef}
+              value={branchId}
+              onChange={(event) => {
+                setBranchId(event.target.value);
+                setError(null);
+              }}
+              className="focus-ring h-8 rounded border border-edge bg-surface-base px-2 text-body text-content-primary"
+            >
+              <option value="">{t("chooseBranch")}</option>
+              {branches.map((branch) => (
+                <option key={branch.id} value={branch.id}>
+                  {branch.name || branch.id.slice(0, 8)}
+                  {branch.model ? ` · ${branch.model}` : ""}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <label className="grid gap-1 text-meta font-medium text-content-secondary">
+          <span>{t("instruction")}</span>
+          <textarea
+            value={instruction}
+            onChange={(event) => {
+              setInstruction(event.target.value);
+              setError(null);
+              setResult(null);
+            }}
+            onKeyDown={(event) => {
+              if (event.nativeEvent.isComposing) return;
+              if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault();
+                void handleSubmit();
+              }
+            }}
+            rows={2}
+            maxLength={32_768}
+            placeholder={t("placeholder")}
+            className="focus-ring min-h-16 resize-y rounded border border-edge bg-surface-base px-2.5 py-2 text-body leading-relaxed text-content-primary placeholder:text-content-muted"
+          />
+        </label>
+      </div>
+
+      {branches.length === 0 && (
+        <p className="mt-2 text-meta text-status-failure">{t("noBranches")}</p>
+      )}
+      {error && (
+        <p role="alert" className="mt-2 text-meta text-status-failure">
+          {error}
+        </p>
+      )}
+      {result && (
+        <div className="mt-2 flex flex-wrap items-center gap-2 rounded border border-status-success/30 bg-status-success-bg px-2.5 py-2 text-body text-status-success">
+          <IconCheck size={13} />
+          <span className="font-medium">{t("accepted")}</span>
+          <Link
+            to="/fleet"
+            search={{ s: result.run_id, invocation: result.invocation_id }}
+            className="focus-ring ms-auto inline-flex items-center gap-1 rounded text-content-primary underline decoration-edge-strong underline-offset-2"
+          >
+            {t("viewActivity")}
+            <span className="max-w-28 truncate font-data text-meta text-content-muted">
+              {result.invocation_id}
+            </span>
+            <IconArrowRight size={12} />
+          </Link>
+        </div>
+      )}
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          disabled={!canResume || submitting}
+          onClick={() => void handleSubmit()}
+          trailing={<IconArrowRight size={12} />}
+        >
+          {submitting ? t("submitting") : t("submit")}
+        </Button>
+        <span className="font-data text-meta text-content-muted">{t("shortcut")}</span>
+      </div>
+
+      <div className="mt-3 border-t border-edge pt-3">
+        <div className="mb-1.5 flex items-center justify-between gap-2">
+          <span className="text-meta font-medium text-content-secondary">{t("cli.title")}</span>
+          <button
+            type="button"
+            disabled={!selectedBranch}
+            onClick={() => void copyCommand()}
+            className="focus-ring inline-flex h-7 items-center gap-1 rounded px-2 text-meta text-content-muted transition-colors hover:bg-surface-overlay hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+            {copied ? t("cli.copied") : t("cli.copy")}
+          </button>
+        </div>
+        <code className="block overflow-x-auto rounded border border-edge bg-surface-base px-2.5 py-2 font-data text-meta text-content-secondary">
+          {command}
+        </code>
+        <p className="mt-1.5 text-meta leading-relaxed text-content-muted">{t("cli.help")}</p>
+      </div>
+    </section>
+  );
+}

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -12,14 +12,21 @@ import InvocationSection from "@/components/history/InvocationDetail";
 import OperationGraphSection from "@/components/history/OperationGraphSection";
 import StatusVerdictChips from "@/components/ui/StatusVerdictChips";
 import ExpectedArtifacts from "@/components/runs/ExpectedArtifacts";
+import ResumeRun from "@/components/history/ResumeRun";
 import RunStepCard, { extractFilePaths } from "@/components/RunStepCard";
 import { IconChevronDown, IconChevronRight } from "@/components/ui/icons";
-import { getSession, streamSession, streamSignals, SESSION_MESSAGE_PAGE } from "@/lib/api";
+import {
+  getInvocation,
+  getSession,
+  streamSession,
+  streamSignals,
+  SESSION_MESSAGE_PAGE,
+} from "@/lib/api";
 import type { SessionDetail, SessionBranch, SessionMessage, SignalEvent } from "@/lib/api";
 import { buildNodeStatusesByName, buildOperationGraph, laneFor } from "@/lib/operationGraph";
 import type { LaneSignal, OperationStatus } from "@/lib/operationGraph";
-import { deriveDisplayStatus } from "@/lib/runStatus";
-import type { RunMessage, RunStep, WorkerGraph } from "@/lib/types";
+import { deriveDisplayStatus, isEffectivelyActive } from "@/lib/runStatus";
+import type { RunMessage, RunResumeResponse, RunStep, WorkerGraph } from "@/lib/types";
 import type { NodeExecStatus } from "@/components/canvas/StepNode";
 
 const WorkerCanvas = lazy(() => import("@/components/canvas/WorkerCanvas"));
@@ -849,6 +856,7 @@ export default function RunDetail({ id }: RunDetailProps) {
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
   const [signalEvents, setSignalEvents] = useState<SignalEvent[]>([]);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const [resumeWatch, setResumeWatch] = useState<RunResumeResponse | null>(null);
   const olderOffsetRef = useRef(SESSION_MESSAGE_PAGE);
   const suppressAutoScrollRef = useRef(false);
   const initialScrollDoneRef = useRef(false);
@@ -904,6 +912,47 @@ export default function RunDetail({ id }: RunDetailProps) {
       })
       .catch((e: unknown) => setError(String(e)));
   }, [id]);
+
+  useEffect(() => {
+    if (!id || !resumeWatch || resumeWatch.run_id !== id) return;
+    let cancelled = false;
+    let timer: number | null = null;
+
+    const poll = async () => {
+      try {
+        // Observe invocation state first. If it is terminal, the session read
+        // that follows is ordered after the worker's terminal transition and
+        // therefore includes its final persisted messages.
+        const invocation = await getInvocation(resumeWatch.invocation_id);
+        const fresh = await getSession(id);
+        if (cancelled) return;
+        setSession((previous) =>
+          previous && previous.id === fresh.id ? mergeCompletedSession(previous, fresh) : fresh,
+        );
+        if (isEffectivelyActive(invocation)) {
+          setDone(false);
+          setLive(true);
+        } else {
+          setDone(true);
+          setLive(false);
+          setResumeWatch(null);
+          return;
+        }
+      } catch {
+        // A just-created invocation can race its first detail read, and a
+        // transient daemon disconnect must not strand a successfully accepted
+        // continuation. Retry until the component unmounts or activity reaches
+        // a terminal state.
+      }
+      if (!cancelled) timer = window.setTimeout(() => void poll(), 750);
+    };
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer != null) window.clearTimeout(timer);
+    };
+  }, [id, resumeWatch]);
 
   useEffect(() => {
     if (!id) return;
@@ -1021,6 +1070,25 @@ export default function RunDetail({ id }: RunDetailProps) {
       .catch((e: unknown) => setError(String(e)))
       .finally(() => setLoadingOlder(false));
   }, [id, loadingOlder]);
+
+  const handleResumed = useCallback(
+    async (result: RunResumeResponse) => {
+      setDone(false);
+      setLive(true);
+      setResumeWatch(result);
+      try {
+        const fresh = await getSession(id);
+        setSession((previous) =>
+          previous && previous.id === fresh.id ? mergeCompletedSession(previous, fresh) : fresh,
+        );
+      } catch {
+        // The accepted resume remains visible in ResumeRun. The existing SSE
+        // subscriptions continue to deliver activity even if this eager
+        // refresh races a transient daemon disconnect.
+      }
+    },
+    [id],
+  );
 
   const sessionStatus = done ? "completed" : live ? "running" : "completed";
 
@@ -1220,6 +1288,12 @@ export default function RunDetail({ id }: RunDetailProps) {
       </div>
 
       <OverviewSection data={overviewData} />
+      <ResumeRun
+        key={session.id}
+        runId={session.id}
+        branches={session.branches}
+        onResumed={handleResumed}
+      />
       {session.invocation_id && (
         <InvocationSection invocationId={session.invocation_id} currentSessionId={session.id} />
       )}

--- a/apps/studio/frontend/src/components/library/AgentDetail.tsx
+++ b/apps/studio/frontend/src/components/library/AgentDetail.tsx
@@ -206,15 +206,15 @@ export function AgentDetail({ agent, onBack }: Props) {
         <button
           type="button"
           onClick={onBack}
-          className="flex shrink-0 items-center gap-1.5 border-b border-edge px-4 py-2 text-[length:var(--t-xs)] text-content-muted"
+          className="flex shrink-0 items-center gap-1.5 border-b border-edge px-4 py-2 text-[length:var(--t-xs)] text-content-muted lg:hidden"
         >
           <IconArrowLeft size={11} strokeWidth={2} /> {t("back")}
         </button>
       )}
 
       {/* Header */}
-      <div className="flex shrink-0 items-center gap-3 border-b border-edge px-4 py-3">
-        <span className="truncate font-data font-medium text-[length:var(--t-lg)] text-content-primary">
+      <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 border-b border-edge px-4 py-3 sm:flex-nowrap">
+        <span className="min-w-0 basis-full break-words font-data font-medium text-[length:var(--t-lg)] leading-snug text-content-primary sm:basis-auto sm:flex-1 sm:truncate">
           {agent.name}
         </span>
         {agent.provider && (
@@ -228,7 +228,7 @@ export function AgentDetail({ agent, onBack }: Props) {
           </span>
         )}
 
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
           {previewVer ? (
             <>
               <span className="text-[length:var(--t-xs)] text-content-muted">

--- a/apps/studio/frontend/src/components/mission/MissionControl.tsx
+++ b/apps/studio/frontend/src/components/mission/MissionControl.tsx
@@ -38,9 +38,7 @@ export default function MissionControl() {
       {/* Page heading row with glanceable summary */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-[length:var(--t-base)] font-semibold text-content-primary">
-            {t("page.title")}
-          </h1>
+          <h1 className="text-page-title font-semibold text-content-primary">{t("page.title")}</h1>
           {isInitialLoad ? (
             <Skeleton className="mt-1.5 h-3 w-40" />
           ) : (

--- a/apps/studio/frontend/src/components/operator/OperatorPanel.test.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.test.tsx
@@ -1,0 +1,432 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import enMessages from "@/messages/en.json";
+import type { OperatorFrame } from "@/lib/types";
+
+const api = vi.hoisted(() => ({
+  acknowledgeOperatorEffect: vi.fn(),
+  cancelOperatorRequest: vi.fn(),
+  createOperatorConversation: vi.fn(),
+  decideOperatorProposal: vi.fn(),
+  getOperatorConversation: vi.fn(),
+  listOperatorConversations: vi.fn(),
+  streamOperatorConversation: vi.fn(() => vi.fn()),
+  submitOperatorTurn: vi.fn(),
+  getRunFile: vi.fn(),
+}));
+const router = vi.hoisted(() => ({ navigate: vi.fn() }));
+
+vi.mock("@/lib/api", () => api);
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children?: React.ReactNode }) => <a href="/fleet">{children}</a>,
+  useLocation: () => ({ pathname: "/", search: {} }),
+  useNavigate: () => router.navigate,
+}));
+
+const { default: OperatorPanel } = await import("./OperatorPanel");
+
+function textFrame(sequence: number, role: "user" | "assistant", content: string): OperatorFrame {
+  return {
+    version: 1,
+    conversationId: "conversation-1",
+    requestId: "request-1",
+    sequence,
+    type: "text",
+    payload: { content, format: "plain", role },
+    createdAt: sequence,
+  };
+}
+
+describe("OperatorPanel", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+        key: (index: number) => [...storage.keys()][index] ?? null,
+        get length() {
+          return storage.size;
+        },
+      },
+    });
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    api.getOperatorConversation.mockReset();
+    api.listOperatorConversations.mockReset();
+    api.listOperatorConversations.mockResolvedValue([]);
+    api.decideOperatorProposal.mockReset();
+    api.decideOperatorProposal.mockResolvedValue({
+      proposalId: "proposal-1",
+      status: "succeeded",
+    });
+    api.acknowledgeOperatorEffect.mockReset();
+    api.acknowledgeOperatorEffect.mockResolvedValue({
+      effectId: "effect-1",
+      status: "applied",
+    });
+    router.navigate.mockReset();
+    router.navigate.mockResolvedValue(undefined);
+    document.documentElement.setAttribute("data-theme", "dark");
+    api.streamOperatorConversation.mockReset();
+    api.streamOperatorConversation.mockReturnValue(vi.fn());
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    Element.prototype.scrollIntoView = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) act(() => root?.unmount());
+    root = null;
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function mount() {
+    await act(async () => {
+      root?.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <OperatorPanel open onClose={vi.fn()} />
+        </IntlProvider>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("is an immediate command front door when no conversation exists", async () => {
+    await mount();
+
+    expect(container.textContent).toContain("What should we do?");
+    expect(container.querySelector("textarea")?.placeholder).toContain("Ask Operator");
+    expect(container.querySelector('button[aria-label="Close Operator"]')).not.toBeNull();
+    expect(api.listOperatorConversations).toHaveBeenCalledOnce();
+    expect(api.getOperatorConversation).not.toHaveBeenCalled();
+  });
+
+  it("restores daemon history using only the persisted conversation id", async () => {
+    window.localStorage.setItem("studio:operator-conversation", "conversation-1");
+    api.listOperatorConversations.mockResolvedValue([
+      {
+        id: "conversation-1",
+        title: "Scheduler check",
+        status: "active",
+        activeRequestId: null,
+        updatedAt: 2,
+      },
+    ]);
+    api.getOperatorConversation.mockResolvedValue({
+      conversation: {
+        id: "conversation-1",
+        status: "active",
+        activeRequestId: null,
+      },
+      frames: [
+        textFrame(1, "user", "Inspect the scheduler"),
+        textFrame(2, "assistant", "The scheduler is healthy."),
+      ],
+    });
+
+    await mount();
+
+    expect(api.getOperatorConversation).toHaveBeenCalledWith("conversation-1");
+    expect(container.textContent).toContain("Inspect the scheduler");
+    expect(container.textContent).toContain("The scheduler is healthy.");
+    expect(api.streamOperatorConversation).toHaveBeenCalledWith(
+      "conversation-1",
+      2,
+      expect.any(Object),
+    );
+    expect(window.localStorage.getItem("studio:operator-conversation")).toBe("conversation-1");
+    expect(
+      [...Array(window.localStorage.length)].map((_, index) => window.localStorage.key(index)),
+    ).not.toContain("studio:operator-token");
+  });
+
+  it("recovers the latest daemon conversation when there is no cached id", async () => {
+    api.listOperatorConversations.mockResolvedValue([
+      {
+        id: "conversation-latest",
+        title: "Latest daemon history",
+        status: "active",
+        activeRequestId: null,
+        updatedAt: 20,
+      },
+      {
+        id: "conversation-older",
+        title: "Older daemon history",
+        status: "active",
+        activeRequestId: null,
+        updatedAt: 10,
+      },
+    ]);
+    api.getOperatorConversation.mockResolvedValue({
+      conversation: {
+        id: "conversation-latest",
+        title: "Latest daemon history",
+        status: "active",
+        activeRequestId: null,
+      },
+      frames: [
+        {
+          ...textFrame(1, "assistant", "Recovered from the daemon."),
+          conversationId: "conversation-latest",
+        },
+      ],
+    });
+
+    await mount();
+
+    expect(api.getOperatorConversation).toHaveBeenCalledWith("conversation-latest");
+    expect(container.textContent).toContain("Recovered from the daemon.");
+    expect(window.localStorage.getItem("studio:operator-conversation")).toBe("conversation-latest");
+    const switcher = container.querySelector('select[aria-label="Operator conversation"]');
+    expect(switcher?.querySelectorAll("option")).toHaveLength(3);
+    expect(switcher?.textContent).toContain("Older daemon history");
+  });
+
+  it("falls back from a stale cached id and keeps earlier daemon history reachable", async () => {
+    window.localStorage.setItem("studio:operator-conversation", "deleted-conversation");
+    api.listOperatorConversations.mockResolvedValue([
+      {
+        id: "conversation-active",
+        title: "Active conversation",
+        status: "active",
+        activeRequestId: null,
+        updatedAt: 20,
+      },
+      {
+        id: "conversation-prior",
+        title: "Prior conversation",
+        status: "active",
+        activeRequestId: null,
+        updatedAt: 10,
+      },
+    ]);
+    api.getOperatorConversation.mockImplementation((id: string) =>
+      Promise.resolve({
+        conversation: { id, title: id, status: "active", activeRequestId: null },
+        frames:
+          id === "conversation-prior"
+            ? [
+                {
+                  ...textFrame(1, "assistant", "Prior daemon transcript"),
+                  conversationId: "conversation-prior",
+                },
+              ]
+            : [],
+      }),
+    );
+
+    await mount();
+
+    expect(api.getOperatorConversation).toHaveBeenCalledWith("conversation-active");
+    expect(window.localStorage.getItem("studio:operator-conversation")).toBe("conversation-active");
+
+    const switcher = container.querySelector(
+      'select[aria-label="Operator conversation"]',
+    ) as HTMLSelectElement;
+    await act(async () => {
+      switcher.value = "conversation-prior";
+      switcher.dispatchEvent(new Event("change", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(api.getOperatorConversation).toHaveBeenCalledWith("conversation-prior");
+    expect(container.textContent).toContain("Prior daemon transcript");
+    expect(window.localStorage.getItem("studio:operator-conversation")).toBe("conversation-prior");
+  });
+
+  it("reveals the bounded proposed command and disables it after a denial", async () => {
+    api.listOperatorConversations.mockResolvedValue([
+      {
+        id: "conversation-1",
+        title: "Permission review",
+        status: "active",
+        activeRequestId: null,
+      },
+    ]);
+    api.getOperatorConversation.mockResolvedValue({
+      conversation: {
+        id: "conversation-1",
+        status: "active",
+        activeRequestId: null,
+      },
+      frames: [
+        {
+          version: 1,
+          conversationId: "conversation-1",
+          requestId: "request-1",
+          sequence: 1,
+          type: "proposal",
+          payload: {
+            proposal: {
+              id: "proposal-1",
+              command: {
+                tool: "Bash",
+                arguments: { command: "git status", authorization: "Bearer secret" },
+              },
+              commandHash: "sha256",
+              risk: "execute",
+              summary: "Inspect repository state",
+              target: {
+                kind: "playbook",
+                id: "review",
+                version: "playbook-fingerprint",
+              },
+              idempotencyKey: "once",
+              expiresAt: 999,
+            },
+          },
+          createdAt: 1,
+        },
+      ] satisfies OperatorFrame[],
+    });
+
+    await mount();
+
+    expect(container.textContent).toContain("Review exact command");
+    expect(container.textContent).toContain("Bash");
+    expect(container.textContent).toContain("git status");
+    expect(container.textContent).toContain("[redacted]");
+    expect(container.textContent).not.toContain("Bearer secret");
+
+    const deny = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Deny",
+    );
+    await act(async () => {
+      deny?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(api.decideOperatorProposal).toHaveBeenCalledWith(
+      "conversation-1",
+      "proposal-1",
+      "deny",
+      "sha256",
+      "playbook-fingerprint",
+    );
+    expect(container.textContent).toContain("Decision recorded");
+    expect(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Allow",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("applies and durably acknowledges a validated theme effect once", async () => {
+    api.listOperatorConversations.mockResolvedValue([
+      {
+        id: "conversation-1",
+        title: "Theme update",
+        status: "active",
+        activeRequestId: null,
+      },
+    ]);
+    api.getOperatorConversation.mockResolvedValue({
+      conversation: {
+        id: "conversation-1",
+        status: "active",
+        activeRequestId: null,
+      },
+      frames: [
+        {
+          version: 1,
+          conversationId: "conversation-1",
+          requestId: "request-1",
+          sequence: 1,
+          type: "ui_command",
+          payload: {
+            effect: { id: "effect-1", kind: "theme", theme: "light" },
+          },
+          createdAt: 1,
+        },
+      ] satisfies OperatorFrame[],
+    });
+
+    await mount();
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(api.acknowledgeOperatorEffect).toHaveBeenCalledWith("conversation-1", "effect-1", {
+      status: "applied",
+      clientRoute: "/",
+    });
+    expect(
+      JSON.parse(window.localStorage.getItem("studio:operator-effects:conversation-1") ?? "[]"),
+    ).toContainEqual(["effect-1", { status: "applied", clientRoute: "/" }]);
+  });
+
+  it("fails closed without replaying an effect when acknowledgement storage is blocked", async () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          if (key.startsWith("studio:operator-effects:")) throw new Error("blocked");
+          storage.set(key, value);
+        },
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+        key: (index: number) => [...storage.keys()][index] ?? null,
+        get length() {
+          return storage.size;
+        },
+      },
+    });
+    api.listOperatorConversations.mockResolvedValue([
+      {
+        id: "conversation-1",
+        title: "Theme update",
+        status: "active",
+        activeRequestId: null,
+      },
+    ]);
+    api.getOperatorConversation.mockResolvedValue({
+      conversation: {
+        id: "conversation-1",
+        status: "active",
+        activeRequestId: null,
+      },
+      frames: [
+        {
+          version: 1,
+          conversationId: "conversation-1",
+          requestId: "request-1",
+          sequence: 1,
+          type: "ui_command",
+          payload: {
+            effect: { id: "effect-1", kind: "theme", theme: "light" },
+          },
+          createdAt: 1,
+        },
+      ] satisfies OperatorFrame[],
+    });
+
+    await mount();
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(api.acknowledgeOperatorEffect).toHaveBeenCalledWith("conversation-1", "effect-1", {
+      status: "rejected",
+      clientRoute: "/",
+      rejectionCode: "client_error",
+    });
+    expect(api.acknowledgeOperatorEffect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/studio/frontend/src/components/operator/OperatorPanel.test.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => router.navigate,
 }));
 
-const { default: OperatorPanel } = await import("./OperatorPanel");
+const { default: OperatorPanel, formatProposalCommand } = await import("./OperatorPanel");
 
 function textFrame(sequence: number, role: "user" | "assistant", content: string): OperatorFrame {
   return {
@@ -252,6 +252,136 @@ describe("OperatorPanel", () => {
     expect(api.getOperatorConversation).toHaveBeenCalledWith("conversation-prior");
     expect(container.textContent).toContain("Prior daemon transcript");
     expect(window.localStorage.getItem("studio:operator-conversation")).toBe("conversation-prior");
+  });
+
+  function mockProposal(command: Record<string, unknown>, risk = "execute") {
+    api.listOperatorConversations.mockResolvedValue([
+      {
+        id: "conversation-1",
+        title: "Permission review",
+        status: "active",
+        activeRequestId: null,
+      },
+    ]);
+    api.getOperatorConversation.mockResolvedValue({
+      conversation: { id: "conversation-1", status: "active", activeRequestId: null },
+      frames: [
+        {
+          version: 1,
+          conversationId: "conversation-1",
+          requestId: "request-1",
+          sequence: 1,
+          type: "proposal",
+          payload: {
+            proposal: {
+              id: "proposal-1",
+              command,
+              commandHash: "sha256",
+              risk,
+              summary: "Update the changelog date.",
+              idempotencyKey: "once",
+              expiresAt: 999,
+            },
+          },
+          createdAt: 1,
+        },
+      ] as unknown as OperatorFrame[],
+    });
+  }
+
+  it("warns outside the disclosure when the rendered command is cut short", async () => {
+    const command = {
+      operation: "shell",
+      note: "x".repeat(6_400),
+      argv: ["rm", "-rf", "/etc"],
+    };
+    // No sensitive keys, no deep nesting, no long arrays: the redaction pass is the
+    // identity here, so the dropped count is computable without the code under test.
+    const dropped = JSON.stringify(command, null, 2).length - 6_000;
+    expect(dropped).toBeGreaterThan(0);
+    expect(dropped).toBeLessThan(1_000); // stays un-grouped in en number formatting
+    mockProposal(command);
+
+    await mount();
+
+    const warning = container.querySelector('[data-testid="proposal-elided"]');
+    expect(warning).not.toBeNull();
+    // A warning inside <details> is one the operator can approve without ever seeing.
+    expect(warning?.closest("details")).toBeNull();
+    expect(warning?.textContent).toContain(String(dropped));
+    expect(container.querySelector("pre")?.textContent).not.toContain("/etc");
+  });
+
+  it("does not warn about elision for a short flat command", async () => {
+    mockProposal({ tool: "Bash", arguments: { command: "rm -rf /etc" } });
+
+    await mount();
+
+    expect(container.querySelector('[data-testid="proposal-elided"]')).toBeNull();
+    expect(container.querySelector("pre")?.textContent).toContain("/etc");
+  });
+
+  it("opens the command disclosure by default so Allow is never live over a hidden command", async () => {
+    mockProposal({ tool: "Bash", arguments: { command: "git status" } });
+
+    await mount();
+
+    const disclosure = container.querySelector("details");
+    expect(disclosure).not.toBeNull();
+    expect(disclosure?.open).toBe(true);
+    expect(
+      Array.from(container.querySelectorAll("button")).find(
+        (button) => button.textContent === "Allow",
+      ),
+    ).toBeDefined();
+  });
+
+  describe("formatProposalCommand", () => {
+    it("reports the length cut with the number of characters dropped", () => {
+      const command = { note: "x".repeat(6_400) };
+      const full = JSON.stringify(command, null, 2);
+      const shown = formatProposalCommand(command);
+
+      expect(shown.elided).toBe(true);
+      expect(shown.droppedCharacters).toBe(full.length - 6_000);
+      expect(shown.text.endsWith("\n…")).toBe(true);
+    });
+
+    it("reports the array cut", () => {
+      const shown = formatProposalCommand({
+        paths: [...Array.from({ length: 50 }, (_, index) => `/safe/${index}`), "/etc/shadow"],
+      });
+
+      expect(shown.elided).toBe(true);
+      expect(shown.droppedCharacters).toBe(0);
+      expect(shown.text).not.toContain("/etc/shadow");
+      expect(shown.text).toContain("[1 more items]");
+    });
+
+    it("reports the depth cut", () => {
+      let nested: Record<string, unknown> = { danger: "rm -rf /" };
+      for (let depth = 0; depth < 8; depth += 1) nested = { nested };
+      const shown = formatProposalCommand(nested);
+
+      expect(shown.elided).toBe(true);
+      expect(shown.text).not.toContain("rm -rf /");
+      expect(shown.text).toContain("[truncated]");
+    });
+
+    it("reports redaction", () => {
+      const shown = formatProposalCommand({ authorization: "Bearer secret" });
+
+      expect(shown.elided).toBe(true);
+      expect(shown.text).toContain("[redacted]");
+    });
+
+    it("reports a short flat command as complete", () => {
+      const shown = formatProposalCommand({ argv: ["rm", "-rf", "/etc"] });
+
+      expect(shown.elided).toBe(false);
+      expect(shown.droppedCharacters).toBe(0);
+      expect(shown.text).toContain("/etc");
+    });
   });
 
   it("reveals the bounded proposed command and disables it after a denial", async () => {

--- a/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
@@ -157,26 +157,61 @@ function findRunId(value: unknown, depth = 0): string | null {
 
 const SENSITIVE_COMMAND_KEY = /(?:authorization|credential|password|secret|token|api[_-]?key)/i;
 
-function redactCommandValue(value: unknown, depth = 0): unknown {
-  if (depth >= 7) return "[truncated]";
+const MAX_RENDERED_COMMAND_CHARS = 6_000;
+
+export interface FormattedProposalCommand {
+  /** The string drawn on screen — not necessarily the whole command. */
+  text: string;
+  /** True when the text is a lossy view: depth cut, array cut, length cut, or redaction. */
+  elided: boolean;
+  /** Characters dropped by the length cut. Zero when the length cut did not fire. */
+  droppedCharacters: number;
+}
+
+function redactCommandValue(value: unknown, depth: number, elided: { hit: boolean }): unknown {
+  if (depth >= 7) {
+    elided.hit = true;
+    return "[truncated]";
+  }
   if (Array.isArray(value)) {
-    const result = value.slice(0, 50).map((item) => redactCommandValue(item, depth + 1));
-    if (value.length > 50) result.push(`[${value.length - 50} more items]`);
+    const result = value.slice(0, 50).map((item) => redactCommandValue(item, depth + 1, elided));
+    if (value.length > 50) {
+      elided.hit = true;
+      result.push(`[${value.length - 50} more items]`);
+    }
     return result;
   }
   if (value == null || typeof value !== "object") return value;
   const redacted: Record<string, unknown> = {};
   for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
-    redacted[key] = SENSITIVE_COMMAND_KEY.test(key)
-      ? "[redacted]"
-      : redactCommandValue(item, depth + 1);
+    if (SENSITIVE_COMMAND_KEY.test(key)) {
+      elided.hit = true;
+      redacted[key] = "[redacted]";
+    } else {
+      redacted[key] = redactCommandValue(item, depth + 1, elided);
+    }
   }
   return redacted;
 }
 
-export function formatProposalCommand(command: Record<string, unknown>): string {
-  const formatted = JSON.stringify(redactCommandValue(command), null, 2);
-  return formatted.length > 6_000 ? `${formatted.slice(0, 6_000)}\n…` : formatted;
+/**
+ * Render a proposal command for review, reporting whether the rendering is lossy.
+ *
+ * The caller must surface `elided` outside any collapsed disclosure: the operator
+ * approves the whole command, so "what you are reading is smaller than what runs"
+ * has to be visible in the same glance as the Allow button.
+ */
+export function formatProposalCommand(command: Record<string, unknown>): FormattedProposalCommand {
+  const elided = { hit: false };
+  const formatted = JSON.stringify(redactCommandValue(command, 0, elided), null, 2);
+  if (formatted.length > MAX_RENDERED_COMMAND_CHARS) {
+    return {
+      text: `${formatted.slice(0, MAX_RENDERED_COMMAND_CHARS)}\n…`,
+      elided: true,
+      droppedCharacters: formatted.length - MAX_RENDERED_COMMAND_CHARS,
+    };
+  }
+  return { text: formatted, elided: elided.hit, droppedCharacters: 0 };
 }
 
 function operatorContext(
@@ -341,6 +376,7 @@ function ProposalCard({
 }) {
   const t = useTranslations("operator");
   const proposal = frame.payload.proposal;
+  const command = formatProposalCommand(proposal.command);
   const target = proposal.target
     ? `${proposal.target.kind} · ${proposal.target.id}`
     : t("proposal.noTarget");
@@ -364,14 +400,37 @@ function ProposalCard({
           <p className="mt-2 truncate font-data text-meta text-content-muted" title={target}>
             {target}
           </p>
-          <details className="mt-3 overflow-hidden rounded border border-status-pending/30 bg-surface-base">
+          {/*
+            Open by default: every proposal that reaches this card needs a permission
+            decision, and Allow must never be live over a command the operator has not
+            been shown.
+          */}
+          <details
+            open
+            className="mt-3 overflow-hidden rounded border border-status-pending/30 bg-surface-base"
+          >
             <summary className="focus-ring cursor-pointer px-2.5 py-2 text-meta font-medium text-content-secondary">
               {t("proposal.review")}
             </summary>
             <pre className="max-h-48 overflow-auto border-t border-status-pending/20 px-2.5 py-2 font-data text-meta leading-relaxed text-content-primary">
-              {formatProposalCommand(proposal.command)}
+              {command.text}
             </pre>
           </details>
+          {/*
+            Outside the disclosure on purpose — a warning rendered inside a collapsible
+            element is a warning the operator can approve without ever seeing.
+          */}
+          {command.elided && (
+            <p
+              data-testid="proposal-elided"
+              className="mt-2 flex items-start gap-1.5 text-meta text-status-failure"
+            >
+              <IconError size={13} className="mt-0.5 shrink-0" />
+              {command.droppedCharacters > 0
+                ? t("proposal.elidedCharacters", { count: command.droppedCharacters })
+                : t("proposal.elided")}
+            </p>
+          )}
           {resolved ? (
             <div className="mt-3 flex items-center gap-1.5 text-body text-status-success">
               <IconCheck size={13} />

--- a/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
@@ -1,0 +1,1139 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex -- the WAI-ARIA separator is an interactive window splitter */
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+import {
+  ApiError,
+  acknowledgeOperatorEffect,
+  cancelOperatorRequest,
+  createOperatorConversation,
+  decideOperatorProposal,
+  getOperatorConversation,
+  listOperatorConversations,
+  streamOperatorConversation,
+  submitOperatorTurn,
+} from "@/lib/api";
+import type {
+  OperatorContextSnapshot,
+  OperatorConfirmationPayload,
+  OperatorConversation,
+  OperatorDonePayload,
+  OperatorErrorPayload,
+  OperatorFrame,
+  OperatorProposalPayload,
+  OperatorTextPayload,
+  OperatorToolCallPayload,
+  OperatorToolResultPayload,
+  OperatorUiCommandPayload,
+} from "@/lib/types";
+import Button from "@/components/ui/Button";
+import Markdown from "@/components/ui/Markdown";
+import {
+  IconArrowRight,
+  IconBan,
+  IconCheck,
+  IconClose,
+  IconError,
+  IconLaunch,
+  IconPause,
+  IconShield,
+  IconTool,
+} from "@/components/ui/icons";
+import { initialOperatorState, operatorReducer, pendingOperatorProposals } from "./operatorReducer";
+import {
+  effectAcknowledgementStorageAvailable,
+  effectPlanRoute,
+  operatorEffectId,
+  planOperatorEffect,
+  readEffectAcknowledgements,
+  rememberEffectAcknowledgement,
+  type StoredEffectAcknowledgement,
+} from "./operatorEffects";
+import { applyTheme } from "@/lib/theme";
+
+const STORAGE_KEY = "studio:operator-conversation";
+const DEFAULT_WIDTH = 408;
+const MIN_WIDTH = 320;
+const MAX_WIDTH = 640;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type DisplayItem =
+  | {
+      kind: "text";
+      key: string;
+      requestId: string;
+      sequence: number;
+      role: "user" | "assistant";
+      format: "plain" | "markdown";
+      content: string;
+    }
+  | { kind: "frame"; key: string; frame: OperatorFrame };
+
+function readStoredConversation(): string | null {
+  if (typeof window === "undefined") return null;
+  const value = window.localStorage.getItem(STORAGE_KEY)?.trim();
+  return value || null;
+}
+
+function conversationLabel(conversation: OperatorConversation): string {
+  const title = conversation.title?.trim();
+  if (title) return title;
+  const timestamp = conversation.updatedAt ?? conversation.createdAt;
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+    const milliseconds = timestamp < 10_000_000_000 ? timestamp * 1000 : timestamp;
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(milliseconds);
+  }
+  return conversation.id.slice(0, 8);
+}
+
+function displayItems(frames: OperatorFrame[]): DisplayItem[] {
+  const items: DisplayItem[] = [];
+  for (const frame of frames) {
+    if (frame.type !== "text") {
+      items.push({ kind: "frame", key: `frame-${frame.sequence}`, frame });
+      continue;
+    }
+    const payload = frame.payload as OperatorTextPayload;
+    const role = payload.role === "user" ? "user" : "assistant";
+    const previous = items.at(-1);
+    if (
+      previous?.kind === "text" &&
+      previous.requestId === frame.requestId &&
+      previous.role === role &&
+      previous.format === payload.format
+    ) {
+      previous.content += payload.content;
+      continue;
+    }
+    items.push({
+      kind: "text",
+      key: `text-${frame.sequence}`,
+      requestId: frame.requestId,
+      sequence: frame.sequence,
+      role,
+      format: payload.format,
+      content: payload.content,
+    });
+  }
+  return items;
+}
+
+function findRunId(value: unknown, depth = 0): string | null {
+  if (depth > 4 || value == null || typeof value !== "object") return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findRunId(item, depth + 1);
+      if (found) return found;
+    }
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of ["runId", "run_id", "sessionId", "session_id"]) {
+    if (typeof record[key] === "string" && record[key]) return record[key];
+  }
+  for (const nested of Object.values(record)) {
+    const found = findRunId(nested, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+const SENSITIVE_COMMAND_KEY = /(?:authorization|credential|password|secret|token|api[_-]?key)/i;
+
+function redactCommandValue(value: unknown, depth = 0): unknown {
+  if (depth >= 7) return "[truncated]";
+  if (Array.isArray(value)) {
+    const result = value.slice(0, 50).map((item) => redactCommandValue(item, depth + 1));
+    if (value.length > 50) result.push(`[${value.length - 50} more items]`);
+    return result;
+  }
+  if (value == null || typeof value !== "object") return value;
+  const redacted: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    redacted[key] = SENSITIVE_COMMAND_KEY.test(key)
+      ? "[redacted]"
+      : redactCommandValue(item, depth + 1);
+  }
+  return redacted;
+}
+
+export function formatProposalCommand(command: Record<string, unknown>): string {
+  const formatted = JSON.stringify(redactCommandValue(command), null, 2);
+  return formatted.length > 6_000 ? `${formatted.slice(0, 6_000)}\n…` : formatted;
+}
+
+function operatorContext(
+  pathname: string,
+  search: Record<string, unknown>,
+): OperatorContextSnapshot {
+  let space: OperatorContextSnapshot["space"] = "mission";
+  if (pathname.startsWith("/library")) space = "library";
+  else if (pathname.startsWith("/schedules")) space = "schedules";
+  else if (pathname.startsWith("/system")) space = "system";
+  else if (pathname.startsWith("/designer")) space = "designer";
+  else if (pathname.startsWith("/history")) space = "history";
+
+  const filters: OperatorContextSnapshot["filters"] = {};
+  const selection: Record<string, string> = {};
+  for (const [key, value] of Object.entries(search)) {
+    if (
+      value == null ||
+      (!Array.isArray(value) &&
+        typeof value !== "string" &&
+        typeof value !== "number" &&
+        typeof value !== "boolean")
+    ) {
+      continue;
+    }
+    filters[key] = value as OperatorContextSnapshot["filters"][string];
+    if ((key === "s" || key === "sel") && typeof value === "string") selection[key] = value;
+  }
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(filters)) {
+    if (Array.isArray(value)) {
+      for (const item of value) query.append(key, String(item));
+    } else if (value != null && typeof value !== "object") {
+      query.set(key, String(value));
+    }
+  }
+  const queryString = query.toString();
+  return {
+    space,
+    route: `${pathname}${queryString ? `?${queryString}` : ""}`,
+    selection: Object.keys(selection).length ? selection : null,
+    filters,
+  };
+}
+
+function ConnectionBadge({
+  state,
+}: {
+  state: "idle" | "connecting" | "open" | "reconnecting" | "error";
+}) {
+  const t = useTranslations("operator");
+  const label = t(`connection.${state}` as Parameters<typeof t>[0]);
+  const color =
+    state === "open"
+      ? "bg-status-success"
+      : state === "error"
+        ? "bg-status-failure"
+        : state === "idle"
+          ? "bg-content-muted"
+          : "bg-status-pending";
+  return (
+    <span
+      className="inline-flex min-w-0 items-center gap-1.5 font-data text-[length:var(--t-xs)] text-content-muted"
+      title={label}
+    >
+      <span aria-hidden className={`h-1.5 w-1.5 shrink-0 rounded-full ${color}`} />
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+function RunLink({ runId }: { runId: string }) {
+  const t = useTranslations("operator");
+  return (
+    <Link
+      to="/fleet"
+      search={{ s: runId }}
+      className="focus-ring mt-2 inline-flex h-8 items-center gap-1.5 rounded border border-edge bg-surface-overlay px-2.5 text-body font-medium text-content-primary transition-colors hover:border-edge-strong"
+    >
+      <IconLaunch size={13} />
+      <span>{t("run.open")}</span>
+      <span className="max-w-32 truncate font-data text-meta text-content-muted">{runId}</span>
+      <IconArrowRight size={12} />
+    </Link>
+  );
+}
+
+function TextMessage({ item }: { item: Extract<DisplayItem, { kind: "text" }> }) {
+  const t = useTranslations("operator");
+  const user = item.role === "user";
+  return (
+    <article
+      aria-label={user ? t("message.you") : t("message.operator")}
+      className={user ? "flex justify-end" : "flex justify-start"}
+    >
+      <div
+        className={
+          user
+            ? "max-w-[88%] rounded-lg border border-edge bg-surface-overlay px-3 py-2 text-body text-content-primary"
+            : "max-w-full min-w-0 text-body leading-relaxed text-content-secondary"
+        }
+      >
+        {item.format === "markdown" && !user ? (
+          <Markdown>{item.content}</Markdown>
+        ) : (
+          <p className="whitespace-pre-wrap break-words">{item.content}</p>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function ToolCallCard({ payload }: { payload: OperatorToolCallPayload }) {
+  const t = useTranslations("operator");
+  return (
+    <details className="rounded border border-edge bg-surface-raised">
+      <summary className="focus-ring flex cursor-pointer list-none items-center gap-2 rounded px-2.5 py-2 text-body text-content-secondary">
+        <IconTool size={13} />
+        <span className="min-w-0 flex-1 truncate font-medium">{payload.tool}</span>
+        <span className="font-data text-meta text-content-muted">{t(`tool.${payload.mode}`)}</span>
+      </summary>
+      <pre className="max-h-48 overflow-auto border-t border-edge px-2.5 py-2 font-data text-meta leading-relaxed text-content-muted">
+        {JSON.stringify(payload.arguments, null, 2)}
+      </pre>
+    </details>
+  );
+}
+
+function ToolResultCard({ payload }: { payload: OperatorToolResultPayload }) {
+  const t = useTranslations("operator");
+  const runId = payload.ok ? findRunId(payload.result) : null;
+  return (
+    <div
+      className={`rounded border px-2.5 py-2 text-body ${
+        payload.ok
+          ? "border-status-success/30 bg-status-success-bg text-content-secondary"
+          : "border-status-failure/30 bg-status-error-bg text-status-failure"
+      }`}
+    >
+      <div className="flex items-center gap-1.5 font-medium">
+        {payload.ok ? <IconCheck size={13} /> : <IconError size={13} />}
+        {payload.ok ? t("tool.done") : t("tool.failed")}
+      </div>
+      {!payload.ok && payload.error?.message && (
+        <p className="mt-1 break-words text-meta">{payload.error.message}</p>
+      )}
+      {runId && <RunLink runId={runId} />}
+    </div>
+  );
+}
+
+function ProposalCard({
+  frame,
+  resolved,
+  deciding,
+  onDecision,
+}: {
+  frame: OperatorFrame<OperatorProposalPayload>;
+  resolved: boolean;
+  deciding: boolean;
+  onDecision: (decision: "allow" | "deny") => void;
+}) {
+  const t = useTranslations("operator");
+  const proposal = frame.payload.proposal;
+  const target = proposal.target
+    ? `${proposal.target.kind} · ${proposal.target.id}`
+    : t("proposal.noTarget");
+  return (
+    <section
+      aria-label={t("proposal.ariaLabel")}
+      className="rounded-lg border border-status-pending/40 bg-status-warning-bg p-3"
+    >
+      <div className="flex items-start gap-2">
+        <IconShield size={15} className="mt-0.5 shrink-0 text-status-pending" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-label font-semibold text-content-primary">{t("proposal.title")}</h3>
+            <span className="rounded border border-status-pending/30 px-1.5 py-0.5 font-data text-meta uppercase tracking-[var(--tracking-meta)] text-status-pending">
+              {t(`proposal.risk.${proposal.risk}`)}
+            </span>
+          </div>
+          <p className="mt-1 text-body leading-relaxed text-content-secondary">
+            {proposal.summary}
+          </p>
+          <p className="mt-2 truncate font-data text-meta text-content-muted" title={target}>
+            {target}
+          </p>
+          <details className="mt-3 overflow-hidden rounded border border-status-pending/30 bg-surface-base">
+            <summary className="focus-ring cursor-pointer px-2.5 py-2 text-meta font-medium text-content-secondary">
+              {t("proposal.review")}
+            </summary>
+            <pre className="max-h-48 overflow-auto border-t border-status-pending/20 px-2.5 py-2 font-data text-meta leading-relaxed text-content-primary">
+              {formatProposalCommand(proposal.command)}
+            </pre>
+          </details>
+          {resolved ? (
+            <div className="mt-3 flex items-center gap-1.5 text-body text-status-success">
+              <IconCheck size={13} />
+              {t("proposal.resolved")}
+            </div>
+          ) : (
+            <div className="mt-3 flex gap-2">
+              <Button
+                variant="primary"
+                size="sm"
+                disabled={deciding}
+                onClick={() => onDecision("allow")}
+              >
+                {deciding ? t("proposal.deciding") : t("proposal.allow")}
+              </Button>
+              <Button
+                variant="danger"
+                size="sm"
+                disabled={deciding}
+                onClick={() => onDecision("deny")}
+              >
+                {t("proposal.deny")}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FrameCard({
+  frame,
+  proposalResolved,
+  deciding,
+  onProposalDecision,
+}: {
+  frame: OperatorFrame;
+  proposalResolved: boolean;
+  deciding: boolean;
+  onProposalDecision: (
+    frame: OperatorFrame<OperatorProposalPayload>,
+    decision: "allow" | "deny",
+  ) => void;
+}) {
+  const t = useTranslations("operator");
+  if (frame.type === "tool_call") {
+    return <ToolCallCard payload={frame.payload as OperatorToolCallPayload} />;
+  }
+  if (frame.type === "tool_result") {
+    return <ToolResultCard payload={frame.payload as OperatorToolResultPayload} />;
+  }
+  if (frame.type === "proposal") {
+    const proposalFrame = frame as OperatorFrame<OperatorProposalPayload>;
+    return (
+      <ProposalCard
+        frame={proposalFrame}
+        resolved={proposalResolved}
+        deciding={deciding}
+        onDecision={(decision) => onProposalDecision(proposalFrame, decision)}
+      />
+    );
+  }
+  if (frame.type === "confirmation") {
+    const payload = frame.payload as OperatorConfirmationPayload;
+    const denied = payload.state === "denied" || payload.state === "cancelled";
+    return (
+      <div className="flex items-center gap-1.5 px-1 text-meta text-content-muted">
+        {denied ? <IconBan size={12} /> : <IconShield size={12} />}
+        {t(`confirmation.${payload.state}` as Parameters<typeof t>[0])}
+      </div>
+    );
+  }
+  if (frame.type === "ui_command") {
+    const payload = frame.payload as OperatorUiCommandPayload;
+    return (
+      <div className="rounded border border-edge bg-surface-raised px-2.5 py-2 text-meta text-content-muted">
+        {t("effect.requested", { kind: payload.effect.kind })}
+      </div>
+    );
+  }
+  if (frame.type === "error") {
+    const payload = frame.payload as OperatorErrorPayload;
+    return (
+      <div className="rounded border border-status-failure/30 bg-status-error-bg px-2.5 py-2 text-body text-status-failure">
+        <div className="flex items-start gap-1.5">
+          <IconError size={13} className="mt-0.5 shrink-0" />
+          <span className="break-words">{payload.error.message}</span>
+        </div>
+      </div>
+    );
+  }
+  if (frame.type === "done") {
+    const payload = frame.payload as OperatorDonePayload;
+    const tone =
+      payload.outcome === "completed"
+        ? "text-status-success"
+        : payload.outcome === "cancelled"
+          ? "text-content-muted"
+          : "text-status-failure";
+    return (
+      <div className={`flex items-center gap-2 py-1 text-meta ${tone}`}>
+        <span aria-hidden className="h-px flex-1 bg-edge" />
+        <span>{t(`outcome.${payload.outcome}`)}</span>
+        <span aria-hidden className="h-px flex-1 bg-edge" />
+      </div>
+    );
+  }
+  return null;
+}
+
+export default function OperatorPanel({ open, onClose }: Props) {
+  const t = useTranslations("operator");
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [state, dispatch] = useReducer(operatorReducer, initialOperatorState);
+  const [instruction, setInstruction] = useState("");
+  const [sending, setSending] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [deciding, setDeciding] = useState<Set<string>>(() => new Set());
+  const [decidedProposalIds, setDecidedProposalIds] = useState<Set<string>>(() => new Set());
+  const [conversations, setConversations] = useState<OperatorConversation[]>([]);
+  const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
+  const [showJump, setShowJump] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(200);
+  const feedRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+  const nearBottomRef = useRef(true);
+  const previousItemCountRef = useRef(0);
+  const anchorHeightRef = useRef<number | null>(null);
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const effectsInFlightRef = useRef<Set<string>>(new Set());
+  const effectsAcknowledgedRef = useRef<Set<string>>(new Set());
+  const effectOutcomesRef = useRef<Map<string, StoredEffectAcknowledgement>>(new Map());
+
+  const loadConversation = useCallback(
+    async (conversationId: string) => {
+      dispatch({ type: "LOAD_START" });
+      try {
+        const snapshot = await getOperatorConversation(conversationId);
+        window.localStorage.setItem(STORAGE_KEY, snapshot.conversation.id);
+        setConversations((current) => {
+          const index = current.findIndex((item) => item.id === snapshot.conversation.id);
+          if (index < 0) return [snapshot.conversation, ...current];
+          return current.map((item, itemIndex) =>
+            itemIndex === index ? snapshot.conversation : item,
+          );
+        });
+        dispatch({
+          type: "LOAD_SUCCESS",
+          conversation: snapshot.conversation,
+          frames: snapshot.frames,
+        });
+      } catch (error) {
+        dispatch({
+          type: "LOAD_ERROR",
+          error: error instanceof Error ? error.message : t("errors.load"),
+        });
+      }
+    },
+    [t],
+  );
+
+  useEffect(() => {
+    let active = true;
+    const stored = readStoredConversation();
+    void listOperatorConversations()
+      .then((available) => {
+        if (!active) return;
+        setConversations(available);
+        const selected =
+          (stored ? available.find((item) => item.id === stored) : null) ??
+          available.find((item) => item.status === "active") ??
+          available[0] ??
+          null;
+        if (selected) {
+          void loadConversation(selected.id);
+        } else if (stored) {
+          window.localStorage.removeItem(STORAGE_KEY);
+        }
+      })
+      .catch(() => {
+        if (!active) return;
+        if (stored) {
+          void loadConversation(stored);
+        } else {
+          setActionError(t("errors.load"));
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [loadConversation, t]);
+
+  useEffect(() => {
+    const conversationId = state.conversation?.id;
+    if (!conversationId || state.loadState !== "ready") return;
+    let queued: OperatorFrame[] = [];
+    let animationFrame: number | null = null;
+    const flush = () => {
+      animationFrame = null;
+      if (queued.length === 0) return;
+      const batch = queued;
+      queued = [];
+      dispatch({ type: "APPEND_FRAMES", frames: batch });
+    };
+    const close = streamOperatorConversation(conversationId, state.lastSequence, {
+      onFrame: (frame) => {
+        queued.push(frame);
+        if (animationFrame == null) animationFrame = window.requestAnimationFrame(flush);
+      },
+      onConnection: (connection) => {
+        dispatch({
+          type: "CONNECTION",
+          state:
+            connection === "open"
+              ? "open"
+              : connection === "reconnecting"
+                ? "reconnecting"
+                : "connecting",
+        });
+      },
+      onError: (error, fatal) => {
+        if (fatal) {
+          dispatch({ type: "CONNECTION", state: "error", error: error.message });
+        } else {
+          dispatch({ type: "CONNECTION", state: "reconnecting" });
+        }
+      },
+    });
+    return () => {
+      close();
+      if (animationFrame != null) window.cancelAnimationFrame(animationFrame);
+      if (queued.length) dispatch({ type: "APPEND_FRAMES", frames: queued });
+    };
+    // Reconnect is owned by streamOperatorConversation; changing cursor must
+    // not tear down a healthy stream after every frame.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.conversation?.id, state.loadState]);
+
+  const applyClientEffect = useCallback(
+    async (effect: unknown): Promise<StoredEffectAcknowledgement> => {
+      const plan = planOperatorEffect(effect);
+      const currentRoute = `${window.location.pathname}${window.location.search}`;
+      if (plan.kind === "reject") {
+        return {
+          status: "rejected",
+          clientRoute: currentRoute,
+          rejectionCode: plan.rejectionCode,
+        };
+      }
+      try {
+        if (plan.kind === "theme") {
+          applyTheme(plan.theme);
+          if (document.documentElement.getAttribute("data-theme") !== plan.theme) {
+            return {
+              status: "rejected",
+              clientRoute: currentRoute,
+              rejectionCode: "client_error",
+            };
+          }
+          return { status: "applied", clientRoute: currentRoute };
+        }
+        await navigate({
+          to: plan.to as never,
+          search: plan.search as never,
+        });
+        return { status: "applied", clientRoute: effectPlanRoute(plan) };
+      } catch {
+        return {
+          status: "rejected",
+          clientRoute: currentRoute,
+          rejectionCode: "client_error",
+        };
+      }
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    const conversationId = state.conversation?.id;
+    if (!conversationId || state.loadState !== "ready") return;
+    const remembered = readEffectAcknowledgements(conversationId);
+    for (const frame of state.frames) {
+      if (frame.type !== "ui_command") continue;
+      const effect = (frame.payload as OperatorUiCommandPayload).effect;
+      const effectId = operatorEffectId(effect);
+      const effectKey = `${conversationId}:${effectId ?? ""}`;
+      if (
+        !effectId ||
+        effectsInFlightRef.current.has(effectKey) ||
+        effectsAcknowledgedRef.current.has(effectKey)
+      ) {
+        continue;
+      }
+      effectsInFlightRef.current.add(effectKey);
+      void (async () => {
+        const previous = effectOutcomesRef.current.get(effectKey) ?? remembered.get(effectId);
+        let acknowledgement = previous;
+        if (!acknowledgement) {
+          if (!effectAcknowledgementStorageAvailable(conversationId)) {
+            acknowledgement = {
+              status: "rejected",
+              clientRoute: `${window.location.pathname}${window.location.search}`,
+              rejectionCode: "client_error",
+            };
+          } else {
+            acknowledgement = await applyClientEffect(effect);
+          }
+          // The in-memory outcome is written before any network await. If
+          // acknowledgement fails, a later frame retries the same ACK without
+          // replaying the visible navigation/theme operation.
+          effectOutcomesRef.current.set(effectKey, acknowledgement);
+          // Persist before the network acknowledgement. If the daemon drops
+          // immediately after applying navigation/theme, replay sends the
+          // same acknowledgement without repeating the visible side effect.
+          rememberEffectAcknowledgement(conversationId, effectId, acknowledgement);
+        }
+        await acknowledgeOperatorEffect(conversationId, effectId, acknowledgement);
+        effectsAcknowledgedRef.current.add(effectKey);
+      })()
+        .catch((error) => {
+          setActionError(error instanceof Error ? error.message : t("errors.effect"));
+        })
+        .finally(() => {
+          effectsInFlightRef.current.delete(effectKey);
+        });
+    }
+  }, [applyClientEffect, state.conversation?.id, state.frames, state.loadState, t]);
+
+  const items = useMemo(() => displayItems(state.frames), [state.frames]);
+  const visibleItems = useMemo(() => items.slice(-visibleCount), [items, visibleCount]);
+  const proposals = useMemo(() => pendingOperatorProposals(state.frames), [state.frames]);
+  const resolvedProposalIds = useMemo(() => {
+    const resolved = new Set(decidedProposalIds);
+    for (const item of proposals) {
+      if (item.resolved) resolved.add(item.frame.payload.proposal.id);
+    }
+    return resolved;
+  }, [decidedProposalIds, proposals]);
+
+  useLayoutEffect(() => {
+    if (!open || !nearBottomRef.current) {
+      if (open && !nearBottomRef.current) setShowJump(true);
+      return;
+    }
+    endRef.current?.scrollIntoView({ block: "end" });
+    setShowJump(false);
+  }, [items.length, open]);
+
+  useEffect(() => {
+    const added = Math.max(0, items.length - previousItemCountRef.current);
+    if (added && !nearBottomRef.current) setVisibleCount((count) => count + added);
+    previousItemCountRef.current = items.length;
+  }, [items.length]);
+
+  useLayoutEffect(() => {
+    const oldHeight = anchorHeightRef.current;
+    const feed = feedRef.current;
+    if (oldHeight == null || !feed) return;
+    feed.scrollTop += feed.scrollHeight - oldHeight;
+    anchorHeightRef.current = null;
+  }, [visibleCount]);
+
+  const handleScroll = useCallback(() => {
+    const feed = feedRef.current;
+    if (!feed) return;
+    const near = feed.scrollHeight - feed.scrollTop - feed.clientHeight < 96;
+    nearBottomRef.current = near;
+    setShowJump(!near);
+  }, []);
+
+  const jumpToLatest = useCallback(() => {
+    nearBottomRef.current = true;
+    endRef.current?.scrollIntoView({ block: "end" });
+    setShowJump(false);
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = instruction.trim();
+    if (!trimmed || sending || state.activeRequestId) return;
+    setSending(true);
+    setActionError(null);
+    try {
+      let conversation = state.conversation;
+      if (!conversation) {
+        conversation = await createOperatorConversation();
+        window.localStorage.setItem(STORAGE_KEY, conversation.id);
+        setConversations((current) => [
+          conversation as OperatorConversation,
+          ...current.filter((item) => item.id !== conversation?.id),
+        ]);
+        dispatch({ type: "LOAD_SUCCESS", conversation, frames: [] });
+      }
+      const context = operatorContext(
+        location.pathname,
+        location.search as Record<string, unknown>,
+      );
+      const accepted = await submitOperatorTurn(conversation.id, {
+        instruction: trimmed,
+        context,
+        expectedLastSequence: state.lastSequence,
+      });
+      dispatch({ type: "TURN_ACCEPTED", requestId: accepted.requestId });
+      setInstruction("");
+      nearBottomRef.current = true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : t("errors.send");
+      setActionError(message);
+      if (
+        error instanceof ApiError &&
+        error.status === 409 &&
+        error.code === "stale_context" &&
+        state.conversation
+      ) {
+        await loadConversation(state.conversation.id);
+      }
+    } finally {
+      setSending(false);
+    }
+  }, [
+    instruction,
+    location.pathname,
+    location.search,
+    sending,
+    state.activeRequestId,
+    state.conversation,
+    state.lastSequence,
+    t,
+    loadConversation,
+  ]);
+
+  const handleStop = useCallback(async () => {
+    if (!state.conversation || !state.activeRequestId || stopping) return;
+    setStopping(true);
+    setActionError(null);
+    try {
+      await cancelOperatorRequest(state.conversation.id, state.activeRequestId);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : t("errors.stop"));
+    } finally {
+      setStopping(false);
+    }
+  }, [state.activeRequestId, state.conversation, stopping, t]);
+
+  const handleProposalDecision = useCallback(
+    async (frame: OperatorFrame<OperatorProposalPayload>, decision: "allow" | "deny") => {
+      if (!state.conversation) return;
+      const proposal = frame.payload.proposal;
+      setDeciding((current) => new Set(current).add(proposal.id));
+      setActionError(null);
+      try {
+        await decideOperatorProposal(
+          state.conversation.id,
+          proposal.id,
+          decision,
+          proposal.commandHash,
+          proposal.target?.version ?? null,
+        );
+        setDecidedProposalIds((current) => new Set(current).add(proposal.id));
+      } catch (error) {
+        setActionError(error instanceof Error ? error.message : t("errors.decision"));
+      } finally {
+        setDeciding((current) => {
+          const next = new Set(current);
+          next.delete(proposal.id);
+          return next;
+        });
+      }
+    },
+    [state.conversation, t],
+  );
+
+  const resetConversation = useCallback(() => {
+    window.localStorage.removeItem(STORAGE_KEY);
+    dispatch({ type: "RESET" });
+    setActionError(null);
+    setInstruction("");
+    setDecidedProposalIds(new Set());
+  }, []);
+
+  const selectConversation = useCallback(
+    (conversationId: string) => {
+      if (!conversationId) {
+        resetConversation();
+        return;
+      }
+      if (conversationId === state.conversation?.id) return;
+      dispatch({ type: "RESET" });
+      setVisibleCount(200);
+      setActionError(null);
+      setDecidedProposalIds(new Set());
+      nearBottomRef.current = true;
+      void loadConversation(conversationId);
+    },
+    [loadConversation, resetConversation, state.conversation?.id],
+  );
+
+  const clampWidth = useCallback(
+    (value: number) => Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, value)),
+    [],
+  );
+
+  if (!open) return null;
+
+  const empty = state.frames.length === 0 && state.loadState !== "loading";
+  const fatalError = state.loadState === "error";
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={t("close")}
+        className="fixed inset-0 z-30 bg-black/40 lg:hidden"
+        onClick={onClose}
+      />
+      <aside
+        aria-label={t("ariaLabel")}
+        className="fixed inset-y-0 end-0 z-40 flex min-h-0 flex-col border-s border-edge bg-surface-base shadow-card lg:relative lg:inset-auto lg:z-auto lg:shrink-0 lg:shadow-none"
+        style={{ width: `min(${panelWidth}px, calc(100vw - 3.5rem))` }}
+      >
+        {/* WAI-ARIA window-splitter pattern: the separator is intentionally
+            focusable and handles pointer/keyboard resizing. */}
+        <div
+          role="separator"
+          aria-label={t("resize")}
+          aria-orientation="vertical"
+          aria-valuemin={MIN_WIDTH}
+          aria-valuemax={MAX_WIDTH}
+          aria-valuenow={Math.round(panelWidth)}
+          tabIndex={0}
+          onPointerDown={(event) => {
+            dragRef.current = { startX: event.clientX, startWidth: panelWidth };
+            event.currentTarget.setPointerCapture(event.pointerId);
+          }}
+          onPointerMove={(event) => {
+            const drag = dragRef.current;
+            if (!drag) return;
+            const rtl = document.documentElement.dir === "rtl";
+            const delta = event.clientX - drag.startX;
+            setPanelWidth(clampWidth(drag.startWidth + (rtl ? delta : -delta)));
+          }}
+          onPointerUp={() => {
+            dragRef.current = null;
+          }}
+          onPointerCancel={() => {
+            dragRef.current = null;
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+            event.preventDefault();
+            const rtl = document.documentElement.dir === "rtl";
+            const towardEnd = event.key === "ArrowRight";
+            const grow = rtl ? towardEnd : !towardEnd;
+            setPanelWidth((width) => clampWidth(width + (grow ? 16 : -16)));
+          }}
+          className="group absolute inset-y-0 start-0 z-10 w-2 -translate-x-1/2 cursor-col-resize focus:outline-none"
+        >
+          <span
+            aria-hidden
+            className="absolute inset-y-0 start-1/2 w-px bg-edge transition-colors group-hover:bg-accent group-focus-visible:bg-accent"
+          />
+        </div>
+
+        <header className="flex h-12 shrink-0 items-center gap-3 border-b border-edge px-3">
+          <div className="flex h-7 w-7 items-center justify-center rounded border border-edge bg-surface-raised text-accent">
+            <IconShield size={15} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate text-label font-semibold text-content-primary">{t("title")}</h2>
+            <div className="flex min-w-0 items-center gap-2">
+              <ConnectionBadge state={state.connectionState} />
+              <select
+                aria-label={t("ariaLabel")}
+                title={t("newConversation")}
+                value={state.conversation?.id ?? ""}
+                onChange={(event) => selectConversation(event.target.value)}
+                className="min-w-0 max-w-36 flex-1 truncate border-0 bg-transparent py-0 font-data text-meta text-content-muted outline-none focus:text-content-primary"
+              >
+                <option value="">{t("newConversation")}</option>
+                {conversations.map((conversation) => (
+                  <option key={conversation.id} value={conversation.id}>
+                    {conversationLabel(conversation)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {state.activeRequestId && (
+            <Button
+              variant="danger"
+              size="sm"
+              leading={<IconPause size={12} />}
+              disabled={stopping}
+              onClick={() => void handleStop()}
+            >
+              {stopping ? t("stopping") : t("stop")}
+            </Button>
+          )}
+          <button
+            type="button"
+            className="focus-ring flex h-8 w-8 items-center justify-center rounded text-content-muted transition-colors hover:bg-surface-overlay hover:text-content-primary"
+            aria-label={t("close")}
+            title={t("close")}
+            onClick={onClose}
+          >
+            <IconClose size={15} />
+          </button>
+        </header>
+
+        <div
+          ref={feedRef}
+          onScroll={handleScroll}
+          className="relative min-h-0 flex-1 overflow-y-auto px-3 py-4"
+          aria-live="polite"
+          aria-busy={state.loadState === "loading" || sending}
+        >
+          {state.loadState === "loading" && state.frames.length === 0 && (
+            <div className="space-y-3" aria-label={t("loading")}>
+              <div className="skeleton h-3 w-28 rounded" />
+              <div className="skeleton h-16 w-full rounded-lg" />
+              <div className="skeleton h-3 w-40 rounded" />
+            </div>
+          )}
+
+          {fatalError && (
+            <div className="flex min-h-full flex-col items-center justify-center px-4 text-center">
+              <IconError size={24} className="text-status-failure" />
+              <h3 className="mt-3 text-label font-semibold text-content-primary">
+                {t("error.title")}
+              </h3>
+              <p className="mt-1 max-w-64 text-body leading-relaxed text-content-muted">
+                {state.error ?? t("errors.load")}
+              </p>
+              <div className="mt-4 flex gap-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => {
+                    const id = readStoredConversation();
+                    if (id) void loadConversation(id);
+                  }}
+                >
+                  {t("retry")}
+                </Button>
+                <Button variant="secondary" size="sm" onClick={resetConversation}>
+                  {t("newConversation")}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {empty && !fatalError && (
+            <div className="flex min-h-full flex-col items-center justify-center px-4 pb-8 text-center">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-edge bg-surface-raised text-accent">
+                <IconShield size={20} />
+              </div>
+              <h3 className="mt-4 text-[length:var(--t-lg)] font-semibold text-content-primary">
+                {t("empty.title")}
+              </h3>
+              <p className="mt-2 max-w-72 text-body leading-relaxed text-content-muted">
+                {t("empty.body")}
+              </p>
+              <p className="mt-3 font-data text-meta text-content-muted">{t("empty.example")}</p>
+            </div>
+          )}
+
+          {!fatalError && items.length > 0 && (
+            <div className="space-y-4">
+              {items.length > visibleItems.length && (
+                <div className="flex justify-center pb-1">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => {
+                      anchorHeightRef.current = feedRef.current?.scrollHeight ?? null;
+                      setVisibleCount((count) => Math.min(items.length, count + 200));
+                    }}
+                  >
+                    {t("loadOlder")}
+                  </Button>
+                </div>
+              )}
+              {visibleItems.map((item) => {
+                if (item.kind === "text") return <TextMessage key={item.key} item={item} />;
+                const proposalId =
+                  item.frame.type === "proposal"
+                    ? (item.frame.payload as OperatorProposalPayload).proposal.id
+                    : "";
+                return (
+                  <FrameCard
+                    key={item.key}
+                    frame={item.frame}
+                    proposalResolved={resolvedProposalIds.has(proposalId)}
+                    deciding={deciding.has(proposalId)}
+                    onProposalDecision={handleProposalDecision}
+                  />
+                );
+              })}
+            </div>
+          )}
+          <div ref={endRef} />
+        </div>
+
+        {showJump && (
+          <button
+            type="button"
+            className="focus-ring absolute bottom-28 end-4 rounded-full border border-edge bg-surface-overlay px-3 py-1.5 text-meta font-medium text-content-primary shadow-card"
+            onClick={jumpToLatest}
+          >
+            {t("jumpToLatest")}
+          </button>
+        )}
+
+        <footer className="shrink-0 border-t border-edge bg-surface-raised p-3">
+          {(actionError || (state.connectionState === "error" && state.error)) && (
+            <div className="mb-2 flex items-start gap-1.5 rounded border border-status-failure/30 bg-status-error-bg px-2 py-1.5 text-meta text-status-failure">
+              <IconError size={12} className="mt-0.5 shrink-0" />
+              <span className="min-w-0 flex-1 break-words">{actionError ?? state.error}</span>
+            </div>
+          )}
+          <label htmlFor="operator-instruction" className="sr-only">
+            {t("composer.label")}
+          </label>
+          <div className="rounded-lg border border-edge bg-surface-base transition-colors focus-within:border-edge-strong focus-within:shadow-[var(--focus-ring)]">
+            <textarea
+              id="operator-instruction"
+              value={instruction}
+              onChange={(event) => setInstruction(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) return;
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  void handleSend();
+                }
+              }}
+              rows={2}
+              maxLength={32_768}
+              disabled={Boolean(state.activeRequestId) || sending || fatalError}
+              placeholder={
+                state.activeRequestId ? t("composer.busyPlaceholder") : t("composer.placeholder")
+              }
+              className="block max-h-40 min-h-14 w-full resize-none bg-transparent px-3 py-2 text-body leading-relaxed text-content-primary outline-none placeholder:text-content-muted disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <div className="flex items-center justify-between px-2 pb-2">
+              <span className="font-data text-meta text-content-muted">{t("composer.hint")}</span>
+              <Button
+                variant="primary"
+                size="sm"
+                trailing={<IconArrowRight size={12} />}
+                disabled={
+                  !instruction.trim() || sending || Boolean(state.activeRequestId) || fatalError
+                }
+                onClick={() => void handleSend()}
+              >
+                {sending ? t("composer.sending") : t("composer.send")}
+              </Button>
+            </div>
+          </div>
+        </footer>
+      </aside>
+    </>
+  );
+}

--- a/apps/studio/frontend/src/components/operator/operatorEffects.test.ts
+++ b/apps/studio/frontend/src/components/operator/operatorEffects.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  effectPlanRoute,
+  effectAcknowledgementStorageAvailable,
+  planOperatorEffect,
+  readEffectAcknowledgements,
+  rememberEffectAcknowledgement,
+} from "./operatorEffects";
+
+describe("Operator client effects", () => {
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => values.get(key) ?? null,
+        setItem: (key: string, value: string) => values.set(key, value),
+        removeItem: (key: string) => values.delete(key),
+        clear: () => values.clear(),
+      },
+    });
+  });
+
+  it("validates and canonicalizes navigation instead of accepting arbitrary routes", () => {
+    const plan = planOperatorEffect({
+      id: "effect-1",
+      kind: "navigate",
+      space: "mission",
+      params: { view: "fleet", status: ["failed"], s: "run-1" },
+    });
+    expect(plan).toEqual({
+      kind: "navigate",
+      to: "/fleet",
+      search: { status: ["failed"], s: "run-1" },
+    });
+    if (plan.kind === "navigate") {
+      expect(effectPlanRoute(plan)).toBe("/fleet?status=failed&s=run-1");
+    }
+
+    expect(
+      planOperatorEffect({
+        id: "effect-2",
+        kind: "navigate",
+        space: "library",
+        params: { tab: "root-shell" },
+      }),
+    ).toEqual({ kind: "reject", rejectionCode: "invalid_params" });
+  });
+
+  it("maps a schedule prefill to the reviewed create form and rejects hidden forms", () => {
+    expect(
+      planOperatorEffect({
+        id: "effect-1",
+        kind: "prefill",
+        form: "schedule",
+        values: { name: "Daily brief", cron_expr: "0 9 * * *", action_prompt: "Summarize" },
+      }),
+    ).toEqual({
+      kind: "navigate",
+      to: "/schedules",
+      search: {
+        create: "1",
+        name: "Daily brief",
+        cron: "0 9 * * *",
+        prompt: "Summarize",
+      },
+    });
+    expect(
+      planOperatorEffect({
+        id: "effect-2",
+        kind: "prefill",
+        form: "workflow",
+        values: {},
+      }),
+    ).toEqual({ kind: "reject", rejectionCode: "not_visible" });
+  });
+
+  it("persists a bounded acknowledgement history to avoid replaying effects", () => {
+    rememberEffectAcknowledgement("conversation-1", "effect-1", {
+      status: "applied",
+      clientRoute: "/fleet?s=run-1",
+    });
+    expect(readEffectAcknowledgements("conversation-1").get("effect-1")).toEqual({
+      status: "applied",
+      clientRoute: "/fleet?s=run-1",
+    });
+  });
+
+  it("reports blocked acknowledgement storage without throwing", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error("blocked");
+        },
+        removeItem: () => undefined,
+      },
+    });
+    expect(effectAcknowledgementStorageAvailable("conversation-1")).toBe(false);
+    expect(
+      rememberEffectAcknowledgement("conversation-1", "effect-1", {
+        status: "applied",
+        clientRoute: "/fleet",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/studio/frontend/src/components/operator/operatorEffects.ts
+++ b/apps/studio/frontend/src/components/operator/operatorEffects.ts
@@ -1,0 +1,278 @@
+import type { OperatorEffectRejectionCode } from "@/lib/api";
+import type { OperatorUiEffect } from "@/lib/types";
+
+type SearchValue = string | number | boolean | string[];
+
+export type OperatorEffectPlan =
+  | {
+      kind: "navigate";
+      to: "/" | "/fleet" | "/library" | "/schedules" | "/system";
+      search: Record<string, SearchValue>;
+    }
+  | { kind: "theme"; theme: "dark" | "light" }
+  | { kind: "reject"; rejectionCode: OperatorEffectRejectionCode };
+
+export type StoredEffectAcknowledgement =
+  | { status: "applied"; clientRoute: string }
+  | {
+      status: "rejected";
+      clientRoute?: string;
+      rejectionCode: OperatorEffectRejectionCode;
+    };
+
+const FLEET_KEYS = new Set([
+  "s",
+  "status",
+  "playbook",
+  "project",
+  "page",
+  "skill",
+  "sessions",
+  "invocation",
+]);
+const LIBRARY_TABS = new Set(["all", "agent", "workflow", "playbook", "skill", "plugin", "engine"]);
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function searchValue(value: unknown): value is SearchValue {
+  return (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    (Array.isArray(value) && value.every((item) => typeof item === "string"))
+  );
+}
+
+function pickSearch(value: unknown, allowed: Set<string>): Record<string, SearchValue> | null {
+  const source = record(value);
+  if (!source) return null;
+  const result: Record<string, SearchValue> = {};
+  for (const [key, item] of Object.entries(source)) {
+    if (!allowed.has(key) || !searchValue(item)) return null;
+    result[key] = item;
+  }
+  return result;
+}
+
+function stringSelection(value: unknown): Record<string, string> | null {
+  const source = record(value);
+  if (!source) return null;
+  const result: Record<string, string> = {};
+  for (const [key, item] of Object.entries(source)) {
+    if (typeof item !== "string" || !item) return null;
+    result[key] = item;
+  }
+  return Object.keys(result).length ? result : null;
+}
+
+export function planOperatorEffect(effect: unknown): OperatorEffectPlan {
+  const raw = record(effect);
+  if (!raw || typeof raw.kind !== "string") {
+    return { kind: "reject", rejectionCode: "unsupported" };
+  }
+
+  if (raw.kind === "theme") {
+    return raw.theme === "dark" || raw.theme === "light"
+      ? { kind: "theme", theme: raw.theme }
+      : { kind: "reject", rejectionCode: "invalid_params" };
+  }
+
+  if (raw.kind === "navigate") {
+    const params = record(raw.params);
+    if (!params || typeof raw.space !== "string") {
+      return { kind: "reject", rejectionCode: "invalid_params" };
+    }
+    if (raw.space === "mission" || raw.space === "history") {
+      const view = params.view;
+      const fleet =
+        raw.space === "history" || view === "fleet" || [...FLEET_KEYS].some((k) => k in params);
+      if (!fleet) {
+        return Object.keys(params).length === 0
+          ? { kind: "navigate", to: "/", search: {} }
+          : { kind: "reject", rejectionCode: "invalid_params" };
+      }
+      const fleetParams = { ...params };
+      delete fleetParams.view;
+      const search = pickSearch(fleetParams, FLEET_KEYS);
+      return search
+        ? { kind: "navigate", to: "/fleet", search }
+        : { kind: "reject", rejectionCode: "invalid_params" };
+    }
+    if (raw.space === "library") {
+      const search = pickSearch(params, new Set(["tab", "sel"]));
+      if (!search || ("tab" in search && !LIBRARY_TABS.has(String(search.tab)))) {
+        return { kind: "reject", rejectionCode: "invalid_params" };
+      }
+      return { kind: "navigate", to: "/library", search };
+    }
+    if (raw.space === "schedules") {
+      const search = pickSearch(params, new Set(["create", "name", "cron", "prompt", "desc", "s"]));
+      return search
+        ? { kind: "navigate", to: "/schedules", search }
+        : { kind: "reject", rejectionCode: "invalid_params" };
+    }
+    if (raw.space === "system") {
+      const search = pickSearch(params, new Set(["tab"]));
+      const tab = search?.tab;
+      if (
+        !search ||
+        (tab != null && tab !== "health" && tab !== "maintenance" && tab !== "settings")
+      ) {
+        return { kind: "reject", rejectionCode: "invalid_params" };
+      }
+      return { kind: "navigate", to: "/system", search };
+    }
+    if (raw.space === "designer") {
+      const search = pickSearch(params, new Set(["sel"]));
+      if (!search) return { kind: "reject", rejectionCode: "invalid_params" };
+      return {
+        kind: "navigate",
+        to: "/library",
+        search: { tab: "workflow", ...search },
+      };
+    }
+    return { kind: "reject", rejectionCode: "unsupported" };
+  }
+
+  if (raw.kind === "select") {
+    const selection = stringSelection(raw.selection);
+    if (!selection || typeof raw.space !== "string") {
+      return { kind: "reject", rejectionCode: "invalid_params" };
+    }
+    if (raw.space === "mission" || raw.space === "history") {
+      const id = selection.s ?? selection.runId ?? selection.run_id ?? selection.sessionId;
+      return id
+        ? { kind: "navigate", to: "/fleet", search: { s: id } }
+        : { kind: "reject", rejectionCode: "invalid_params" };
+    }
+    if (raw.space === "library") {
+      const selected = selection.sel;
+      return selected
+        ? { kind: "navigate", to: "/library", search: { sel: selected } }
+        : { kind: "reject", rejectionCode: "invalid_params" };
+    }
+    if (raw.space === "schedules") {
+      const id = selection.s ?? selection.id;
+      return id
+        ? { kind: "navigate", to: "/schedules", search: { s: id } }
+        : { kind: "reject", rejectionCode: "invalid_params" };
+    }
+    if (raw.space === "designer") {
+      const selected = selection.sel ?? selection.id;
+      return selected
+        ? {
+            kind: "navigate",
+            to: "/library",
+            search: {
+              tab: "workflow",
+              sel: selected.startsWith("workflow:") ? selected : `workflow:${selected}`,
+            },
+          }
+        : { kind: "reject", rejectionCode: "invalid_params" };
+    }
+    return { kind: "reject", rejectionCode: "unsupported" };
+  }
+
+  if (raw.kind === "prefill") {
+    if (raw.form !== "schedule") {
+      return { kind: "reject", rejectionCode: "not_visible" };
+    }
+    const values = record(raw.values);
+    if (!values) return { kind: "reject", rejectionCode: "invalid_params" };
+    const aliases: Record<string, string> = {
+      name: "name",
+      cron: "cron",
+      cron_expr: "cron",
+      prompt: "prompt",
+      action_prompt: "prompt",
+      desc: "desc",
+      description: "desc",
+    };
+    const search: Record<string, SearchValue> = { create: "1" };
+    for (const [key, value] of Object.entries(values)) {
+      const target = aliases[key];
+      if (!target || typeof value !== "string") {
+        return { kind: "reject", rejectionCode: "invalid_params" };
+      }
+      search[target] = value;
+    }
+    return { kind: "navigate", to: "/schedules", search };
+  }
+
+  return { kind: "reject", rejectionCode: "unsupported" };
+}
+
+export function effectPlanRoute(plan: Extract<OperatorEffectPlan, { kind: "navigate" }>): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(plan.search)) {
+    if (Array.isArray(value)) {
+      for (const item of value) query.append(key, item);
+    } else {
+      query.set(key, String(value));
+    }
+  }
+  const suffix = query.toString();
+  return `${plan.to}${suffix ? `?${suffix}` : ""}`;
+}
+
+function storageKey(conversationId: string): string {
+  return `studio:operator-effects:${conversationId}`;
+}
+
+export function readEffectAcknowledgements(
+  conversationId: string,
+): Map<string, StoredEffectAcknowledgement> {
+  if (typeof window === "undefined") return new Map();
+  try {
+    const raw = JSON.parse(window.localStorage.getItem(storageKey(conversationId)) ?? "[]");
+    if (!Array.isArray(raw)) return new Map();
+    const entries = raw.filter(
+      (item): item is [string, StoredEffectAcknowledgement] =>
+        Array.isArray(item) &&
+        typeof item[0] === "string" &&
+        item[1] != null &&
+        typeof item[1] === "object",
+    );
+    return new Map(entries);
+  } catch {
+    return new Map();
+  }
+}
+
+export function rememberEffectAcknowledgement(
+  conversationId: string,
+  effectId: string,
+  acknowledgement: StoredEffectAcknowledgement,
+): boolean {
+  try {
+    const acknowledgements = readEffectAcknowledgements(conversationId);
+    acknowledgements.delete(effectId);
+    acknowledgements.set(effectId, acknowledgement);
+    const entries = [...acknowledgements.entries()].slice(-256);
+    window.localStorage.setItem(storageKey(conversationId), JSON.stringify(entries));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function effectAcknowledgementStorageAvailable(conversationId: string): boolean {
+  if (typeof window === "undefined") return false;
+  const probeKey = `${storageKey(conversationId)}:probe`;
+  try {
+    window.localStorage.setItem(probeKey, "1");
+    window.localStorage.removeItem(probeKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function operatorEffectId(effect: OperatorUiEffect | unknown): string | null {
+  const raw = record(effect);
+  return typeof raw?.id === "string" && raw.id ? raw.id : null;
+}

--- a/apps/studio/frontend/src/components/operator/operatorReducer.test.ts
+++ b/apps/studio/frontend/src/components/operator/operatorReducer.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import type { OperatorConversation, OperatorFrame } from "@/lib/types";
+import {
+  initialOperatorState,
+  mergeOperatorFrames,
+  operatorReducer,
+  pendingOperatorProposals,
+} from "./operatorReducer";
+
+const conversation: OperatorConversation = {
+  id: "conversation-1",
+  status: "active",
+  activeRequestId: "request-1",
+};
+
+function frame(
+  sequence: number,
+  type: OperatorFrame["type"] = "text",
+  payload: Record<string, unknown> = { content: `${sequence}`, format: "plain" },
+): OperatorFrame {
+  return {
+    version: 1,
+    conversationId: conversation.id,
+    requestId: "request-1",
+    sequence,
+    type,
+    payload: payload as unknown as OperatorFrame["payload"],
+    createdAt: sequence,
+  };
+}
+
+describe("operatorReducer", () => {
+  it("sorts replayed frames and deduplicates redelivery by sequence", () => {
+    const merged = mergeOperatorFrames([frame(2)], [frame(1), frame(2), frame(3)]);
+    expect(merged.map((item) => item.sequence)).toEqual([1, 2, 3]);
+  });
+
+  it("loads daemon history and clears the active request only after done", () => {
+    let state = operatorReducer(initialOperatorState, {
+      type: "LOAD_SUCCESS",
+      conversation,
+      frames: [frame(1)],
+    });
+    expect(state.activeRequestId).toBe("request-1");
+    expect(state.lastSequence).toBe(1);
+
+    state = operatorReducer(state, {
+      type: "APPEND_FRAMES",
+      frames: [
+        frame(2, "done", {
+          outcome: "completed",
+          lastSequence: 2,
+        }),
+      ],
+    });
+    expect(state.activeRequestId).toBeNull();
+    expect(state.lastSequence).toBe(2);
+  });
+
+  it("does not resurrect a request when done streams before turn acceptance", () => {
+    const state = operatorReducer(
+      {
+        ...initialOperatorState,
+        conversation,
+        frames: [
+          frame(1),
+          frame(2, "done", {
+            outcome: "completed",
+            lastSequence: 2,
+          }),
+        ],
+        lastSequence: 2,
+      },
+      { type: "TURN_ACCEPTED", requestId: "request-1" },
+    );
+
+    expect(state.activeRequestId).toBeNull();
+  });
+
+  it("ignores a frame from another conversation", () => {
+    const foreign = { ...frame(2), conversationId: "conversation-2" };
+    const state = operatorReducer(
+      {
+        ...initialOperatorState,
+        conversation,
+        frames: [frame(1)],
+        lastSequence: 1,
+      },
+      { type: "APPEND_FRAMES", frames: [foreign] },
+    );
+    expect(state.frames.map((item) => item.sequence)).toEqual([1]);
+  });
+
+  it("marks proposals resolved after a terminal confirmation frame", () => {
+    const proposal = frame(1, "proposal", {
+      proposal: {
+        id: "proposal-1",
+        command: {},
+        commandHash: "hash",
+        risk: "execute",
+        summary: "Launch report",
+        idempotencyKey: "key",
+        expiresAt: 999,
+      },
+    });
+    const confirmation = frame(2, "confirmation", {
+      proposalId: "proposal-1",
+      state: "executed",
+    });
+
+    expect(pendingOperatorProposals([proposal])[0]?.resolved).toBe(false);
+    expect(pendingOperatorProposals([proposal, confirmation])[0]?.resolved).toBe(true);
+  });
+
+  it.each(["denied", "cancelled"] as const)(
+    "marks proposals resolved after a durable %s confirmation",
+    (state) => {
+      const proposal = frame(1, "proposal", {
+        proposal: {
+          id: "proposal-1",
+          command: { tool: "Bash", arguments: { command: "git status" } },
+          commandHash: "hash",
+          risk: "execute",
+          summary: "Inspect the repository",
+          idempotencyKey: "key",
+          expiresAt: 999,
+        },
+      });
+      const confirmation = frame(2, "confirmation", {
+        proposalId: "proposal-1",
+        state,
+      });
+
+      expect(pendingOperatorProposals([proposal, confirmation])[0]?.resolved).toBe(true);
+    },
+  );
+});

--- a/apps/studio/frontend/src/components/operator/operatorReducer.test.ts
+++ b/apps/studio/frontend/src/components/operator/operatorReducer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { OperatorConversation, OperatorFrame } from "@/lib/types";
 import {
+  MAX_RETAINED_FRAMES,
   initialOperatorState,
   mergeOperatorFrames,
   operatorReducer,
@@ -110,6 +111,85 @@ describe("operatorReducer", () => {
 
     expect(pendingOperatorProposals([proposal])[0]?.resolved).toBe(false);
     expect(pendingOperatorProposals([proposal, confirmation])[0]?.resolved).toBe(true);
+  });
+
+  it("clears the active request on a terminal error frame", () => {
+    const state = operatorReducer(
+      {
+        ...initialOperatorState,
+        conversation,
+        frames: [frame(1)],
+        lastSequence: 1,
+        activeRequestId: "request-1",
+      },
+      {
+        type: "APPEND_FRAMES",
+        frames: [
+          frame(2, "error", {
+            error: { code: "engine_failed", message: "stream torn down" },
+          }),
+        ],
+      },
+    );
+
+    expect(state.activeRequestId).toBeNull();
+  });
+
+  it("caps retained frames and keeps the newest", () => {
+    const overflow = MAX_RETAINED_FRAMES + 100;
+    const frames = Array.from({ length: overflow }, (_, index) => frame(index + 1));
+
+    const merged = mergeOperatorFrames([], frames, conversation.id);
+
+    expect(merged).toHaveLength(MAX_RETAINED_FRAMES);
+    expect(merged.at(0)?.sequence).toBe(overflow - MAX_RETAINED_FRAMES + 1);
+    expect(merged.at(-1)?.sequence).toBe(overflow);
+  });
+
+  function proposalFrame(sequence: number, id: string): OperatorFrame {
+    return frame(sequence, "proposal", {
+      proposal: {
+        id,
+        command: { tool: "Bash", arguments: { command: "rm -rf /etc" } },
+        commandHash: "hash",
+        risk: "admin",
+        summary: "Remove configuration",
+        idempotencyKey: `key-${id}`,
+        expiresAt: 999,
+      },
+    });
+  }
+
+  it("retains an unresolved proposal that eviction would otherwise drop", () => {
+    const overflow = MAX_RETAINED_FRAMES + 100;
+    const frames = [
+      proposalFrame(1, "proposal-old"),
+      ...Array.from({ length: overflow }, (_, index) => frame(index + 2)),
+    ];
+
+    const merged = mergeOperatorFrames([], frames, conversation.id);
+
+    // The oldest frame by age, but a live permission prompt: evicting it would
+    // take Allow/Deny off the screen while the daemon still waits for a decision.
+    expect(merged.at(0)?.sequence).toBe(1);
+    expect(pendingOperatorProposals(merged).map((item) => item.frame.payload.proposal.id)).toEqual([
+      "proposal-old",
+    ]);
+    expect(merged.at(-1)?.sequence).toBe(overflow + 1);
+  });
+
+  it("evicts an old proposal once it has been resolved", () => {
+    const overflow = MAX_RETAINED_FRAMES + 100;
+    const frames = [
+      proposalFrame(1, "proposal-old"),
+      frame(2, "confirmation", { proposalId: "proposal-old", state: "executed" }),
+      ...Array.from({ length: overflow }, (_, index) => frame(index + 3)),
+    ];
+
+    const merged = mergeOperatorFrames([], frames, conversation.id);
+
+    expect(merged).toHaveLength(MAX_RETAINED_FRAMES);
+    expect(merged.some((item) => item.sequence === 1)).toBe(false);
   });
 
   it.each(["denied", "cancelled"] as const)(

--- a/apps/studio/frontend/src/components/operator/operatorReducer.ts
+++ b/apps/studio/frontend/src/components/operator/operatorReducer.ts
@@ -36,6 +36,34 @@ export type OperatorAction =
   | { type: "CONNECTION"; state: OperatorConnectionState; error?: string }
   | { type: "RESET" };
 
+/**
+ * Frames retained in browser memory for one conversation. A long turn would
+ * otherwise grow the array — and the DOM — without limit, and every append
+ * re-sorts the whole thing.
+ */
+export const MAX_RETAINED_FRAMES = 2_000;
+
+/**
+ * Drop the oldest frames past the cap, except unresolved proposals.
+ *
+ * An unresolved proposal is a live permission prompt the daemon is still waiting
+ * on. Evicting one by age would take Allow/Deny off the screen with no way back,
+ * which is a worse failure than an unbounded array.
+ */
+function evictOldestFrames(frames: OperatorFrame[]): OperatorFrame[] {
+  if (frames.length <= MAX_RETAINED_FRAMES) return frames;
+  const unresolved = new Set(
+    pendingOperatorProposals(frames)
+      .filter((proposal) => !proposal.resolved)
+      .map((proposal) => proposal.frame.sequence),
+  );
+  const retained = frames.slice(-MAX_RETAINED_FRAMES);
+  const rescued = frames
+    .slice(0, frames.length - MAX_RETAINED_FRAMES)
+    .filter((frame) => unresolved.has(frame.sequence));
+  return rescued.length === 0 ? retained : [...rescued, ...retained];
+}
+
 export function mergeOperatorFrames(
   current: OperatorFrame[],
   incoming: OperatorFrame[],
@@ -48,7 +76,7 @@ export function mergeOperatorFrames(
     if (conversationId && frame.conversationId !== conversationId) continue;
     if (!bySequence.has(frame.sequence)) bySequence.set(frame.sequence, frame);
   }
-  return [...bySequence.values()].sort((a, b) => a.sequence - b.sequence);
+  return evictOldestFrames([...bySequence.values()].sort((a, b) => a.sequence - b.sequence));
 }
 
 function activeRequestAfterFrames(
@@ -56,7 +84,12 @@ function activeRequestAfterFrames(
   frames: OperatorFrame[],
 ): string | null {
   if (!activeRequestId) return null;
-  return frames.some((frame) => frame.requestId === activeRequestId && frame.type === "done")
+  // A terminal `error` frame ends the request just as `done` does; leaving the id
+  // set there strands the composer disabled until the operator reloads.
+  return frames.some(
+    (frame) =>
+      frame.requestId === activeRequestId && (frame.type === "done" || frame.type === "error"),
+  )
     ? null
     : activeRequestId;
 }

--- a/apps/studio/frontend/src/components/operator/operatorReducer.ts
+++ b/apps/studio/frontend/src/components/operator/operatorReducer.ts
@@ -1,0 +1,154 @@
+import type { OperatorConversation, OperatorFrame, OperatorProposalPayload } from "@/lib/types";
+
+export type OperatorLoadState = "idle" | "loading" | "ready" | "error";
+export type OperatorConnectionState = "idle" | "connecting" | "open" | "reconnecting" | "error";
+
+export interface OperatorState {
+  conversation: OperatorConversation | null;
+  frames: OperatorFrame[];
+  lastSequence: number;
+  activeRequestId: string | null;
+  loadState: OperatorLoadState;
+  connectionState: OperatorConnectionState;
+  error: string | null;
+}
+
+export const initialOperatorState: OperatorState = {
+  conversation: null,
+  frames: [],
+  lastSequence: 0,
+  activeRequestId: null,
+  loadState: "idle",
+  connectionState: "idle",
+  error: null,
+};
+
+export type OperatorAction =
+  | { type: "LOAD_START" }
+  | {
+      type: "LOAD_SUCCESS";
+      conversation: OperatorConversation;
+      frames: OperatorFrame[];
+    }
+  | { type: "LOAD_ERROR"; error: string }
+  | { type: "APPEND_FRAMES"; frames: OperatorFrame[] }
+  | { type: "TURN_ACCEPTED"; requestId: string }
+  | { type: "CONNECTION"; state: OperatorConnectionState; error?: string }
+  | { type: "RESET" };
+
+export function mergeOperatorFrames(
+  current: OperatorFrame[],
+  incoming: OperatorFrame[],
+  conversationId?: string,
+): OperatorFrame[] {
+  if (incoming.length === 0) return current;
+  const bySequence = new Map<number, OperatorFrame>();
+  for (const frame of current) bySequence.set(frame.sequence, frame);
+  for (const frame of incoming) {
+    if (conversationId && frame.conversationId !== conversationId) continue;
+    if (!bySequence.has(frame.sequence)) bySequence.set(frame.sequence, frame);
+  }
+  return [...bySequence.values()].sort((a, b) => a.sequence - b.sequence);
+}
+
+function activeRequestAfterFrames(
+  activeRequestId: string | null,
+  frames: OperatorFrame[],
+): string | null {
+  if (!activeRequestId) return null;
+  return frames.some((frame) => frame.requestId === activeRequestId && frame.type === "done")
+    ? null
+    : activeRequestId;
+}
+
+export function operatorReducer(state: OperatorState, action: OperatorAction): OperatorState {
+  switch (action.type) {
+    case "LOAD_START":
+      return {
+        ...state,
+        loadState: "loading",
+        connectionState: "idle",
+        error: null,
+      };
+    case "LOAD_SUCCESS": {
+      const frames = mergeOperatorFrames([], action.frames, action.conversation.id);
+      const lastSequence = frames.at(-1)?.sequence ?? 0;
+      return {
+        conversation: action.conversation,
+        frames,
+        lastSequence,
+        activeRequestId: activeRequestAfterFrames(
+          action.conversation.activeRequestId ?? null,
+          frames,
+        ),
+        loadState: "ready",
+        connectionState: "connecting",
+        error: null,
+      };
+    }
+    case "LOAD_ERROR":
+      return {
+        ...state,
+        loadState: "error",
+        connectionState: "error",
+        error: action.error,
+      };
+    case "APPEND_FRAMES": {
+      const frames = mergeOperatorFrames(state.frames, action.frames, state.conversation?.id);
+      return {
+        ...state,
+        frames,
+        lastSequence: Math.max(state.lastSequence, frames.at(-1)?.sequence ?? 0),
+        activeRequestId: activeRequestAfterFrames(state.activeRequestId, frames),
+      };
+    }
+    case "TURN_ACCEPTED":
+      return {
+        ...state,
+        // A fast provider can persist and stream `done` before the 202 submit
+        // response reaches the browser. Never let that later acceptance race
+        // resurrect a request the durable frame log already closed.
+        activeRequestId: activeRequestAfterFrames(action.requestId, state.frames),
+        error: null,
+      };
+    case "CONNECTION":
+      return {
+        ...state,
+        connectionState: action.state,
+        error: action.error ?? (action.state === "open" ? null : state.error),
+      };
+    case "RESET":
+      return initialOperatorState;
+  }
+}
+
+export interface PendingOperatorProposal {
+  frame: OperatorFrame<OperatorProposalPayload>;
+  resolved: boolean;
+}
+
+export function pendingOperatorProposals(frames: OperatorFrame[]): PendingOperatorProposal[] {
+  const resolutions = new Map<string, string>();
+  for (const frame of frames) {
+    if (frame.type !== "confirmation") continue;
+    const payload = frame.payload as { proposalId?: unknown; state?: unknown };
+    if (typeof payload.proposalId === "string" && typeof payload.state === "string") {
+      resolutions.set(payload.proposalId, payload.state);
+    }
+  }
+
+  return frames
+    .filter((frame): frame is OperatorFrame<OperatorProposalPayload> => frame.type === "proposal")
+    .map((frame) => {
+      const state = resolutions.get(frame.payload.proposal.id);
+      return {
+        frame,
+        resolved:
+          state === "confirmed" ||
+          state === "denied" ||
+          state === "cancelled" ||
+          state === "expired" ||
+          state === "executed",
+      };
+    });
+}

--- a/apps/studio/frontend/src/components/schedules/SchedulesCalendar.test.tsx
+++ b/apps/studio/frontend/src/components/schedules/SchedulesCalendar.test.tsx
@@ -11,7 +11,7 @@
 import { describe, it, expect } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { groupAgendaByHour, truncateMiddle } from "./SchedulesCalendar";
+import { formatCalendarDayLabel, groupAgendaByHour, truncateMiddle } from "./SchedulesCalendar";
 import type { ScheduleSummary } from "@/lib/types";
 import type { RunRow } from "./data";
 
@@ -158,6 +158,23 @@ describe("truncateMiddle", () => {
     expect(out).toContain("…");
     expect(long.startsWith(out.split("…")[0])).toBe(true);
     expect(long.endsWith(out.split("…")[1])).toBe(true);
+  });
+});
+
+describe("calendar day accessible names", () => {
+  it("uses the full localized date so adjacent-month numerals are unambiguous", () => {
+    const june30 = formatCalendarDayLabel(new Date(2026, 5, 30), "en-US", "Today");
+    const july30 = formatCalendarDayLabel(new Date(2026, 6, 30), "en-US", "Today");
+    expect(june30).toContain("June 30, 2026");
+    expect(july30).toContain("July 30, 2026");
+    expect(june30).not.toBe(july30);
+  });
+
+  it("adds today context while selection is exposed separately with aria-pressed", () => {
+    expect(formatCalendarDayLabel(new Date(2026, 6, 30), "en-US", "Today", true)).toContain(
+      "Today",
+    );
+    expect(SRC).toContain("aria-pressed={isSelected}");
   });
 });
 

--- a/apps/studio/frontend/src/components/schedules/SchedulesCalendar.tsx
+++ b/apps/studio/frontend/src/components/schedules/SchedulesCalendar.tsx
@@ -293,7 +293,22 @@ function truncateMiddle(text: string, max = 30): string {
   return `${text.slice(0, half)}…${text.slice(text.length - half)}`;
 }
 
-export { groupAgendaByHour, truncateMiddle };
+function formatCalendarDayLabel(
+  date: Date,
+  locale: string,
+  todayLabel: string,
+  isToday = false,
+): string {
+  const fullDate = date.toLocaleDateString(locale, {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  return isToday ? `${fullDate}, ${todayLabel}` : fullDate;
+}
+
+export { formatCalendarDayLabel, groupAgendaByHour, truncateMiddle };
 export type { AgendaEntry, AgendaGroup };
 
 export default function SchedulesCalendar({
@@ -571,9 +586,9 @@ export default function SchedulesCalendar({
     );
 
   return (
-    <div className="flex flex-col gap-3 px-6 pb-6">
+    <div className="flex flex-col gap-3 px-3 pb-6 sm:px-6">
       {/* Period nav + view switcher */}
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <IconButton
           aria-label={t("prevPeriod")}
           size="md"
@@ -590,7 +605,7 @@ export default function SchedulesCalendar({
         >
           ›
         </IconButton>
-        <span className="font-data text-label font-semibold text-content-primary">
+        <span className="min-w-0 flex-1 truncate font-data text-label font-semibold text-content-primary">
           {periodLabel}
         </span>
         {!isCurrentPeriod && (
@@ -605,8 +620,7 @@ export default function SchedulesCalendar({
             {t("today")}
           </button>
         )}
-        <div className="flex-1" />
-        <div className="flex overflow-hidden rounded border border-edge">
+        <div className="flex max-w-full overflow-x-auto rounded border border-edge [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {(["month", "week", "day"] as const).map((m) => (
             <button
               key={m}
@@ -652,6 +666,8 @@ export default function SchedulesCalendar({
                 <button
                   key={key}
                   type="button"
+                  aria-label={formatCalendarDayLabel(date, locale, t("today"), isToday)}
+                  aria-pressed={isSelected}
                   onClick={() => setSelectedDay(isSelected ? null : key)}
                   className={[
                     "flex h-[96px] flex-col items-stretch border-edge p-1.5 text-left transition-colors duration-100",
@@ -702,6 +718,8 @@ export default function SchedulesCalendar({
                 <button
                   key={key}
                   type="button"
+                  aria-label={formatCalendarDayLabel(d, locale, t("today"), isToday)}
+                  aria-pressed={selectedDay === key}
                   onClick={() => setSelectedDay(selectedDay === key ? null : key)}
                   className={[
                     "flex items-center gap-1.5 border-l border-edge px-2 py-1.5 text-left transition-colors duration-100 first:border-l-0",
@@ -801,6 +819,8 @@ export default function SchedulesCalendar({
                 <button
                   key={key}
                   type="button"
+                  aria-label={formatCalendarDayLabel(d, locale, t("today"), isToday)}
+                  aria-pressed={selectedDay === key}
                   onClick={() => setSelectedDay(selectedDay === key ? null : key)}
                   className={[
                     "flex items-center gap-1.5 border-l border-edge px-2 py-1.5 text-left transition-colors duration-100",

--- a/apps/studio/frontend/src/components/shell/AppShell.tsx
+++ b/apps/studio/frontend/src/components/shell/AppShell.tsx
@@ -5,31 +5,24 @@ import IconRail from "./IconRail";
 import CommandPalette from "./CommandPalette";
 import StatusFooter from "./StatusFooter";
 import TopBar from "./TopBar";
+import OperatorPanel from "@/components/operator/OperatorPanel";
+import { applyTheme, getTheme, THEME_CHANGE_EVENT } from "@/lib/theme";
 
 interface Props {
   children: ReactNode;
   onLocaleChange: (l: string) => void;
 }
 
-function getTheme(): "dark" | "light" {
-  if (typeof document === "undefined") return "dark";
-  return (document.documentElement.getAttribute("data-theme") as "dark" | "light") ?? "dark";
-}
-
-function applyTheme(theme: "dark" | "light") {
-  document.documentElement.setAttribute("data-theme", theme);
-  if (theme === "dark") {
-    document.documentElement.classList.add("dark");
-  } else {
-    document.documentElement.classList.remove("dark");
-  }
-  localStorage.setItem("theme", theme);
+function getOperatorOpen(): boolean {
+  if (typeof window === "undefined") return true;
+  return window.localStorage.getItem("studio:operator-visibility") !== "closed";
 }
 
 export default function AppShell({ children, onLocaleChange }: Props) {
   const t = useTranslations("shell");
   const [dark, setDark] = useState(() => getTheme() === "dark");
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [operatorOpen, setOperatorOpen] = useState(getOperatorOpen);
 
   const toggleTheme = useCallback(() => {
     const next = !dark;
@@ -37,17 +30,43 @@ export default function AppShell({ children, onLocaleChange }: Props) {
     applyTheme(next ? "dark" : "light");
   }, [dark]);
 
+  const toggleOperator = useCallback(() => {
+    setOperatorOpen((current) => {
+      const next = !current;
+      window.localStorage.setItem("studio:operator-visibility", next ? "open" : "closed");
+      return next;
+    });
+  }, []);
+
+  const closeOperator = useCallback(() => {
+    window.localStorage.setItem("studio:operator-visibility", "closed");
+    setOperatorOpen(false);
+  }, []);
+
+  useEffect(() => {
+    const syncTheme = () => setDark(getTheme() === "dark");
+    window.addEventListener(THEME_CHANGE_EVENT, syncTheme);
+    window.addEventListener("storage", syncTheme);
+    return () => {
+      window.removeEventListener(THEME_CHANGE_EVENT, syncTheme);
+      window.removeEventListener("storage", syncTheme);
+    };
+  }, []);
+
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       if (e.isComposing) return;
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         setPaletteOpen((v) => !v);
+      } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "j") {
+        e.preventDefault();
+        toggleOperator();
       }
     }
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, []);
+  }, [toggleOperator]);
 
   const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
 
@@ -64,7 +83,13 @@ export default function AppShell({ children, onLocaleChange }: Props) {
         )}
 
         {/* Icon rail */}
-        <IconRail dark={dark} onToggleTheme={toggleTheme} onLocaleChange={onLocaleChange} />
+        <IconRail
+          dark={dark}
+          operatorOpen={operatorOpen}
+          onToggleOperator={toggleOperator}
+          onToggleTheme={toggleTheme}
+          onLocaleChange={onLocaleChange}
+        />
 
         {/* Main area */}
         <div className="flex flex-1 flex-col overflow-hidden">
@@ -90,7 +115,10 @@ export default function AppShell({ children, onLocaleChange }: Props) {
           open={paletteOpen}
           onClose={() => setPaletteOpen(false)}
           toggleTheme={toggleTheme}
+          toggleOperator={toggleOperator}
         />
+
+        <OperatorPanel open={operatorOpen} onClose={closeOperator} />
       </div>
     </ToastProvider>
   );

--- a/apps/studio/frontend/src/components/shell/CommandPalette.tsx
+++ b/apps/studio/frontend/src/components/shell/CommandPalette.tsx
@@ -7,11 +7,13 @@ interface Props {
   open: boolean;
   onClose: () => void;
   toggleTheme: () => void;
+  toggleOperator: () => void;
 }
 
 /** Inner palette — mounted with a fresh key each time `open` goes true. */
-function PaletteInner({ onClose, toggleTheme }: Omit<Props, "open">) {
+function PaletteInner({ onClose, toggleTheme, toggleOperator }: Omit<Props, "open">) {
   const t = useTranslations("shell");
+  const operatorT = useTranslations("operator");
   const locale = useLocale();
   const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -31,7 +33,12 @@ function PaletteInner({ onClose, toggleTheme }: Omit<Props, "open">) {
     [navigate, onClose],
   );
 
-  const commands: Command[] = buildRegistry(doNavigate, toggleTheme);
+  const commands: Command[] = buildRegistry(
+    doNavigate,
+    toggleTheme,
+    toggleOperator,
+    operatorT("command"),
+  );
   const filtered = commands.filter((c) => fuzzyMatch(query, c));
 
   const execute = useCallback(
@@ -213,7 +220,7 @@ function PaletteInner({ onClose, toggleTheme }: Omit<Props, "open">) {
 }
 
 /** Outer wrapper — mounts PaletteInner with a fresh key each time `open` toggles true. */
-export default function CommandPalette({ open, onClose, toggleTheme }: Props) {
+export default function CommandPalette({ open, onClose, toggleTheme, toggleOperator }: Props) {
   const [epoch, setEpoch] = useState(0);
 
   const prevOpenRef = useRef(open);
@@ -226,5 +233,12 @@ export default function CommandPalette({ open, onClose, toggleTheme }: Props) {
 
   if (!open) return null;
 
-  return <PaletteInner key={epoch} onClose={onClose} toggleTheme={toggleTheme} />;
+  return (
+    <PaletteInner
+      key={epoch}
+      onClose={onClose}
+      toggleTheme={toggleTheme}
+      toggleOperator={toggleOperator}
+    />
+  );
 }

--- a/apps/studio/frontend/src/components/shell/IconRail.tsx
+++ b/apps/studio/frontend/src/components/shell/IconRail.tsx
@@ -136,6 +136,25 @@ function IconCalendar() {
   );
 }
 
+function IconOperator() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12a8 8 0 0 1-8 8H6l-4 2 1.5-4.5A8.5 8.5 0 1 1 21 12Z" />
+      <path d="M8 12h.01M12 12h.01M16 12h.01" />
+    </svg>
+  );
+}
+
 const SPACES: Space[] = [
   { id: "home", href: "/", labelKey: "rail.home", icon: <IconTarget />, key: 1 },
   { id: "library", href: "/library", labelKey: "rail.library", icon: <IconGrid />, key: 2 },
@@ -259,6 +278,8 @@ function LangListbox({ id, locale, labelText, onSelect, onClose, triggerRef }: L
 
 interface Props {
   dark: boolean;
+  operatorOpen: boolean;
+  onToggleOperator: () => void;
   onToggleTheme: () => void;
   onLocaleChange: (locale: string) => void;
 }
@@ -268,7 +289,13 @@ function isActive(href: string, pathname: string): boolean {
   return pathname === href || pathname.startsWith(`${href}/`);
 }
 
-export default function IconRail({ dark, onToggleTheme, onLocaleChange }: Props) {
+export default function IconRail({
+  dark,
+  operatorOpen,
+  onToggleOperator,
+  onToggleTheme,
+  onLocaleChange,
+}: Props) {
   const t = useTranslations("shell");
   const locale = useLocale();
   const pathname = useLocation().pathname;
@@ -318,6 +345,34 @@ export default function IconRail({ dark, onToggleTheme, onLocaleChange }: Props)
     >
       {/* Spaces */}
       <ul className="flex flex-1 flex-col items-center gap-1">
+        <li className="mb-2 border-b border-edge pb-2">
+          <button
+            type="button"
+            onClick={onToggleOperator}
+            aria-label={`${t("rail.operator")} (⌘J)`}
+            aria-keyshortcuts="Meta+J Control+J"
+            aria-pressed={operatorOpen}
+            className={`group relative flex h-10 w-10 items-center justify-center rounded border transition-colors duration-100 ${
+              operatorOpen
+                ? "border-accent/40 bg-surface-overlay text-accent"
+                : "border-edge bg-surface-base text-content-secondary hover:border-edge-strong hover:text-content-primary"
+            }`}
+            title={`${t("rail.operator")} — ⌘J`}
+          >
+            {operatorOpen && (
+              <span
+                aria-hidden="true"
+                className="absolute bottom-2 start-0 top-2 w-0.5 rounded-e bg-accent"
+              />
+            )}
+            <span
+              className={operatorOpen ? "opacity-100" : "opacity-[0.7] group-hover:opacity-100"}
+            >
+              <IconOperator />
+            </span>
+          </button>
+        </li>
+
         {SPACES.map((space) => {
           const active = isActive(space.href, pathname);
           const label = t(space.labelKey as Parameters<typeof t>[0]);

--- a/apps/studio/frontend/src/components/shell/NoDaemonGate.test.tsx
+++ b/apps/studio/frontend/src/components/shell/NoDaemonGate.test.tsx
@@ -1,18 +1,18 @@
 /**
- * NoDaemonGate — daemon connectivity banner.
+ * NoDaemonGate — daemon connectivity recovery surface.
  *
  * No @testing-library/react in this project (see history/InvocationDetail.test.tsx);
  * mounts via react-dom/client + act and drives the real /health probe through
  * a stubbed global fetch, same pattern as mission/usePulse.test.tsx.
  *
  * Covers:
- * - children always render, in every connectivity state (never blanks the app)
+ * - a composed shell skeleton renders while the first probe is pending
+ * - data-dependent children render only after a real, authenticated daemon answers
  * - unreachable (fetch throws — no daemon, CORS, or nothing listening)
  * - wrongApp (fetch resolves but the body isn't the lionagi `{ status: "ok" }` shape)
- * - connected (fetch resolves with the exact lionagi health shape) — no banner
- * - retry re-probes and clears the banner on success
- * - dismiss hides the banner; a fresh connectivity failure reported after a
- *   successful recovery shows the banner again
+ * - pairing required (public health succeeds but the protected identity returns 401)
+ * - connected (health and authenticated OpenAPI identity both match)
+ * - retry re-probes and restores the app on success
  * - a connectivity failure reported from elsewhere in the app (any other
  *   fetchJson call hitting a network-level error) triggers an immediate
  *   re-probe instead of waiting for the poll interval
@@ -28,14 +28,18 @@ import { reportConnectivityFailure } from "@/lib/connectivity";
 
 vi.mock("@/lib/api", () => ({
   resolveApiBase: () => "http://127.0.0.1:8765",
+  resolveAuthToken: () => "paired-browser-token",
 }));
 
-function jsonResponse(body: unknown, ok = true): Response {
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 404): Response {
   return {
     ok,
+    status,
     json: () => Promise.resolve(body),
   } as Response;
 }
+
+const studioIdentity = { info: { title: "Lion Studio Server" } };
 
 describe("NoDaemonGate", () => {
   let container: HTMLDivElement;
@@ -77,37 +81,46 @@ describe("NoDaemonGate", () => {
     });
   }
 
-  it("renders children immediately in the 'checking' state, before the probe resolves", async () => {
+  it("renders a composed shell skeleton while the first probe is pending", async () => {
     fetchMock.mockReturnValue(new Promise(() => {}));
     await mount();
-    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
     expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.textContent).toContain("LION STUDIO");
   });
 
-  it("keeps rendering children and shows no banner once a real daemon answers", async () => {
-    fetchMock.mockResolvedValue(jsonResponse({ status: "ok" }));
+  it("renders children once a real daemon answers", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ status: "ok" }))
+      .mockResolvedValueOnce(jsonResponse(studioIdentity));
     await mount();
     expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
     expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      headers: { Authorization: "Bearer paired-browser-token" },
+    });
   });
 
-  it("shows the unreachable banner on a network failure, without unmounting children", async () => {
+  it("shows the unreachable recovery state on a network failure", async () => {
     fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
     await mount();
-    expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
-    const banner = container.querySelector('[role="alert"]');
-    expect(banner).not.toBeNull();
-    expect(banner?.textContent).toContain("Studio needs a local lionagi daemon");
-    expect(banner?.textContent).toContain("li studio");
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
+    const recovery = container.querySelector('[role="alert"]');
+    expect(recovery).not.toBeNull();
+    expect(recovery?.textContent).toContain("Studio needs a local lionagi daemon");
+    expect(recovery?.textContent).toContain('pip install "lionagi[studio]"');
+    expect(recovery?.textContent).toContain("li studio");
   });
 
-  it("shows the wrong-app banner when something answers but not with the lionagi health shape", async () => {
+  it("shows a distinct wrong-app recovery state when the health shape is invalid", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ hello: "world" }));
     await mount();
-    const banner = container.querySelector('[role="alert"]');
-    expect(banner).not.toBeNull();
-    expect(banner?.textContent).toContain("Another program is using this port");
-    expect(banner?.textContent).toContain("li studio --port 8766");
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
+    const recovery = container.querySelector('[role="alert"]');
+    expect(recovery).not.toBeNull();
+    expect(recovery?.textContent).toContain("Another program is using this port");
+    expect(recovery?.textContent).toContain("li studio --port 8766");
   });
 
   it("shows the wrong-app banner when the port answers with a non-JSON body", async () => {
@@ -129,12 +142,37 @@ describe("NoDaemonGate", () => {
     );
   });
 
-  it("retry re-probes and clears the banner once the daemon comes up", async () => {
+  it("keeps an unpaired tab in a designed recovery state", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ status: "ok" }))
+      .mockResolvedValueOnce(jsonResponse({ detail: "unauthorized" }, false, 401));
+    await mount();
+
+    const recovery = container.querySelector('[role="alert"]');
+    expect(recovery?.textContent).toContain("Open Studio from the daemon");
+    expect(recovery?.textContent).toContain("li studio");
+    expect(recovery?.textContent).not.toContain("--no-open");
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
+  });
+
+  it("rejects a health lookalike without the Studio API identity", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ status: "ok" }))
+      .mockResolvedValueOnce(jsonResponse({ info: { title: "Other API" } }));
+    await mount();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "Another program is using this port",
+    );
+  });
+
+  it("retry re-probes and restores the app once the daemon comes up", async () => {
     fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
     await mount();
     expect(container.querySelector('[role="alert"]')).not.toBeNull();
 
-    fetchMock.mockResolvedValueOnce(jsonResponse({ status: "ok" }));
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ status: "ok" }))
+      .mockResolvedValueOnce(jsonResponse(studioIdentity));
     const retryButton = Array.from(container.querySelectorAll("button")).find((b) =>
       b.textContent?.includes("Retry"),
     );
@@ -145,46 +183,16 @@ describe("NoDaemonGate", () => {
       await Promise.resolve();
     });
     expect(container.querySelector('[role="alert"]')).toBeNull();
-  });
-
-  it("dismiss hides the banner immediately; a later failure after recovery shows it again", async () => {
-    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
-    await mount();
-    const dismissButton = container.querySelector('[aria-label="Dismiss"]');
-    expect(dismissButton).not.toBeNull();
-    await act(async () => {
-      dismissButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-    expect(container.querySelector('[role="alert"]')).toBeNull();
-    // children still render while dismissed
     expect(container.querySelector('[data-testid="child"]')).not.toBeNull();
-
-    // background poll: daemon recovers — the gate stops polling once
-    // connected, so the dismissal flag has been cleared for whatever comes
-    // next.
-    fetchMock.mockResolvedValueOnce(jsonResponse({ status: "ok" }));
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5000);
-    });
-    expect(container.querySelector('[role="alert"]')).toBeNull();
-
-    // some other view's API call now fails at the network level — the gate
-    // re-probes off that signal (it isn't polling anymore) and the banner
-    // must reappear rather than staying hidden from the earlier dismissal.
-    fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
-    await act(async () => {
-      reportConnectivityFailure();
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    expect(container.querySelector('[role="alert"]')).not.toBeNull();
   });
 
   it("re-probes on a connectivity failure reported elsewhere in the app, even while already connected", async () => {
-    fetchMock.mockResolvedValue(jsonResponse({ status: "ok" }));
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ status: "ok" }))
+      .mockResolvedValueOnce(jsonResponse(studioIdentity));
     await mount();
     expect(container.querySelector('[role="alert"]')).toBeNull();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
     fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
     await act(async () => {
@@ -192,7 +200,7 @@ describe("NoDaemonGate", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(container.querySelector('[role="alert"]')).not.toBeNull();
   });
 

--- a/apps/studio/frontend/src/components/shell/NoDaemonGate.tsx
+++ b/apps/studio/frontend/src/components/shell/NoDaemonGate.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useTranslations } from "use-intl";
 import Button from "@/components/ui/Button";
-import { IconClose, IconPort, IconTerminal } from "@/components/ui/icons";
-import { resolveApiBase } from "@/lib/api";
+import { IconPort, IconShield, IconTerminal } from "@/components/ui/icons";
+import { resolveApiBase, resolveAuthToken } from "@/lib/api";
 import { onConnectivityFailure } from "@/lib/connectivity";
 
 const POLL_INTERVAL_MS = 5000;
@@ -11,17 +11,18 @@ const POLL_INTERVAL_MS = 5000;
 // one /health check instead of one per request.
 const FAILURE_REPROBE_THROTTLE_MS = 2000;
 
-type ConnectivityStatus = "checking" | "connected" | "unreachable" | "wrongApp";
+type ConnectivityStatus = "checking" | "connected" | "unreachable" | "wrongApp" | "needsPairing";
 
 /**
- * Probe the configured API base's /health endpoint and classify what answered.
- * The lionagi daemon serves an unauthenticated `{ status: "ok" }` at /health
- * (lionagi/studio/app.py) with no auth gate — any other shape, a non-2xx, or
- * a body that isn't JSON at all means something other than the daemon is on
- * that port. A network-level failure (nothing listening, CORS) is a separate
- * bucket: there's no program to point at, just nothing running yet.
+ * Probe both the daemon's public liveness response and its authenticated
+ * OpenAPI identity. `/health` alone cannot establish a usable connection:
+ * a `li studio --no-open` process answers there while every application API
+ * correctly rejects an unpaired browser. Keeping that tab behind a designed
+ * pairing state prevents the shell from opening into a wall of 401s.
  */
-async function probeDaemon(apiBase: string): Promise<"connected" | "unreachable" | "wrongApp"> {
+async function probeDaemon(
+  apiBase: string,
+): Promise<"connected" | "unreachable" | "wrongApp" | "needsPairing"> {
   let response: Response;
   try {
     response = await fetch(`${apiBase}/health`);
@@ -35,22 +36,42 @@ async function probeDaemon(apiBase: string): Promise<"connected" | "unreachable"
     return "wrongApp";
   }
   const status = (body as { status?: unknown } | null)?.status;
-  return response.ok && status === "ok" ? "connected" : "wrongApp";
+  if (!response.ok || status !== "ok") return "wrongApp";
+
+  const token = resolveAuthToken();
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  try {
+    response = await fetch(`${apiBase}/openapi.json`, { headers });
+  } catch {
+    return "unreachable";
+  }
+  if (response.status === 401 || response.status === 403) return "needsPairing";
+  try {
+    body = await response.json();
+  } catch {
+    return "wrongApp";
+  }
+  const title = (
+    body as {
+      info?: { title?: unknown };
+    } | null
+  )?.info?.title;
+  return response.ok && title === "Lion Studio Server" ? "connected" : "wrongApp";
 }
 
 /**
  * Wraps the app shell with connectivity awareness. The daemon is the
  * operator's own `li studio` process, not a backend this app controls — a
  * failed probe means "not started yet" or "something else is on this port",
- * not an app crash. The shell keeps rendering underneath a dismissible
- * banner rather than blanking the screen; views that don't need the daemon
- * stay usable.
+ * not an app crash. A failed probe replaces the data-dependent application
+ * with a composed recovery surface so stale or malformed content never sits
+ * behind a dismissible warning.
  */
 export default function NoDaemonGate({ children }: { children: ReactNode }) {
   const t = useTranslations("daemon");
   const apiBase = resolveApiBase();
   const [status, setStatus] = useState<ConnectivityStatus>("checking");
-  const [dismissed, setDismissed] = useState(false);
   const activeRef = useRef(true);
   const lastReprobeRef = useRef(0);
 
@@ -58,14 +79,10 @@ export default function NoDaemonGate({ children }: { children: ReactNode }) {
     const result = await probeDaemon(apiBase);
     if (!activeRef.current) return;
     setStatus(result);
-    // Recovering clears any earlier dismissal so the NEXT failure surfaces
-    // the banner again instead of staying silently hidden forever.
-    if (result === "connected") setDismissed(false);
   }, [apiBase]);
 
   useEffect(() => {
     activeRef.current = true;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial /health probe on mount; setState only lands after the async fetch resolves, guarded by activeRef against a torn-down effect
     void check();
     return () => {
       activeRef.current = false;
@@ -95,67 +112,157 @@ export default function NoDaemonGate({ children }: { children: ReactNode }) {
   }, [check]);
 
   const displayBase = apiBase || "http://127.0.0.1:8765";
-  const showBanner = (status === "unreachable" || status === "wrongApp") && !dismissed;
+
+  if (status === "connected") return <>{children}</>;
+
+  const isChecking = status === "checking";
+  const isWrongApp = status === "wrongApp";
+  const needsPairing = status === "needsPairing";
 
   return (
-    <>
-      {children}
-      {showBanner && (
-        <div
-          role="alert"
-          className="fixed inset-x-0 bottom-0 z-40 flex flex-col gap-2.5 border-t border-edge bg-surface-raised px-4 py-3 shadow-card-hover sm:flex-row sm:items-start sm:justify-between"
-          style={{ boxShadow: "var(--shadow-card-hover)" }}
-        >
-          <div className="flex items-start gap-2.5 text-body text-content-primary">
-            <span className="mt-0.5 shrink-0 text-content-muted">
-              {status === "wrongApp" ? <IconPort size={16} /> : <IconTerminal size={16} />}
-            </span>
-            {status === "wrongApp" ? (
-              <div>
-                <p className="font-medium">{t("wrongApp.title")}</p>
-                <p className="text-meta text-content-muted">
-                  {t("wrongApp.body", { base: displayBase })}
-                </p>
-                <p className="mt-1 text-meta text-content-muted">
-                  {t("wrongApp.fix")}{" "}
-                  <span className="font-data text-content-secondary">{t("wrongApp.command")}</span>
-                </p>
-              </div>
-            ) : (
-              <div>
-                <p className="font-medium">{t("unreachable.title")}</p>
-                <p className="text-meta text-content-muted">
-                  {t("unreachable.body", { base: displayBase })}
-                </p>
-                <p className="mt-1 text-meta text-content-secondary">
-                  <span className="font-data">{t("unreachable.install")}</span>
-                  {" · "}
-                  <span className="font-data">{t("unreachable.run")}</span>
-                </p>
-                <p className="text-meta text-content-muted">
-                  {t("unreachable.runAltNote")}{" "}
-                  <span className="font-data text-content-secondary">
-                    {t("unreachable.runAlt")}
-                  </span>
-                </p>
-              </div>
-            )}
-          </div>
-          <div className="flex shrink-0 items-center gap-2 self-end sm:self-start">
-            <Button variant="primary" size="sm" onClick={() => void check()}>
-              {t("retry")}
-            </Button>
-            <button
-              type="button"
-              aria-label={t("dismiss")}
-              onClick={() => setDismissed(true)}
-              className="text-content-muted transition-colors duration-100 hover:text-content-primary"
-            >
-              <IconClose size={12} strokeWidth={2.25} />
-            </button>
-          </div>
+    <div className="flex h-dvh min-h-[32rem] overflow-hidden bg-surface-base text-content-primary">
+      <aside
+        aria-hidden="true"
+        className="hidden w-14 shrink-0 flex-col items-center border-r border-edge bg-surface-raised py-4 sm:flex"
+      >
+        <div className="grid size-8 place-items-center rounded-md border border-edge-strong bg-surface-raised font-data text-xs font-semibold text-content-primary">
+          LI
         </div>
-      )}
-    </>
+        <div className="mt-8 flex flex-col gap-4">
+          {Array.from({ length: 5 }, (_, index) => (
+            <span
+              key={index}
+              className="block size-5 rounded bg-surface-overlay"
+              style={{ opacity: 1 - index * 0.12 }}
+            />
+          ))}
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex h-12 shrink-0 items-center border-b border-edge bg-surface-raised px-4">
+          <span className="font-data text-xs font-semibold tracking-wide text-content-secondary">
+            LION STUDIO
+          </span>
+          <span className="ml-auto inline-flex items-center gap-1.5 text-meta text-content-muted">
+            <span className="size-1.5 rounded-full bg-status-pending" />
+            {isChecking
+              ? null
+              : isWrongApp
+                ? t("wrongApp.title")
+                : needsPairing
+                  ? t("pairing.title")
+                  : t("unreachable.title")}
+          </span>
+        </header>
+
+        <main
+          role={isChecking ? "status" : "alert"}
+          aria-live="polite"
+          className="grid min-h-0 flex-1 place-items-center overflow-y-auto px-5 py-10 sm:px-10"
+        >
+          {isChecking ? (
+            <div
+              aria-label="Lion Studio"
+              className="w-full max-w-xl rounded-xl border border-edge bg-surface-raised p-6 shadow-card"
+            >
+              <div className="flex items-center gap-3">
+                <span className="grid size-10 place-items-center rounded-lg bg-surface-overlay text-content-muted">
+                  <IconTerminal size={20} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="h-3 w-40 animate-pulse rounded bg-surface-overlay" />
+                  <div className="mt-2 h-2.5 w-64 max-w-full animate-pulse rounded bg-surface-overlay" />
+                </div>
+              </div>
+              <div className="mt-6 space-y-2.5">
+                <div className="h-9 animate-pulse rounded-md bg-surface-overlay" />
+                <div className="h-9 animate-pulse rounded-md bg-surface-overlay" />
+              </div>
+            </div>
+          ) : (
+            <section className="w-full max-w-xl rounded-xl border border-edge bg-surface-raised p-6 shadow-card sm:p-8">
+              <div className="flex items-start gap-4">
+                <span
+                  className={`grid size-11 shrink-0 place-items-center rounded-lg ${
+                    isWrongApp || needsPairing
+                      ? "bg-status-warning-bg text-status-warning"
+                      : "bg-surface-overlay text-content-secondary"
+                  }`}
+                >
+                  {isWrongApp ? (
+                    <IconPort size={22} />
+                  ) : needsPairing ? (
+                    <IconShield size={22} />
+                  ) : (
+                    <IconTerminal size={22} />
+                  )}
+                </span>
+                <div className="min-w-0">
+                  <h1 className="text-xl font-semibold tracking-tight text-content-primary">
+                    {isWrongApp
+                      ? t("wrongApp.title")
+                      : needsPairing
+                        ? t("pairing.title")
+                        : t("unreachable.title")}
+                  </h1>
+                  <p className="mt-2 text-body leading-relaxed text-content-secondary">
+                    {isWrongApp
+                      ? t("wrongApp.body", { base: displayBase })
+                      : needsPairing
+                        ? t("pairing.body", { base: displayBase })
+                        : t("unreachable.body", { base: displayBase })}
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-6 border-t border-edge pt-5">
+                {isWrongApp ? (
+                  <>
+                    <p className="text-body text-content-secondary">{t("wrongApp.fix")}</p>
+                    <code className="mt-2 block overflow-x-auto rounded-md border border-edge bg-surface-base px-3 py-2.5 font-data text-xs text-content-primary">
+                      {t("wrongApp.command")}
+                    </code>
+                  </>
+                ) : needsPairing ? (
+                  <>
+                    <p className="text-body text-content-secondary">{t("pairing.fix")}</p>
+                    <code className="mt-2 block overflow-x-auto rounded-md border border-edge bg-surface-base px-3 py-2.5 font-data text-xs text-content-primary">
+                      {t("pairing.command")}
+                    </code>
+                  </>
+                ) : (
+                  <div className="space-y-3">
+                    <div>
+                      <code className="block overflow-x-auto rounded-md border border-edge bg-surface-base px-3 py-2.5 font-data text-xs text-content-primary">
+                        {t("unreachable.install")}
+                      </code>
+                    </div>
+                    <div>
+                      <code className="block overflow-x-auto rounded-md border border-edge bg-surface-base px-3 py-2.5 font-data text-xs text-content-primary">
+                        {t("unreachable.run")}
+                      </code>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-6 flex flex-col-reverse gap-3 border-t border-edge pt-5 sm:flex-row sm:items-center sm:justify-between">
+                <p className="min-w-0 truncate font-data text-[11px] text-content-muted">
+                  {displayBase}
+                </p>
+                <Button variant="primary" size="sm" onClick={() => void check()}>
+                  {t("retry")}
+                </Button>
+              </div>
+            </section>
+          )}
+        </main>
+
+        <footer className="flex h-7 shrink-0 items-center border-t border-edge bg-surface-raised px-3 text-[11px] text-content-muted">
+          <span className="font-data">lionagi</span>
+        </footer>
+      </div>
+    </div>
   );
 }

--- a/apps/studio/frontend/src/components/shell/StatusFooter.tsx
+++ b/apps/studio/frontend/src/components/shell/StatusFooter.tsx
@@ -48,9 +48,9 @@ export default function StatusFooter() {
   const version = import.meta.env.VITE_APP_VERSION as string | undefined;
 
   return (
-    <footer className="flex h-6 shrink-0 items-center gap-3 border-t border-edge px-3 font-data text-[length:var(--t-xs)] text-content-muted">
+    <footer className="flex h-6 min-w-0 shrink-0 items-center gap-3 border-t border-edge px-3 font-data text-[length:var(--t-xs)] text-content-muted">
       {/* Health dot + backend base */}
-      <span className="flex items-center gap-1.5">
+      <span className="flex min-w-0 items-center gap-1.5">
         <span
           aria-label={healthy === false ? t("footer.unhealthy") : t("footer.healthy")}
           className="inline-block h-[5px] w-[5px] rounded-full"
@@ -63,7 +63,9 @@ export default function StatusFooter() {
                   : "var(--status-failure)",
           }}
         />
-        <span className="tabular-nums text-[length:var(--t-xs)]">{apiBase || "localhost"}</span>
+        <span className="truncate tabular-nums text-[length:var(--t-xs)]">
+          {apiBase || "localhost"}
+        </span>
       </span>
 
       {/* DB size */}
@@ -87,7 +89,7 @@ export default function StatusFooter() {
       ) : null}
 
       {/* Ecosystem note */}
-      <span className="ml-auto truncate">
+      <span className="ml-auto hidden truncate sm:inline">
         {t("footer.ecosystemPrefix")}{" "}
         <bdi>
           <a

--- a/apps/studio/frontend/src/components/shell/TabBar.tsx
+++ b/apps/studio/frontend/src/components/shell/TabBar.tsx
@@ -22,14 +22,17 @@ export interface TabSpec {
 
 export default function TabBar({ tabs, ariaLabel }: { tabs: TabSpec[]; ariaLabel?: string }) {
   return (
-    <nav aria-label={ariaLabel} className="flex items-end gap-1 border-b border-edge">
+    <nav
+      aria-label={ariaLabel}
+      className="flex items-end gap-1 overflow-x-auto border-b border-edge [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    >
       {tabs.map((tab) => (
         <Link
           key={tab.id}
           to={tab.to}
           search={tab.search}
           aria-current={tab.active ? "page" : undefined}
-          className={`relative px-3 pb-2 pt-1 text-[length:var(--t-sm)] transition-colors duration-100 ${
+          className={`relative shrink-0 whitespace-nowrap px-3 pb-2 pt-1 text-[length:var(--t-sm)] transition-colors duration-100 ${
             tab.active ? "font-semibold text-content-primary" : "font-normal text-content-muted"
           }`}
         >

--- a/apps/studio/frontend/src/components/ui/DrawerBackButton.tsx
+++ b/apps/studio/frontend/src/components/ui/DrawerBackButton.tsx
@@ -15,7 +15,7 @@ export default function DrawerBackButton({ children, ...rest }: DrawerBackButton
     <button
       type="button"
       {...rest}
-      className="flex shrink-0 items-center gap-1.5 border-b border-edge px-4 py-2 text-[length:var(--t-xs)] text-content-muted"
+      className="flex shrink-0 items-center gap-1.5 border-b border-edge px-4 py-2 text-[length:var(--t-xs)] text-content-muted lg:hidden"
     >
       <IconArrowLeft size={11} strokeWidth={2} /> {children}
     </button>

--- a/apps/studio/frontend/src/components/ui/DrawerHeader.tsx
+++ b/apps/studio/frontend/src/components/ui/DrawerHeader.tsx
@@ -17,8 +17,8 @@ export interface DrawerHeaderProps {
  */
 export default function DrawerHeader({ name, badge, badgeColor, trailing }: DrawerHeaderProps) {
   return (
-    <div className="flex shrink-0 items-center gap-3 border-b border-edge px-4 py-3">
-      <span className="truncate font-data font-medium text-[length:var(--t-lg)] text-content-primary">
+    <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 border-b border-edge px-4 py-3 sm:flex-nowrap">
+      <span className="min-w-0 basis-full break-words font-data font-medium text-[length:var(--t-lg)] leading-snug text-content-primary sm:basis-auto sm:flex-1 sm:truncate">
         {name}
       </span>
       {badge != null && (
@@ -31,7 +31,11 @@ export default function DrawerHeader({ name, badge, badgeColor, trailing }: Draw
           {badge}
         </span>
       )}
-      {trailing != null && <div className="ml-auto flex items-center gap-2">{trailing}</div>}
+      {trailing != null && (
+        <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
+          {trailing}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/studio/frontend/src/components/ui/PageHeader.tsx
+++ b/apps/studio/frontend/src/components/ui/PageHeader.tsx
@@ -50,7 +50,7 @@ export default function PageHeader({
 
       <div className="flex flex-wrap items-start gap-3">
         <div className="flex min-w-0 flex-1 items-center gap-2.5">
-          <h1 className="font-mono text-xl font-semibold tracking-tight text-content-primary truncate">
+          <h1 className="truncate font-mono text-page-title font-semibold text-content-primary">
             {title}
           </h1>
           {badges ? <div className="flex shrink-0 items-center gap-2">{badges}</div> : null}

--- a/apps/studio/frontend/src/globals.css
+++ b/apps/studio/frontend/src/globals.css
@@ -165,6 +165,11 @@
     line-height: 1.3;
     letter-spacing: -0.01em;
   }
+  .text-page-title {
+    font-size: var(--t-xl);
+    line-height: 1.25;
+    letter-spacing: -0.018em;
+  }
 
   /* Card shadow utilities */
   .shadow-card {

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -4,8 +4,7 @@
  * Covers:
  * - LOCALES/RTL_LOCALES metadata shape (16 codes, ar/ur marked rtl).
  * - applyDocumentLocale flips <html lang>/<html dir> for rtl vs ltr locales.
- * - Every messages/*.json file has the exact same leaf-key set as en.json
- *   (700 leaves).
+ * - Every messages/*.json file has the exact same leaf-key set as en.json.
  * - Every locale's messages parse under a real ICU translator with no
  *   FORMATTING_ERROR, including the true {count, plural, ...} strings and
  *   the pre-existing bare-{plural} anti-pattern in prunePhantoms.
@@ -102,6 +101,7 @@ const SAMPLE_VALUES = {
   group: "alpha",
   id: "abc123",
   interval: "5m",
+  kind: "navigate",
   label: "Tab",
   logPages: 10,
   message: "oops",
@@ -194,8 +194,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 700 leaves", () => {
-    expect(EN_LEAVES.size).toBe(700);
+  it("en.json has 785 leaves", () => {
+    expect(EN_LEAVES.size).toBe(785);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -194,8 +194,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 785 leaves", () => {
-    expect(EN_LEAVES.size).toBe(785);
+  it("en.json has 787 leaves", () => {
+    expect(EN_LEAVES.size).toBe(787);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -8,7 +8,16 @@ import type {
   PlaybookFormat,
   ProjectDetail,
   ProjectSummary,
+  OperatorConversation,
+  OperatorConversationSnapshot,
+  OperatorFrame,
+  OperatorFrameType,
+  OperatorProposalResult,
+  OperatorTurnAccepted,
+  OperatorTurnRequest,
   RunDetail,
+  RunResumeRequest,
+  RunResumeResponse,
   RunSummary,
   ScheduleDetail,
   ScheduleRunSummary,
@@ -68,6 +77,25 @@ export function resolveApiBase(): string {
 
 export const API_BASE = resolveApiBase();
 
+export class ApiError extends Error {
+  readonly status: number;
+  readonly detail: unknown;
+  readonly code?: string;
+  readonly retryable?: boolean;
+
+  constructor(status: number, message: string, detail?: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.detail = detail;
+    if (detail != null && typeof detail === "object" && !Array.isArray(detail)) {
+      const record = detail as Record<string, unknown>;
+      if (typeof record.code === "string") this.code = record.code;
+      if (typeof record.retryable === "boolean") this.retryable = record.retryable;
+    }
+  }
+}
+
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
   const url = `${API_BASE}${path}`;
 
@@ -92,14 +120,22 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
     // Preserve the backend `detail` field (FastAPI/Pydantic validation errors,
     // our structured 409 body, etc.) so callers can surface it to the operator.
     // Falls back to the status code when the body is not JSON or has no detail.
-    let detail: string | undefined;
+    let detail: unknown;
     try {
-      const body = (await response.json()) as { detail?: string };
-      if (typeof body?.detail === "string") detail = body.detail;
+      const body = (await response.json()) as { detail?: unknown };
+      detail = body?.detail;
     } catch {
       // not JSON — ignore
     }
-    throw new Error(detail ?? `Request failed: ${response.status}`);
+    const message =
+      typeof detail === "string"
+        ? detail
+        : detail != null && typeof detail === "object" && !Array.isArray(detail)
+          ? typeof (detail as Record<string, unknown>).message === "string"
+            ? String((detail as Record<string, unknown>).message)
+            : `Request failed: ${response.status}`
+          : `Request failed: ${response.status}`;
+    throw new ApiError(response.status, message, detail);
   }
   // 204/empty-body responses have nothing to parse — return as-is (matches
   // callers that type these as `unknown`/`{ ok: boolean }` but never actually
@@ -188,6 +224,384 @@ function sseSubscribe(path: string, onData: (data: string) => void): () => void 
   return close;
 }
 
+// ─── Operator conversations (ADR-0083 v1) ──────────────────────────────────
+
+const OPERATOR_FRAME_TYPES = new Set<OperatorFrameType>([
+  "text",
+  "tool_call",
+  "tool_result",
+  "ui_command",
+  "proposal",
+  "confirmation",
+  "error",
+  "done",
+]);
+
+type RawRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): RawRecord {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as RawRecord)
+    : {};
+}
+
+function normalizeOperatorConversation(value: unknown): OperatorConversation {
+  const raw = asRecord(value);
+  const id = raw.id;
+  if (typeof id !== "string" || !id) {
+    throw new Error("Operator conversation response did not include an id.");
+  }
+  const status =
+    raw.status === "archived" || raw.status === "deleted" ? raw.status : ("active" as const);
+  const readNumber = (camel: string, snake: string): number | undefined => {
+    const candidate = raw[camel] ?? raw[snake];
+    return typeof candidate === "number" ? candidate : undefined;
+  };
+  const readString = (camel: string, snake: string): string | undefined => {
+    const candidate = raw[camel] ?? raw[snake];
+    return typeof candidate === "string" ? candidate : undefined;
+  };
+  return {
+    id,
+    status,
+    project: typeof raw.project === "string" ? raw.project : null,
+    title: typeof raw.title === "string" ? raw.title : null,
+    nextSequence: readNumber("nextSequence", "next_sequence"),
+    activeRequestId: readString("activeRequestId", "active_request_id") ?? null,
+    createdAt: readNumber("createdAt", "created_at"),
+    updatedAt: readNumber("updatedAt", "updated_at"),
+  };
+}
+
+export function isOperatorFrame(value: unknown): value is OperatorFrame {
+  const raw = asRecord(value);
+  return (
+    raw.version === 1 &&
+    typeof raw.conversationId === "string" &&
+    typeof raw.requestId === "string" &&
+    typeof raw.sequence === "number" &&
+    Number.isInteger(raw.sequence) &&
+    raw.sequence >= 1 &&
+    typeof raw.type === "string" &&
+    OPERATOR_FRAME_TYPES.has(raw.type as OperatorFrameType) &&
+    raw.payload != null &&
+    typeof raw.payload === "object" &&
+    typeof raw.createdAt === "number"
+  );
+}
+
+export async function createOperatorConversation(input?: {
+  project?: string | null;
+  title?: string | null;
+}): Promise<OperatorConversation> {
+  const response = await fetchJson<unknown>("/api/operator/conversations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input ?? {}),
+  });
+  const raw = asRecord(response);
+  return normalizeOperatorConversation(raw.conversation ?? raw);
+}
+
+export async function listOperatorConversations(): Promise<OperatorConversation[]> {
+  const response = await fetchJson<unknown>("/api/operator/conversations");
+  const raw = asRecord(response);
+  if (!Array.isArray(raw.conversations)) {
+    throw new Error("Operator conversation list response was invalid.");
+  }
+  return raw.conversations.map(normalizeOperatorConversation);
+}
+
+export async function getOperatorConversation(
+  conversationId: string,
+): Promise<OperatorConversationSnapshot> {
+  const pageSize = 1000;
+  let afterSequence = 0;
+  let conversation: OperatorConversation | null = null;
+  const frames: OperatorFrame[] = [];
+
+  for (;;) {
+    const response = await fetchJson<unknown>(
+      `/api/operator/conversations/${encodeURIComponent(conversationId)}?after_sequence=${afterSequence}&limit=${pageSize}`,
+    );
+    const raw = asRecord(response);
+    conversation = normalizeOperatorConversation(raw.conversation ?? raw);
+    const framesValue = raw.frames ?? raw.events;
+    const page = Array.isArray(framesValue) ? framesValue : [];
+    for (const frame of page) {
+      if (!isOperatorFrame(frame)) {
+        throw new Error("Operator history contains an unsupported protocol frame.");
+      }
+    }
+    frames.push(...page);
+    const hasMore = typeof raw.hasMore === "boolean" ? raw.hasMore : page.length >= pageSize;
+    if (!hasMore) break;
+    const reportedNext = raw.nextAfterSequence;
+    const nextSequence =
+      typeof reportedNext === "number"
+        ? reportedNext
+        : Math.max(...page.map((frame) => (frame as OperatorFrame).sequence));
+    if (nextSequence <= afterSequence) {
+      throw new Error("Operator history pagination did not advance.");
+    }
+    afterSequence = nextSequence;
+  }
+
+  if (!conversation) {
+    throw new Error("Operator conversation response was empty.");
+  }
+  return { conversation, frames };
+}
+
+export async function submitOperatorTurn(
+  conversationId: string,
+  request: OperatorTurnRequest,
+): Promise<OperatorTurnAccepted> {
+  return fetchJson<OperatorTurnAccepted>(
+    `/api/operator/conversations/${encodeURIComponent(conversationId)}/turns`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        instruction: request.instruction,
+        context: request.context,
+        expected_last_sequence: request.expectedLastSequence,
+      }),
+    },
+  );
+}
+
+export async function cancelOperatorRequest(
+  conversationId: string,
+  requestId: string,
+): Promise<void> {
+  await fetchJson<unknown>(
+    `/api/operator/conversations/${encodeURIComponent(conversationId)}/requests/${encodeURIComponent(requestId)}/cancel`,
+    { method: "POST" },
+  );
+}
+
+export type OperatorEffectRejectionCode =
+  | "unsupported"
+  | "invalid_params"
+  | "stale_context"
+  | "not_visible"
+  | "client_error";
+
+export async function acknowledgeOperatorEffect(
+  conversationId: string,
+  effectId: string,
+  acknowledgement:
+    | { status: "applied"; clientRoute: string }
+    | {
+        status: "rejected";
+        clientRoute?: string;
+        rejectionCode: OperatorEffectRejectionCode;
+      },
+): Promise<{ effectId: string; status: "applied" | "rejected" }> {
+  return fetchJson(
+    `/api/operator/conversations/${encodeURIComponent(conversationId)}/effects/${encodeURIComponent(effectId)}/ack`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(acknowledgement),
+    },
+  );
+}
+
+export async function confirmOperatorProposal(
+  conversationId: string,
+  proposalId: string,
+  expectedCommandHash: string,
+  expectedTargetVersion?: string | null,
+): Promise<OperatorProposalResult> {
+  return fetchJson<OperatorProposalResult>(
+    `/api/operator/conversations/${encodeURIComponent(conversationId)}/proposals/${encodeURIComponent(proposalId)}/confirm`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        expectedCommandHash,
+        expectedTargetVersion: expectedTargetVersion ?? null,
+      }),
+    },
+  );
+}
+
+export async function decideOperatorProposal(
+  conversationId: string,
+  proposalId: string,
+  decision: "allow" | "deny",
+  expectedCommandHash?: string,
+  expectedTargetVersion?: string | null,
+): Promise<OperatorProposalResult> {
+  return fetchJson<OperatorProposalResult>(
+    `/api/operator/conversations/${encodeURIComponent(conversationId)}/proposals/${encodeURIComponent(proposalId)}/decision`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        decision,
+        ...(expectedCommandHash ? { expectedCommandHash } : {}),
+        expectedTargetVersion: expectedTargetVersion ?? null,
+      }),
+    },
+  );
+}
+
+export interface OperatorSseChunk {
+  data: string[];
+  rest: string;
+}
+
+/**
+ * Consume complete SSE records while retaining a possibly-fragmented tail.
+ * Handles both LF and CRLF records and joins multi-line data fields.
+ */
+export function consumeOperatorSse(input: string): OperatorSseChunk {
+  const data: string[] = [];
+  let rest = input;
+  for (;;) {
+    const match = /\r?\n\r?\n/.exec(rest);
+    if (!match || match.index == null) break;
+    const record = rest.slice(0, match.index);
+    rest = rest.slice(match.index + match[0].length);
+    const payload = record
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).replace(/^ /, ""))
+      .join("\n");
+    if (payload) data.push(payload);
+  }
+  return { data, rest };
+}
+
+export type OperatorStreamConnection = "connecting" | "open" | "reconnecting";
+
+export interface OperatorStreamHandlers {
+  onFrame: (frame: OperatorFrame) => void;
+  onConnection?: (state: OperatorStreamConnection) => void;
+  onError?: (error: Error, fatal: boolean) => void;
+}
+
+/**
+ * Authenticated, replayable SSE subscription. The cursor advances only after
+ * a validated v1 frame and is sent on every reconnect, so delivery may repeat
+ * but never silently skips a durable frame.
+ */
+export function streamOperatorConversation(
+  conversationId: string,
+  afterSequence: number,
+  handlers: OperatorStreamHandlers,
+): () => void {
+  let closed = false;
+  let cursor = Math.max(0, afterSequence);
+  let controller: AbortController | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const wait = (delay: number) =>
+    new Promise<void>((resolve) => {
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        resolve();
+      }, delay);
+    });
+
+  const close = () => {
+    closed = true;
+    controller?.abort();
+    if (retryTimer) clearTimeout(retryTimer);
+  };
+
+  void (async () => {
+    let retryMs = 750;
+    let firstAttempt = true;
+    while (!closed) {
+      handlers.onConnection?.(firstAttempt ? "connecting" : "reconnecting");
+      controller = new AbortController();
+      try {
+        const query = new URLSearchParams({ after_sequence: String(cursor) });
+        const headers: Record<string, string> = { Accept: "text/event-stream" };
+        const token = resolveAuthToken();
+        if (token) headers.Authorization = `Bearer ${token}`;
+        const response = await fetch(
+          `${API_BASE}/api/operator/conversations/${encodeURIComponent(conversationId)}/stream?${query}`,
+          { headers, signal: controller.signal },
+        );
+        if (!response.ok || !response.body) {
+          const fatal =
+            response.status < 500 &&
+            response.status !== 408 &&
+            response.status !== 425 &&
+            response.status !== 429;
+          const error = new Error(`Operator stream request failed: ${response.status}`);
+          handlers.onError?.(error, fatal);
+          if (fatal) {
+            closed = true;
+            break;
+          }
+          throw error;
+        }
+
+        handlers.onConnection?.("open");
+        retryMs = 750;
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        while (!closed) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const chunk = consumeOperatorSse(buffer);
+          buffer = chunk.rest;
+          for (const payload of chunk.data) {
+            let candidate: unknown;
+            try {
+              candidate = JSON.parse(payload);
+            } catch {
+              const error = new Error("Operator stream sent malformed JSON.");
+              handlers.onError?.(error, true);
+              closed = true;
+              controller.abort();
+              break;
+            }
+            if (!isOperatorFrame(candidate)) {
+              const error = new Error("Operator stream sent an unsupported protocol frame.");
+              handlers.onError?.(error, true);
+              closed = true;
+              controller.abort();
+              break;
+            }
+            if (candidate.conversationId !== conversationId) {
+              const error = new Error("Operator stream frame belongs to another conversation.");
+              handlers.onError?.(error, true);
+              closed = true;
+              controller.abort();
+              break;
+            }
+            cursor = Math.max(cursor, candidate.sequence);
+            handlers.onFrame(candidate);
+          }
+        }
+      } catch (error) {
+        if (closed || controller.signal.aborted) break;
+        reportConnectivityFailure();
+        handlers.onError?.(
+          error instanceof Error ? error : new Error("Operator stream disconnected."),
+          false,
+        );
+      }
+      if (!closed) {
+        firstAttempt = false;
+        await wait(retryMs);
+        retryMs = Math.min(Math.round(retryMs * 1.8), 10_000);
+      }
+    }
+  })();
+
+  return close;
+}
+
 // ─── Runs ─────────────────────────────────────────────────────────────────────
 
 export interface RunListParams {
@@ -225,6 +639,17 @@ export async function listRuns(params?: RunListParams): Promise<RunListResponse>
 
 export async function getRun(runId: string): Promise<RunDetail> {
   return fetchJson<RunDetail>(`/api/runs/${encodeURIComponent(runId)}`);
+}
+
+export async function resumeRun(
+  runId: string,
+  request: RunResumeRequest,
+): Promise<RunResumeResponse> {
+  return fetchJson<RunResumeResponse>(`/api/runs/${encodeURIComponent(runId)}/resume`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
 }
 
 export interface RunFileContent {

--- a/apps/studio/frontend/src/lib/commands.ts
+++ b/apps/studio/frontend/src/lib/commands.ts
@@ -13,6 +13,8 @@ export type CommandRegistry = Command[];
 export function buildRegistry(
   _navigate: (href: string) => void,
   toggleTheme: () => void,
+  toggleOperator?: () => void,
+  operatorLabel = "Operator",
 ): CommandRegistry {
   return [
     /* ── Primary spaces ── */
@@ -98,6 +100,13 @@ export function buildRegistry(
       section: "Library",
     },
     /* ── Actions ── */
+    {
+      id: "action:toggle-operator",
+      label: operatorLabel,
+      keywords: ["operator", "assistant", "command", "chat"],
+      action: toggleOperator,
+      section: "Actions",
+    },
     {
       id: "action:toggle-theme",
       label: "Toggle theme",

--- a/apps/studio/frontend/src/lib/connectionBootstrap.test.ts
+++ b/apps/studio/frontend/src/lib/connectionBootstrap.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const html = fs.readFileSync(path.resolve(__dirname, "../../index.html"), "utf-8");
+const bootstrapMatch = html.match(/<script id="studio-connection-bootstrap">([\s\S]*?)<\/script>/);
+if (!bootstrapMatch) throw new Error("connection bootstrap script not found");
+const bootstrap = bootstrapMatch[1];
+const analyticsMatch = html.match(/<script id="studio-analytics-bootstrap">([\s\S]*?)<\/script>/);
+if (!analyticsMatch) throw new Error("analytics bootstrap script not found");
+const analyticsBootstrap = analyticsMatch[1];
+
+function executeBootstrap(options: {
+  hash: string;
+  initial?: Record<string, string>;
+  storageBlocked?: boolean;
+}) {
+  const values = new Map(Object.entries(options.initial ?? {}));
+  const replaced: string[] = [];
+  const fakeWindow = {
+    location: {
+      hash: options.hash,
+      pathname: "/",
+      search: "?view=fleet",
+    },
+    history: {
+      state: { preserved: true },
+      replaceState: (_state: unknown, _title: string, url: string) => replaced.push(url),
+    },
+  } as unknown as Window;
+  const storage = {
+    setItem(key: string, value: string) {
+      if (options.storageBlocked) throw new Error("blocked");
+      values.set(key, value);
+    },
+    getItem(key: string) {
+      if (options.storageBlocked) throw new Error("blocked");
+      return values.get(key) ?? null;
+    },
+  };
+  const run = new Function(
+    "window",
+    "document",
+    "sessionStorage",
+    "URLSearchParams",
+    "URL",
+    bootstrap,
+  );
+  run(fakeWindow, { title: "Lion Studio" }, storage, URLSearchParams, URL);
+  return { fakeWindow, values, replaced };
+}
+
+describe("pre-module Studio connection bootstrap", () => {
+  it("runs before analytics and the main module", () => {
+    const bootstrapIndex = html.indexOf('id="studio-connection-bootstrap"');
+    expect(bootstrapIndex).toBeGreaterThan(0);
+    expect(bootstrapIndex).toBeLessThan(html.indexOf("analytics.khive.ai"));
+    expect(bootstrapIndex).toBeLessThan(html.indexOf('type="module"'));
+  });
+
+  it("never injects third-party analytics into an authenticated control-plane tab", () => {
+    expect(analyticsBootstrap).toContain("if (window.__STUDIO_AUTH_TOKEN__) return");
+    const appended: unknown[] = [];
+    const run = new Function("window", "document", analyticsBootstrap);
+    run(
+      { __STUDIO_AUTH_TOKEN__: "sensitive" },
+      {
+        createElement: () => {
+          throw new Error("analytics must not be created");
+        },
+        head: { appendChild: (node: unknown) => appended.push(node) },
+      },
+    );
+    expect(appended).toEqual([]);
+
+    const created: Record<string, unknown> = {
+      setAttribute(name: string, value: string) {
+        this[name] = value;
+      },
+    };
+    run(
+      {},
+      {
+        createElement: () => created,
+        head: { appendChild: (node: unknown) => appended.push(node) },
+      },
+    );
+    expect(appended).toEqual([created]);
+    expect(created.src).toBe("https://analytics.khive.ai/script.js");
+  });
+
+  it("hydrates globals, persists the tab session, and scrubs credentials", () => {
+    const { fakeWindow, values, replaced } = executeBootstrap({
+      hash: "#studio-api=http%3A%2F%2F127.0.0.1%3A8765&studio-human-token=secret&keep=yes",
+    });
+    expect(fakeWindow.__STUDIO_API_BASE__).toBe("http://127.0.0.1:8765");
+    expect(fakeWindow.__STUDIO_AUTH_TOKEN__).toBe("secret");
+    expect(values.get("studio-api")).toBe("http://127.0.0.1:8765");
+    expect(values.get("studio-token")).toBe("secret");
+    expect(replaced).toEqual(["/?view=fleet#keep=yes"]);
+    expect(replaced[0]).not.toContain("secret");
+  });
+
+  it("restores on reload and still initializes when storage is blocked", () => {
+    const restored = executeBootstrap({
+      hash: "",
+      initial: {
+        "studio-api": "http://127.0.0.1:9999",
+        "studio-token": "restored-token",
+      },
+    });
+    expect(restored.fakeWindow.__STUDIO_API_BASE__).toBe("http://127.0.0.1:9999");
+    expect(restored.fakeWindow.__STUDIO_AUTH_TOKEN__).toBe("restored-token");
+
+    const blocked = executeBootstrap({
+      hash: "#apiBase=http%3A%2F%2F127.0.0.1%3A8765&humanToken=one-load-token",
+      storageBlocked: true,
+    });
+    expect(blocked.fakeWindow.__STUDIO_API_BASE__).toBe("http://127.0.0.1:8765");
+    expect(blocked.fakeWindow.__STUDIO_AUTH_TOKEN__).toBe("one-load-token");
+    expect(blocked.replaced).toEqual(["/?view=fleet"]);
+  });
+
+  it("never pairs a partial or non-loopback fragment with a stored bearer", () => {
+    const priorPair = {
+      "studio-api": "http://127.0.0.1:8765",
+      "studio-token": "prior-token",
+    };
+    const malicious = executeBootstrap({
+      hash: "#studio-api=https%3A%2F%2Fevil.example",
+      initial: priorPair,
+    });
+    expect(malicious.fakeWindow.__STUDIO_API_BASE__).toBe("http://127.0.0.1:8765");
+    expect(malicious.fakeWindow.__STUDIO_AUTH_TOKEN__).toBe("prior-token");
+    expect(malicious.fakeWindow.__STUDIO_API_BASE__).not.toContain("evil.example");
+    expect(malicious.replaced).toEqual(["/?view=fleet"]);
+
+    const partialLoopback = executeBootstrap({
+      hash: "#studio-api=http%3A%2F%2Flocalhost%3A9999",
+      initial: priorPair,
+    });
+    expect(partialLoopback.fakeWindow.__STUDIO_API_BASE__).toBe("http://127.0.0.1:8765");
+    expect(partialLoopback.fakeWindow.__STUDIO_AUTH_TOKEN__).toBe("prior-token");
+  });
+});

--- a/apps/studio/frontend/src/lib/operatorApi.test.ts
+++ b/apps/studio/frontend/src/lib/operatorApi.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ApiError,
+  acknowledgeOperatorEffect,
+  consumeOperatorSse,
+  decideOperatorProposal,
+  getOperatorConversation,
+  isOperatorFrame,
+  listOperatorConversations,
+  submitOperatorTurn,
+} from "./api";
+import type { OperatorFrame } from "./types";
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function frame(sequence: number): OperatorFrame {
+  return {
+    version: 1,
+    conversationId: "conversation-1",
+    requestId: "request-1",
+    sequence,
+    type: "text",
+    payload: { content: String(sequence), format: "plain", role: "assistant" },
+    createdAt: sequence,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("Operator API v1", () => {
+  it("normalizes the daemon-backed conversation index", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          json({
+            conversations: [
+              {
+                id: "conversation-new",
+                title: "Release check",
+                status: "active",
+                next_sequence: 4,
+                active_request_id: null,
+                created_at: 10,
+                updated_at: 20,
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    await expect(listOperatorConversations()).resolves.toEqual([
+      {
+        id: "conversation-new",
+        project: null,
+        title: "Release check",
+        status: "active",
+        nextSequence: 4,
+        activeRequestId: null,
+        createdAt: 10,
+        updatedAt: 20,
+      },
+    ]);
+  });
+
+  it("pages every retained frame instead of truncating history at 1000", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        calls.push(url);
+        const after = Number(new URL(url, "http://studio.test").searchParams.get("after_sequence"));
+        const frames =
+          after === 0
+            ? Array.from({ length: 1000 }, (_, index) => frame(index + 1))
+            : [frame(1001)];
+        return Promise.resolve(
+          json({
+            conversation: {
+              id: "conversation-1",
+              status: "active",
+              nextSequence: 1002,
+              activeRequestId: null,
+            },
+            frames,
+          }),
+        );
+      }),
+    );
+
+    const snapshot = await getOperatorConversation("conversation-1");
+
+    expect(snapshot.frames).toHaveLength(1001);
+    expect(snapshot.frames.at(-1)?.sequence).toBe(1001);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain("after_sequence=0");
+    expect(calls[1]).toContain("after_sequence=1000");
+  });
+
+  it("serializes the turn concurrency cursor with the ADR field name", async () => {
+    let captured: RequestInit | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => {
+        captured = init;
+        return Promise.resolve(
+          json(
+            {
+              conversationId: "conversation-1",
+              requestId: "request-1",
+              acceptedSequence: 8,
+            },
+            202,
+          ),
+        );
+      }),
+    );
+
+    await submitOperatorTurn("conversation-1", {
+      instruction: "Investigate the failure",
+      context: {
+        space: "mission",
+        route: "/",
+        selection: null,
+        filters: {},
+      },
+      expectedLastSequence: 7,
+    });
+
+    expect(JSON.parse(String(captured?.body))).toMatchObject({
+      instruction: "Investigate the failure",
+      expected_last_sequence: 7,
+    });
+  });
+
+  it("preserves structured stale-context details on a 409", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          json(
+            {
+              detail: {
+                code: "stale_context",
+                message: "Conversation advanced",
+                retryable: true,
+                details: { latestSequence: 9 },
+              },
+            },
+            409,
+          ),
+        ),
+      ),
+    );
+
+    const rejected = submitOperatorTurn("conversation-1", {
+      instruction: "Continue",
+      context: { space: "mission", route: "/", selection: null, filters: {} },
+      expectedLastSequence: 7,
+    });
+
+    await expect(rejected).rejects.toMatchObject({
+      name: "ApiError",
+      status: 409,
+      code: "stale_context",
+      retryable: true,
+      message: "Conversation advanced",
+    } satisfies Partial<ApiError>);
+  });
+
+  it("posts an explicit allow/deny proposal decision with the exact command hash", async () => {
+    let url = "";
+    let captured: RequestInit | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string, init?: RequestInit) => {
+        url = input;
+        captured = init;
+        return Promise.resolve(
+          json({ proposalId: "proposal-1", status: "executing", result: null }),
+        );
+      }),
+    );
+
+    await decideOperatorProposal(
+      "conversation-1",
+      "proposal-1",
+      "deny",
+      "sha256",
+      "playbook-fingerprint",
+    );
+
+    expect(url).toContain("/proposals/proposal-1/decision");
+    expect(JSON.parse(String(captured?.body))).toEqual({
+      decision: "deny",
+      expectedCommandHash: "sha256",
+      expectedTargetVersion: "playbook-fingerprint",
+    });
+  });
+
+  it("acknowledges a validated client effect with the resulting route", async () => {
+    let url = "";
+    let captured: RequestInit | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string, init?: RequestInit) => {
+        url = input;
+        captured = init;
+        return Promise.resolve(json({ effectId: "effect-1", status: "applied" }));
+      }),
+    );
+
+    await acknowledgeOperatorEffect("conversation-1", "effect-1", {
+      status: "applied",
+      clientRoute: "/fleet?s=run-1",
+    });
+
+    expect(url).toContain("/effects/effect-1/ack");
+    expect(JSON.parse(String(captured?.body))).toEqual({
+      status: "applied",
+      clientRoute: "/fleet?s=run-1",
+    });
+  });
+});
+
+describe("Operator SSE framing", () => {
+  it("retains a fragmented tail and consumes LF plus CRLF records", () => {
+    const first = consumeOperatorSse('data: {"a":1}\r\n\r\ndata: {"b"');
+    expect(first.data).toEqual(['{"a":1}']);
+    const second = consumeOperatorSse(`${first.rest}:2}\n\n`);
+    expect(second.data).toEqual(['{"b":2}']);
+    expect(second.rest).toBe("");
+  });
+
+  it("joins multi-line data and rejects unknown protocol versions or frame types", () => {
+    const consumed = consumeOperatorSse("event: ignored\ndata: hello\ndata: world\n\n");
+    expect(consumed.data).toEqual(["hello\nworld"]);
+    expect(isOperatorFrame(frame(1))).toBe(true);
+    expect(isOperatorFrame({ ...frame(1), version: 2 })).toBe(false);
+    expect(isOperatorFrame({ ...frame(1), type: "future_type" })).toBe(false);
+  });
+});

--- a/apps/studio/frontend/src/lib/retiredRoutes.ts
+++ b/apps/studio/frontend/src/lib/retiredRoutes.ts
@@ -11,7 +11,7 @@ export type RetiredSearchPrimitive = string | number | boolean;
 export type RetiredSearchValue = RetiredSearchPrimitive | RetiredSearchPrimitive[];
 export type RetiredSearch = Record<string, RetiredSearchValue>;
 
-export type RetiredRedirectTo = "/fleet" | "/library" | "/schedules" | "/system";
+export type RetiredRedirectTo = "/" | "/fleet" | "/library" | "/schedules" | "/system";
 
 export interface RetiredRedirectTarget<TTo extends RetiredRedirectTo = RetiredRedirectTo> {
   to: TTo;

--- a/apps/studio/frontend/src/lib/runResumeApi.test.ts
+++ b/apps/studio/frontend/src/lib/runResumeApi.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resumeRun } from "./api";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("resumeRun API", () => {
+  it("posts the follow-up and selected branch to the run resume endpoint", async () => {
+    let url = "";
+    let init: RequestInit | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: string, request?: RequestInit) => {
+        url = input;
+        init = request;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              run_id: "run-1",
+              branch_id: "branch-1",
+              invocation_id: "invocation-1",
+            }),
+            { status: 202, headers: { "content-type": "application/json" } },
+          ),
+        );
+      }),
+    );
+
+    const result = await resumeRun("run-1", {
+      instruction: "Continue and verify",
+      branch_id: "branch-1",
+    });
+
+    expect(url).toContain("/api/runs/run-1/resume");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      instruction: "Continue and verify",
+      branch_id: "branch-1",
+    });
+    expect(result.invocation_id).toBe("invocation-1");
+  });
+});

--- a/apps/studio/frontend/src/lib/theme.ts
+++ b/apps/studio/frontend/src/lib/theme.ts
@@ -1,0 +1,16 @@
+export type StudioTheme = "dark" | "light";
+
+export const THEME_CHANGE_EVENT = "studio:theme-change";
+
+export function getTheme(): StudioTheme {
+  if (typeof document === "undefined") return "dark";
+  return document.documentElement.getAttribute("data-theme") === "light" ? "light" : "dark";
+}
+
+export function applyTheme(theme: StudioTheme): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.setAttribute("data-theme", theme);
+  document.documentElement.classList.toggle("dark", theme === "dark");
+  window.localStorage.setItem("theme", theme);
+  window.dispatchEvent(new CustomEvent<StudioTheme>(THEME_CHANGE_EVENT, { detail: theme }));
+}

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -158,6 +158,18 @@ export interface RunDetail {
   artifact_verification_json?: ArtifactVerification | null;
 }
 
+export interface RunResumeRequest {
+  instruction: string;
+  branch_id?: string;
+  model?: string;
+}
+
+export interface RunResumeResponse {
+  run_id: string;
+  branch_id: string;
+  invocation_id: string;
+}
+
 // ─── Worker / Playbook types ──────────────────────────────────────────────────
 
 export interface WorkerSummary {
@@ -387,4 +399,201 @@ export interface ScheduleRunSummary {
 
 export interface ScheduleDetail extends ScheduleSummary {
   recent_runs: ScheduleRunSummary[];
+}
+
+// ─── Operator conversation protocol (ADR-0083 v1) ──────────────────────────
+
+export type OperatorConversationStatus = "active" | "archived" | "deleted";
+
+export interface OperatorConversation {
+  id: string;
+  project?: string | null;
+  title?: string | null;
+  status: OperatorConversationStatus;
+  nextSequence?: number;
+  activeRequestId?: string | null;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+export type OperatorErrorCode =
+  | "auth_required"
+  | "validation"
+  | "not_found"
+  | "denied"
+  | "conflict"
+  | "stale_context"
+  | "rate_limited"
+  | "model_failure"
+  | "provider_unavailable"
+  | "service_failure"
+  | "service_restarted"
+  | "audit_unavailable"
+  | "replay_gap"
+  | "cancelled"
+  | "protocol_version";
+
+export interface OperatorProtocolError {
+  code: OperatorErrorCode;
+  message: string;
+  retryable: boolean;
+  retryAfterMs?: number;
+  details?: Record<string, unknown>;
+}
+
+export type OperatorSpace = "mission" | "designer" | "library" | "history" | "schedules" | "system";
+
+export type OperatorJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | OperatorJsonValue[]
+  | { [key: string]: OperatorJsonValue };
+
+export interface OperatorContextSnapshot {
+  project?: string | null;
+  space: OperatorSpace;
+  route: string;
+  selection?: Record<string, string> | null;
+  filters: Record<string, OperatorJsonValue>;
+}
+
+export interface OperatorTextPayload {
+  content: string;
+  format: "plain" | "markdown";
+  /** Additive backend field used to distinguish the persisted instruction. */
+  role?: "user" | "assistant";
+}
+
+export interface OperatorToolCallPayload {
+  callId: string;
+  tool: string;
+  arguments: Record<string, unknown>;
+  mode: "read" | "draft";
+}
+
+export interface OperatorToolResultPayload {
+  callId: string;
+  ok: boolean;
+  result?: unknown;
+  error?: OperatorProtocolError;
+}
+
+export type OperatorUiEffect =
+  | {
+      id?: string;
+      kind: "navigate";
+      space: OperatorSpace;
+      params: Record<string, OperatorJsonValue>;
+    }
+  | {
+      id?: string;
+      kind: "select";
+      space: Exclude<OperatorSpace, "system">;
+      selection: Record<string, string>;
+    }
+  | {
+      id?: string;
+      kind: "prefill";
+      form: "schedule" | "workflow" | "playbook";
+      values: Record<string, OperatorJsonValue>;
+    }
+  | {
+      id?: string;
+      kind: "theme";
+      theme: "light" | "dark";
+    };
+
+export interface OperatorUiCommandPayload {
+  effect: OperatorUiEffect;
+}
+
+export interface OperatorResourceVersion {
+  kind: string;
+  id: string;
+  version: string;
+}
+
+export interface OperatorCommandProposal {
+  id: string;
+  command: Record<string, unknown>;
+  commandHash: string;
+  risk: "mutate" | "execute" | "admin";
+  summary: string;
+  target?: OperatorResourceVersion | null;
+  idempotencyKey: string;
+  expiresAt: number;
+}
+
+export interface OperatorProposalPayload {
+  proposal: OperatorCommandProposal;
+}
+
+export interface OperatorConfirmationPayload {
+  proposalId: string;
+  state: "required" | "confirmed" | "denied" | "cancelled" | "expired" | "executed";
+}
+
+export interface OperatorErrorPayload {
+  error: OperatorProtocolError;
+}
+
+export interface OperatorDonePayload {
+  outcome: "completed" | "failed" | "cancelled";
+  lastSequence: number;
+}
+
+export type OperatorFrameType =
+  | "text"
+  | "tool_call"
+  | "tool_result"
+  | "ui_command"
+  | "proposal"
+  | "confirmation"
+  | "error"
+  | "done";
+
+export type OperatorPayload =
+  | OperatorTextPayload
+  | OperatorToolCallPayload
+  | OperatorToolResultPayload
+  | OperatorUiCommandPayload
+  | OperatorProposalPayload
+  | OperatorConfirmationPayload
+  | OperatorErrorPayload
+  | OperatorDonePayload;
+
+export interface OperatorFrame<T extends OperatorPayload = OperatorPayload> {
+  version: 1;
+  conversationId: string;
+  requestId: string;
+  sequence: number;
+  type: OperatorFrameType;
+  payload: T;
+  createdAt: number;
+}
+
+export interface OperatorConversationSnapshot {
+  conversation: OperatorConversation;
+  frames: OperatorFrame[];
+}
+
+export interface OperatorTurnRequest {
+  instruction: string;
+  context: OperatorContextSnapshot;
+  expectedLastSequence: number;
+}
+
+export interface OperatorTurnAccepted {
+  conversationId: string;
+  requestId: string;
+  acceptedSequence: number;
+}
+
+export interface OperatorProposalResult {
+  proposalId: string;
+  status: "succeeded" | "failed" | "conflict" | "expired" | "executing";
+  result?: Record<string, OperatorJsonValue> | null;
+  error?: OperatorProtocolError | null;
 }

--- a/apps/studio/frontend/src/lib/vercelRewrite.test.ts
+++ b/apps/studio/frontend/src/lib/vercelRewrite.test.ts
@@ -17,7 +17,7 @@ vi.mock("@tanstack/router-plugin/vite", () => ({
   TanStackRouterVite: () => ({ name: "router-test-plugin" }),
 }));
 
-import { hostedApiBaseInjector } from "../../vite.config.mjs";
+import { hostedApiBaseInjector, studioProxy } from "../../vite.config.mjs";
 
 const vercelConfig = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "../../vercel.json"), "utf-8"),
@@ -70,5 +70,13 @@ describe("hosted API base injection", () => {
 
   it("injects nothing into plain builds", () => {
     expect(transformFor({})).toBeUndefined();
+  });
+});
+
+describe("local daemon proxy", () => {
+  it("proxies API requests, liveness, and the authenticated daemon identity", () => {
+    expect(Object.keys(studioProxy).sort()).toEqual(["/api", "/health", "/openapi.json"]);
+    expect(studioProxy["/health"]).toBe(studioProxy["/api"]);
+    expect(studioProxy["/openapi.json"]).toBe(studioProxy["/api"]);
   });
 });

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -6,6 +6,7 @@
       "library": "المكتبة",
       "schedules": "الجداول",
       "system": "النظام",
+      "operator": "المشغّل",
       "toggleTheme": "تبديل السمة",
       "switchToZh": "التبديل إلى الصينية",
       "switchToEn": "التبديل إلى الإنجليزية",
@@ -40,6 +41,99 @@
       "newTab": "يفتح في علامة تبويب جديدة"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "ساحة التشغيل",
     "subtitle": "كل Play والجلسات قيد التشغيل أو في الصف عبر المشاريع",
@@ -70,6 +164,9 @@
     "newWorkflow": "سير عمل جديد",
     "newAgent": "وكيل جديد",
     "loading": "جارٍ التحميل…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "لم يتم العثور على عناصر.",
       "allHint": "أنشئ أول وكيل أو سير عمل للبدء.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -6,6 +6,7 @@
       "library": "লাইব্রেরি",
       "schedules": "শিডিউল",
       "system": "সিস্টেম",
+      "operator": "অপারেটর",
       "toggleTheme": "থিম টগল করুন",
       "switchToZh": "চীনা ভাষায় যান",
       "switchToEn": "ইংরেজিতে যান",
@@ -40,6 +41,99 @@
       "newTab": "নতুন ট্যাবে খুলবে"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Playfield",
     "subtitle": "সব প্রোজেক্ট জুড়ে রানিং ও কিউড Play এবং সেশন",
@@ -70,6 +164,9 @@
     "newWorkflow": "নতুন ওয়ার্কফ্লো",
     "newAgent": "নতুন এজেন্ট",
     "loading": "লোড হচ্ছে…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "কোনো আইটেম পাওয়া যায়নি।",
       "allHint": "শুরু করতে আপনার প্রথম এজেন্ট বা ওয়ার্কফ্লো তৈরি করুন।",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -6,6 +6,7 @@
       "library": "Bibliothek",
       "schedules": "Zeitpläne",
       "system": "System",
+      "operator": "Operator",
       "toggleTheme": "Design umschalten",
       "switchToZh": "Zu Chinesisch wechseln",
       "switchToEn": "Zu Englisch wechseln",
@@ -40,6 +41,99 @@
       "newTab": "öffnet in einem neuen Tab"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Playfield",
     "subtitle": "Alle laufenden und eingereihten Plays und Sessions über Projekte hinweg",
@@ -70,6 +164,9 @@
     "newWorkflow": "Neuer Workflow",
     "newAgent": "Neuer Agent",
     "loading": "Wird geladen…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "Keine Elemente gefunden.",
       "allHint": "Erstelle deinen ersten Agenten oder Workflow, um loszulegen.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -6,6 +6,7 @@
       "library": "Library",
       "schedules": "Schedules",
       "system": "System",
+      "operator": "Operator",
       "toggleTheme": "Toggle theme",
       "switchToZh": "Switch to Chinese",
       "switchToEn": "Switch to English",
@@ -40,6 +41,117 @@
       "homeAria": "Home tabs"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": {
+      "title": "Conversation unavailable"
+    },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": {
+      "you": "You",
+      "operator": "Operator"
+    },
+    "tool": {
+      "read": "read",
+      "draft": "draft",
+      "done": "Tool completed",
+      "failed": "Tool failed"
+    },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": {
+        "mutate": "change",
+        "execute": "execute",
+        "admin": "admin"
+      },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": {
+      "requested": "Requested interface action: {kind}"
+    },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": {
+      "open": "Open run"
+    }
+  },
   "playfield": {
     "title": "Playfield",
     "subtitle": "All running and queued plays and sessions across projects",
@@ -70,6 +182,9 @@
     "newWorkflow": "New Workflow",
     "newAgent": "New Agent",
     "loading": "Loading…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "No items found.",
       "allHint": "Create your first agent or workflow to get started.",
@@ -822,9 +937,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -122,6 +122,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": {
         "mutate": "change",
         "execute": "execute",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -6,6 +6,7 @@
       "library": "Biblioteca",
       "schedules": "Programaciones",
       "system": "Sistema",
+      "operator": "Operador",
       "toggleTheme": "Cambiar tema",
       "switchToZh": "Cambiar a chino",
       "switchToEn": "Cambiar a inglés",
@@ -40,6 +41,99 @@
       "newTab": "se abre en una pestaña nueva"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Área de Plays",
     "subtitle": "Todos los Plays y sesiones en ejecución o en cola en todos los proyectos",
@@ -70,6 +164,9 @@
     "newWorkflow": "Nuevo flujo de trabajo",
     "newAgent": "Nuevo agente",
     "loading": "Cargando…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "No se encontraron elementos.",
       "allHint": "Crea tu primer agente o flujo de trabajo para empezar.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -6,6 +6,7 @@
       "library": "Bibliothèque",
       "schedules": "Planifications",
       "system": "Système",
+      "operator": "Opérateur",
       "toggleTheme": "Changer de thème",
       "switchToZh": "Passer au chinois",
       "switchToEn": "Passer à l’anglais",
@@ -40,6 +41,99 @@
       "newTab": "s'ouvre dans un nouvel onglet"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Zone de Play",
     "subtitle": "Tous les plays et sessions en cours ou en file d'attente sur les projets",
@@ -70,6 +164,9 @@
     "newWorkflow": "Nouveau workflow",
     "newAgent": "Nouvel agent",
     "loading": "Chargement…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "Aucun élément trouvé.",
       "allHint": "Créez votre premier agent ou workflow pour commencer.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -6,6 +6,7 @@
       "library": "लाइब्रेरी",
       "schedules": "शेड्यूल",
       "system": "सिस्टम",
+      "operator": "ऑपरेटर",
       "toggleTheme": "थीम बदलें",
       "switchToZh": "चीनी पर स्विच करें",
       "switchToEn": "अंग्रेज़ी पर स्विच करें",
@@ -40,6 +41,99 @@
       "newTab": "नए टैब में खुलता है"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "प्लेफ़ील्ड",
     "subtitle": "प्रोजेक्ट्स में चल रहे और क्यू किए गए सभी प्ले और सेशन",
@@ -70,6 +164,9 @@
     "newWorkflow": "नया वर्कफ़्लो",
     "newAgent": "नया एजेंट",
     "loading": "लोड हो रहा है…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "कोई आइटम नहीं मिला।",
       "allHint": "शुरू करने के लिए अपना पहला एजेंट या वर्कफ़्लो बनाएँ।",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -6,6 +6,7 @@
       "library": "Pustaka",
       "schedules": "Penjadwalan",
       "system": "Sistem",
+      "operator": "Operator",
       "toggleTheme": "Alihkan tema",
       "switchToZh": "Beralih ke bahasa Mandarin",
       "switchToEn": "Beralih ke bahasa Inggris",
@@ -40,6 +41,99 @@
       "newTab": "membuka di tab baru"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Playfield",
     "subtitle": "Semua play dan sesi yang berjalan atau diantrekan di semua proyek",
@@ -70,6 +164,9 @@
     "newWorkflow": "Alur kerja baru",
     "newAgent": "Agen baru",
     "loading": "Memuat…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "Tidak ada item ditemukan.",
       "allHint": "Buat agen atau alur kerja pertama Anda untuk memulai.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -6,6 +6,7 @@
       "library": "ライブラリ",
       "schedules": "スケジュール",
       "system": "システム",
+      "operator": "オペレーター",
       "toggleTheme": "テーマを切り替え",
       "switchToZh": "中国語に切り替え",
       "switchToEn": "英語に切り替え",
@@ -40,6 +41,99 @@
       "newTab": "新しいタブで開きます"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "プレイフィールド",
     "subtitle": "プロジェクト横断の実行中およびキュー中のプレイとセッション",
@@ -70,6 +164,9 @@
     "newWorkflow": "新規ワークフロー",
     "newAgent": "新規エージェント",
     "loading": "読み込み中…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "項目が見つかりません。",
       "allHint": "最初のエージェントまたはワークフローを作成して開始しましょう。",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -6,6 +6,7 @@
       "library": "라이브러리",
       "schedules": "일정",
       "system": "시스템",
+      "operator": "오퍼레이터",
       "toggleTheme": "테마 전환",
       "switchToZh": "중국어로 전환",
       "switchToEn": "영어로 전환",
@@ -40,6 +41,99 @@
       "newTab": "새 탭에서 열림"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "플레이필드",
     "subtitle": "프로젝트 전체의 실행 중이거나 대기 중인 플레이와 세션",
@@ -70,6 +164,9 @@
     "newWorkflow": "새 워크플로",
     "newAgent": "새 에이전트",
     "loading": "로드 중…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "항목을 찾을 수 없습니다.",
       "allHint": "첫 에이전트 또는 워크플로를 만들어 시작하세요.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -6,6 +6,7 @@
       "library": "Biblioteca",
       "schedules": "Agendamentos",
       "system": "Sistema",
+      "operator": "Operador",
       "toggleTheme": "Alternar tema",
       "switchToZh": "Mudar para chinês",
       "switchToEn": "Mudar para inglês",
@@ -40,6 +41,99 @@
       "newTab": "abre em nova aba"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Playfield",
     "subtitle": "Todos os plays e sessões em execução ou na fila em todos os projetos",
@@ -70,6 +164,9 @@
     "newWorkflow": "Novo fluxo de trabalho",
     "newAgent": "Novo agente",
     "loading": "Carregando…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "Nenhum item encontrado.",
       "allHint": "Crie seu primeiro agente ou fluxo de trabalho para começar.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -6,6 +6,7 @@
       "library": "Библиотека",
       "schedules": "Расписания",
       "system": "Система",
+      "operator": "Оператор",
       "toggleTheme": "Сменить тему",
       "switchToZh": "Переключить на китайский",
       "switchToEn": "Переключить на английский",
@@ -40,6 +41,99 @@
       "newTab": "открывается в новой вкладке"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Поле выполнения",
     "subtitle": "Все запущенные и ожидающие Play и сессии по проектам",
@@ -70,6 +164,9 @@
     "newWorkflow": "Новый рабочий процесс",
     "newAgent": "Новый агент",
     "loading": "Загрузка…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "Элементы не найдены.",
       "allHint": "Создайте первого агента или рабочий процесс, чтобы начать.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -6,6 +6,7 @@
       "library": "kitaplık",
       "schedules": "zamanlamalar",
       "system": "sistem",
+      "operator": "Operatör",
       "toggleTheme": "temayı değiştir",
       "switchToZh": "Çinceye geç",
       "switchToEn": "İngilizceye geç",
@@ -40,6 +41,99 @@
       "newTab": "yeni sekmede açılır"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Playfield",
     "subtitle": "projeler genelindeki çalışan ve kuyruğa alınmış Play ve oturumlar",
@@ -70,6 +164,9 @@
     "newWorkflow": "yeni iş akışı",
     "newAgent": "yeni ajan",
     "loading": "yükleniyor…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "öğe bulunamadı.",
       "allHint": "başlamak için ilk ajanını veya iş akışını oluştur.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -6,6 +6,7 @@
       "library": "لائبریری",
       "schedules": "شیڈولز",
       "system": "سسٹم",
+      "operator": "آپریٹر",
       "toggleTheme": "تھیم بدلیں",
       "switchToZh": "چینی پر سوئچ کریں",
       "switchToEn": "انگریزی پر سوئچ کریں",
@@ -40,6 +41,99 @@
       "newTab": "نئے ٹیب میں کھلتا ہے"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Playfield",
     "subtitle": "تمام پروجیکٹس کے چل رہے اور کیو شدہ Plays اور سیشنز",
@@ -70,6 +164,9 @@
     "newWorkflow": "نیا ورک فلو",
     "newAgent": "نیا ایجنٹ",
     "loading": "لوڈ ہو رہا ہے…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "کوئی آئٹم نہیں ملا۔",
       "allHint": "شروع کرنے کے لیے اپنا پہلا ایجنٹ یا ورک فلو بنائیں۔",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -6,6 +6,7 @@
       "library": "thư viện",
       "schedules": "lịch chạy",
       "system": "hệ thống",
+      "operator": "Điều hành",
       "toggleTheme": "đổi giao diện",
       "switchToZh": "chuyển sang tiếng Trung",
       "switchToEn": "chuyển sang tiếng Anh",
@@ -40,6 +41,99 @@
       "newTab": "mở trong thẻ mới"
     }
   },
+  "runResume": {
+    "title": "Continue this run",
+    "description": "Send a follow-up into the saved branch, even after the original run finished.",
+    "branch": "Branch",
+    "chooseBranch": "Choose a branch",
+    "instruction": "Follow-up instruction",
+    "placeholder": "What should this branch do next?",
+    "instructionRequired": "Enter a follow-up instruction.",
+    "noBranches": "This run has no resumable branch.",
+    "failed": "Could not resume this run.",
+    "copyFailed": "Could not copy the command.",
+    "accepted": "Follow-up accepted",
+    "viewActivity": "View activity",
+    "submitting": "Resuming…",
+    "submit": "Resume",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI escape hatch",
+      "copy": "Copy",
+      "copied": "Copied",
+      "help": "Use this command in a terminal if browser resume is unavailable."
+    }
+  },
+  "operator": {
+    "title": "Operator",
+    "command": "Toggle Operator",
+    "ariaLabel": "Operator conversation",
+    "close": "Close Operator",
+    "resize": "Resize Operator",
+    "loading": "Loading conversation",
+    "stop": "Stop",
+    "stopping": "Stopping…",
+    "retry": "Retry",
+    "newConversation": "Start a new conversation",
+    "jumpToLatest": "Jump to latest",
+    "loadOlder": "Load earlier activity",
+    "connection": {
+      "idle": "Ready",
+      "connecting": "Connecting",
+      "open": "Live",
+      "reconnecting": "Reconnecting",
+      "error": "Connection error"
+    },
+    "empty": {
+      "title": "What should we do?",
+      "body": "Ask Operator to investigate, explain, launch work, or prepare a change. Work it starts remains visible across Studio.",
+      "example": "Try: “Show me what needs attention.”"
+    },
+    "error": { "title": "Conversation unavailable" },
+    "errors": {
+      "load": "Could not load this conversation.",
+      "send": "Could not send this instruction.",
+      "stop": "Could not stop the current turn.",
+      "decision": "Could not record that decision.",
+      "effect": "Could not acknowledge this interface action."
+    },
+    "composer": {
+      "label": "Instruction",
+      "placeholder": "Ask Operator to investigate or run something…",
+      "busyPlaceholder": "Operator is working…",
+      "hint": "Enter to send · Shift+Enter for a new line",
+      "send": "Send",
+      "sending": "Sending…"
+    },
+    "message": { "you": "You", "operator": "Operator" },
+    "tool": { "read": "read", "draft": "draft", "done": "Tool completed", "failed": "Tool failed" },
+    "proposal": {
+      "ariaLabel": "Action requiring permission",
+      "title": "Permission required",
+      "noTarget": "No versioned target",
+      "review": "Review exact command",
+      "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
+      "allow": "Allow",
+      "deny": "Deny",
+      "deciding": "Saving…",
+      "resolved": "Decision recorded"
+    },
+    "confirmation": {
+      "required": "Waiting for your decision",
+      "confirmed": "Permission granted",
+      "denied": "Permission denied",
+      "cancelled": "Action cancelled",
+      "expired": "Permission expired",
+      "executed": "Approved action completed"
+    },
+    "effect": { "requested": "Requested interface action: {kind}" },
+    "outcome": {
+      "completed": "Turn completed",
+      "failed": "Turn failed",
+      "cancelled": "Turn stopped"
+    },
+    "run": { "open": "Open run" }
+  },
   "playfield": {
     "title": "Playfield",
     "subtitle": "tất cả play và phiên đang chạy hoặc đang trong hàng đợi của các dự án",
@@ -70,6 +164,9 @@
     "newWorkflow": "quy trình làm việc mới",
     "newAgent": "tác nhân mới",
     "loading": "đang tải…",
+    "loadError": "Some catalog sources are unavailable.",
+    "detailEmptyTitle": "Choose something to inspect",
+    "detailEmptyBody": "Select an item from the catalog to see its configuration and activity.",
     "empty": {
       "all": "không tìm thấy mục nào.",
       "allHint": "tạo tác nhân hoặc quy trình làm việc đầu tiên để bắt đầu.",
@@ -822,9 +919,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -112,6 +112,8 @@
       "title": "Permission required",
       "noTarget": "No versioned target",
       "review": "Review exact command",
+      "elided": "Part of this command is hidden. Allow approves all of it.",
+      "elidedCharacters": "{count} characters are hidden. Allow approves all of it.",
       "risk": { "mutate": "change", "execute": "execute", "admin": "admin" },
       "allow": "Allow",
       "deny": "Deny",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -122,6 +122,8 @@
       "title": "需要你的许可",
       "noTarget": "无版本化目标",
       "review": "查看确切命令",
+      "elided": "此命令的部分内容未显示。允许即批准完整命令。",
+      "elidedCharacters": "有 {count} 个字符未显示。允许即批准完整命令。",
       "risk": {
         "mutate": "更改",
         "execute": "执行",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -6,6 +6,7 @@
       "library": "资源库",
       "schedules": "计划任务",
       "system": "系统",
+      "operator": "操作台",
       "toggleTheme": "切换主题",
       "switchToZh": "切换到中文",
       "switchToEn": "切换到英文",
@@ -40,6 +41,117 @@
       "homeAria": "首页标签页"
     }
   },
+  "runResume": {
+    "title": "继续此运行",
+    "description": "向已保存的分支发送后续指令，即使原运行已经结束也可以继续。",
+    "branch": "分支",
+    "chooseBranch": "选择分支",
+    "instruction": "后续指令",
+    "placeholder": "这个分支接下来应该做什么？",
+    "instructionRequired": "请输入后续指令。",
+    "noBranches": "此运行没有可恢复的分支。",
+    "failed": "无法恢复此运行。",
+    "copyFailed": "无法复制命令。",
+    "accepted": "已接受后续任务",
+    "viewActivity": "查看活动",
+    "submitting": "正在恢复…",
+    "submit": "继续运行",
+    "shortcut": "⌘/Ctrl+Enter",
+    "cli": {
+      "title": "CLI 备用方式",
+      "copy": "复制",
+      "copied": "已复制",
+      "help": "如果浏览器无法恢复，请在终端中使用此命令。"
+    }
+  },
+  "operator": {
+    "title": "操作台",
+    "command": "打开或关闭操作台",
+    "ariaLabel": "操作台对话",
+    "close": "关闭操作台",
+    "resize": "调整操作台宽度",
+    "loading": "正在加载对话",
+    "stop": "停止",
+    "stopping": "正在停止…",
+    "retry": "重试",
+    "newConversation": "开始新对话",
+    "jumpToLatest": "跳到最新消息",
+    "loadOlder": "加载更早的活动",
+    "connection": {
+      "idle": "就绪",
+      "connecting": "正在连接",
+      "open": "实时",
+      "reconnecting": "正在重新连接",
+      "error": "连接错误"
+    },
+    "empty": {
+      "title": "接下来要做什么？",
+      "body": "让操作台调查、解释、启动工作或准备变更。它启动的工作会在 Studio 各处保持可见。",
+      "example": "试试：“告诉我哪些事项需要处理。”"
+    },
+    "error": {
+      "title": "对话暂时不可用"
+    },
+    "errors": {
+      "load": "无法加载此对话。",
+      "send": "无法发送此指令。",
+      "stop": "无法停止当前回合。",
+      "decision": "无法保存该决定。",
+      "effect": "无法确认此界面操作。"
+    },
+    "composer": {
+      "label": "指令",
+      "placeholder": "让操作台调查或运行任务…",
+      "busyPlaceholder": "操作台正在工作…",
+      "hint": "按 Enter 发送 · Shift+Enter 换行",
+      "send": "发送",
+      "sending": "正在发送…"
+    },
+    "message": {
+      "you": "你",
+      "operator": "操作台"
+    },
+    "tool": {
+      "read": "读取",
+      "draft": "草拟",
+      "done": "工具已完成",
+      "failed": "工具失败"
+    },
+    "proposal": {
+      "ariaLabel": "需要权限的操作",
+      "title": "需要你的许可",
+      "noTarget": "无版本化目标",
+      "review": "查看确切命令",
+      "risk": {
+        "mutate": "更改",
+        "execute": "执行",
+        "admin": "管理"
+      },
+      "allow": "允许",
+      "deny": "拒绝",
+      "deciding": "正在保存…",
+      "resolved": "决定已记录"
+    },
+    "confirmation": {
+      "required": "等待你的决定",
+      "confirmed": "已授予权限",
+      "denied": "已拒绝权限",
+      "cancelled": "操作已取消",
+      "expired": "权限请求已过期",
+      "executed": "已完成获批操作"
+    },
+    "effect": {
+      "requested": "请求界面操作：{kind}"
+    },
+    "outcome": {
+      "completed": "回合已完成",
+      "failed": "回合失败",
+      "cancelled": "回合已停止"
+    },
+    "run": {
+      "open": "打开运行"
+    }
+  },
   "playfield": {
     "title": "运行场",
     "subtitle": "所有项目中正在运行及排队的执行与会话",
@@ -70,6 +182,9 @@
     "newWorkflow": "新建工作流",
     "newAgent": "新建智能体",
     "loading": "加载中…",
+    "loadError": "部分资源目录暂时不可用。",
+    "detailEmptyTitle": "选择要查看的内容",
+    "detailEmptyBody": "从目录中选择一项，查看其配置和活动。",
     "empty": {
       "all": "暂无内容。",
       "allHint": "创建你的第一个智能体或工作流，马上开始。",
@@ -822,9 +937,13 @@
       "title": "Studio needs a local lionagi daemon",
       "body": "Studio couldn't reach a daemon at {base}. Default port is 8765; your data stays on your machine.",
       "install": "pip install \"lionagi[studio]\"",
-      "run": "li studio",
-      "runAlt": "li studio --no-open",
-      "runAltNote": "Already have this page open?"
+      "run": "li studio"
+    },
+    "pairing": {
+      "title": "Open Studio from the daemon",
+      "body": "A lionagi daemon answered at {base}, but this tab is not paired with it.",
+      "fix": "Run this command. Studio opens a new, authenticated tab:",
+      "command": "li studio"
     },
     "wrongApp": {
       "title": "Another program is using this port",

--- a/apps/studio/frontend/src/routeTree.gen.ts
+++ b/apps/studio/frontend/src/routeTree.gen.ts
@@ -10,8 +10,16 @@
 
 import { Route as rootRouteImport } from "./routes/__root";
 import { Route as SystemRouteImport } from "./routes/system";
+import { Route as ShowsRouteImport } from "./routes/shows";
+import { Route as RoutingRouteImport } from "./routes/routing";
+import { Route as OutcomesRouteImport } from "./routes/outcomes";
+import { Route as MissionRouteImport } from "./routes/mission";
 import { Route as LibraryRouteImport } from "./routes/library";
+import { Route as HistoryRouteImport } from "./routes/history";
 import { Route as FleetRouteImport } from "./routes/fleet";
+import { Route as DesignerRouteImport } from "./routes/designer";
+import { Route as CanvasRouteImport } from "./routes/canvas";
+import { Route as AgentsRouteImport } from "./routes/agents";
 import { Route as IndexRouteImport } from "./routes/index";
 import { Route as SkillsIndexRouteImport } from "./routes/skills/index";
 import { Route as SchedulesIndexRouteImport } from "./routes/schedules/index";
@@ -36,14 +44,54 @@ const SystemRoute = SystemRouteImport.update({
   path: "/system",
   getParentRoute: () => rootRouteImport,
 } as any);
+const ShowsRoute = ShowsRouteImport.update({
+  id: "/shows",
+  path: "/shows",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const RoutingRoute = RoutingRouteImport.update({
+  id: "/routing",
+  path: "/routing",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const OutcomesRoute = OutcomesRouteImport.update({
+  id: "/outcomes",
+  path: "/outcomes",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const MissionRoute = MissionRouteImport.update({
+  id: "/mission",
+  path: "/mission",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const LibraryRoute = LibraryRouteImport.update({
   id: "/library",
   path: "/library",
   getParentRoute: () => rootRouteImport,
 } as any);
+const HistoryRoute = HistoryRouteImport.update({
+  id: "/history",
+  path: "/history",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const FleetRoute = FleetRouteImport.update({
   id: "/fleet",
   path: "/fleet",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const DesignerRoute = DesignerRouteImport.update({
+  id: "/designer",
+  path: "/designer",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const CanvasRoute = CanvasRouteImport.update({
+  id: "/canvas",
+  path: "/canvas",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const AgentsRoute = AgentsRouteImport.update({
+  id: "/agents",
+  path: "/agents",
   getParentRoute: () => rootRouteImport,
 } as any);
 const IndexRoute = IndexRouteImport.update({
@@ -139,8 +187,16 @@ const PlaybooksNameEditIndexRoute = PlaybooksNameEditIndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute;
+  "/agents": typeof AgentsRoute;
+  "/canvas": typeof CanvasRoute;
+  "/designer": typeof DesignerRoute;
   "/fleet": typeof FleetRoute;
+  "/history": typeof HistoryRoute;
   "/library": typeof LibraryRoute;
+  "/mission": typeof MissionRoute;
+  "/outcomes": typeof OutcomesRoute;
+  "/routing": typeof RoutingRoute;
+  "/shows": typeof ShowsRoute;
   "/system": typeof SystemRoute;
   "/invocations/$id": typeof InvocationsIdRoute;
   "/runs/$id": typeof RunsIdRoute;
@@ -162,8 +218,16 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
+  "/agents": typeof AgentsRoute;
+  "/canvas": typeof CanvasRoute;
+  "/designer": typeof DesignerRoute;
   "/fleet": typeof FleetRoute;
+  "/history": typeof HistoryRoute;
   "/library": typeof LibraryRoute;
+  "/mission": typeof MissionRoute;
+  "/outcomes": typeof OutcomesRoute;
+  "/routing": typeof RoutingRoute;
+  "/shows": typeof ShowsRoute;
   "/system": typeof SystemRoute;
   "/invocations/$id": typeof InvocationsIdRoute;
   "/runs/$id": typeof RunsIdRoute;
@@ -186,8 +250,16 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/": typeof IndexRoute;
+  "/agents": typeof AgentsRoute;
+  "/canvas": typeof CanvasRoute;
+  "/designer": typeof DesignerRoute;
   "/fleet": typeof FleetRoute;
+  "/history": typeof HistoryRoute;
   "/library": typeof LibraryRoute;
+  "/mission": typeof MissionRoute;
+  "/outcomes": typeof OutcomesRoute;
+  "/routing": typeof RoutingRoute;
+  "/shows": typeof ShowsRoute;
   "/system": typeof SystemRoute;
   "/invocations/$id": typeof InvocationsIdRoute;
   "/runs/$id": typeof RunsIdRoute;
@@ -211,8 +283,16 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
     | "/"
+    | "/agents"
+    | "/canvas"
+    | "/designer"
     | "/fleet"
+    | "/history"
     | "/library"
+    | "/mission"
+    | "/outcomes"
+    | "/routing"
+    | "/shows"
     | "/system"
     | "/invocations/$id"
     | "/runs/$id"
@@ -234,8 +314,16 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/"
+    | "/agents"
+    | "/canvas"
+    | "/designer"
     | "/fleet"
+    | "/history"
     | "/library"
+    | "/mission"
+    | "/outcomes"
+    | "/routing"
+    | "/shows"
     | "/system"
     | "/invocations/$id"
     | "/runs/$id"
@@ -257,8 +345,16 @@ export interface FileRouteTypes {
   id:
     | "__root__"
     | "/"
+    | "/agents"
+    | "/canvas"
+    | "/designer"
     | "/fleet"
+    | "/history"
     | "/library"
+    | "/mission"
+    | "/outcomes"
+    | "/routing"
+    | "/shows"
     | "/system"
     | "/invocations/$id"
     | "/runs/$id"
@@ -281,8 +377,16 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
+  AgentsRoute: typeof AgentsRoute;
+  CanvasRoute: typeof CanvasRoute;
+  DesignerRoute: typeof DesignerRoute;
   FleetRoute: typeof FleetRoute;
+  HistoryRoute: typeof HistoryRoute;
   LibraryRoute: typeof LibraryRoute;
+  MissionRoute: typeof MissionRoute;
+  OutcomesRoute: typeof OutcomesRoute;
+  RoutingRoute: typeof RoutingRoute;
+  ShowsRoute: typeof ShowsRoute;
   SystemRoute: typeof SystemRoute;
   InvocationsIdRoute: typeof InvocationsIdRoute;
   RunsIdRoute: typeof RunsIdRoute;
@@ -312,6 +416,34 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof SystemRouteImport;
       parentRoute: typeof rootRouteImport;
     };
+    "/shows": {
+      id: "/shows";
+      path: "/shows";
+      fullPath: "/shows";
+      preLoaderRoute: typeof ShowsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/routing": {
+      id: "/routing";
+      path: "/routing";
+      fullPath: "/routing";
+      preLoaderRoute: typeof RoutingRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/outcomes": {
+      id: "/outcomes";
+      path: "/outcomes";
+      fullPath: "/outcomes";
+      preLoaderRoute: typeof OutcomesRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/mission": {
+      id: "/mission";
+      path: "/mission";
+      fullPath: "/mission";
+      preLoaderRoute: typeof MissionRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     "/library": {
       id: "/library";
       path: "/library";
@@ -319,11 +451,39 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof LibraryRouteImport;
       parentRoute: typeof rootRouteImport;
     };
+    "/history": {
+      id: "/history";
+      path: "/history";
+      fullPath: "/history";
+      preLoaderRoute: typeof HistoryRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     "/fleet": {
       id: "/fleet";
       path: "/fleet";
       fullPath: "/fleet";
       preLoaderRoute: typeof FleetRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/designer": {
+      id: "/designer";
+      path: "/designer";
+      fullPath: "/designer";
+      preLoaderRoute: typeof DesignerRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/canvas": {
+      id: "/canvas";
+      path: "/canvas";
+      fullPath: "/canvas";
+      preLoaderRoute: typeof CanvasRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/agents": {
+      id: "/agents";
+      path: "/agents";
+      fullPath: "/agents";
+      preLoaderRoute: typeof AgentsRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/": {
@@ -457,8 +617,16 @@ declare module "@tanstack/react-router" {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AgentsRoute: AgentsRoute,
+  CanvasRoute: CanvasRoute,
+  DesignerRoute: DesignerRoute,
   FleetRoute: FleetRoute,
+  HistoryRoute: HistoryRoute,
   LibraryRoute: LibraryRoute,
+  MissionRoute: MissionRoute,
+  OutcomesRoute: OutcomesRoute,
+  RoutingRoute: RoutingRoute,
+  ShowsRoute: ShowsRoute,
   SystemRoute: SystemRoute,
   InvocationsIdRoute: InvocationsIdRoute,
   RunsIdRoute: RunsIdRoute,

--- a/apps/studio/frontend/src/routes/agents.tsx
+++ b/apps/studio/frontend/src/routes/agents.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { preserveRetiredSearch, retiredRedirect } from "@/lib/retiredRoutes";
+
+export const Route = createFileRoute("/agents")({
+  validateSearch: preserveRetiredSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect(retiredRedirect("/library", search, { tab: "agent" }));
+  },
+  component: () => null,
+});

--- a/apps/studio/frontend/src/routes/canvas.tsx
+++ b/apps/studio/frontend/src/routes/canvas.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { preserveRetiredSearch, retiredRedirect } from "@/lib/retiredRoutes";
+
+export const Route = createFileRoute("/canvas")({
+  validateSearch: preserveRetiredSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect(retiredRedirect("/library", search, { tab: "workflow" }));
+  },
+  component: () => null,
+});

--- a/apps/studio/frontend/src/routes/designer.tsx
+++ b/apps/studio/frontend/src/routes/designer.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { preserveRetiredSearch, retiredRedirect } from "@/lib/retiredRoutes";
+
+export const Route = createFileRoute("/designer")({
+  validateSearch: preserveRetiredSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect(retiredRedirect("/library", search, { tab: "workflow" }));
+  },
+  component: () => null,
+});

--- a/apps/studio/frontend/src/routes/fleet.tsx
+++ b/apps/studio/frontend/src/routes/fleet.tsx
@@ -49,7 +49,21 @@ function FleetPage() {
           ]}
         />
       </div>
-      <Suspense fallback={null}>
+      <Suspense
+        fallback={
+          <div className="flex min-h-0 flex-1">
+            <div className="w-[25rem] shrink-0 space-y-2 border-e border-edge p-4">
+              <div className="skeleton h-6 w-28 rounded" />
+              {Array.from({ length: 7 }, (_, index) => (
+                <div key={index} className="skeleton h-10 rounded" />
+              ))}
+            </div>
+            <div className="hidden min-w-0 flex-1 place-items-center p-8 sm:grid">
+              <div className="skeleton h-44 w-full max-w-xl rounded-lg" />
+            </div>
+          </div>
+        }
+      >
         <FleetView />
       </Suspense>
     </div>

--- a/apps/studio/frontend/src/routes/history.tsx
+++ b/apps/studio/frontend/src/routes/history.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { preserveRetiredSearch, retiredRedirect } from "@/lib/retiredRoutes";
+
+export const Route = createFileRoute("/history")({
+  validateSearch: preserveRetiredSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect(retiredRedirect("/fleet", search));
+  },
+  component: () => null,
+});

--- a/apps/studio/frontend/src/routes/library.tsx
+++ b/apps/studio/frontend/src/routes/library.tsx
@@ -83,6 +83,15 @@ function useLibraryData() {
         if (!alive) return;
 
         const out: LibraryItem[] = [];
+        const results = [
+          agentsRes,
+          builtinsRes,
+          playbooksRes,
+          workflowsRes,
+          skillsRes,
+          pluginsRes,
+          enginesRes,
+        ];
 
         if (agentsRes.status === "fulfilled") {
           setAllAgents(agentsRes.value.agents);
@@ -176,6 +185,9 @@ function useLibraryData() {
         }
 
         setItems(out);
+        if (results.some((result) => result.status === "rejected")) {
+          setError("degraded");
+        }
         setLoading(false);
       },
     );
@@ -257,6 +269,7 @@ function encodeSel(kind: LibraryKind, name: string, subKind?: PlaybookSubKind): 
 
 function LibraryPage() {
   const t = useTranslations("library");
+  const tDaemon = useTranslations("daemon");
   const { items, loading, error, reload, allAgents, allEngines } = useLibraryData();
   const navigate = useNavigate({ from: "/library" });
   const { tab, sel } = Route.useSearch();
@@ -406,8 +419,14 @@ function LibraryPage() {
 
       {/* Error banner */}
       {error && (
-        <div className="shrink-0 border-b border-edge px-3 py-1.5 text-[length:var(--t-xs)] text-status-failure">
-          {error}
+        <div
+          role="alert"
+          className="flex shrink-0 items-center justify-between gap-3 border-b border-edge bg-status-error-bg px-3 py-2 text-body text-content-secondary"
+        >
+          <span>{t("loadError")}</span>
+          <Button size="sm" variant="secondary" onClick={reload}>
+            {tDaemon("retry")}
+          </Button>
         </div>
       )}
 
@@ -445,7 +464,7 @@ function LibraryPage() {
                 className="text-[length:var(--t-xs)] uppercase tracking-[0.08em] text-content-muted border-b border-edge bg-surface-raised"
                 style={{ position: "sticky", top: 0, zIndex: 1 }}
               >
-                <th className="w-8 px-3 py-2 font-medium" aria-label="Kind" />
+                <th className="w-8 px-3 py-2 font-medium" aria-label={t("drawer.kind")} />
                 <th className="px-2 py-2 font-medium">{t("table.name")}</th>
               </tr>
             </thead>
@@ -457,8 +476,15 @@ function LibraryPage() {
                   <tr
                     key={item.key}
                     onClick={() => selectItem(item)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        selectItem(item);
+                      }
+                    }}
+                    tabIndex={0}
                     aria-selected={isSelected}
-                    className="cursor-pointer border-b border-edge"
+                    className="cursor-pointer border-b border-edge focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent"
                     style={{
                       background: isSelected ? "var(--surface-overlay)" : "transparent",
                     }}
@@ -479,9 +505,17 @@ function LibraryPage() {
                       <div className="font-data text-[length:var(--t-base)] font-medium leading-snug text-content-primary">
                         {item.name}
                       </div>
-                      {item.meta && (
-                        <div className="font-data text-[length:var(--t-xs)] leading-snug text-content-muted">
-                          {item.meta}
+                      {(item.description || item.meta) && (
+                        <div
+                          className="overflow-hidden font-data text-[length:var(--t-xs)] leading-snug text-content-muted"
+                          title={item.description ?? item.meta}
+                          style={{
+                            display: "-webkit-box",
+                            WebkitBoxOrient: "vertical",
+                            WebkitLineClamp: 2,
+                          }}
+                        >
+                          {item.description ?? item.meta}
                         </div>
                       )}
                     </td>
@@ -558,9 +592,12 @@ function LibraryPage() {
     );
   } else {
     detailPane = (
-      <div className="flex h-full items-center justify-center text-[length:var(--t-sm)] text-content-muted">
-        {t("loading")}
-      </div>
+      <EmptyState
+        glyph="⌁"
+        title={t("detailEmptyTitle")}
+        body={t("detailEmptyBody")}
+        className="h-full px-8 py-16"
+      />
     );
   }
 

--- a/apps/studio/frontend/src/routes/mission.tsx
+++ b/apps/studio/frontend/src/routes/mission.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { preserveRetiredSearch, retiredRedirect } from "@/lib/retiredRoutes";
+
+export const Route = createFileRoute("/mission")({
+  validateSearch: preserveRetiredSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect(retiredRedirect("/", search));
+  },
+  component: () => null,
+});

--- a/apps/studio/frontend/src/routes/outcomes.tsx
+++ b/apps/studio/frontend/src/routes/outcomes.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { preserveRetiredSearch, retiredRedirect } from "@/lib/retiredRoutes";
+
+export const Route = createFileRoute("/outcomes")({
+  validateSearch: preserveRetiredSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect(retiredRedirect("/fleet", search));
+  },
+  component: () => null,
+});

--- a/apps/studio/frontend/src/routes/routing.tsx
+++ b/apps/studio/frontend/src/routes/routing.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { preserveRetiredSearch, retiredRedirect } from "@/lib/retiredRoutes";
+
+export const Route = createFileRoute("/routing")({
+  validateSearch: preserveRetiredSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect(retiredRedirect("/library", search, { tab: "workflow" }));
+  },
+  component: () => null,
+});

--- a/apps/studio/frontend/src/routes/schedules/index.tsx
+++ b/apps/studio/frontend/src/routes/schedules/index.tsx
@@ -55,7 +55,7 @@ function ViewToggle({ view, onChange }: { view: View; onChange: (v: View) => voi
       onClick={() => onChange(v)}
       aria-pressed={view === v}
       className={[
-        "h-7 rounded px-3 text-[length:var(--t-xs)] font-medium transition-colors duration-100",
+        "h-7 shrink-0 rounded px-2 text-[length:var(--t-xs)] font-medium transition-colors duration-100 sm:px-3",
         view === v
           ? "bg-surface-overlay text-content-primary"
           : "text-content-muted hover:text-content-primary",
@@ -65,7 +65,7 @@ function ViewToggle({ view, onChange }: { view: View; onChange: (v: View) => voi
     </button>
   );
   return (
-    <div className="flex items-center gap-0.5 rounded-md border border-edge p-0.5">
+    <div className="flex max-w-full items-center gap-0.5 overflow-x-auto rounded-md border border-edge p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       {seg("cards", t("viewCards"))}
       {seg("table", t("viewTable"))}
       {seg("calendar", t("calendar"))}
@@ -93,7 +93,7 @@ function EmptyState({ onNew }: { onNew: () => void }) {
 
 function TableSkeleton() {
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2 px-6 pb-6">
+    <div className="flex min-h-0 flex-1 flex-col gap-2 px-4 pb-6 sm:px-6">
       {Array.from({ length: 6 }, (_, i) => (
         <div key={i} className="skeleton h-10 rounded-md" />
       ))}
@@ -103,6 +103,7 @@ function TableSkeleton() {
 
 function SchedulesSpace() {
   const t = useTranslations("schedules");
+  const tDaemon = useTranslations("daemon");
   const { schedules, runs, nowMs, loading, error, refresh } = useSchedulesData();
   const [view, setView] = useState<View>("cards");
   const [showModal, setShowModal] = useState(false);
@@ -151,22 +152,33 @@ function SchedulesSpace() {
 
   return (
     <main className="flex h-full w-full flex-col animate-page-enter">
-      <header className="flex shrink-0 items-end justify-between gap-4 px-6 pb-4 pt-5">
+      <header className="flex shrink-0 flex-col items-stretch gap-3 px-4 pb-4 pt-5 sm:flex-row sm:items-end sm:justify-between sm:gap-4 sm:px-6">
         <div className="flex flex-col gap-0.5">
-          <h1 className="text-heading font-semibold text-content-primary">{t("title")}</h1>
+          <h1 className="text-page-title font-semibold text-content-primary">{t("title")}</h1>
           <p className="text-body text-content-muted">{t("subtitle")}</p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex max-w-full flex-wrap items-center gap-2 sm:justify-end">
           <ViewToggle view={view} onChange={setView} />
-          <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+          <Button
+            variant="primary"
+            size="sm"
+            className="shrink-0"
+            onClick={() => setShowModal(true)}
+          >
             + {t("newSchedule")}
           </Button>
         </div>
       </header>
 
       {error && (
-        <div className="mx-6 mb-3 rounded border border-status-error/30 bg-status-error-bg px-3 py-2 text-body text-status-error">
-          {t("loadError")}
+        <div
+          role="alert"
+          className="mx-4 mb-3 flex flex-wrap items-center justify-between gap-3 rounded border border-status-error/30 bg-status-error-bg px-3 py-2 text-body text-content-secondary sm:mx-6"
+        >
+          <span>{t("loadError")}</span>
+          <Button variant="secondary" size="sm" onClick={refresh}>
+            {tDaemon("retry")}
+          </Button>
         </div>
       )}
 

--- a/apps/studio/frontend/src/routes/shows.tsx
+++ b/apps/studio/frontend/src/routes/shows.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { preserveRetiredSearch, retiredRedirect } from "@/lib/retiredRoutes";
+
+export const Route = createFileRoute("/shows")({
+  validateSearch: preserveRetiredSearch,
+  beforeLoad: ({ search }) => {
+    throw redirect(retiredRedirect("/fleet", search));
+  },
+  component: () => null,
+});

--- a/apps/studio/frontend/src/routes/system.tsx
+++ b/apps/studio/frontend/src/routes/system.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "use-intl";
 import Timestamp from "@/components/ui/Timestamp";
 import { API_BASE, getAdminDoctor, runMaintenance } from "@/lib/api";
 import type { AdminDoctorResponse, MaintenanceAction } from "@/lib/api";
 import { IconHealth, IconTool, IconSettings } from "@/components/ui/icons";
 import { LOCALES } from "@/i18n/locales";
+import { applyTheme, getTheme, THEME_CHANGE_EVENT } from "@/lib/theme";
 
 // Old tab values are accepted so deep links keep working; the page itself
 // renders every section in one column.
@@ -34,21 +35,6 @@ function formatBytes(value: number): string {
   return `${(value / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
 }
 
-function applyTheme(theme: "dark" | "light") {
-  document.documentElement.setAttribute("data-theme", theme);
-  if (theme === "dark") {
-    document.documentElement.classList.add("dark");
-  } else {
-    document.documentElement.classList.remove("dark");
-  }
-  localStorage.setItem("theme", theme);
-}
-
-function getTheme(): "dark" | "light" {
-  if (typeof document === "undefined") return "dark";
-  return (document.documentElement.getAttribute("data-theme") as "dark" | "light") ?? "dark";
-}
-
 // ─── Section header ───────────────────────────────────────────────────────────
 
 function SectionHead({
@@ -73,14 +59,19 @@ function SectionHead({
 
 // ─── Health section ───────────────────────────────────────────────────────────
 
-function HealthSection({ doctor }: { doctor: AdminDoctorResponse | null; loading: boolean }) {
+function HealthSection({ doctor }: { doctor: AdminDoctorResponse }) {
   const t = useTranslations("system");
-  if (!doctor) return null;
+  const tShell = useTranslations("shell");
   const h = doctor.db_health;
   const phantoms = doctor.phantom_sessions.length;
   return (
     <section className="flex flex-col gap-3">
-      <SectionHead icon={<IconHealth size={18} />} label={t("sections.health")} />
+      <SectionHead icon={<IconHealth size={18} />} label={t("sections.health")}>
+        <span className="inline-flex items-center gap-1.5 font-data text-meta text-status-success">
+          <span className="size-1.5 rounded-full bg-status-success" />
+          {tShell("footer.healthy")}
+        </span>
+      </SectionHead>
       <div className="flex flex-wrap gap-x-6 gap-y-1 text-body text-content-secondary">
         <span>
           <span className="font-mono text-content-primary">{formatBytes(h.size_bytes)}</span>{" "}
@@ -256,6 +247,16 @@ function SettingsSection() {
     return m ? m[1] : "en";
   });
 
+  useEffect(() => {
+    const syncTheme = () => setTheme(getTheme());
+    window.addEventListener(THEME_CHANGE_EVENT, syncTheme);
+    window.addEventListener("storage", syncTheme);
+    return () => {
+      window.removeEventListener(THEME_CHANGE_EVENT, syncTheme);
+      window.removeEventListener("storage", syncTheme);
+    };
+  }, []);
+
   function toggleTheme() {
     const next: "dark" | "light" = theme === "dark" ? "light" : "dark";
     setTheme(next);
@@ -333,29 +334,70 @@ function SettingsSection() {
 
 function SystemPage() {
   const t = useTranslations("system");
+  const tDaemon = useTranslations("daemon");
   const [doctor, setDoctor] = useState<AdminDoctorResponse | null>(null);
   const [healthLoading, setHealthLoading] = useState(true);
-  const fetchedRef = useRef(false);
+  const [healthError, setHealthError] = useState(false);
 
-  useEffect(() => {
-    if (fetchedRef.current) return;
-    fetchedRef.current = true;
-    getAdminDoctor()
-      .then(setDoctor)
-      .catch(() => setDoctor(null))
-      .finally(() => setHealthLoading(false));
+  const loadHealth = useCallback(async () => {
+    setHealthLoading(true);
+    setHealthError(false);
+    try {
+      setDoctor(await getAdminDoctor());
+    } catch {
+      setDoctor(null);
+      setHealthError(true);
+    } finally {
+      setHealthLoading(false);
+    }
   }, []);
 
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial async health request owns the loading/error lifecycle
+    void loadHealth();
+  }, [loadHealth]);
+
   return (
-    <main className="flex w-full flex-col gap-8 px-6 py-6 animate-page-enter">
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-6 animate-page-enter sm:px-6 lg:py-8">
       <header className="flex flex-col gap-0.5">
-        <h1 className="text-heading font-semibold text-content-primary">{t("title")}</h1>
+        <h1 className="text-page-title font-semibold text-content-primary">{t("title")}</h1>
         <p className="text-body text-content-muted">{t("subtitle")}</p>
       </header>
 
-      <div className="flex w-full max-w-3xl flex-col gap-8">
-        {!healthLoading && <HealthSection doctor={doctor} loading={healthLoading} />}
-        <MaintenanceSection doctor={doctor} />
+      <div className="grid w-full gap-8 lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)] lg:items-start">
+        <div className="flex min-w-0 flex-col gap-8">
+          {healthLoading ? (
+            <section className="flex flex-col gap-3" aria-busy="true">
+              <SectionHead icon={<IconHealth size={18} />} label={t("sections.health")} />
+              <div className="space-y-2">
+                <div className="h-4 w-2/3 animate-pulse rounded bg-surface-overlay" />
+                <div className="h-4 w-1/2 animate-pulse rounded bg-surface-overlay" />
+              </div>
+            </section>
+          ) : healthError || !doctor ? (
+            <section className="flex flex-col gap-3">
+              <SectionHead icon={<IconHealth size={18} />} label={t("sections.health")} />
+              <div
+                role="alert"
+                className="flex flex-wrap items-center justify-between gap-3 rounded border border-status-failure/30 bg-status-error-bg px-3 py-3"
+              >
+                <p className="text-body text-content-secondary">
+                  {t("maintenance.operationFailed")}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void loadHealth()}
+                  className="rounded border border-edge-strong bg-surface-raised px-3 py-1.5 text-meta font-medium text-content-primary transition-colors hover:bg-surface-overlay"
+                >
+                  {tDaemon("retry")}
+                </button>
+              </div>
+            </section>
+          ) : (
+            <HealthSection doctor={doctor} />
+          )}
+          <MaintenanceSection doctor={doctor} />
+        </div>
         <SettingsSection />
       </div>
     </main>

--- a/apps/studio/frontend/vite.config.mts
+++ b/apps/studio/frontend/vite.config.mts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vitest/config'
-import type { Plugin } from 'vite'
-import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
-import path from 'path'
+import { defineConfig } from "vitest/config";
+import type { Plugin } from "vite";
+import react from "@vitejs/plugin-react";
+import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
+import path from "path";
 
 // The hosted Studio (lion-studio.khive.ai and any Vercel preview) is a static,
 // local-first deploy: its origin has no API of its own, the page talks to the
@@ -15,22 +15,22 @@ import path from 'path'
 // (which run the same `vite build`) on their correct same-origin default.
 // Loopback http from an https page is exempt from mixed-content blocking.
 export function hostedApiBaseInjector(env: NodeJS.ProcessEnv = process.env): Plugin {
-  const onVercel = env.VERCEL === '1'
-  const base = env.STUDIO_HOSTED_API_BASE ?? 'http://127.0.0.1:8765'
+  const onVercel = env.VERCEL === "1";
+  const base = env.STUDIO_HOSTED_API_BASE ?? "http://127.0.0.1:8765";
   return {
-    name: 'studio-hosted-api-base',
-    apply: 'build',
+    name: "studio-hosted-api-base",
+    apply: "build",
     transformIndexHtml() {
-      if (!onVercel) return
+      if (!onVercel) return;
       return [
         {
-          tag: 'script',
+          tag: "script",
           children: `window.__STUDIO_API_BASE__=${JSON.stringify(base)};`,
-          injectTo: 'head-prepend',
+          injectTo: "head-prepend",
         },
-      ]
+      ];
     },
-  }
+  };
 }
 
 // The e2e harness points this at a seeded daemon on a dynamically-allocated
@@ -40,40 +40,68 @@ export function hostedApiBaseInjector(env: NodeJS.ProcessEnv = process.env): Plu
 // though preview itself (bound to --host 127.0.0.1) is healthy.
 // STUDIO_API_URL overrides the whole target (e.g. an isolated dev daemon).
 const apiTarget =
-  process.env.STUDIO_API_URL ?? `http://127.0.0.1:${process.env.STUDIO_E2E_API_PORT ?? '8765'}`
+  process.env.STUDIO_API_URL ?? `http://127.0.0.1:${process.env.STUDIO_E2E_API_PORT ?? "8765"}`;
+
+export const studioProxy = {
+  "/api": apiTarget,
+  "/health": apiTarget,
+  "/openapi.json": apiTarget,
+};
 
 export default defineConfig({
   plugins: [
     TanStackRouterVite({
-      routesDirectory: './src/routes',
-      generatedRouteTree: './src/routeTree.gen.ts',
+      routesDirectory: "./src/routes",
+      generatedRouteTree: "./src/routeTree.gen.ts",
+      autoCodeSplitting: true,
     }),
     react(),
     hostedApiBaseInjector(),
   ],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
   server: {
-    proxy: {
-      '/api': apiTarget,
-    },
+    proxy: studioProxy,
   },
   // `vite preview` serves the production build the same way the e2e harness
   // does: a single static origin proxying /api server-side, so the browser
   // never needs CORS and resolveApiBase() picks up the same-origin ("") path.
   preview: {
-    proxy: {
-      '/api': apiTarget,
+    proxy: studioProxy,
+  },
+  build: {
+    // Keep two large, independently stable payload families out of the shell.
+    // Broad node_modules chunking creates circular React/Zustand imports under
+    // Rolldown; these exact boundaries have one-way dependencies and preserve
+    // route-level splitting.
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: "locale",
+              test: /src[\\/]messages[\\/]/,
+              maxSize: 100_000,
+              priority: 2,
+            },
+            {
+              name: "markdown",
+              test: /node_modules[\\/]react-markdown[\\/]/,
+              priority: 1,
+            },
+          ],
+        },
+      },
     },
   },
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
     // e2e/ holds Playwright specs (see playwright.config.ts) -- a different
     // test runner with its own test()/expect(), never vitest's.
-    exclude: ['e2e/**', 'node_modules/**'],
+    exclude: ["e2e/**", "node_modules/**"],
   },
-})
+});

--- a/docs/guides/studio.md
+++ b/docs/guides/studio.md
@@ -1,7 +1,8 @@
-# Studio and Schedules
+# Studio, Operator, and schedules
 
-Lion Studio is an operational UI backed by a local daemon. Schedules use that
-same daemon, so it must be running when triggers are created or fired.
+Lion Studio is an operational UI backed by a local daemon. Operator
+conversations, Runs, and schedules use that daemon as their durable source, so
+keep it running while work is active.
 
 ## Install the Studio dependencies
 
@@ -16,6 +17,27 @@ Or with an activated `pip` environment:
 ```bash
 python -m pip install "lionagi[studio]"
 ```
+
+## Prepare Claude Code for Operator
+
+Operator uses the locally installed Claude Code CLI by default. The
+`lionagi[studio]` extra installs Studio, but it does not install Claude Code or
+authenticate a Claude account.
+
+Install and authenticate Claude Code before sending the first Operator
+instruction:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude --version
+claude auth login
+```
+
+Claude Code can also authenticate when you launch `claude` interactively. Its
+existing CLI login is used directly; no Anthropic API key is required in
+LionAGI for a subscription-backed login. See the
+[Claude Code setup guide](https://code.claude.com/docs/en/setup) for supported
+installation and enterprise authentication options.
 
 ## Start Studio
 
@@ -45,6 +67,155 @@ li doctor
 ```
 
 The `studio_daemon` check should now be healthy.
+
+## Work from the Operator dock
+
+Open Operator with the speech-bubble button at the top of Studio's left rail.
+You can also press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>J</kbd> or open the
+command palette and choose **Toggle Operator**.
+
+Type an instruction and press <kbd>Enter</kbd> to send it.
+<kbd>Shift</kbd>+<kbd>Enter</kbd> inserts a new line. Operator streams its
+reply and tool activity into the same conversation.
+
+### Durable history
+
+The daemon, not the browser transcript, owns the conversation history. The
+browser remembers which conversation is selected, then reloads its full
+history from the daemon. Closing and reopening the dock, navigating to another
+Studio surface, or reloading the page therefore keeps the conversation
+scrollable from where you left it.
+
+Closing the dock does not stop an active turn. Its **Live** or
+**Reconnecting** indicator reports the stream state, and missed activity replays
+after a reconnect.
+
+### Stop an active turn
+
+While Operator is working, **Stop** appears in the dock header. It requests
+cancellation of the current turn and ends that turn as stopped. History and
+completed tool results remain visible; Stop does not roll back work that
+already finished.
+
+If a permission decision is waiting, **Stop** cancels the whole turn. **Deny**
+only rejects the individual proposed operation.
+
+### Decide gated work
+
+When Operator requests a disk write, command, or other gated native operation,
+the conversation shows a **Permission required** card and Operator waits.
+
+- **Allow** grants that exact request and lets the turn continue.
+- **Deny** blocks that request. Operator receives the denial and may explain,
+  revise its plan, or finish without the operation.
+- Each later gated operation requires its own decision. An Allow is not a
+  blanket approval for the rest of the turn.
+
+Leaving the card unanswered leaves Operator waiting; it is not silently
+approved.
+
+### Follow work into Fleet and Runs
+
+Every Operator turn creates a normal Studio run. Use **Open run** in the
+conversation to inspect its status, messages, tool results, and activity in
+Fleet's Runs view.
+
+Run detail includes **Continue this run** for every live or terminal run that
+still has a persisted branch:
+
+1. Enter the follow-up instruction.
+2. If the run has more than one branch, select the branch to continue. A
+   one-branch run is selected automatically.
+3. Choose **Resume**. Studio reports **Follow-up accepted**, links the new
+   activity, and refreshes the run.
+
+Completed, failed, cancelled, and timed-out status do not prevent a resume.
+The underlying branch snapshot must still exist. If history retention has
+removed it, Studio leaves the instruction in place and reports that the run can
+no longer be resumed.
+
+For a run whose current leg is still active, Studio accepts one follow-up and
+queues it behind that leg. The queued worker waits for the source session's
+terminal transition, validates the final branch snapshot, and only then starts
+the resumed `li agent` process. Repeating the identical request returns the
+same accepted invocation; a different concurrent follow-up for that branch
+returns a conflict instead of starting parallel work.
+
+The always-visible **CLI escape hatch** shows and copies the equivalent command:
+
+```bash
+li agent -r '<branch-id>' --prompt '<follow-up instruction>'
+```
+
+For a multi-branch run, select a branch first. When no branch is available, the
+placeholder remains visible but copying is disabled.
+
+## Verify the real local Operator path
+
+Automated tests cannot establish that a local Claude Code installation is
+present and authenticated. Before relying on Operator on a new machine or
+shipping a release, exercise the real path in a disposable project:
+
+1. Run `claude --version`, then authenticate with `claude auth login` if
+   needed.
+2. Start Studio with `li studio` and open Operator.
+3. Send `Reply with exactly: operator-ready` and confirm text arrives
+   incrementally, the turn completes, and **Open run** reaches the matching
+   run.
+4. Reload Studio and confirm the conversation and completed turn return.
+5. Ask Operator to create a harmless temporary file. Choose **Deny** and
+   confirm the file was not created. Ask again, choose **Allow**, and confirm
+   the file was created; then remove it.
+6. Start a longer inspection, choose **Stop**, and confirm the conversation
+   reports **Turn stopped** and the linked run reaches a cancelled state.
+7. From that run, use **Continue this run** to send a follow-up and confirm the
+   new activity appears.
+
+This check uses the actual Claude Code executable, account, stream, permission
+gate, cancellation path, and durable run store.
+
+## Understand the browser approval credential
+
+Bare `li studio` and `li studio --dev` generate a launch-scoped bearer for both
+the local API boundary and human Operator decisions. The launcher places the
+daemon URL and bearer in the opened page's URL fragment. Before the app starts,
+the bootstrap script copies that pair into the current tab's `sessionStorage`
+and scrubs it from the address bar. Closing the tab ends that browser session;
+the credential is not written to persistent browser storage or printed by the
+CLI.
+
+`li studio --no-open` still protects the daemon but intentionally does not
+print the bearer. Restart without `--no-open` to open a credentialed Operator
+tab. `li studio --no-frontend` is API-only and cannot originate human
+approvals; the desktop app is the exception because it passes a generated
+credential to its child daemon through a private stdin pipe.
+
+Direct uvicorn startup with no configured token keeps ordinary local API
+routes open, but Operator submission and decisions fail closed because there
+is no trusted human credential.
+
+Environment tokens remain supported for ordinary API clients:
+
+```text
+Authorization: Bearer <LIONAGI_STUDIO_AUTH_TOKEN>
+```
+
+They are deliberately not accepted for Operator approvals. Process
+environments can remain observable after startup, so setting
+`LIONAGI_STUDIO_AUTH_TOKEN`, `LIONAGI_STUDIO_HUMAN_TOKEN`, or both disables
+Operator submission and decisions with a remediation message. Unset both and
+restart with bare `li studio` to use the generated browser credential.
+
+## Understand the CI stub boundary
+
+The automated Operator suite uses a deterministic provider stub. It verifies
+the conversation workflow, durable replay, streamed activity, Stop and
+permission interactions, and Runs linkage without contacting a paid provider.
+
+A green CI run does **not** prove that Claude Code is installed, that its local
+login is valid, or that a live Claude Code release can complete the native
+permission prompt. The real-local verification above is the release check for
+those provider-dependent behaviors.
 
 ## Create a schedule
 

--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -536,9 +536,12 @@ incrementing it; the set is empty by default and no profile name is hardcoded in
 `stamp_agent_depth(agent_name)` (called from `_run_agent`) and `stamp_worker_depth()` (called
 from `_run_fanout` and `_run_flow`, which also covers `li play`) both set
 `os.environ["LIONAGI_AGENT_DEPTH"]` before any engine spawn. `_cli_subprocess.py`'s
-`ndjson_from_cli` passes `env=None` to `create_subprocess_exec` for all three CLI-backed engines
-(`claude_code`, `codex`, `gemini_code`), so the child inherits this process's `os.environ`
-verbatim — the stamp propagates with zero endpoint changes. `inherited_depth()` is captured once
+`ndjson_from_cli` hands `create_subprocess_exec` a copy of this process's `os.environ` for all
+three CLI-backed engines (`claude_code`, `codex`, `gemini_code`), so the child receives the
+stamp — it propagates with zero endpoint changes. The copy is not verbatim in one respect:
+the keys in `_STUDIO_CREDENTIAL_ENV_KEYS` are dropped, so an engine subprocess cannot call
+back into Studio holding the credentials of whoever launched it. Everything else passes
+through, which is what the stamp relies on. `inherited_depth()` is captured once
 at import as a module constant rather than read live, so `_run_agent`'s in-process auto-resume
 recursion re-stamps to the same depth instead of double-incrementing.
 

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -927,11 +927,12 @@ async def teardown_persist(
             await db.close()
         except Exception as exc:
             _log.warning("live persist db.close failed: %s", exc, exc_info=True)
-        # Sweep the shared-db registry (our connection plus any stray a hook
-        # opened) so no non-daemon aiosqlite worker thread blocks process exit.
-        from lionagi.state.db import close_shared_db
+        if ctx.get("shared_db_registered", True):
+            # Ordinary CLI runs retain the historical sweep. Embedded daemon
+            # callers opt out so teardown cannot close unrelated shared state.
+            from lionagi.state.db import close_shared_db
 
-        await close_shared_db()
+            await close_shared_db()
 
 
 # Keep old names as aliases so callers don't break.
@@ -949,22 +950,24 @@ async def teardown_orchestration_persist(*args, **kwargs) -> str:
     return await teardown_persist(*args, **kwargs)
 
 
-async def _open_shared_db():
-    """Open a StateDB and register it as the process-wide shared connection."""
+async def _open_shared_db(*, register: bool = True):
+    """Open a StateDB, optionally registering it as the process-wide handle."""
     from lionagi.state.db import StateDB, register_shared_db, unregister_shared_db
 
     db = StateDB()
     try:
         await db.open()
-        # Lifecycle hooks reach a db via get_shared_db(); register ours so they reuse
-        # this connection rather than opening a second one whose worker thread leaks.
-        await register_shared_db(db)
+        if register:
+            # Ordinary CLI lifecycle hooks reuse this connection. Embedded
+            # callers bind their observer/message handlers directly instead.
+            await register_shared_db(db)
     except Exception:
         try:
             await db.close()
         except Exception as close_exc:
             _log.warning("fallback db.close after open failure also failed: %s", close_exc)
-        unregister_shared_db(db)
+        if register:
+            unregister_shared_db(db)
         raise
     return db
 
@@ -1143,6 +1146,8 @@ async def setup_agent_persist(
     provider: str | None = None,
     effort: str | None = None,
     project: str | None = None,
+    run_id: str | None = None,
+    share_db: bool = True,
 ) -> dict | None:
     from lionagi.session.session import Session
     from lionagi.state import provenance as _provenance
@@ -1156,7 +1161,7 @@ async def setup_agent_persist(
         session_id = str(session.id)
         branch_id = str(branch.id)
 
-        db = await _open_shared_db()
+        db = await _open_shared_db(register=share_db)
 
         existing_branch = await db.get_branch(branch_id)
         existing_session = None
@@ -1212,7 +1217,10 @@ async def setup_agent_persist(
             await db.create_session(
                 {
                     "id": session_id,
-                    "run_id": active_run_id(),
+                    # Embedded callers may own a RunDir without mutating the
+                    # CLI process-global allocation pointer. Ordinary CLI
+                    # callers omit this and retain the established behavior.
+                    "run_id": run_id if run_id is not None else active_run_id(),
                     "created_at": session_dict["created_at"],
                     "node_metadata": _node_meta,
                     "name": session_dict.get("name"),
@@ -1299,6 +1307,7 @@ async def setup_agent_persist(
             "message_retry_queues": message_retry_queues,
             "artifacts_path": artifacts_path,
             "artifact_contract": artifact_contract,
+            "shared_db_registered": share_db,
         }
 
         _on_message = _make_message_handler(
@@ -1338,8 +1347,9 @@ async def setup_agent_persist(
                 await db.close()
             except Exception as close_exc:
                 _log.warning("fallback db.close after setup failure also failed: %s", close_exc)
-            # Drop the now-closed handle so get_shared_db() can't hand it out.
-            from lionagi.state.db import unregister_shared_db
+            if share_db:
+                # Drop the now-closed handle so get_shared_db() can't hand it out.
+                from lionagi.state.db import unregister_shared_db
 
-            unregister_shared_db(db)
+                unregister_shared_db(db)
         return None

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -8,6 +8,7 @@ import codecs
 import contextlib
 import json
 import logging
+import os
 import shutil
 from collections.abc import AsyncIterator, Callable
 from functools import partial
@@ -23,6 +24,10 @@ log = logging.getLogger(__name__)
 # Sentinel that means "do not pass stdin to create_subprocess_exec at all"
 # (inherits the parent process stdin, matching the old Gemini/Pi behaviour).
 _INHERIT_STDIN = object()
+_STUDIO_CREDENTIAL_ENV_KEYS = (
+    "LIONAGI_STUDIO_AUTH_TOKEN",
+    "LIONAGI_STUDIO_HUMAN_TOKEN",
+)
 
 
 async def ndjson_from_cli(
@@ -45,9 +50,12 @@ async def ndjson_from_cli(
     output nobody is draining), and the pipe is closed afterwards so the child
     sees EOF rather than waiting forever for more input.
     """
+    child_env = dict(os.environ if env is None else env)
+    for key in _STUDIO_CREDENTIAL_ENV_KEYS:
+        child_env.pop(key, None)
     kwargs: dict[str, Any] = dict(
         cwd=str(cwd) if cwd else None,
-        env=env,
+        env=child_env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         start_new_session=True,

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -571,6 +571,14 @@ async def stream_claude_code_cli(  # noqa: C901
         session = CLISession()
     theme = request.cli_display_theme or "light"
     seen_system_ids: set[str] = set()
+    # ``--include-partial-messages`` emits ``stream_event`` envelopes before
+    # the ordinary, complete ``assistant`` message.  Track the message ids for
+    # which text/thinking deltas were forwarded so the complete envelope can
+    # still populate ``session.messages`` without duplicating its content in
+    # the provider-neutral StreamChunk stream.
+    partial_message_ids: set[str] = set()
+    current_partial_message_id: str | None = None
+    partial_without_message_id = False
 
     stream = stream_cc_cli_events(request)
     try:
@@ -599,16 +607,75 @@ async def stream_claude_code_cli(  # noqa: C901
                 session.chunks.append(sc)
                 yield sc
 
+            # ------------------------ PARTIAL ASSISTANT ------------------------
+            elif typ == "stream_event":
+                event = obj.get("event") or {}
+                event_type = event.get("type")
+
+                if event_type == "message_start":
+                    message = event.get("message") or {}
+                    current_partial_message_id = message.get("id")
+                    continue
+
+                if event_type == "message_stop":
+                    current_partial_message_id = None
+                    continue
+
+                if event_type != "content_block_delta":
+                    continue
+
+                delta = event.get("delta") or {}
+                delta_type = delta.get("type")
+                content: str | None = None
+                chunk_type: str | None = None
+                callback = None
+
+                if delta_type == "text_delta":
+                    content = delta.get("text")
+                    chunk_type = "text"
+                    callback = on_text
+                elif delta_type == "thinking_delta":
+                    content = delta.get("thinking")
+                    chunk_type = "thinking"
+                    callback = on_thinking
+
+                if not content or chunk_type is None:
+                    continue
+
+                message_id = current_partial_message_id
+                if message_id:
+                    partial_message_ids.add(message_id)
+                else:
+                    partial_without_message_id = True
+
+                if callback:
+                    await maybe_await(callback(content))
+                sc = StreamChunk(
+                    type=chunk_type,
+                    content=content,
+                    is_delta=True,
+                    metadata=obj,
+                )
+                session.chunks.append(sc)
+                yield sc
+
             # ------------------------ ASSISTANT --------------------------------
             elif typ == "assistant":
                 msg = obj["message"]
                 session.messages.append(msg)
+                msg_id = msg.get("id")
+                has_forwarded_partials = bool(
+                    (msg_id and msg_id in partial_message_ids)
+                    or (not msg_id and partial_without_message_id)
+                )
 
                 for blk in msg.get("content", []):
                     btype = blk.get("type")
                     if btype == "thinking":
                         thought = blk.get("thinking", "").strip()
                         session.thinking_log.append(thought)
+                        if has_forwarded_partials:
+                            continue
                         if on_thinking:
                             await maybe_await(on_thinking(thought))
                         if request.verbose_output:
@@ -619,6 +686,8 @@ async def stream_claude_code_cli(  # noqa: C901
 
                     elif btype == "text":
                         text = blk.get("text", "")
+                        if has_forwarded_partials:
+                            continue
                         if on_text:
                             await maybe_await(on_text(text))
                         if request.verbose_output:

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -1221,6 +1221,7 @@ class Branch(Element, Relational):
         image_detail="auto",
         stream_persist: bool = False,
         persist_dir: str | None = None,
+        snapshot_dir: str | None = None,
         response_format=None,
         **kwargs,
     ) -> "AsyncGenerator[RoledMessage, None]":
@@ -1242,6 +1243,8 @@ class Branch(Element, Relational):
             param_kw["imodel"] = chat_model
         if persist_dir is not None:
             param_kw["persist_dir"] = persist_dir
+        if snapshot_dir is not None:
+            param_kw["snapshot_dir"] = snapshot_dir
         if kwargs:
             param_kw["imodel_kw"] = kwargs
 

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
 import logging
 import os
 import re
@@ -35,6 +36,17 @@ _GUARDED_NON_API_PATHS = frozenset(
         "/docs/oauth2-redirect",
     }
 )
+
+
+def _bearer_matches(presented: str, token: str) -> bool:
+    """Constant-time comparison of a presented Authorization header against the
+    expected bearer. `compare_digest` only accepts ASCII-only str, so a header
+    carrying non-ASCII bytes is a mismatch — same as before, not a 500.
+    """
+    try:
+        return hmac.compare_digest(presented, f"Bearer {token}")
+    except TypeError:
+        return False
 
 
 def _collect_cors_methods(application: FastAPI) -> list[str]:
@@ -352,7 +364,8 @@ def create_app() -> FastAPI:
             return await call_next(request)
         token = request.app.state.studio_auth_token or studio_auth_token()
         path = request.url.path
-        if token and request.headers.get("authorization") != f"Bearer {token}":
+        presented = request.headers.get("authorization") or ""
+        if token and not _bearer_matches(presented, token):
             # /api/* and schema/docs are gated; non-API GET/HEAD (SPA shell,
             # hashed assets) stay public or the UI becomes unloadable.
             is_api = path == "/api" or path.startswith("/api/")

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -49,9 +49,13 @@ def _collect_cors_methods(application: FastAPI) -> list[str]:
     return sorted(methods)
 
 
-def _emit_startup_warnings() -> None:
+def _emit_startup_warnings(application: FastAPI | None = None) -> None:
     """Emit security warnings once at startup — no-op if conditions are safe."""
-    token = os.getenv("LIONAGI_STUDIO_AUTH_TOKEN")
+    from .security import studio_auth_token
+
+    token = (
+        getattr(application.state, "studio_auth_token", None) if application is not None else None
+    ) or studio_auth_token()
     if not token:
         bind_host = os.getenv("LIONAGI_STUDIO_HOST", HOST)
         if bind_host == "0.0.0.0":  # noqa: S104
@@ -160,6 +164,7 @@ async def lifespan(app_instance):
 
     from .scheduler.engine import scheduler
     from .services.lifecycle import run_startup_reconciliation
+    from .services.operator import operator_shutdown, operator_startup
 
     # First, before anything else can run and long before the first request:
     # read where this process's code came from. The modules in memory were fixed
@@ -171,7 +176,7 @@ async def lifespan(app_instance):
     # verdict on top.
     await asyncio.to_thread(snapshot_git_position)
 
-    _emit_startup_warnings()
+    _emit_startup_warnings(app_instance)
     # The second of the two settings-driven notify bootstrap points (CLI is the first).
     from lionagi.state.lifecycle.notify_settings import register_settings_terminal_callback
 
@@ -179,6 +184,9 @@ async def lifespan(app_instance):
     await scheduler.start()
     # Corrects phantom/stale-status rows /api routes read directly; must precede serving.
     await run_startup_reconciliation()
+    # Recover any accepted Operator turn that was interrupted by a prior daemon
+    # exit before accepting new submissions.
+    await operator_startup()
     mirror_stop, mirror_task = _start_claude_mirror()
     # Pure maintenance; deferred so readiness isn't gated on it.
     warmup_task = asyncio.create_task(_startup_warmup(), name="studio-startup-warmup")
@@ -187,6 +195,7 @@ async def lifespan(app_instance):
 
     await _finalize_warmup(warmup_task)
     await _stop_claude_mirror(mirror_stop, mirror_task)
+    await operator_shutdown()
     await shutdown_launches()
     await scheduler.stop()
 
@@ -303,7 +312,30 @@ def _mount_spa(application: FastAPI, dist: Path) -> None:
 def create_app() -> FastAPI:
     """Build and return a fresh Studio FastAPI app instance, so callers
     (notably tests) can get a clean one without `importlib.reload`."""
+    # Capture direct-uvicorn credentials into app memory. Environment removal
+    # keeps them out of children we launch, but their environment origin is
+    # retained because process inspection can still reveal an initial value.
+    configured_auth = os.environ.pop("LIONAGI_STUDIO_AUTH_TOKEN", None)
+    configured_human = os.environ.pop("LIONAGI_STUDIO_HUMAN_TOKEN", None)
+    from .security import (
+        studio_auth_token,
+        studio_human_token,
+        studio_operator_credential_origin,
+    )
+
     application = FastAPI(title="Lion Studio Server", lifespan=lifespan)
+    application.state.studio_auth_token = configured_auth or studio_auth_token()
+    application.state.studio_human_token = (
+        configured_auth
+        or configured_human
+        or application.state.studio_auth_token
+        or studio_human_token()
+    )
+    application.state.studio_operator_credential_origin = (
+        "environment"
+        if configured_auth is not None or configured_human is not None
+        else studio_operator_credential_origin()
+    )
 
     @application.exception_handler(LionError)
     async def _lion_error_handler(request: Request, exc: LionError) -> JSONResponse:
@@ -318,7 +350,7 @@ def create_app() -> FastAPI:
         # CORS preflight has no Authorization header by design; let it through.
         if request.method == "OPTIONS":
             return await call_next(request)
-        token = os.getenv("LIONAGI_STUDIO_AUTH_TOKEN")
+        token = request.app.state.studio_auth_token or studio_auth_token()
         path = request.url.path
         if token and request.headers.get("authorization") != f"Bearer {token}":
             # /api/* and schema/docs are gated; non-API GET/HEAD (SPA shell,

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode
 
 from lionagi._paths import ensure_lionagi_dir
 from lionagi.cli._argtypes import JsonArgument
@@ -89,6 +90,13 @@ def _add_studio_flags(parser: argparse.ArgumentParser, *, suppress_defaults: boo
         action="store_true",
         default=_default(False),
         dest="no_docker",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--operator-token-stdin",
+        action="store_true",
+        default=_default(False),
+        dest="operator_token_stdin",
         help=argparse.SUPPRESS,
     )
     mode = parser.add_mutually_exclusive_group()
@@ -190,6 +198,38 @@ def _has_docker() -> bool:
     return shutil.which("docker") is not None
 
 
+def _effective_browser_token(*, generate: bool) -> str | None:
+    from .security import capture_studio_credentials
+
+    return capture_studio_credentials(generate_human=generate)
+
+
+def _browser_url(ui_url: str, api_url: str, token: str) -> str:
+    return ui_url + "#" + urlencode({"studio-api": api_url, "studio-token": token})
+
+
+def _warn_if_environment_operator_disabled() -> None:
+    from .security import studio_operator_credential_origin
+
+    if studio_operator_credential_origin() == "environment":
+        print(
+            "Operator turns and approvals are disabled because an environment-derived "
+            "credential can remain visible in process metadata. Unset "
+            "LIONAGI_STUDIO_AUTH_TOKEN and LIONAGI_STUDIO_HUMAN_TOKEN, then restart "
+            "with `li studio` to use a generated browser credential.",
+            file=sys.stderr,
+        )
+
+
+def _open_browser(url: str, *, no_open: bool) -> None:
+    if no_open or not sys.stdin.isatty() or not sys.stdout.isatty():
+        return
+    import webbrowser
+
+    with contextlib.suppress(Exception):
+        webbrowser.open(url)
+
+
 def _studio_start(args: argparse.Namespace) -> int:
     try:
         import uvicorn  # noqa: F401
@@ -199,6 +239,22 @@ def _studio_start(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
+
+    if getattr(args, "operator_token_stdin", False):
+        from .security import install_generated_studio_token
+
+        stream = sys.stdin
+        try:
+            token = stream.readline(4098).rstrip("\r\n")
+            stream.close()
+            # The pipe is authoritative. A stale parent environment must not
+            # overwrite this launch-scoped token during later CLI setup.
+            os.environ.pop("LIONAGI_STUDIO_AUTH_TOKEN", None)
+            os.environ.pop("LIONAGI_STUDIO_HUMAN_TOKEN", None)
+            install_generated_studio_token(token)
+        except (OSError, ValueError) as exc:
+            print(f"Invalid Studio token bootstrap: {exc}", file=sys.stderr)
+            return 1
 
     port_from_env = os.environ.get("LIONAGI_STUDIO_PORT")
     port: int = (
@@ -219,11 +275,25 @@ def _studio_start(args: argparse.Namespace) -> int:
         )
 
     if no_frontend:
+        if _effective_browser_token(generate=False) is None:
+            print(
+                "Operator approvals are unavailable in API-only mode without a "
+                "browser-held credential; use `li studio` to open a credentialed UI.",
+                file=sys.stderr,
+            )
+        _warn_if_environment_operator_disabled()
         return _start_backend_only(host, port)
 
     if dev_mode:
         frontend_dir = _find_frontend_dir()
-        return _start_local(host, port, frontend_port, frontend_dir, dev_mode=True)
+        return _start_local(
+            host,
+            port,
+            frontend_port,
+            frontend_dir,
+            dev_mode=True,
+            no_open=no_open,
+        )
 
     if use_docker:
         if not _has_docker():
@@ -237,19 +307,26 @@ def _studio_start(args: argparse.Namespace) -> int:
 
 def _start_hosted(host: str, port: int, no_open: bool) -> int:
     daemon_url = f"http://127.0.0.1:{port}"
+    browser_token = _effective_browser_token(generate=True)
+    assert browser_token is not None
+    _warn_if_environment_operator_disabled()
+    launch_url = _browser_url(_HOSTED_URL, daemon_url, browser_token)
     print(f"Lion Studio: {_HOSTED_URL}")
     print(f"  connects to your local daemon at {daemon_url}")
+    if no_open:
+        print(
+            "  Operator approvals require reopening without --no-open; the generated "
+            "browser credential is intentionally not printed"
+        )
     print()
-    if not no_open and sys.stdin.isatty() and sys.stdout.isatty():
-        import webbrowser
-
-        with contextlib.suppress(Exception):
-            webbrowser.open(_HOSTED_URL)
+    _open_browser(launch_url, no_open=no_open)
     return _start_backend_only(host, port)
 
 
 def _start_backend_only(host: str, port: int) -> int:
     import uvicorn
+
+    from .security import clear_captured_studio_credentials
 
     if not _ensure_apps_importable():
         print(
@@ -262,7 +339,10 @@ def _start_backend_only(host: str, port: int) -> int:
     print(f"Lion Studio API: http://{host}:{port}")
     # Set before uvicorn.run: the app is loaded via import string and reads this from env.
     os.environ["LIONAGI_STUDIO_HOST"] = host
-    uvicorn.run("lionagi.studio.app:app", host=host, port=port)
+    try:
+        uvicorn.run("lionagi.studio.app:app", host=host, port=port)
+    finally:
+        clear_captured_studio_credentials()
     return 0
 
 
@@ -348,8 +428,11 @@ def _start_local(
     frontend_port: int,
     frontend_dir: Path | None,
     dev_mode: bool,
+    no_open: bool = False,
 ) -> int:
     import uvicorn
+
+    from .security import clear_captured_studio_credentials
 
     if frontend_dir is None:
         print("Error: --dev requires the lionagi repo. Clone it first.", file=sys.stderr)
@@ -375,10 +458,24 @@ def _start_local(
     if dev_mode:
         # Dev mode: hot-reload Vite dev server + uvicorn side-by-side.
         # Vite proxies /api → uvicorn (configured in vite.config.mts).
-        frontend_proc = _launch_vite_dev(frontend_dir, frontend_port)
+        api_url = f"http://127.0.0.1:{port}"
+        ui_url = f"http://127.0.0.1:{frontend_port}"
+        browser_token = _effective_browser_token(generate=True)
+        assert browser_token is not None
+        _warn_if_environment_operator_disabled()
+        frontend_proc = _launch_vite_dev(frontend_dir, frontend_port, api_url=api_url)
         if frontend_proc:
             print(f"Lion Studio UI (dev):  http://{host}:{frontend_port}")
         print(f"Lion Studio API:       http://{host}:{port}")
+        if no_open:
+            print(
+                "Operator approvals require reopening without --no-open; the generated "
+                "browser credential is intentionally not printed"
+            )
+        _open_browser(
+            _browser_url(ui_url, ui_url, browser_token),
+            no_open=no_open,
+        )
     else:
         # Production mode: build dist/ once, then uvicorn serves both UI and API
         # from the same origin — no second process needed.
@@ -408,6 +505,7 @@ def _start_local(
             except subprocess.TimeoutExpired:
                 frontend_proc.kill()
                 frontend_proc.wait()
+        clear_captured_studio_credentials()
     return 0
 
 
@@ -523,9 +621,15 @@ def _ensure_frontend_built(frontend_dir: Path) -> bool:
 def _launch_vite_dev(
     frontend_dir: Path,
     frontend_port: int,
+    *,
+    api_url: str | None = None,
 ) -> subprocess.Popen | None:
     """Spawn `npx vite --port <N>` for hot-reload dev mode."""
     env = {**os.environ, "PORT": str(frontend_port)}
+    env.pop("LIONAGI_STUDIO_AUTH_TOKEN", None)
+    env.pop("LIONAGI_STUDIO_HUMAN_TOKEN", None)
+    if api_url is not None:
+        env["STUDIO_API_URL"] = api_url
     try:
         return subprocess.Popen(  # noqa: S603
             ["npx", "vite", "--port", str(frontend_port)],  # noqa: S607

--- a/lionagi/studio/operator/__init__.py
+++ b/lionagi/studio/operator/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Durable Studio Operator protocol.
+
+The Operator conversation is deliberately separate from LionAGI runtime
+``Session`` rows.  Runtime work launched by an Operator command still goes
+through the ordinary Studio launch service and therefore appears in Runs.
+"""
+
+from .coordinator import (
+    OperatorCoordinator,
+    get_operator_coordinator,
+    reset_operator_coordinator_for_testing,
+)
+
+__all__ = (
+    "OperatorCoordinator",
+    "get_operator_coordinator",
+    "reset_operator_coordinator_for_testing",
+)

--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Strict stdio MCP bridge for real Studio Operator application tools.
+
+The bridge exposes a deliberately small capability set. Read tools return
+bounded projections, UI tools only append durable ADR-0083 effects, and the
+single launch tool creates a durable proposal then waits for the daemon's
+authenticated human-decision path. It never accepts a URL, filesystem path,
+shell command, or raw endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path, PureWindowsPath
+from typing import Any, Literal
+
+import anyio
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from .store import OperatorStore
+
+OperatorSpace = Literal[
+    "mission",
+    "designer",
+    "library",
+    "history",
+    "schedules",
+    "system",
+]
+
+
+class _StrictInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class RecentRunsInput(_StrictInput):
+    limit: int = Field(default=10, ge=1, le=20)
+    status: Literal["pending", "running", "completed", "failed", "cancelled"] | None = None
+
+
+class NavigateInput(_StrictInput):
+    space: OperatorSpace = Field(
+        description=(
+            "Studio space to open. Use 'history' for the first-class Fleet/run-history view."
+        )
+    )
+    status: Literal["pending", "running", "completed", "failed", "cancelled"] | None = None
+
+
+class PrefillScheduleInput(_StrictInput):
+    name: str = Field(min_length=1, max_length=160)
+    cron: str = Field(min_length=1, max_length=160)
+    prompt: str = Field(min_length=1, max_length=32_768)
+    description: str = Field(default="", max_length=1_000)
+
+    @field_validator("cron")
+    @classmethod
+    def _valid_cron(cls, value: str) -> str:
+        from lionagi.studio.services.schedules import _svc_validate_cron_expr
+
+        _svc_validate_cron_expr(value, required=True)
+        return value
+
+
+class LaunchPlaybookInput(_StrictInput):
+    playbook: str = Field(
+        min_length=1,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9_.-]*$",
+    )
+    note: str = Field(default="", max_length=500)
+
+
+class _NavigateEffect(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["navigate"] = "navigate"
+    space: OperatorSpace
+    params: dict[str, str]
+
+
+class _PrefillEffect(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["prefill"] = "prefill"
+    form: Literal["schedule"] = "schedule"
+    values: dict[str, str]
+
+
+_TOOL_MODELS: dict[str, type[_StrictInput]] = {
+    "list_recent_runs": RecentRunsInput,
+    "navigate": NavigateInput,
+    "prefill_schedule": PrefillScheduleInput,
+    "launch_playbook": LaunchPlaybookInput,
+}
+
+_TOOL_DESCRIPTIONS = {
+    "list_recent_runs": ("List at most 20 recent Studio runs as a redacted read-only projection."),
+    "navigate": (
+        "Request a typed Studio navigation effect. The browser applies and "
+        "acknowledges it; this tool does not claim that navigation completed. "
+        "The canonical 'history' space opens Fleet/run history."
+    ),
+    "prefill_schedule": (
+        "Request a typed schedule-form prefill for human review. This never creates a schedule."
+    ),
+    "launch_playbook": (
+        "Propose launching one named Studio playbook. This blocks until the "
+        "human explicitly allows or denies the exact durable proposal."
+    ),
+}
+
+_TOOL_SCHEMAS = [
+    {
+        "name": name,
+        "description": _TOOL_DESCRIPTIONS[name],
+        "inputSchema": model.model_json_schema(),
+    }
+    for name, model in _TOOL_MODELS.items()
+]
+
+
+def _identity() -> tuple[OperatorStore, str, str]:
+    db_path = os.environ.get("LIONAGI_OPERATOR_DB_PATH")
+    conversation_id = os.environ.get("LIONAGI_OPERATOR_CONVERSATION_ID")
+    request_id = os.environ.get("LIONAGI_OPERATOR_REQUEST_ID")
+    if not db_path or not conversation_id or not request_id:
+        raise RuntimeError("Studio application bridge is missing its durable turn identity")
+    return OperatorStore(db_path), conversation_id, request_id
+
+
+async def list_recent_runs(arguments: dict[str, Any]) -> dict[str, Any]:
+    args = RecentRunsInput.model_validate(arguments)
+    from lionagi.studio.services.runs import list_runs
+
+    rows = await list_runs(status=args.status, limit=args.limit, offset=0)
+
+    def public_project(value: Any) -> str | None:
+        if not isinstance(value, str) or not value:
+            return None
+        if Path(value).is_absolute():
+            return Path(value).name or "external-project"
+        windows_path = PureWindowsPath(value)
+        if windows_path.is_absolute():
+            return windows_path.name or "external-project"
+        return value[:160]
+
+    projected = [
+        {
+            "id": row.get("id"),
+            "agentName": row.get("agent_name"),
+            "status": row.get("status"),
+            "project": public_project(row.get("project")),
+            "startedAt": row.get("started_at"),
+            "endedAt": row.get("ended_at"),
+            "href": f"/runs/{row.get('id')}",
+        }
+        for row in rows[: args.limit]
+        if isinstance(row.get("id"), str)
+    ]
+    return {"runs": projected, "count": len(projected), "bounded": True}
+
+
+async def navigate(arguments: dict[str, Any]) -> dict[str, Any]:
+    args = NavigateInput.model_validate(arguments)
+    if args.status is not None and args.space not in {"mission", "history"}:
+        raise ValueError("status is only valid for mission/history run navigation")
+    params = {"status": args.status} if args.status is not None else {}
+    effect = _NavigateEffect(space=args.space, params=params).model_dump()
+    store, conversation_id, request_id = _identity()
+    frame = await store.append_effect(conversation_id, request_id, effect)
+    if frame is None:
+        raise RuntimeError("The Operator turn ended before the UI effect was persisted")
+    stored = frame["payload"]["effect"]
+    return {
+        "status": "pending",
+        "effectId": stored["id"],
+        "kind": stored["kind"],
+    }
+
+
+async def prefill_schedule(arguments: dict[str, Any]) -> dict[str, Any]:
+    args = PrefillScheduleInput.model_validate(arguments)
+    effect = _PrefillEffect(
+        values={
+            "name": args.name,
+            "cron": args.cron,
+            "prompt": args.prompt,
+            "description": args.description,
+        }
+    ).model_dump()
+    store, conversation_id, request_id = _identity()
+    frame = await store.append_effect(conversation_id, request_id, effect)
+    if frame is None:
+        raise RuntimeError("The Operator turn ended before the UI effect was persisted")
+    stored = frame["payload"]["effect"]
+    return {
+        "status": "pending",
+        "effectId": stored["id"],
+        "kind": stored["kind"],
+    }
+
+
+def _redacted_launch_result(proposal: dict[str, Any]) -> dict[str, Any]:
+    raw = proposal.get("result")
+    result = raw if isinstance(raw, dict) else {}
+    allowed = {
+        key: result[key]
+        for key in ("invocation_id", "run_id", "href", "action_kind")
+        if isinstance(result.get(key), (str, int, float, bool))
+    }
+    return {
+        "status": proposal["status"],
+        "proposalId": proposal["id"],
+        "result": allowed,
+        "errorCode": proposal.get("errorCode"),
+    }
+
+
+async def resolve_playbook_version(playbook: str) -> str:
+    """Fingerprint the exact playbook content without exposing its host path."""
+    from lionagi.studio.services.playbooks import fingerprint_playbook
+
+    return await anyio.to_thread.run_sync(fingerprint_playbook, playbook)
+
+
+async def launch_playbook(arguments: dict[str, Any]) -> dict[str, Any]:
+    args = LaunchPlaybookInput.model_validate(arguments)
+    store, conversation_id, request_id = _identity()
+    target_version = await resolve_playbook_version(args.playbook)
+    command = {
+        "action_kind": "play",
+        "action_playbook": args.playbook,
+    }
+    stable = store.canonical_hash(
+        {
+            "requestId": request_id,
+            "tool": "launch_playbook",
+            "command": command,
+            "targetVersion": target_version,
+        }
+    )
+    summary = f"Launch playbook '{args.playbook}'"
+    if args.note:
+        summary += f" — {args.note}"
+    proposal = await store.create_proposal(
+        conversation_id,
+        request_id,
+        command_type="launch",
+        command=command,
+        risk="execute",
+        summary=summary,
+        idempotency_key=f"operator-app:{stable}",
+        target_version=target_version,
+    )
+    while True:
+        proposal = await store.get_proposal(proposal["id"])
+        status = proposal["status"]
+        if status == "pending" and proposal["expiresAt"] <= time.time():
+            proposal = await store.expire_proposal(proposal["id"])
+            status = proposal["status"]
+        if status in {"succeeded", "failed", "cancelled", "expired", "conflict"}:
+            return _redacted_launch_result(proposal)
+        await asyncio.sleep(0.1)
+
+
+_TOOL_HANDLERS = {
+    "list_recent_runs": list_recent_runs,
+    "navigate": navigate,
+    "prefill_schedule": prefill_schedule,
+    "launch_playbook": launch_playbook,
+}
+
+
+async def _dispatch(message: dict[str, Any]) -> dict[str, Any] | None:
+    method = message.get("method")
+    message_id = message.get("id")
+    if message_id is None:
+        return None
+    if method == "initialize":
+        requested = (message.get("params") or {}).get("protocolVersion")
+        return {
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "result": {
+                "protocolVersion": requested or "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "studio-operator", "version": "1"},
+            },
+        }
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": message_id, "result": {}}
+    if method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "result": {"tools": _TOOL_SCHEMAS},
+        }
+    if method == "tools/call":
+        params = message.get("params") or {}
+        name = params.get("name")
+        handler = _TOOL_HANDLERS.get(name)
+        if handler is None:
+            return _tool_response(message_id, {"error": "Unknown Operator tool"}, error=True)
+        try:
+            result = await handler(params.get("arguments") or {})
+            return _tool_response(message_id, result)
+        except ValidationError as exc:
+            return _tool_response(
+                message_id,
+                {
+                    "error": "Invalid Operator tool arguments",
+                    "details": exc.errors(
+                        include_url=False,
+                        include_context=False,
+                        include_input=False,
+                    ),
+                },
+                error=True,
+            )
+        except ValueError as exc:
+            return _tool_response(message_id, {"error": str(exc)}, error=True)
+        except Exception:  # noqa: BLE001
+            return _tool_response(
+                message_id,
+                {"error": "Studio Operator application service is unavailable"},
+                error=True,
+            )
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {"code": -32601, "message": f"Method not found: {method}"},
+    }
+
+
+def _tool_response(
+    message_id: Any,
+    value: dict[str, Any],
+    *,
+    error: bool = False,
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(value, sort_keys=True, separators=(",", ":")),
+                }
+            ],
+            **({"isError": True} if error else {}),
+        },
+    }
+
+
+async def _main() -> None:
+    while True:
+        line = await asyncio.to_thread(sys.stdin.buffer.readline)
+        if not line:
+            return
+        try:
+            message = json.loads(line)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        response = await _dispatch(message)
+        if response is not None:
+            sys.stdout.write(json.dumps(response, sort_keys=True, separators=(",", ":")) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -1,0 +1,705 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Coordinator for durable Operator turns, cancellation, and permissions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+import uuid
+from contextlib import suppress
+from typing import Any
+
+from .engine import (
+    BranchOperatorEngine,
+    OperatorProviderUnavailableError,
+    build_operator_branch,
+    compile_operator_history,
+    write_resumable_operator_snapshot,
+)
+from .store import (
+    OperatorAuditUnavailableError,
+    OperatorConflictError,
+    OperatorStore,
+)
+from .types import (
+    CommandExecutor,
+    OperatorEngineEvent,
+    OperatorEngineFactory,
+    OperatorEngineTurn,
+    PermissionDecision,
+)
+
+_log = logging.getLogger(__name__)
+
+
+class ApplicationTargetConflictError(RuntimeError):
+    """The exact target approved by a human is no longer current."""
+
+
+async def _verify_application_target(proposal: dict[str, Any]) -> None:
+    target_version = proposal.get("targetVersion")
+    if target_version is None:
+        return
+    command = proposal["command"]
+    if (
+        proposal["commandType"] != "launch"
+        or command.get("action_kind") != "play"
+        or not isinstance(command.get("action_playbook"), str)
+    ):
+        raise ApplicationTargetConflictError("Unsupported versioned application target")
+    from .application_mcp import resolve_playbook_version
+
+    try:
+        current_version = await resolve_playbook_version(command["action_playbook"])
+    except Exception as exc:  # noqa: BLE001
+        raise ApplicationTargetConflictError(
+            "The approved playbook target is no longer available"
+        ) from exc
+    if current_version != target_version:
+        raise ApplicationTargetConflictError("The approved playbook changed before execution")
+
+
+async def _execute_application_command(
+    command_type: str, command: dict[str, Any]
+) -> dict[str, Any]:
+    if command_type != "launch":
+        raise ValueError(f"Unsupported Operator application command: {command_type!r}")
+    from lionagi.studio.services.launches import launch
+
+    result = await launch(command)
+    invocation_id = result.get("invocation_id")
+    if not invocation_id:
+        return result
+
+    # A launch's canonical Run row is created by the child process. Give it a
+    # short opportunity to appear so the confirmation can carry a direct run
+    # link; retain the invocation link if startup takes longer.
+    from lionagi.studio.services.invocations import get_invocation
+
+    run_id = None
+    for _ in range(20):
+        detail = await get_invocation(str(invocation_id))
+        sessions = detail.get("sessions", []) if detail else []
+        if sessions:
+            run_id = sessions[0].get("id")
+            break
+        await asyncio.sleep(0.1)
+    return {
+        **result,
+        "run_id": run_id,
+        "href": f"/runs/{run_id}" if run_id else f"/invocations/{invocation_id}",
+    }
+
+
+class OperatorCoordinator:
+    def __init__(
+        self,
+        *,
+        store: OperatorStore | None = None,
+        engine_factory: OperatorEngineFactory | None = None,
+        command_executor: CommandExecutor | None = None,
+    ) -> None:
+        self.store = store or OperatorStore()
+        self.engine_factory = engine_factory or BranchOperatorEngine
+        self.command_executor = command_executor or _execute_application_command
+        self._tasks: dict[str, asyncio.Task] = {}
+        self._started = False
+
+    async def startup(self) -> list[str]:
+        await self.store.ensure_schema()
+        recovered = await self.store.recover_interrupted_turns()
+        self._started = True
+        return recovered
+
+    async def ensure_started(self) -> None:
+        if not self._started:
+            # Route-level fallback for direct ASGI/service tests. Normal daemon
+            # startup calls startup() before accepting requests.
+            await self.startup()
+
+    async def shutdown(self) -> None:
+        tasks = list(self._tasks.items())
+        for request_id, task in tasks:
+            if task.done():
+                continue
+            try:
+                turn = await self.store.get_turn(request_id)
+            except Exception:  # noqa: BLE001
+                turn = None
+            # A done frame makes the turn terminal before canonical Run
+            # teardown closes its StateDB handle and writes its final
+            # snapshot. Let that bounded cleanup finish; cancelling it here
+            # can strand the aiosqlite worker/connection.
+            if turn is None or turn["status"] not in {
+                "completed",
+                "failed",
+                "cancelled",
+            }:
+                task.cancel()
+        if tasks:
+            await asyncio.gather(
+                *(task for _request_id, task in tasks),
+                return_exceptions=True,
+            )
+        self._tasks.clear()
+        self._started = False
+
+    async def create_conversation(
+        self, *, project: str | None = None, title: str | None = None
+    ) -> dict[str, Any]:
+        await self.ensure_started()
+        conversation = await self.store.create_conversation(project=project, title=title)
+        return {"conversation": conversation, "frames": []}
+
+    async def snapshot(
+        self,
+        conversation_id: str,
+        *,
+        after_sequence: int = 0,
+        limit: int = 1000,
+    ) -> dict[str, Any]:
+        await self.ensure_started()
+        frames = await self.store.list_frames(
+            conversation_id, after_sequence=after_sequence, limit=limit
+        )
+        # Read the tail after the page so metadata cannot predate a frame the
+        # page itself already contains.
+        conversation = await self.store.get_conversation(conversation_id)
+        page_tail = frames[-1]["sequence"] if frames else after_sequence
+        latest = int(conversation["nextSequence"]) - 1
+        return {
+            "conversation": conversation,
+            "frames": frames,
+            "hasMore": page_tail < latest,
+            "nextAfterSequence": page_tail,
+            "latestSequence": latest,
+        }
+
+    async def submit(
+        self,
+        conversation_id: str,
+        *,
+        instruction: str,
+        context: dict[str, Any],
+        expected_last_sequence: int,
+    ) -> dict[str, Any]:
+        await self.ensure_started()
+        accepted = await self.store.submit_turn(
+            conversation_id,
+            instruction=instruction,
+            context=context,
+            expected_last_sequence=expected_last_sequence,
+        )
+        request_id = accepted["requestId"]
+        ready = asyncio.Event()
+        task = asyncio.create_task(
+            self._run_turn(request_id, ready), name=f"operator-turn-{request_id}"
+        )
+        self._tasks[request_id] = task
+
+        def discard(done: asyncio.Task) -> None:
+            ready.set()
+            self._tasks.pop(request_id, None)
+            if done.cancelled():
+                return
+            exc = done.exception()
+            if exc is not None:
+                _log.error("Operator turn task escaped", exc_info=exc)
+
+        task.add_done_callback(discard)
+        # A successful 202 identifies a canonical Run, not merely a future
+        # intention to create one. The event is set after the durable run-link
+        # frames land (or when setup terminally fails).
+        await ready.wait()
+        return accepted
+
+    async def _run_turn(self, request_id: str, ready: asyncio.Event) -> None:
+        turn_row = await self.store.get_turn(request_id)
+        if not await self.store.mark_running(request_id):
+            return
+        conversation_id = turn_row["conversationId"]
+        live = None
+        run_branch = None
+        run_dir = None
+        started_at: float | None = None
+        terminal_status = "completed"
+        terminal_exc: BaseException | None = None
+        try:
+            complete_turns = await self.store.list_complete_turn_frame_groups(
+                conversation_id,
+                exclude_request_id=request_id,
+                limit=64,
+            )
+            compiled = compile_operator_history(complete_turns)
+            compiled_context = await self.store.record_context_compilation(
+                request_id, compiled.metadata
+            )
+
+            async def request_permission(
+                command_type: str,
+                command: dict[str, Any],
+                risk: str,
+                summary: str,
+            ) -> PermissionDecision:
+                proposal = await self.store.create_proposal(
+                    conversation_id,
+                    request_id,
+                    command_type=command_type,
+                    command=command,
+                    risk=risk,
+                    summary=summary,
+                )
+                while True:
+                    current = await self.store.get_proposal(proposal["id"])
+                    if current["status"] == "pending" and current["expiresAt"] <= time.time():
+                        current = await self.store.expire_proposal(current["id"])
+                    if current["status"] in {"confirmed", "succeeded"}:
+                        return PermissionDecision(True, current["id"], result=current.get("result"))
+                    if current["status"] in {
+                        "cancelled",
+                        "expired",
+                        "failed",
+                        "conflict",
+                    }:
+                        return PermissionDecision(False, current["id"])
+                    await asyncio.sleep(0.05)
+
+            engine_turn = OperatorEngineTurn(
+                conversation_id=conversation_id,
+                request_id=request_id,
+                instruction=turn_row["instruction"],
+                context=compiled_context,
+                history=compiled.frames,
+                request_permission=request_permission,
+                store_path=str(self.store.path()),
+            )
+            run_branch = build_operator_branch(engine_turn)
+            engine_turn = OperatorEngineTurn(
+                conversation_id=engine_turn.conversation_id,
+                request_id=engine_turn.request_id,
+                instruction=engine_turn.instruction,
+                context=engine_turn.context,
+                history=engine_turn.history,
+                request_permission=engine_turn.request_permission,
+                runtime_branch=run_branch,
+                store_path=engine_turn.store_path,
+            )
+            from lionagi.cli import _runs as cli_runs
+
+            file_run_id = f"operator-{uuid.uuid4().hex[:12]}"
+            run_dir = cli_runs.RunDir(
+                run_id=file_run_id,
+                state_root=cli_runs.RUNS_ROOT / file_run_id,
+                artifact_root=cli_runs.RUNS_ROOT / file_run_id / "artifacts",
+            )
+            run_dir.ensure_state_dirs()
+            run_dir.ensure_artifact_root()
+            started_at = time.time()
+            run_dir.write_manifest(
+                {
+                    "kind": "agent",
+                    "agent_name": "Operator",
+                    "branch_id": str(run_branch.id),
+                    "provider": os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code"),
+                    "model": os.environ.get("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet"),
+                    "status": "running",
+                    "started_at": started_at,
+                    "ended_at": None,
+                }
+            )
+            # Scripted/test engines may not call Branch.run themselves; the
+            # canonical snapshot still exists before the run link is emitted.
+            await write_resumable_operator_snapshot(run_branch, run_dir.branches_dir)
+
+            provider = os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
+            model_name = os.environ.get("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet")
+            live = await cli_runs.setup_agent_persist(
+                run_branch,
+                agent_name="Operator",
+                artifacts_path=str(run_dir.artifact_root),
+                model=model_name,
+                provider=provider,
+                project=turn_row["context"].get("project"),
+                run_id=run_dir.run_id,
+                share_db=False,
+            )
+            if live is None:
+                raise RuntimeError("Could not create the canonical Operator run")
+            run_id = live["session_id"]
+            await self.store.append_frame(
+                conversation_id,
+                request_id,
+                "tool_result",
+                {
+                    "callId": f"run:{request_id}",
+                    "ok": True,
+                    "result": {
+                        "runId": run_id,
+                        "branchId": str(run_branch.id),
+                        "href": f"/runs/{run_id}",
+                    },
+                },
+            )
+            await self.store.append_frame(
+                conversation_id,
+                request_id,
+                "text",
+                {
+                    "content": f"[Open this Operator run](/runs/{run_id})",
+                    "format": "markdown",
+                    "role": "assistant",
+                },
+            )
+            ready.set()
+            engine = self.engine_factory()
+            engine_turn = OperatorEngineTurn(
+                conversation_id=engine_turn.conversation_id,
+                request_id=engine_turn.request_id,
+                instruction=engine_turn.instruction,
+                context=engine_turn.context,
+                history=engine_turn.history,
+                request_permission=engine_turn.request_permission,
+                runtime_branch=engine_turn.runtime_branch,
+                store_path=engine_turn.store_path,
+                run_dir=run_dir,
+            )
+            async for event in engine.stream(engine_turn):
+                if not isinstance(event, OperatorEngineEvent):
+                    raise TypeError("Operator engine yielded an invalid event")
+                if event.type == "done":
+                    continue
+                if event.type == "ui_command":
+                    effect = event.payload.get("effect")
+                    if not isinstance(effect, dict):
+                        raise TypeError("Operator engine yielded an invalid UI effect")
+                    await self.store.append_effect(conversation_id, request_id, effect)
+                else:
+                    if event.type == "tool_result":
+                        call_id = event.payload.get("callId")
+                        if isinstance(call_id, str):
+                            completed = await self.store.complete_provider_permission(
+                                request_id,
+                                call_id,
+                                ok=bool(event.payload.get("ok")),
+                            )
+                            if completed is not None:
+                                await self.store.append_frame(
+                                    conversation_id,
+                                    request_id,
+                                    "confirmation",
+                                    {
+                                        "proposalId": completed["id"],
+                                        "state": "executed",
+                                    },
+                                )
+                    await self.store.append_frame(
+                        conversation_id, request_id, event.type, event.payload
+                    )
+            await self.store.finish_turn(request_id, outcome="completed")
+        except asyncio.CancelledError:
+            terminal_status = "cancelled"
+            await self.store.finish_turn(
+                request_id,
+                outcome="cancelled",
+                error={
+                    "code": "cancelled",
+                    "message": "The operator cancelled this turn",
+                    "retryable": False,
+                },
+            )
+            raise
+        except OperatorProviderUnavailableError as exc:
+            terminal_status = "failed"
+            terminal_exc = exc
+            await self.store.finish_turn(
+                request_id,
+                outcome="failed",
+                error={
+                    "code": "provider_unavailable",
+                    "message": str(exc),
+                    "retryable": False,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            terminal_status = "failed"
+            terminal_exc = exc
+            _log.exception("Operator turn failed: %s", request_id)
+            await self.store.finish_turn(
+                request_id,
+                outcome="failed",
+                error={
+                    "code": "model_failure",
+                    "message": (
+                        f"The Operator engine failed ({type(exc).__name__}); "
+                        "see daemon logs for diagnostics"
+                    ),
+                    "retryable": True,
+                },
+            )
+        finally:
+            # Publish the final checkpoint before marking the canonical
+            # session terminal. Queued resume workers use that transition as
+            # the hand-off boundary.
+            if run_branch is not None and run_dir is not None:
+                with suppress(Exception):
+                    await write_resumable_operator_snapshot(run_branch, run_dir.branches_dir)
+            if live is not None:
+                from lionagi.cli._runs import teardown_agent_persist
+
+                with suppress(Exception):
+                    await teardown_agent_persist(
+                        live,
+                        status=terminal_status,
+                        exception=terminal_exc,
+                    )
+            if run_branch is not None and run_dir is not None:
+                with suppress(Exception):
+                    run_dir.write_manifest(
+                        {
+                            "kind": "agent",
+                            "agent_name": "Operator",
+                            "branch_id": str(run_branch.id),
+                            "session_id": live["session_id"] if live is not None else None,
+                            "provider": os.environ.get(
+                                "LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code"
+                            ),
+                            "model": os.environ.get("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet"),
+                            "status": terminal_status,
+                            "started_at": started_at or time.time(),
+                            "ended_at": time.time(),
+                        }
+                    )
+            ready.set()
+
+    async def cancel(self, conversation_id: str, request_id: str) -> dict[str, Any]:
+        await self.ensure_started()
+        result = await self.store.request_cancel(conversation_id, request_id)
+        task = self._tasks.get(request_id)
+        if task is not None and not task.done():
+            task.cancel()
+        if result["cancelRequested"]:
+            # Do not rely on the task's coroutine body having started: a task
+            # cancelled immediately after create_task() never enters its
+            # try/except. finish_turn is idempotent with the running task's
+            # cancellation cleanup.
+            await self.store.finish_turn(
+                request_id,
+                outcome="cancelled",
+                error={
+                    "code": "cancelled",
+                    "message": "The operator cancelled this turn",
+                    "retryable": False,
+                },
+            )
+        return result
+
+    async def decide(
+        self,
+        conversation_id: str,
+        proposal_id: str,
+        *,
+        allow: bool,
+        expected_command_hash: str | None,
+        expected_target_version: str | None,
+    ) -> dict[str, Any]:
+        await self.ensure_started()
+        before = await self.store.get_proposal(proposal_id)
+        if before["conversationId"] != conversation_id:
+            raise OperatorConflictError("Proposal does not belong to this conversation")
+
+        try:
+            # Validation, audit insertion, and the pending -> executing claim
+            # share one SQLite transaction. A concurrent allow therefore sees
+            # executing and cannot invoke the application command again.
+            proposal = await self.store.decide_proposal(
+                conversation_id,
+                proposal_id,
+                allow=allow,
+                expected_command_hash=expected_command_hash,
+                expected_target_version=expected_target_version,
+                audit=True,
+                claim_execution=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if isinstance(exc, OperatorConflictError):
+                raise
+            raise OperatorAuditUnavailableError("Mutation audit is unavailable") from exc
+
+        if not allow:
+            return self._proposal_result(proposal)
+
+        if proposal["commandType"] == "provider_permission":
+            return self._proposal_result(proposal)
+        if not proposal.get("_claimedExecution"):
+            return self._proposal_result(proposal)
+
+        try:
+            # Re-fingerprint after the durable execution claim and immediately
+            # before invoking the application service. A changed or removed
+            # playbook fails closed without executing the approved command.
+            await _verify_application_target(proposal)
+        except ApplicationTargetConflictError as exc:
+            _log.warning("Operator application target conflict: %s", proposal_id)
+            try:
+                proposal = await self.store.complete_proposal(
+                    proposal_id,
+                    status="conflict",
+                    error_code="stale_context",
+                    result={"message": str(exc)},
+                    audit=True,
+                )
+            except Exception as persist_exc:  # noqa: BLE001
+                raise OperatorAuditUnavailableError(
+                    "Target conflict outcome is indeterminate; reconciliation is required"
+                ) from persist_exc
+            await self.store.append_frame(
+                conversation_id,
+                proposal["requestId"],
+                "tool_result",
+                {
+                    "callId": proposal_id,
+                    "ok": False,
+                    "error": {
+                        "code": "stale_context",
+                        "message": str(exc),
+                        "retryable": False,
+                    },
+                },
+            )
+            return self._proposal_result(proposal)
+
+        try:
+            result = await self.command_executor(proposal["commandType"], proposal["command"])
+        except Exception as exc:  # noqa: BLE001
+            public_message = (
+                f"Application command failed ({type(exc).__name__}); "
+                "see daemon logs for diagnostics"
+            )
+            _log.exception("Operator application command failed: %s", proposal_id)
+            try:
+                proposal = await self.store.complete_proposal(
+                    proposal_id,
+                    status="failed",
+                    error_code="service_failure",
+                    result={"message": public_message},
+                    audit=True,
+                )
+            except Exception as persist_exc:  # noqa: BLE001
+                # The application was attempted but its terminal audit could
+                # not be committed. Leave the durable claim executing so an
+                # automatic retry cannot duplicate an indeterminate command.
+                _log.exception(
+                    "Operator command failure outcome could not be audited: %s",
+                    proposal_id,
+                )
+                raise OperatorAuditUnavailableError(
+                    "Command outcome is indeterminate; reconciliation is required"
+                ) from persist_exc
+            await self.store.append_frame(
+                conversation_id,
+                proposal["requestId"],
+                "tool_result",
+                {
+                    "callId": proposal_id,
+                    "ok": False,
+                    "error": {
+                        "code": "service_failure",
+                        "message": public_message,
+                        "retryable": False,
+                    },
+                },
+            )
+            return self._proposal_result(proposal)
+
+        try:
+            proposal = await self.store.complete_proposal(
+                proposal_id, status="succeeded", result=result, audit=True
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Execution happened. Never rewrite this as a safe failure or run
+            # it again: the executing claim and idempotency key intentionally
+            # remain for manual reconciliation.
+            _log.exception("Operator command result audit failed: %s", proposal_id)
+            raise OperatorAuditUnavailableError(
+                "Command outcome is indeterminate; reconciliation is required"
+            ) from exc
+        await self.store.append_frame(
+            conversation_id,
+            proposal["requestId"],
+            "confirmation",
+            {"proposalId": proposal_id, "state": "executed"},
+        )
+        await self.store.append_frame(
+            conversation_id,
+            proposal["requestId"],
+            "tool_result",
+            {
+                "callId": proposal_id,
+                "ok": True,
+                "result": result,
+            },
+        )
+        href = result.get("href")
+        if isinstance(href, str):
+            label = "Open run" if result.get("run_id") else "Open launch invocation"
+            await self.store.append_frame(
+                conversation_id,
+                proposal["requestId"],
+                "text",
+                {
+                    "content": f"[{label}]({href})",
+                    "format": "markdown",
+                    "role": "assistant",
+                },
+            )
+        return self._proposal_result(proposal)
+
+    @staticmethod
+    def _proposal_result(proposal: dict[str, Any]) -> dict[str, Any]:
+        status = proposal["status"]
+        wire_status = {
+            "confirmed": "executing",
+            "cancelled": "failed",
+        }.get(status, status)
+        return {
+            "proposalId": proposal["id"],
+            "status": wire_status,
+            "result": proposal.get("result"),
+            "error": (
+                {
+                    "code": proposal.get("errorCode") or "denied",
+                    "message": (
+                        "The approved target changed before execution"
+                        if proposal.get("errorCode") == "stale_context"
+                        else "Permission was not granted"
+                    ),
+                    "retryable": False,
+                }
+                if status in {"cancelled", "failed", "expired", "conflict"}
+                else None
+            ),
+        }
+
+
+_COORDINATOR: OperatorCoordinator | None = None
+
+
+def get_operator_coordinator() -> OperatorCoordinator:
+    global _COORDINATOR
+    if _COORDINATOR is None:
+        _COORDINATOR = OperatorCoordinator()
+    return _COORDINATOR
+
+
+async def reset_operator_coordinator_for_testing(
+    coordinator: OperatorCoordinator | None = None,
+) -> OperatorCoordinator:
+    global _COORDINATOR
+    if _COORDINATOR is not None:
+        with suppress(Exception):
+            await _COORDINATOR.shutdown()
+    _COORDINATOR = coordinator or OperatorCoordinator()
+    return _COORDINATOR

--- a/lionagi/studio/operator/engine.py
+++ b/lionagi/studio/operator/engine.py
@@ -1,0 +1,464 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Default Branch-backed engine for Studio Operator turns."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import sys
+from collections.abc import Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .types import OperatorEngineEvent, OperatorEngineTurn
+
+_SYSTEM_PROMPT = """\
+You are the resident Operator for Lion Studio. Be concise and factual.
+You may inspect the current project and help operate LionAGI. Never claim that
+an action completed until its tool result says so. Disk writes, commands, and
+other gated native work must go through the configured Studio permission
+prompt; wait for the human decision. Use the strict studio_operator MCP tools
+for recent-run queries, typed UI navigation/prefill, and playbook launches.
+The launch tool creates its own human-confirmed durable proposal. Do not
+attempt to bypass either gate or invent raw Studio endpoints.
+"""
+
+_END = object()
+_ONE_TURN_PERMISSION_KEYS = {
+    "permission_prompt_tool_name",
+    "strict_mcp_config",
+    "setting_sources",
+    "allowed_tools",
+}
+_REQUEST_SCOPED_MCP_SERVERS = {"studio_permission", "studio_operator"}
+_OPERATOR_MCP_TOOLS = [
+    "mcp__studio_operator__list_recent_runs",
+    "mcp__studio_operator__navigate",
+    "mcp__studio_operator__prefill_schedule",
+    "mcp__studio_operator__launch_playbook",
+]
+_MODEL_CONTEXT_FRAME_LIMIT = 64
+_MODEL_CONTEXT_BYTE_LIMIT = 128 * 1024
+
+
+class OperatorProviderUnavailableError(RuntimeError):
+    """The configured local Operator CLI is not installed."""
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledOperatorHistory:
+    """A bounded, replayable history plus its durable compilation receipt."""
+
+    frames: tuple[dict[str, Any], ...]
+    metadata: dict[str, Any]
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _render_history_frame(frame: dict[str, Any]) -> str | None:
+    """Render one normalized history frame for the provider-neutral prompt."""
+    frame_type = frame.get("type")
+    payload = frame.get("payload") or {}
+    if frame_type == "text":
+        content = payload.get("content")
+        if not isinstance(content, str) or not content:
+            return None
+        role = payload.get("role", "assistant")
+        return f"{role}: {content}"
+    if frame_type == "tool_call":
+        return (
+            f"assistant tool call {payload.get('tool', 'native_tool')} "
+            f"[{payload.get('callId', '')}]: "
+            f"{_canonical_json(payload.get('arguments') or {})}"
+        )
+    if frame_type == "tool_result":
+        state = "ok" if payload.get("ok") else "error"
+        return (
+            f"tool result [{payload.get('callId', '')}] ({state}): "
+            f"{_canonical_json(payload.get('result') or {})}"
+        )
+    if frame_type in {"proposal", "confirmation", "error"}:
+        return f"{frame_type}: {_canonical_json(payload)}"
+    return None
+
+
+def _normalize_complete_turn(
+    frames: Sequence[dict[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    """Merge streaming deltas and retain only complete native-tool pairs."""
+    if not frames or not any(frame.get("type") == "done" for frame in frames):
+        return ()
+
+    pending_calls: dict[str, list[int]] = {}
+    paired_tool_indices: set[int] = set()
+    for index, frame in enumerate(frames):
+        payload = frame.get("payload") or {}
+        call_id = payload.get("callId")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        if frame.get("type") == "tool_call":
+            pending_calls.setdefault(call_id, []).append(index)
+        elif frame.get("type") == "tool_result":
+            candidates = pending_calls.get(call_id)
+            if candidates:
+                paired_tool_indices.add(candidates.pop(0))
+                paired_tool_indices.add(index)
+
+    normalized: list[dict[str, Any]] = []
+    previous_raw_was_text = False
+    for index, frame in enumerate(frames):
+        frame_type = frame.get("type")
+        payload = frame.get("payload") or {}
+        if frame_type == "text":
+            content = payload.get("content")
+            if not isinstance(content, str) or not content:
+                previous_raw_was_text = False
+                continue
+            role = payload.get("role", "assistant")
+            text_format = payload.get("format", "plain")
+            if (
+                previous_raw_was_text
+                and normalized
+                and normalized[-1]["type"] == "text"
+                and normalized[-1]["payload"].get("role", "assistant") == role
+            ):
+                prior = normalized[-1]["payload"]
+                separator = "" if prior.get("format", "plain") == text_format else "\n\n"
+                prior["content"] += separator + content
+                prior["format"] = text_format
+            else:
+                normalized.append(
+                    {
+                        "version": 1,
+                        "conversationId": frame.get("conversationId"),
+                        "requestId": frame.get("requestId"),
+                        "type": "text",
+                        "payload": {
+                            "content": content,
+                            "format": text_format,
+                            "role": role,
+                        },
+                    }
+                )
+            previous_raw_was_text = True
+            continue
+
+        previous_raw_was_text = False
+        if frame_type in {"tool_call", "tool_result"}:
+            if index not in paired_tool_indices:
+                continue
+        elif frame_type not in {"proposal", "confirmation", "error"}:
+            continue
+        normalized.append(
+            {
+                "version": 1,
+                "conversationId": frame.get("conversationId"),
+                "requestId": frame.get("requestId"),
+                "type": frame_type,
+                "payload": dict(payload),
+            }
+        )
+    return tuple(normalized)
+
+
+def compile_operator_history(
+    complete_turns_newest_first: Sequence[Sequence[dict[str, Any]]],
+) -> CompiledOperatorHistory:
+    """Select newest complete turns atomically under the model history budget."""
+    selected: list[tuple[Sequence[dict[str, Any]], tuple[dict[str, Any], ...]]] = []
+    used_frames = 0
+    used_bytes = 0
+    for source_frames in complete_turns_newest_first:
+        normalized = _normalize_complete_turn(source_frames)
+        if not normalized:
+            continue
+        rendered = [
+            text for frame in normalized if (text := _render_history_frame(frame)) is not None
+        ]
+        group_bytes = sum(len(text.encode("utf-8")) for text in rendered)
+        group_bytes += max(0, len(rendered) - 1)
+        separator_bytes = 1 if selected and rendered else 0
+        if (
+            used_frames + len(normalized) > _MODEL_CONTEXT_FRAME_LIMIT
+            or used_bytes + separator_bytes + group_bytes > _MODEL_CONTEXT_BYTE_LIMIT
+        ):
+            # Do not skip a newer complete turn to admit an older one.
+            break
+        selected.append((source_frames, normalized))
+        used_frames += len(normalized)
+        used_bytes += separator_bytes + group_bytes
+
+    chronological = list(reversed(selected))
+    compiled_frames = tuple(frame for _source, group in chronological for frame in group)
+    source_sequences = [
+        int(frame["sequence"])
+        for source, _group in chronological
+        for frame in source
+        if isinstance(frame.get("sequence"), int)
+    ]
+    digest = hashlib.sha256(_canonical_json(compiled_frames).encode("utf-8")).hexdigest()
+    metadata = {
+        "version": 1,
+        "firstSequence": min(source_sequences) if source_sequences else None,
+        "lastSequence": max(source_sequences) if source_sequences else None,
+        "frameCount": len(compiled_frames),
+        "turnCount": len(selected),
+        "byteCount": used_bytes,
+        "hash": digest,
+    }
+    return CompiledOperatorHistory(compiled_frames, metadata)
+
+
+def _compile_operator_prompt(turn: OperatorEngineTurn) -> str:
+    """Render the coordinator's already-bounded, turn-atomic history."""
+    rendered = [
+        text for frame in turn.history if (text := _render_history_frame(frame)) is not None
+    ]
+    if not rendered:
+        return turn.instruction
+    return (
+        "Recent durable Operator conversation (oldest to newest):\n"
+        + "\n".join(rendered)
+        + "\n\nCurrent operator instruction:\n"
+        + turn.instruction
+    )
+
+
+async def write_resumable_operator_snapshot(branch: Any, snapshot_dir: str | Path) -> None:
+    """Write a branch snapshot without its request-scoped permission bridge.
+
+    The live branch must retain the MCP bridge while its provider subprocess
+    runs. A detached resume cannot reuse that bridge: it names a completed
+    Operator request. Temporarily removing the bridge only for serialization
+    preserves messages and provider state while making resumed gated work fail
+    closed through the CLI's ordinary permission mode.
+    """
+    from lionagi.cli._runs import _atomic_write_json
+
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    original = dict(kwargs)
+    try:
+        for key in _ONE_TURN_PERMISSION_KEYS:
+            kwargs.pop(key, None)
+        servers = kwargs.get("mcp_servers")
+        if isinstance(servers, dict):
+            remaining = {
+                name: config
+                for name, config in servers.items()
+                if name not in _REQUEST_SCOPED_MCP_SERVERS
+            }
+            if remaining:
+                kwargs["mcp_servers"] = remaining
+            else:
+                kwargs.pop("mcp_servers", None)
+        snapshot_path = Path(snapshot_dir) / f"{branch.id}.json"
+        snapshot = branch.to_dict()
+        await asyncio.to_thread(_atomic_write_json, snapshot_path, snapshot)
+    finally:
+        kwargs.clear()
+        kwargs.update(original)
+
+
+def _message_text(message: Any) -> str | None:
+    """Best-effort final-message fallback for providers without delta chunks."""
+    for attr in ("response", "content"):
+        value = getattr(message, attr, None)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, dict):
+            for key in ("content", "text"):
+                text = value.get(key)
+                if isinstance(text, str) and text:
+                    return text
+    rendered = getattr(message, "rendered", None)
+    if isinstance(rendered, str) and rendered:
+        return rendered
+    return None
+
+
+class BranchOperatorEngine:
+    """Stream a fresh, bounded-context ``Branch.run`` for each durable turn.
+
+    The Branch is an execution detail, not the Operator conversation record.
+    Conversation continuity is reconstructed from durable frames supplied in
+    ``turn.history``.
+    """
+
+    def stream(self, turn: OperatorEngineTurn):
+        return self._stream(turn)
+
+    async def _stream(self, turn: OperatorEngineTurn):
+        provider = os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
+        if provider == "claude_code":
+            from lionagi.providers.anthropic.claude_code import CLAUDE_CLI
+
+            if not CLAUDE_CLI:
+                raise OperatorProviderUnavailableError(
+                    "Claude Code CLI is unavailable. Install it with "
+                    "`npm install -g @anthropic-ai/claude-code`, then run "
+                    "`claude auth login`."
+                )
+        branch = turn.runtime_branch or build_operator_branch(turn)
+        chat_model = branch.chat_model
+
+        prompt = _compile_operator_prompt(turn)
+
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        saw_text = False
+
+        async def on_chunk(chunk: Any) -> None:
+            nonlocal saw_text
+            typ = getattr(chunk, "type", None)
+            if typ == "text":
+                content = getattr(chunk, "content", None)
+                if content:
+                    saw_text = True
+                    await queue.put(
+                        OperatorEngineEvent(
+                            "text",
+                            {"content": str(content), "format": "markdown", "role": "assistant"},
+                        )
+                    )
+            elif typ == "tool_use":
+                tool_name = getattr(chunk, "tool_name", None) or "native_tool"
+                lowered = tool_name.lower()
+                mode = (
+                    "draft"
+                    if any(
+                        token in lowered
+                        for token in (
+                            "bash",
+                            "write",
+                            "edit",
+                            "notebook",
+                            "command",
+                            "launch",
+                            "navigate",
+                            "prefill",
+                        )
+                    )
+                    else "read"
+                )
+                await queue.put(
+                    OperatorEngineEvent(
+                        "tool_call",
+                        {
+                            "callId": getattr(chunk, "tool_id", None) or "",
+                            "tool": tool_name,
+                            "arguments": getattr(chunk, "tool_input", None) or {},
+                            "mode": mode,
+                        },
+                    )
+                )
+            elif typ == "tool_result":
+                await queue.put(
+                    OperatorEngineEvent(
+                        "tool_result",
+                        {
+                            "callId": getattr(chunk, "tool_id", None) or "",
+                            "ok": not bool(getattr(chunk, "is_error", False)),
+                            # Native output may contain secrets or unbounded logs.
+                            "result": {"nativeToolCompleted": True},
+                        },
+                    )
+                )
+
+        chat_model.streaming_process_func = on_chunk
+
+        async def consume() -> None:
+            final_text: str | None = None
+            try:
+                # The coordinator owns canonical Operator snapshots because
+                # Branch.run would serialize the live request-scoped MCP
+                # permission bridge. StateDB message hooks still persist each
+                # turn; the coordinator writes a sanitized snapshot at link
+                # publication and terminalization.
+                async for message in branch.run(prompt):
+                    candidate = _message_text(message)
+                    if candidate:
+                        final_text = candidate
+                if final_text and not saw_text:
+                    await queue.put(
+                        OperatorEngineEvent(
+                            "text",
+                            {"content": final_text, "format": "markdown", "role": "assistant"},
+                        )
+                    )
+            except BaseException as exc:
+                await queue.put(exc)
+            finally:
+                await queue.put(_END)
+
+        task = asyncio.create_task(consume(), name=f"operator-provider-{turn.request_id}")
+        try:
+            while True:
+                item = await queue.get()
+                if item is _END:
+                    break
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+        finally:
+            if not task.done():
+                task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await task
+
+
+def build_operator_branch(turn: OperatorEngineTurn):
+    """Build the real, permission-gated Branch used by a canonical turn run."""
+    from lionagi.service.manager import iModel
+    from lionagi.session.branch import Branch
+
+    provider = os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
+    model_name = os.environ.get("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet")
+    model_kwargs: dict[str, Any] = {}
+    if provider == "claude_code":
+        from .store import OperatorStore
+
+        db_path = turn.store_path or str(OperatorStore().path())
+        model_kwargs = {
+            "endpoint": "query_cli",
+            # Claude's own auth is used by the CLI endpoint.
+            "api_key": "dummy",
+            "permission_mode": "default",
+            "include_partial_messages": True,
+            # These request-scoped application tools are safe to invoke
+            # directly: reads are bounded, UI effects remain client-ACKed, and
+            # launch_playbook performs its own durable human proposal.
+            "allowed_tools": _OPERATOR_MCP_TOOLS,
+            "permission_prompt_tool_name": "mcp__studio_permission__request_permission",
+            "strict_mcp_config": True,
+            # Do not inherit project/user MCP servers into this privileged
+            # control-plane conversation.
+            "setting_sources": "",
+            "mcp_servers": {
+                "studio_permission": {
+                    "command": sys.executable,
+                    "args": ["-m", "lionagi.studio.operator.permission_mcp"],
+                    "env": {
+                        "LIONAGI_OPERATOR_DB_PATH": db_path,
+                        "LIONAGI_OPERATOR_CONVERSATION_ID": turn.conversation_id,
+                        "LIONAGI_OPERATOR_REQUEST_ID": turn.request_id,
+                    },
+                },
+                "studio_operator": {
+                    "command": sys.executable,
+                    "args": ["-m", "lionagi.studio.operator.application_mcp"],
+                    "env": {
+                        "LIONAGI_OPERATOR_DB_PATH": db_path,
+                        "LIONAGI_OPERATOR_CONVERSATION_ID": turn.conversation_id,
+                        "LIONAGI_OPERATOR_REQUEST_ID": turn.request_id,
+                    },
+                },
+            },
+        }
+    chat_model = iModel(provider=provider, model=model_name, **model_kwargs)
+    return Branch(system=_SYSTEM_PROMPT, chat_model=chat_model)

--- a/lionagi/studio/operator/permission_mcp.py
+++ b/lionagi/studio/operator/permission_mcp.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Dependency-free stdio MCP permission bridge for Claude Code.
+
+Claude invokes ``request_permission`` before gated native tool work. The helper
+persists the exact tool/input as an Operator proposal and polls the shared
+StateDB until the daemon's authenticated human-decision endpoint records allow
+or deny. Nothing is auto-approved in this subprocess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from typing import Any
+
+from .store import OperatorStore
+
+_TOOL_SCHEMA = {
+    "name": "request_permission",
+    "description": "Ask the Lion Studio human operator to allow or deny gated work.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "tool_name": {"type": "string"},
+            "input": {"type": "object"},
+            "tool_use_id": {"type": "string"},
+        },
+        "required": ["tool_name", "input", "tool_use_id"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _risk(tool_name: str) -> str:
+    lowered = tool_name.lower()
+    if any(part in lowered for part in ("bash", "command", "terminal", "execute")):
+        return "execute"
+    return "mutate"
+
+
+async def request_permission(arguments: dict[str, Any]) -> dict[str, Any]:
+    db_path = os.environ.get("LIONAGI_OPERATOR_DB_PATH")
+    conversation_id = os.environ.get("LIONAGI_OPERATOR_CONVERSATION_ID")
+    request_id = os.environ.get("LIONAGI_OPERATOR_REQUEST_ID")
+    if not db_path or not conversation_id or not request_id:
+        return {
+            "behavior": "deny",
+            "message": "Studio permission bridge is missing its durable turn identity",
+        }
+
+    tool_name = arguments.get("tool_name")
+    tool_input = arguments.get("input")
+    tool_use_id = arguments.get("tool_use_id")
+    if (
+        not isinstance(tool_name, str)
+        or not tool_name
+        or not isinstance(tool_input, dict)
+        or not isinstance(tool_use_id, str)
+        or not tool_use_id
+    ):
+        return {"behavior": "deny", "message": "Invalid permission request"}
+
+    command = {
+        "toolName": tool_name,
+        "input": tool_input,
+        "toolUseId": tool_use_id,
+    }
+    store = OperatorStore(db_path)
+    stable = store.canonical_hash(
+        {
+            "requestId": request_id,
+            "toolUseId": tool_use_id,
+            "toolName": tool_name,
+            "command": command,
+        }
+    )
+    proposal = await store.create_proposal(
+        conversation_id,
+        request_id,
+        command_type="provider_permission",
+        command=command,
+        risk=_risk(tool_name),
+        summary=f"Allow {tool_name} for this Operator turn",
+        idempotency_key=f"provider:{stable}",
+    )
+    while True:
+        proposal = await store.get_proposal(proposal["id"])
+        status = proposal["status"]
+        if status == "pending" and proposal["expiresAt"] <= time.time():
+            proposal = await store.expire_proposal(proposal["id"])
+            status = proposal["status"]
+        if status in {"confirmed", "succeeded"}:
+            return {"behavior": "allow", "updatedInput": tool_input}
+        if status in {"cancelled", "expired", "failed", "conflict"}:
+            return {
+                "behavior": "deny",
+                "message": "The Lion Studio operator denied this tool request",
+            }
+        await asyncio.sleep(0.1)
+
+
+async def _dispatch(message: dict[str, Any]) -> dict[str, Any] | None:
+    method = message.get("method")
+    message_id = message.get("id")
+    if message_id is None:
+        return None
+    if method == "initialize":
+        requested = (message.get("params") or {}).get("protocolVersion")
+        return {
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "result": {
+                "protocolVersion": requested or "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "studio-permission", "version": "1"},
+            },
+        }
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": message_id, "result": {}}
+    if method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "result": {"tools": [_TOOL_SCHEMA]},
+        }
+    if method == "tools/call":
+        params = message.get("params") or {}
+        if params.get("name") != "request_permission":
+            return {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {
+                    "content": [{"type": "text", "text": "Unknown permission tool"}],
+                    "isError": True,
+                },
+            }
+        try:
+            decision = await request_permission(params.get("arguments") or {})
+            return {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(decision, sort_keys=True, separators=(",", ":")),
+                        }
+                    ]
+                },
+            }
+        except Exception:  # noqa: BLE001
+            # The provider gets a stable denial; local paths/DB errors are never
+            # reflected into its prompt or the browser.
+            decision = {
+                "behavior": "deny",
+                "message": "Studio permission service is unavailable",
+            }
+            return {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(decision, sort_keys=True),
+                        }
+                    ],
+                    "isError": True,
+                },
+            }
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {"code": -32601, "message": f"Method not found: {method}"},
+    }
+
+
+async def _main() -> None:
+    while True:
+        line = await asyncio.to_thread(sys.stdin.buffer.readline)
+        if not line:
+            return
+        try:
+            message = json.loads(line)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        response = await _dispatch(message)
+        if response is not None:
+            rendered = json.dumps(response, sort_keys=True, separators=(",", ":"))
+            sys.stdout.write(rendered + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -6,6 +6,15 @@ These defensive ``CREATE TABLE IF NOT EXISTS`` statements intentionally make
 the protocol usable by direct Studio service callers as well as through the
 normal StateDB-opening daemon lifespan.  The tables use the canonical StateDB
 file and never fall back to process memory.
+
+Streamed frames are written once per provider chunk, so the durable record
+carries an explicit retention contract enforced on the write path -- see
+``MAX_FRAME_PAYLOAD_BYTES``, ``MAX_FRAMES_PER_TURN`` and
+``MAX_TURN_PAYLOAD_BYTES``.  Nothing is ever dropped silently: an oversized
+payload is stored truncated and says so, and frames refused past a turn's
+budget are counted into a single ``truncation`` summary frame naming what was
+elided and how much.  Terminal ``done`` frames are exempt so a turn can always
+be closed.
 """
 
 from __future__ import annotations
@@ -103,6 +112,13 @@ CREATE TABLE IF NOT EXISTS studio_operator_effects (
 );
 """
 
+# Durable retention contract for streamed frames, enforced in append_frame so
+# direct store callers cannot bypass it.
+MAX_FRAME_PAYLOAD_BYTES = 64 * 1024
+MAX_FRAMES_PER_TURN = 2000
+MAX_TURN_PAYLOAD_BYTES = 8 * 1024 * 1024
+TRUNCATION_FRAME_TYPE = "truncation"
+
 
 class OperatorStoreError(RuntimeError):
     code = "service_failure"
@@ -168,6 +184,52 @@ class OperatorStore:
     @staticmethod
     def _json(value: Any) -> str:
         return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+    @staticmethod
+    def _byte_len(text: str) -> int:
+        return len(text.encode("utf-8"))
+
+    @classmethod
+    def _truncate_strings(cls, value: Any, budget: int) -> Any:
+        if isinstance(value, str):
+            raw = value.encode("utf-8")
+            if len(raw) <= budget:
+                return value
+            kept = raw[:budget].decode("utf-8", "ignore")
+            elided = len(raw) - len(kept.encode("utf-8"))
+            return f"{kept}…[{elided} bytes elided]"
+        if isinstance(value, dict):
+            return {key: cls._truncate_strings(item, budget) for key, item in value.items()}
+        if isinstance(value, list):
+            return [cls._truncate_strings(item, budget) for item in value]
+        return value
+
+    @classmethod
+    def _cap_frame_payload(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        """Return a payload within ``MAX_FRAME_PAYLOAD_BYTES`` that states any elision."""
+        original_bytes = cls._byte_len(cls._json(payload))
+        if original_bytes <= MAX_FRAME_PAYLOAD_BYTES:
+            return payload
+        capped = cls._truncate_strings(payload, MAX_FRAME_PAYLOAD_BYTES // 2)
+        note = {
+            "reason": "frame_payload_bytes",
+            "limitBytes": MAX_FRAME_PAYLOAD_BYTES,
+            "originalBytes": original_bytes,
+        }
+        capped = {**capped, "truncation": note}
+        # Leave headroom for the storedBytes field added below.
+        if cls._byte_len(cls._json(capped)) > MAX_FRAME_PAYLOAD_BYTES - 64:
+            # The payload's own structure, not one long string, is oversized.
+            fields = sorted(map(str, payload))
+            capped = {
+                "truncation": {
+                    **note,
+                    "elidedFieldCount": len(fields),
+                    "elidedFields": [field[:64] for field in fields[:32]],
+                }
+            }
+        capped["truncation"]["storedBytes"] = cls._byte_len(cls._json(capped))
+        return capped
 
     @staticmethod
     def canonical_hash(value: Any) -> str:
@@ -557,6 +619,103 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
             "cancelRequestedAt": row["cancel_requested_at"],
         }
 
+    @staticmethod
+    async def _turn_budget_exceeded(db: Any, request_id: str, payload_bytes: int) -> str | None:
+        """Name the retention limit this frame would breach, or None if it fits."""
+        usage = await (
+            await db.execute(
+                "SELECT COUNT(*) AS frame_count, "
+                "COALESCE(SUM(LENGTH(CAST(payload_json AS BLOB))), 0) AS payload_bytes "
+                "FROM studio_operator_frames WHERE request_id=?",
+                (request_id,),
+            )
+        ).fetchone()
+        if int(usage["frame_count"]) >= MAX_FRAMES_PER_TURN:
+            return "frames_per_turn"
+        if int(usage["payload_bytes"]) + payload_bytes > MAX_TURN_PAYLOAD_BYTES:
+            return "turn_payload_bytes"
+        return None
+
+    async def _record_elided_frame(
+        self,
+        db: Any,
+        *,
+        conversation_id: str,
+        request_id: str,
+        frame_type: str,
+        payload_bytes: int,
+        sequence: int,
+        reason: str,
+        now: float,
+    ) -> dict[str, Any] | None:
+        """Fold one refused frame into the turn's single truncation summary frame."""
+        existing = await (
+            await db.execute(
+                "SELECT sequence, payload_json FROM studio_operator_frames "
+                "WHERE request_id=? AND frame_type=? LIMIT 1",
+                (request_id, TRUNCATION_FRAME_TYPE),
+            )
+        ).fetchone()
+        if existing is not None:
+            summary = json.loads(existing["payload_json"])
+            summary["elidedFrames"] = int(summary.get("elidedFrames", 0)) + 1
+            summary["elidedBytes"] = int(summary.get("elidedBytes", 0)) + payload_bytes
+            by_type = dict(summary.get("elidedFrameTypes") or {})
+            by_type[frame_type] = int(by_type.get(frame_type, 0)) + 1
+            summary["elidedFrameTypes"] = by_type
+            summary["lastElidedAt"] = now
+            await db.execute(
+                "UPDATE studio_operator_frames SET payload_json=? "
+                "WHERE request_id=? AND sequence=?",
+                (self._json(summary), request_id, existing["sequence"]),
+            )
+            await db.commit()
+            return None
+        summary = {
+            "reason": reason,
+            "limits": {
+                "maxFramesPerTurn": MAX_FRAMES_PER_TURN,
+                "maxTurnPayloadBytes": MAX_TURN_PAYLOAD_BYTES,
+                "maxFramePayloadBytes": MAX_FRAME_PAYLOAD_BYTES,
+            },
+            "elidedFrames": 1,
+            "elidedBytes": payload_bytes,
+            "elidedFrameTypes": {frame_type: 1},
+            "firstElidedAt": now,
+            "lastElidedAt": now,
+            "message": (
+                "This turn reached its durable retention limit; frames after this "
+                "point were not stored and are counted here."
+            ),
+        }
+        await db.execute(
+            "UPDATE studio_operator_conversations SET next_sequence=?, updated_at=? WHERE id=?",
+            (sequence + 1, now, conversation_id),
+        )
+        await db.execute(
+            "INSERT INTO studio_operator_frames "
+            "(conversation_id, sequence, request_id, frame_type, payload_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                conversation_id,
+                sequence,
+                request_id,
+                TRUNCATION_FRAME_TYPE,
+                self._json(summary),
+                now,
+            ),
+        )
+        await db.commit()
+        return {
+            "version": 1,
+            "conversationId": conversation_id,
+            "requestId": request_id,
+            "sequence": sequence,
+            "type": TRUNCATION_FRAME_TYPE,
+            "payload": summary,
+            "createdAt": now,
+        }
+
     async def append_frame(
         self,
         conversation_id: str,
@@ -564,7 +723,12 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
         frame_type: str,
         payload: dict[str, Any],
     ) -> dict[str, Any] | None:
-        """Insert before returning; returned frames are therefore safe to yield."""
+        """Insert before returning; returned frames are therefore safe to yield.
+
+        Enforces the per-turn retention contract: an oversized payload is stored
+        truncated, and once the turn's frame or byte budget is spent the frame is
+        folded into a single durable ``truncation`` summary instead of a new row.
+        """
         await self.ensure_schema()
         now = time.time()
         async with open_db(str(self.path())) as db:
@@ -590,9 +754,26 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
                 await db.rollback()
                 return None
             sequence = int(row["next_sequence"])
-            stored_payload = dict(payload)
+            stored_payload = self._cap_frame_payload(dict(payload))
             if frame_type == "done":
                 stored_payload["lastSequence"] = sequence
+            else:
+                over_budget = await self._turn_budget_exceeded(
+                    db,
+                    request_id,
+                    self._byte_len(self._json(stored_payload)),
+                )
+                if over_budget is not None:
+                    return await self._record_elided_frame(
+                        db,
+                        conversation_id=conversation_id,
+                        request_id=request_id,
+                        frame_type=frame_type,
+                        payload_bytes=self._byte_len(self._json(stored_payload)),
+                        sequence=sequence,
+                        reason=over_budget,
+                        now=now,
+                    )
             await db.execute(
                 "UPDATE studio_operator_conversations SET next_sequence=?, updated_at=? WHERE id=?",
                 (sequence + 1, now, conversation_id),

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -1,0 +1,1493 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""SQLite-backed durable store for the ADR-0083 Operator protocol.
+
+These defensive ``CREATE TABLE IF NOT EXISTS`` statements intentionally make
+the protocol usable by direct Studio service callers as well as through the
+normal StateDB-opening daemon lifespan.  The tables use the canonical StateDB
+file and never fall back to process memory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from lionagi.state import db as state_db_mod
+
+from ..services._db import open_db
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS studio_operator_conversations (
+  id                 TEXT PRIMARY KEY,
+  project            TEXT,
+  title              TEXT,
+  status             TEXT NOT NULL DEFAULT 'active'
+                     CHECK(status IN ('active', 'archived', 'deleted')),
+  next_sequence      INTEGER NOT NULL DEFAULT 1,
+  active_request_id  TEXT,
+  created_at         REAL NOT NULL,
+  updated_at         REAL NOT NULL,
+  archived_at        REAL,
+  deleted_at         REAL
+);
+
+CREATE TABLE IF NOT EXISTS studio_operator_turns (
+  request_id          TEXT PRIMARY KEY,
+  conversation_id    TEXT NOT NULL REFERENCES studio_operator_conversations(id),
+  instruction        TEXT NOT NULL,
+  context_json        TEXT NOT NULL,
+  context_hash        TEXT NOT NULL,
+  status              TEXT NOT NULL
+                      CHECK(status IN ('queued', 'running', 'awaiting_confirmation',
+                                       'completed', 'failed', 'cancelled')),
+  error_code          TEXT,
+  created_at          REAL NOT NULL,
+  started_at          REAL,
+  ended_at            REAL,
+  cancel_requested_at REAL
+);
+
+CREATE TABLE IF NOT EXISTS studio_operator_frames (
+  conversation_id   TEXT NOT NULL REFERENCES studio_operator_conversations(id),
+  sequence          INTEGER NOT NULL,
+  request_id        TEXT NOT NULL REFERENCES studio_operator_turns(request_id),
+  frame_type        TEXT NOT NULL,
+  payload_json      TEXT NOT NULL,
+  created_at        REAL NOT NULL,
+  PRIMARY KEY(conversation_id, sequence)
+);
+CREATE INDEX IF NOT EXISTS idx_operator_frames_request
+  ON studio_operator_frames(request_id, sequence);
+
+CREATE TABLE IF NOT EXISTS studio_operator_proposals (
+  id                 TEXT PRIMARY KEY,
+  conversation_id   TEXT NOT NULL REFERENCES studio_operator_conversations(id),
+  request_id         TEXT NOT NULL REFERENCES studio_operator_turns(request_id),
+  command_type       TEXT NOT NULL,
+  command_json       TEXT NOT NULL,
+  command_hash       TEXT NOT NULL,
+  target_version     TEXT,
+  risk               TEXT NOT NULL CHECK(risk IN ('mutate', 'execute', 'admin')),
+  summary            TEXT NOT NULL,
+  idempotency_key    TEXT NOT NULL UNIQUE,
+  status             TEXT NOT NULL
+                     CHECK(status IN ('pending', 'confirmed', 'executing', 'succeeded',
+                                      'failed', 'expired', 'cancelled', 'conflict')),
+  expires_at         REAL NOT NULL,
+  confirmed_at       REAL,
+  completed_at       REAL,
+  result_json        TEXT,
+  error_code         TEXT,
+  created_at         REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_operator_proposals_request
+  ON studio_operator_proposals(request_id, created_at);
+
+CREATE TABLE IF NOT EXISTS studio_operator_effects (
+  id                 TEXT PRIMARY KEY,
+  conversation_id   TEXT NOT NULL REFERENCES studio_operator_conversations(id),
+  request_id         TEXT NOT NULL REFERENCES studio_operator_turns(request_id),
+  effect_type        TEXT NOT NULL,
+  effect_json        TEXT NOT NULL,
+  status             TEXT NOT NULL DEFAULT 'pending'
+                     CHECK(status IN ('pending', 'applied', 'rejected', 'expired')),
+  emitted_at         REAL NOT NULL,
+  acknowledged_at    REAL,
+  rejection_code     TEXT
+);
+"""
+
+
+class OperatorStoreError(RuntimeError):
+    code = "service_failure"
+
+
+class OperatorNotFoundError(OperatorStoreError):
+    code = "not_found"
+
+
+class OperatorAuditUnavailableError(OperatorStoreError):
+    code = "audit_unavailable"
+
+
+class OperatorConflictError(OperatorStoreError):
+    code = "conflict"
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = details or {}
+
+
+class OperatorStore:
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self._db_path = Path(db_path) if db_path is not None else None
+        self._schema_ready: tuple[Path, int, int] | None = None
+        self._schema_lock = asyncio.Lock()
+
+    def path(self) -> Path:
+        if self._db_path is not None:
+            return self._db_path
+        path = state_db_mod.state_db_file()
+        if path is None:
+            raise OperatorStoreError(
+                "Studio Operator currently requires a local StateDB file; "
+                "no ephemeral fallback is available"
+            )
+        return path
+
+    async def ensure_schema(self) -> None:
+        path = self.path().resolve()
+        try:
+            stat = path.stat()
+            identity = (path, stat.st_dev, stat.st_ino)
+        except FileNotFoundError:
+            identity = None
+        if self._schema_ready == identity and identity is not None:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        async with self._schema_lock:
+            try:
+                stat = path.stat()
+                identity = (path, stat.st_dev, stat.st_ino)
+            except FileNotFoundError:
+                identity = None
+            if self._schema_ready == identity and identity is not None:
+                return
+            async with open_db(str(path)) as db:
+                await db.executescript(_SCHEMA)
+                await db.commit()
+            stat = path.stat()
+            self._schema_ready = (path, stat.st_dev, stat.st_ino)
+
+    @staticmethod
+    def _json(value: Any) -> str:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+    @staticmethod
+    def canonical_hash(value: Any) -> str:
+        return hashlib.sha256(OperatorStore._json(value).encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _conversation(row: Any) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "project": row["project"],
+            "title": row["title"],
+            "status": row["status"],
+            "nextSequence": row["next_sequence"],
+            "activeRequestId": row["active_request_id"],
+            "createdAt": row["created_at"],
+            "updatedAt": row["updated_at"],
+        }
+
+    @staticmethod
+    def _frame(row: Any) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "conversationId": row["conversation_id"],
+            "requestId": row["request_id"],
+            "sequence": row["sequence"],
+            "type": row["frame_type"],
+            "payload": json.loads(row["payload_json"]),
+            "createdAt": row["created_at"],
+        }
+
+    @staticmethod
+    def _proposal(row: Any) -> dict[str, Any]:
+        result = json.loads(row["result_json"]) if row["result_json"] else None
+        return {
+            "id": row["id"],
+            "conversationId": row["conversation_id"],
+            "requestId": row["request_id"],
+            "commandType": row["command_type"],
+            "command": json.loads(row["command_json"]),
+            "commandHash": row["command_hash"],
+            "targetVersion": row["target_version"],
+            "risk": row["risk"],
+            "summary": row["summary"],
+            "idempotencyKey": row["idempotency_key"],
+            "status": row["status"],
+            "expiresAt": row["expires_at"],
+            "confirmedAt": row["confirmed_at"],
+            "completedAt": row["completed_at"],
+            "result": result,
+            "errorCode": row["error_code"],
+            "createdAt": row["created_at"],
+        }
+
+    @staticmethod
+    def _proposal_target(
+        command_type: str,
+        command: dict[str, Any],
+        target_version: str | None,
+    ) -> dict[str, str] | None:
+        if target_version is None:
+            return None
+        if (
+            command_type == "launch"
+            and command.get("action_kind") == "play"
+            and isinstance(command.get("action_playbook"), str)
+        ):
+            return {
+                "kind": "playbook",
+                "id": command["action_playbook"],
+                "version": target_version,
+            }
+        return {
+            "kind": command_type,
+            "id": command_type,
+            "version": target_version,
+        }
+
+    @classmethod
+    def _proposal_audit_details(
+        cls,
+        row: Any,
+        *,
+        decision: str,
+        result: dict[str, Any] | None = None,
+        error_code: str | None = None,
+        confirmed_at: float | None = None,
+        completed_at: float | None = None,
+    ) -> dict[str, Any]:
+        """Build the exact ADR-0083 audit envelope from a proposal row."""
+        target = cls._proposal_target(
+            row["command_type"],
+            json.loads(row["command_json"]),
+            row["target_version"],
+        )
+        return {
+            "conversation_id": row["conversation_id"],
+            "request_id": row["request_id"],
+            "proposal_id": row["id"],
+            "command_type": row["command_type"],
+            "command_hash": row["command_hash"],
+            "target": target,
+            "risk": row["risk"],
+            "idempotency_key": row["idempotency_key"],
+            "decision": decision,
+            "result": result or {},
+            "error_code": error_code,
+            "confirmed_at": confirmed_at,
+            "completed_at": completed_at,
+        }
+
+    async def create_conversation(
+        self, *, project: str | None = None, title: str | None = None
+    ) -> dict[str, Any]:
+        await self.ensure_schema()
+        now = time.time()
+        conversation_id = str(uuid.uuid4())
+        async with open_db(str(self.path())) as db:
+            await db.execute(
+                "INSERT INTO studio_operator_conversations "
+                "(id, project, title, status, next_sequence, created_at, updated_at) "
+                "VALUES (?, ?, ?, 'active', 1, ?, ?)",
+                (conversation_id, project, title, now, now),
+            )
+            await db.commit()
+        return await self.get_conversation(conversation_id)
+
+    async def list_conversations(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            rows = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_conversations "
+                    "WHERE status != 'deleted' ORDER BY updated_at DESC LIMIT ?",
+                    (limit,),
+                )
+            ).fetchall()
+        return [self._conversation(row) for row in rows]
+
+    async def get_conversation(self, conversation_id: str) -> dict[str, Any]:
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            row = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_conversations WHERE id = ?",
+                    (conversation_id,),
+                )
+            ).fetchone()
+        if row is None or row["status"] == "deleted":
+            raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
+        return self._conversation(row)
+
+    async def archive_or_delete(self, conversation_id: str) -> None:
+        await self.ensure_schema()
+        now = time.time()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT status, active_request_id FROM studio_operator_conversations "
+                    "WHERE id = ?",
+                    (conversation_id,),
+                )
+            ).fetchone()
+            if row is None or row["status"] == "deleted":
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
+            if row["active_request_id"]:
+                await db.rollback()
+                raise OperatorConflictError("Cannot delete a conversation with an active turn")
+            await db.execute(
+                "UPDATE studio_operator_conversations SET status='deleted', deleted_at=?, "
+                "updated_at=? WHERE id=?",
+                (now, now, conversation_id),
+            )
+            await db.commit()
+
+    async def list_frames(
+        self, conversation_id: str, *, after_sequence: int = 0, limit: int = 1000
+    ) -> list[dict[str, Any]]:
+        await self.get_conversation(conversation_id)
+        async with open_db(str(self.path())) as db:
+            rows = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_frames "
+                    "WHERE conversation_id=? AND sequence>? "
+                    "ORDER BY sequence ASC LIMIT ?",
+                    (conversation_id, after_sequence, limit),
+                )
+            ).fetchall()
+        return [self._frame(row) for row in rows]
+
+    async def list_recent_frames(
+        self, conversation_id: str, *, limit: int = 64
+    ) -> list[dict[str, Any]]:
+        """Return the newest ``limit`` frames, ordered chronologically."""
+        await self.get_conversation(conversation_id)
+        async with open_db(str(self.path())) as db:
+            rows = await (
+                await db.execute(
+                    "SELECT * FROM (SELECT * FROM studio_operator_frames "
+                    "WHERE conversation_id=? ORDER BY sequence DESC LIMIT ?) "
+                    "ORDER BY sequence ASC",
+                    (conversation_id, limit),
+                )
+            ).fetchall()
+        return [self._frame(row) for row in rows]
+
+    async def list_complete_turn_frame_groups(
+        self,
+        conversation_id: str,
+        *,
+        exclude_request_id: str,
+        limit: int = 64,
+    ) -> list[tuple[dict[str, Any], ...]]:
+        """Return recent durable turn frames, grouped newest-complete-turn first."""
+        await self.get_conversation(conversation_id)
+        bounded_limit = max(1, min(limit, 64))
+        async with open_db(str(self.path())) as db:
+            requests = await (
+                await db.execute(
+                    "SELECT t.request_id, MAX(f.sequence) AS terminal_sequence "
+                    "FROM studio_operator_turns AS t "
+                    "JOIN studio_operator_frames AS f "
+                    "ON f.request_id=t.request_id AND f.frame_type='done' "
+                    "WHERE t.conversation_id=? AND t.request_id!=? "
+                    "AND t.status IN ('completed','failed','cancelled') "
+                    "GROUP BY t.request_id "
+                    "ORDER BY terminal_sequence DESC LIMIT ?",
+                    (conversation_id, exclude_request_id, bounded_limit),
+                )
+            ).fetchall()
+            request_ids = [str(row["request_id"]) for row in requests]
+            if not request_ids:
+                return []
+            placeholders = ",".join("?" for _ in request_ids)
+            query = f"""\
+SELECT * FROM studio_operator_frames
+WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
+"""  # noqa: S608
+            rows = await (await db.execute(query, tuple(request_ids))).fetchall()
+
+        grouped: dict[str, list[dict[str, Any]]] = {request_id: [] for request_id in request_ids}
+        for row in rows:
+            grouped[str(row["request_id"])].append(self._frame(row))
+        return [tuple(grouped[request_id]) for request_id in request_ids]
+
+    async def record_context_compilation(
+        self, request_id: str, metadata: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Persist the exact durable-frame compilation receipt for one turn."""
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT context_json FROM studio_operator_turns WHERE request_id=?",
+                    (request_id,),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator request '{request_id}' not found")
+            context = json.loads(row["context_json"])
+            context["operatorCompilation"] = dict(metadata)
+            context_json = self._json(context)
+            await db.execute(
+                "UPDATE studio_operator_turns SET context_json=?, context_hash=? "
+                "WHERE request_id=?",
+                (context_json, self.canonical_hash(context), request_id),
+            )
+            await db.commit()
+        return context
+
+    async def submit_turn(
+        self,
+        conversation_id: str,
+        *,
+        instruction: str,
+        context: dict[str, Any],
+        expected_last_sequence: int,
+    ) -> dict[str, Any]:
+        await self.ensure_schema()
+        request_id = str(uuid.uuid4())
+        now = time.time()
+        context_json = self._json(context)
+        context_hash = self.canonical_hash(context)
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT status, next_sequence, active_request_id "
+                    "FROM studio_operator_conversations WHERE id=?",
+                    (conversation_id,),
+                )
+            ).fetchone()
+            if row is None or row["status"] == "deleted":
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
+            if row["status"] != "active":
+                await db.rollback()
+                raise OperatorConflictError("Archived Operator conversations are read-only")
+            if row["active_request_id"] is not None:
+                await db.rollback()
+                raise OperatorConflictError(
+                    "This conversation already has an active turn",
+                    details={"activeRequestId": row["active_request_id"]},
+                )
+            actual_last = int(row["next_sequence"]) - 1
+            if expected_last_sequence != actual_last:
+                await db.rollback()
+                raise OperatorConflictError(
+                    "Conversation cursor is stale",
+                    details={
+                        "code": "stale_context",
+                        "expectedLastSequence": expected_last_sequence,
+                        "actualLastSequence": actual_last,
+                    },
+                )
+            sequence = int(row["next_sequence"])
+            await db.execute(
+                "INSERT INTO studio_operator_turns "
+                "(request_id, conversation_id, instruction, context_json, context_hash, "
+                "status, created_at) VALUES (?, ?, ?, ?, ?, 'queued', ?)",
+                (request_id, conversation_id, instruction, context_json, context_hash, now),
+            )
+            await db.execute(
+                "UPDATE studio_operator_conversations SET active_request_id=?, "
+                "next_sequence=?, updated_at=? WHERE id=? AND active_request_id IS NULL",
+                (request_id, sequence + 1, now, conversation_id),
+            )
+            await db.execute(
+                "INSERT INTO studio_operator_frames "
+                "(conversation_id, sequence, request_id, frame_type, payload_json, created_at) "
+                "VALUES (?, ?, ?, 'text', ?, ?)",
+                (
+                    conversation_id,
+                    sequence,
+                    request_id,
+                    self._json(
+                        {
+                            "content": instruction,
+                            "format": "plain",
+                            # Additive discriminator used by the chat renderer.
+                            "role": "user",
+                        }
+                    ),
+                    now,
+                ),
+            )
+            await db.commit()
+        return {
+            "conversationId": conversation_id,
+            "requestId": request_id,
+            "acceptedSequence": sequence,
+        }
+
+    async def mark_running(self, request_id: str) -> bool:
+        await self.ensure_schema()
+        now = time.time()
+        async with open_db(str(self.path())) as db:
+            cur = await db.execute(
+                "UPDATE studio_operator_turns SET status='running', started_at=? "
+                "WHERE request_id=? AND status='queued'",
+                (now, request_id),
+            )
+            await db.commit()
+        return cur.rowcount == 1
+
+    async def get_turn(self, request_id: str) -> dict[str, Any]:
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            row = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_turns WHERE request_id=?", (request_id,)
+                )
+            ).fetchone()
+        if row is None:
+            raise OperatorNotFoundError(f"Operator request '{request_id}' not found")
+        return {
+            "requestId": row["request_id"],
+            "conversationId": row["conversation_id"],
+            "instruction": row["instruction"],
+            "context": json.loads(row["context_json"]),
+            "contextHash": row["context_hash"],
+            "status": row["status"],
+            "errorCode": row["error_code"],
+            "cancelRequestedAt": row["cancel_requested_at"],
+        }
+
+    async def append_frame(
+        self,
+        conversation_id: str,
+        request_id: str,
+        frame_type: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Insert before returning; returned frames are therefore safe to yield."""
+        await self.ensure_schema()
+        now = time.time()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            terminal = await (
+                await db.execute(
+                    "SELECT 1 FROM studio_operator_frames "
+                    "WHERE request_id=? AND frame_type='done' LIMIT 1",
+                    (request_id,),
+                )
+            ).fetchone()
+            if terminal is not None:
+                await db.rollback()
+                return None
+            row = await (
+                await db.execute(
+                    "SELECT next_sequence FROM studio_operator_conversations "
+                    "WHERE id=? AND active_request_id=?",
+                    (conversation_id, request_id),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                return None
+            sequence = int(row["next_sequence"])
+            stored_payload = dict(payload)
+            if frame_type == "done":
+                stored_payload["lastSequence"] = sequence
+            await db.execute(
+                "UPDATE studio_operator_conversations SET next_sequence=?, updated_at=? WHERE id=?",
+                (sequence + 1, now, conversation_id),
+            )
+            await db.execute(
+                "INSERT INTO studio_operator_frames "
+                "(conversation_id, sequence, request_id, frame_type, payload_json, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    conversation_id,
+                    sequence,
+                    request_id,
+                    frame_type,
+                    self._json(stored_payload),
+                    now,
+                ),
+            )
+            await db.commit()
+        return {
+            "version": 1,
+            "conversationId": conversation_id,
+            "requestId": request_id,
+            "sequence": sequence,
+            "type": frame_type,
+            "payload": stored_payload,
+            "createdAt": now,
+        }
+
+    async def append_effect(
+        self,
+        conversation_id: str,
+        request_id: str,
+        effect: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Persist one pending UI effect and its frame in the same transaction."""
+        await self.ensure_schema()
+        kind = effect.get("kind")
+        if kind not in {"navigate", "select", "prefill", "theme"}:
+            raise OperatorConflictError("Operator emitted an unsupported UI effect")
+        effect_id = str(uuid.uuid4())
+        stored_effect = {**effect, "id": effect_id}
+        payload = {"effect": stored_effect}
+        now = time.time()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            terminal = await (
+                await db.execute(
+                    "SELECT 1 FROM studio_operator_frames "
+                    "WHERE request_id=? AND frame_type='done' LIMIT 1",
+                    (request_id,),
+                )
+            ).fetchone()
+            row = await (
+                await db.execute(
+                    "SELECT next_sequence FROM studio_operator_conversations "
+                    "WHERE id=? AND active_request_id=?",
+                    (conversation_id, request_id),
+                )
+            ).fetchone()
+            if terminal is not None or row is None:
+                await db.rollback()
+                return None
+            sequence = int(row["next_sequence"])
+            await db.execute(
+                "INSERT INTO studio_operator_effects "
+                "(id, conversation_id, request_id, effect_type, effect_json, "
+                "status, emitted_at) VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+                (
+                    effect_id,
+                    conversation_id,
+                    request_id,
+                    str(kind),
+                    self._json(stored_effect),
+                    now,
+                ),
+            )
+            await db.execute(
+                "UPDATE studio_operator_conversations SET next_sequence=?, updated_at=? WHERE id=?",
+                (sequence + 1, now, conversation_id),
+            )
+            await db.execute(
+                "INSERT INTO studio_operator_frames "
+                "(conversation_id, sequence, request_id, frame_type, payload_json, created_at) "
+                "VALUES (?, ?, ?, 'ui_command', ?, ?)",
+                (conversation_id, sequence, request_id, self._json(payload), now),
+            )
+            await db.commit()
+        return {
+            "version": 1,
+            "conversationId": conversation_id,
+            "requestId": request_id,
+            "sequence": sequence,
+            "type": "ui_command",
+            "payload": payload,
+            "createdAt": now,
+        }
+
+    async def finish_turn(
+        self,
+        request_id: str,
+        *,
+        outcome: str,
+        error: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Append optional error + exactly one done and clear the active CAS."""
+        await self.ensure_schema()
+        now = time.time()
+        inserted: list[dict[str, Any]] = []
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            turn = await (
+                await db.execute(
+                    "SELECT conversation_id FROM studio_operator_turns WHERE request_id=?",
+                    (request_id,),
+                )
+            ).fetchone()
+            if turn is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator request '{request_id}' not found")
+            conversation_id = turn["conversation_id"]
+            existing = await (
+                await db.execute(
+                    "SELECT 1 FROM studio_operator_frames "
+                    "WHERE request_id=? AND frame_type='done' LIMIT 1",
+                    (request_id,),
+                )
+            ).fetchone()
+            if existing is not None:
+                await db.rollback()
+                return []
+            conv = await (
+                await db.execute(
+                    "SELECT next_sequence FROM studio_operator_conversations WHERE id=?",
+                    (conversation_id,),
+                )
+            ).fetchone()
+            sequence = int(conv["next_sequence"])
+            unfinished_proposals = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals "
+                    "WHERE request_id=? AND status IN ('pending','confirmed')",
+                    (request_id,),
+                )
+            ).fetchall()
+            confirmed_without_result = [
+                proposal
+                for proposal in unfinished_proposals
+                if proposal["status"] == "confirmed" and outcome != "cancelled"
+            ]
+            terminal_error = error
+            if confirmed_without_result and outcome == "completed":
+                outcome = "failed"
+                terminal_error = {
+                    "code": "service_failure",
+                    "message": (
+                        "The provider ended without returning a terminal result "
+                        "for an approved tool"
+                    ),
+                    "retryable": False,
+                }
+            status = {
+                "completed": "completed",
+                "failed": "failed",
+                "cancelled": "cancelled",
+            }[outcome]
+            missing_result_error = {
+                "code": "service_failure",
+                "message": (
+                    "The provider ended without returning a terminal result for this approved tool"
+                ),
+                "retryable": False,
+            }
+            for proposal in confirmed_without_result:
+                command = json.loads(proposal["command_json"])
+                call_id = command.get("toolUseId") or proposal["id"]
+                payload = {
+                    "callId": call_id,
+                    "ok": False,
+                    "error": missing_result_error,
+                }
+                await db.execute(
+                    "INSERT INTO studio_operator_frames "
+                    "(conversation_id, sequence, request_id, frame_type, "
+                    "payload_json, created_at) "
+                    "VALUES (?, ?, ?, 'tool_result', ?, ?)",
+                    (
+                        conversation_id,
+                        sequence,
+                        request_id,
+                        self._json(payload),
+                        now,
+                    ),
+                )
+                inserted.append(
+                    {
+                        "version": 1,
+                        "conversationId": conversation_id,
+                        "requestId": request_id,
+                        "sequence": sequence,
+                        "type": "tool_result",
+                        "payload": payload,
+                        "createdAt": now,
+                    }
+                )
+                sequence += 1
+            if terminal_error is not None:
+                await db.execute(
+                    "INSERT INTO studio_operator_frames "
+                    "(conversation_id, sequence, request_id, frame_type, payload_json, created_at) "
+                    "VALUES (?, ?, ?, 'error', ?, ?)",
+                    (
+                        conversation_id,
+                        sequence,
+                        request_id,
+                        self._json({"error": terminal_error}),
+                        now,
+                    ),
+                )
+                inserted.append(
+                    {
+                        "version": 1,
+                        "conversationId": conversation_id,
+                        "requestId": request_id,
+                        "sequence": sequence,
+                        "type": "error",
+                        "payload": {"error": terminal_error},
+                        "createdAt": now,
+                    }
+                )
+                sequence += 1
+            done_payload = {"outcome": outcome, "lastSequence": sequence}
+            await db.execute(
+                "INSERT INTO studio_operator_frames "
+                "(conversation_id, sequence, request_id, frame_type, payload_json, created_at) "
+                "VALUES (?, ?, ?, 'done', ?, ?)",
+                (conversation_id, sequence, request_id, self._json(done_payload), now),
+            )
+            inserted.append(
+                {
+                    "version": 1,
+                    "conversationId": conversation_id,
+                    "requestId": request_id,
+                    "sequence": sequence,
+                    "type": "done",
+                    "payload": done_payload,
+                    "createdAt": now,
+                }
+            )
+            await db.execute(
+                "UPDATE studio_operator_turns SET status=?, error_code=?, ended_at=? "
+                "WHERE request_id=?",
+                (
+                    status,
+                    terminal_error["code"] if terminal_error else None,
+                    now,
+                    request_id,
+                ),
+            )
+            for proposal in unfinished_proposals:
+                was_pending = proposal["status"] == "pending"
+                proposal_status = "cancelled" if was_pending else "failed"
+                proposal_error = (
+                    "cancelled"
+                    if was_pending or outcome == "cancelled"
+                    else "provider_result_missing"
+                )
+                decision = "denied" if was_pending else "indeterminate"
+                details = self._proposal_audit_details(
+                    proposal,
+                    decision=decision,
+                    error_code=proposal_error,
+                    confirmed_at=proposal["confirmed_at"],
+                    completed_at=now,
+                )
+                await db.execute(
+                    "INSERT INTO admin_events "
+                    "(id, created_at, action, target_id, details, actor) "
+                    "VALUES (?, ?, 'studio.operator.command', ?, ?, 'studio_operator')",
+                    (
+                        uuid.uuid4().hex[:12],
+                        now,
+                        proposal["id"],
+                        self._json(details),
+                    ),
+                )
+                await db.execute(
+                    "UPDATE studio_operator_proposals SET status=?, completed_at=?, "
+                    "error_code=? WHERE id=? AND status=?",
+                    (
+                        proposal_status,
+                        now,
+                        proposal_error,
+                        proposal["id"],
+                        proposal["status"],
+                    ),
+                )
+            await db.execute(
+                "UPDATE studio_operator_conversations SET active_request_id=NULL, "
+                "next_sequence=?, updated_at=? "
+                "WHERE id=? AND active_request_id=?",
+                (sequence + 1, now, conversation_id, request_id),
+            )
+            await db.commit()
+        return inserted
+
+    async def request_cancel(self, conversation_id: str, request_id: str) -> dict[str, Any]:
+        await self.ensure_schema()
+        now = time.time()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT status FROM studio_operator_turns "
+                    "WHERE request_id=? AND conversation_id=?",
+                    (request_id, conversation_id),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator request '{request_id}' not found")
+            terminal = row["status"] in {"completed", "failed", "cancelled"}
+            if not terminal:
+                await db.execute(
+                    "UPDATE studio_operator_turns SET cancel_requested_at=COALESCE("
+                    "cancel_requested_at, ?) WHERE request_id=?",
+                    (now, request_id),
+                )
+            await db.commit()
+        return {
+            "conversationId": conversation_id,
+            "requestId": request_id,
+            "status": row["status"],
+            "cancelRequested": not terminal,
+        }
+
+    async def create_proposal(
+        self,
+        conversation_id: str,
+        request_id: str,
+        *,
+        command_type: str,
+        command: dict[str, Any],
+        risk: str,
+        summary: str,
+        idempotency_key: str | None = None,
+        target_version: str | None = None,
+    ) -> dict[str, Any]:
+        await self.ensure_schema()
+        proposal_id = str(uuid.uuid4())
+        idempotency_key = idempotency_key or str(uuid.uuid4())
+        command_hash = self.canonical_hash(command)
+        now = time.time()
+        expires_at = now + 600
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            existing = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals WHERE idempotency_key=?",
+                    (idempotency_key,),
+                )
+            ).fetchone()
+            if existing is not None:
+                await db.rollback()
+                same_proposal = (
+                    existing["conversation_id"] == conversation_id
+                    and existing["request_id"] == request_id
+                    and existing["command_type"] == command_type
+                    and existing["command_json"] == self._json(command)
+                    and existing["command_hash"] == command_hash
+                    and existing["target_version"] == target_version
+                    and existing["risk"] == risk
+                )
+                if not same_proposal:
+                    raise OperatorConflictError(
+                        "Idempotency key was reused for a different Operator proposal",
+                        details={
+                            "idempotencyKey": idempotency_key,
+                            "existingProposalId": existing["id"],
+                        },
+                    )
+                return self._proposal(existing)
+            turn = await (
+                await db.execute(
+                    "SELECT status FROM studio_operator_turns "
+                    "WHERE request_id=? AND conversation_id=?",
+                    (request_id, conversation_id),
+                )
+            ).fetchone()
+            if turn is None or turn["status"] not in {"running", "awaiting_confirmation"}:
+                await db.rollback()
+                raise OperatorConflictError("Permission request is not attached to a running turn")
+            await db.execute(
+                "INSERT INTO studio_operator_proposals "
+                "(id, conversation_id, request_id, command_type, command_json, command_hash, "
+                "target_version, risk, summary, idempotency_key, status, expires_at, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)",
+                (
+                    proposal_id,
+                    conversation_id,
+                    request_id,
+                    command_type,
+                    self._json(command),
+                    command_hash,
+                    target_version,
+                    risk,
+                    summary,
+                    idempotency_key,
+                    expires_at,
+                    now,
+                ),
+            )
+            await db.execute(
+                "UPDATE studio_operator_turns SET status='awaiting_confirmation' "
+                "WHERE request_id=? AND status='running'",
+                (request_id,),
+            )
+            await db.commit()
+        proposal = await self.get_proposal(proposal_id)
+        await self.append_frame(
+            conversation_id,
+            request_id,
+            "proposal",
+            {
+                "proposal": {
+                    "id": proposal_id,
+                    "command": command,
+                    "commandHash": command_hash,
+                    "risk": risk,
+                    "summary": summary,
+                    "target": self._proposal_target(
+                        command_type,
+                        command,
+                        target_version,
+                    ),
+                    "idempotencyKey": idempotency_key,
+                    "expiresAt": expires_at,
+                }
+            },
+        )
+        await self.append_frame(
+            conversation_id,
+            request_id,
+            "confirmation",
+            {"proposalId": proposal_id, "state": "required"},
+        )
+        return proposal
+
+    async def get_proposal(self, proposal_id: str) -> dict[str, Any]:
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            row = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals WHERE id=?", (proposal_id,)
+                )
+            ).fetchone()
+        if row is None:
+            raise OperatorNotFoundError(f"Operator proposal '{proposal_id}' not found")
+        return self._proposal(row)
+
+    async def find_proposal_by_idempotency(self, idempotency_key: str) -> dict[str, Any] | None:
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            row = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals WHERE idempotency_key=?",
+                    (idempotency_key,),
+                )
+            ).fetchone()
+        return self._proposal(row) if row is not None else None
+
+    async def list_proposals_for_request(self, request_id: str) -> list[dict[str, Any]]:
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            rows = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals WHERE request_id=? "
+                    "ORDER BY created_at ASC",
+                    (request_id,),
+                )
+            ).fetchall()
+        return [self._proposal(row) for row in rows]
+
+    async def decide_proposal(
+        self,
+        conversation_id: str,
+        proposal_id: str,
+        *,
+        allow: bool,
+        expected_command_hash: str | None,
+        expected_target_version: str | None,
+        audit: bool = False,
+        claim_execution: bool = False,
+    ) -> dict[str, Any]:
+        await self.ensure_schema()
+        now = time.time()
+        transitioned = False
+        claimed_execution = False
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals WHERE id=? AND conversation_id=?",
+                    (proposal_id, conversation_id),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator proposal '{proposal_id}' not found")
+            conversation = await (
+                await db.execute(
+                    "SELECT status FROM studio_operator_conversations WHERE id=?",
+                    (conversation_id,),
+                )
+            ).fetchone()
+            if conversation is None or conversation["status"] != "active":
+                await db.rollback()
+                raise OperatorConflictError("Operator conversation is no longer active")
+            if allow and expected_command_hash is None:
+                await db.rollback()
+                raise OperatorConflictError("Proposal command hash is required before execution")
+            if expected_command_hash and expected_command_hash != row["command_hash"]:
+                await db.rollback()
+                raise OperatorConflictError("Proposal command hash does not match")
+            if expected_target_version != row["target_version"]:
+                await db.rollback()
+                raise OperatorConflictError("Proposal target version changed")
+            if row["expires_at"] <= now and row["status"] == "pending":
+                if audit:
+                    details = self._proposal_audit_details(
+                        row,
+                        decision="expired",
+                        error_code="stale_context",
+                        confirmed_at=None,
+                        completed_at=now,
+                    )
+                    await db.execute(
+                        "INSERT INTO admin_events "
+                        "(id, created_at, action, target_id, details, actor) "
+                        "VALUES (?, ?, 'studio.operator.command', ?, ?, 'studio_operator')",
+                        (
+                            uuid.uuid4().hex[:12],
+                            now,
+                            proposal_id,
+                            self._json(details),
+                        ),
+                    )
+                await db.execute(
+                    "UPDATE studio_operator_proposals SET status='expired', "
+                    "completed_at=?, error_code='stale_context' WHERE id=?",
+                    (now, proposal_id),
+                )
+                await db.execute(
+                    "UPDATE studio_operator_turns SET status='running' "
+                    "WHERE request_id=? AND status='awaiting_confirmation'",
+                    (row["request_id"],),
+                )
+                await db.commit()
+                transitioned = True
+                expired = True
+            else:
+                expired = False
+            if expired:
+                pass
+            elif row["status"] != "pending":
+                await db.rollback()
+                existing = self._proposal(row)
+                existing["_claimedExecution"] = False
+                return existing
+            else:
+                status = (
+                    (
+                        "executing"
+                        if claim_execution and row["command_type"] != "provider_permission"
+                        else "confirmed"
+                    )
+                    if allow
+                    else "cancelled"
+                )
+                if audit:
+                    audit_details = self._proposal_audit_details(
+                        row,
+                        decision="confirmed" if allow else "denied",
+                        error_code=None if allow else "denied",
+                        confirmed_at=now,
+                        completed_at=now if not allow else None,
+                    )
+                    await db.execute(
+                        "INSERT INTO admin_events "
+                        "(id, created_at, action, target_id, details, actor) "
+                        "VALUES (?, ?, 'studio.operator.command', ?, ?, 'studio_operator')",
+                        (
+                            uuid.uuid4().hex[:12],
+                            now,
+                            proposal_id,
+                            self._json(audit_details),
+                        ),
+                    )
+                await db.execute(
+                    "UPDATE studio_operator_proposals SET status=?, confirmed_at=?, "
+                    "completed_at=CASE WHEN ?='cancelled' THEN ? ELSE completed_at END, "
+                    "error_code=CASE WHEN ?='cancelled' THEN 'denied' ELSE error_code END "
+                    "WHERE id=? AND status='pending'",
+                    (status, now, status, now, status, proposal_id),
+                )
+                await db.execute(
+                    "UPDATE studio_operator_turns SET status='running' "
+                    "WHERE request_id=? AND status='awaiting_confirmation'",
+                    (row["request_id"],),
+                )
+                await db.commit()
+                transitioned = True
+                claimed_execution = status == "executing"
+        if expired:
+            await self.append_frame(
+                conversation_id,
+                row["request_id"],
+                "confirmation",
+                {"proposalId": proposal_id, "state": "expired"},
+            )
+        elif transitioned and allow:
+            await self.append_frame(
+                conversation_id,
+                row["request_id"],
+                "confirmation",
+                {"proposalId": proposal_id, "state": "confirmed"},
+            )
+        elif transitioned:
+            await self.append_frame(
+                conversation_id,
+                row["request_id"],
+                "confirmation",
+                {"proposalId": proposal_id, "state": "cancelled"},
+            )
+            await self.append_frame(
+                conversation_id,
+                row["request_id"],
+                "error",
+                {
+                    "error": {
+                        "code": "denied",
+                        "message": "The operator denied this permission request",
+                        "retryable": False,
+                    }
+                },
+            )
+        proposal = await self.get_proposal(proposal_id)
+        proposal["_claimedExecution"] = claimed_execution
+        return proposal
+
+    async def complete_proposal(
+        self,
+        proposal_id: str,
+        *,
+        status: str,
+        result: dict[str, Any] | None = None,
+        error_code: str | None = None,
+        audit: bool = False,
+    ) -> dict[str, Any]:
+        await self.ensure_schema()
+        now = time.time()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals WHERE id=?",
+                    (proposal_id,),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator proposal '{proposal_id}' not found")
+            cur = await db.execute(
+                "UPDATE studio_operator_proposals SET status=?, result_json=?, "
+                "error_code=?, completed_at=? WHERE id=? "
+                "AND status IN ('confirmed','executing')",
+                (
+                    status,
+                    self._json(result) if result is not None else None,
+                    error_code,
+                    now,
+                    proposal_id,
+                ),
+            )
+            if cur.rowcount and audit:
+                details = self._proposal_audit_details(
+                    row,
+                    decision="executed" if status == "succeeded" else "failed",
+                    result=result,
+                    error_code=error_code,
+                    confirmed_at=row["confirmed_at"],
+                    completed_at=now,
+                )
+                await db.execute(
+                    "INSERT INTO admin_events "
+                    "(id, created_at, action, target_id, details, actor) "
+                    "VALUES (?, ?, 'studio.operator.command', ?, ?, 'studio_operator')",
+                    (
+                        uuid.uuid4().hex[:12],
+                        now,
+                        proposal_id,
+                        self._json(details),
+                    ),
+                )
+            await db.commit()
+        return await self.get_proposal(proposal_id)
+
+    async def complete_provider_permission(
+        self,
+        request_id: str,
+        tool_use_id: str,
+        *,
+        ok: bool,
+    ) -> dict[str, Any] | None:
+        """Terminalize the confirmed provider proposal for one native tool result."""
+        if not tool_use_id:
+            return None
+        await self.ensure_schema()
+        now = time.time()
+        matched_id: str | None = None
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            rows = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals "
+                    "WHERE request_id=? AND command_type='provider_permission' "
+                    "AND status='confirmed'",
+                    (request_id,),
+                )
+            ).fetchall()
+            row = next(
+                (
+                    candidate
+                    for candidate in rows
+                    if json.loads(candidate["command_json"]).get("toolUseId") == tool_use_id
+                ),
+                None,
+            )
+            if row is None:
+                await db.rollback()
+                return None
+            matched_id = row["id"]
+            status = "succeeded" if ok else "failed"
+            result = {"nativeToolCompleted": ok}
+            error_code = None if ok else "provider_tool_failed"
+            cur = await db.execute(
+                "UPDATE studio_operator_proposals SET status=?, result_json=?, "
+                "error_code=?, completed_at=? WHERE id=? AND status='confirmed'",
+                (
+                    status,
+                    self._json(result),
+                    error_code,
+                    now,
+                    matched_id,
+                ),
+            )
+            if not cur.rowcount:
+                await db.rollback()
+                return None
+            details = self._proposal_audit_details(
+                row,
+                decision="executed" if ok else "failed",
+                result=result,
+                error_code=error_code,
+                confirmed_at=row["confirmed_at"],
+                completed_at=now,
+            )
+            await db.execute(
+                "INSERT INTO admin_events "
+                "(id, created_at, action, target_id, details, actor) "
+                "VALUES (?, ?, 'studio.operator.command', ?, ?, 'studio_operator')",
+                (
+                    uuid.uuid4().hex[:12],
+                    now,
+                    matched_id,
+                    self._json(details),
+                ),
+            )
+            await db.commit()
+        return await self.get_proposal(matched_id)
+
+    async def expire_proposal(self, proposal_id: str) -> dict[str, Any]:
+        """Expire one still-pending proposal and release its waiting turn."""
+        await self.ensure_schema()
+        now = time.time()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_proposals WHERE id=?",
+                    (proposal_id,),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator proposal '{proposal_id}' not found")
+            cur = await db.execute(
+                "UPDATE studio_operator_proposals SET status='expired', "
+                "completed_at=?, error_code='stale_context' "
+                "WHERE id=? AND status='pending' AND expires_at<=?",
+                (now, proposal_id, now),
+            )
+            if cur.rowcount:
+                details = self._proposal_audit_details(
+                    row,
+                    decision="expired",
+                    error_code="stale_context",
+                    confirmed_at=None,
+                    completed_at=now,
+                )
+                await db.execute(
+                    "INSERT INTO admin_events "
+                    "(id, created_at, action, target_id, details, actor) "
+                    "VALUES (?, ?, 'studio.operator.command', ?, ?, 'studio_operator')",
+                    (
+                        uuid.uuid4().hex[:12],
+                        now,
+                        proposal_id,
+                        self._json(details),
+                    ),
+                )
+                await db.execute(
+                    "UPDATE studio_operator_turns SET status='running' "
+                    "WHERE request_id=? AND status='awaiting_confirmation'",
+                    (row["request_id"],),
+                )
+            await db.commit()
+        if cur.rowcount:
+            await self.append_frame(
+                row["conversation_id"],
+                row["request_id"],
+                "confirmation",
+                {"proposalId": proposal_id, "state": "expired"},
+            )
+        return await self.get_proposal(proposal_id)
+
+    async def recover_interrupted_turns(self) -> list[str]:
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            rows = await (
+                await db.execute(
+                    "SELECT request_id FROM studio_operator_turns "
+                    "WHERE status IN ('queued','running','awaiting_confirmation')"
+                )
+            ).fetchall()
+        recovered: list[str] = []
+        for row in rows:
+            request_id = row["request_id"]
+            await self.finish_turn(
+                request_id,
+                outcome="failed",
+                error={
+                    "code": "service_restarted",
+                    "message": "The Operator daemon restarted during this turn",
+                    "retryable": True,
+                },
+            )
+            recovered.append(request_id)
+        return recovered
+
+    async def acknowledge_effect(
+        self,
+        conversation_id: str,
+        effect_id: str,
+        *,
+        status: str,
+        rejection_code: str | None,
+    ) -> dict[str, Any]:
+        await self.ensure_schema()
+        now = time.time()
+        desired = "applied" if status == "applied" else "rejected"
+        if desired == "applied" and rejection_code is not None:
+            raise OperatorConflictError("Applied effects cannot carry a rejection code")
+        if desired == "rejected" and rejection_code is None:
+            raise OperatorConflictError("Rejected effects require a rejection code")
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT * FROM studio_operator_effects WHERE id=? AND conversation_id=?",
+                    (effect_id, conversation_id),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator effect '{effect_id}' not found")
+            if row["status"] != "pending":
+                same_rejection = desired != "rejected" or row["rejection_code"] == rejection_code
+                if row["status"] != desired or not same_rejection:
+                    await db.rollback()
+                    raise OperatorConflictError("Effect was already acknowledged differently")
+            if row["status"] == "pending":
+                await db.execute(
+                    "UPDATE studio_operator_effects SET status=?, acknowledged_at=?, "
+                    "rejection_code=? WHERE id=?",
+                    (desired, now, rejection_code, effect_id),
+                )
+            await db.commit()
+        return {"effectId": effect_id, "status": desired}

--- a/lionagi/studio/operator/types.py
+++ b/lionagi/studio/operator/types.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Wire and engine-side types for the ADR-0083 Operator protocol."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+OperatorFrameType = Literal[
+    "text",
+    "tool_call",
+    "tool_result",
+    "ui_command",
+    "proposal",
+    "confirmation",
+    "error",
+    "done",
+]
+OperatorErrorCode = Literal[
+    "auth_required",
+    "validation",
+    "not_found",
+    "denied",
+    "conflict",
+    "stale_context",
+    "rate_limited",
+    "model_failure",
+    "provider_unavailable",
+    "service_failure",
+    "service_restarted",
+    "audit_unavailable",
+    "replay_gap",
+    "cancelled",
+    "protocol_version",
+]
+
+
+def _to_camel(value: str) -> str:
+    head, *tail = value.split("_")
+    return head + "".join(part.capitalize() for part in tail)
+
+
+class WireModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=_to_camel,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+
+class CreateConversationRequest(WireModel):
+    project: str | None = Field(default=None, max_length=512)
+    title: str | None = Field(default=None, max_length=512)
+
+
+class OperatorContextSnapshot(WireModel):
+    project: str | None = Field(default=None, max_length=512)
+    space: Literal["mission", "designer", "library", "history", "schedules", "system"]
+    route: str = Field(min_length=1, max_length=4096)
+    selection: dict[str, str] | None = None
+    filters: dict[str, Any] = Field(default_factory=dict)
+
+
+class OperatorTurnRequest(WireModel):
+    instruction: str = Field(min_length=1, max_length=32_768)
+    context: OperatorContextSnapshot
+    expected_last_sequence: int = Field(ge=0)
+
+
+class ConfirmProposalRequest(WireModel):
+    expected_command_hash: str = Field(min_length=64, max_length=64)
+    expected_target_version: str | None = None
+
+
+class DecideProposalRequest(WireModel):
+    decision: Literal["allow", "deny"]
+    expected_command_hash: str | None = Field(default=None, min_length=64, max_length=64)
+    expected_target_version: str | None = None
+
+    @model_validator(mode="after")
+    def _require_hash_for_allow(self) -> DecideProposalRequest:
+        # A denial never executes the command, but an allow must bind the
+        # human's decision to the exact command that was rendered.
+        if self.decision == "allow" and self.expected_command_hash is None:
+            raise ValueError("expectedCommandHash is required when allowing a proposal")
+        return self
+
+
+class AcknowledgeEffectRequest(WireModel):
+    status: Literal["applied", "rejected"]
+    client_route: str | None = None
+    rejection_code: (
+        Literal[
+            "unsupported",
+            "invalid_params",
+            "stale_context",
+            "not_visible",
+            "client_error",
+        ]
+        | None
+    ) = None
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorEngineEvent:
+    """One provider-neutral event emitted by an Operator engine."""
+
+    type: OperatorFrameType
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionDecision:
+    allowed: bool
+    proposal_id: str
+    result: dict[str, Any] | None = None
+
+
+PermissionRequester = Callable[
+    [str, dict[str, Any], Literal["mutate", "execute", "admin"], str],
+    Awaitable[PermissionDecision],
+]
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorEngineTurn:
+    conversation_id: str
+    request_id: str
+    instruction: str
+    context: dict[str, Any]
+    history: tuple[dict[str, Any], ...]
+    request_permission: PermissionRequester
+    runtime_branch: Any | None = None
+    store_path: str | None = None
+    run_dir: Any | None = None
+
+
+class OperatorEngine(Protocol):
+    def stream(self, turn: OperatorEngineTurn) -> AsyncIterator[OperatorEngineEvent]: ...
+
+
+OperatorEngineFactory = Callable[[], OperatorEngine]
+CommandExecutor = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]

--- a/lionagi/studio/registry.py
+++ b/lionagi/studio/registry.py
@@ -43,6 +43,7 @@ _DEDUP_KEYS: set[tuple[str, str, str, str]] = set()
 _STUDIO_ROUTE_MODULES: tuple[str, ...] = (
     "lionagi.studio.services.casts",
     "lionagi.studio.services.runs",
+    "lionagi.studio.services.run_resume",
     "lionagi.studio.services.engine_runs",
     "lionagi.studio.services.definitions",
     "lionagi.studio.services.agents",
@@ -58,7 +59,7 @@ _STUDIO_ROUTE_MODULES: tuple[str, ...] = (
     "lionagi.studio.services.workflow_defs",
     "lionagi.studio.services.sessions",
     "lionagi.studio.services.run_tags",
-    "lionagi.studio.services.leo",
+    "lionagi.studio.services.operator",
     "lionagi.studio.services.approvals",
     "lionagi.studio.services.admin",
     "lionagi.studio.services.schedules",

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -638,6 +638,8 @@ async def spawn_and_wait(
         _validate_command_allowlisted(command)
 
     env = {**os.environ, "LIONAGI_INVOCATION_ID": invocation_id}
+    env.pop("LIONAGI_STUDIO_AUTH_TOKEN", None)
+    env.pop("LIONAGI_STUDIO_HUMAN_TOKEN", None)
 
     _log.info("Spawning: %s", " ".join(argv))
     proc = await asyncio.create_subprocess_exec(

--- a/lionagi/studio/security.py
+++ b/lionagi/studio/security.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Process-local Studio browser credentials and their trust origin.
+
+Removing a variable from ``os.environ`` does not reliably remove the process's
+initial environment from operating-system process inspection. Environment-
+derived credentials therefore remain valid for ordinary Studio API auth but
+are never trusted as the Operator's human-approval boundary.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+
+_AUTH_TOKEN: str | None = None
+_HUMAN_TOKEN: str | None = None
+_CREDENTIAL_ORIGIN: str | None = None
+
+
+def install_generated_studio_token(token: str) -> None:
+    """Install one trusted token received through a non-environment channel."""
+    global _AUTH_TOKEN, _CREDENTIAL_ORIGIN, _HUMAN_TOKEN
+    if not isinstance(token, str) or not 32 <= len(token) <= 4096:
+        raise ValueError("Studio bootstrap token must contain 32 to 4096 characters")
+    if "\x00" in token or "\r" in token or "\n" in token:
+        raise ValueError("Studio bootstrap token contains an invalid control character")
+    _AUTH_TOKEN = _HUMAN_TOKEN = token
+    _CREDENTIAL_ORIGIN = "generated"
+
+
+def capture_studio_credentials(*, generate_human: bool) -> str | None:
+    """Capture configured credentials, optionally minting a human-only token."""
+    global _AUTH_TOKEN, _CREDENTIAL_ORIGIN, _HUMAN_TOKEN
+    auth = os.environ.pop("LIONAGI_STUDIO_AUTH_TOKEN", None)
+    human = os.environ.pop("LIONAGI_STUDIO_HUMAN_TOKEN", None)
+    if auth is not None or human is not None:
+        _AUTH_TOKEN = auth
+        _HUMAN_TOKEN = human
+        _CREDENTIAL_ORIGIN = "environment"
+    if _AUTH_TOKEN:
+        return _AUTH_TOKEN
+    if not _HUMAN_TOKEN and generate_human:
+        # The browser uses one launch-scoped bearer for both the API boundary
+        # and human-only Operator decisions. Keeping the generated capability
+        # out of the environment is what makes that single-token scheme safe.
+        _AUTH_TOKEN = _HUMAN_TOKEN = secrets.token_urlsafe(32)
+        _CREDENTIAL_ORIGIN = "generated"
+    return _HUMAN_TOKEN
+
+
+def studio_auth_token() -> str | None:
+    """Credential protecting the whole API, if configured."""
+    return _AUTH_TOKEN or os.environ.get("LIONAGI_STUDIO_AUTH_TOKEN")
+
+
+def studio_human_token() -> str | None:
+    """Effective credential for human-only decisions."""
+    return (
+        _AUTH_TOKEN
+        or os.environ.get("LIONAGI_STUDIO_AUTH_TOKEN")
+        or _HUMAN_TOKEN
+        or os.environ.get("LIONAGI_STUDIO_HUMAN_TOKEN")
+    )
+
+
+def studio_operator_credential_origin() -> str | None:
+    """Return ``generated`` or ``environment`` for the effective credential."""
+    if os.environ.get("LIONAGI_STUDIO_AUTH_TOKEN") is not None:
+        return "environment"
+    if os.environ.get("LIONAGI_STUDIO_HUMAN_TOKEN") is not None:
+        return "environment"
+    return _CREDENTIAL_ORIGIN
+
+
+def clear_captured_studio_credentials() -> None:
+    """Forget process-local credentials after the embedded daemon exits."""
+    global _AUTH_TOKEN, _CREDENTIAL_ORIGIN, _HUMAN_TOKEN
+    _AUTH_TOKEN = None
+    _HUMAN_TOKEN = None
+    _CREDENTIAL_ORIGIN = None

--- a/lionagi/studio/services/launches.py
+++ b/lionagi/studio/services/launches.py
@@ -17,7 +17,7 @@ from lionagi.state.db import StateDB
 
 from .. import config
 from ..registry import studio_route
-from ..scheduler.subprocess import build_argv
+from ..scheduler.subprocess import build_argv, resolve_li_executable
 from ..services.schedules import (
     _svc_validate_action_model,
     _svc_validate_extra_args,
@@ -39,6 +39,10 @@ _launch_semaphore: asyncio.Semaphore | None = None
 
 class TooManyLaunchesError(Exception):
     """Raised when the in-flight launch count reaches the configured cap."""
+
+
+class LiExecutableUnavailableError(RuntimeError):
+    """The daemon cannot resolve the installed ``li`` console script."""
 
 
 def _get_semaphore() -> asyncio.Semaphore:
@@ -124,7 +128,55 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
             if defn.get(k) is not None:
                 opts[k] = defn[k]
         schedule_dict["action_engine_options"] = opts
-    argv, tmp_path = build_argv(schedule_dict, {})
+    if data["action_kind"] == "command":
+        # Allow-listed command actions execute their own binary directly.
+        argv, tmp_path = build_argv(schedule_dict, {})
+    else:
+        executable_prefix, resolve_error = resolve_li_executable()
+        if executable_prefix is None:
+            raise LiExecutableUnavailableError(
+                "The Studio daemon could not resolve the installed `li` executable"
+                + (f": {resolve_error}" if resolve_error else "")
+            )
+        argv, tmp_path = build_argv(
+            schedule_dict,
+            {},
+            executable_prefix=executable_prefix,
+        )
+
+    inv_id = await launch_detached_argv(
+        argv,
+        skill=f"launch:{data['action_kind']}",
+        plugin="studio_launch",
+        prompt=data.get("action_prompt") or data.get("action_playbook"),
+        tmp_path=tmp_path,
+        action_kind=data["action_kind"],
+    )
+
+    return {
+        "invocation_id": inv_id,
+        "action_kind": data["action_kind"],
+    }
+
+
+async def launch_detached_argv(
+    argv: list[str],
+    *,
+    skill: str,
+    plugin: str,
+    prompt: str | None,
+    tmp_path: str | None = None,
+    action_kind: str | None = None,
+    node_metadata: dict[str, Any] | None = None,
+) -> str:
+    """Record and supervise one already-validated argv launch.
+
+    Callers own argv construction and validation. This helper owns the shared
+    launch admission cap, canonical invocation row, detached task retention,
+    cancellation lookup, and terminal status update.
+    """
+    if not argv or any(not isinstance(token, str) or "\x00" in token for token in argv):
+        raise ValueError("argv must be a non-empty list of NUL-free string tokens")
 
     sem = _get_semaphore()
     if sem.locked():
@@ -142,16 +194,17 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
             await db.create_invocation(
                 {
                     "id": inv_id,
-                    "skill": f"launch:{data['action_kind']}",
-                    "plugin": "studio_launch",
-                    "prompt": data.get("action_prompt") or data.get("action_playbook"),
+                    "skill": skill,
+                    "plugin": plugin,
+                    "prompt": prompt,
                     "started_at": now,
                     "status": "running",
+                    "node_metadata": node_metadata,
                 }
             )
 
         task = asyncio.create_task(
-            _spawn_detached(argv, inv_id, tmp_path=tmp_path, action_kind=data["action_kind"]),
+            _spawn_detached(argv, inv_id, tmp_path=tmp_path, action_kind=action_kind),
             name=f"launch-{inv_id}",
         )
     except BaseException:
@@ -161,11 +214,7 @@ async def launch(data: dict[str, Any]) -> dict[str, Any]:
     task.add_done_callback(lambda _t: sem.release())
     _detached_tasks.add(task)
     task.add_done_callback(_detached_tasks.discard)
-
-    return {
-        "invocation_id": inv_id,
-        "action_kind": data["action_kind"],
-    }
+    return inv_id
 
 
 async def _resolve_engine_def(ref: str) -> dict[str, Any]:
@@ -279,6 +328,8 @@ async def launch_run(body: LaunchRequest) -> dict[str, Any]:
         return await launch(body.model_dump(exclude_none=True))
     except TooManyLaunchesError as exc:
         raise HTTPException(status_code=429, detail=str(exc)) from exc
+    except LiExecutableUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/lionagi/studio/services/leo.py
+++ b/lionagi/studio/services/leo.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Leo: the Studio operator agent — session registry, tool definitions, and routes.
+"""Retired Leo compatibility helpers.
 
-Security boundary: mutating tools never execute; they return a proposed_action for
-the frontend to confirm and call the real endpoint directly.
+The HTTP surface was superseded by the durable Operator protocol and is
+deliberately not registered. Mutating helpers still return inert
+``proposed_action`` values for callers that import this legacy module directly.
 """
 
 # NOTE: no `from __future__ import annotations` — Leo tool callables are
@@ -22,7 +23,6 @@ from pydantic import BaseModel
 
 from lionagi._errors import NotFoundError
 
-from ..registry import studio_route
 from ._sse import sse_response
 
 # ---------------------------------------------------------------------------
@@ -130,7 +130,7 @@ def build_branch() -> Any:
             endpoint="query_cli",
             model=model,
             api_key="dummy",
-            permission_mode="bypassPermissions",
+            permission_mode="default",
         )
     else:
         chat_model = iModel(provider=provider, model=model)
@@ -320,7 +320,8 @@ async def tool_run_maintenance(action: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Route handlers — leo area
+# Unregistered compatibility handlers. Importing this module must never add
+# the retired endpoints back to a fresh Studio app.
 # ---------------------------------------------------------------------------
 
 
@@ -376,19 +377,11 @@ async def _run_turn_locked(sess: LeoSession, user_content: str):
         sess.lock.release()
 
 
-@studio_route("/leo/sessions", method="POST", area="leo", name="create_leo_session")
 async def create_leo_session_route() -> dict[str, str]:
     sess = create_session()
     return {"id": sess.id}
 
 
-@studio_route(
-    "/leo/sessions/{session_id}/messages",
-    method="POST",
-    area="leo",
-    name="send_leo_message",
-    response_class=None,
-)
 async def send_leo_message_route(session_id: str, body: _MessageBody):
     sess = get_session(session_id)
     if sess is None:

--- a/lionagi/studio/services/operator.py
+++ b/lionagi/studio/services/operator.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP surface for the durable ADR-0083 Studio Operator protocol."""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+from typing import Any
+
+from fastapi import HTTPException, Query, Request
+
+from ..operator.coordinator import get_operator_coordinator
+from ..operator.store import (
+    OperatorConflictError,
+    OperatorNotFoundError,
+    OperatorStoreError,
+)
+from ..operator.types import (
+    AcknowledgeEffectRequest,
+    ConfirmProposalRequest,
+    CreateConversationRequest,
+    DecideProposalRequest,
+    OperatorTurnRequest,
+)
+from ..registry import studio_route
+from ._sse import sse_response
+
+
+def _http_error(exc: OperatorStoreError) -> HTTPException:
+    if isinstance(exc, OperatorNotFoundError):
+        status = 404
+    elif isinstance(exc, OperatorConflictError):
+        status = 409
+    else:
+        status = 503
+    detail: dict[str, Any] = {
+        "code": exc.code,
+        "message": str(exc),
+        "retryable": False,
+    }
+    details = getattr(exc, "details", None)
+    if details:
+        if details.get("code") == "stale_context":
+            detail["code"] = "stale_context"
+        detail["details"] = details
+    return HTTPException(status_code=status, detail=detail)
+
+
+async def operator_startup() -> list[str]:
+    return await get_operator_coordinator().startup()
+
+
+async def operator_shutdown() -> None:
+    await get_operator_coordinator().shutdown()
+
+
+@studio_route("/operator/conversations", method="GET", area="operator")
+async def list_operator_conversations(
+    limit: int = Query(default=100, ge=1, le=500),
+) -> dict[str, Any]:
+    coordinator = get_operator_coordinator()
+    try:
+        await coordinator.ensure_started()
+        rows = await coordinator.store.list_conversations(limit=limit)
+        return {"conversations": rows}
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+
+@studio_route("/operator/conversations", method="POST", area="operator")
+async def create_operator_conversation(
+    body: CreateConversationRequest | None = None,
+) -> dict[str, Any]:
+    body = body or CreateConversationRequest()
+    try:
+        return await get_operator_coordinator().create_conversation(
+            project=body.project, title=body.title
+        )
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+
+@studio_route("/operator/conversations/{conversation_id}", method="GET", area="operator")
+async def get_operator_conversation(
+    conversation_id: str,
+    after_sequence: int = Query(default=0, ge=0),
+    limit: int = Query(default=1000, ge=1, le=1000),
+) -> dict[str, Any]:
+    try:
+        return await get_operator_coordinator().snapshot(
+            conversation_id, after_sequence=after_sequence, limit=limit
+        )
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+
+@studio_route("/operator/conversations/{conversation_id}", method="DELETE", area="operator")
+async def delete_operator_conversation(conversation_id: str) -> dict[str, Any]:
+    coordinator = get_operator_coordinator()
+    try:
+        await coordinator.ensure_started()
+        await coordinator.store.archive_or_delete(conversation_id)
+        return {"ok": True, "conversationId": conversation_id}
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+
+@studio_route(
+    "/operator/conversations/{conversation_id}/turns",
+    method="POST",
+    area="operator",
+    status_code=202,
+)
+async def submit_operator_turn(
+    conversation_id: str, body: OperatorTurnRequest, request: Request
+) -> dict[str, Any]:
+    _require_safe_operator_credential_origin(request)
+    try:
+        return await get_operator_coordinator().submit(
+            conversation_id,
+            instruction=body.instruction,
+            context=body.context.model_dump(by_alias=True),
+            expected_last_sequence=body.expected_last_sequence,
+        )
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+
+@studio_route(
+    "/operator/conversations/{conversation_id}/requests/{request_id}/cancel",
+    method="POST",
+    area="operator",
+    status_code=202,
+)
+async def cancel_operator_turn(conversation_id: str, request_id: str) -> dict[str, Any]:
+    try:
+        return await get_operator_coordinator().cancel(conversation_id, request_id)
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+
+@studio_route(
+    "/operator/conversations/{conversation_id}/stream",
+    method="GET",
+    area="operator",
+    include_in_schema=True,
+)
+async def stream_operator_conversation(
+    conversation_id: str,
+    request: Request,
+    after_sequence: int = Query(default=0, ge=0),
+):
+    coordinator = get_operator_coordinator()
+    try:
+        await coordinator.ensure_started()
+        await coordinator.store.get_conversation(conversation_id)
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+    async def events():
+        cursor = after_sequence
+        heartbeat_at = asyncio.get_running_loop().time() + 5
+        while True:
+            if await request.is_disconnected():
+                return
+            frames = await coordinator.store.list_frames(
+                conversation_id, after_sequence=cursor, limit=250
+            )
+            if frames:
+                for frame in frames:
+                    # The row was committed before list_frames returned.
+                    cursor = frame["sequence"]
+                    yield (
+                        "data:" + json.dumps(frame, sort_keys=True, separators=(",", ":")) + "\n\n"
+                    )
+                heartbeat_at = asyncio.get_running_loop().time() + 5
+                continue
+            now = asyncio.get_running_loop().time()
+            if now >= heartbeat_at:
+                yield ": heartbeat\n\n"
+                heartbeat_at = now + 5
+            await asyncio.sleep(0.05)
+
+    return sse_response(events())
+
+
+def _require_safe_operator_credential_origin(request: Request) -> None:
+    """Fail closed when process inspection can recover the browser credential."""
+    from ..security import studio_operator_credential_origin
+
+    application = request.scope.get("app")
+    origin = (
+        getattr(
+            getattr(application, "state", None),
+            "studio_operator_credential_origin",
+            None,
+        )
+        or studio_operator_credential_origin()
+    )
+    if origin == "environment":
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Operator turns and approvals are disabled for environment-derived "
+                "credentials. Unset LIONAGI_STUDIO_AUTH_TOKEN and "
+                "LIONAGI_STUDIO_HUMAN_TOKEN, then start with `li studio` to use "
+                "a generated browser credential."
+            ),
+        )
+    if origin != "generated":
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Operator turns and approvals require a generated browser credential. "
+                "Start Studio with `li studio` and use the tab it opens."
+            ),
+        )
+
+
+async def _require_human(request: Request) -> None:
+    """Require the browser-held human bearer; network locality is not identity."""
+    _require_safe_operator_credential_origin(request)
+    if request.headers.get("x-lionagi-operator-principal"):
+        raise HTTPException(
+            status_code=403,
+            detail="Operator decisions require the human principal",
+        )
+    # AUTH is also enforced by the app-wide middleware, so it is the effective
+    # browser credential when both variables are configured.
+    from ..security import studio_human_token
+
+    application = request.scope.get("app")
+    token = (
+        getattr(getattr(application, "state", None), "studio_human_token", None)
+        or studio_human_token()
+    )
+    if not token:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Operator decisions require a generated browser credential; "
+                "restart with `li studio`"
+            ),
+        )
+    presented = request.headers.get("authorization") or ""
+    if not hmac.compare_digest(presented, f"Bearer {token}"):
+        raise HTTPException(
+            status_code=403,
+            detail="Operator decisions require the human principal",
+        )
+
+
+@studio_route(
+    "/operator/conversations/{conversation_id}/proposals/{proposal_id}/confirm",
+    method="POST",
+    area="operator",
+)
+async def confirm_operator_proposal(
+    conversation_id: str,
+    proposal_id: str,
+    body: ConfirmProposalRequest,
+    request: Request,
+) -> dict[str, Any]:
+    await _require_human(request)
+    try:
+        return await get_operator_coordinator().decide(
+            conversation_id,
+            proposal_id,
+            allow=True,
+            expected_command_hash=body.expected_command_hash,
+            expected_target_version=body.expected_target_version,
+        )
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+
+@studio_route(
+    "/operator/conversations/{conversation_id}/proposals/{proposal_id}/decision",
+    method="POST",
+    area="operator",
+)
+async def decide_operator_proposal(
+    conversation_id: str,
+    proposal_id: str,
+    body: DecideProposalRequest,
+    request: Request,
+) -> dict[str, Any]:
+    await _require_human(request)
+    try:
+        return await get_operator_coordinator().decide(
+            conversation_id,
+            proposal_id,
+            allow=body.decision == "allow",
+            expected_command_hash=body.expected_command_hash,
+            expected_target_version=body.expected_target_version,
+        )
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc
+
+
+@studio_route(
+    "/operator/conversations/{conversation_id}/effects/{effect_id}/ack",
+    method="POST",
+    area="operator",
+)
+async def acknowledge_operator_effect(
+    conversation_id: str,
+    effect_id: str,
+    body: AcknowledgeEffectRequest,
+) -> dict[str, Any]:
+    coordinator = get_operator_coordinator()
+    try:
+        await coordinator.ensure_started()
+        return await coordinator.store.acknowledge_effect(
+            conversation_id,
+            effect_id,
+            status=body.status,
+            rejection_code=body.rejection_code,
+        )
+    except OperatorStoreError as exc:
+        raise _http_error(exc) from exc

--- a/lionagi/studio/services/operator.py
+++ b/lionagi/studio/services/operator.py
@@ -27,6 +27,10 @@ from ..operator.types import (
 from ..registry import studio_route
 from ._sse import sse_response
 
+_CREDENTIAL_REQUIRED_DETAIL = (
+    "Operator conversations require a generated browser credential; restart with `li studio`"
+)
+
 
 def _http_error(exc: OperatorStoreError) -> HTTPException:
     if isinstance(exc, OperatorNotFoundError):
@@ -58,8 +62,10 @@ async def operator_shutdown() -> None:
 
 @studio_route("/operator/conversations", method="GET", area="operator")
 async def list_operator_conversations(
+    request: Request,
     limit: int = Query(default=100, ge=1, le=500),
 ) -> dict[str, Any]:
+    _require_operator_credential(request)
     coordinator = get_operator_coordinator()
     try:
         await coordinator.ensure_started()
@@ -71,8 +77,10 @@ async def list_operator_conversations(
 
 @studio_route("/operator/conversations", method="POST", area="operator")
 async def create_operator_conversation(
+    request: Request,
     body: CreateConversationRequest | None = None,
 ) -> dict[str, Any]:
+    _require_operator_credential(request)
     body = body or CreateConversationRequest()
     try:
         return await get_operator_coordinator().create_conversation(
@@ -85,9 +93,11 @@ async def create_operator_conversation(
 @studio_route("/operator/conversations/{conversation_id}", method="GET", area="operator")
 async def get_operator_conversation(
     conversation_id: str,
+    request: Request,
     after_sequence: int = Query(default=0, ge=0),
     limit: int = Query(default=1000, ge=1, le=1000),
 ) -> dict[str, Any]:
+    _require_operator_credential(request)
     try:
         return await get_operator_coordinator().snapshot(
             conversation_id, after_sequence=after_sequence, limit=limit
@@ -97,7 +107,8 @@ async def get_operator_conversation(
 
 
 @studio_route("/operator/conversations/{conversation_id}", method="DELETE", area="operator")
-async def delete_operator_conversation(conversation_id: str) -> dict[str, Any]:
+async def delete_operator_conversation(conversation_id: str, request: Request) -> dict[str, Any]:
+    _require_operator_credential(request)
     coordinator = get_operator_coordinator()
     try:
         await coordinator.ensure_started()
@@ -116,7 +127,7 @@ async def delete_operator_conversation(conversation_id: str) -> dict[str, Any]:
 async def submit_operator_turn(
     conversation_id: str, body: OperatorTurnRequest, request: Request
 ) -> dict[str, Any]:
-    _require_safe_operator_credential_origin(request)
+    _require_operator_credential(request)
     try:
         return await get_operator_coordinator().submit(
             conversation_id,
@@ -134,7 +145,10 @@ async def submit_operator_turn(
     area="operator",
     status_code=202,
 )
-async def cancel_operator_turn(conversation_id: str, request_id: str) -> dict[str, Any]:
+async def cancel_operator_turn(
+    conversation_id: str, request_id: str, request: Request
+) -> dict[str, Any]:
+    _require_operator_credential(request)
     try:
         return await get_operator_coordinator().cancel(conversation_id, request_id)
     except OperatorStoreError as exc:
@@ -152,6 +166,7 @@ async def stream_operator_conversation(
     request: Request,
     after_sequence: int = Query(default=0, ge=0),
 ):
+    _require_operator_credential(request)
     coordinator = get_operator_coordinator()
     try:
         await coordinator.ensure_started()
@@ -219,6 +234,46 @@ def _require_safe_operator_credential_origin(request: Request) -> None:
         )
 
 
+def _require_operator_credential(request: Request) -> None:
+    """The single authorization boundary for Operator conversation state.
+
+    Every route that reads or mutates a conversation goes through here, so the
+    app-wide Studio bearer — which is optional, and lets everything through when
+    unset — is never the only guard. Fails closed: an absent, empty or
+    unreadable credential is a refusal, never an allow.
+    """
+    _require_safe_operator_credential_origin(request)
+    # AUTH is also enforced by the app-wide middleware, so it is the effective
+    # browser credential when both variables are configured.
+    from ..security import studio_human_token
+
+    try:
+        application = request.scope.get("app")
+        token = (
+            getattr(getattr(application, "state", None), "studio_human_token", None)
+            or studio_human_token()
+        )
+    except Exception as exc:  # noqa: BLE001 — an unreadable credential is a refusal
+        raise HTTPException(
+            status_code=403,
+            detail=_CREDENTIAL_REQUIRED_DETAIL,
+        ) from exc
+    if not isinstance(token, str) or not token:
+        raise HTTPException(status_code=403, detail=_CREDENTIAL_REQUIRED_DETAIL)
+    presented = request.headers.get("authorization") or ""
+    try:
+        matched = hmac.compare_digest(presented, f"Bearer {token}")
+    except TypeError:
+        # compare_digest only accepts ASCII-only str; a non-ASCII header is a
+        # mismatch, not a server error.
+        matched = False
+    if not matched:
+        raise HTTPException(
+            status_code=403,
+            detail="Operator conversations require the browser credential",
+        )
+
+
 async def _require_human(request: Request) -> None:
     """Require the browser-held human bearer; network locality is not identity."""
     _require_safe_operator_credential_origin(request)
@@ -227,29 +282,7 @@ async def _require_human(request: Request) -> None:
             status_code=403,
             detail="Operator decisions require the human principal",
         )
-    # AUTH is also enforced by the app-wide middleware, so it is the effective
-    # browser credential when both variables are configured.
-    from ..security import studio_human_token
-
-    application = request.scope.get("app")
-    token = (
-        getattr(getattr(application, "state", None), "studio_human_token", None)
-        or studio_human_token()
-    )
-    if not token:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                "Operator decisions require a generated browser credential; "
-                "restart with `li studio`"
-            ),
-        )
-    presented = request.headers.get("authorization") or ""
-    if not hmac.compare_digest(presented, f"Bearer {token}"):
-        raise HTTPException(
-            status_code=403,
-            detail="Operator decisions require the human principal",
-        )
+    _require_operator_credential(request)
 
 
 @studio_route(
@@ -309,7 +342,9 @@ async def acknowledge_operator_effect(
     conversation_id: str,
     effect_id: str,
     body: AcknowledgeEffectRequest,
+    request: Request,
 ) -> dict[str, Any]:
+    _require_operator_credential(request)
     coordinator = get_operator_coordinator()
     try:
         await coordinator.ensure_started()

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import shutil
 from functools import partial
 from pathlib import Path
@@ -174,6 +175,17 @@ def get_playbook(name: str) -> dict[str, Any] | None:
         except OSError:
             pass
     return result
+
+
+def fingerprint_playbook(name: str) -> str:
+    """Return the exact content version used to gate a playbook launch."""
+    stem = name.removesuffix(".playbook.yaml").removesuffix(".yaml")
+    safe_path_join(_PLAYBOOKS_ROOT, f"{stem}.playbook.yaml")
+    path = _PLAYBOOKS_ROOT / f"{stem}.playbook.yaml"
+    if not path.is_file():
+        raise FileNotFoundError(f"Playbook {stem!r} not found")
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return f"sha256:{digest}"
 
 
 def list_builtin_playbooks() -> list[dict[str, Any]]:

--- a/lionagi/studio/services/run_resume.py
+++ b/lionagi/studio/services/run_resume.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Resume an existing Studio run through the durable ``li agent`` path."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+import tempfile
+from typing import Any
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
+from lionagi.state.db import StateDB, state_db_known_absent
+
+from ..registry import studio_route
+from ..scheduler import subprocess as _subprocess
+from . import launches as _launches
+from .schedules import (
+    _svc_validate_action_model,
+    _svc_validate_identifier,
+    _svc_validate_prompt,
+)
+
+_log = logging.getLogger(__name__)
+
+
+class RunNotFoundError(LookupError):
+    """The requested run/session does not exist."""
+
+
+class RunBranchConflictError(RuntimeError):
+    """The run does not resolve to exactly one resumable branch."""
+
+
+class RunBranchMembershipError(ValueError):
+    """An explicitly requested branch does not belong to the run."""
+
+
+class RunResumeUnavailableError(RuntimeError):
+    """The branch exists in StateDB but its resumable snapshot is unavailable."""
+
+
+class RunResumeInProgressError(RuntimeError):
+    """Another queued or executing resume already owns this branch."""
+
+
+class RunResumeRequest(BaseModel):
+    instruction: str = Field(min_length=1, max_length=MAX_SPEC_PROMPT_CHARS)
+    branch_id: str | None = None
+    model: str | None = None
+
+
+_resume_admission_lock = asyncio.Lock()
+
+
+def _validate_resume_inputs(
+    instruction: str,
+    *,
+    branch_id: str | None,
+    model: str | None,
+) -> None:
+    if not instruction.strip():
+        raise ValueError("instruction must contain non-whitespace text")
+    if len(instruction) > MAX_SPEC_PROMPT_CHARS:
+        raise ValueError(f"instruction exceeds the {MAX_SPEC_PROMPT_CHARS}-character prompt limit")
+    _svc_validate_prompt(instruction)
+
+    if branch_id is not None:
+        if not branch_id:
+            raise ValueError("branch_id must be non-empty when provided")
+        _svc_validate_identifier(branch_id, "branch_id")
+
+    if model is not None:
+        if not model:
+            raise ValueError("model must be non-empty when provided")
+        _svc_validate_action_model(model)
+
+
+async def _resolve_branch(run_id: str, requested_branch_id: str | None) -> str:
+    """Resolve one branch owned by *run_id* without hydrating its messages."""
+    _svc_validate_identifier(run_id, "run_id")
+    if state_db_known_absent():
+        raise RunNotFoundError(f"Run {run_id!r} not found")
+
+    async with StateDB(readonly=True) as db:
+        session = await db.get_session(run_id)
+        if session is None:
+            raise RunNotFoundError(f"Run {run_id!r} not found")
+        branches = await db.list_branches(run_id)
+
+    branch_ids = [str(branch["id"]) for branch in branches]
+    if requested_branch_id is not None:
+        if requested_branch_id not in branch_ids:
+            raise RunBranchMembershipError(
+                f"Branch {requested_branch_id!r} does not belong to run {run_id!r}"
+            )
+        return requested_branch_id
+
+    if not branch_ids:
+        raise RunBranchConflictError(f"Run {run_id!r} has no branch to resume")
+    if len(branch_ids) > 1:
+        raise RunBranchConflictError(
+            f"Run {run_id!r} has {len(branch_ids)} branches; branch_id is required"
+        )
+    return branch_ids[0]
+
+
+async def _run_status(run_id: str) -> str:
+    async with StateDB(readonly=True) as db:
+        session = await db.get_session(run_id)
+    if session is None:
+        raise RunNotFoundError(f"Run {run_id!r} not found")
+    return str(session.get("status") or "")
+
+
+async def _active_resume_for_branch(branch_id: str) -> dict[str, Any] | None:
+    async with StateDB(readonly=True) as db:
+        rows = await db.list_invocations(
+            skill="resume:agent",
+            status="running",
+            limit=200,
+            offset=0,
+        )
+    for row in rows:
+        metadata = row.get("node_metadata")
+        if isinstance(metadata, str):
+            try:
+                metadata = json.loads(metadata)
+            except json.JSONDecodeError:
+                metadata = None
+        if isinstance(metadata, dict) and metadata.get("branch_id") == branch_id:
+            return {**row, "node_metadata": metadata}
+    return None
+
+
+async def _ensure_branch_snapshot_available(branch_id: str) -> None:
+    """Require the exact branch snapshot that ``li agent -r`` will reopen."""
+    from lionagi.cli._runs import find_branch
+    from lionagi.cli._util import AmbiguousIdError
+
+    try:
+        _snapshot_run_id, snapshot_path = await asyncio.to_thread(find_branch, branch_id)
+    except (OSError, AmbiguousIdError) as exc:
+        raise RunResumeUnavailableError(
+            f"Branch {branch_id!r} has no available CLI snapshot and cannot be resumed"
+        ) from exc
+
+    # find_branch deliberately accepts prefixes for CLI convenience. The API
+    # resolved an exact StateDB member, so silently accepting a different
+    # snapshot whose id merely starts with this value would resume the wrong
+    # conversation.
+    if snapshot_path.name not in {branch_id, f"{branch_id}.json"}:
+        raise RunResumeUnavailableError(
+            f"Branch {branch_id!r} has no exact CLI snapshot and cannot be resumed"
+        )
+
+    def hydrate_exact_snapshot() -> None:
+        from lionagi.session.branch import Branch
+
+        serialized = json.loads(snapshot_path.read_text())
+        branch = Branch.from_dict(serialized)
+        if str(branch.id) != branch_id:
+            raise ValueError("snapshot branch identity does not match")
+
+    try:
+        await asyncio.to_thread(hydrate_exact_snapshot)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("Refusing incompatible branch snapshot %s: %s", branch_id, exc)
+        raise RunResumeUnavailableError(
+            f"Branch {branch_id!r} has an invalid CLI snapshot and cannot be resumed"
+        ) from exc
+
+
+def _build_resume_argv(
+    executable_prefix: list[str],
+    *,
+    branch_id: str,
+    instruction: str,
+    model: str | None,
+) -> list[str]:
+    """Build the existing CLI resume command without permission-bypass flags."""
+    argv = [*executable_prefix, "agent", "-r", branch_id]
+    if model is not None:
+        # With --prompt carrying the instruction, the sole positional is the
+        # optional model override accepted by ``li agent``.
+        argv.append(model)
+    # argparse treats an option-looking next token as another flag instead of
+    # the value to --prompt. Keep the ordinary command human-readable while
+    # using its assignment form for a literal instruction that starts with '-'.
+    if instruction.startswith("-"):
+        argv.append(f"--prompt={instruction}")
+    else:
+        argv.extend(["--prompt", instruction])
+    return argv
+
+
+def _write_queued_resume_config(
+    *,
+    run_id: str,
+    branch_id: str,
+    instruction: str,
+    model: str | None,
+    executable_prefix: list[str],
+) -> str:
+    fd, path = tempfile.mkstemp(prefix="lionagi-resume-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as file:
+            json.dump(
+                {
+                    "run_id": run_id,
+                    "branch_id": branch_id,
+                    "instruction": instruction,
+                    "model": model,
+                    "executable_prefix": executable_prefix,
+                },
+                file,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+    except BaseException:
+        os.unlink(path)
+        raise
+    return path
+
+
+async def resume_run(
+    run_id: str,
+    *,
+    instruction: str,
+    branch_id: str | None = None,
+    model: str | None = None,
+) -> dict[str, Any]:
+    """Launch a follow-up turn on an existing run's durable branch."""
+    _validate_resume_inputs(instruction, branch_id=branch_id, model=model)
+    resolved_branch_id = await _resolve_branch(run_id, branch_id)
+
+    executable_prefix, resolve_error = _subprocess.resolve_li_executable()
+    if executable_prefix is None:
+        if resolve_error:
+            _log.error("Could not resolve the installed `li` executable: %s", resolve_error)
+        raise _launches.LiExecutableUnavailableError(
+            "The Studio daemon could not resolve the installed `li` executable; "
+            "reinstall LionAGI with the Studio extra and restart Studio"
+        )
+
+    async with _resume_admission_lock:
+        active = await _active_resume_for_branch(resolved_branch_id)
+        if active is not None:
+            metadata = active["node_metadata"]
+            if (
+                active.get("prompt") == instruction
+                and metadata.get("model") == model
+                and metadata.get("run_id") == run_id
+            ):
+                return {
+                    "run_id": run_id,
+                    "branch_id": resolved_branch_id,
+                    "invocation_id": active["id"],
+                }
+            raise RunResumeInProgressError(
+                f"Branch {resolved_branch_id!r} already has a resume in progress"
+            )
+
+        source_status = await _run_status(run_id)
+        from lionagi.state.db import SESSION_TERMINAL_STATUSES
+
+        queued = source_status not in SESSION_TERMINAL_STATUSES
+        tmp_path: str | None = None
+        if queued:
+            tmp_path = _write_queued_resume_config(
+                run_id=run_id,
+                branch_id=resolved_branch_id,
+                instruction=instruction,
+                model=model,
+                executable_prefix=executable_prefix,
+            )
+            argv = [
+                sys.executable,
+                "-m",
+                "lionagi.studio.services.run_resume_worker",
+                "--config",
+                tmp_path,
+            ]
+        else:
+            await _ensure_branch_snapshot_available(resolved_branch_id)
+            argv = _build_resume_argv(
+                executable_prefix,
+                branch_id=resolved_branch_id,
+                instruction=instruction,
+                model=model,
+            )
+        try:
+            invocation_id = await _launches.launch_detached_argv(
+                argv,
+                skill="resume:agent",
+                plugin="studio_run_resume",
+                prompt=instruction,
+                tmp_path=tmp_path,
+                action_kind="agent",
+                node_metadata={
+                    "run_id": run_id,
+                    "branch_id": resolved_branch_id,
+                    "resume": True,
+                    "queued_for_terminal": queued,
+                    "model": model,
+                },
+            )
+        except BaseException:
+            if tmp_path is not None:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_path)
+            raise
+    return {
+        "run_id": run_id,
+        "branch_id": resolved_branch_id,
+        "invocation_id": invocation_id,
+    }
+
+
+@studio_route(
+    "/runs/{run_id}/resume",
+    method="POST",
+    area="runs",
+    status_code=202,
+    name="resume_run",
+)
+async def resume_run_route(run_id: str, body: RunResumeRequest) -> dict[str, Any]:
+    """Resume any run that has an underlying branch, including terminal runs."""
+    try:
+        return await resume_run(
+            run_id,
+            instruction=body.instruction,
+            branch_id=body.branch_id,
+            model=body.model,
+        )
+    except RunNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (
+        RunBranchConflictError,
+        RunResumeInProgressError,
+        RunResumeUnavailableError,
+    ) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except (RunBranchMembershipError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except _launches.TooManyLaunchesError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from exc
+    except _launches.LiExecutableUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/lionagi/studio/services/run_resume_worker.py
+++ b/lionagi/studio/services/run_resume_worker.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""One-shot worker that serializes resumes behind an active source run."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from lionagi.state.db import SESSION_TERMINAL_STATUSES, StateDB, state_db_file
+
+
+def _load_config(path: str) -> dict[str, Any]:
+    config_path = Path(path)
+    try:
+        value = json.loads(config_path.read_text())
+    finally:
+        # The parent also owns best-effort cleanup; removing immediately keeps
+        # the user's instruction off disk while this worker waits.
+        config_path.unlink(missing_ok=True)
+    if not isinstance(value, dict):
+        raise ValueError("resume worker config must be a JSON object")
+    return value
+
+
+@contextmanager
+def _branch_resume_lock(branch_id: str):
+    """Serialize queued legs for one branch for the lifetime of each child."""
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - Windows fallback
+        yield
+        return
+
+    db_path = state_db_file()
+    if db_path is None:
+        raise RuntimeError("queued resume requires a local StateDB")
+    lock_dir = Path(db_path).parent / "resume-locks"
+    lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    digest = hashlib.sha256(branch_id.encode()).hexdigest()
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(lock_dir / f"{digest}.lock", flags, 0o600)
+    with os.fdopen(fd, "w") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+async def _wait_for_terminal(run_id: str) -> None:
+    while True:
+        async with StateDB(readonly=True) as db:
+            session = await db.get_session(run_id)
+        if session is None:
+            raise RuntimeError("source run disappeared while its resume was queued")
+        if session.get("status") in SESSION_TERMINAL_STATUSES:
+            return
+        await asyncio.sleep(0.25)
+
+
+async def run_worker(config: dict[str, Any]) -> int:
+    from .run_resume import (
+        _build_resume_argv,
+        _ensure_branch_snapshot_available,
+        _validate_resume_inputs,
+    )
+
+    run_id = config.get("run_id")
+    branch_id = config.get("branch_id")
+    instruction = config.get("instruction")
+    model = config.get("model")
+    executable_prefix = config.get("executable_prefix")
+    if not all(isinstance(value, str) and value for value in (run_id, branch_id, instruction)):
+        raise ValueError("resume worker config is missing an identity or instruction")
+    if model is not None and not isinstance(model, str):
+        raise ValueError("resume worker model must be a string or null")
+    if (
+        not isinstance(executable_prefix, list)
+        or not executable_prefix
+        or any(not isinstance(token, str) or not token for token in executable_prefix)
+    ):
+        raise ValueError("resume worker executable prefix is invalid")
+    _validate_resume_inputs(instruction, branch_id=branch_id, model=model)
+
+    with _branch_resume_lock(branch_id):
+        await _wait_for_terminal(run_id)
+        # Terminal status is the hand-off signal: canonical writers publish
+        # their atomic final branch snapshot before setting it.
+        await _ensure_branch_snapshot_available(branch_id)
+        argv = _build_resume_argv(
+            executable_prefix,
+            branch_id=branch_id,
+            instruction=instruction,
+            model=model,
+        )
+        process = await asyncio.create_subprocess_exec(*argv)
+        return await process.wait()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--config", required=True)
+    args = parser.parse_args(argv)
+    try:
+        config = _load_config(args.config)
+        return asyncio.run(run_worker(config))
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"Queued Studio resume failed ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -54,13 +54,14 @@ from ._helpers import run_async  # noqa: E402
 _DOCS_PATHS = frozenset({"/openapi.json", "/docs", "/redoc", "/docs/oauth2-redirect"})
 
 # Sorted (method, path) pairs for every non-docs route mounted on the live
-# app, pinned 2026-07-12 against the actual route table (see
+# app, pinned 2026-07-30 against the actual route table (see
 # lionagi/studio/registry.py::_STUDIO_ROUTE_MODULES for the area modules that
 # populate it, and app.py::_mount_studio_routes for the "/api" + route.path
 # mounting rule).
 _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("DELETE", "/api/agents/{name}"),
     ("DELETE", "/api/engine-defs/{def_id}"),
+    ("DELETE", "/api/operator/conversations/{conversation_id}"),
     ("DELETE", "/api/playbooks/{name}"),
     ("DELETE", "/api/projects/{name}"),
     ("DELETE", "/api/schedules/{schedule_id}"),
@@ -86,6 +87,9 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("GET", "/api/engine-runs/{run_id}"),
     ("GET", "/api/invocations/"),
     ("GET", "/api/invocations/{invocation_id}"),
+    ("GET", "/api/operator/conversations"),
+    ("GET", "/api/operator/conversations/{conversation_id}"),
+    ("GET", "/api/operator/conversations/{conversation_id}/stream"),
     ("GET", "/api/playbook-templates/"),
     ("GET", "/api/playbook-templates/{name}"),
     ("GET", "/api/playbooks/"),
@@ -138,14 +142,28 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("POST", "/api/engine-defs/"),
     ("POST", "/api/invocations/{invocation_id}/cancel"),
     ("POST", "/api/launches/"),
-    ("POST", "/api/leo/sessions"),
-    ("POST", "/api/leo/sessions/{session_id}/messages"),
+    ("POST", "/api/operator/conversations"),
+    ("POST", "/api/operator/conversations/{conversation_id}/effects/{effect_id}/ack"),
+    (
+        "POST",
+        "/api/operator/conversations/{conversation_id}/proposals/{proposal_id}/confirm",
+    ),
+    (
+        "POST",
+        "/api/operator/conversations/{conversation_id}/proposals/{proposal_id}/decision",
+    ),
+    (
+        "POST",
+        "/api/operator/conversations/{conversation_id}/requests/{request_id}/cancel",
+    ),
+    ("POST", "/api/operator/conversations/{conversation_id}/turns"),
     ("POST", "/api/playbook-templates/{name}/install"),
     ("POST", "/api/playbooks/{name}"),
     ("POST", "/api/playbooks/{name}/run"),
     ("POST", "/api/playbooks/{name}/validate"),
     ("POST", "/api/projects/"),
     ("POST", "/api/projects/{name}/assign"),
+    ("POST", "/api/runs/{run_id}/resume"),
     ("POST", "/api/schedules/"),
     ("POST", "/api/schedules/{schedule_id}/disable"),
     ("POST", "/api/schedules/{schedule_id}/enable"),
@@ -237,7 +255,7 @@ def test_golden_route_table_matches_pinned_snapshot():
 
 
 def test_golden_route_count_pinned():
-    assert len(_GOLDEN_ROUTES) == 100
+    assert len(_GOLDEN_ROUTES) == 109
 
 
 def _compiled_match_shape(path_template: str) -> str:

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -330,15 +330,27 @@ class TestLaunchArgvPath:
         """launch() delegates argv construction to build_argv."""
         captured = {}
 
-        def _fake_build_argv(schedule, ctx):
+        def _consume(coro, **kw):
+            coro.close()
+            return MagicMock()
+
+        def _fake_build_argv(schedule, ctx, *, executable_prefix=None):
             captured["schedule"] = schedule
             captured["ctx"] = ctx
-            return (["uv", "run", "li", "agent", "--", "sonnet", "hi"], None)
+            captured["executable_prefix"] = executable_prefix
+            return ([*executable_prefix, "agent", "--", "sonnet", "hi"], None)
 
         with (
             patch("lionagi.studio.services.launches.build_argv", side_effect=_fake_build_argv),
+            patch(
+                "lionagi.studio.services.launches.resolve_li_executable",
+                return_value=(["/opt/lionagi/bin/li"], None),
+            ),
             patch("lionagi.studio.services.launches.StateDB") as MockDB,
-            patch("lionagi.studio.services.launches.asyncio.create_task"),
+            patch(
+                "lionagi.studio.services.launches.asyncio.create_task",
+                side_effect=_consume,
+            ),
         ):
             mock_db = AsyncMock()
             mock_db.create_invocation = AsyncMock()
@@ -356,6 +368,7 @@ class TestLaunchArgvPath:
         assert captured["schedule"]["action_model"] == "sonnet"
         assert captured["schedule"]["action_prompt"] == "hi"
         assert captured["ctx"] == {}
+        assert captured["executable_prefix"] == ["/opt/lionagi/bin/li"]
 
     def test_launch_returns_invocation_id_on_agent(self):
         """launch() must return a 12-char hex invocation_id for agent kind."""
@@ -381,6 +394,24 @@ class TestLaunchArgvPath:
 
         assert "invocation_id" in result
         assert len(result["invocation_id"]) == 12
+
+    def test_unresolved_installed_li_returns_503_before_recording(self, tmp_path, monkeypatch):
+        """A pip-installed daemon with no resolvable console script fails clearly."""
+        monkeypatch.setattr(
+            "lionagi.studio.services.launches.resolve_li_executable",
+            lambda: (None, "no 'li' console_scripts entry point registered"),
+        )
+        mock_db = _stub_db_and_spawn(monkeypatch)
+        client = _make_client(monkeypatch, fake_db=tmp_path / "state.db")
+
+        response = client.post(
+            "/api/launches",
+            json={"action_kind": "agent", "action_model": "sonnet", "action_prompt": "hello"},
+        )
+
+        assert response.status_code == 503, response.text
+        assert "console_scripts entry point" in response.json()["detail"]
+        mock_db.create_invocation.assert_not_awaited()
 
     def test_validate_request_rejects_flag_model(self):
         """_validate_request must reject action_model starting with '-'."""
@@ -825,7 +856,7 @@ class TestEngineScheduleAssembly:
         _stub_engine_def(monkeypatch, defn)
         captured = {}
 
-        def _fake_build_argv(schedule, ctx):
+        def _fake_build_argv(schedule, ctx, *, executable_prefix=None):
             captured["schedule"] = schedule
             return (["uv", "run", "li", "engine", "run", "--", "research", "spec"], None)
 
@@ -1303,7 +1334,7 @@ class TestLaunchFlowYamlKind:
 
         captured = {}
 
-        def _fake_build_argv(schedule, ctx):
+        def _fake_build_argv(schedule, ctx, *, executable_prefix=None):
             captured["schedule"] = schedule
             return (
                 ["uv", "run", "li", "o", "flow", "-f", "/tmp/x.yaml", "--", "sonnet"],
@@ -1486,7 +1517,7 @@ class TestLaunchCommandKind:
         monkeypatch.setenv(_COMMAND_ALLOWLIST_ENV, "echo")
         captured = {}
 
-        def _fake_build_argv(schedule, ctx):
+        def _fake_build_argv(schedule, ctx, *, executable_prefix=None):
             captured["schedule"] = schedule
             return (["echo", "hi"], None)
 

--- a/tests/apps_studio_server/test_leo.py
+++ b/tests/apps_studio_server/test_leo.py
@@ -1,13 +1,14 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the Leo (Studio operator agent) endpoints.
+"""Tests for the retired Leo compatibility helpers.
 
-No network or real LLM calls — the Branch is monkey-patched with a fake ReAct().
+The legacy HTTP routes must stay unregistered. No network or real LLM calls —
+the compatibility Branch is monkey-patched with a fake ReAct().
 """
 
 from __future__ import annotations
 
-import threading
+import asyncio
 import time
 from pathlib import Path
 from typing import Any
@@ -41,9 +42,9 @@ def _make_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
     monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
-    from lionagi.studio.app import app
+    from lionagi.studio.app import create_app
 
-    return TestClient(app, base_url="http://127.0.0.1:8765")
+    return TestClient(create_app(), base_url="http://127.0.0.1:8765")
 
 
 @pytest.fixture(autouse=True)
@@ -57,23 +58,25 @@ def _clear_leo_sessions():
 
 
 # ---------------------------------------------------------------------------
-# Session create
+# Retired HTTP surface and direct session compatibility
 # ---------------------------------------------------------------------------
 
 
-def test_leo_create_session(tmp_path, monkeypatch):
-    client = _make_client(tmp_path, monkeypatch)
-    r = client.post("/api/leo/sessions")
-    assert r.status_code == 200
-    data = r.json()
-    assert "id" in data
-    assert isinstance(data["id"], str)
-    assert len(data["id"]) == 36  # UUID
+def test_legacy_leo_routes_are_retired(tmp_path, monkeypatch):
+    with _make_client(tmp_path, monkeypatch) as client:
+        create = client.post("/api/leo/sessions")
+        send = client.post(
+            "/api/leo/sessions/does-not-exist/messages",
+            json={"content": "hello"},
+        )
+    assert create.status_code == 404
+    assert send.status_code == 404
 
 
-def test_leo_create_session_unique_ids(tmp_path, monkeypatch):
-    client = _make_client(tmp_path, monkeypatch)
-    ids = {client.post("/api/leo/sessions").json()["id"] for _ in range(3)}
+def test_leo_compatibility_session_unique_ids():
+    from lionagi.studio.services import leo as leo_svc
+
+    ids = {leo_svc.create_session().id for _ in range(3)}
     assert len(ids) == 3
 
 
@@ -171,23 +174,26 @@ def test_session_registry_idle_eviction_runs_on_create():
 
 
 # ---------------------------------------------------------------------------
-# 404 on unknown session
+# Direct compatibility handler rejects an unknown session
 # ---------------------------------------------------------------------------
 
 
-def test_leo_message_unknown_session(tmp_path, monkeypatch):
-    client = _make_client(tmp_path, monkeypatch)
-    r = client.post(
-        "/api/leo/sessions/does-not-exist/messages",
-        json={"content": "hello"},
-    )
-    assert r.status_code == 404
+def test_leo_compatibility_message_unknown_session():
+    from lionagi._errors import NotFoundError
+    from lionagi.studio.services import leo as leo_svc
+
+    with pytest.raises(NotFoundError):
+        asyncio.run(
+            leo_svc.send_leo_message_route(
+                "does-not-exist",
+                leo_svc._MessageBody(content="hello"),
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
-# Auth gate — the studio bearer-token middleware guards /api/leo like any
-# other /api/* route; no per-route auth code, so this proves the mount point
-# lands under the guarded prefix.
+# Auth gate — retired paths remain under the global /api/* bearer boundary,
+# even though an authenticated caller receives a route-level 404.
 # ---------------------------------------------------------------------------
 
 
@@ -200,23 +206,31 @@ def test_leo_requires_bearer_when_token_set(tmp_path, monkeypatch):
     # unlike importlib.reload(app_mod), there is no shared singleton to
     # restore afterwards.
     app = app_mod.create_app()
-    client = TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
-    r = client.post("/api/leo/sessions")
+    with TestClient(
+        app,
+        raise_server_exceptions=False,
+        base_url="http://127.0.0.1:8765",
+    ) as client:
+        r = client.post("/api/leo/sessions")
     assert r.status_code == 401
 
 
-def test_leo_correct_token_not_401(tmp_path, monkeypatch):
+def test_leo_correct_token_reaches_retired_route_404(tmp_path, monkeypatch):
     monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "test-leo-secret")
 
     import lionagi.studio.app as app_mod
 
     app = app_mod.create_app()
-    client = TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
-    r = client.post(
-        "/api/leo/sessions",
-        headers={"Authorization": "Bearer test-leo-secret"},
-    )
-    assert r.status_code == 200
+    with TestClient(
+        app,
+        raise_server_exceptions=False,
+        base_url="http://127.0.0.1:8765",
+    ) as client:
+        r = client.post(
+            "/api/leo/sessions",
+            headers={"Authorization": "Bearer test-leo-secret"},
+        )
+    assert r.status_code == 404
 
 
 # ---------------------------------------------------------------------------
@@ -386,29 +400,23 @@ def _fake_branch_with_response(text: str) -> MagicMock:
     return branch
 
 
-def test_leo_message_turn_text_response(tmp_path, monkeypatch):
-    client = _make_client(tmp_path, monkeypatch)
-
-    # Create a session
-    sid = client.post("/api/leo/sessions").json()["id"]
-
-    # Inject a fake branch into the session registry
+def _run_compatibility_turn(sess: Any, content: str) -> list[dict[str, Any]]:
     from lionagi.studio.services import leo as leo_svc
 
-    sess = leo_svc.get_session(sid)
-    assert sess is not None
+    async def collect() -> str:
+        await sess.lock.acquire()
+        return "".join([chunk async for chunk in leo_svc._run_turn_locked(sess, content)])
+
+    return _parse_sse(asyncio.run(collect()))
+
+
+def test_leo_message_turn_text_response():
+    from lionagi.studio.services import leo as leo_svc
+
+    sess = leo_svc.create_session()
     sess.branch = _fake_branch_with_response("There are 3 running playbooks.")
 
-    # Send a message and collect SSE
-    r = client.post(
-        f"/api/leo/sessions/{sid}/messages",
-        json={"content": "How many runs are running?"},
-    )
-    assert r.status_code == 200
-    assert "text/event-stream" in r.headers["content-type"]
-
-    # Parse SSE frames
-    events = _parse_sse(r.text)
+    events = _run_compatibility_turn(sess, "How many runs are running?")
     types = [e.get("type") for e in events]
     assert "text" in types
     assert "done" in types
@@ -417,15 +425,11 @@ def test_leo_message_turn_text_response(tmp_path, monkeypatch):
     assert "3 running playbooks" in text_event["content"]
 
 
-def test_leo_message_turn_proposed_action_surfaced(tmp_path, monkeypatch):
+def test_leo_message_turn_proposed_action_surfaced():
     """A mock branch that returns a proposed_action in an ActionResponse-like message."""
-    client = _make_client(tmp_path, monkeypatch)
-    sid = client.post("/api/leo/sessions").json()["id"]
-
     from lionagi.studio.services import leo as leo_svc
 
-    sess = leo_svc.get_session(sid)
-    assert sess is not None
+    sess = leo_svc.create_session()
 
     proposed = {
         "kind": "launch_playbook",
@@ -450,12 +454,7 @@ def test_leo_message_turn_proposed_action_surfaced(tmp_path, monkeypatch):
     branch.ReAct = AsyncMock(side_effect=fake_turn)
     sess.branch = branch
 
-    r = client.post(
-        f"/api/leo/sessions/{sid}/messages",
-        json={"content": "Launch the ci-sweep playbook"},
-    )
-    assert r.status_code == 200
-    events = _parse_sse(r.text)
+    events = _run_compatibility_turn(sess, "Launch the ci-sweep playbook")
     types = [e.get("type") for e in events]
     assert "proposed_action" in types
     assert "text" in types
@@ -465,15 +464,11 @@ def test_leo_message_turn_proposed_action_surfaced(tmp_path, monkeypatch):
     assert pa_event["action"]["kind"] == "launch_playbook"
 
 
-def test_leo_message_turn_ui_command_surfaced(tmp_path, monkeypatch):
+def test_leo_message_turn_ui_command_surfaced():
     """ui_command tool outputs stream as ui_command events before the text."""
-    client = _make_client(tmp_path, monkeypatch)
-    sid = client.post("/api/leo/sessions").json()["id"]
-
     from lionagi.studio.services import leo as leo_svc
 
-    sess = leo_svc.get_session(sid)
-    assert sess is not None
+    sess = leo_svc.create_session()
 
     command = {"kind": "navigate", "space": "fleet", "params": {"status": "failed"}}
 
@@ -491,12 +486,7 @@ def test_leo_message_turn_ui_command_surfaced(tmp_path, monkeypatch):
     branch.ReAct = AsyncMock(side_effect=fake_turn)
     sess.branch = branch
 
-    r = client.post(
-        f"/api/leo/sessions/{sid}/messages",
-        json={"content": "what are some failed jobs recently"},
-    )
-    assert r.status_code == 200
-    events = _parse_sse(r.text)
+    events = _run_compatibility_turn(sess, "what are some failed jobs recently")
     types = [e.get("type") for e in events]
     assert "ui_command" in types
     assert "text" in types
@@ -506,15 +496,11 @@ def test_leo_message_turn_ui_command_surfaced(tmp_path, monkeypatch):
     assert cmd_event["command"] == command
 
 
-def test_leo_prior_turn_proposals_not_reemitted(tmp_path, monkeypatch):
+def test_leo_prior_turn_proposals_not_reemitted():
     """Proposals from earlier turns must not resurface on later turns."""
-    client = _make_client(tmp_path, monkeypatch)
-    sid = client.post("/api/leo/sessions").json()["id"]
-
     from lionagi.studio.services import leo as leo_svc
 
-    sess = leo_svc.get_session(sid)
-    assert sess is not None
+    sess = leo_svc.create_session()
 
     stale_msg = ActionResponse(
         content={
@@ -531,12 +517,7 @@ def test_leo_prior_turn_proposals_not_reemitted(tmp_path, monkeypatch):
     branch.ReAct = AsyncMock(return_value="Nothing new to propose.")
     sess.branch = branch
 
-    r = client.post(
-        f"/api/leo/sessions/{sid}/messages",
-        json={"content": "Anything running?"},
-    )
-    assert r.status_code == 200
-    events = _parse_sse(r.text)
+    events = _run_compatibility_turn(sess, "Anything running?")
     types = [e.get("type") for e in events]
     assert "proposed_action" not in types
     assert "ui_command" not in types
@@ -545,50 +526,29 @@ def test_leo_prior_turn_proposals_not_reemitted(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Concurrent turns on the same session: the second must 409, never interleave
+# Compatibility handler rejects a second turn while the session is busy
 # ---------------------------------------------------------------------------
 
 
-def test_leo_concurrent_turn_second_gets_409(tmp_path, monkeypatch):
-    client = _make_client(tmp_path, monkeypatch)
+def test_leo_concurrent_turn_second_gets_409():
+    from fastapi import HTTPException
 
-    with client:
-        sid = client.post("/api/leo/sessions").json()["id"]
+    from lionagi.studio.services import leo as leo_svc
 
-        from lionagi.studio.services import leo as leo_svc
+    async def scenario() -> None:
+        sess = leo_svc.create_session()
+        await sess.lock.acquire()
+        try:
+            with pytest.raises(HTTPException) as error:
+                await leo_svc.send_leo_message_route(
+                    sess.id,
+                    leo_svc._MessageBody(content="hello"),
+                )
+            assert error.value.status_code == 409
+        finally:
+            sess.lock.release()
 
-        sess = leo_svc.get_session(sid)
-        assert sess is not None
-
-        async def slow_react(**_kwargs):
-            import asyncio
-
-            await asyncio.sleep(0.3)
-            return "done"
-
-        branch = MagicMock()
-        branch.messages = []
-        branch.ReAct = AsyncMock(side_effect=slow_react)
-        sess.branch = branch
-
-        results: dict[str, Any] = {}
-
-        def _post(key: str) -> None:
-            results[key] = client.post(
-                f"/api/leo/sessions/{sid}/messages",
-                json={"content": "hello"},
-            )
-
-        t1 = threading.Thread(target=_post, args=("first",))
-        t1.start()
-        time.sleep(0.1)  # let the first request acquire the session lock
-        t2 = threading.Thread(target=_post, args=("second",))
-        t2.start()
-        t1.join(timeout=5)
-        t2.join(timeout=5)
-
-    assert results["first"].status_code == 200
-    assert results["second"].status_code == 409
+    asyncio.run(scenario())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_operator_authorization.py
+++ b/tests/apps_studio_server/test_operator_authorization.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Every Operator route that touches conversation state refuses an unauthenticated caller.
+
+The failing configuration is the one with NO Studio bearer configured: the
+app-wide middleware deliberately lets every request through in that mode, so a
+route with no per-request authorization of its own is reachable by anyone who
+can open a socket. These tests exercise that mode directly.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from lionagi.studio.operator.coordinator import OperatorCoordinator
+from lionagi.studio.operator.store import OperatorStore
+
+# Anything but 127.0.0.1/localhost is rejected by the Host-header guard with a
+# 400 before auth runs, which would make every assertion below measure the
+# wrong thing.
+BASE_URL = "http://127.0.0.1:8765"
+
+
+def _patch_state_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    import lionagi.cli._runs as runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.sessions as sessions_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", path)
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", path)
+    monkeypatch.setattr(sessions_mod, "_DB", str(path))
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", path.parent / "runs")
+
+
+class _IdleEngine:
+    async def _stream(self, _turn):
+        return
+        yield  # pragma: no cover
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
+@pytest.fixture()
+async def no_credential_operator(tmp_path, monkeypatch):
+    """A live app plus coordinator with BOTH credential variables cleared."""
+    from lionagi.studio.app import create_app
+    from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+    from lionagi.studio.security import clear_captured_studio_credentials
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    clear_captured_studio_credentials()
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+
+    app = create_app()
+    assert app.state.studio_auth_token is None
+    assert app.state.studio_operator_credential_origin is None
+    assert "LIONAGI_STUDIO_AUTH_TOKEN" not in os.environ
+    assert "LIONAGI_STUDIO_HUMAN_TOKEN" not in os.environ
+
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=_IdleEngine)
+    await reset_operator_coordinator_for_testing(coordinator)
+    await coordinator.startup()
+    try:
+        yield app, coordinator
+    finally:
+        await coordinator.shutdown()
+        clear_captured_studio_credentials()
+
+
+def _client(app):
+    httpx = pytest.importorskip("httpx")
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 54321))
+    return httpx.AsyncClient(transport=transport, base_url=BASE_URL)
+
+
+@pytest.mark.asyncio
+async def test_no_token_mode_refuses_unauthenticated_create(no_credential_operator):
+    app, coordinator = no_credential_operator
+    before = await coordinator.store.list_conversations(limit=500)
+
+    async with _client(app) as client:
+        created = await client.post(
+            "/api/operator/conversations", json={"title": "should not exist"}
+        )
+
+    assert created.status_code == 403, created.text
+    assert "credential" in str(created.json()["detail"])
+    # The refusal has to be a refusal, not a 403 issued after the write.
+    after = await coordinator.store.list_conversations(limit=500)
+    assert len(after) == len(before)
+
+
+@pytest.mark.asyncio
+async def test_no_token_mode_refuses_unauthenticated_delete(no_credential_operator):
+    app, coordinator = no_credential_operator
+    cid = (await coordinator.create_conversation(title="keep me"))["conversation"]["id"]
+
+    async with _client(app) as client:
+        deleted = await client.delete(f"/api/operator/conversations/{cid}")
+
+    assert deleted.status_code == 403, deleted.text
+    # The conversation survived: the reported end-to-end exploit deleted it and
+    # a follow-up read returned 404.
+    assert (await coordinator.store.get_conversation(cid))["id"] == cid
+
+
+@pytest.mark.asyncio
+async def test_no_token_mode_refuses_unauthenticated_cancel(no_credential_operator):
+    app, coordinator = no_credential_operator
+    cid = (await coordinator.create_conversation(title="cancel target"))["conversation"]["id"]
+    accepted = await coordinator.store.submit_turn(
+        cid,
+        instruction="in flight",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    request_id = accepted["requestId"]
+
+    async with _client(app) as client:
+        cancelled = await client.post(
+            f"/api/operator/conversations/{cid}/requests/{request_id}/cancel",
+            headers={"content-type": "application/json"},
+        )
+
+    assert cancelled.status_code == 403, cancelled.text
+    conversation = await coordinator.store.get_conversation(cid)
+    assert conversation["activeRequestId"] == request_id
+
+
+@pytest.mark.asyncio
+async def test_no_token_mode_refuses_every_conversation_state_route(no_credential_operator):
+    """The whole surface, not just the three routes named in the report."""
+    app, coordinator = no_credential_operator
+    cid = (await coordinator.create_conversation(title="surface"))["conversation"]["id"]
+
+    async with _client(app) as client:
+        responses = {
+            "list": await client.get("/api/operator/conversations"),
+            "snapshot": await client.get(f"/api/operator/conversations/{cid}"),
+            "create": await client.post("/api/operator/conversations", json={}),
+            "delete": await client.delete(f"/api/operator/conversations/{cid}"),
+            "stream": await client.get(f"/api/operator/conversations/{cid}/stream"),
+            "submit": await client.post(
+                f"/api/operator/conversations/{cid}/turns",
+                json={
+                    "instruction": "no",
+                    "context": {"space": "mission", "route": "/", "filters": {}},
+                    "expectedLastSequence": 0,
+                },
+            ),
+            "cancel": await client.post(
+                f"/api/operator/conversations/{cid}/requests/r1/cancel",
+                headers={"content-type": "application/json"},
+            ),
+            # Bodies are valid on purpose: FastAPI validates before the handler
+            # runs, so an invalid body would score a 422 and prove nothing.
+            "ack": await client.post(
+                f"/api/operator/conversations/{cid}/effects/e1/ack",
+                json={"status": "applied"},
+            ),
+            "confirm": await client.post(
+                f"/api/operator/conversations/{cid}/proposals/p1/confirm",
+                json={"expectedCommandHash": "a" * 64},
+            ),
+            "decision": await client.post(
+                f"/api/operator/conversations/{cid}/proposals/p1/decision",
+                json={"decision": "allow", "expectedCommandHash": "a" * 64},
+            ),
+        }
+
+    assert {name: r.status_code for name, r in responses.items()} == {
+        name: 403 for name in responses
+    }
+
+
+@pytest.mark.asyncio
+async def test_bearer_configured_but_absent_header_is_refused_and_correct_header_works(
+    tmp_path, monkeypatch
+):
+    """The generated-credential mode still works, and a wrong bearer does not."""
+    from lionagi.studio.app import create_app
+    from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+    from lionagi.studio.security import (
+        capture_studio_credentials,
+        clear_captured_studio_credentials,
+    )
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    clear_captured_studio_credentials()
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    token = capture_studio_credentials(generate_human=True)
+    assert token
+
+    app = create_app()
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=_IdleEngine)
+    await reset_operator_coordinator_for_testing(coordinator)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="guarded"))["conversation"]["id"]
+
+    async with _client(app) as client:
+        assert (await client.post("/api/operator/conversations", json={})).status_code == 401
+        assert (await client.delete(f"/api/operator/conversations/{cid}")).status_code == 401
+        wrong = await client.post(
+            "/api/operator/conversations",
+            json={},
+            headers={"authorization": "Bearer not-the-token"},
+        )
+        assert wrong.status_code == 401
+        good = await client.post(
+            "/api/operator/conversations",
+            json={"title": "authorized"},
+            headers={"authorization": f"Bearer {token}"},
+        )
+        assert good.status_code == 200
+        removed = await client.delete(
+            f"/api/operator/conversations/{cid}",
+            headers={"authorization": f"Bearer {token}"},
+        )
+        assert removed.status_code == 200
+
+    await coordinator.shutdown()
+    clear_captured_studio_credentials()
+
+
+@pytest.mark.asyncio
+async def test_environment_credential_cannot_authorize_conversation_state(tmp_path, monkeypatch):
+    """An environment-derived bearer opens the API but not Operator state.
+
+    Its value is recoverable by process inspection, so it is not the human
+    boundary — the same rule submit already applied, now applied everywhere.
+    """
+    from lionagi.studio.app import create_app
+    from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+    from lionagi.studio.security import clear_captured_studio_credentials
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    clear_captured_studio_credentials()
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "environment-secret")
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+
+    app = create_app()
+    assert app.state.studio_operator_credential_origin == "environment"
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=_IdleEngine)
+    await reset_operator_coordinator_for_testing(coordinator)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="env"))["conversation"]["id"]
+
+    headers = {"authorization": "Bearer environment-secret"}
+    async with _client(app) as client:
+        # The app-wide bearer gate is satisfied — these 403s come from the route.
+        assert (await client.get("/openapi.json", headers=headers)).status_code == 200
+        assert (
+            await client.post("/api/operator/conversations", json={}, headers=headers)
+        ).status_code == 403
+        assert (
+            await client.delete(f"/api/operator/conversations/{cid}", headers=headers)
+        ).status_code == 403
+
+    assert (await coordinator.store.get_conversation(cid))["id"] == cid
+    await coordinator.shutdown()
+    clear_captured_studio_credentials()
+
+
+def test_studio_bearer_middleware_uses_constant_time_compare():
+    """The app-wide gate routes its bearer check through `compare_digest`.
+
+    This is a structural check, not a timing measurement: it asserts the
+    comparison the middleware performs, and that the comparator behaves on the
+    edge cases `!=` used to absorb. A wall-clock timing assay on an in-process
+    ASGI app would not discriminate.
+    """
+    import inspect
+
+    from lionagi.studio import app as app_module
+
+    # A non-ASCII header is a mismatch, not a TypeError escaping as a 500.
+    assert app_module._bearer_matches("Bearer ÿ", "secret") is False
+    assert app_module._bearer_matches("Bearer secret", "secret") is True
+    assert app_module._bearer_matches("", "secret") is False
+    assert "hmac.compare_digest" in inspect.getsource(app_module._bearer_matches)
+
+    source = inspect.getsource(app_module.create_app)
+    assert "_bearer_matches(presented, token)" in source
+    assert 'request.headers.get("authorization") != f"Bearer {token}"' not in source

--- a/tests/apps_studio_server/test_operator_frame_retention.py
+++ b/tests/apps_studio_server/test_operator_frame_retention.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The durable Operator frame record must be bounded and say when it was capped."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.studio.operator import store as store_mod
+from lionagi.studio.operator.store import OperatorStore
+from lionagi.studio.services._db import open_db
+
+
+async def _start_turn(store: OperatorStore) -> tuple[str, str]:
+    conversation = await store.create_conversation(title="Retention")
+    conversation_id = conversation["id"]
+    accepted = await store.submit_turn(
+        conversation_id,
+        instruction="hello",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    request_id = accepted["requestId"]
+    assert await store.mark_running(request_id)
+    return conversation_id, request_id
+
+
+async def _stored(store: OperatorStore, request_id: str) -> tuple[int, int]:
+    """Return the real row count and payload bytes SQLite holds for one turn."""
+    async with open_db(str(store.path())) as db:
+        row = await (
+            await db.execute(
+                "SELECT COUNT(*) AS rows_stored, "
+                "COALESCE(SUM(LENGTH(CAST(payload_json AS BLOB))), 0) AS bytes_stored "
+                "FROM studio_operator_frames WHERE request_id=?",
+                (request_id,),
+            )
+        ).fetchone()
+    return int(row["rows_stored"]), int(row["bytes_stored"])
+
+
+@pytest.mark.asyncio
+async def test_frame_count_cap_bounds_rows_and_records_what_it_elided(tmp_path, monkeypatch):
+    frame_limit = 12
+    monkeypatch.setattr(store_mod, "MAX_FRAMES_PER_TURN", frame_limit, raising=False)
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id, request_id = await _start_turn(store)
+
+    for index in range(200):
+        await store.append_frame(
+            conversation_id,
+            request_id,
+            "text",
+            {"content": f"chunk {index}", "format": "plain", "role": "assistant"},
+        )
+
+    rows, _ = await _stored(store, request_id)
+    # The refused frames collapse into one summary row, so the turn stays bounded.
+    assert rows <= frame_limit + 1
+
+    frames = await store.list_frames(conversation_id, limit=10_000)
+    summaries = [f for f in frames if f["type"] == store_mod.TRUNCATION_FRAME_TYPE]
+    assert len(summaries) == 1
+    summary = summaries[0]["payload"]
+    assert summary["reason"] == "frames_per_turn"
+    assert summary["limits"]["maxFramesPerTurn"] == frame_limit
+    stored_text = len([f for f in frames if f["type"] == "text"])
+    # 200 appended + the submit frame, minus what actually survived.
+    assert summary["elidedFrames"] == 201 - stored_text
+    assert summary["elidedFrameTypes"] == {"text": summary["elidedFrames"]}
+    assert summary["elidedBytes"] > 0
+    assert summary["message"]
+
+    # A terminal frame is never refused: the turn can always be closed.
+    await store.finish_turn(request_id, outcome="completed")
+    frames = await store.list_frames(conversation_id, limit=10_000)
+    assert frames[-1]["type"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_turn_byte_cap_bounds_stored_bytes_and_names_the_limit(tmp_path, monkeypatch):
+    byte_limit = 8 * 1024
+    monkeypatch.setattr(store_mod, "MAX_TURN_PAYLOAD_BYTES", byte_limit, raising=False)
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id, request_id = await _start_turn(store)
+
+    for _ in range(200):
+        await store.append_frame(
+            conversation_id,
+            request_id,
+            "text",
+            {"content": "x" * 512, "format": "plain", "role": "assistant"},
+        )
+
+    _, stored_bytes = await _stored(store, request_id)
+    # Only the single summary row may be written past the cap.
+    assert stored_bytes <= byte_limit + 1024
+
+    frames = await store.list_frames(conversation_id, limit=10_000)
+    summaries = [f for f in frames if f["type"] == store_mod.TRUNCATION_FRAME_TYPE]
+    assert len(summaries) == 1
+    summary = summaries[0]["payload"]
+    assert summary["reason"] == "turn_payload_bytes"
+    assert summary["limits"]["maxTurnPayloadBytes"] == byte_limit
+    assert summary["elidedFrames"] > 0
+    assert summary["elidedBytes"] >= summary["elidedFrames"] * 512
+
+
+@pytest.mark.asyncio
+async def test_oversized_payload_is_stored_truncated_and_reports_the_original_size(tmp_path):
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id, request_id = await _start_turn(store)
+    oversized = "a" * (256 * 1024)
+
+    frame = await store.append_frame(
+        conversation_id,
+        request_id,
+        "text",
+        {"content": oversized, "format": "plain", "role": "assistant"},
+    )
+
+    assert frame is not None
+    note = frame["payload"]["truncation"]
+    assert note["reason"] == "frame_payload_bytes"
+    assert note["originalBytes"] > store_mod.MAX_FRAME_PAYLOAD_BYTES
+    assert note["storedBytes"] <= store_mod.MAX_FRAME_PAYLOAD_BYTES
+    assert "bytes elided" in frame["payload"]["content"]
+    assert len(frame["payload"]["content"]) < len(oversized)
+
+    _, stored_bytes = await _stored(store, request_id)
+    assert stored_bytes <= store_mod.MAX_FRAME_PAYLOAD_BYTES + 1024
+
+    # The truncated payload is what a reader gets back, not the original.
+    frames = await store.list_frames(conversation_id, limit=10_000)
+    assert frames[-1]["payload"]["truncation"]["originalBytes"] == note["originalBytes"]
+
+
+@pytest.mark.asyncio
+async def test_normal_short_turn_is_stored_complete_and_unmodified(tmp_path):
+    """Control: the cap must not pass by truncating an ordinary turn."""
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id, request_id = await _start_turn(store)
+    payloads = [
+        {"content": f"line {index}", "format": "plain", "role": "assistant"} for index in range(5)
+    ]
+    for payload in payloads:
+        assert (await store.append_frame(conversation_id, request_id, "text", payload)) is not None
+    await store.finish_turn(request_id, outcome="completed")
+
+    frames = await store.list_frames(conversation_id, limit=10_000)
+    assert [frame["type"] for frame in frames] == ["text"] * 6 + ["done"]
+    assert [frame["sequence"] for frame in frames] == list(range(1, 8))
+    assert [frame["payload"] for frame in frames[1:6]] == payloads
+    assert not any(
+        frame["type"] == "truncation" or "truncation" in frame["payload"] for frame in frames
+    )

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -1602,7 +1602,9 @@ async def test_direct_app_without_browser_credential_rejects_operator_submit(tmp
         base_url="http://127.0.0.1:8765",
     ) as client:
         assert (await client.get("/openapi.json")).status_code == 200
-        assert (await client.get(f"/api/operator/conversations/{cid}")).status_code == 200
+        # No configured credential means no Operator access at all — the
+        # conversation snapshot is state, and state is gated.
+        assert (await client.get(f"/api/operator/conversations/{cid}")).status_code == 403
         blocked = await client.post(
             f"/api/operator/conversations/{cid}/turns",
             json={
@@ -1726,10 +1728,18 @@ async def test_generated_browser_bearer_guards_operator_get_sse_and_submit(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_sse_replays_committed_frames_in_sequence(tmp_path):
+async def test_sse_replays_committed_frames_in_sequence(tmp_path, monkeypatch):
     from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+    from lionagi.studio.security import (
+        capture_studio_credentials,
+        clear_captured_studio_credentials,
+    )
     from lionagi.studio.services.operator import stream_operator_conversation
 
+    clear_captured_studio_credentials()
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    token = capture_studio_credentials(generate_human=True)
     store = OperatorStore(tmp_path / "state.db")
     coordinator = OperatorCoordinator(store=store, engine_factory=BlockingEngine)
     await reset_operator_coordinator_for_testing(coordinator)
@@ -1743,6 +1753,11 @@ async def test_sse_replays_committed_frames_in_sequence(tmp_path):
     )
 
     class Connected:
+        # The stream route authorizes before it replays, so the stand-in has to
+        # carry a credential like a real request does.
+        scope: dict = {}
+        headers = {"authorization": f"Bearer {token}"}
+
         async def is_disconnected(self):
             return False
 
@@ -1755,6 +1770,7 @@ async def test_sse_replays_committed_frames_in_sequence(tmp_path):
     assert payload["payload"]["role"] == "user"
     await iterator.aclose()
     await coordinator.shutdown()
+    clear_captured_studio_credentials()
 
 
 @pytest.mark.asyncio

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -1,0 +1,1816 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for the durable ADR-0083 Studio Operator protocol."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from starlette.requests import Request
+
+from lionagi.studio.operator.coordinator import OperatorCoordinator
+from lionagi.studio.operator.permission_mcp import request_permission as mcp_permission
+from lionagi.studio.operator.store import (
+    OperatorAuditUnavailableError,
+    OperatorConflictError,
+    OperatorStore,
+)
+from lionagi.studio.operator.types import OperatorEngineEvent
+
+
+class ScriptedEngine:
+    async def _stream(self, _turn):
+        yield OperatorEngineEvent(
+            "text",
+            {"content": "first ", "format": "plain", "role": "assistant"},
+        )
+        yield OperatorEngineEvent(
+            "text",
+            {"content": "second", "format": "plain", "role": "assistant"},
+        )
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
+class BlockingEngine:
+    async def _stream(self, _turn):
+        await asyncio.Event().wait()
+        yield  # pragma: no cover
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
+class PermissionEngine:
+    def __init__(self, command_type: str = "provider_permission") -> None:
+        self.command_type = command_type
+
+    async def _stream(self, turn):
+        decision = await turn.request_permission(
+            self.command_type,
+            {"toolName": "Bash", "input": {"command": "git status"}, "toolUseId": "t1"},
+            "execute",
+            "Allow Bash for this turn",
+        )
+        yield OperatorEngineEvent(
+            "text",
+            {
+                "content": "allowed" if decision.allowed else "denied",
+                "format": "plain",
+                "role": "assistant",
+            },
+        )
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
+class NativePermissionEngine(PermissionEngine):
+    async def _stream(self, turn):
+        decision = await turn.request_permission(
+            "provider_permission",
+            {"toolName": "Bash", "input": {"command": "git status"}, "toolUseId": "t1"},
+            "execute",
+            "Allow Bash for this turn",
+        )
+        if decision.allowed:
+            yield OperatorEngineEvent(
+                "tool_result",
+                {
+                    "callId": "t1",
+                    "ok": True,
+                    "result": {"nativeToolCompleted": True},
+                },
+            )
+
+
+class UiEffectEngine:
+    async def _stream(self, _turn):
+        yield OperatorEngineEvent(
+            "ui_command",
+            {
+                "effect": {
+                    "kind": "navigate",
+                    "space": "history",
+                    "params": {"status": "failed"},
+                }
+            },
+        )
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
+def test_real_operator_branch_exposes_only_strict_request_scoped_mcp_tools(tmp_path):
+    from lionagi.studio.operator.engine import build_operator_branch
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("branch construction cannot request permission")
+
+    branch = build_operator_branch(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="inspect recent failures",
+            context={},
+            history=(),
+            request_permission=request_permission,
+            store_path=str(tmp_path / "state.db"),
+        )
+    )
+    kwargs = branch.chat_model.endpoint.config.kwargs
+    assert kwargs["permission_mode"] == "default"
+    assert kwargs["strict_mcp_config"] is True
+    assert kwargs.get("allow_dangerously_skip_permissions") is not True
+    assert set(kwargs["mcp_servers"]) == {"studio_permission", "studio_operator"}
+    assert kwargs["permission_prompt_tool_name"] == ("mcp__studio_permission__request_permission")
+    assert set(kwargs["allowed_tools"]) == {
+        "mcp__studio_operator__list_recent_runs",
+        "mcp__studio_operator__navigate",
+        "mcp__studio_operator__prefill_schedule",
+        "mcp__studio_operator__launch_playbook",
+    }
+    for server in kwargs["mcp_servers"].values():
+        assert "LIONAGI_STUDIO_AUTH_TOKEN" not in server["env"]
+        assert "LIONAGI_STUDIO_HUMAN_TOKEN" not in server["env"]
+
+
+@pytest.mark.asyncio
+async def test_application_mcp_read_query_is_bounded_and_redacted(monkeypatch):
+    from lionagi.studio.operator.application_mcp import list_recent_runs
+    from lionagi.studio.services import runs as runs_service
+
+    observed = {}
+
+    async def fake_list_runs(*, status, limit, offset):
+        observed.update(status=status, limit=limit, offset=offset)
+        return [
+            {
+                "id": "run-1",
+                "agent_name": "Operator",
+                "status": "failed",
+                "project": "/Users/example/private",
+                "started_at": 1.0,
+                "ended_at": 2.0,
+                "prompt": "must not leave the service",
+                "artifacts_path": "/secret/path",
+            },
+            {
+                "id": "run-2",
+                "agent_name": "Researcher",
+                "status": "failed",
+                "project": "acme/research",
+                "started_at": 3.0,
+                "ended_at": 4.0,
+            },
+        ]
+
+    monkeypatch.setattr(runs_service, "list_runs", fake_list_runs)
+    result = await list_recent_runs({"limit": 2, "status": "failed"})
+    assert observed == {"status": "failed", "limit": 2, "offset": 0}
+    assert result == {
+        "runs": [
+            {
+                "id": "run-1",
+                "agentName": "Operator",
+                "status": "failed",
+                "project": "private",
+                "startedAt": 1.0,
+                "endedAt": 2.0,
+                "href": "/runs/run-1",
+            },
+            {
+                "id": "run-2",
+                "agentName": "Researcher",
+                "status": "failed",
+                "project": "acme/research",
+                "startedAt": 3.0,
+                "endedAt": 4.0,
+                "href": "/runs/run-2",
+            },
+        ],
+        "count": 2,
+        "bounded": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_application_mcp_effects_are_typed_durable_and_client_acknowledged(
+    tmp_path, monkeypatch
+):
+    from lionagi.studio.operator.application_mcp import (
+        _dispatch,
+        navigate,
+        prefill_schedule,
+    )
+
+    path = tmp_path / "state.db"
+    store = OperatorStore(path)
+    cid = (await store.create_conversation())["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="drive the UI",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    navigation = await navigate({"space": "history", "status": "failed"})
+    prefill = await prefill_schedule(
+        {
+            "name": "Daily triage",
+            "cron": "0 9 * * *",
+            "prompt": "Review recent failures",
+        }
+    )
+    assert navigation["status"] == prefill["status"] == "pending"
+    frames = await store.list_frames(cid)
+    effects = [frame["payload"]["effect"] for frame in frames if frame["type"] == "ui_command"]
+    assert effects == [
+        {
+            "id": navigation["effectId"],
+            "kind": "navigate",
+            "space": "history",
+            "params": {"status": "failed"},
+        },
+        {
+            "id": prefill["effectId"],
+            "kind": "prefill",
+            "form": "schedule",
+            "values": {
+                "name": "Daily triage",
+                "cron": "0 9 * * *",
+                "prompt": "Review recent failures",
+                "description": "",
+            },
+        },
+    ]
+    invalid = await _dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "navigate",
+                "arguments": {
+                    "space": "history",
+                    "raw_url": "https://attacker.invalid",
+                },
+            },
+        }
+    )
+    assert invalid["result"]["isError"] is True
+    assert navigation["effectId"] != prefill["effectId"]
+    assert (
+        await store.acknowledge_effect(
+            cid,
+            navigation["effectId"],
+            status="applied",
+            rejection_code=None,
+        )
+    ) == {"effectId": navigation["effectId"], "status": "applied"}
+    await store.finish_turn(accepted["requestId"], outcome="completed")
+
+
+@pytest.mark.asyncio
+async def test_application_mcp_launch_blocks_on_real_durable_human_proposal(tmp_path, monkeypatch):
+    from lionagi.state.db import StateDB
+    from lionagi.studio.operator.application_mcp import launch_playbook
+    from lionagi.studio.services import playbooks as playbooks_service
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    playbooks_root = tmp_path / "playbooks"
+    playbooks_root.mkdir()
+    monkeypatch.setattr(playbooks_service, "_PLAYBOOKS_ROOT", playbooks_root)
+    (playbooks_root / "daily-triage.playbook.yaml").write_text(
+        "description: Daily triage\nsteps: []\n"
+    )
+    async with StateDB():
+        pass
+    calls = []
+
+    async def execute(command_type, command):
+        calls.append((command_type, command))
+        return {
+            "invocation_id": "inv-1",
+            "action_kind": "play",
+            "href": "/invocations/inv-1",
+        }
+
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(
+        store=store,
+        engine_factory=ScriptedEngine,
+        command_executor=execute,
+    )
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="launch the safe playbook",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    task = asyncio.create_task(
+        launch_playbook({"playbook": "daily-triage", "note": "review first"})
+    )
+    proposal = await _wait_proposal(store, accepted["requestId"])
+    assert not task.done()
+    assert proposal["commandType"] == "launch"
+    assert proposal["command"] == {
+        "action_kind": "play",
+        "action_playbook": "daily-triage",
+    }
+    assert proposal["targetVersion"].startswith("sha256:")
+    proposal_frame = await _wait_frame(store, cid, frame_type="proposal")
+    assert proposal_frame["payload"]["proposal"]["target"] == {
+        "kind": "playbook",
+        "id": "daily-triage",
+        "version": proposal["targetVersion"],
+    }
+    assert "endpoint" not in proposal["command"]
+    assert "command" not in proposal["command"]
+
+    decision = await coordinator.decide(
+        cid,
+        proposal["id"],
+        allow=True,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=proposal["targetVersion"],
+    )
+    result = await asyncio.wait_for(task, timeout=2)
+    assert decision["status"] == "succeeded"
+    assert calls == [
+        (
+            "launch",
+            {
+                "action_kind": "play",
+                "action_playbook": "daily-triage",
+            },
+        )
+    ]
+    assert result == {
+        "status": "succeeded",
+        "proposalId": proposal["id"],
+        "result": {
+            "invocation_id": "inv-1",
+            "action_kind": "play",
+            "href": "/invocations/inv-1",
+        },
+        "errorCode": None,
+    }
+    await store.finish_turn(accepted["requestId"], outcome="completed")
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_application_mcp_playbook_mutation_after_proposal_conflicts_before_execution(
+    tmp_path, monkeypatch
+):
+    from lionagi.state.db import StateDB
+    from lionagi.studio.operator.application_mcp import launch_playbook
+    from lionagi.studio.services import playbooks as playbooks_service
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    playbooks_root = tmp_path / "playbooks"
+    playbooks_root.mkdir()
+    monkeypatch.setattr(playbooks_service, "_PLAYBOOKS_ROOT", playbooks_root)
+    playbook_path = playbooks_root / "daily-triage.playbook.yaml"
+    playbook_path.write_text("description: First approved version\nsteps: []\n")
+    async with StateDB():
+        pass
+    calls = []
+
+    async def execute(command_type, command):
+        calls.append((command_type, command))
+        return {"invocation_id": "must-not-run"}
+
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(
+        store=store,
+        engine_factory=ScriptedEngine,
+        command_executor=execute,
+    )
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="launch exactly the version I approve",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    task = asyncio.create_task(launch_playbook({"playbook": "daily-triage"}))
+    proposal = await _wait_proposal(store, accepted["requestId"])
+    approved_version = proposal["targetVersion"]
+    playbook_path.write_text("description: Mutated after rendering\nsteps: []\n")
+
+    decision = await coordinator.decide(
+        cid,
+        proposal["id"],
+        allow=True,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=approved_version,
+    )
+    result = await asyncio.wait_for(task, timeout=2)
+    assert calls == []
+    assert decision["status"] == "conflict"
+    assert decision["error"]["code"] == "stale_context"
+    assert result["status"] == "conflict"
+    assert result["errorCode"] == "stale_context"
+    frames = await store.list_frames(cid)
+    failed_result = next(
+        frame
+        for frame in frames
+        if frame["type"] == "tool_result" and frame["payload"].get("callId") == proposal["id"]
+    )
+    assert failed_result["payload"]["ok"] is False
+    assert failed_result["payload"]["error"]["code"] == "stale_context"
+    assert await _audit_decisions(proposal["id"]) == ["confirmed", "failed"]
+    await store.finish_turn(accepted["requestId"], outcome="completed")
+    await coordinator.shutdown()
+
+
+async def _wait_done(
+    store: OperatorStore, conversation_id: str, *, timeout: float = 5
+) -> list[dict]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        frames = await store.list_frames(conversation_id)
+        if any(frame["type"] == "done" for frame in frames):
+            return frames
+        await asyncio.sleep(0.01)
+    raise TimeoutError("Operator turn did not finish")
+
+
+async def _wait_proposal(store: OperatorStore, request_id: str, *, timeout: float = 5) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        rows = await store.list_proposals_for_request(request_id)
+        if rows:
+            return rows[0]
+        await asyncio.sleep(0.01)
+    raise TimeoutError("Operator proposal did not appear")
+
+
+async def _wait_frame(
+    store: OperatorStore,
+    conversation_id: str,
+    *,
+    frame_type: str,
+    timeout: float = 5,
+) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        frames = await store.list_frames(conversation_id)
+        match = next((frame for frame in frames if frame["type"] == frame_type), None)
+        if match is not None:
+            return match
+        await asyncio.sleep(0.01)
+    raise TimeoutError(f"Operator {frame_type!r} frame did not appear")
+
+
+async def _audit_decisions(proposal_id: str) -> list[str]:
+    from lionagi.state.db import StateDB
+
+    async with StateDB(readonly=True) as db:
+        events = await db.list_admin_events(target_id=proposal_id)
+    details = [
+        json.loads(event["details"]) if isinstance(event["details"], str) else event["details"]
+        for event in events
+    ]
+    return [detail["decision"] for detail in reversed(details)]
+
+
+def _patch_state_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    import lionagi.cli._runs as runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.sessions as sessions_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", path)
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", path)
+    monkeypatch.setattr(sessions_mod, "_DB", str(path))
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", path.parent / "runs")
+
+
+@pytest.mark.asyncio
+async def test_store_is_restart_durable_monotonic_and_single_active(tmp_path):
+    path = tmp_path / "state.db"
+    store = OperatorStore(path)
+    conversation = await store.create_conversation(title="Persistent")
+    cid = conversation["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="hello",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    with pytest.raises(OperatorConflictError):
+        await store.submit_turn(
+            cid,
+            instruction="racing",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=1,
+        )
+    assert await store.mark_running(accepted["requestId"])
+    for index in range(5):
+        await store.append_frame(
+            cid,
+            accepted["requestId"],
+            "text",
+            {"content": str(index), "format": "plain", "role": "assistant"},
+        )
+    await store.finish_turn(accepted["requestId"], outcome="completed")
+
+    reopened = OperatorStore(path)
+    frames = await reopened.list_frames(cid)
+    assert [frame["sequence"] for frame in frames] == list(range(1, 8))
+    assert frames[0]["payload"]["role"] == "user"
+    assert frames[-1]["payload"] == {"outcome": "completed", "lastSequence": 7}
+    page_one = await reopened.list_frames(cid, after_sequence=0, limit=3)
+    page_two = await reopened.list_frames(cid, after_sequence=page_one[-1]["sequence"], limit=3)
+    assert [f["sequence"] for f in page_one + page_two] == [1, 2, 3, 4, 5, 6]
+    coordinator = OperatorCoordinator(store=reopened, engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    snapshot = await coordinator.snapshot(cid, after_sequence=0, limit=3)
+    assert snapshot["hasMore"] is True
+    assert snapshot["nextAfterSequence"] == 3
+    assert snapshot["latestSequence"] == 7
+
+
+@pytest.mark.asyncio
+async def test_default_store_reinitializes_schema_when_database_file_changes(
+    tmp_path,
+    monkeypatch,
+):
+    """A process-global store must not carry schema readiness across test/DB files."""
+    import lionagi.state.db as state_db_mod
+
+    first_path = tmp_path / "first.db"
+    second_path = tmp_path / "second.db"
+    store = OperatorStore()
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", first_path)
+    first = await store.create_conversation(title="First")
+    assert (await store.get_conversation(first["id"]))["title"] == "First"
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", second_path)
+    second = await store.create_conversation(title="Second")
+    assert (await store.get_conversation(second["id"]))["title"] == "Second"
+    assert first_path.is_file()
+    assert second_path.is_file()
+
+
+@pytest.mark.asyncio
+async def test_proposal_idempotency_key_rejects_changed_command(tmp_path):
+    store = OperatorStore(tmp_path / "state.db")
+    cid = (await store.create_conversation())["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="write the approved content",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    kwargs = {
+        "conversation_id": cid,
+        "request_id": accepted["requestId"],
+        "command_type": "provider_permission",
+        "risk": "mutate",
+        "summary": "Allow Write for this Operator turn",
+        "idempotency_key": "provider:fixed",
+    }
+    original = await store.create_proposal(
+        **kwargs,
+        command={
+            "toolName": "Write",
+            "input": {"file_path": "notes.txt", "content": "approved"},
+            "toolUseId": "native-1",
+        },
+    )
+    replay = await store.create_proposal(
+        **kwargs,
+        command={
+            "toolName": "Write",
+            "input": {"file_path": "notes.txt", "content": "approved"},
+            "toolUseId": "native-1",
+        },
+    )
+    assert replay["id"] == original["id"]
+
+    with pytest.raises(OperatorConflictError, match="different Operator proposal"):
+        await store.create_proposal(
+            **kwargs,
+            command={
+                "toolName": "Write",
+                "input": {"file_path": "notes.txt", "content": "unreviewed"},
+                "toolUseId": "native-1",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_scripted_turn_streams_and_is_visible_as_canonical_run(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    snapshot = await coordinator.create_conversation(title="Canonical")
+    cid = snapshot["conversation"]["id"]
+    accepted = await coordinator.submit(
+        cid,
+        instruction="run it",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    frames = await _wait_done(coordinator.store, cid)
+    assert [f["sequence"] for f in frames] == list(range(1, len(frames) + 1))
+    assert sum(frame["type"] == "done" for frame in frames) == 1
+    link = next(
+        frame
+        for frame in frames
+        if frame["type"] == "tool_result"
+        and isinstance(frame["payload"].get("result"), dict)
+        and frame["payload"]["result"].get("runId")
+    )
+    run_id = link["payload"]["result"]["runId"]
+    branch_id = link["payload"]["result"]["branchId"]
+
+    from lionagi.cli._runs import find_branch
+    from lionagi.session.branch import Branch
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.run_resume import (
+        _ensure_branch_snapshot_available,
+        _resolve_branch,
+    )
+
+    # The Operator's canonical Run is not display-only: the exact branch
+    # and DB run mapping consumed by `li agent -r` already exist.
+    async with StateDB(readonly=True) as db:
+        session = await db.get_session(run_id)
+        db_branches = await db.list_branches(run_id)
+    assert session is not None
+    assert [row["id"] for row in db_branches] == [branch_id]
+    assert await _resolve_branch(run_id, None) == branch_id
+    await _ensure_branch_snapshot_available(branch_id)
+    snapshot_run_id, snapshot_path = find_branch(branch_id)
+    assert snapshot_run_id == session["run_id"]
+    serialized = json.loads(snapshot_path.read_text())
+    assert str(Branch.from_dict(serialized).id) == branch_id
+    request_kwargs = serialized["chat_model"]["endpoint"]["config"]["kwargs"]
+    assert "permission_prompt_tool_name" not in request_kwargs
+    assert "strict_mcp_config" not in request_kwargs
+    assert "setting_sources" not in request_kwargs
+    assert "allowed_tools" not in request_kwargs
+    assert "studio_permission" not in request_kwargs.get("mcp_servers", {})
+    assert "studio_operator" not in request_kwargs.get("mcp_servers", {})
+
+    from lionagi.studio.services.runs import list_runs
+
+    runs = await list_runs(limit=50, offset=0)
+    run = next(item for item in runs if item["id"] == run_id)
+    assert run["agent_name"] == "Operator"
+    assert (await coordinator.store.get_turn(accepted["requestId"]))["status"] == "completed"
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_missing_claude_cli_finishes_with_public_provider_fix(tmp_path, monkeypatch):
+    from lionagi.providers.anthropic import claude_code
+    from lionagi.studio.operator.engine import BranchOperatorEngine
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    monkeypatch.setattr(claude_code, "CLAUDE_CLI", None)
+    coordinator = OperatorCoordinator(
+        store=OperatorStore(path), engine_factory=BranchOperatorEngine
+    )
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    await coordinator.submit(
+        cid,
+        instruction="inspect this project",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    frames = await _wait_done(coordinator.store, cid)
+    error = next(frame for frame in frames if frame["type"] == "error")
+    assert error["payload"]["error"] == {
+        "code": "provider_unavailable",
+        "message": (
+            "Claude Code CLI is unavailable. Install it with "
+            "`npm install -g @anthropic-ai/claude-code`, then run "
+            "`claude auth login`."
+        ),
+        "retryable": False,
+    }
+    assert frames[-1]["payload"]["outcome"] == "failed"
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_allow_claims_and_executes_application_command_once(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    calls = 0
+    executing = asyncio.Event()
+    release = asyncio.Event()
+
+    async def execute(_command_type, _command):
+        nonlocal calls
+        calls += 1
+        executing.set()
+        await release.wait()
+        return {"href": "/runs/child", "run_id": "child"}
+
+    coordinator = OperatorCoordinator(
+        store=OperatorStore(path),
+        engine_factory=lambda: PermissionEngine("launch"),
+        command_executor=execute,
+    )
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await coordinator.submit(
+        cid,
+        instruction="launch once",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    proposal = await _wait_proposal(coordinator.store, accepted["requestId"])
+
+    original_decide = coordinator.store.decide_proposal
+
+    async def audit_down(*_args, **_kwargs):
+        raise RuntimeError("audit database unavailable")
+
+    monkeypatch.setattr(coordinator.store, "decide_proposal", audit_down)
+    with pytest.raises(OperatorAuditUnavailableError):
+        await coordinator.decide(
+            cid,
+            proposal["id"],
+            allow=True,
+            expected_command_hash=proposal["commandHash"],
+            expected_target_version=None,
+        )
+    assert calls == 0
+    assert (await coordinator.store.get_proposal(proposal["id"]))["status"] == "pending"
+    monkeypatch.setattr(coordinator.store, "decide_proposal", original_decide)
+
+    # Validation precedes the audit/claim transaction.
+    with pytest.raises(OperatorConflictError):
+        await coordinator.decide(
+            cid,
+            proposal["id"],
+            allow=True,
+            expected_command_hash="0" * 64,
+            expected_target_version=None,
+        )
+    from lionagi.state.db import StateDB
+
+    async with StateDB(readonly=True) as db:
+        assert await db.list_admin_events(target_id=proposal["id"]) == []
+
+    first = asyncio.create_task(
+        coordinator.decide(
+            cid,
+            proposal["id"],
+            allow=True,
+            expected_command_hash=proposal["commandHash"],
+            expected_target_version=None,
+        )
+    )
+    await asyncio.wait_for(executing.wait(), timeout=2)
+    second = await asyncio.wait_for(
+        coordinator.decide(
+            cid,
+            proposal["id"],
+            allow=True,
+            expected_command_hash=proposal["commandHash"],
+            expected_target_version=None,
+        ),
+        timeout=2,
+    )
+    assert calls == 1
+    assert second["status"] == "executing"
+    release.set()
+    first_result = await asyncio.wait_for(first, timeout=2)
+    assert first_result["status"] == "succeeded"
+    assert calls == 1
+
+    async with StateDB(readonly=True) as db:
+        audits = await db.list_admin_events(target_id=proposal["id"])
+    for event in audits:
+        if isinstance(event["details"], str):
+            event["details"] = json.loads(event["details"])
+    assert {event["actor"] for event in audits} == {"studio_operator"}
+    assert {event["details"]["decision"] for event in audits} == {
+        "confirmed",
+        "executed",
+    }
+    required_keys = {
+        "conversation_id",
+        "request_id",
+        "proposal_id",
+        "command_type",
+        "command_hash",
+        "target",
+        "risk",
+        "idempotency_key",
+        "decision",
+        "result",
+        "error_code",
+        "confirmed_at",
+        "completed_at",
+    }
+    assert all(set(event["details"]) == required_keys for event in audits)
+    await _wait_done(coordinator.store, cid)
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ui_effect_is_persisted_before_frame_and_ack_is_idempotent(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=UiEffectEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    await coordinator.submit(
+        cid,
+        instruction="show failed runs",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    frames = await _wait_done(coordinator.store, cid)
+    effect_frame = next(frame for frame in frames if frame["type"] == "ui_command")
+    effect = effect_frame["payload"]["effect"]
+    assert effect["kind"] == "navigate"
+    assert effect["id"]
+
+    first = await coordinator.store.acknowledge_effect(
+        cid, effect["id"], status="applied", rejection_code=None
+    )
+    repeated = await coordinator.store.acknowledge_effect(
+        cid, effect["id"], status="applied", rejection_code=None
+    )
+    assert first == repeated == {"effectId": effect["id"], "status": "applied"}
+    with pytest.raises(OperatorConflictError):
+        await coordinator.store.acknowledge_effect(
+            cid, effect["id"], status="rejected", rejection_code="client_error"
+        )
+    await coordinator.shutdown()
+
+
+def test_allow_decision_requires_the_rendered_command_hash():
+    from pydantic import ValidationError
+
+    from lionagi.studio.operator.types import DecideProposalRequest
+
+    with pytest.raises(ValidationError):
+        DecideProposalRequest(decision="allow")
+    assert DecideProposalRequest(decision="deny").expected_command_hash is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_route_threads_the_rendered_target_version(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    from lionagi.studio.operator.types import ConfirmProposalRequest
+    from lionagi.studio.services import operator as operator_svc
+
+    coordinator = MagicMock()
+    coordinator.decide = AsyncMock(return_value={"status": "succeeded"})
+    require_human = AsyncMock()
+    monkeypatch.setattr(operator_svc, "get_operator_coordinator", lambda: coordinator)
+    monkeypatch.setattr(operator_svc, "_require_human", require_human)
+    command_hash = "a" * 64
+    target_version = "sha256:rendered-playbook"
+    body = ConfirmProposalRequest.model_validate(
+        {
+            "expectedCommandHash": command_hash,
+            "expectedTargetVersion": target_version,
+        }
+    )
+
+    result = await operator_svc.confirm_operator_proposal(
+        "conversation",
+        "proposal",
+        body,
+        MagicMock(),
+    )
+
+    assert result == {"status": "succeeded"}
+    require_human.assert_awaited_once()
+    coordinator.decide.assert_awaited_once_with(
+        "conversation",
+        "proposal",
+        allow=True,
+        expected_command_hash=command_hash,
+        expected_target_version=target_version,
+    )
+
+
+def test_context_compiler_keeps_newest_complete_turn_when_older_turn_exceeds_budget():
+    from lionagi.studio.operator.engine import (
+        _compile_operator_prompt,
+        compile_operator_history,
+    )
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("context compilation cannot request permission")
+
+    newer = [
+        {
+            "conversationId": "conversation",
+            "requestId": "newer",
+            "sequence": 3,
+            "type": "text",
+            "payload": {
+                "role": "user",
+                "format": "plain",
+                "content": "recent context survives",
+            },
+        },
+        {
+            "conversationId": "conversation",
+            "requestId": "newer",
+            "sequence": 4,
+            "type": "done",
+            "payload": {"outcome": "completed", "lastSequence": 4},
+        },
+    ]
+    older = [
+        {
+            "conversationId": "conversation",
+            "requestId": "older",
+            "sequence": 1,
+            "type": "text",
+            "payload": {
+                "role": "assistant",
+                "format": "plain",
+                "content": "x" * (129 * 1024),
+            },
+        },
+        {
+            "conversationId": "conversation",
+            "requestId": "older",
+            "sequence": 2,
+            "type": "done",
+            "payload": {"outcome": "completed", "lastSequence": 2},
+        },
+    ]
+    compiled = compile_operator_history([newer, older])
+    prompt = _compile_operator_prompt(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="current instruction",
+            context={},
+            history=compiled.frames,
+            request_permission=request_permission,
+        )
+    )
+    assert compiled.metadata["turnCount"] == 1
+    assert compiled.metadata["firstSequence"] == 3
+    assert compiled.metadata["lastSequence"] == 4
+    assert "recent context survives" in prompt
+    assert "x" * 1024 not in prompt
+    assert prompt.endswith("current instruction")
+
+
+@pytest.mark.asyncio
+async def test_context_compilation_groups_complete_turns_merges_deltas_and_persists_receipt(
+    tmp_path,
+):
+    from lionagi.studio.operator.engine import (
+        _compile_operator_prompt,
+        compile_operator_history,
+    )
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("context compilation cannot request permission")
+
+    store = OperatorStore(tmp_path / "state.db")
+    cid = (await store.create_conversation())["id"]
+    first = await store.submit_turn(
+        cid,
+        instruction="remember the original requirement",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(first["requestId"])
+    for index in range(70):
+        await store.append_frame(
+            cid,
+            first["requestId"],
+            "text",
+            {
+                "content": f"delta-{index}|",
+                "format": "plain",
+                "role": "assistant",
+            },
+        )
+    await store.append_frame(
+        cid,
+        first["requestId"],
+        "tool_call",
+        {
+            "callId": "paired-1",
+            "tool": "Inspect",
+            "arguments": {"path": "README.md"},
+            "mode": "read",
+        },
+    )
+    await store.append_frame(
+        cid,
+        first["requestId"],
+        "tool_result",
+        {
+            "callId": "paired-1",
+            "ok": True,
+            "result": {"summary": "found"},
+        },
+    )
+    await store.finish_turn(first["requestId"], outcome="completed")
+
+    latest = (await store.get_conversation(cid))["nextSequence"] - 1
+    second = await store.submit_turn(
+        cid,
+        instruction="newer complete request",
+        context={"space": "history", "route": "/fleet", "filters": {}},
+        expected_last_sequence=latest,
+    )
+    assert await store.mark_running(second["requestId"])
+    await store.append_frame(
+        cid,
+        second["requestId"],
+        "text",
+        {
+            "content": "newer complete answer",
+            "format": "plain",
+            "role": "assistant",
+        },
+    )
+    await store.finish_turn(second["requestId"], outcome="completed")
+
+    latest = (await store.get_conversation(cid))["nextSequence"] - 1
+    current = await store.submit_turn(
+        cid,
+        instruction="use both prior turns",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=latest,
+    )
+    assert await store.mark_running(current["requestId"])
+    groups = await store.list_complete_turn_frame_groups(
+        cid, exclude_request_id=current["requestId"]
+    )
+    compiled = compile_operator_history(groups)
+    repeated = compile_operator_history(groups)
+
+    text = [frame["payload"]["content"] for frame in compiled.frames if frame["type"] == "text"]
+    assert text[0] == "remember the original requirement"
+    assert "delta-0|" in text[1]
+    assert "delta-69|" in text[1]
+    assert text[-2:] == ["newer complete request", "newer complete answer"]
+    tool_frames = [frame for frame in compiled.frames if frame["type"].startswith("tool_")]
+    assert [frame["type"] for frame in tool_frames] == ["tool_call", "tool_result"]
+    assert {frame["payload"]["callId"] for frame in tool_frames} == {"paired-1"}
+    assert compiled.metadata == repeated.metadata
+    assert compiled.metadata["frameCount"] == 6
+    assert compiled.metadata["turnCount"] == 2
+    assert compiled.metadata["firstSequence"] == 1
+    assert compiled.metadata["lastSequence"] == current["acceptedSequence"] - 1
+    assert len(compiled.metadata["hash"]) == 64
+
+    context = await store.record_context_compilation(current["requestId"], compiled.metadata)
+    turn = await store.get_turn(current["requestId"])
+    assert context["operatorCompilation"] == compiled.metadata
+    assert turn["context"] == context
+    assert turn["contextHash"] == store.canonical_hash(context)
+    prompt = _compile_operator_prompt(
+        OperatorEngineTurn(
+            conversation_id=cid,
+            request_id=current["requestId"],
+            instruction="use both prior turns",
+            context=context,
+            history=compiled.frames,
+            request_permission=request_permission,
+        )
+    )
+    assert "remember the original requirement" in prompt
+    assert "delta-69|" in prompt
+    assert "assistant tool call Inspect [paired-1]" in prompt
+    assert "tool result [paired-1] (ok)" in prompt
+    assert prompt.endswith("use both prior turns")
+    await store.finish_turn(current["requestId"], outcome="cancelled")
+
+
+@pytest.mark.asyncio
+async def test_agent_and_scheduler_children_do_not_inherit_studio_credentials(
+    monkeypatch,
+):
+    from lionagi.providers._cli_subprocess import ndjson_from_cli
+    from lionagi.studio.scheduler.subprocess import spawn_and_wait
+
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "must-not-reach-child")
+    monkeypatch.setenv("LIONAGI_STUDIO_HUMAN_TOKEN", "human-must-not-reach-child")
+    probe = (
+        "import json,os;"
+        "print(json.dumps({'auth':os.getenv('LIONAGI_STUDIO_AUTH_TOKEN'),"
+        "'human':os.getenv('LIONAGI_STUDIO_HUMAN_TOKEN')}))"
+    )
+    rows = [row async for row in ndjson_from_cli([sys.executable, "-c", probe])]
+    assert rows == [{"auth": None, "human": None}]
+
+    scheduler_probe = (
+        "import os,sys;"
+        "sys.stderr.write(repr((os.getenv('LIONAGI_STUDIO_AUTH_TOKEN'),"
+        "os.getenv('LIONAGI_STUDIO_HUMAN_TOKEN'))))"
+    )
+    exit_code, stderr = await spawn_and_wait(
+        [sys.executable, "-c", scheduler_probe], "operator-env-probe"
+    )
+    assert exit_code == 0
+    assert stderr == "(None, None)"
+
+
+@pytest.mark.asyncio
+async def test_immediate_and_repeated_cancel_always_terminalize(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=BlockingEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await coordinator.submit(
+        cid,
+        instruction="wait",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    first = await coordinator.cancel(cid, accepted["requestId"])
+    second = await coordinator.cancel(cid, accepted["requestId"])
+    frames = await _wait_done(coordinator.store, cid)
+    assert first["cancelRequested"] is True
+    assert second["cancelRequested"] is False
+    assert sum(frame["type"] == "done" for frame in frames) == 1
+    assert frames[-1]["payload"]["outcome"] == "cancelled"
+    assert (await coordinator.store.get_conversation(cid))["activeRequestId"] is None
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_startup_recovers_interrupted_turn_with_error_and_done(tmp_path):
+    store = OperatorStore(tmp_path / "state.db")
+    cid = (await store.create_conversation())["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="interrupted",
+        context={"space": "system", "route": "/system", "filters": {}},
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    recovered = await OperatorCoordinator(store=store, engine_factory=ScriptedEngine).startup()
+    assert recovered == [accepted["requestId"]]
+    frames = await store.list_frames(cid)
+    assert [frame["type"] for frame in frames[-2:]] == ["error", "done"]
+    assert frames[-2]["payload"]["error"]["code"] == "service_restarted"
+    assert frames[-1]["payload"]["outcome"] == "failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("allow", "word"), [(True, "allowed"), (False, "denied")])
+async def test_engine_permission_really_blocks_until_allow_or_deny(
+    tmp_path, monkeypatch, allow, word
+):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=PermissionEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await coordinator.submit(
+        cid,
+        instruction="gated",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    proposal = await _wait_proposal(coordinator.store, accepted["requestId"])
+    before = await coordinator.store.list_frames(cid)
+    assert not any(frame["type"] == "done" for frame in before)
+    assert proposal["command"]["toolName"] == "Bash"
+    assert proposal["command"]["input"] == {"command": "git status"}
+
+    result = await coordinator.decide(
+        cid,
+        proposal["id"],
+        allow=allow,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=None,
+    )
+    frames = await _wait_done(coordinator.store, cid)
+    text = "".join(
+        frame["payload"].get("content", "") for frame in frames if frame["type"] == "text"
+    )
+    assert word in text
+    assert result["status"] == ("executing" if allow else "failed")
+    if not allow:
+        assert any(
+            frame["type"] == "confirmation"
+            and frame["payload"] == {"proposalId": proposal["id"], "state": "cancelled"}
+            for frame in frames
+        )
+        assert (await coordinator.store.get_proposal(proposal["id"]))["status"] == "cancelled"
+        assert await _audit_decisions(proposal["id"]) == ["denied"]
+    else:
+        unfinished = await coordinator.store.get_proposal(proposal["id"])
+        assert unfinished["status"] == "failed"
+        assert unfinished["errorCode"] == "provider_result_missing"
+        missing_result = next(
+            frame
+            for frame in frames
+            if frame["type"] == "tool_result" and frame["payload"].get("callId") == "t1"
+        )
+        assert missing_result["payload"] == {
+            "callId": "t1",
+            "ok": False,
+            "error": {
+                "code": "service_failure",
+                "message": (
+                    "The provider ended without returning a terminal result for this approved tool"
+                ),
+                "retryable": False,
+            },
+        }
+        assert frames[-1]["payload"]["outcome"] == "failed"
+        assert (await coordinator.store.get_turn(accepted["requestId"]))["status"] == "failed"
+        assert await _audit_decisions(proposal["id"]) == [
+            "confirmed",
+            "indeterminate",
+        ]
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_native_tool_result_terminalizes_and_audits_provider_permission(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(
+        store=OperatorStore(path), engine_factory=NativePermissionEngine
+    )
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await coordinator.submit(
+        cid,
+        instruction="gated native tool",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    proposal = await _wait_proposal(coordinator.store, accepted["requestId"])
+    await coordinator.decide(
+        cid,
+        proposal["id"],
+        allow=True,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=None,
+    )
+    frames = await _wait_done(coordinator.store, cid)
+    terminal = await coordinator.store.get_proposal(proposal["id"])
+    assert terminal["status"] == "succeeded"
+    assert terminal["result"] == {"nativeToolCompleted": True}
+    assert await _audit_decisions(proposal["id"]) == ["confirmed", "executed"]
+    assert any(
+        frame["type"] == "confirmation"
+        and frame["payload"] == {"proposalId": proposal["id"], "state": "executed"}
+        for frame in frames
+    )
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("terminalizer", "proposal_status", "audit_decision"),
+    [
+        ("cancel", "cancelled", "denied"),
+        ("expire", "expired", "expired"),
+    ],
+)
+async def test_pending_provider_permission_cancel_and_expiry_are_audited(
+    tmp_path, monkeypatch, terminalizer, proposal_status, audit_decision
+):
+    from lionagi.studio.services._db import open_db
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=PermissionEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await coordinator.submit(
+        cid,
+        instruction="pending permission",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    proposal = await _wait_proposal(coordinator.store, accepted["requestId"])
+    if terminalizer == "cancel":
+        await coordinator.cancel(cid, accepted["requestId"])
+    else:
+        async with open_db(str(path)) as db:
+            await db.execute(
+                "UPDATE studio_operator_proposals SET expires_at=0 WHERE id=?",
+                (proposal["id"],),
+            )
+            await db.commit()
+    await _wait_done(coordinator.store, cid)
+    terminal = await coordinator.store.get_proposal(proposal["id"])
+    assert terminal["status"] == proposal_status
+    assert await _audit_decisions(proposal["id"]) == [audit_decision]
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_stdio_permission_bridge_polls_durable_decision(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    store = OperatorStore(path)
+    cid = (await store.create_conversation())["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="native tool",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+    task = asyncio.create_task(
+        mcp_permission(
+            {
+                "tool_name": "Write",
+                "input": {"file_path": "notes.txt", "content": "hello"},
+                "tool_use_id": "native-1",
+            }
+        )
+    )
+    proposal = await _wait_proposal(store, accepted["requestId"])
+    await asyncio.sleep(0)
+    assert not task.done()
+    await store.decide_proposal(
+        cid,
+        proposal["id"],
+        allow=True,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=None,
+    )
+    decision = await asyncio.wait_for(task, timeout=2)
+    assert decision == {
+        "behavior": "allow",
+        "updatedInput": {"file_path": "notes.txt", "content": "hello"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_stdio_permission_bridge_never_reuses_approval_for_changed_input(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "state.db"
+    store = OperatorStore(path)
+    cid = (await store.create_conversation())["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="native tool",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    first_input = {"file_path": "notes.txt", "content": "approved"}
+    first_task = asyncio.create_task(
+        mcp_permission(
+            {
+                "tool_name": "Write",
+                "input": first_input,
+                "tool_use_id": "native-1",
+            }
+        )
+    )
+    first = await _wait_proposal(store, accepted["requestId"])
+    await store.decide_proposal(
+        cid,
+        first["id"],
+        allow=True,
+        expected_command_hash=first["commandHash"],
+        expected_target_version=None,
+    )
+    assert await asyncio.wait_for(first_task, timeout=2) == {
+        "behavior": "allow",
+        "updatedInput": first_input,
+    }
+
+    changed_input = {"file_path": "notes.txt", "content": "not yet approved"}
+    changed_task = asyncio.create_task(
+        mcp_permission(
+            {
+                "tool_name": "Write",
+                "input": changed_input,
+                "tool_use_id": "native-1",
+            }
+        )
+    )
+    deadline = time.monotonic() + 2
+    proposals = []
+    while time.monotonic() < deadline:
+        proposals = await store.list_proposals_for_request(accepted["requestId"])
+        if len(proposals) == 2:
+            break
+        await asyncio.sleep(0.01)
+    assert len(proposals) == 2
+    changed = proposals[1]
+    assert changed["id"] != first["id"]
+    assert changed["command"]["input"] == changed_input
+    assert changed["status"] == "pending"
+    assert not changed_task.done()
+
+    await store.decide_proposal(
+        cid,
+        changed["id"],
+        allow=False,
+        expected_command_hash=changed["commandHash"],
+        expected_target_version=None,
+    )
+    assert await asyncio.wait_for(changed_task, timeout=2) == {
+        "behavior": "deny",
+        "message": "The Lion Studio operator denied this tool request",
+    }
+
+
+def _request(
+    *,
+    client: str = "127.0.0.1",
+    headers: dict[str, str] | None = None,
+) -> Request:
+    raw_headers = [(key.lower().encode(), value.encode()) for key, value in (headers or {}).items()]
+    if not any(key == b"host" for key, _ in raw_headers):
+        raw_headers.append((b"host", b"127.0.0.1:8765"))
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/",
+            "raw_path": b"/",
+            "query_string": b"",
+            "headers": raw_headers,
+            "client": (client, 1234),
+            "server": ("127.0.0.1", 8765),
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_operator_human_gate_requires_exact_browser_credential(monkeypatch):
+    from fastapi import HTTPException
+
+    from lionagi.studio.security import (
+        capture_studio_credentials,
+        clear_captured_studio_credentials,
+    )
+    from lionagi.studio.services.operator import (
+        _require_human,
+        _require_safe_operator_credential_origin,
+    )
+
+    clear_captured_studio_credentials()
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    with pytest.raises(HTTPException) as missing:
+        _require_safe_operator_credential_origin(_request())
+    assert missing.value.status_code == 403
+    assert "generated browser credential" in missing.value.detail
+    with pytest.raises(HTTPException):
+        await _require_human(_request())
+
+    monkeypatch.setenv("LIONAGI_STUDIO_HUMAN_TOKEN", "human-secret")
+    with pytest.raises(HTTPException) as unsafe:
+        await _require_human(_request(headers={"authorization": "Bearer human-secret"}))
+    assert unsafe.value.status_code == 403
+    assert "environment-derived" in unsafe.value.detail
+
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    generated = capture_studio_credentials(generate_human=True)
+    assert generated
+    with pytest.raises(HTTPException):
+        await _require_human(_request(headers={"authorization": "Bearer wrong"}))
+    with pytest.raises(HTTPException):
+        await _require_human(
+            _request(
+                headers={
+                    "authorization": f"Bearer {generated}",
+                    "x-lionagi-operator-principal": "service",
+                }
+            )
+        )
+    await _require_human(_request(headers={"authorization": f"Bearer {generated}"}))
+    clear_captured_studio_credentials()
+
+
+@pytest.mark.asyncio
+async def test_direct_app_factory_captures_and_erases_environment_credential(
+    monkeypatch,
+):
+    from fastapi import HTTPException
+
+    from lionagi.studio.app import create_app
+    from lionagi.studio.security import clear_captured_studio_credentials
+    from lionagi.studio.services.operator import (
+        _require_human,
+        _require_safe_operator_credential_origin,
+    )
+
+    clear_captured_studio_credentials()
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "direct-uvicorn-secret")
+    monkeypatch.setenv("LIONAGI_STUDIO_HUMAN_TOKEN", "lower-priority-secret")
+    app = create_app()
+    assert "LIONAGI_STUDIO_AUTH_TOKEN" not in os.environ
+    assert "LIONAGI_STUDIO_HUMAN_TOKEN" not in os.environ
+    assert app.state.studio_auth_token == "direct-uvicorn-secret"
+    assert app.state.studio_human_token == "direct-uvicorn-secret"
+    assert app.state.studio_operator_credential_origin == "environment"
+
+    request = _request(headers={"authorization": "Bearer direct-uvicorn-secret"})
+    request.scope["app"] = app
+    with pytest.raises(HTTPException) as origin_error:
+        _require_safe_operator_credential_origin(request)
+    assert origin_error.value.status_code == 403
+    assert "environment-derived" in origin_error.value.detail
+    with pytest.raises(HTTPException):
+        await _require_human(request)
+    clear_captured_studio_credentials()
+
+
+@pytest.mark.asyncio
+async def test_direct_app_without_browser_credential_rejects_operator_submit(tmp_path, monkeypatch):
+    httpx = pytest.importorskip("httpx")
+    from lionagi.studio.app import create_app
+    from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+    from lionagi.studio.security import clear_captured_studio_credentials
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    clear_captured_studio_credentials()
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    app = create_app()
+    coordinator = OperatorCoordinator(
+        store=OperatorStore(path),
+        engine_factory=ScriptedEngine,
+    )
+    await reset_operator_coordinator_for_testing(coordinator)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 54321))
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://127.0.0.1:8765",
+    ) as client:
+        assert (await client.get("/openapi.json")).status_code == 200
+        assert (await client.get(f"/api/operator/conversations/{cid}")).status_code == 200
+        blocked = await client.post(
+            f"/api/operator/conversations/{cid}/turns",
+            json={
+                "instruction": "This must not start.",
+                "context": {"space": "mission", "route": "/", "filters": {}},
+                "expectedLastSequence": 0,
+            },
+        )
+    assert blocked.status_code == 403
+    assert "generated browser credential" in blocked.json()["detail"]
+    assert await coordinator.store.list_frames(cid) == []
+    await coordinator.shutdown()
+    clear_captured_studio_credentials()
+
+
+@pytest.mark.asyncio
+async def test_generated_browser_bearer_guards_operator_get_sse_and_submit(tmp_path, monkeypatch):
+    httpx = pytest.importorskip("httpx")
+    from lionagi.studio.app import create_app
+    from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+    from lionagi.studio.security import (
+        capture_studio_credentials,
+        clear_captured_studio_credentials,
+    )
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    clear_captured_studio_credentials()
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    token = capture_studio_credentials(generate_human=True)
+    assert token
+    app = create_app()
+    assert app.state.studio_auth_token == token
+    assert app.state.studio_human_token == token
+    assert app.state.studio_operator_credential_origin == "generated"
+
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=ScriptedEngine)
+    await reset_operator_coordinator_for_testing(coordinator)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 54321))
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:8765") as client:
+        assert (await client.get("/openapi.json")).status_code == 401
+        assert (await client.get(f"/api/operator/conversations/{cid}")).status_code == 401
+        assert (await client.get(f"/api/operator/conversations/{cid}/stream")).status_code == 401
+        unauthenticated_submit = await client.post(
+            f"/api/operator/conversations/{cid}/turns",
+            json={
+                "instruction": "must be rejected",
+                "context": {"space": "mission", "route": "/", "filters": {}},
+                "expectedLastSequence": 0,
+            },
+        )
+        assert unauthenticated_submit.status_code == 401
+
+        headers = {"Authorization": f"Bearer {token}"}
+        assert (
+            await client.get(f"/api/operator/conversations/{cid}", headers=headers)
+        ).status_code == 200
+        submitted = await client.post(
+            f"/api/operator/conversations/{cid}/turns",
+            headers=headers,
+            json={
+                "instruction": "authenticated turn",
+                "context": {"space": "mission", "route": "/", "filters": {}},
+                "expectedLastSequence": 0,
+            },
+        )
+        assert submitted.status_code == 202
+    await _wait_done(coordinator.store, cid)
+
+    messages: list[dict] = []
+    request_sent = False
+    body_sent = asyncio.Event()
+
+    async def receive():
+        nonlocal request_sent
+        if not request_sent:
+            request_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await body_sent.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        messages.append(message)
+        if message["type"] == "http.response.body" and message.get("body"):
+            body_sent.set()
+
+    await asyncio.wait_for(
+        app(
+            {
+                "type": "http",
+                "asgi": {"version": "3.0"},
+                "http_version": "1.1",
+                "method": "GET",
+                "scheme": "http",
+                "path": f"/api/operator/conversations/{cid}/stream",
+                "raw_path": f"/api/operator/conversations/{cid}/stream".encode(),
+                "query_string": b"after_sequence=0",
+                "headers": [
+                    (b"host", b"127.0.0.1:8765"),
+                    (b"authorization", f"Bearer {token}".encode()),
+                ],
+                "client": ("127.0.0.1", 54321),
+                "server": ("127.0.0.1", 8765),
+            },
+            receive,
+            send,
+        ),
+        timeout=2,
+    )
+    start = next(message for message in messages if message["type"] == "http.response.start")
+    streamed = b"".join(
+        message.get("body", b"") for message in messages if message["type"] == "http.response.body"
+    )
+    assert start["status"] == 200
+    assert b"data:" in streamed
+    await coordinator.shutdown()
+    clear_captured_studio_credentials()
+
+
+@pytest.mark.asyncio
+async def test_sse_replays_committed_frames_in_sequence(tmp_path):
+    from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+    from lionagi.studio.services.operator import stream_operator_conversation
+
+    store = OperatorStore(tmp_path / "state.db")
+    coordinator = OperatorCoordinator(store=store, engine_factory=BlockingEngine)
+    await reset_operator_coordinator_for_testing(coordinator)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="replay me",
+        context={"space": "history", "route": "/fleet", "filters": {}},
+        expected_last_sequence=0,
+    )
+
+    class Connected:
+        async def is_disconnected(self):
+            return False
+
+    response = await stream_operator_conversation(cid, Connected(), after_sequence=0)
+    iterator = response.body_iterator
+    first = await anext(iterator)
+    payload = json.loads(first.removeprefix("data:").strip())
+    assert payload["requestId"] == accepted["requestId"]
+    assert payload["sequence"] == 1
+    assert payload["payload"]["role"] == "user"
+    await iterator.aclose()
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_http_create_submit_and_paged_replay_contract(tmp_path, monkeypatch):
+    httpx = pytest.importorskip("httpx")
+    from lionagi.studio.app import create_app
+    from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+    from lionagi.studio.security import (
+        capture_studio_credentials,
+        clear_captured_studio_credentials,
+    )
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    clear_captured_studio_credentials()
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    token = capture_studio_credentials(generate_human=True)
+    assert token
+    app = create_app()
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=ScriptedEngine)
+    await reset_operator_coordinator_for_testing(coordinator)
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 54321))
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://127.0.0.1:8765",
+        headers={"authorization": f"Bearer {token}"},
+    ) as client:
+        created = await client.post(
+            "/api/operator/conversations",
+            json={"title": "HTTP contract"},
+        )
+        assert created.status_code == 200
+        cid = created.json()["conversation"]["id"]
+        submitted = await client.post(
+            f"/api/operator/conversations/{cid}/turns",
+            json={
+                "instruction": "hello over HTTP",
+                "context": {"space": "mission", "route": "/", "filters": {}},
+                "expectedLastSequence": 0,
+            },
+        )
+        assert submitted.status_code == 202
+        accepted = submitted.json()
+        assert accepted["acceptedSequence"] == 1
+
+        await _wait_done(coordinator.store, cid)
+        replay = await client.get(
+            f"/api/operator/conversations/{cid}",
+            params={"after_sequence": 0, "limit": 2},
+        )
+        assert replay.status_code == 200
+        body = replay.json()
+        assert body["hasMore"] is True
+        assert body["nextAfterSequence"] == 2
+        assert body["latestSequence"] >= 5
+        assert body["frames"][0]["requestId"] == accepted["requestId"]
+    await coordinator.shutdown()
+    clear_captured_studio_credentials()

--- a/tests/apps_studio_server/test_route_registry.py
+++ b/tests/apps_studio_server/test_route_registry.py
@@ -247,7 +247,7 @@ _MIGRATED_AREAS = {
     "engine-defs",
     "workflow-defs",
     "sessions",
-    "leo",
+    "operator",
     "approvals",
     "admin",
     "schedules",
@@ -298,3 +298,8 @@ def test_live_app_projects_route_present():
 def test_live_app_sessions_signals_route_present():
     paths = {getattr(r, "path", None) for r in _live_app.routes}
     assert "/api/sessions/{session_id}/signals" in paths
+
+
+def test_legacy_bypass_permission_leo_routes_are_not_mounted():
+    paths = {getattr(r, "path", None) for r in _live_app.routes}
+    assert not any(path and path.startswith("/api/leo") for path in paths)

--- a/tests/apps_studio_server/test_run_resume.py
+++ b/tests/apps_studio_server/test_run_resume.py
@@ -1,0 +1,540 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Focused contract tests for POST /api/runs/{run_id}/resume."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.state.reasons import RunReasons  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _seed_run(
+    db_path: Path,
+    *,
+    run_id: str,
+    status: str = "completed",
+    branch_ids: list[str] | None = None,
+) -> None:
+    async with StateDB(db_path) as db:
+        session_progression_id = f"{run_id}-progression"
+        await db.create_progression(session_progression_id)
+        await db.create_session(
+            {
+                "id": run_id,
+                "progression_id": session_progression_id,
+                "name": f"run-{run_id}",
+                "status": status,
+                "invocation_kind": "agent",
+            }
+        )
+        for index, branch_id in enumerate(branch_ids or []):
+            branch_progression_id = f"{branch_id}-progression"
+            await db.create_progression(branch_progression_id)
+            await db.create_branch(
+                {
+                    "id": branch_id,
+                    "created_at": float(index + 1),
+                    "name": f"branch-{index + 1}",
+                    "session_id": run_id,
+                    "progression_id": branch_progression_id,
+                    "model": "claude_code/sonnet",
+                    "provider": "claude_code",
+                }
+            )
+
+
+@pytest.fixture
+def resume_harness(tmp_path: Path, monkeypatch: Any):
+    import lionagi.cli._runs as cli_runs
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.run_resume as resume_svc
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    launched: list[tuple[list[str], dict[str, Any]]] = []
+
+    async def _fake_launch(argv: list[str], **kwargs: Any) -> str:
+        launched.append((argv, kwargs))
+        async with StateDB(db_path) as db:
+            await db.create_invocation(
+                {
+                    "id": "resumeinv123",
+                    "skill": kwargs["skill"],
+                    "plugin": kwargs["plugin"],
+                    "prompt": kwargs["prompt"],
+                    "started_at": time.time(),
+                    "status": "running",
+                    "node_metadata": kwargs.get("node_metadata"),
+                }
+            )
+        return "resumeinv123"
+
+    monkeypatch.setattr(resume_svc._launches, "launch_detached_argv", _fake_launch)
+    monkeypatch.setattr(
+        resume_svc._subprocess,
+        "resolve_li_executable",
+        lambda: (["/opt/lionagi/bin/li"], None),
+    )
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir()
+
+    def _find_snapshot(branch_id: str):
+        from lionagi.ln import json_dumps
+        from lionagi.service.manager import iModel
+        from lionagi.session.branch import Branch
+
+        snapshot = snapshots / f"{branch_id}.json"
+        if not snapshot.exists():
+            branch = Branch(
+                chat_model=iModel(
+                    provider="claude_code",
+                    model="sonnet",
+                    api_key="dummy",
+                )
+            )
+            serialized = branch.to_dict()
+            serialized["id"] = branch_id
+            snapshot.write_text(json_dumps(serialized))
+        return ("fixture-run", snapshot)
+
+    monkeypatch.setattr(
+        cli_runs,
+        "find_branch",
+        _find_snapshot,
+    )
+
+    from lionagi.studio.app import create_app
+
+    client = TestClient(
+        create_app(),
+        raise_server_exceptions=False,
+        base_url="http://127.0.0.1:8765",
+    )
+    try:
+        yield resume_svc, db_path, client, launched
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("terminal_status", ["completed", "failed", "cancelled", "timed_out"])
+def test_resume_terminal_run_launches_exact_cli_contract(resume_harness, terminal_status):
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    branch_id = str(uuid.uuid4())
+    _run(
+        _seed_run(
+            db_path,
+            run_id=run_id,
+            status=terminal_status,
+            branch_ids=[branch_id],
+        )
+    )
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "Continue with the next step."},
+    )
+
+    assert response.status_code == 202, response.text
+    assert response.json() == {
+        "run_id": run_id,
+        "branch_id": branch_id,
+        "invocation_id": "resumeinv123",
+    }
+    assert launched == [
+        (
+            [
+                "/opt/lionagi/bin/li",
+                "agent",
+                "-r",
+                branch_id,
+                "--prompt",
+                "Continue with the next step.",
+            ],
+            {
+                "skill": "resume:agent",
+                "plugin": "studio_run_resume",
+                "prompt": "Continue with the next step.",
+                "tmp_path": None,
+                "action_kind": "agent",
+                "node_metadata": {
+                    "run_id": run_id,
+                    "branch_id": branch_id,
+                    "resume": True,
+                    "queued_for_terminal": False,
+                    "model": None,
+                },
+            },
+        )
+    ]
+    assert "--bypass" not in launched[0][0]
+    assert "--yolo" not in launched[0][0]
+
+
+def test_resume_running_run_queues_until_terminal_and_coalesces_duplicate(
+    resume_harness, monkeypatch
+):
+    import lionagi.cli._runs as cli_runs
+
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    branch_id = str(uuid.uuid4())
+    _run(
+        _seed_run(
+            db_path,
+            run_id=run_id,
+            status="running",
+            branch_ids=[branch_id],
+        )
+    )
+
+    def _snapshot_must_not_be_read_while_active(_branch_id: str):
+        raise AssertionError("active branch snapshot was read before terminal hand-off")
+
+    monkeypatch.setattr(cli_runs, "find_branch", _snapshot_must_not_be_read_while_active)
+    body = {"instruction": "Continue after the active leg finishes."}
+    first = client.post(f"/api/runs/{run_id}/resume", json=body)
+    assert first.status_code == 202, first.text
+    assert first.json() == {
+        "run_id": run_id,
+        "branch_id": branch_id,
+        "invocation_id": "resumeinv123",
+    }
+    assert len(launched) == 1
+    worker_argv, worker_kwargs = launched[0]
+    assert worker_argv[:4] == [
+        sys.executable,
+        "-m",
+        "lionagi.studio.services.run_resume_worker",
+        "--config",
+    ]
+    config_path = worker_argv[4]
+    config = json.loads(Path(config_path).read_text())
+    assert config == {
+        "run_id": run_id,
+        "branch_id": branch_id,
+        "instruction": body["instruction"],
+        "model": None,
+        "executable_prefix": ["/opt/lionagi/bin/li"],
+    }
+    assert worker_kwargs["tmp_path"] == config_path
+    assert worker_kwargs["node_metadata"]["queued_for_terminal"] is True
+
+    repeated = client.post(f"/api/runs/{run_id}/resume", json=body)
+    assert repeated.status_code == 202
+    assert repeated.json() == first.json()
+    assert len(launched) == 1
+
+    conflict = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "A different concurrent continuation."},
+    )
+    assert conflict.status_code == 409
+    assert "already has a resume in progress" in conflict.json()["detail"]
+    assert len(launched) == 1
+    os.unlink(config_path)
+
+
+@pytest.mark.asyncio
+async def test_queued_resume_worker_waits_for_terminal_snapshot_before_spawning(
+    tmp_path, monkeypatch
+):
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.run_resume as resume_svc
+    import lionagi.studio.services.run_resume_worker as worker
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    run_id = str(uuid.uuid4())
+    branch_id = str(uuid.uuid4())
+    await _seed_run(
+        db_path,
+        run_id=run_id,
+        status="running",
+        branch_ids=[branch_id],
+    )
+    events: list[tuple[str, Any]] = []
+
+    async def ensure_snapshot(value: str) -> None:
+        events.append(("snapshot", value))
+
+    class Process:
+        async def wait(self) -> int:
+            events.append(("wait", None))
+            return 0
+
+    async def create_subprocess_exec(*argv: str):
+        events.append(("spawn", list(argv)))
+        return Process()
+
+    monkeypatch.setattr(
+        resume_svc,
+        "_ensure_branch_snapshot_available",
+        ensure_snapshot,
+    )
+    monkeypatch.setattr(worker.asyncio, "create_subprocess_exec", create_subprocess_exec)
+    task = asyncio.create_task(
+        worker.run_worker(
+            {
+                "run_id": run_id,
+                "branch_id": branch_id,
+                "instruction": "Continue only after hand-off.",
+                "model": None,
+                "executable_prefix": ["/opt/lionagi/bin/li"],
+            }
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert events == []
+
+    async with StateDB(db_path) as db:
+        await db.update_session(
+            run_id,
+            status="completed",
+            ended_at=time.time(),
+            reason_code=RunReasons.COMPLETED_OK,
+        )
+    assert await asyncio.wait_for(task, timeout=1) == 0
+    assert events == [
+        ("snapshot", branch_id),
+        (
+            "spawn",
+            [
+                "/opt/lionagi/bin/li",
+                "agent",
+                "-r",
+                branch_id,
+                "--prompt",
+                "Continue only after hand-off.",
+            ],
+        ),
+        ("wait", None),
+    ]
+
+
+def test_explicit_member_branch_and_model_override(resume_harness):
+    resume_svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    first_branch = str(uuid.uuid4())
+    second_branch = str(uuid.uuid4())
+    _run(_seed_run(db_path, run_id=run_id, branch_ids=[first_branch, second_branch]))
+    monkey_prefix = ["/opt/lionagi/bin/python", "-m", "lionagi.cli"]
+    resume_svc._subprocess.resolve_li_executable = lambda: (monkey_prefix, None)
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={
+            "instruction": "Use the alternate branch.",
+            "branch_id": second_branch,
+            "model": "codex/gpt-5.3-codex",
+        },
+    )
+
+    assert response.status_code == 202, response.text
+    assert response.json()["branch_id"] == second_branch
+    assert launched[0][0] == [
+        *monkey_prefix,
+        "agent",
+        "-r",
+        second_branch,
+        "codex/gpt-5.3-codex",
+        "--prompt",
+        "Use the alternate branch.",
+    ]
+
+
+def test_multiple_branches_require_explicit_selection(resume_harness):
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    _run(
+        _seed_run(
+            db_path,
+            run_id=run_id,
+            branch_ids=[str(uuid.uuid4()), str(uuid.uuid4())],
+        )
+    )
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "Continue."},
+    )
+
+    assert response.status_code == 409, response.text
+    assert "branch_id is required" in response.json()["detail"]
+    assert launched == []
+
+
+def test_branch_must_belong_to_run(resume_harness):
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    foreign_run_id = str(uuid.uuid4())
+    member_branch = str(uuid.uuid4())
+    foreign_branch = str(uuid.uuid4())
+    _run(_seed_run(db_path, run_id=run_id, branch_ids=[member_branch]))
+    _run(_seed_run(db_path, run_id=foreign_run_id, branch_ids=[foreign_branch]))
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "Continue.", "branch_id": foreign_branch},
+    )
+
+    assert response.status_code == 422, response.text
+    assert "does not belong" in response.json()["detail"]
+    assert launched == []
+
+
+def test_missing_run_returns_404(resume_harness):
+    _svc, _db_path, client, launched = resume_harness
+
+    response = client.post(
+        f"/api/runs/{uuid.uuid4()}/resume",
+        json={"instruction": "Continue."},
+    )
+
+    assert response.status_code == 404, response.text
+    assert launched == []
+
+
+def test_run_without_branch_returns_conflict(resume_harness):
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    _run(_seed_run(db_path, run_id=run_id, branch_ids=[]))
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "Continue."},
+    )
+
+    assert response.status_code == 409, response.text
+    assert "no branch to resume" in response.json()["detail"]
+    assert launched == []
+
+
+def test_unresolved_installed_cli_returns_503(resume_harness):
+    resume_svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    branch_id = str(uuid.uuid4())
+    _run(_seed_run(db_path, run_id=run_id, branch_ids=[branch_id]))
+    resume_svc._subprocess.resolve_li_executable = lambda: (
+        None,
+        "no console script registered",
+    )
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "Continue."},
+    )
+
+    assert response.status_code == 503, response.text
+    assert "reinstall LionAGI with the Studio extra" in response.json()["detail"]
+    assert "no console script registered" not in response.json()["detail"]
+    assert launched == []
+
+
+def test_missing_cli_branch_snapshot_returns_conflict_before_launch(resume_harness, monkeypatch):
+    import lionagi.cli._runs as cli_runs
+
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    branch_id = str(uuid.uuid4())
+    _run(_seed_run(db_path, run_id=run_id, branch_ids=[branch_id]))
+
+    def _missing_snapshot(_branch_id: str):
+        raise FileNotFoundError("snapshot was pruned")
+
+    monkeypatch.setattr(cli_runs, "find_branch", _missing_snapshot)
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "Continue."},
+    )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == (
+        f"Branch {branch_id!r} has no available CLI snapshot and cannot be resumed"
+    )
+    assert launched == []
+
+
+def test_corrupt_cli_branch_snapshot_returns_conflict_before_launch(
+    resume_harness, monkeypatch, tmp_path
+):
+    import lionagi.cli._runs as cli_runs
+
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    branch_id = str(uuid.uuid4())
+    _run(_seed_run(db_path, run_id=run_id, branch_ids=[branch_id]))
+    snapshot = tmp_path / f"{branch_id}.json"
+    snapshot.write_text("{not-json")
+    monkeypatch.setattr(
+        cli_runs,
+        "find_branch",
+        lambda _branch_id: ("fixture-run", snapshot),
+    )
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "Continue."},
+    )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"] == (
+        f"Branch {branch_id!r} has an invalid CLI snapshot and cannot be resumed"
+    )
+    assert launched == []
+
+
+def test_option_looking_instruction_cannot_become_bypass_flag(resume_harness):
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    branch_id = str(uuid.uuid4())
+    _run(_seed_run(db_path, run_id=run_id, branch_ids=[branch_id]))
+
+    response = client.post(
+        f"/api/runs/{run_id}/resume",
+        json={"instruction": "--bypass is text to discuss, not a CLI option"},
+    )
+
+    assert response.status_code == 202, response.text
+    assert launched[0][0][-1] == "--prompt=--bypass is text to discuss, not a CLI option"
+    assert "--bypass" not in launched[0][0]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"instruction": "   "},
+        {"instruction": "--"},
+        {"instruction": "Continue.", "model": "--bypass"},
+        {"instruction": "Continue.", "branch_id": "--foreign"},
+    ],
+)
+def test_invalid_resume_input_returns_422_without_launch(resume_harness, body):
+    _svc, db_path, client, launched = resume_harness
+    run_id = str(uuid.uuid4())
+    _run(_seed_run(db_path, run_id=run_id, branch_ids=[str(uuid.uuid4())]))
+
+    response = client.post(f"/api/runs/{run_id}/resume", json=body)
+
+    assert response.status_code == 422, response.text
+    assert launched == []

--- a/tests/cli/test_agent_depth_wiring.py
+++ b/tests/cli/test_agent_depth_wiring.py
@@ -5,9 +5,14 @@
 `_run_flow`, and the engine subprocess spawn (`ndjson_from_cli`).
 
 The stamp must land in os.environ BEFORE any provider/engine spawn — the
-mechanism (see docs/internals/cli.md) relies on `ndjson_from_cli` passing
-env=None to create_subprocess_exec so the spawned engine inherits this
-process's os.environ verbatim.
+mechanism (see docs/internals/cli.md) relies on the environment
+`ndjson_from_cli` hands create_subprocess_exec still carrying this process's
+stamp at the moment of the spawn.
+
+It used to achieve that by passing env=None and letting the child inherit
+os.environ wholesale. The spawn now builds an explicit copy instead, so that it
+can drop Studio's own credentials on the way out, and these tests assert what
+reaches the child rather than how it was assembled.
 """
 
 from __future__ import annotations
@@ -85,10 +90,17 @@ async def test_run_flow_stamps_depth_before_setup(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ndjson_from_cli_inherits_stamped_depth(monkeypatch):
-    """The CLI engine spawn (shared by claude_code/codex/gemini_code) must
-    pass env=None to create_subprocess_exec while LIONAGI_AGENT_DEPTH is
-    already set in this process's os.environ — that combination is what
-    makes the child inherit the stamp with zero endpoint changes."""
+    """The CLI engine spawn (shared by claude_code/codex/gemini_code) must hand
+    create_subprocess_exec an environment that carries LIONAGI_AGENT_DEPTH,
+    with the stamp already set in this process's os.environ at spawn time —
+    that combination is what makes the child inherit the stamp with zero
+    endpoint changes.
+
+    Asserted against the environment the child receives, not against
+    ``env is None``. Passing None was the old way of arranging it; the spawn now
+    assembles the environment explicitly so it can drop Studio credentials, and
+    pinning the old mechanism would fail that change while the contract it
+    stands for is intact."""
     import asyncio
 
     from lionagi.providers._cli_subprocess import ndjson_from_cli
@@ -112,5 +124,53 @@ async def test_ndjson_from_cli_inherits_stamped_depth(monkeypatch):
     async for obj in ndjson_from_cli(["true"]):
         chunks.append(obj)
 
-    assert captured_kwargs["env"] is None
+    assert captured_kwargs["env"][DEPTH_ENV] == "1"
     assert captured_kwargs["_depth_at_spawn"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_ndjson_from_cli_withholds_studio_credentials_from_the_child(monkeypatch):
+    """A spawned CLI engine must not inherit Studio's own credentials.
+
+    Studio puts them in its process environment so its routes can authenticate
+    the caller. An engine subprocess that inherited them could call back into
+    Studio holding the credentials of whoever launched it, which is a different
+    and larger authority than running an agent. So the spawn drops them while
+    passing the rest of the environment through — the same pass-through the
+    depth stamp above relies on.
+    """
+    import asyncio
+
+    from lionagi.providers._cli_subprocess import (
+        _STUDIO_CREDENTIAL_ENV_KEYS,
+        ndjson_from_cli,
+    )
+
+    # If this tuple were ever emptied, the withholding loop below would assert
+    # over nothing and pass. Fail here instead of passing vacuously.
+    assert _STUDIO_CREDENTIAL_ENV_KEYS
+
+    for key in _STUDIO_CREDENTIAL_ENV_KEYS:
+        monkeypatch.setenv(key, "must-not-reach-the-child")
+    monkeypatch.setenv("LIONAGI_UNRELATED_PASSTHROUGH", "keep-me")
+
+    captured_kwargs: dict = {}
+    real_create_subprocess_exec = asyncio.create_subprocess_exec
+
+    async def _spy_create_subprocess_exec(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return await real_create_subprocess_exec(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spy_create_subprocess_exec)
+
+    async for _ in ndjson_from_cli(["true"]):
+        pass
+
+    child_env = captured_kwargs["env"]
+    for key in _STUDIO_CREDENTIAL_ENV_KEYS:
+        # Absent, not blanked: an empty string is still a value a reader picks up.
+        assert key not in child_env
+
+    # The drop has to be surgical. Without this, handing the child an empty
+    # environment would satisfy every assertion above.
+    assert child_env["LIONAGI_UNRELATED_PASSTHROUGH"] == "keep-me"

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -6,14 +6,24 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import os
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
 
 
 @contextlib.contextmanager
 def _stubbed_serve():
     """Stub uvicorn.run and _ensure_frontend_built; restores env vars that the real CLI mutates (xdist isolation)."""
-    saved = {k: os.environ.get(k) for k in ("LIONAGI_STUDIO_FRONTEND_DIST", "LIONAGI_STUDIO_HOST")}
+    saved = {
+        k: os.environ.get(k)
+        for k in (
+            "LIONAGI_STUDIO_FRONTEND_DIST",
+            "LIONAGI_STUDIO_HOST",
+            "LIONAGI_STUDIO_AUTH_TOKEN",
+            "LIONAGI_STUDIO_HUMAN_TOKEN",
+        )
+    }
     try:
         with (
             patch("uvicorn.run") as mock_run,
@@ -120,19 +130,180 @@ def test_studio_web_does_not_build_local_frontend():
     mock_build.assert_not_called()
 
 
-def test_studio_web_opens_browser_when_interactive(monkeypatch):
+def test_studio_web_opens_browser_with_ephemeral_human_fragment(monkeypatch, capsys):
     """A TTY session opens the hosted URL unless --no-open is set."""
     import lionagi.studio.cli as studio_cli
 
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
     monkeypatch.setattr(studio_cli.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(studio_cli.sys.stdout, "isatty", lambda: True)
-    with patch("webbrowser.open") as mock_open, patch("uvicorn.run"):
+    with _stubbed_serve(), patch("webbrowser.open") as mock_open:
         from lionagi.cli.main import main
 
         result = main(["studio", "--web"])
 
     assert result == 0
-    mock_open.assert_called_once_with("https://lion-studio.khive.ai")
+    opened_url = mock_open.call_args.args[0]
+    parsed = urlsplit(opened_url)
+    fragment = parse_qs(parsed.fragment)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://lion-studio.khive.ai"
+    assert fragment["studio-api"] == ["http://127.0.0.1:8765"]
+    assert len(fragment["studio-token"]) == 1
+    assert len(fragment["studio-token"][0]) >= 32
+    assert fragment["studio-token"][0] not in capsys.readouterr().out
+
+
+def test_studio_web_reuses_configured_auth_token_but_disables_operator(monkeypatch, capsys):
+    import lionagi.studio.cli as studio_cli
+
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "configured-browser-token")
+    monkeypatch.setattr(studio_cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(studio_cli.sys.stdout, "isatty", lambda: True)
+    with _stubbed_serve(), patch("webbrowser.open") as mock_open:
+        from lionagi.cli.main import main
+
+        assert main(["studio", "--web"]) == 0
+
+    fragment = parse_qs(urlsplit(mock_open.call_args.args[0]).fragment)
+    assert fragment["studio-token"] == ["configured-browser-token"]
+    assert "environment-derived credential" in capsys.readouterr().err
+
+
+def test_studio_web_dual_token_uses_middleware_auth_token(monkeypatch):
+    import lionagi.studio.cli as studio_cli
+
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "middleware-token")
+    monkeypatch.setenv("LIONAGI_STUDIO_HUMAN_TOKEN", "lower-priority-human-token")
+    monkeypatch.setattr(studio_cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(studio_cli.sys.stdout, "isatty", lambda: True)
+    with _stubbed_serve(), patch("webbrowser.open") as mock_open:
+        from lionagi.cli.main import main
+
+        assert main(["studio", "--web"]) == 0
+
+    fragment = parse_qs(urlsplit(mock_open.call_args.args[0]).fragment)
+    assert fragment["studio-token"] == ["middleware-token"]
+
+
+def test_studio_generated_token_is_process_local_not_environment(monkeypatch):
+    import lionagi.studio.cli as studio_cli
+
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    monkeypatch.setattr(studio_cli.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(studio_cli.sys.stdout, "isatty", lambda: False)
+    observed: dict[str, str | None] = {}
+
+    def _serve(*_args, **_kwargs):
+        from lionagi.studio.security import (
+            studio_human_token,
+            studio_operator_credential_origin,
+        )
+
+        observed["auth_env"] = os.environ.get("LIONAGI_STUDIO_AUTH_TOKEN")
+        observed["human_env"] = os.environ.get("LIONAGI_STUDIO_HUMAN_TOKEN")
+        observed["captured"] = studio_human_token()
+        observed["origin"] = studio_operator_credential_origin()
+
+    with patch("uvicorn.run", side_effect=_serve):
+        from lionagi.cli.main import main
+
+        assert main(["studio", "--web"]) == 0
+
+    assert observed["auth_env"] is None
+    assert observed["human_env"] is None
+    assert observed["captured"]
+    assert observed["origin"] == "generated"
+
+
+def test_studio_desktop_token_stdin_is_trusted_and_never_enters_environment(
+    monkeypatch,
+):
+    import lionagi.studio.cli as studio_cli
+
+    token = "desktop-generated-token-" + ("x" * 32)
+    monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "stale-parent-auth")
+    monkeypatch.setenv("LIONAGI_STUDIO_HUMAN_TOKEN", "stale-parent-human")
+    monkeypatch.setattr(studio_cli.sys, "stdin", io.StringIO(token + "\n"))
+    observed = {}
+
+    def _serve(*_args, **_kwargs):
+        from lionagi.studio.security import (
+            studio_auth_token,
+            studio_human_token,
+            studio_operator_credential_origin,
+        )
+
+        observed["auth"] = studio_auth_token()
+        observed["human"] = studio_human_token()
+        observed["origin"] = studio_operator_credential_origin()
+        observed["auth_env"] = os.environ.get("LIONAGI_STUDIO_AUTH_TOKEN")
+        observed["human_env"] = os.environ.get("LIONAGI_STUDIO_HUMAN_TOKEN")
+
+    with patch("uvicorn.run", side_effect=_serve):
+        from lionagi.cli.main import main
+
+        assert (
+            main(
+                [
+                    "studio",
+                    "--no-frontend",
+                    "--operator-token-stdin",
+                ]
+            )
+            == 0
+        )
+
+    assert observed == {
+        "auth": token,
+        "human": token,
+        "origin": "generated",
+        "auth_env": None,
+        "human_env": None,
+    }
+
+
+def test_studio_dev_uses_frontend_proxy_origin_and_custom_api_port(monkeypatch, tmp_path):
+    import lionagi.studio.cli as studio_cli
+
+    monkeypatch.delenv("LIONAGI_STUDIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("LIONAGI_STUDIO_HUMAN_TOKEN", raising=False)
+    monkeypatch.setattr(studio_cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(studio_cli.sys.stdout, "isatty", lambda: True)
+    with (
+        patch("lionagi.studio.cli._find_frontend_dir", return_value=tmp_path),
+        patch("lionagi.studio.cli.shutil.which", return_value="/usr/bin/node"),
+        patch("lionagi.studio.cli._ensure_apps_importable", return_value=True),
+        patch("lionagi.studio.cli._launch_vite_dev") as launch_vite,
+        patch("webbrowser.open") as open_browser,
+        patch("uvicorn.run"),
+    ):
+        from lionagi.cli.main import main
+
+        assert (
+            main(
+                [
+                    "studio",
+                    "--dev",
+                    "--port",
+                    "9123",
+                    "--frontend-port",
+                    "3456",
+                ]
+            )
+            == 0
+        )
+
+    launch_vite.assert_called_once_with(
+        tmp_path,
+        3456,
+        api_url="http://127.0.0.1:9123",
+    )
+    fragment = parse_qs(urlsplit(open_browser.call_args.args[0]).fragment)
+    assert fragment["studio-api"] == ["http://127.0.0.1:3456"]
+    assert fragment["studio-token"]
 
 
 def test_studio_web_no_open_flag_suppresses_browser(monkeypatch):

--- a/tests/e2e_studio/harness.py
+++ b/tests/e2e_studio/harness.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import os
 import shutil
 import signal
@@ -34,6 +35,39 @@ from .fixtures import seed_filesystem_fixtures, seed_state_db
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REAL_LIONAGI_HOME = Path("~/.lionagi").expanduser().resolve()
+
+_OPERATOR_SCRIPT = {
+    "version": 1,
+    "responses": [
+        {
+            "type": "error",
+            "kind": "timeout",
+            "message": "scripted wait",
+            "delay_ms": 10_000,
+            "when": {"prompt_contains": "wait until I stop you"},
+        },
+        {
+            "type": "stream",
+            "chunks": [
+                {
+                    "type": "text",
+                    "content": "Continuation complete.",
+                    "is_delta": True,
+                },
+                {"type": "result", "metadata": {"done": True}},
+            ],
+            "when": {"prompt_contains": "Continue with the next check."},
+        },
+        {
+            "type": "stream",
+            "chunks": [
+                {"type": "text", "content": "Fleet ", "is_delta": True},
+                {"type": "text", "content": "ready.", "is_delta": True},
+                {"type": "result", "metadata": {"done": True}},
+            ],
+        },
+    ],
+}
 
 
 def _free_port() -> int:
@@ -117,8 +151,17 @@ class SeededDaemon:
         # nondeterministic content and violate the "never touch the real
         # home dir" rule in spirit even though it's a different tree.
         env["LIONAGI_STUDIO_MIRROR_CLAUDE"] = "0"
-        # Deterministic no-auth, API-only daemon regardless of ambient shell env.
+        operator_script = tmp_dir / "operator-script.json"
+        operator_script.write_text(json.dumps(_OPERATOR_SCRIPT), encoding="utf-8")
+        env["LIONAGI_STUDIO_OPERATOR_PROVIDER"] = "scripted"
+        env["LIONAGI_STUDIO_OPERATOR_MODEL"] = "scripted-test"
+        env["LIONAGI_TEST_SCRIPT"] = str(operator_script)
+        # Ambient Studio credentials are never inherited. The test-only ASGI
+        # module mints its deterministic human bearer in process, matching the
+        # safe production launch mode rather than treating an environment
+        # variable as a trusted human principal.
         env.pop("LIONAGI_STUDIO_AUTH_TOKEN", None)
+        env.pop("LIONAGI_STUDIO_HUMAN_TOKEN", None)
         env.pop("LIONAGI_STUDIO_FRONTEND_DIST", None)
         env.pop("LIONAGI_STUDIO_URL", None)
 
@@ -127,7 +170,7 @@ class SeededDaemon:
                 sys.executable,
                 "-m",
                 "uvicorn",
-                "lionagi.studio.app:app",
+                "tests.e2e_studio.studio_app:app",
                 "--host",
                 host,
                 "--port",

--- a/tests/e2e_studio/studio_app.py
+++ b/tests/e2e_studio/studio_app.py
@@ -1,0 +1,102 @@
+"""Test-only Studio ASGI app for deterministic Operator browser contracts.
+
+This module is imported only by the isolated seeded-daemon harness.  It
+installs a coordinator before the production app module creates its FastAPI
+application, so browser tests exercise the real HTTP, persistence, SSE, and
+permission-decision paths without invoking a real model or application
+command.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from lionagi.studio.operator import coordinator as coordinator_module
+from lionagi.studio.operator.coordinator import OperatorCoordinator
+from lionagi.studio.operator.types import OperatorEngineEvent, OperatorEngineTurn
+from lionagi.studio.security import capture_studio_credentials
+
+# Mint the same deterministic, test-only bearer the browser spec knows. The
+# production credential path still sees this as process-generated (not an
+# environment-derived secret), which is the real mode in which Operator turns
+# and human approvals are enabled.
+with patch(
+    "lionagi.studio.security.secrets.token_urlsafe",
+    return_value="lionagi-studio-e2e-human-principal",
+):
+    capture_studio_credentials(generate_human=True)
+
+_EXECUTED_MARKERS: set[str] = set()
+
+
+async def _execute_harmless_command(
+    command_type: str, command: dict[str, object]
+) -> dict[str, object]:
+    """Record an in-memory marker; never touch the filesystem or launch work."""
+    if command_type != "e2e_harmless_action":
+        raise ValueError(f"unsupported e2e command type: {command_type}")
+    marker = command.get("marker")
+    if not isinstance(marker, str) or not marker:
+        raise ValueError("e2e command marker is required")
+    _EXECUTED_MARKERS.add(marker)
+    return {"executed": True, "marker": marker}
+
+
+class DeterministicOperatorEngine:
+    """Stable test engine covering streaming, cancellation, and permissions."""
+
+    def stream(self, turn: OperatorEngineTurn):
+        return self._stream(turn)
+
+    async def _stream(self, turn: OperatorEngineTurn):
+        instruction = turn.instruction.casefold()
+
+        if "wait until i stop you" in instruction:
+            await asyncio.sleep(10)
+            return
+
+        if "gated demo action" in instruction:
+            marker = f"permission-{turn.request_id}"
+            decision = await turn.request_permission(
+                "e2e_harmless_action",
+                {
+                    "operation": "record_permission_decision",
+                    "marker": marker,
+                    "scope": "isolated_e2e_memory",
+                },
+                "execute",
+                "Record a harmless marker in the isolated browser-test process",
+            )
+            executed = marker in _EXECUTED_MARKERS
+            if decision.allowed and executed:
+                content = "Demo action allowed and completed safely."
+            elif not decision.allowed and not executed:
+                content = "Demo action denied. Nothing was changed."
+            else:  # Make an execution/decision mismatch fail the browser contract loudly.
+                raise AssertionError("permission decision did not match harmless command execution")
+            yield OperatorEngineEvent(
+                "text",
+                {"content": content, "format": "plain", "role": "assistant"},
+            )
+            return
+
+        yield OperatorEngineEvent(
+            "text",
+            {"content": "Fleet ", "format": "plain", "role": "assistant"},
+        )
+        await asyncio.sleep(0)
+        yield OperatorEngineEvent(
+            "text",
+            {"content": "ready.", "format": "plain", "role": "assistant"},
+        )
+
+
+# Install the test coordinator before importing lionagi.studio.app: that
+# module creates its FastAPI application at import time.
+coordinator_module._COORDINATOR = OperatorCoordinator(  # noqa: SLF001
+    engine_factory=DeterministicOperatorEngine,
+    command_executor=_execute_harmless_command,
+)
+
+from lionagi.studio.app import app  # noqa: E402  (intentional import ordering)

--- a/tests/mcp/golden_projections/studio__start.json
+++ b/tests/mcp/golden_projections/studio__start.json
@@ -38,6 +38,11 @@
         "type": "boolean",
         "x-flag": "--no-open"
       },
+      "operator_token_stdin": {
+        "description": "==SUPPRESS==",
+        "type": "boolean",
+        "x-flag": "--operator-token-stdin"
+      },
       "port": {
         "description": "Backend API port (default: LIONAGI_STUDIO_PORT env or 8765)",
         "type": "integer",

--- a/tests/providers/test_claude_code_partial_streaming.py
+++ b/tests/providers/test_claude_code_partial_streaming.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest, stream_claude_code_cli
+from lionagi.service.types import StreamChunk
+
+
+async def _chunks(events: list[dict]) -> list[StreamChunk]:
+    async def fake_events(_request):
+        for event in events:
+            yield event
+
+    out: list[StreamChunk] = []
+    request = ClaudeCodeRequest(prompt="test", include_partial_messages=True)
+    with patch(
+        "lionagi.providers.anthropic.claude_code.stream_cc_cli_events",
+        side_effect=fake_events,
+    ):
+        async for item in stream_claude_code_cli(request):
+            if isinstance(item, StreamChunk):
+                out.append(item)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_partial_text_events_are_forwarded_as_deltas_without_duplicate_final_text():
+    events = [
+        {
+            "type": "stream_event",
+            "event": {"type": "message_start", "message": {"id": "msg-1"}},
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "hel"},
+            },
+        },
+        {
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "lo"},
+            },
+        },
+        {"type": "stream_event", "event": {"type": "message_stop"}},
+        {
+            "type": "assistant",
+            "message": {
+                "id": "msg-1",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+        },
+        {"type": "done"},
+    ]
+
+    chunks = await _chunks(events)
+    text_chunks = [chunk for chunk in chunks if chunk.type == "text"]
+
+    assert [chunk.content for chunk in text_chunks] == ["hel", "lo"]
+    assert all(chunk.is_delta for chunk in text_chunks)
+
+
+@pytest.mark.asyncio
+async def test_complete_assistant_text_is_kept_when_no_partial_delta_arrived():
+    chunks = await _chunks(
+        [
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg-1",
+                    "content": [{"type": "text", "text": "complete"}],
+                },
+            },
+            {"type": "done"},
+        ]
+    )
+
+    text_chunks = [chunk for chunk in chunks if chunk.type == "text"]
+    assert [(chunk.content, chunk.is_delta) for chunk in text_chunks] == [("complete", False)]
+
+
+@pytest.mark.asyncio
+async def test_partial_text_does_not_suppress_final_tool_use_from_same_message():
+    chunks = await _chunks(
+        [
+            {
+                "type": "stream_event",
+                "event": {"type": "message_start", "message": {"id": "msg-1"}},
+            },
+            {
+                "type": "stream_event",
+                "event": {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Checking"},
+                },
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg-1",
+                    "content": [
+                        {"type": "text", "text": "Checking"},
+                        {
+                            "type": "tool_use",
+                            "id": "tool-1",
+                            "name": "Read",
+                            "input": {"file_path": "README.md"},
+                        },
+                    ],
+                },
+            },
+            {"type": "done"},
+        ]
+    )
+
+    assert [chunk.content for chunk in chunks if chunk.type == "text"] == ["Checking"]
+    tool_chunks = [chunk for chunk in chunks if chunk.type == "tool_use"]
+    assert len(tool_chunks) == 1
+    assert tool_chunks[0].tool_name == "Read"


### PR DESCRIPTION
Adds an Operator surface to Studio: a conversational way to ask for work, watch it run, and approve the changes it proposes, without having to learn the rest of the Studio UI first.

## What is here

**A durable Operator runtime** (`lionagi/studio/operator/`). Conversations, turns, proposals and effects are persisted rather than held in memory, so a conversation survives a daemon restart and a reconnecting browser resumes where it left off instead of losing the thread. `store.py` owns persistence, `coordinator.py` the turn lifecycle, `engine.py` the model interaction, and `types.py` the wire models.

**A permission boundary for the actions it proposes.** Two MCP surfaces are separated on purpose: `application_mcp.py` is what the Operator may do on its own, and `permission_mcp.py` is what requires a person to say yes first.

**The workspace itself** — an Operator panel in the Studio shell, with connection state, streaming turns, proposal review, and localized strings across the sixteen shipped locales.

**Run resume** (`lionagi/studio/services/run_resume.py` and its worker): send a follow-up into a saved branch after the original run has finished, with a CLI escape hatch for when browser resume is not available.

## The credential boundary, which is the part worth reviewing closely

Human approval is gated on where the browser credential came from, not just on presenting it.

Removing a variable from `os.environ` does not reliably remove it from the process's initial environment as the operating system reports it. A token supplied through the environment can therefore be recovered by another local process, which makes it unsuitable as evidence that a *person* approved something. So `lionagi/studio/security.py` records the origin of the effective credential, and the Operator's turn and approval routes refuse to act on one derived from the environment, directing the operator to start with `li studio` and use the generated launch-scoped credential instead.

The check fails closed: it rejects `environment` explicitly and also rejects any origin that is not `generated`, so an unset origin is refused rather than allowed. Approval routes additionally reject a request carrying the agent principal header, and compare the bearer with a constant-time comparison. Environment-derived credentials remain valid for ordinary Studio API authentication; the restriction is specific to the approval boundary.

## Tests

122 new tests covering the Operator protocol, run resume, the CLI credential paths, and partial streaming; plus end-to-end coverage of the Operator flows. The surrounding Studio server suite passes at 1143 tests.

## State

Draft. The branch is cut from an earlier `main` and will need updating before it merges.
