### PR TITLE
feat(studio): the Operator continues its session and can answer about the app

### DIFF
--- a/apps/studio/frontend/src/components/library/AgentDetail.tsx
+++ b/apps/studio/frontend/src/components/library/AgentDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "use-intl";
 import { IconArrowLeft } from "@/components/ui/icons";
 import { getDefinition, saveDefinition, rollbackDefinition, getDefinitionVersion } from "@/lib/api";
@@ -6,6 +6,9 @@ import type { DefinitionDetail, DefinitionVersion } from "@/lib/api";
 import type { AgentProfileSummary } from "@/lib/types";
 import SectionLabel from "@/components/ui/SectionLabel";
 import Button from "@/components/ui/Button";
+
+// Definitions are authored as markdown; the editor keeps the raw source.
+const Markdown = lazy(() => import("@/components/ui/Markdown"));
 
 interface ParsedFm {
   model?: string;
@@ -396,9 +399,23 @@ export function AgentDetail({ agent, onBack }: Props) {
             placeholder={t("systemPromptPlaceholder")}
           />
         ) : (
-          <pre className="flex-1 overflow-auto whitespace-pre-wrap break-words bg-surface-base p-4 font-data text-[length:var(--t-sm)] leading-relaxed text-content-secondary">
-            {dispBody.trim() || <span className="italic text-content-muted">{t("noContent")}</span>}
-          </pre>
+          <div className="flex-1 overflow-auto bg-surface-base px-5 py-4">
+            {dispBody.trim() ? (
+              <Suspense
+                fallback={
+                  <pre className="whitespace-pre-wrap break-words font-data text-[length:var(--t-sm)] leading-relaxed text-content-secondary">
+                    {dispBody.trim()}
+                  </pre>
+                }
+              >
+                <Markdown className="max-w-4xl text-[length:var(--t-sm)]">
+                  {dispBody.trim()}
+                </Markdown>
+              </Suspense>
+            ) : (
+              <span className="italic text-content-muted">{t("noContent")}</span>
+            )}
+          </div>
         )}
       </div>
 

--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -43,6 +43,27 @@ class RecentRunsInput(_StrictInput):
     status: Literal["pending", "running", "completed", "failed", "cancelled"] | None = None
 
 
