### PR TITLE
fix(mirror): harden the orchestrated-rollout absorption

### DIFF
--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -576,21 +576,34 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
             # rollout into two sessions — and committing head_checked would let
             # an orchestrated rollout slip past the skip forever.
             return 0
+        if meta and meta.get("originator") in SKIPPED_ORIGINATORS:
+            # An orchestrator's own run (e.g. a lionagi agent leg) — its
+            # session already exists under the agent's name; importing the
+            # rollout too is the double entry. Absorb what an older version
+            # may have imported (under either id this file was ever keyed
+            # by), then never read this file again.
+            prior_uid = state.session_uid  # a stem fallback from a pre-header pass
+            resolved_uid = meta["rollout_uid"] or path.stem
+            await absorb_orchestrated_session(db, resolved_uid)
+            if prior_uid and prior_uid != resolved_uid:
+                await absorb_orchestrated_session(db, prior_uid)
+            # Nothing is committed to the state until both absorptions return,
+            # so a failed attempt leaves exactly what the next one needs to
+            # repeat it. Committing head_checked would stop the header being
+            # re-read, and the rollout would then be mirrored after all —
+            # the same failure the torn-header branch above declines to cause.
+            # Committing orchestrated would retire the file with a row nobody
+            # ever tore down. Overwriting session_uid would lose the stem the
+            # second absorption call needs. Absorption fails for an ordinary
+            # reason now that a contended teardown gives up rather than waiting,
+            # so this path carries real traffic.
+            state.session_uid = resolved_uid
+            state.head_checked = True
+            state.orchestrated = True
+            return 0
         state.head_checked = True
         if meta:
-            prior_uid = state.session_uid  # a stem fallback from a pre-header pass
             state.session_uid = meta["rollout_uid"] or path.stem
-            if meta.get("originator") in SKIPPED_ORIGINATORS:
-                # An orchestrator's own run (e.g. a lionagi agent leg) — its
-                # session already exists under the agent's name; importing the
-                # rollout too is the double entry. Absorb what an older version
-                # may have imported (under either id this file was ever keyed
-                # by), then never read this file again.
-                state.orchestrated = True
-                await absorb_orchestrated_session(db, state.session_uid)
-                if prior_uid and prior_uid != state.session_uid:
-                    await absorb_orchestrated_session(db, prior_uid)
-                return 0
             if meta.get("cwd"):
                 state.project, state.project_source = _resolve_project_for_mirror(meta["cwd"])
     if not state.session_uid:

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -499,11 +499,12 @@ def _peek_codex_head(path: Path) -> tuple[str, dict[str, Any] | None]:
     """Classify a rollout's first line without consuming the tail.
 
     Returns ``("meta", meta)`` for a parsed session_meta header,
-    ``("headerless", None)`` for a complete first record that is not one (such a
-    file will never gain a header — rollouts are append-only), and
-    ``("torn", None)`` when the line is unreadable or still being written. A
-    successful JSON parse is what proves the line is complete; a torn line
-    cannot parse.
+    ``("headerless", None)`` for a complete first line that is not one, and
+    ``("torn", None)`` when the line is still being written or unreadable.
+    Completeness is decided by the trailing newline: rollouts are append-only
+    JSONL, so a newline-terminated line that cannot parse is permanently
+    corrupt — it settles as headerless and the normal reader accounts for the
+    bad line — while a line without its newline is still arriving and defers.
     """
     from lionagi.state.codex_mirror import session_meta
 
@@ -514,8 +515,8 @@ def _peek_codex_head(path: Path) -> tuple[str, dict[str, Any] | None]:
         return "torn", None
     try:
         rec = json.loads(line)
