### PR TITLE
ci: run pull_request workflows when a draft is marked ready

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,6 +9,12 @@ name: Benchmarks
 on:
   push:
     branches: [ main, master ]
+  # Deliberately left on the default activity types, unlike the other
+  # pull_request workflows here. They name ready_for_review so that marking a
+  # draft ready starts a run; this one emits no required check, and a benchmark
+  # re-run costs real machine time and adds a timing sample nobody asked for.
+  # If a benchmark result is ever made a required check, add ready_for_review
+  # here too, with [ opened, synchronize, reopened ] listed back alongside it.
   pull_request:
     branches: [ main, master ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,16 @@ on:
   # No paths-ignore on pull_request either: ci-gate is a required status check,
   # so the workflow must report on every PR — a filtered-out PR would block on
   # a check that never runs.
+  #
+  # types is spelled out for the same reason, one event class further out. The
+  # default is [opened, synchronize, reopened], which does not include
+  # ready_for_review, so marking a draft PR ready raises no event and starts no
+  # run. Whatever ci-gate last reported then stands as the required check on a
+  # PR that has since changed state, and if a job is ever made conditional on
+  # draft it will not have run at all. Listing the defaults back is mandatory:
+  # naming types replaces them rather than adding to them.
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
     branches: [ main, develop ]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,11 @@ name: "CodeQL"
 on:
   push:
     branches: [ main, develop ]
+  # ready_for_review is not a default activity type, so without this a draft PR
+  # marked ready starts no run. Naming types replaces the defaults rather than
+  # extending them, so the three defaults are listed back.
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
     branches: [ main, develop ]
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/marketplace-lint.yml
+++ b/.github/workflows/marketplace-lint.yml
@@ -1,7 +1,11 @@
 name: marketplace-lint
 
 on:
+  # ready_for_review is not a default activity type, so without this a draft PR
+  # marked ready starts no run. Naming types replaces the defaults rather than
+  # extending them, so the three defaults are listed back.
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths:
       - 'marketplace/**'
       - '.claude-plugin/**'

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,7 +5,11 @@ on:
     branches: [ main, develop ]
     paths-ignore:
       - '**/*.ipynb'
+  # ready_for_review is not a default activity type, so without this a draft PR
+  # marked ready starts no run. Naming types replaces the defaults rather than
+  # extending them, so the three defaults are listed back.
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
     branches: [ main, develop ]
     paths-ignore:
       - '**/*.ipynb'


### PR DESCRIPTION
GitHub's default `pull_request` activity types are `opened`, `synchronize` and `reopened`. `ready_for_review` is not among them, so marking a draft PR ready raises no event and starts no workflow run.

The consequence here: `ci-gate` is this repository's only required status check, and it is emitted by `ci.yml`, which triggered on the defaults. A PR flipped from draft to ready without a subsequent push kept whatever `ci-gate` had last reported as the required check for a PR that had since changed state.

No job in `ci.yml` is currently conditional on draft state, so no result was actually wrong today. The exposure is forward-looking: adding such a condition would stop the gating job from running while the PR was a draft, never re-fire on the flip, and report `skipped` — which most readings of a gate count as satisfied. Nothing about that change would look like it touched trigger semantics.

**Scope.** `ci.yml` carries the only required check, so it is the one that mattered. `codeql.yml`, `typecheck.yml` and `marketplace-lint.yml` get the same treatment so the trigger set does not have to be looked up per file. `benchmarks.yml` is deliberately left on the defaults, with the reason recorded in the file itself: it gates nothing, and a re-run costs real machine time plus a timing sample nobody asked for.

**The trap this had to avoid.** Naming `types` *replaces* the default list rather than extending it. Every workflow changed here lists `opened`, `synchronize` and `reopened` back alongside `ready_for_review`. Omitting them would have disabled the triggers that do all the day-to-day work, which is a much worse failure than the one being fixed.

Opened ready rather than as a draft deliberately: the fix is not on `main` yet, so flipping this PR would hit the exact gap it closes.