+class ListSchedulesInput(_StrictInput):
+    limit: int = Field(default=20, ge=1, le=50)
+    enabled: bool | None = None
+
+
+class ListAgentsInput(_StrictInput):
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+class ListPlaybooksInput(_StrictInput):
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+class RunStatsInput(_StrictInput):
+    window: Literal["24h", "7d"] = "24h"
+
+
+class CurrentViewInput(_StrictInput):
+    """No arguments: the view is a property of the turn, not of the request."""
+
+
 class NavigateInput(_StrictInput):
     space: OperatorSpace = Field(
         description=(
@@ -94,6 +115,11 @@ class _PrefillEffect(BaseModel):
 
 _TOOL_MODELS: dict[str, type[_StrictInput]] = {
     "list_recent_runs": RecentRunsInput,
+    "run_stats": RunStatsInput,
+    "get_current_view": CurrentViewInput,
+    "list_schedules": ListSchedulesInput,
+    "list_agents": ListAgentsInput,
+    "list_playbooks": ListPlaybooksInput,
     "navigate": NavigateInput,
     "prefill_schedule": PrefillScheduleInput,
     "launch_playbook": LaunchPlaybookInput,
@@ -101,6 +127,24 @@ _TOOL_MODELS: dict[str, type[_StrictInput]] = {
 
 _TOOL_DESCRIPTIONS = {
     "list_recent_runs": ("List at most 20 recent Studio runs as a redacted read-only projection."),
+    "run_stats": (
+        "Count runs over a whole window (24h or 7d) with per-status totals and "
+        "completion rate. Use this for 'how many runs did I have', which "
+        "list_recent_runs cannot answer because it only returns the newest 20."
+    ),
+    "get_current_view": (
+        "Read the Studio view the human is on right now: space, route, "
+        "selection and filters. Read-only and always current for this turn."
+    ),
+    "list_schedules": (
+        "List Studio schedules as a redacted read-only projection: trigger, "
+        "next fire time, and recent health."
+    ),
+    "list_agents": ("List the agent profiles in the library, names and models only."),
+    "list_playbooks": (
+        "List playbook names available to launch_playbook. Call this before "
+        "proposing a launch: launch_playbook needs an exact existing name."
+    ),
     "navigate": (
         "Request a typed Studio navigation effect. The browser applies and "
         "acknowledges it; this tool does not claim that navigation completed. "
@@ -134,21 +178,23 @@ def _identity() -> tuple[OperatorStore, str, str]:
     return OperatorStore(db_path), conversation_id, request_id
 
 
+def public_project(value: Any) -> str | None:
+    """Reduce a project to a leaf name so no filesystem layout is disclosed."""
+    if not isinstance(value, str) or not value:
+        return None
+    if Path(value).is_absolute():
+        return Path(value).name or "external-project"
+    windows_path = PureWindowsPath(value)
+    if windows_path.is_absolute():
+        return windows_path.name or "external-project"
+    return value[:160]
+
+
 async def list_recent_runs(arguments: dict[str, Any]) -> dict[str, Any]:
     args = RecentRunsInput.model_validate(arguments)
     from lionagi.studio.services.runs import list_runs
 
     rows = await list_runs(status=args.status, limit=args.limit, offset=0)
-
-    def public_project(value: Any) -> str | None:
-        if not isinstance(value, str) or not value:
-            return None
-        if Path(value).is_absolute():
-            return Path(value).name or "external-project"
-        windows_path = PureWindowsPath(value)
-        if windows_path.is_absolute():
-            return windows_path.name or "external-project"
-        return value[:160]
 
     projected = [
         {
@@ -164,6 +210,103 @@ async def list_recent_runs(arguments: dict[str, Any]) -> dict[str, Any]:
         if isinstance(row.get("id"), str)
     ]
     return {"runs": projected, "count": len(projected), "bounded": True}
+
+
+async def run_stats(arguments: dict[str, Any]) -> dict[str, Any]:
+    args = RunStatsInput.model_validate(arguments)
+    from lionagi.studio.services.stats import get_activity_stats
+
+    stats = await get_activity_stats(args.window)
+    buckets = stats.get("buckets") or []
+    totals = {key: 0 for key in ("completed", "failed", "cancelled", "running")}
+    for bucket in buckets:
+        for key in totals:
+            value = bucket.get(key)
+            if isinstance(value, int):
+                totals[key] += value
+    return {
+        "window": stats.get("window"),
+        "total": stats.get("total"),
+        "byStatus": totals,
+        "completionRate": stats.get("completion_rate"),
+    }
+
+
+async def get_current_view(arguments: dict[str, Any]) -> dict[str, Any]:
+    CurrentViewInput.model_validate(arguments)
+    store, _conversation_id, request_id = _identity()
+    turn = await store.get_turn(request_id)
+    context = turn.get("context")
+    if not isinstance(context, dict):
+        return {"known": False}
+    return {
+        "known": True,
+        "space": context.get("space"),
+        "route": context.get("route"),
+        "project": public_project(context.get("project")),
+        "selection": context.get("selection"),
+        "filters": context.get("filters"),
+    }
+
+
+async def list_schedules(arguments: dict[str, Any]) -> dict[str, Any]:
+    args = ListSchedulesInput.model_validate(arguments)
+    from lionagi.studio.services.schedules import list_schedules as _list_schedules
+
+    rows = await _list_schedules(enabled=args.enabled)
+    projected = [
+        {
+            "id": row.get("id"),
+            "name": row.get("name"),
+            "enabled": bool(row.get("enabled")),
+            "triggerType": row.get("trigger_type"),
+            "cron": row.get("cron_expr"),
+            "intervalSec": row.get("interval_sec"),
+            "actionKind": row.get("action_kind"),
+            "nextFireAt": row.get("next_fire_at"),
+            "lastFiredAt": row.get("last_fired_at"),
+            "lastStatus": row.get("last_status"),
+            "consecutiveFailures": row.get("consecutive_failures"),
+            "project": public_project(row.get("project")),
+        }
+        for row in rows[: args.limit]
+        if isinstance(row.get("id"), str)
+    ]
+    return {"schedules": projected, "count": len(projected), "bounded": True}
+
+
+async def list_agents(arguments: dict[str, Any]) -> dict[str, Any]:
+    args = ListAgentsInput.model_validate(arguments)
+    from lionagi.studio.services.agents import list_agents as _list_agents
+
+    rows = await anyio.to_thread.run_sync(_list_agents)
+    projected = [
+        {
+            "name": row.get("name"),
+            "provider": row.get("provider") or None,
+            "model": row.get("model") or None,
+            "description": (row.get("description") or "")[:500] or None,
+        }
+        for row in rows[: args.limit]
+        if isinstance(row.get("name"), str)
+    ]
+    return {"agents": projected, "count": len(projected), "bounded": True}
+
+
+async def list_playbooks(arguments: dict[str, Any]) -> dict[str, Any]:
+    args = ListPlaybooksInput.model_validate(arguments)
+    from lionagi.studio.services.playbooks import list_playbooks as _list_playbooks
+
+    rows = await anyio.to_thread.run_sync(_list_playbooks)
+    projected = [
+        {
+            "name": row.get("name"),
+            "description": (row.get("description") or "")[:500] or None,
+        }
+        for row in rows[: args.limit]
+        if isinstance(row.get("name"), str)
+    ]
+    return {"playbooks": projected, "count": len(projected), "bounded": True}
 
 
 async def navigate(arguments: dict[str, Any]) -> dict[str, Any]:
@@ -271,6 +414,11 @@ async def launch_playbook(arguments: dict[str, Any]) -> dict[str, Any]:
 
 _TOOL_HANDLERS = {
     "list_recent_runs": list_recent_runs,
+    "run_stats": run_stats,
+    "get_current_view": get_current_view,
+    "list_schedules": list_schedules,
+    "list_agents": list_agents,
+    "list_playbooks": list_playbooks,
     "navigate": navigate,
     "prefill_schedule": prefill_schedule,
     "launch_playbook": launch_playbook,

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -267,6 +267,8 @@ class OperatorCoordinator:
                         return PermissionDecision(False, current["id"])
                     await asyncio.sleep(0.05)
 
+            conversation_row = await self.store.get_conversation(conversation_id)
+            resumed_session_id = conversation_row.get("providerSessionId")
             engine_turn = OperatorEngineTurn(
                 conversation_id=conversation_id,
                 request_id=request_id,
@@ -275,6 +277,9 @@ class OperatorCoordinator:
                 history=compiled.frames,
                 request_permission=request_permission,
                 store_path=str(self.store.path()),
+                provider_session_id=(
+                    resumed_session_id if isinstance(resumed_session_id, str) else None
+                ),
             )
             run_branch = build_operator_branch(engine_turn)
             engine_turn = OperatorEngineTurn(
@@ -286,6 +291,7 @@ class OperatorCoordinator:
                 request_permission=engine_turn.request_permission,
                 runtime_branch=run_branch,
                 store_path=engine_turn.store_path,
+                provider_session_id=engine_turn.provider_session_id,
             )
             from lionagi.cli import _runs as cli_runs
 
@@ -348,7 +354,10 @@ class OperatorCoordinator:
                 request_id,
                 "text",
                 {
-                    "content": f"[Open this Operator run](/runs/{run_id})",
+                    # Trailing break: consecutive assistant text frames are
+                    # concatenated for display, so without it this link runs
+                    # straight into the first word of the model's reply.
+                    "content": f"[Open this Operator run](/runs/{run_id})\n\n",
                     "format": "markdown",
                     "role": "assistant",
                 },
@@ -370,6 +379,14 @@ class OperatorCoordinator:
                 if not isinstance(event, OperatorEngineEvent):
                     raise TypeError("Operator engine yielded an invalid event")
                 if event.type == "done":
+                    continue
+                if event.type == "session":
+                    # Continuity state, not conversation content: remembered on
+                    # the conversation so the next turn resumes, never appended
+                    # as a frame the human has to read.
+                    session_id = event.payload.get("providerSessionId")
+                    if isinstance(session_id, str) and session_id:
+                        await self.store.set_provider_session_id(conversation_id, session_id)
                     continue
                 if event.type == "ui_command":
                     effect = event.payload.get("effect")

--- a/lionagi/studio/operator/engine.py
+++ b/lionagi/studio/operator/engine.py
@@ -23,9 +23,23 @@ You may inspect the current project and help operate LionAGI. Never claim that
 an action completed until its tool result says so. Disk writes, commands, and
 other gated native work must go through the configured Studio permission
 prompt; wait for the human decision. Use the strict studio_operator MCP tools
-for recent-run queries, typed UI navigation/prefill, and playbook launches.
-The launch tool creates its own human-confirmed durable proposal. Do not
-attempt to bypass either gate or invent raw Studio endpoints.
+for reads, typed UI navigation/prefill, and playbook launches. The launch tool
+creates its own human-confirmed durable proposal. Do not attempt to bypass
+either gate or invent raw Studio endpoints.
+
+Pick the right read tool. list_recent_runs returns only the newest 20, so it
+can never answer "how many" — use run_stats for any count or rate over a
+window. Use list_schedules, list_agents and list_playbooks to answer what
+exists; call list_playbooks before proposing a launch, because launch_playbook
+needs an exact existing name.
+
+Every turn tells you which Studio view the human is on, including the route
+and any selection or filters, and get_current_view re-reads it on demand. Use
+it instead of asking, and never say you cannot tell what they are looking at.
+There is no pixel screenshot: the view snapshot is the structured equivalent
+and is what you should reason from. You also cannot restyle the page. A visual
+change means editing source files through the permission prompt and
+rebuilding, so say that plainly rather than implying a live tweak.
 """
 
 _END = object()
@@ -38,12 +52,18 @@ _ONE_TURN_PERMISSION_KEYS = {
 _REQUEST_SCOPED_MCP_SERVERS = {"studio_permission", "studio_operator"}
 _OPERATOR_MCP_TOOLS = [
     "mcp__studio_operator__list_recent_runs",
+    "mcp__studio_operator__run_stats",
+    "mcp__studio_operator__get_current_view",
+    "mcp__studio_operator__list_schedules",
+    "mcp__studio_operator__list_agents",
+    "mcp__studio_operator__list_playbooks",
     "mcp__studio_operator__navigate",
     "mcp__studio_operator__prefill_schedule",
     "mcp__studio_operator__launch_playbook",
 ]
 _MODEL_CONTEXT_FRAME_LIMIT = 64
 _MODEL_CONTEXT_BYTE_LIMIT = 128 * 1024
+_CONTEXT_VALUE_BYTE_LIMIT = 2 * 1024
 
 
 class OperatorProviderUnavailableError(RuntimeError):
@@ -216,19 +236,57 @@ def compile_operator_history(
     return CompiledOperatorHistory(compiled_frames, metadata)
 
 
+def _render_operator_context(context: Any) -> str | None:
+    """Render the caller's view snapshot so the Operator knows where the human is.
+
+    The browser sends this with every turn and the store persists it. Dropping
+    it here is what makes the Operator answer "I cannot see which page you are
+    on" — a statement about this function, not about what the turn carries.
+    ``filters`` and ``selection`` are open-ended, so each rendered value is
+    capped the same way history frames are.
+    """
+    if not isinstance(context, dict):
+        return None
+    lines: list[str] = []
+
+    def add(label: str, value: Any) -> None:
+        if value is None or value == {} or value == "":
+            return
+        text = value if isinstance(value, str) else _canonical_json(value)
+        if len(text) > _CONTEXT_VALUE_BYTE_LIMIT:
+            text = text[:_CONTEXT_VALUE_BYTE_LIMIT] + "… (truncated)"
+        lines.append(f"- {label}: {text}")
+
+    add("space", context.get("space"))
+    add("route", context.get("route"))
+    add("project", context.get("project"))
+    add("selection", context.get("selection"))
+    add("filters", context.get("filters"))
+    if not lines:
+        return None
+    return (
+        "The human is looking at this Studio view right now. Treat it as "
+        "current fact and resolve their deictic references ('this page', "
+        "'this agent', 'what am I looking at') against it:\n" + "\n".join(lines)
+    )
+
+
 def _compile_operator_prompt(turn: OperatorEngineTurn) -> str:
-    """Render the coordinator's already-bounded, turn-atomic history."""
+    """Render the caller's view plus the coordinator's bounded, turn-atomic history."""
+    sections: list[str] = []
+    if (view := _render_operator_context(turn.context)) is not None:
+        sections.append(view)
     rendered = [
         text for frame in turn.history if (text := _render_history_frame(frame)) is not None
     ]
-    if not rendered:
+    if rendered:
+        sections.append(
+            "Recent durable Operator conversation (oldest to newest):\n" + "\n".join(rendered)
+        )
+    if not sections:
         return turn.instruction
-    return (
-        "Recent durable Operator conversation (oldest to newest):\n"
-        + "\n".join(rendered)
-        + "\n\nCurrent operator instruction:\n"
-        + turn.instruction
-    )
+    sections.append("Current operator instruction:\n" + turn.instruction)
+    return "\n\n".join(sections)
 
 
 async def write_resumable_operator_snapshot(branch: Any, snapshot_dir: str | Path) -> None:
@@ -316,7 +374,14 @@ class BranchOperatorEngine:
         async def on_chunk(chunk: Any) -> None:
             nonlocal saw_text
             typ = getattr(chunk, "type", None)
-            if typ == "text":
+            if typ == "system":
+                metadata = getattr(chunk, "metadata", None) or {}
+                session_id = metadata.get("session_id")
+                if isinstance(session_id, str) and session_id:
+                    await queue.put(
+                        OperatorEngineEvent("session", {"providerSessionId": session_id})
+                    )
+            elif typ == "text":
                 content = getattr(chunk, "content", None)
                 if content:
                     saw_text = True
@@ -436,6 +501,10 @@ def build_operator_branch(turn: OperatorEngineTurn):
             "allowed_tools": _OPERATOR_MCP_TOOLS,
             "permission_prompt_tool_name": "mcp__studio_permission__request_permission",
             "strict_mcp_config": True,
+            # Continue the conversation's own provider session instead of
+            # meeting the human as a stranger on every turn. Absent on the
+            # first turn, which is the only turn that should start fresh.
+            **({"resume": turn.provider_session_id} if turn.provider_session_id else {}),
             # Do not inherit project/user MCP servers into this privileged
             # control-plane conversation.
             "setting_sources": "",

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -40,6 +40,9 @@ CREATE TABLE IF NOT EXISTS studio_operator_conversations (
                      CHECK(status IN ('active', 'archived', 'deleted')),
   next_sequence      INTEGER NOT NULL DEFAULT 1,
   active_request_id  TEXT,
+  -- The provider-side session this conversation resumes, so a second turn
+  -- continues the first instead of starting a stranger.
+  provider_session_id TEXT,
   created_at         REAL NOT NULL,
   updated_at         REAL NOT NULL,
   archived_at        REAL,
@@ -177,9 +180,26 @@ class OperatorStore:
                 return
             async with open_db(str(path)) as db:
                 await db.executescript(_SCHEMA)
+                # CREATE TABLE IF NOT EXISTS is a no-op on a database created
+                # before a column was added, so additive columns need their own
+                # migration or an existing conversation store silently lacks them.
+                await self._add_missing_columns(
+                    db,
+                    "studio_operator_conversations",
+                    {"provider_session_id": "TEXT"},
+                )
                 await db.commit()
             stat = path.stat()
             self._schema_ready = (path, stat.st_dev, stat.st_ino)
+
+    @staticmethod
+    async def _add_missing_columns(db: Any, table: str, columns: dict[str, str]) -> None:
+        """Add additive columns a pre-existing database was created without."""
+        rows = await (await db.execute(f"PRAGMA table_info({table})")).fetchall()
+        present = {row[1] for row in rows}
+        for name, decl in columns.items():
+            if name not in present:
+                await db.execute(f"ALTER TABLE {table} ADD COLUMN {name} {decl}")
 
     @staticmethod
     def _json(value: Any) -> str:
@@ -244,6 +264,7 @@ class OperatorStore:
             "status": row["status"],
             "nextSequence": row["next_sequence"],
             "activeRequestId": row["active_request_id"],
+            "providerSessionId": row["provider_session_id"],
             "createdAt": row["created_at"],
             "updatedAt": row["updated_at"],
         }
@@ -380,6 +401,22 @@ class OperatorStore:
         if row is None or row["status"] == "deleted":
             raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
         return self._conversation(row)
+
+    async def set_provider_session_id(self, conversation_id: str, session_id: str) -> None:
+        """Remember the provider session so the next turn resumes this one.
+
+        Written every turn rather than only the first: the provider is free to
+        hand back a new session id on resume, and pinning the first one forever
+        would silently stop resuming the moment it does.
+        """
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            await db.execute(
+                "UPDATE studio_operator_conversations "
+                "SET provider_session_id = ?, updated_at = ? WHERE id = ?",
+                (session_id, time.time(), conversation_id),
+            )
+            await db.commit()
 
     async def archive_or_delete(self, conversation_id: str) -> None:
         await self.ensure_schema()

--- a/lionagi/studio/operator/types.py
+++ b/lionagi/studio/operator/types.py
@@ -137,6 +137,7 @@ class OperatorEngineTurn:
     runtime_branch: Any | None = None
     store_path: str | None = None
     run_dir: Any | None = None
+    provider_session_id: str | None = None
 
 
 class OperatorEngine(Protocol):

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -132,12 +132,44 @@ def test_real_operator_branch_exposes_only_strict_request_scoped_mcp_tools(tmp_p
     assert kwargs.get("allow_dangerously_skip_permissions") is not True
     assert set(kwargs["mcp_servers"]) == {"studio_permission", "studio_operator"}
     assert kwargs["permission_prompt_tool_name"] == ("mcp__studio_permission__request_permission")
+    # Widening this set is a deliberate act. Everything added since the
+    # original four is read-only; the three gated tools are unchanged.
     assert set(kwargs["allowed_tools"]) == {
         "mcp__studio_operator__list_recent_runs",
+        "mcp__studio_operator__run_stats",
+        "mcp__studio_operator__get_current_view",
+        "mcp__studio_operator__list_schedules",
+        "mcp__studio_operator__list_agents",
+        "mcp__studio_operator__list_playbooks",
         "mcp__studio_operator__navigate",
         "mcp__studio_operator__prefill_schedule",
         "mcp__studio_operator__launch_playbook",
     }
+    # The first turn of a conversation has nothing to resume.
+    assert "resume" not in kwargs
+
+
+def test_operator_branch_resumes_the_conversations_provider_session(tmp_path):
+    """A second turn continues the same provider session instead of a new one."""
+    from lionagi.studio.operator.engine import build_operator_branch
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("branch construction cannot request permission")
+
+    branch = build_operator_branch(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request-2",
+            instruction="and what about yesterday?",
+            context={},
+            history=(),
+            request_permission=request_permission,
+            store_path=str(tmp_path / "state.db"),
+            provider_session_id="session-abc",
+        )
+    )
+    assert branch.chat_model.endpoint.config.kwargs["resume"] == "session-abc"
 
 
 @pytest.mark.asyncio
@@ -991,6 +1023,117 @@ def test_context_compiler_keeps_newest_complete_turn_when_older_turn_exceeds_bud
     assert "recent context survives" in prompt
     assert "x" * 1024 not in prompt
     assert prompt.endswith("current instruction")
+
+
+@pytest.mark.asyncio
+async def test_provider_session_column_is_added_to_a_preexisting_conversation_store(tmp_path):
+    """CREATE TABLE IF NOT EXISTS is a no-op on an existing database.
+
+    The demo store predates this column, so without the additive migration the
+    round-trip below raises and every turn silently starts a new session.
+    """
+    import aiosqlite
+
+    db_path = tmp_path / "state.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "CREATE TABLE studio_operator_conversations ("
+            "id TEXT PRIMARY KEY, project TEXT, title TEXT, "
+            "status TEXT NOT NULL DEFAULT 'active', "
+            "next_sequence INTEGER NOT NULL DEFAULT 1, active_request_id TEXT, "
+            "created_at REAL NOT NULL, updated_at REAL NOT NULL, "
+            "archived_at REAL, deleted_at REAL)"
+        )
+        await db.commit()
+
+    store = OperatorStore(db_path)
+    conversation_id = (await store.create_conversation())["id"]
+    assert (await store.get_conversation(conversation_id))["providerSessionId"] is None
+
+    await store.set_provider_session_id(conversation_id, "session-xyz")
+    assert (await store.get_conversation(conversation_id))["providerSessionId"] == "session-xyz"
+
+
+def test_compiled_prompt_carries_the_view_the_human_is_looking_at():
+    """The browser sends a view snapshot every turn; the prompt must show it.
+
+    Without this the Operator answers "I cannot tell which page you are on"
+    while the turn it is answering carries the route verbatim.
+    """
+    from lionagi.studio.operator.engine import _compile_operator_prompt
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("prompt compilation cannot request permission")
+
+    prompt = _compile_operator_prompt(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="which page am I on?",
+            context={
+                "space": "library",
+                "route": "/library?sel=agent%3Aadvisor",
+                "project": "lionagi",
+                "selection": {"agent": "advisor"},
+                "filters": {"kind": "agent"},
+            },
+            history=(),
+            request_permission=request_permission,
+        )
+    )
+    assert "library" in prompt
+    assert "/library?sel=agent%3Aadvisor" in prompt
+    assert "advisor" in prompt
+    # The instruction stays last so the model reads the view as background.
+    assert prompt.endswith("which page am I on?")
+
+
+def test_compiled_prompt_bounds_an_oversized_filter_payload():
+    from lionagi.studio.operator.engine import (
+        _CONTEXT_VALUE_BYTE_LIMIT,
+        _compile_operator_prompt,
+    )
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("prompt compilation cannot request permission")
+
+    prompt = _compile_operator_prompt(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="current instruction",
+            context={"space": "history", "route": "/fleet", "filters": {"q": "y" * 16_384}},
+            history=(),
+            request_permission=request_permission,
+        )
+    )
+    assert "truncated" in prompt
+    assert "y" * (_CONTEXT_VALUE_BYTE_LIMIT + 1) not in prompt
+    assert prompt.endswith("current instruction")
+
+
+def test_compiled_prompt_is_the_bare_instruction_without_view_or_history():
+    from lionagi.studio.operator.engine import _compile_operator_prompt
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("prompt compilation cannot request permission")
+
+    assert (
+        _compile_operator_prompt(
+            OperatorEngineTurn(
+                conversation_id="conversation",
+                request_id="request",
+                instruction="current instruction",
+                context={},
+                history=(),
+                request_permission=request_permission,
+            )
+        )
+        == "current instruction"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Three things the Operator panel could not do, and now can.

**It starts a new session every turn.** Each turn built a fresh provider session, so the second message in a conversation met a stranger; continuity was faked by replaying prior frames as prompt text. Conversations now persist their provider session id and resume it. The id is re-read every turn rather than pinned on first write, because a resumed session is free to hand back a new id and pinning would silently stop resuming the moment it did.

**It could not see the page you were on.** The browser sends a view snapshot with every turn and the store persists it, but the prompt compiler rendered only history and instruction. The Operator's "I have no way to read your current page" was a statement about that function, not about what the turn carried. The snapshot is now rendered into every prompt, bounded per value the same way history frames are, and readable on demand.

**It could not answer questions about the app.** Five read-only tools:

| tool | closes |
|---|---|
| `run_stats` | "how many runs did I have last week" — `list_recent_runs` caps at 20 and can never answer a count |
| `get_current_view` | space, route, selection, filters |
| `list_schedules` | what is scheduled, next fire, recent health |
| `list_agents` | what is in the library |
| `list_playbooks` | `launch_playbook` requires an exact name and nothing listed the valid ones |

Every one is a bounded, explicitly projected read; project paths go through the same leaf-name redaction as the existing run list. The three gated tools are untouched.

## Also

- Agent definitions render as markdown instead of raw preformatted text, reusing the existing `Markdown` component. No new i18n keys, so no catalog churn across 16 locales.
- The run link carried no trailing break, so it ran into the first word of the reply on every turn.

## Notes for review

- `studio_operator_conversations` gains a nullable `provider_session_id`. `CREATE TABLE IF NOT EXISTS` is a no-op on an existing database, so this needs the additive migration in `ensure_schema`; a test builds a pre-migration store and pins the round-trip.
- The strict-allowlist guard test is widened deliberately, with a comment saying so. Everything added is read-only.

## Verification

- `tests/apps_studio_server/` + `tests/studio`: 2043 tests, 0 failures, 0 errors
- frontend: `tsc --noEmit` clean, vitest 46 files / 951 tests
- `ruff check` + `ruff format --check` clean
- New read tools exercised against live data: `run_stats` 7d returned 4156 runs at a 97.3% completion rate, a figure the 20-row list cannot produce; schedules, agents and playbooks all returned real rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)