-    except json.JSONDecodeError:
-        return "torn", None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return ("headerless", None) if line.endswith(b"\n") else ("torn", None)
     meta = session_meta(rec) if isinstance(rec, dict) else None
     return ("meta", meta) if meta else ("headerless", None)
 

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -495,20 +495,29 @@ async def _one_pass(db, root: Path, states, offsets, *, since, live_window, line
     return total
 
 
-def _peek_codex_meta(path: Path) -> dict[str, Any] | None:
-    """Read a rollout's session_meta (its first line) without consuming the tail."""
+def _peek_codex_head(path: Path) -> tuple[str, dict[str, Any] | None]:
+    """Classify a rollout's first line without consuming the tail.
+
+    Returns ``("meta", meta)`` for a parsed session_meta header,
+    ``("headerless", None)`` for a complete first record that is not one (such a
+    file will never gain a header — rollouts are append-only), and
+    ``("torn", None)`` when the line is unreadable or still being written. A
+    successful JSON parse is what proves the line is complete; a torn line
+    cannot parse.
+    """
     from lionagi.state.codex_mirror import session_meta
 
     try:
         with path.open("rb") as fh:
             line = fh.readline()
     except OSError:
-        return None
+        return "torn", None
     try:
         rec = json.loads(line)
     except json.JSONDecodeError:
-        return None
-    return session_meta(rec) if isinstance(rec, dict) else None
+        return "torn", None
+    meta = session_meta(rec) if isinstance(rec, dict) else None
+    return ("meta", meta) if meta else ("headerless", None)
 
 
 def _derive_codex_metadata(state: _FileState, records: list[dict[str, Any]]) -> None:
@@ -553,13 +562,17 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
 
     meta: dict[str, Any] | None = None
     if not state.head_checked:
-        meta = _peek_codex_meta(path)
+        head_status, meta = _peek_codex_head(path)
+        if head_status == "torn":
+            # The first line is still being written (or unreadable), so the
+            # rollout's identity is unknown. Mirroring waits along with the
+            # classification: writing records now would key them under the path
+            # stem while the header's real UID arrives next pass, splitting one
+            # rollout into two sessions — and committing head_checked would let
+            # an orchestrated rollout slip past the skip forever.
+            return 0
+        state.head_checked = True
         if meta:
-            # Only a successfully parsed header settles classification. A file
-            # whose first line is still being written peeks as None and MUST be
-            # re-peeked next pass — committing head_checked here would let an
-            # orchestrated rollout slip past the skip forever.
-            state.head_checked = True
             prior_uid = state.session_uid  # a stem fallback from a pre-header pass
             state.session_uid = meta["rollout_uid"] or path.stem
             if meta.get("originator") in SKIPPED_ORIGINATORS:
@@ -807,9 +820,13 @@ async def _run(args: argparse.Namespace) -> int:
     hint(f"li mirror: {mode} over {trees}")
 
     async with StateDB() as db:
-        if want_codex:
-            await _absorb_backfill(db)
+        # Retried every pass until one sweep completes cleanly, same as the
+        # studio's mirror_forever — a transient failure on the first attempt
+        # must not retire the backfill for the process lifetime.
+        backfilled = not want_codex
         while True:
+            if not backfilled:
+                backfilled = await _absorb_backfill(db)
             n = 0
             if want_claude:
                 n += await _one_pass(

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -307,7 +307,7 @@ def _read_new_events(path: Path, state: _FileState) -> tuple[list[dict[str, Any]
             continue
         try:
             obj = json.loads(raw)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             unreadable += 1
             continue
         if isinstance(obj, dict):
@@ -501,10 +501,12 @@ def _peek_codex_head(path: Path) -> tuple[str, dict[str, Any] | None]:
     Returns ``("meta", meta)`` for a parsed session_meta header,
     ``("headerless", None)`` for a complete first line that is not one, and
     ``("torn", None)`` when the line is still being written or unreadable.
-    Completeness is decided by the trailing newline: rollouts are append-only
-    JSONL, so a newline-terminated line that cannot parse is permanently
-    corrupt — it settles as headerless and the normal reader accounts for the
-    bad line — while a line without its newline is still arriving and defers.
+    Completeness is decided by the trailing newline BEFORE any parse attempt:
+    rollouts are append-only JSONL, so a line without its newline is still
+    arriving and defers even when the bytes so far happen to parse — later
+    appends can extend or corrupt it. A newline-terminated line that cannot
+    parse is permanently corrupt and settles as headerless; the normal reader
+    accounts for the bad line.
     """
     from lionagi.state.codex_mirror import session_meta
 
@@ -513,10 +515,12 @@ def _peek_codex_head(path: Path) -> tuple[str, dict[str, Any] | None]:
             line = fh.readline()
     except OSError:
         return "torn", None
+    if not line.endswith(b"\n"):
+        return "torn", None
     try:
         rec = json.loads(line)
     except (json.JSONDecodeError, UnicodeDecodeError):
-        return ("headerless", None) if line.endswith(b"\n") else ("torn", None)
+        return "headerless", None
     meta = session_meta(rec) if isinstance(rec, dict) else None
     return ("meta", meta) if meta else ("headerless", None)
 

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -553,17 +553,25 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
 
     meta: dict[str, Any] | None = None
     if not state.head_checked:
-        state.head_checked = True
         meta = _peek_codex_meta(path)
         if meta:
+            # Only a successfully parsed header settles classification. A file
+            # whose first line is still being written peeks as None and MUST be
+            # re-peeked next pass — committing head_checked here would let an
+            # orchestrated rollout slip past the skip forever.
+            state.head_checked = True
+            prior_uid = state.session_uid  # a stem fallback from a pre-header pass
             state.session_uid = meta["rollout_uid"] or path.stem
             if meta.get("originator") in SKIPPED_ORIGINATORS:
                 # An orchestrator's own run (e.g. a lionagi agent leg) — its
                 # session already exists under the agent's name; importing the
                 # rollout too is the double entry. Absorb what an older version
-                # may have imported, then never read this file again.
+                # may have imported (under either id this file was ever keyed
+                # by), then never read this file again.
                 state.orchestrated = True
                 await absorb_orchestrated_session(db, state.session_uid)
+                if prior_uid and prior_uid != state.session_uid:
+                    await absorb_orchestrated_session(db, prior_uid)
                 return 0
             if meta.get("cwd"):
                 state.project, state.project_source = _resolve_project_for_mirror(meta["cwd"])
@@ -654,23 +662,30 @@ async def _codex_pass(db, root: Path, states, offsets, *, since, live_window, th
     return total
 
 
-async def _absorb_backfill(db) -> None:
+async def _absorb_backfill(db) -> bool:
     """Remove previously-imported rows for orchestrator-spawned rollouts.
 
-    Runs once per mirror process. It reads recorded provenance rather than the
-    rollout tree, so it also reaches rows whose files fall outside the sweep
-    window; per-file absorption in ``_mirror_one_codex`` covers the rest. Errors
-    are logged and swallowed — reconciliation must never keep the mirror down.
+    It reads recorded provenance rather than the rollout tree, so it also
+    reaches rows whose files fall outside the sweep window; per-file absorption
+    in ``_mirror_one_codex`` covers the rest. Returns whether the sweep
+    completed cleanly — a caller that runs this once per process must only
+    stand down on True, else one bad pass would retire the backfill for the
+    process lifetime. Errors are logged, never raised: reconciliation must not
+    keep the mirror down.
     """
     from lionagi.state.codex_mirror import absorb_orchestrated_backfill
 
     try:
-        removed = await absorb_orchestrated_backfill(db)
+        removed, failed = await absorb_orchestrated_backfill(db)
     except Exception:
         _log.exception("codex mirror orchestrated-session backfill failed")
-        return
+        return False
     if removed:
         progress(f"  mirror: absorbed {removed} orchestrator-spawned codex session(s)")
+    if failed:
+        warn(f"codex mirror backfill: {failed} row(s) failed to reconcile; will retry")
+        return False
+    return True
 
 
 async def mirror_forever(
@@ -715,11 +730,10 @@ async def mirror_forever(
     while not stop.is_set():
         try:
             async with StateDB() as db:
-                if want_codex and not backfilled:
-                    backfilled = True
-                    await _absorb_backfill(db)
                 while not stop.is_set():
                     try:
+                        if want_codex and not backfilled:
+                            backfilled = await _absorb_backfill(db)
                         if want_claude and root.exists():
                             await _one_pass(
                                 db,

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -546,39 +546,44 @@ async def reconcile_session_status(
 async def absorb_orchestrated_session(db: StateDB, rollout_uid: str) -> bool:
     """Remove the row a previous version imported for a now-skipped rollout.
 
-    Only rows this mirror wrote are deletable (``delete_imported_session`` refuses
-    anything whose source_kind is not imported), so absorbing an id that a live
+    Only rows this mirror wrote are deletable (``delete_imported_session``
+    requires this mirror's exact source kind), so absorbing an id that a live
     run happens to own is a no-op rather than a data loss.
     """
-    return await db.delete_imported_session(session_db_id(rollout_uid))
+    return await db.delete_imported_session(
+        session_db_id(rollout_uid), require_source_kind=SOURCE_KIND
+    )
 
 
-async def absorb_orchestrated_backfill(db: StateDB) -> int:
+async def absorb_orchestrated_backfill(db: StateDB) -> tuple[int, int]:
     """One sweep over already-imported rows, deleting those whose recorded
-    originator is in ``SKIPPED_ORIGINATORS``; returns how many were removed.
+    originator is in ``SKIPPED_ORIGINATORS``; returns ``(removed, failed)``.
 
     The originator is read from the provenance each import wrote on its own row
     (``node_metadata.codex.originator``), so this reaches rows whose rollout
     files are older than the mirror's sweep window and would otherwise never be
-    revisited. Rows with no recorded originator are left alone: absence of
-    provenance is not evidence of orchestration.
+    revisited. Only a string originator counts, and each row is handled in
+    isolation: one malformed row must not stop the rest of the sweep. Rows with
+    no recorded originator are left alone — absence of provenance is not
+    evidence of orchestration.
     """
     removed = 0
+    failed = 0
     for row in await db.sessions_by_source_kind(SOURCE_KIND):
-        meta = row.get("node_metadata")
-        if isinstance(meta, str):
-            try:
+        try:
+            meta = row.get("node_metadata")
+            if isinstance(meta, str):
                 meta = json.loads(meta)
-            except (TypeError, ValueError):
+            if not isinstance(meta, dict):
                 continue
-        if not isinstance(meta, dict):
-            continue
-        codex_block = meta.get("codex")
-        originator = codex_block.get("originator") if isinstance(codex_block, dict) else None
-        if originator in SKIPPED_ORIGINATORS:
-            if await db.delete_imported_session(row["id"]):
-                removed += 1
-    return removed
+            codex_block = meta.get("codex")
+            originator = codex_block.get("originator") if isinstance(codex_block, dict) else None
+            if isinstance(originator, str) and originator in SKIPPED_ORIGINATORS:
+                if await db.delete_imported_session(row["id"], require_source_kind=SOURCE_KIND):
+                    removed += 1
+        except Exception:
+            failed += 1
+    return removed, failed
 
 
 async def link_session_lineage(

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -14,6 +14,7 @@ a row is what there is to subtract against.
 from __future__ import annotations
 
 import json
+import logging
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -46,6 +47,8 @@ __all__ = (
     "ID_FIELD",
     "SKIPPED_ORIGINATORS",
 )
+
+_log = logging.getLogger(__name__)
 
 # Provenance value for a session this mirror wrote, as opposed to one lionagi ran.
 SOURCE_KIND = "imported_codex"
@@ -582,6 +585,11 @@ async def absorb_orchestrated_backfill(db: StateDB) -> tuple[int, int]:
                 if await db.delete_imported_session(row["id"], require_source_kind=SOURCE_KIND):
                     removed += 1
         except Exception:
+            # The count alone says a row did not reconcile, never why. A
+            # contended teardown gives up rather than waiting, so this path now
+            # carries an ordinary, recurring cause that an operator watching the
+            # retry warning has no other way to see.
+            _log.exception("codex mirror: absorbing imported session %s failed", row.get("id"))
             failed += 1
     return removed, failed
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2455,19 +2455,64 @@ class StateDB:
             # (kind, name) slot may already be taken by an unattached row or one
             # under the same invocation. Deterministic policy: a colliding row
             # keeps its data and takes a suffixed name recording the session it
-            # came from; non-colliding rows keep their names.
-            await conn.execute(
-                text(
-                    "UPDATE artifacts SET name = name || ' (detached ' || :id || ')' "
-                    "WHERE session_id = :id AND EXISTS ("
-                    "SELECT 1 FROM artifacts o WHERE o.id != artifacts.id "
-                    "AND o.session_id IS NULL "
-                    "AND o.kind = artifacts.kind AND o.name = artifacts.name "
-                    "AND ((artifacts.invocation_id IS NULL AND o.invocation_id IS NULL) "
-                    "OR o.invocation_id = artifacts.invocation_id))"
-                ),
-                {"id": session_id},
+            # came from; non-colliding rows keep their names. The suffixed name
+            # is allocated against BOTH the destination domain and this
+            # session's own soon-to-detach rows — a fixed suffix can itself be
+            # occupied, and a UNIQUE failure here rolls back the whole
+            # absorption.
+            srows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT id, kind, name, invocation_id FROM artifacts "
+                            "WHERE session_id = :id ORDER BY id"
+                        ),
+                        {"id": session_id},
+                    )
+                )
+                .mappings()
+                .all()
             )
+            if srows:
+                kinds = sorted({str(r["kind"]) for r in srows})
+                external: dict[tuple[Any, str], set[str]] = {}
+                for chunk in _chunks(kinds):
+                    ph = ", ".join(f":k{i}" for i in range(len(chunk)))
+                    rows = (
+                        (
+                            await conn.execute(
+                                text(
+                                    f"SELECT kind, name, invocation_id FROM artifacts "  # noqa: S608
+                                    f"WHERE session_id IS NULL AND kind IN ({ph})"
+                                ),
+                                {f"k{i}": k for i, k in enumerate(chunk)},
+                            )
+                        )
+                        .mappings()
+                        .all()
+                    )
+                    for r in rows:
+                        external.setdefault((r["invocation_id"], str(r["kind"])), set()).add(
+                            str(r["name"])
+                        )
+                taken = {dom: set(names) for dom, names in external.items()}
+                for r in srows:
+                    dom = (r["invocation_id"], str(r["kind"]))
+                    taken.setdefault(dom, set()).add(str(r["name"]))
+                for r in srows:
+                    dom = (r["invocation_id"], str(r["kind"]))
+                    if str(r["name"]) not in external.get(dom, set()):
+                        continue
+                    final = f"{r['name']} (detached {session_id})"
+                    n = 2
+                    while final in taken[dom]:
+                        final = f"{r['name']} (detached {session_id} {n})"
+                        n += 1
+                    taken[dom].add(final)
+                    await conn.execute(
+                        text("UPDATE artifacts SET name = :nm WHERE id = :aid"),
+                        {"nm": final, "aid": r["id"]},
+                    )
             # Soft session FKs (no CASCADE) are someone else's rows pointing at
             # this one — nullify the pointer, keep the row, same as the studio
             # prune path (db_maintenance.py). Only artifacts carry unique indexes

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2325,11 +2325,15 @@ class StateDB:
         alone does not: at READ COMMITTED the check reads a snapshot, a
         concurrent writer can commit a new reference after it, and the delete
         would then proceed against a set that is no longer accurate. The table
-        lock below closes that window. It is taken NOWAIT, so a teardown that
-        cannot hold every relevant table at once raises instead of waiting; both
-        callers treat that as a row to revisit on a later sweep. Refusing to
-        wait is what keeps this transaction out of any deadlock cycle with a
-        writer that touches the same tables in another order.
+        lock below closes that window. It is taken NOWAIT, and the transaction
+        also runs under a bounded lock_timeout, so a teardown that cannot hold
+        what it needs gives up rather than queueing behind live writers; both
+        callers treat that as a row to revisit on a later sweep. Bounding the
+        waits is what keeps this transaction from sitting in a deadlock cycle
+        with a writer that reaches the same tables in another order. It does not
+        make one impossible: the guarantee is that no wait here lasts long
+        enough to become a detected cycle on a server using PostgreSQL's default
+        deadlock_timeout.
         """
         if not require_source_kind.startswith("imported_"):
             return False
@@ -2345,20 +2349,37 @@ class StateDB:
                 # and UPDATE already take, so the writers need no changes and pay
                 # nothing on their own path.
                 #
-                # NOWAIT is load-bearing, not an optimisation. A comma-separated
-                # LOCK TABLE takes the three locks one at a time in the written
-                # order rather than atomically, so a blocking form holds one
-                # table while waiting for the next, and that closes a cycle with
-                # any writer touching the same tables in a different order.
+                # Two separate guards, because they cover different waits.
+                #
+                # lock_timeout bounds every wait this transaction can make,
+                # including the ones after the table locks are already held --
+                # the soft-FK nulling below updates artifacts and four other
+                # tables, and those rows can be held by someone else. A wait
+                # while holding is what a deadlock cycle is made of, so bounding
+                # it is what keeps the teardown from sitting in one. 250ms is
+                # chosen against PostgreSQL's deadlock_timeout, whose default is
+                # 1s: a wait here gives up well before the detector runs, while
+                # still being far longer than the row-lock holds of the ordinary
+                # writers, so everyday contention resolves instead of aborting a
+                # teardown. A server configured with a deadlock_timeout below
+                # this bound can still detect a cycle first; the teardown then
+                # aborts with a deadlock error rather than a lock timeout, which
+                # the callers treat identically.
+                #
+                # NOWAIT covers the acquisition itself, where waiting is
+                # pointless rather than merely bounded. A comma-separated LOCK
+                # TABLE takes the three locks one at a time in the written order
+                # rather than atomically, so a blocking form holds one table
+                # while waiting for the next, which closes a cycle with any
+                # writer touching the same tables in a different order.
                 # prune_old_data is exactly such a writer: it updates sessions
                 # before deleting from progressions, the reverse of the order
-                # here. Refusing to wait takes this transaction out of every
-                # possible cycle, because a deadlock needs it to wait while
-                # holding something and it now never waits at all. That holds
-                # for writers added later too, which a chosen lock order would
-                # not. The cost falls entirely on this rare teardown: a
-                # conflicting lock aborts the attempt, and both callers already
-                # log the failure and retry on a later sweep.
+                # here.
+                #
+                # The cost falls entirely on this rare teardown: a conflicting
+                # lock aborts the attempt, and both callers log the failure and
+                # retry on a later sweep.
+                await conn.execute(text("SET LOCAL lock_timeout = '250ms'"))
                 await conn.execute(
                     text("LOCK TABLE branches, progressions, sessions IN EXCLUSIVE MODE NOWAIT")
                 )

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import shutil
 import sqlite3
@@ -15,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import JSON, MetaData, bindparam, event, inspect, text
-from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.exc import IntegrityError, OperationalError, SQLAlchemyError
 from sqlalchemy.schema import CreateTable
 
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
@@ -572,6 +573,9 @@ async def _restore_foreign_keys(conn, driver) -> None:
 
     if not confirmed:
         await shield(conn.invalidate)
+
+
+_log = logging.getLogger(__name__)
 
 
 class StateDB:
@@ -2383,23 +2387,53 @@ class StateDB:
                 if self.dialect == "sqlite"
                 else "LATERAL json_array_elements_text(p.collection::json) je(value)"
             )
+            # A malformed collection on some UNRELATED progression must not sink
+            # the whole absorb: SQLite filters those rows out; on other dialects
+            # the savepoint below catches the cast error and fails toward
+            # retention for that chunk.
+            valid_guard = " AND json_valid(p.collection)" if self.dialect == "sqlite" else ""
             # Interpolations are bound-param placeholder names, never values.
-            shared_sql = f"SELECT DISTINCT je.value AS mid FROM progressions p, {unnest} WHERE p.id NOT IN ({prog_ph}) AND je.value IN ({{msg_ph}})"  # noqa: S608, E501
+            shared_sql = f"SELECT DISTINCT je.value AS mid FROM progressions p, {unnest} WHERE p.id NOT IN ({prog_ph}){valid_guard} AND je.value IN ({{msg_ph}})"  # noqa: S608, E501
             shared: set[str] = set()
             for chunk in _chunks(sorted(msg_ids)):
                 params = {f"m{i}": mid for i, mid in enumerate(chunk)}
                 msg_ph = ", ".join(f":{k}" for k in params)
-                rows = (
-                    (
-                        await conn.execute(
-                            text(shared_sql.format(msg_ph=msg_ph)),  # noqa: S608
-                            {**prog_params, **params},
+                try:
+                    async with conn.begin_nested():
+                        rows = (
+                            (
+                                await conn.execute(
+                                    text(shared_sql.format(msg_ph=msg_ph)),  # noqa: S608
+                                    {**prog_params, **params},
+                                )
+                            )
+                            .mappings()
+                            .all()
                         )
+                except SQLAlchemyError:
+                    # Retaining is the safe direction: an over-retained message is
+                    # a stray row a later maintenance pass can orphan-collect; an
+                    # over-deleted one breaks a live session.
+                    _log.warning(
+                        "delete_imported_session: shared-reference check failed for a "
+                        "chunk of %d message(s); retaining them",
+                        len(chunk),
+                        exc_info=True,
                     )
-                    .mappings()
-                    .all()
-                )
+                    shared.update(chunk)
+                    continue
                 shared.update(str(r["mid"]) for r in rows)
+
+            # Soft session FKs (no CASCADE) are someone else's rows pointing at
+            # this one — nullify the pointer, keep the row, same as the studio
+            # prune path (db_maintenance.py).
+            for table in ("artifacts", "plays", "team_messages", "dispatch_outbox", "approvals"):
+                await conn.execute(
+                    text(
+                        f"UPDATE {table} SET session_id = NULL WHERE session_id = :id"  # noqa: S608
+                    ),
+                    {"id": session_id},
+                )
 
             # Referencing rows go before what they reference: branches (their
             # system_msg_id points at messages), then the session (first/last
@@ -2409,11 +2443,22 @@ class StateDB:
                 text("DELETE FROM branches WHERE session_id = :id"), {"id": session_id}
             )
             await conn.execute(text("DELETE FROM sessions WHERE id = :id"), {"id": session_id})
+            # This session's own rows are already gone, so any first/last/system
+            # pointer the subquery still sees belongs to a survivor — such a
+            # message is retained even when no progression carries it.
+            retain_refs = (
+                " AND id NOT IN ("
+                "SELECT first_msg_id FROM sessions WHERE first_msg_id IS NOT NULL"
+                " UNION SELECT last_msg_id FROM sessions WHERE last_msg_id IS NOT NULL"
+                " UNION SELECT system_msg_id FROM branches WHERE system_msg_id IS NOT NULL)"
+            )
             for chunk in _chunks(sorted(msg_ids - shared)):
                 params = {f"m{i}": mid for i, mid in enumerate(chunk)}
                 placeholders = ", ".join(f":{k}" for k in params)
                 await conn.execute(
-                    text(f"DELETE FROM messages WHERE id IN ({placeholders})"),  # noqa: S608
+                    text(
+                        f"DELETE FROM messages WHERE id IN ({placeholders}){retain_refs}"  # noqa: S608, E501
+                    ),
                     params,
                 )
             for chunk in _chunks(prog_ids):
@@ -2423,6 +2468,15 @@ class StateDB:
                     text(f"DELETE FROM progressions WHERE id IN ({placeholders})"),  # noqa: S608
                     params,
                 )
+            # terminal_deliveries holds an FK into status_transitions: children first.
+            await conn.execute(
+                text(
+                    "DELETE FROM terminal_deliveries WHERE transition_id IN ("
+                    "SELECT id FROM status_transitions "
+                    "WHERE entity_type = 'session' AND entity_id = :id)"
+                ),
+                {"id": session_id},
+            )
             await conn.execute(
                 text(
                     "DELETE FROM status_transitions "

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2295,17 +2295,28 @@ class StateDB:
             )
         return [self._row_to_dict(row) for row in rows]
 
-    async def delete_imported_session(self, session_id: str) -> bool:
+    async def delete_imported_session(self, session_id: str, *, require_source_kind: str) -> bool:
         """Delete a mirror-imported session and everything the mirror wrote for it:
-        the session row, its branches, their progressions, and the messages those
-        progressions hold. Returns True only when a row was actually deleted.
+        the session row, its branches, their progressions, the messages those
+        progressions hold, and the session's status-transition history. Returns
+        True only when a row was actually deleted.
 
-        Fails closed on ownership: rows whose ``source_kind`` does not start with
-        ``imported_`` are refused, so a live run's session can never be deleted by
-        an importer reconciling its own output. Mirror-written message ids are
-        derived per-rollout (uuid5 under the mirror's namespace), so the messages
-        deleted here cannot be shared with any other session.
+        Fails closed on ownership twice over: the row's ``source_kind`` must equal
+        ``require_source_kind`` exactly AND that value must start with
+        ``imported_`` — a live run's session is never eligible, and an importer
+        can only reconcile rows of its own kind (an fs-import, which records
+        first/last message pointers this teardown does not manage, is refused
+        rather than half-deleted). Messages still referenced by any progression
+        outside this session are retained, not deleted: a reference someone else
+        holds is not this session's to destroy.
+
+        Concurrency: on SQLite the process write lock serialises this with the
+        mirror's own writes. On PostgreSQL the orphan check runs in the same
+        transaction as the deletes; quiesce concurrent importers of the same
+        rollout tree before bulk reconciliation.
         """
+        if not require_source_kind.startswith("imported_"):
+            return False
         async with self._tx() as conn:
             row = (
                 (
@@ -2319,7 +2330,7 @@ class StateDB:
             )
             if row is None:
                 return False
-            if not str(row["source_kind"] or "").startswith("imported_"):
+            if str(row["source_kind"] or "") != require_source_kind:
                 return False
 
             prog_ids: list[str] = [row["progression_id"]] if row["progression_id"] else []
@@ -2363,19 +2374,48 @@ class StateDB:
                 for i in range(0, len(values), size):
                     yield values[i : i + size]
 
+            # A message referenced by any progression OUTSIDE this session is not
+            # ours to delete — drop it from the candidate set instead.
+            prog_params = {f"pp{i}": pid for i, pid in enumerate(prog_ids)}
+            prog_ph = ", ".join(f":{k}" for k in prog_params) or "''"
+            unnest = (
+                "json_each(p.collection) je"
+                if self.dialect == "sqlite"
+                else "LATERAL json_array_elements_text(p.collection::json) je(value)"
+            )
+            # Interpolations are bound-param placeholder names, never values.
+            shared_sql = f"SELECT DISTINCT je.value AS mid FROM progressions p, {unnest} WHERE p.id NOT IN ({prog_ph}) AND je.value IN ({{msg_ph}})"  # noqa: S608, E501
+            shared: set[str] = set()
             for chunk in _chunks(sorted(msg_ids)):
+                params = {f"m{i}": mid for i, mid in enumerate(chunk)}
+                msg_ph = ", ".join(f":{k}" for k in params)
+                rows = (
+                    (
+                        await conn.execute(
+                            text(shared_sql.format(msg_ph=msg_ph)),  # noqa: S608
+                            {**prog_params, **params},
+                        )
+                    )
+                    .mappings()
+                    .all()
+                )
+                shared.update(str(r["mid"]) for r in rows)
+
+            # Referencing rows go before what they reference: branches (their
+            # system_msg_id points at messages), then the session (first/last
+            # message pointers and the progression FK), then the now-unreferenced
+            # messages, then the progressions.
+            await conn.execute(
+                text("DELETE FROM branches WHERE session_id = :id"), {"id": session_id}
+            )
+            await conn.execute(text("DELETE FROM sessions WHERE id = :id"), {"id": session_id})
+            for chunk in _chunks(sorted(msg_ids - shared)):
                 params = {f"m{i}": mid for i, mid in enumerate(chunk)}
                 placeholders = ", ".join(f":{k}" for k in params)
                 await conn.execute(
                     text(f"DELETE FROM messages WHERE id IN ({placeholders})"),  # noqa: S608
                     params,
                 )
-            # Rows that reference the progressions go first (branches, then the
-            # session), else the progression deletes trip their FKs.
-            await conn.execute(
-                text("DELETE FROM branches WHERE session_id = :id"), {"id": session_id}
-            )
-            await conn.execute(text("DELETE FROM sessions WHERE id = :id"), {"id": session_id})
             for chunk in _chunks(prog_ids):
                 params = {f"p{i}": pid for i, pid in enumerate(chunk)}
                 placeholders = ", ".join(f":{k}" for k in params)
@@ -2383,6 +2423,13 @@ class StateDB:
                     text(f"DELETE FROM progressions WHERE id IN ({placeholders})"),  # noqa: S608
                     params,
                 )
+            await conn.execute(
+                text(
+                    "DELETE FROM status_transitions "
+                    "WHERE entity_type = 'session' AND entity_id = :id"
+                ),
+                {"id": session_id},
+            )
         return True
 
     @staticmethod

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2329,11 +2329,12 @@ class StateDB:
         also runs under a bounded lock_timeout, so a teardown that cannot hold
         what it needs gives up rather than queueing behind live writers; both
         callers treat that as a row to revisit on a later sweep. Bounding the
-        waits is what keeps this transaction from sitting in a deadlock cycle
-        with a writer that reaches the same tables in another order. It does not
-        make one impossible: the guarantee is that no wait here lasts long
-        enough to become a detected cycle on a server using PostgreSQL's default
-        deadlock_timeout.
+        lock waits is what keeps this transaction from sitting in a deadlock
+        cycle with a writer that reaches the same tables in another order. It
+        does not make one impossible, and it is not a deadline for the whole
+        teardown: the guarantee is only that no single lock-acquisition wait
+        lasts long enough to become a detected cycle on a server using
+        PostgreSQL's default deadlock_timeout.
         """
         if not require_source_kind.startswith("imported_"):
             return False
@@ -2351,19 +2352,25 @@ class StateDB:
                 #
                 # Two separate guards, because they cover different waits.
                 #
-                # lock_timeout bounds every wait this transaction can make,
-                # including the ones after the table locks are already held --
-                # the soft-FK nulling below updates artifacts and four other
-                # tables, and those rows can be held by someone else. A wait
-                # while holding is what a deadlock cycle is made of, so bounding
-                # it is what keeps the teardown from sitting in one. 250ms is
-                # chosen against PostgreSQL's deadlock_timeout, whose default is
-                # 1s: a wait here gives up well before the detector runs, while
-                # still being far longer than the row-lock holds of the ordinary
-                # writers, so everyday contention resolves instead of aborting a
-                # teardown. A server configured with a deadlock_timeout below
-                # this bound can still detect a cycle first; the teardown then
-                # aborts with a deadlock error rather than a lock timeout, which
+                # lock_timeout bounds each LOCK-ACQUISITION wait, including the
+                # ones after the table locks are already held -- the soft-FK
+                # nulling below updates artifacts and four other tables, and
+                # those rows can be held by someone else. A wait while holding is
+                # what a deadlock cycle is made of, so bounding it is what keeps
+                # the teardown from sitting in one. It is not a deadline for the
+                # transaction: it caps no single statement's execution, no sum of
+                # successive lock waits, and nothing about commit or connection
+                # checkout. A long statement can still hold all three EXCLUSIVE
+                # locks, and nothing here bounds that. 250ms is chosen against
+                # PostgreSQL's deadlock_timeout, whose default is 1s, so one lock
+                # wait gives up well before the detector runs. It is also meant
+                # to sit above the row-lock holds of the ordinary writers so
+                # everyday contention resolves instead of aborting a teardown;
+                # that second half is the design intent behind the number and is
+                # not something this change measures. A server configured with a
+                # deadlock_timeout below this bound can still detect a cycle
+                # first; the teardown then aborts with a deadlock error rather
+                # than a lock timeout, which
                 # the callers treat identically.
                 #
                 # NOWAIT covers the acquisition itself, where waiting is

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2307,10 +2307,12 @@ class StateDB:
 
         Fails closed on ownership twice over: the row's ``source_kind`` must equal
         ``require_source_kind`` exactly AND that value must start with
-        ``imported_`` — a live run's session is never eligible, and an importer
-        can only reconcile rows of its own kind (an fs-import, which records
-        first/last message pointers this teardown does not manage, is refused
-        rather than half-deleted). Anything a survivor still references is
+        ``imported_``. A live run's session is never eligible, and an importer
+        naming its own kind cannot reach a different importer's rows. The kind is
+        a mismatch guard rather than an authorization boundary: a caller that
+        names a valid imported kind tears down rows of that kind, so every
+        importer reconciles its own imports through this one method. Anything a
+        survivor still references is
         retained, not deleted: messages held by an outside progression or
         pointed at by a surviving session/branch, and target progressions a
         survivor's progression_id names (together with their messages) — a
@@ -2323,7 +2325,11 @@ class StateDB:
         alone does not: at READ COMMITTED the check reads a snapshot, a
         concurrent writer can commit a new reference after it, and the delete
         would then proceed against a set that is no longer accurate. The table
-        lock below closes that window.
+        lock below closes that window. It is taken NOWAIT, so a teardown that
+        cannot hold every relevant table at once raises instead of waiting; both
+        callers treat that as a row to revisit on a later sweep. Refusing to
+        wait is what keeps this transaction out of any deadlock cycle with a
+        writer that touches the same tables in another order.
         """
         if not require_source_kind.startswith("imported_"):
             return False
@@ -2337,11 +2343,24 @@ class StateDB:
                 # message pointers at rows this teardown would otherwise remove.
                 # EXCLUSIVE conflicts with the ROW EXCLUSIVE that ordinary INSERT
                 # and UPDATE already take, so the writers need no changes and pay
-                # nothing on their own path; only this rare teardown waits.
-                # One statement, fixed order, so it cannot deadlock against
-                # itself.
+                # nothing on their own path.
+                #
+                # NOWAIT is load-bearing, not an optimisation. A comma-separated
+                # LOCK TABLE takes the three locks one at a time in the written
+                # order rather than atomically, so a blocking form holds one
+                # table while waiting for the next, and that closes a cycle with
+                # any writer touching the same tables in a different order.
+                # prune_old_data is exactly such a writer: it updates sessions
+                # before deleting from progressions, the reverse of the order
+                # here. Refusing to wait takes this transaction out of every
+                # possible cycle, because a deadlock needs it to wait while
+                # holding something and it now never waits at all. That holds
+                # for writers added later too, which a chosen lock order would
+                # not. The cost falls entirely on this rare teardown: a
+                # conflicting lock aborts the attempt, and both callers already
+                # log the failure and retry on a later sweep.
                 await conn.execute(
-                    text("LOCK TABLE branches, progressions, sessions IN EXCLUSIVE MODE")
+                    text("LOCK TABLE branches, progressions, sessions IN EXCLUSIVE MODE NOWAIT")
                 )
             row = (
                 (

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2310,9 +2310,11 @@ class StateDB:
         ``imported_`` — a live run's session is never eligible, and an importer
         can only reconcile rows of its own kind (an fs-import, which records
         first/last message pointers this teardown does not manage, is refused
-        rather than half-deleted). Messages still referenced by any progression
-        outside this session are retained, not deleted: a reference someone else
-        holds is not this session's to destroy.
+        rather than half-deleted). Anything a survivor still references is
+        retained, not deleted: messages held by an outside progression or
+        pointed at by a surviving session/branch, and target progressions a
+        survivor's progression_id names (together with their messages) — a
+        reference someone else holds is not this session's to destroy.
 
         Concurrency: on SQLite the process write lock serialises this with the
         mirror's own writes. On PostgreSQL the orphan check runs in the same
@@ -2350,8 +2352,36 @@ class StateDB:
             )
             prog_ids.extend(b["progression_id"] for b in branch_rows if b["progression_id"])
 
+            # Chunked IN-lists keep each statement under SQLite's bound-variable cap.
+            def _chunks(values: list[str], size: int = 400):
+                for i in range(0, len(values), size):
+                    yield values[i : i + size]
+
+            # A survivor session or branch may point its progression_id FK at one
+            # of these progressions — such a progression, and the messages it
+            # holds, are not ours to delete.
+            kept_progs: set[str] = set()
+            for chunk in _chunks(prog_ids):
+                params = {f"p{i}": pid for i, pid in enumerate(chunk)}
+                ph = ", ".join(f":{k}" for k in params)
+                rows = (
+                    (
+                        await conn.execute(
+                            text(
+                                f"SELECT progression_id AS pid FROM sessions WHERE id != :sid AND progression_id IN ({ph}) "  # noqa: S608, E501
+                                f"UNION SELECT progression_id FROM branches WHERE session_id != :sid AND progression_id IN ({ph})"  # noqa: S608, E501
+                            ),
+                            {"sid": session_id, **params},
+                        )
+                    )
+                    .mappings()
+                    .all()
+                )
+                kept_progs.update(str(r["pid"]) for r in rows)
+            deletable_progs = [p for p in prog_ids if p not in kept_progs]
+
             msg_ids: set[str] = set()
-            for pid in prog_ids:
+            for pid in deletable_progs:
                 prow = (
                     (
                         await conn.execute(
@@ -2373,14 +2403,10 @@ class StateDB:
                 if isinstance(collection, list):
                     msg_ids.update(str(m) for m in collection)
 
-            # Chunked IN-lists keep each statement under SQLite's bound-variable cap.
-            def _chunks(values: list[str], size: int = 400):
-                for i in range(0, len(values), size):
-                    yield values[i : i + size]
-
-            # A message referenced by any progression OUTSIDE this session is not
-            # ours to delete — drop it from the candidate set instead.
-            prog_params = {f"pp{i}": pid for i, pid in enumerate(prog_ids)}
+            # A message referenced by any progression OUTSIDE the deletable set is
+            # not ours to delete — a retained target progression counts as an
+            # outside holder here, so its shared messages survive with it.
+            prog_params = {f"pp{i}": pid for i, pid in enumerate(deletable_progs)}
             prog_ph = ", ".join(f":{k}" for k in prog_params) or "''"
             unnest = (
                 "json_each(p.collection) je"
@@ -2424,9 +2450,28 @@ class StateDB:
                     continue
                 shared.update(str(r["mid"]) for r in rows)
 
+            # Detaching an artifact moves it into another partial unique-index
+            # domain (schema.sql idx_artifacts_natural_key_*), where its
+            # (kind, name) slot may already be taken by an unattached row or one
+            # under the same invocation. Deterministic policy: a colliding row
+            # keeps its data and takes a suffixed name recording the session it
+            # came from; non-colliding rows keep their names.
+            await conn.execute(
+                text(
+                    "UPDATE artifacts SET name = name || ' (detached ' || :id || ')' "
+                    "WHERE session_id = :id AND EXISTS ("
+                    "SELECT 1 FROM artifacts o WHERE o.id != artifacts.id "
+                    "AND o.session_id IS NULL "
+                    "AND o.kind = artifacts.kind AND o.name = artifacts.name "
+                    "AND ((artifacts.invocation_id IS NULL AND o.invocation_id IS NULL) "
+                    "OR o.invocation_id = artifacts.invocation_id))"
+                ),
+                {"id": session_id},
+            )
             # Soft session FKs (no CASCADE) are someone else's rows pointing at
             # this one — nullify the pointer, keep the row, same as the studio
-            # prune path (db_maintenance.py).
+            # prune path (db_maintenance.py). Only artifacts carry unique indexes
+            # over session_id (handled above); the other four tables do not.
             for table in ("artifacts", "plays", "team_messages", "dispatch_outbox", "approvals"):
                 await conn.execute(
                     text(
@@ -2461,7 +2506,7 @@ class StateDB:
                     ),
                     params,
                 )
-            for chunk in _chunks(prog_ids):
+            for chunk in _chunks(deletable_progs):
                 params = {f"p{i}": pid for i, pid in enumerate(chunk)}
                 placeholders = ", ".join(f":{k}" for k in params)
                 await conn.execute(

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2316,14 +2316,33 @@ class StateDB:
         survivor's progression_id names (together with their messages) — a
         reference someone else holds is not this session's to destroy.
 
-        Concurrency: on SQLite the process write lock serialises this with the
-        mirror's own writes. On PostgreSQL the orphan check runs in the same
-        transaction as the deletes; quiesce concurrent importers of the same
-        rollout tree before bulk reconciliation.
+        Concurrency: the retention checks and the deletes they authorise are
+        serialised against every writer that could create a new reference, so a
+        reference that appears after the check cannot be destroyed by the delete.
+        On SQLite the process write lock does this. On PostgreSQL a transaction
+        alone does not: at READ COMMITTED the check reads a snapshot, a
+        concurrent writer can commit a new reference after it, and the delete
+        would then proceed against a set that is no longer accurate. The table
+        lock below closes that window.
         """
         if not require_source_kind.startswith("imported_"):
             return False
         async with self._tx() as conn:
+            if self.dialect != "sqlite":
+                # Taken before the first read, so everything read afterwards
+                # stays true for the rest of the transaction and no re-check is
+                # needed. These three tables are exactly the ones a survivor's
+                # reference can live in: a progression's collection holds message
+                # ids, and sessions and branches point progression_id and their
+                # message pointers at rows this teardown would otherwise remove.
+                # EXCLUSIVE conflicts with the ROW EXCLUSIVE that ordinary INSERT
+                # and UPDATE already take, so the writers need no changes and pay
+                # nothing on their own path; only this rare teardown waits.
+                # One statement, fixed order, so it cannot deadlock against
+                # itself.
+                await conn.execute(
+                    text("LOCK TABLE branches, progressions, sessions IN EXCLUSIVE MODE")
+                )
             row = (
                 (
                     await conn.execute(

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1250,3 +1250,59 @@ async def test_interactive_rollout_still_mirrors(tmp_path):
         row = await db.get_session(codex_sid(uid))
         assert row is not None
         assert row["source_kind"] == CODEX_SOURCE_KIND
+
+
+async def test_partial_header_defers_classification_instead_of_bypassing_it(tmp_path):
+    """A rollout whose first line is still being written must not settle its
+    classification: committing the head check on an unreadable header would let
+    an orchestrated rollout mirror forever once the header completed."""
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-000000000004"
+    full = _codex_rollout_lines(uid, "codex_exec")
+    header_line = full.splitlines(keepends=True)[0]
+    path = tmp_path / "rollout-partial.jsonl"
+    path.write_text(header_line[: len(header_line) // 2])  # torn mid-JSON, no newline
+
+    state = _FileState(session_uid="")
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        assert await _mirror_one_codex(db, path, state, {}) == 0
+        assert not state.head_checked  # classification deferred, not spent
+        assert not state.orchestrated
+
+        path.write_text(full)  # the writer finished the file
+        assert await _mirror_one_codex(db, path, state, {}) == 0
+        assert state.orchestrated
+        assert await db.get_session(codex_sid(uid)) is None
+
+
+async def test_reclassification_absorbs_a_row_keyed_by_the_stem_fallback(tmp_path):
+    """An earlier version that failed the header peek imported the file under
+    its path stem. When classification finally lands, that stem-keyed row is
+    absorbed too, not just the rollout-uid one."""
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import mirror_session as codex_mirror_session
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-000000000005"
+    path = tmp_path / "rollout-stem-import.jsonl"
+    path.write_text(_codex_rollout_lines(uid, "codex_exec"))
+    stem = path.stem
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        await codex_mirror_session(
+            db,
+            rollout_uid=stem,  # what the old fallback keyed the row by
+            records=[json.loads(line) for line in path.read_text().splitlines()],
+            tool_names={},
+            source_path=str(path),
+        )
+        assert await db.get_session(codex_sid(stem)) is not None
+
+        # Restart shape: the persisted state still carries the stem uid.
+        state = _FileState(session_uid=stem)
+        assert await _mirror_one_codex(db, path, state, {}) == 0
+        assert state.orchestrated
+        assert await db.get_session(codex_sid(stem)) is None
+        assert await db.get_session(codex_sid(uid)) is None

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1410,3 +1410,28 @@ async def test_cli_tail_loop_retries_a_failed_backfill(tmp_path, monkeypatch):
     # Iteration 1 attempted and failed, iteration 2 retried and succeeded,
     # iteration 3 stood down: exactly two attempts across three passes.
     assert len(attempts) == 2
+
+
+async def test_complete_corrupt_header_settles_headerless_and_mirrors_the_body(tmp_path):
+    """A newline-terminated first line that cannot parse is permanently corrupt
+    (append-only file), not torn: the file settles as headerless and its valid
+    body records still mirror instead of being suppressed forever."""
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    full = _codex_rollout_lines("ignored-uid", "x")
+    body = "".join(full.splitlines(keepends=True)[1:])  # the two valid records
+
+    corrupt = tmp_path / "rollout-corrupt-header.jsonl"
+    corrupt.write_text('{"broken":\n' + body)  # complete but unparseable first line
+
+    bad_utf8 = tmp_path / "rollout-bad-utf8-header.jsonl"
+    bad_utf8.write_bytes(b"\xff\xfe garbage\n" + body.encode())
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        for path in (corrupt, bad_utf8):
+            state = _FileState(session_uid="")
+            assert await _mirror_one_codex(db, path, state, {}) == 2
+            assert state.head_checked
+            assert state.session_uid == path.stem
+            assert await db.get_session(codex_sid(path.stem)) is not None

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1428,10 +1428,42 @@ async def test_complete_corrupt_header_settles_headerless_and_mirrors_the_body(t
     bad_utf8 = tmp_path / "rollout-bad-utf8-header.jsonl"
     bad_utf8.write_bytes(b"\xff\xfe garbage\n" + body.encode())
 
+    # A BOM-shaped prefix surfaces as JSONDecodeError; a bare invalid byte
+    # surfaces as UnicodeDecodeError — the body reader must survive both.
+    bad_byte = tmp_path / "rollout-bad-byte-header.jsonl"
+    bad_byte.write_bytes(b"\x80 invalid utf8\n" + body.encode())
+
     async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
-        for path in (corrupt, bad_utf8):
+        for path in (corrupt, bad_utf8, bad_byte):
             state = _FileState(session_uid="")
             assert await _mirror_one_codex(db, path, state, {}) == 2
             assert state.head_checked
             assert state.session_uid == path.stem
             assert await db.get_session(codex_sid(path.stem)) is not None
+
+
+async def test_valid_but_unterminated_header_stays_torn_until_the_newline(tmp_path):
+    """A first line that parses as session_meta but has no trailing newline is
+    still being written — appended bytes could extend or corrupt it — so the
+    file defers instead of spending the identity fence on a provisional parse."""
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex, _peek_codex_head
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-000000000007"
+    full = _codex_rollout_lines(uid, "Codex Desktop")
+    header_line = full.splitlines(keepends=True)[0]
+    path = tmp_path / "rollout-unterminated-meta.jsonl"
+    path.write_text(header_line.rstrip("\n"))  # valid JSON, newline not yet written
+
+    assert _peek_codex_head(path) == ("torn", None)
+
+    state = _FileState(session_uid="")
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        assert await _mirror_one_codex(db, path, state, {}) == 0
+        assert not state.head_checked
+        assert await db.get_session(codex_sid(path.stem)) is None
+
+        path.write_text(full)  # the writer finished the header and the body
+        assert await _mirror_one_codex(db, path, state, {}) == 2
+        assert state.session_uid == uid
+        assert await db.get_session(codex_sid(uid)) is not None

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1512,3 +1512,53 @@ async def test_a_failed_absorption_does_not_retire_the_file(tmp_path, monkeypatc
         assert state.orchestrated
 
     assert len(attempts) == 2, f"absorption was attempted {len(attempts)} time(s), not 2"
+
+
+async def test_a_failed_prior_stem_absorption_also_leaves_the_file_eligible(tmp_path, monkeypatch):
+    """The orchestrated branch absorbs under two ids when the file was keyed by a
+    stem before its header arrived. Failure-atomicity has to cover the second
+    call as well as the first.
+
+    The arm that matters is the id list on the retry. If any field were committed
+    between the two calls, the retry would resolve `prior_uid` differently and the
+    stem-keyed row would never be absorbed at all — a row nobody tears down, from
+    a failure that looked like it had been retried.
+    """
+    from lionagi.cli import mirror as mirror_mod
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+
+    uid = "0199bbbb-0000-0000-0000-000000000010"
+    path = tmp_path / "rollout-exec-prior.jsonl"
+    path.write_text(_codex_rollout_lines(uid, "codex_exec"))
+    # A pre-header pass keyed this file by its stem.
+    stem = path.stem
+    state = _FileState(session_uid=stem)
+
+    calls: list[str] = []
+
+    async def flaky_absorb(db, rollout_uid):
+        calls.append(rollout_uid)
+        # Fail the SECOND call of the first pass, the prior-stem one.
+        if len(calls) == 2:
+            raise RuntimeError("lock not available")
+        return True
+
+    monkeypatch.setattr(mirror_mod, "absorb_orchestrated_session", flaky_absorb, raising=False)
+    monkeypatch.setattr(
+        "lionagi.state.codex_mirror.absorb_orchestrated_session", flaky_absorb, raising=False
+    )
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        with pytest.raises(RuntimeError):
+            await _mirror_one_codex(db, path, state, {})
+        assert not state.orchestrated
+        assert not state.head_checked
+        assert state.session_uid == stem, (
+            "session_uid was overwritten before both absorptions returned, so the "
+            "retry can no longer tell which prior id this file was keyed by"
+        )
+
+        assert await _mirror_one_codex(db, path, state, {}) == 0
+        assert state.orchestrated
+
+    assert calls == [uid, stem, uid, stem], f"absorption ids across both passes: {calls}"

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1467,3 +1467,48 @@ async def test_valid_but_unterminated_header_stays_torn_until_the_newline(tmp_pa
         assert await _mirror_one_codex(db, path, state, {}) == 2
         assert state.session_uid == uid
         assert await db.get_session(codex_sid(uid)) is not None
+
+
+async def test_a_failed_absorption_does_not_retire_the_file(tmp_path, monkeypatch):
+    """A contended teardown gives up rather than waiting, so absorption can fail
+    for an ordinary reason. The file must stay eligible when it does.
+
+    Marking the rollout absorbed before the absorption returns retires it on the
+    early guard, and no later pass ever attempts the deletion again: a row nobody
+    tears down, recorded as done. The discriminating assertion is the second
+    attempt — with the flag set first, the observed attempt count is one.
+    """
+    from lionagi.cli import mirror as mirror_mod
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+
+    uid = "0199bbbb-0000-0000-0000-00000000000f"
+    path = tmp_path / "rollout-exec-contended.jsonl"
+    path.write_text(_codex_rollout_lines(uid, "codex_exec"))
+    state = _FileState(session_uid="")
+
+    attempts = []
+
+    async def flaky_absorb(db, rollout_uid):
+        attempts.append(rollout_uid)
+        if len(attempts) == 1:
+            raise RuntimeError("lock not available")
+        return True
+
+    monkeypatch.setattr(mirror_mod, "absorb_orchestrated_session", flaky_absorb, raising=False)
+    monkeypatch.setattr(
+        "lionagi.state.codex_mirror.absorb_orchestrated_session", flaky_absorb, raising=False
+    )
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        with pytest.raises(RuntimeError):
+            await _mirror_one_codex(db, path, state, {})
+        assert not state.orchestrated, (
+            "the rollout was marked absorbed even though absorption failed, so no "
+            "later pass will retry the teardown"
+        )
+
+        # The next sweep reaches absorption again and completes.
+        assert await _mirror_one_codex(db, path, state, {}) == 0
+        assert state.orchestrated
+
+    assert len(attempts) == 2, f"absorption was attempted {len(attempts)} time(s), not 2"

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1306,3 +1306,107 @@ async def test_reclassification_absorbs_a_row_keyed_by_the_stem_fallback(tmp_pat
         assert state.orchestrated
         assert await db.get_session(codex_sid(stem)) is None
         assert await db.get_session(codex_sid(uid)) is None
+
+
+async def test_torn_header_defers_mirroring_so_one_rollout_stays_one_session(tmp_path):
+    """When the header is torn the whole file waits: writing records under the
+    path stem while the real UID arrives next pass would split one interactive
+    rollout into two sessions."""
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-000000000006"
+    full = _codex_rollout_lines(uid, "Codex Desktop")
+    header_line = full.splitlines(keepends=True)[0]
+    path = tmp_path / "rollout-torn-interactive.jsonl"
+    path.write_text(header_line[: len(header_line) // 2])  # torn mid-JSON, no newline
+
+    state = _FileState(session_uid="")
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        assert await _mirror_one_codex(db, path, state, {}) == 0
+        assert not state.head_checked
+        assert not state.session_uid  # nothing was keyed under the stem
+        assert await db.get_session(codex_sid(path.stem)) is None
+
+        path.write_text(full)  # the writer finished the file
+        assert await _mirror_one_codex(db, path, state, {}) == 2
+        assert state.session_uid == uid
+        assert await db.get_session(codex_sid(uid)) is not None
+        assert await db.get_session(codex_sid(path.stem)) is None
+
+
+async def test_headerless_rollout_still_mirrors_under_the_stem(tmp_path):
+    """A complete first line that is not a session_meta settles classification:
+    an append-only file never gains a header later, so the stem fallback is
+    correct and the file keeps mirroring."""
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    full = _codex_rollout_lines("ignored-uid", "x")
+    body = "".join(full.splitlines(keepends=True)[1:])  # drop the meta line
+    path = tmp_path / "rollout-headerless.jsonl"
+    path.write_text(body)
+
+    state = _FileState(session_uid="")
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        assert await _mirror_one_codex(db, path, state, {}) == 2
+        assert state.head_checked
+        assert state.session_uid == path.stem
+        assert await db.get_session(codex_sid(path.stem)) is not None
+
+
+async def test_cli_tail_loop_retries_a_failed_backfill(tmp_path, monkeypatch):
+    """The plain `li mirror` tail loop keeps retrying an unclean backfill sweep
+    instead of retiring it after one failed attempt (parity with the studio's
+    mirror_forever)."""
+    import argparse
+
+    from lionagi.cli import mirror as mirror_mod
+
+    attempts: list[bool] = []
+
+    async def fake_backfill(db):
+        attempts.append(True)
+        return len(attempts) >= 2  # first sweep fails, second is clean
+
+    async def fake_codex_pass(db, root, states, offsets, *, since, live_window, threads):
+        return 0
+
+    class _Stop(Exception):
+        pass
+
+    sleeps: list[int] = []
+
+    async def fake_sleep(_):
+        sleeps.append(1)
+        if len(sleeps) >= 3:
+            raise _Stop
+
+    class FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(mirror_mod, "_absorb_backfill", fake_backfill)
+    monkeypatch.setattr(mirror_mod, "_codex_pass", fake_codex_pass)
+    monkeypatch.setattr(mirror_mod, "_load_states", lambda: {})
+    monkeypatch.setattr(mirror_mod, "_save_states", lambda states: None)
+    monkeypatch.setattr("lionagi.state.db.StateDB", lambda: FakeDB())
+    monkeypatch.setattr("anyio.sleep", fake_sleep)
+
+    args = argparse.Namespace(
+        root=None,
+        codex_root=str(tmp_path),
+        source="codex",
+        since=None,
+        once=False,
+        interval=0.01,
+        live_window=300.0,
+    )
+    with pytest.raises(_Stop):
+        await mirror_mod._run(args)
+    # Iteration 1 attempted and failed, iteration 2 retried and succeeded,
+    # iteration 3 stood down: exactly two attempts across three passes.
+    assert len(attempts) == 2

--- a/tests/cli/test_playbook_plugin.py
+++ b/tests/cli/test_playbook_plugin.py
@@ -148,9 +148,7 @@ def test_local_playbook_shadows_global_playbook_and_warns(tmp_path, monkeypatch,
 
     assert err is None
     assert path.read_text() == "prompt: from-local\n"
-    assert any(
-        "deploy" in rec.message and "global" in rec.message for rec in caplog.records
-    )
+    assert any("deploy" in rec.message and "global" in rec.message for rec in caplog.records)
 
 
 def test_local_playbook_without_global_collision_does_not_warn(tmp_path, monkeypatch, caplog):

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -744,3 +744,73 @@ async def test_detached_artifact_suffix_allocation_is_collision_free(db):
     assert rows["art-inv-att"]["name"] == f"verdict (detached {sid})"
     for aid in ("art-att", "art-att2", "art-inv-att"):
         assert rows[aid]["session_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_delete_refuses_a_mismatched_kind_and_still_honours_survivor_pointers(db):
+    """``require_source_kind`` is a mismatch guard, and the teardown honours a
+    survivor's first/last message pointers whichever importer owns the row.
+
+    The fs importer is the other writer of an ``imported_`` kind, and it sets
+    ``first_msg_id``/``last_msg_id`` where the codex mirror does not. This pins
+    both halves of what that means: the codex mirror cannot reach an fs row by
+    naming its own kind, and a caller that does name the fs kind still gets the
+    retention rule, because a message a surviving session points at is not the
+    deleted session's to destroy.
+
+    Both directions are here on purpose. The retained message alone cannot tell
+    a correct rule from one that retains everything, so the unpointed sibling is
+    what makes it evidence.
+    """
+    msg_pointed = _det("fs-case", "pointed")
+    msg_own = _det("fs-case", "own")
+    for mid in (msg_pointed, msg_own):
+        await db.insert_message(
+            {"id": mid, "created_at": 1.0, "content": {"text": "x"}, "role": "user"}
+        )
+
+    fs_prog, fs_sid = _det("fs-case", "prog"), _det("fs-case", "sid")
+    await db.create_progression(fs_prog, [msg_pointed, msg_own])
+    await db.create_session(
+        {
+            "id": fs_sid,
+            "progression_id": fs_prog,
+            "status": "completed",
+            "created_at": 1.0,
+            "updated_at": 1.0,
+            "source_kind": "imported_fs",
+        }
+    )
+
+    # A live survivor whose last_msg_id is the only thing pointing at
+    # msg_pointed: no progression carries it once the fs row goes.
+    survivor_sid = _det("fs-case", "survivor")
+    survivor_prog = _det("fs-case", "survivor-prog")
+    await db.create_progression(survivor_prog, [])
+    await db.create_session(
+        {
+            "id": survivor_sid,
+            "progression_id": survivor_prog,
+            "last_msg_id": msg_pointed,
+            "status": "running",
+            "created_at": 1.0,
+            "updated_at": 1.0,
+            "source_kind": "live",
+        }
+    )
+
+    # The codex mirror names its own kind, so an fs row is not reachable.
+    assert await db.delete_imported_session(fs_sid, require_source_kind=SOURCE_KIND) is False
+    assert await db.get_session(fs_sid) is not None
+
+    # Naming the fs kind does tear the fs row down, and the retention rule
+    # applies to it exactly as it does to a codex row.
+    assert await db.delete_imported_session(fs_sid, require_source_kind="imported_fs") is True
+    assert await db.get_session(fs_sid) is None
+    assert await db.get_session(survivor_sid) is not None
+    assert await db.get_message(msg_pointed) is not None, (
+        "a message a surviving session's last_msg_id points at was deleted"
+    )
+    assert await db.get_message(msg_own) is None, (
+        "the message nobody points at survived, so the arm above proves nothing"
+    )

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -469,3 +469,112 @@ async def test_delete_retains_messages_another_progression_references(db):
     for mid in other_mids:
         assert await db.get_message(mid) is None
     assert await db.get_progression(outside_prog) == [shared_mid]
+
+
+async def test_delete_retains_a_message_a_live_session_points_at(db):
+    """A surviving session's first/last message pointer blocks deletion of that
+    message: direct FK references count as ownership, not just progressions."""
+    from sqlalchemy import text
+
+    written, _ = await _mirror(db, _records())
+    assert written == 4
+    sid = session_db_id(ROLLOUT_UID)
+    msg_ids = await db.get_progression(_det(ROLLOUT_UID, "sprog"))
+    pointed_mid, other_mids = msg_ids[0], msg_ids[1:]
+
+    prog = "live-prog-ptr"
+    await db.create_progression(prog)
+    await db.create_session(
+        {
+            "id": "live-session-ptr",
+            "created_at": 1.0,
+            "progression_id": prog,
+            "name": "agent",
+            "status": "running",
+            "source_kind": "live",
+        }
+    )
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE sessions SET first_msg_id = :m WHERE id = 'live-session-ptr'"),
+            {"m": pointed_mid},
+        )
+
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is True
+    assert await db.get_session(sid) is None
+    assert await db.get_message(pointed_mid) is not None  # retained: pointed at
+    for mid in other_mids:
+        assert await db.get_message(mid) is None
+    assert await db.get_session("live-session-ptr") is not None
+
+
+async def test_delete_survives_soft_references_and_delivery_acks(db):
+    """An artifact pointing at the imported session keeps its row with the
+    pointer nullified, and an acked terminal delivery goes with its transition
+    instead of aborting the whole absorb on the FK."""
+    from sqlalchemy import text
+
+    written, _ = await _mirror(db, _records())
+    assert written == 4
+    sid = session_db_id(ROLLOUT_UID)
+
+    async with db._tx() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO artifacts (id, session_id, created_at, updated_at, kind, name, content) "
+                "VALUES ('art-1', :sid, 1.0, 1.0, 'review', 'verdict', '{}')"
+            ),
+            {"sid": sid},
+        )
+        await conn.execute(
+            text(
+                "INSERT INTO status_transitions "
+                "(id, entity_type, entity_id, status, reason_code, source, created_at) "
+                "VALUES ('tr-1', 'session', :sid, 'completed', 'imported', 'system', 1.0)"
+            ),
+            {"sid": sid},
+        )
+        await conn.execute(
+            text(
+                "INSERT INTO terminal_deliveries (transition_id, consumer, acked_at) "
+                "VALUES ('tr-1', 'test-consumer', 2.0)"
+            )
+        )
+
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is True
+    assert await db.get_session(sid) is None
+    async with db._tx() as conn:
+        art = (
+            await conn.execute(text("SELECT session_id FROM artifacts WHERE id = 'art-1'"))
+        ).first()
+        assert art is not None and art[0] is None  # row kept, pointer cleared
+        assert (
+            await conn.execute(text("SELECT 1 FROM status_transitions WHERE id = 'tr-1'"))
+        ).first() is None
+        assert (
+            await conn.execute(
+                text("SELECT 1 FROM terminal_deliveries WHERE transition_id = 'tr-1'")
+            )
+        ).first() is None
+
+
+async def test_delete_tolerates_a_malformed_unrelated_progression(db):
+    """One damaged collection elsewhere in the store must not sink an absorb:
+    the shared-reference check filters it out rather than erroring globally."""
+    from sqlalchemy import text
+
+    written, _ = await _mirror(db, _records())
+    assert written == 4
+    sid = session_db_id(ROLLOUT_UID)
+    msg_ids = await db.get_progression(_det(ROLLOUT_UID, "sprog"))
+
+    await db.create_progression("damaged-prog")
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE progressions SET collection = 'not-json' WHERE id = 'damaged-prog'")
+        )
+
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is True
+    assert await db.get_session(sid) is None
+    for mid in msg_ids:
+        assert await db.get_message(mid) is None

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -578,3 +578,75 @@ async def test_delete_tolerates_a_malformed_unrelated_progression(db):
     assert await db.get_session(sid) is None
     for mid in msg_ids:
         assert await db.get_message(mid) is None
+
+
+async def test_delete_retains_a_progression_a_survivor_references(db):
+    """A survivor session whose progression_id names one of the imported
+    session's progressions keeps that progression and its messages; the absorb
+    still completes instead of aborting on the FK."""
+    from sqlalchemy import text
+
+    written, _ = await _mirror(db, _records())
+    assert written == 4
+    sid = session_db_id(ROLLOUT_UID)
+    sprog = _det(ROLLOUT_UID, "sprog")
+    msgs_in_sprog = await db.get_progression(sprog)
+    assert msgs_in_sprog
+
+    await db.create_progression("survivor-own-prog")
+    await db.create_session(
+        {
+            "id": "survivor-1",
+            "created_at": 1.0,
+            "progression_id": "survivor-own-prog",
+            "name": "agent",
+            "status": "running",
+            "source_kind": "live",
+        }
+    )
+    async with db._tx() as conn:
+        await conn.execute(
+            text("UPDATE sessions SET progression_id = :p WHERE id = 'survivor-1'"),
+            {"p": sprog},
+        )
+
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is True
+    assert await db.get_session(sid) is None
+    assert await db.get_session("survivor-1") is not None
+    assert await db.get_progression(sprog) == msgs_in_sprog  # progression + messages kept
+    for mid in msgs_in_sprog:
+        assert await db.get_message(mid) is not None
+
+
+async def test_detached_artifact_renames_instead_of_colliding(db):
+    """Detaching a session-scoped artifact whose (kind, name) is already taken
+    in the unattached index domain renames the detached row deterministically
+    instead of aborting the absorb on the unique constraint."""
+    from sqlalchemy import text
+
+    written, _ = await _mirror(db, _records())
+    assert written == 4
+    sid = session_db_id(ROLLOUT_UID)
+
+    async with db._tx() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO artifacts (id, session_id, created_at, updated_at, kind, name, content) "
+                "VALUES ('art-free', NULL, 1.0, 1.0, 'review', 'verdict', '{}'), "
+                "('art-att', :sid, 1.0, 1.0, 'review', 'verdict', '{}')"
+            ),
+            {"sid": sid},
+        )
+
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is True
+    assert await db.get_session(sid) is None
+    async with db._tx() as conn:
+        rows = {
+            r["id"]: dict(r)
+            for r in (
+                await conn.execute(text("SELECT id, name, session_id FROM artifacts"))
+            ).mappings()
+        }
+    assert rows["art-free"]["name"] == "verdict"  # untouched
+    assert rows["art-att"]["session_id"] is None
+    assert rows["art-att"]["name"] == f"verdict (detached {sid})"

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -650,3 +650,60 @@ async def test_detached_artifact_renames_instead_of_colliding(db):
     assert rows["art-free"]["name"] == "verdict"  # untouched
     assert rows["art-att"]["session_id"] is None
     assert rows["art-att"]["name"] == f"verdict (detached {sid})"
+
+
+async def test_detached_artifact_suffix_allocation_is_collision_free(db):
+    """The derived "(detached <sid>)" name can itself be occupied — by an
+    unattached row or by another artifact of the deleted session — and the
+    invocation-only domain collides independently of the unattached one. Each
+    final name must be proven unused before the session_id flips, or the
+    UNIQUE failure rolls back the whole absorption."""
+    from sqlalchemy import text
+
+    written, _ = await _mirror(db, _records())
+    assert written == 4
+    sid = session_db_id(ROLLOUT_UID)
+
+    async with db._tx() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO invocations (id, skill, started_at, created_at, updated_at) "
+                "VALUES ('inv-1', 's', 1.0, 1.0, 1.0)"
+            )
+        )
+        await conn.execute(
+            text(
+                "INSERT INTO artifacts "
+                "(id, session_id, invocation_id, created_at, updated_at, kind, name, content) VALUES "
+                "('art-free', NULL, NULL, 1.0, 1.0, 'review', 'verdict', '{}'), "
+                "('art-sfx', NULL, NULL, 1.0, 1.0, 'review', 'verdict (detached ' || :sid || ')', '{}'), "
+                "('art-att', :sid, NULL, 1.0, 1.0, 'review', 'verdict', '{}'), "
+                "('art-att2', :sid, NULL, 1.0, 1.0, 'review', 'verdict (detached ' || :sid || ')', '{}'), "
+                "('art-inv-free', NULL, 'inv-1', 1.0, 1.0, 'review', 'verdict', '{}'), "
+                "('art-inv-att', :sid, 'inv-1', 1.0, 1.0, 'review', 'verdict', '{}')"
+            ),
+            {"sid": sid},
+        )
+
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is True
+    assert await db.get_session(sid) is None
+    async with db._tx() as conn:
+        rows = {
+            r["id"]: dict(r)
+            for r in (
+                await conn.execute(
+                    text("SELECT id, name, session_id, invocation_id FROM artifacts")
+                )
+            ).mappings()
+        }
+    assert rows["art-free"]["name"] == "verdict"  # untouched
+    assert rows["art-sfx"]["name"] == f"verdict (detached {sid})"  # untouched
+    # base and first suffix both occupied in the unattached domain
+    assert rows["art-att"]["name"] == f"verdict (detached {sid} 2)"
+    # a session row whose own name IS the derived name of another
+    assert rows["art-att2"]["name"] == f"verdict (detached {sid}) (detached {sid})"
+    # invocation-only domain collides independently; its base suffix is free
+    assert rows["art-inv-free"]["name"] == "verdict"
+    assert rows["art-inv-att"]["name"] == f"verdict (detached {sid})"
+    for aid in ("art-att", "art-att2", "art-inv-att"):
+        assert rows[aid]["session_id"] is None

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -583,7 +583,13 @@ async def test_delete_tolerates_a_malformed_unrelated_progression(db):
 async def test_delete_retains_a_progression_a_survivor_references(db):
     """A survivor session whose progression_id names one of the imported
     session's progressions keeps that progression and its messages; the absorb
-    still completes instead of aborting on the FK."""
+    still completes instead of aborting on the FK.
+
+    Both directions live in this one fixture on purpose. Asserting only that the
+    referenced progression survives cannot distinguish a correct retention rule
+    from one that retains every progression, so the unreferenced sibling below is
+    the arm that makes the retained one mean something.
+    """
     from sqlalchemy import text
 
     written, _ = await _mirror(db, _records())
@@ -592,6 +598,25 @@ async def test_delete_retains_a_progression_a_survivor_references(db):
     sprog = _det(ROLLOUT_UID, "sprog")
     msgs_in_sprog = await db.get_progression(sprog)
     assert msgs_in_sprog
+
+    # The sibling nobody will reference: same imported session, must be deleted.
+    async with db._tx() as conn:
+        unreferenced = [
+            r["progression_id"]
+            for r in (
+                await conn.execute(
+                    text(
+                        "SELECT progression_id FROM branches "
+                        "WHERE session_id = :sid AND progression_id IS NOT NULL"
+                    ),
+                    {"sid": sid},
+                )
+            ).mappings()
+            if r["progression_id"] != sprog
+        ]
+    assert unreferenced, "fixture must contain a progression no survivor references"
+    msgs_unreferenced = await db.get_progression(unreferenced[0])
+    assert msgs_unreferenced
 
     await db.create_progression("survivor-own-prog")
     await db.create_session(
@@ -616,6 +641,18 @@ async def test_delete_retains_a_progression_a_survivor_references(db):
     assert await db.get_progression(sprog) == msgs_in_sprog  # progression + messages kept
     for mid in msgs_in_sprog:
         assert await db.get_message(mid) is not None
+
+    # The opposite direction, same fixture: no survivor names this progression,
+    # so it and its messages go. Without this arm a retain-everything bug passes.
+    async with db._tx() as conn:
+        assert (
+            await conn.execute(
+                text("SELECT 1 FROM progressions WHERE id = :p"), {"p": unreferenced[0]}
+            )
+        ).first() is None
+    for mid in msgs_unreferenced:
+        if mid not in msgs_in_sprog:  # a message both progressions hold is retained
+            assert await db.get_message(mid) is None
 
 
 async def test_detached_artifact_renames_instead_of_colliding(db):

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -338,14 +338,14 @@ async def test_delete_imported_session_removes_the_whole_graph(db):
     msg_ids = await db.get_progression(sprog)
     assert msg_ids  # the graph exists before the delete
 
-    assert await db.delete_imported_session(sid) is True
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is True
 
     assert await db.get_session(sid) is None
     assert await db.get_progression(sprog) == []
     for mid in msg_ids:
         assert await db.get_message(mid) is None
     # Idempotent: a second delete finds nothing and says so.
-    assert await db.delete_imported_session(sid) is False
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is False
 
 
 async def test_delete_imported_session_refuses_live_rows(db):
@@ -363,7 +363,12 @@ async def test_delete_imported_session_refuses_live_rows(db):
             "source_kind": "live",
         }
     )
-    assert await db.delete_imported_session("live-session-1") is False
+    assert (
+        await db.delete_imported_session("live-session-1", require_source_kind="imported_live")
+        is False
+    )
+    # Even naming the row's own kind cannot make a non-imported row eligible.
+    assert await db.delete_imported_session("live-session-1", require_source_kind="live") is False
     assert await db.get_session("live-session-1") is not None
 
 
@@ -398,11 +403,69 @@ async def test_backfill_absorbs_only_orchestrated_imports(db):
             source_path=f"/tmp/rollout-{uid}.jsonl",
         )
 
-    removed = await absorb_orchestrated_backfill(db)
+    removed, failed = await absorb_orchestrated_backfill(db)
 
-    assert removed == 1
+    assert (removed, failed) == (1, 0)
     assert await db.get_session(session_db_id(uid_exec)) is None
     # Interactive history stays; a row with no recorded originator is not treated
     # as orchestrated, because absent provenance is not evidence.
     assert await db.get_session(session_db_id(uid_desktop)) is not None
     assert await db.get_session(session_db_id(uid_bare)) is not None
+
+
+async def test_backfill_skips_malformed_originator_without_dying(db):
+    """One row whose recorded originator is not a string must neither crash the
+    sweep nor be treated as orchestrated; the rest of the sweep still runs."""
+    from lionagi.state.codex_mirror import absorb_orchestrated_backfill
+
+    def rollout(uid: str) -> list[dict]:
+        return [
+            _rec("session_meta", {"id": uid, "cwd": "/x"}),
+            _rec(
+                "response_item",
+                {"type": "message", "role": "user", "id": "m1", "content": [{"text": "q"}]},
+            ),
+        ]
+
+    uid_bad = "0199cccc-0000-0000-0000-000000000001"
+    uid_exec = "0199cccc-0000-0000-0000-000000000002"
+    for uid, meta in (
+        (uid_bad, {"codex": {"originator": []}}),
+        (uid_exec, {"codex": {"originator": "codex_exec"}}),
+    ):
+        await mirror_session(
+            db,
+            rollout_uid=uid,
+            records=rollout(uid),
+            tool_names={},
+            node_metadata=meta,
+            source_path=f"/tmp/rollout-{uid}.jsonl",
+        )
+
+    removed, failed = await absorb_orchestrated_backfill(db)
+
+    assert (removed, failed) == (1, 0)
+    assert await db.get_session(session_db_id(uid_bad)) is not None
+    assert await db.get_session(session_db_id(uid_exec)) is None
+
+
+async def test_delete_retains_messages_another_progression_references(db):
+    """A message some other progression also holds is not this session's to
+    destroy: the delete removes the session graph but keeps that message."""
+    written, _ = await _mirror(db, _records())
+    assert written == 4
+    sid = session_db_id(ROLLOUT_UID)
+    msg_ids = await db.get_progression(_det(ROLLOUT_UID, "sprog"))
+    shared_mid, other_mids = msg_ids[0], msg_ids[1:]
+
+    outside_prog = "outside-progression-1"
+    await db.create_progression(outside_prog)
+    await db.append_to_progression(outside_prog, shared_mid)
+
+    assert await db.delete_imported_session(sid, require_source_kind=SOURCE_KIND) is True
+
+    assert await db.get_session(sid) is None
+    assert await db.get_message(shared_mid) is not None  # retained: still referenced
+    for mid in other_mids:
+        assert await db.get_message(mid) is None
+    assert await db.get_progression(outside_prog) == [shared_mid]

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -975,3 +975,115 @@ async def test_postgres_teardown_does_not_deadlock_the_maintenance_writer(pg_url
         assert await db.get_session(imported_sid) is None
     finally:
         await db.close()
+
+
+@pytest.mark.asyncio
+async def test_postgres_teardown_gives_up_rather_than_deadlocking_after_it_holds_the_locks(
+    pg_url,
+):
+    """The table locks are not the only place this transaction can wait.
+
+    Once the three EXCLUSIVE locks are held, the teardown still nulls the soft
+    session FKs, and those rows can be held by someone else. A wait there is a
+    wait while holding, which is what a deadlock cycle is made of, so NOWAIT on
+    the acquisition does not by itself keep the teardown out of one. The bounded
+    lock_timeout does: the wait gives up well inside PostgreSQL's default
+    deadlock_timeout, so the cycle breaks before the detector runs.
+
+    The discriminating assertion is the SQLSTATE. Remove the lock_timeout and
+    this interleaving returns 40P01, a detected deadlock, instead of the
+    retryable 55P03 both callers already handle.
+    """
+    import asyncio
+
+    from sqlalchemy import text
+
+    db = StateDB(url=pg_url)
+    await db.open()
+    try:
+        assert db.dialect == "postgresql"
+
+        now = time.time()
+        msg = _uid()
+        await db.insert_message(
+            {"id": msg, "created_at": now, "content": {"text": "x"}, "role": "user"}
+        )
+        prog, sid = _uid(), _uid()
+        await db.create_progression(prog, [msg])
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": prog,
+                "status": "completed",
+                "created_at": now,
+                "updated_at": now,
+                "source_kind": "imported_codex",
+            }
+        )
+        artifact_id = _uid()
+        async with db._tx() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO artifacts (id, session_id, created_at, updated_at, "
+                    "kind, name, content) VALUES (:i, :s, :c, :c, 'log', 'a', '{}')"
+                ),
+                {"i": artifact_id, "s": sid, "c": now},
+            )
+
+        holds_the_artifact = asyncio.Event()
+        teardown_is_waiting = asyncio.Event()
+        other_outcome: dict[str, object] = {}
+
+        async def other_writer() -> None:
+            """artifacts then sessions: the reverse of the teardown's order."""
+            async with db._tx() as conn:
+                await conn.execute(
+                    text("UPDATE artifacts SET name = 'held' WHERE id = :i"),
+                    {"i": artifact_id},
+                )
+                holds_the_artifact.set()
+                await teardown_is_waiting.wait()
+                try:
+                    await conn.execute(
+                        text("UPDATE sessions SET updated_at = updated_at WHERE id = :s"),
+                        {"s": sid},
+                    )
+                    other_outcome["second"] = "ok"
+                except Exception as exc:  # noqa: BLE001 — inspected below
+                    other_outcome["second"] = exc
+
+        writer_task = asyncio.create_task(other_writer())
+        await asyncio.wait_for(holds_the_artifact.wait(), timeout=10)
+
+        teardown = asyncio.create_task(
+            db.delete_imported_session(sid, require_source_kind="imported_codex")
+        )
+        # Long enough for the teardown to take its three table locks and settle
+        # into the artifacts wait, and short enough to be inside the 250ms bound.
+        await asyncio.sleep(0.1)
+        teardown_is_waiting.set()
+
+        teardown_error = None
+        try:
+            await asyncio.wait_for(teardown, timeout=30)
+        except Exception as exc:  # noqa: BLE001 — classified below
+            teardown_error = exc
+        await asyncio.wait_for(writer_task, timeout=30)
+
+        sqlstate = getattr(getattr(teardown_error, "orig", None), "sqlstate", None)
+        assert sqlstate != "40P01", (
+            "the teardown was a deadlock participant after taking its table "
+            f"locks, so bounding its later waits is not working: {teardown_error!r}"
+        )
+        assert sqlstate == "55P03", (
+            "expected the teardown to give up on the contended soft-FK write; "
+            f"got {teardown_error!r}"
+        )
+        assert other_outcome.get("second") == "ok", (
+            f"the ordinary writer did not complete: {other_outcome.get('second')!r}"
+        )
+        # Nothing was half-torn-down: the whole transaction rolled back.
+        assert await db.get_session(sid) is not None
+        assert await db.get_message(msg) is not None
+    finally:
+        await db.close()

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -736,12 +736,12 @@ async def test_postgres_delete_imported_session_waits_for_an_open_writer(pg_url)
     go. Asserting only the first cannot tell a correct delete from one that
     retains everything.
 
-    The discriminating step is the "still blocked" assertion. Without the table
-    lock the delete does not wait for the open writer at all: it reads a snapshot
-    that predates the uncommitted reference, concludes the message is an orphan,
-    and removes it, so the delete task is already finished at that point and the
-    assertion fails. With the lock the delete cannot even begin reading until the
-    writer commits.
+    The discriminating step is what happens during the writer's open
+    transaction. Without the table lock the delete does not notice the writer at
+    all: it reads a snapshot that predates the uncommitted reference, concludes
+    the message is an orphan, and removes it. With the lock the delete cannot
+    begin reading, so the claimed message is still there for the writer to
+    commit its reference against.
     """
     import asyncio
 
@@ -806,19 +806,43 @@ async def test_postgres_delete_imported_session_waits_for_an_open_writer(pg_url)
         writer_task = asyncio.create_task(writer())
         await asyncio.wait_for(writer_holds_the_row.wait(), timeout=10)
 
-        delete_task = asyncio.create_task(
-            db.delete_imported_session(imported_sid, require_source_kind="imported_codex")
+        # The lock is taken NOWAIT, so the contended attempt refuses instead of
+        # queueing. What matters is the outcome, not which of the two shapes
+        # produced it: while another transaction can still commit a new
+        # reference, this delete must not run at all. Asserting the refusal
+        # alone would be asserting the mechanism, so the retention arms below
+        # are the real evidence — with no lock statement the delete completes
+        # here and destroys the message the writer is about to claim.
+        contended_error: Exception | None = None
+        try:
+            await db.delete_imported_session(imported_sid, require_source_kind="imported_codex")
+        except Exception as exc:  # noqa: BLE001 — classified below
+            contended_error = exc
+
+        # The outcome is the evidence, so it is asserted before the shape of the
+        # refusal: while another transaction can still commit a new reference,
+        # this delete must not have run at all.
+        assert await db.get_session(imported_sid) is not None, (
+            "the delete ran while a writer held an uncommitted reference, so its "
+            "retention check read a snapshot the writer was about to invalidate"
         )
-        # Give the delete every chance to finish if nothing is holding it back.
-        await asyncio.sleep(1.0)
-        assert not delete_task.done(), (
-            "the delete did not wait for the open writer, so its retention check "
-            "is reading a snapshot the writer is about to invalidate"
+        assert await db.get_message(msg_claimed) is not None, (
+            "the message the open writer is in the middle of claiming was destroyed"
+        )
+        # Having established that, the refusal must come from the table lock and
+        # not from something unrelated that would fake this result.
+        assert contended_error is not None, "the contended attempt neither ran nor failed"
+        assert getattr(contended_error.orig, "sqlstate", None) == "55P03", (
+            "the delete failed for some reason other than the unavailable table "
+            f"lock, so this test is no longer exercising the race: {contended_error!r}"
         )
 
         writer_may_commit.set()
         await asyncio.wait_for(writer_task, timeout=10)
-        assert await asyncio.wait_for(delete_task, timeout=30) is True
+        # Uncontended now, so the same call must go through.
+        assert (
+            await db.delete_imported_session(imported_sid, require_source_kind="imported_codex")
+        ) is True
 
         assert await db.get_session(imported_sid) is None
         assert await db.get_session(survivor_sid) is not None
@@ -828,5 +852,126 @@ async def test_postgres_delete_imported_session_waits_for_an_open_writer(pg_url)
         # Direction two: claimed by nobody, so gone. Without this arm a
         # delete that retained every message would pass the assertion above.
         assert await db.get_message(msg_orphan) is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_postgres_teardown_does_not_deadlock_the_maintenance_writer(pg_url):
+    """The teardown and ``prune_old_data`` reach the same tables in opposite
+    orders, which is the shape a lock cycle needs.
+
+    ``prune_old_data`` updates ``sessions`` and then deletes from
+    ``progressions``; the teardown's lock statement names ``branches`` and
+    ``progressions`` before ``sessions``. A comma-separated ``LOCK TABLE`` takes
+    those one at a time rather than atomically, so a blocking form holds the
+    first two while waiting for the third and deadlocks against a maintenance
+    pass already holding a ``sessions`` row. This drives that exact interleaving
+    with the maintenance writer's real statement order.
+
+    The discriminating assertion is that the maintenance transaction's second
+    statement completes. Restore the blocking lock and PostgreSQL detects the
+    cycle and aborts one of the two transactions with ``40P01``, which is a
+    whole pass lost rather than a slow one.
+    """
+    import asyncio
+
+    from sqlalchemy import text
+
+    db = StateDB(url=pg_url)
+    await db.open()
+    try:
+        assert db.dialect == "postgresql"
+
+        now = time.time()
+        msg = _uid()
+        await db.insert_message(
+            {"id": msg, "created_at": now, "content": {"text": "x"}, "role": "user"}
+        )
+        imported_prog, imported_sid = _uid(), _uid()
+        await db.create_progression(imported_prog, [msg])
+        await db.create_session(
+            {
+                "id": imported_sid,
+                "progression_id": imported_prog,
+                "status": "completed",
+                "created_at": now,
+                "updated_at": now,
+                "source_kind": "imported_codex",
+            }
+        )
+        # What the maintenance pass touches: a session row it locks first, and
+        # an unrelated progression it deletes second.
+        maint_prog, maint_sid = _uid(), _uid()
+        maint_own_prog = _uid()
+        await db.create_progression(maint_prog, [])
+        await db.create_progression(maint_own_prog, [])
+        await db.create_session(
+            {
+                "id": maint_sid,
+                "progression_id": maint_own_prog,
+                "status": "completed",
+                "created_at": now,
+                "updated_at": now,
+                "source_kind": "live",
+            }
+        )
+
+        holds_the_session_row = asyncio.Event()
+        may_issue_second = asyncio.Event()
+        outcome: dict[str, object] = {}
+
+        async def maintenance() -> None:
+            """prune_old_data's order: sessions first, then progressions."""
+            async with db._tx() as conn:
+                await conn.execute(
+                    text("UPDATE sessions SET updated_at = updated_at WHERE id = :id"),
+                    {"id": maint_sid},
+                )
+                holds_the_session_row.set()
+                await may_issue_second.wait()
+                try:
+                    await conn.execute(
+                        text("DELETE FROM progressions WHERE id = :p"), {"p": maint_prog}
+                    )
+                    outcome["second"] = "ok"
+                except Exception as exc:  # noqa: BLE001 — the point of the test
+                    outcome["second"] = exc
+
+        maint_task = asyncio.create_task(maintenance())
+        await asyncio.wait_for(holds_the_session_row.wait(), timeout=10)
+
+        delete_task = asyncio.create_task(
+            db.delete_imported_session(imported_sid, require_source_kind="imported_codex")
+        )
+        # Long enough for the teardown to reach its lock statement and either
+        # refuse (NOWAIT) or settle into waiting (blocking).
+        await asyncio.sleep(1.0)
+        may_issue_second.set()
+        await asyncio.wait_for(maint_task, timeout=30)
+
+        second = outcome.get("second")
+        assert second == "ok", (
+            "the maintenance writer's second statement did not complete, so the "
+            f"teardown's table lock is deadlocking a shipped writer: {second!r}"
+        )
+
+        delete_error = None
+        try:
+            await asyncio.wait_for(delete_task, timeout=30)
+        except Exception as exc:  # noqa: BLE001 — inspected below
+            delete_error = exc
+        # Refusing the lock is fine and expected; being chosen as a deadlock
+        # victim is the failure this test exists to catch, on either side.
+        assert getattr(getattr(delete_error, "orig", None), "sqlstate", None) != "40P01", (
+            f"the teardown was aborted as a deadlock victim: {delete_error!r}"
+        )
+
+        # The teardown is retried on a later sweep, and nothing above left the
+        # row in a state that stops it going through.
+        assert (
+            await db.delete_imported_session(imported_sid, require_source_kind="imported_codex")
+        ) is True
+        assert await db.get_session(imported_sid) is None
     finally:
         await db.close()

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -710,3 +710,123 @@ async def test_postgres_wrapper_parity_cas_conflict_and_same_status_append(pg_ur
         assert row["status"] == "running"
     finally:
         await db.close()
+
+
+# ── Postgres leg: the delete/writer race on delete_imported_session ───────────
+# Lives in this module for the reason stated above: it needs the session-scoped
+# `pg_url` fixture, and a second module requesting it in the same run breaks
+# asyncpg's loop-bound connections.
+#
+# The race this pins is not hypothetical. At READ COMMITTED a transaction's
+# retention check reads a snapshot, so a reference committed after that check is
+# invisible to it while the delete authorised by it still proceeds — the delete
+# destroys a message a survivor is by then pointing at. SQLite never had the
+# exposure because `_tx()` holds a process write lock there; Postgres took a bare
+# `engine.begin()`. The fix is a table lock taken as the transaction's first
+# statement, which works because ordinary INSERT and UPDATE already hold ROW
+# EXCLUSIVE and that conflicts with EXCLUSIVE.
+
+
+async def test_postgres_delete_imported_session_waits_for_an_open_writer(pg_url):
+    """A writer holding an uncommitted reference blocks the delete, and the
+    reference it commits is then honoured.
+
+    Both directions are forced in one fixture, per the retention contract: the
+    message the writer claims must survive, and the message nobody claims must
+    go. Asserting only the first cannot tell a correct delete from one that
+    retains everything.
+
+    The discriminating step is the "still blocked" assertion. Without the table
+    lock the delete does not wait for the open writer at all: it reads a snapshot
+    that predates the uncommitted reference, concludes the message is an orphan,
+    and removes it, so the delete task is already finished at that point and the
+    assertion fails. With the lock the delete cannot even begin reading until the
+    writer commits.
+    """
+    import asyncio
+
+    from sqlalchemy import text
+
+    from lionagi.state.db import _to_json_column
+
+    db = StateDB(url=pg_url)
+    await db.open()
+    try:
+        assert db.dialect == "postgresql"
+
+        now = time.time()
+        msg_claimed, msg_orphan = _uid(), _uid()
+        for mid in (msg_claimed, msg_orphan):
+            await db.insert_message(
+                {"id": mid, "created_at": now, "content": {"text": "x"}, "role": "user"}
+            )
+
+        # The imported session holds both messages and is the delete's target.
+        imported_prog, imported_sid = _uid(), _uid()
+        await db.create_progression(imported_prog, [msg_claimed, msg_orphan])
+        await db.create_session(
+            {
+                "id": imported_sid,
+                "progression_id": imported_prog,
+                "status": "completed",
+                "created_at": now,
+                "updated_at": now,
+                "source_kind": "imported_codex",
+            }
+        )
+
+        # The survivor starts out referencing neither message.
+        survivor_prog, survivor_sid = _uid(), _uid()
+        await db.create_progression(survivor_prog, [])
+        await db.create_session(
+            {
+                "id": survivor_sid,
+                "progression_id": survivor_prog,
+                "status": "running",
+                "created_at": now,
+                "updated_at": now,
+                "source_kind": "live",
+            }
+        )
+
+        writer_holds_the_row = asyncio.Event()
+        writer_may_commit = asyncio.Event()
+
+        async def writer() -> None:
+            """Claim msg_claimed for the survivor, then hold the transaction open."""
+            async with db._tx() as conn:
+                await conn.execute(
+                    text("UPDATE progressions SET collection = :col WHERE id = :id"),
+                    {"col": _to_json_column([msg_claimed]), "id": survivor_prog},
+                )
+                writer_holds_the_row.set()
+                await writer_may_commit.wait()
+            # commit happens on context exit
+
+        writer_task = asyncio.create_task(writer())
+        await asyncio.wait_for(writer_holds_the_row.wait(), timeout=10)
+
+        delete_task = asyncio.create_task(
+            db.delete_imported_session(imported_sid, require_source_kind="imported_codex")
+        )
+        # Give the delete every chance to finish if nothing is holding it back.
+        await asyncio.sleep(1.0)
+        assert not delete_task.done(), (
+            "the delete did not wait for the open writer, so its retention check "
+            "is reading a snapshot the writer is about to invalidate"
+        )
+
+        writer_may_commit.set()
+        await asyncio.wait_for(writer_task, timeout=10)
+        assert await asyncio.wait_for(delete_task, timeout=30) is True
+
+        assert await db.get_session(imported_sid) is None
+        assert await db.get_session(survivor_sid) is not None
+        # Direction one: claimed by a survivor, so retained.
+        assert await db.get_progression(survivor_prog) == [msg_claimed]
+        assert await db.get_message(msg_claimed) is not None
+        # Direction two: claimed by nobody, so gone. Without this arm a
+        # delete that retained every message would pass the assertion above.
+        assert await db.get_message(msg_orphan) is None
+    finally:
+        await db.close()


### PR DESCRIPTION
Follow-up to #2728, which merged before its review findings were addressed. Four defects in the skip/absorb path, each fixed with a regression test:

1. **Partial header permanently bypassed the skip.** The head check was spent on an unreadable peek (file mid-write), so the rollout mirrored as a duplicate forever once the header completed. Classification now only settles on a parsed header, and reclassification also absorbs a row an older version keyed by the path-stem fallback.
2. **The delete could remove a message another progression still referenced.** Messages referenced outside the session being deleted are now retained (checked inside the delete transaction, dialect-aware for SQLite/PostgreSQL).
3. **FK-unsafe ordering + over-broad eligibility.** The delete accepted any `imported_*` row while removing messages before the rows referencing them — an fs-import records first/last message pointers and would abort mid-cleanup. Callers now name the exact source kind they own; branches and the session row are deleted before their referenced messages; the session's status-transition history is cleaned up with it.
4. **One malformed originator killed the whole startup backfill** after the once-per-process flag was set. Rows are handled in isolation, only string originators count, and the flag stands down only after a clean sweep (failed rows retry next pass).

`tests/state` + `tests/cli`: 85 targeted tests pass; full failure set byte-identical to the `main` baseline (71 pre-existing environment-dependent failures, zero new).

The v0.32.1 release (version already bumped on main via #2728) should be cut after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)