### PR TITLE
feat(studio): serve the Operator model catalog from the backend, with provider and effort selection

### DIFF
--- a/apps/studio/frontend/src/components/operator/OperatorPanel.test.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.test.tsx
@@ -10,6 +10,7 @@ const api = vi.hoisted(() => ({
   cancelOperatorRequest: vi.fn(),
   createOperatorConversation: vi.fn(),
   decideOperatorProposal: vi.fn(),
+  fetchOperatorModelCatalog: vi.fn(() => Promise.resolve({ models: [] })),
   getOperatorConversation: vi.fn(),
   listOperatorConversations: vi.fn(),
   streamOperatorConversation: vi.fn(() => vi.fn()),

--- a/apps/studio/frontend/src/components/operator/OperatorPanel.test.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.test.tsx
@@ -3,14 +3,16 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { IntlProvider } from "use-intl";
 import enMessages from "@/messages/en.json";
-import type { OperatorFrame } from "@/lib/types";
+import type { OperatorFrame, OperatorModelCatalogEntry } from "@/lib/types";
 
 const api = vi.hoisted(() => ({
   acknowledgeOperatorEffect: vi.fn(),
   cancelOperatorRequest: vi.fn(),
   createOperatorConversation: vi.fn(),
   decideOperatorProposal: vi.fn(),
-  fetchOperatorModelCatalog: vi.fn(() => Promise.resolve({ models: [] })),
+  fetchOperatorModelCatalog: vi.fn(() =>
+    Promise.resolve({ models: [] as OperatorModelCatalogEntry[] }),
+  ),
   getOperatorConversation: vi.fn(),
   listOperatorConversations: vi.fn(),
   streamOperatorConversation: vi.fn(() => vi.fn()),
@@ -559,5 +561,121 @@ describe("OperatorPanel", () => {
       rejectionCode: "client_error",
     });
     expect(api.acknowledgeOperatorEffect).toHaveBeenCalledTimes(1);
+  });
+
+  describe("the model menu and a conversation's stored pin", () => {
+    const pinned = {
+      id: "conversation-1",
+      title: "Pinned",
+      status: "active" as const,
+      activeRequestId: null,
+      provider: "codex",
+      providerModel: "gpt-5.4",
+    };
+
+    function pin(conversation: Record<string, unknown>) {
+      api.listOperatorConversations.mockResolvedValue([conversation]);
+      api.getOperatorConversation.mockResolvedValue({ conversation, frames: [] });
+      api.submitOperatorTurn.mockReset();
+      api.submitOperatorTurn.mockResolvedValue({
+        conversationId: conversation.id,
+        requestId: "request-1",
+        acceptedSequence: 1,
+      });
+    }
+
+    function modelSelect() {
+      return container.querySelector('select[aria-label="Model"]') as HTMLSelectElement;
+    }
+
+    async function send(text: string) {
+      const textarea = container.querySelector("textarea") as HTMLTextAreaElement;
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
+        setter?.call(textarea, text);
+        textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+      const sendButton = [...container.querySelectorAll("button")].find((button) =>
+        button.textContent?.startsWith("Send"),
+      );
+      expect(sendButton, "the composer's Send button").toBeDefined();
+      expect(sendButton?.disabled).toBe(false);
+      await act(async () => {
+        sendButton?.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+
+    it("shows the pinned model rather than reporting Default", async () => {
+      pin(pinned);
+      api.fetchOperatorModelCatalog.mockResolvedValue({
+        models: [
+          { id: "gpt-5.4", label: "Codex (gpt-5.4)", provider: "codex", efforts: ["high"] },
+          { id: "sonnet", label: "Claude Sonnet", provider: "claude_code", efforts: ["high"] },
+        ],
+      });
+
+      await mount();
+
+      // The daemon keeps using this pin for a turn that names no model, so a
+      // menu reading "Default" would state the opposite of what will run.
+      expect(modelSelect().value).toBe("gpt-5.4");
+    });
+
+    it("names a pinned model the catalog no longer offers instead of hiding it", async () => {
+      pin({ ...pinned, providerModel: "gpt-5.3-retired" });
+      api.fetchOperatorModelCatalog.mockResolvedValue({
+        models: [{ id: "sonnet", label: "Claude Sonnet", provider: "claude_code", efforts: [] }],
+      });
+
+      await mount();
+
+      const select = modelSelect();
+      expect(select.value).toBe("gpt-5.3-retired");
+      const option = [...select.options].find((item) => item.value === "gpt-5.3-retired");
+      expect(option?.textContent).toContain("unavailable");
+    });
+
+    it("asks for the pin to be dropped when the menu is moved back to Default", async () => {
+      pin(pinned);
+      api.fetchOperatorModelCatalog.mockResolvedValue({
+        models: [{ id: "gpt-5.4", label: "Codex (gpt-5.4)", provider: "codex", efforts: [] }],
+      });
+
+      await mount();
+      const select = modelSelect();
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set;
+        setter?.call(select, "");
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      await send("go");
+
+      // Omitting the model would leave the pin in force. Selecting Default has
+      // to be able to undo a pin, so it says so explicitly.
+      expect(api.submitOperatorTurn).toHaveBeenCalledTimes(1);
+      const [, request] = api.submitOperatorTurn.mock.calls[0];
+      expect(request.clearSelection).toBe(true);
+      expect(request.model).toBeUndefined();
+    });
+
+    it("does not ask to clear a conversation that was never pinned", async () => {
+      pin({ id: "conversation-1", title: "Fresh", status: "active", activeRequestId: null });
+      api.fetchOperatorModelCatalog.mockResolvedValue({
+        models: [{ id: "gpt-5.4", label: "Codex (gpt-5.4)", provider: "codex", efforts: [] }],
+      });
+
+      await mount();
+      expect(modelSelect().value).toBe("");
+      await send("go");
+
+      expect(api.submitOperatorTurn).toHaveBeenCalledTimes(1);
+      const [, request] = api.submitOperatorTurn.mock.calls[0];
+      expect(request.clearSelection).toBeUndefined();
+    });
   });
 });

--- a/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
@@ -682,15 +682,18 @@ export default function OperatorPanel({ open, onClose }: Props) {
       .then((catalog) => {
         if (!active) return;
         setModelCatalog(catalog.models);
-        // Leave an unrecognized selection to clear, but never replace "no
-        // selection" with the catalog's first entry: the composer still
-        // works with no model chosen -- the daemon falls back to its own
-        // env-var default for a turn that omits one, and picking one here
-        // on the caller's behalf would silently override that default the
-        // moment the catalog loads, before the human ever touched the menu.
-        setModel((current) =>
-          current && catalog.models.some((entry) => entry.id === current) ? current : "",
-        );
+        // Never replace "no selection" with the catalog's first entry: the
+        // composer still works with no model chosen -- the daemon falls back
+        // to its own env-var default for a turn that omits one, and picking
+        // one here on the caller's behalf would silently override that
+        // default the moment the catalog loads, before the human ever
+        // touched the menu.
+        //
+        // A selection the catalog does not offer is not cleared either. It is
+        // usually the conversation's own stored pin, which the daemon will
+        // keep using; clearing it would show "Default" for a turn that runs
+        // on something else. The menu renders it as unavailable instead, so
+        // the operator can see what is in force and change it.
       })
       .catch(() => {
         // The composer still works with no model selected -- the daemon
@@ -700,6 +703,25 @@ export default function OperatorPanel({ open, onClose }: Props) {
       active = false;
     };
   }, []);
+
+  // A conversation remembers the provider and model it was pinned to, and the
+  // daemon keeps using that pin for a turn that names neither. Showing
+  // "Default" while a pin is in force tells the operator the opposite of what
+  // will happen, so the stored selection is hydrated whenever the conversation
+  // changes. Effort is per turn rather than per conversation, so it starts
+  // empty and the operator chooses it again.
+  const hydratedConversationRef = useRef<string | null>(null);
+  useEffect(() => {
+    const conversation = state.conversation;
+    if (!conversation) {
+      hydratedConversationRef.current = null;
+      return;
+    }
+    if (hydratedConversationRef.current === conversation.id) return;
+    hydratedConversationRef.current = conversation.id;
+    setModel(conversation.providerModel ?? "");
+    setEffort("");
+  }, [state.conversation]);
 
   const effortChoices = useMemo(
     () => modelCatalog.find((entry) => entry.id === model)?.efforts ?? [],
@@ -944,12 +966,18 @@ export default function OperatorPanel({ open, onClose }: Props) {
         location.pathname,
         location.search as Record<string, unknown>,
       );
+      // The menu is hydrated from the conversation's pin, so an empty
+      // selection here means the operator moved it back to Default. Sending
+      // nothing would leave the pin in force, which is the opposite of what
+      // the menu now says, so ask for it to be dropped.
+      const clearing = !model && Boolean(conversation.provider || conversation.providerModel);
       const accepted = await submitOperatorTurn(conversation.id, {
         instruction: trimmed,
         context,
         expectedLastSequence: state.lastSequence,
         ...(model ? { model } : {}),
         ...(effectiveEffort ? { effort: effectiveEffort } : {}),
+        ...(clearing ? { clearSelection: true } : {}),
       });
       dispatch({ type: "TURN_ACCEPTED", requestId: accepted.requestId });
       setInstruction("");
@@ -1150,6 +1178,9 @@ export default function OperatorPanel({ open, onClose }: Props) {
                 className="shrink-0 border-0 bg-transparent py-0 font-data text-meta text-content-muted outline-none focus:text-content-primary"
               >
                 <option value="">{t("model.default")}</option>
+                {model && !modelCatalog.some((entry) => entry.id === model) && (
+                  <option value={model}>{t("model.unavailable", { model })}</option>
+                )}
                 {modelCatalog.map((entry) => (
                   <option key={entry.id} value={entry.id}>
                     {entry.label}

--- a/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
@@ -682,10 +682,14 @@ export default function OperatorPanel({ open, onClose }: Props) {
       .then((catalog) => {
         if (!active) return;
         setModelCatalog(catalog.models);
+        // Leave an unrecognized selection to clear, but never replace "no
+        // selection" with the catalog's first entry: the composer still
+        // works with no model chosen -- the daemon falls back to its own
+        // env-var default for a turn that omits one, and picking one here
+        // on the caller's behalf would silently override that default the
+        // moment the catalog loads, before the human ever touched the menu.
         setModel((current) =>
-          current && catalog.models.some((entry) => entry.id === current)
-            ? current
-            : (catalog.models[0]?.id ?? ""),
+          current && catalog.models.some((entry) => entry.id === current) ? current : "",
         );
       })
       .catch(() => {
@@ -1145,6 +1149,7 @@ export default function OperatorPanel({ open, onClose }: Props) {
                 }}
                 className="shrink-0 border-0 bg-transparent py-0 font-data text-meta text-content-muted outline-none focus:text-content-primary"
               >
+                <option value="">{t("model.default")}</option>
                 {modelCatalog.map((entry) => (
                   <option key={entry.id} value={entry.id}>
                     {entry.label}

--- a/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
+++ b/apps/studio/frontend/src/components/operator/OperatorPanel.tsx
@@ -16,6 +16,7 @@ import {
   cancelOperatorRequest,
   createOperatorConversation,
   decideOperatorProposal,
+  fetchOperatorModelCatalog,
   getOperatorConversation,
   listOperatorConversations,
   streamOperatorConversation,
@@ -26,15 +27,16 @@ import type {
   OperatorConfirmationPayload,
   OperatorConversation,
   OperatorDonePayload,
+  OperatorEffort,
   OperatorErrorPayload,
   OperatorFrame,
+  OperatorModelCatalogEntry,
   OperatorProposalPayload,
   OperatorTextPayload,
   OperatorToolCallPayload,
   OperatorToolResultPayload,
   OperatorUiCommandPayload,
 } from "@/lib/types";
-import { OPERATOR_MODELS, type OperatorModel } from "@/lib/types";
 import Button from "@/components/ui/Button";
 import Markdown from "@/components/ui/Markdown";
 import {
@@ -624,7 +626,9 @@ export default function OperatorPanel({ open, onClose }: Props) {
   const navigate = useNavigate();
   const [state, dispatch] = useReducer(operatorReducer, initialOperatorState);
   const [instruction, setInstruction] = useState("");
-  const [model, setModel] = useState<OperatorModel>(OPERATOR_MODELS[0]);
+  const [modelCatalog, setModelCatalog] = useState<OperatorModelCatalogEntry[]>([]);
+  const [model, setModel] = useState<string>("");
+  const [effort, setEffort] = useState<OperatorEffort | "">("");
   const [sending, setSending] = useState(false);
   const [stopping, setStopping] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -671,6 +675,35 @@ export default function OperatorPanel({ open, onClose }: Props) {
     },
     [t],
   );
+
+  useEffect(() => {
+    let active = true;
+    void fetchOperatorModelCatalog()
+      .then((catalog) => {
+        if (!active) return;
+        setModelCatalog(catalog.models);
+        setModel((current) =>
+          current && catalog.models.some((entry) => entry.id === current)
+            ? current
+            : (catalog.models[0]?.id ?? ""),
+        );
+      })
+      .catch(() => {
+        // The composer still works with no model selected -- the daemon
+        // falls back to its own env-var default for a turn that omits one.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const effortChoices = useMemo(
+    () => modelCatalog.find((entry) => entry.id === model)?.efforts ?? [],
+    [modelCatalog, model],
+  );
+  // Derived, not synced via effect: a stale selection from a previous model
+  // just stops being offered rather than needing a setState-on-effect sync.
+  const effectiveEffort = effort && effortChoices.includes(effort) ? effort : "";
 
   useEffect(() => {
     let active = true;
@@ -911,7 +944,8 @@ export default function OperatorPanel({ open, onClose }: Props) {
         instruction: trimmed,
         context,
         expectedLastSequence: state.lastSequence,
-        model,
+        ...(model ? { model } : {}),
+        ...(effectiveEffort ? { effort: effectiveEffort } : {}),
       });
       dispatch({ type: "TURN_ACCEPTED", requestId: accepted.requestId });
       setInstruction("");
@@ -934,6 +968,8 @@ export default function OperatorPanel({ open, onClose }: Props) {
     instruction,
     location.pathname,
     location.search,
+    model,
+    effectiveEffort,
     sending,
     state.activeRequestId,
     state.conversation,
@@ -1100,15 +1136,37 @@ export default function OperatorPanel({ open, onClose }: Props) {
                 aria-label={t("model.label")}
                 title={t("model.label")}
                 value={model}
-                onChange={(event) => setModel(event.target.value as OperatorModel)}
+                onChange={(event) => {
+                  setModel(event.target.value);
+                  // A previous model's effort selection may not exist on the
+                  // new one; clear it explicitly rather than carrying a value
+                  // effortChoices no longer offers.
+                  setEffort("");
+                }}
                 className="shrink-0 border-0 bg-transparent py-0 font-data text-meta text-content-muted outline-none focus:text-content-primary"
               >
-                {OPERATOR_MODELS.map((name) => (
-                  <option key={name} value={name}>
-                    {name}
+                {modelCatalog.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.label}
                   </option>
                 ))}
               </select>
+              {effortChoices.length > 0 && (
+                <select
+                  aria-label={t("effort.label")}
+                  title={t("effort.label")}
+                  value={effectiveEffort}
+                  onChange={(event) => setEffort(event.target.value as OperatorEffort)}
+                  className="shrink-0 border-0 bg-transparent py-0 font-data text-meta text-content-muted outline-none focus:text-content-primary"
+                >
+                  <option value="">{t("effort.default")}</option>
+                  {effortChoices.map((choice) => (
+                    <option key={choice} value={choice}>
+                      {choice}
+                    </option>
+                  ))}
+                </select>
+              )}
             </div>
           </div>
           <button

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -194,8 +194,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 788 leaves", () => {
-    expect(EN_LEAVES.size).toBe(788);
+  it("en.json has 789 leaves", () => {
+    expect(EN_LEAVES.size).toBe(789);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -194,8 +194,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 786 leaves", () => {
-    expect(EN_LEAVES.size).toBe(786);
+  it("en.json has 788 leaves", () => {
+    expect(EN_LEAVES.size).toBe(788);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -194,8 +194,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 789 leaves", () => {
-    expect(EN_LEAVES.size).toBe(789);
+  it("en.json has 790 leaves", () => {
+    expect(EN_LEAVES.size).toBe(790);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   OperatorConversationSnapshot,
   OperatorFrame,
   OperatorFrameType,
+  OperatorModelCatalog,
   OperatorProposalResult,
   OperatorTurnAccepted,
   OperatorTurnRequest,
@@ -367,9 +368,15 @@ export async function submitOperatorTurn(
         context: request.context,
         expected_last_sequence: request.expectedLastSequence,
         ...(request.model ? { model: request.model } : {}),
+        ...(request.provider ? { provider: request.provider } : {}),
+        ...(request.effort ? { effort: request.effort } : {}),
       }),
     },
   );
+}
+
+export async function fetchOperatorModelCatalog(): Promise<OperatorModelCatalog> {
+  return fetchJson<OperatorModelCatalog>("/api/operator/models");
 }
 
 export async function cancelOperatorRequest(

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -370,6 +370,7 @@ export async function submitOperatorTurn(
         ...(request.model ? { model: request.model } : {}),
         ...(request.provider ? { provider: request.provider } : {}),
         ...(request.effort ? { effort: request.effort } : {}),
+        ...(request.clearSelection ? { clear_selection: true } : {}),
       }),
     },
   );

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -412,6 +412,10 @@ export interface OperatorConversation {
   status: OperatorConversationStatus;
   nextSequence?: number;
   activeRequestId?: string | null;
+  /** The provider and model this conversation is pinned to. The daemon keeps
+   * using them for a turn that names neither, so the composer has to show
+   * them rather than reporting "Default". */
+  provider?: string | null;
   providerModel?: string | null;
   createdAt?: number;
   updatedAt?: number;
@@ -616,6 +620,9 @@ export interface OperatorTurnRequest {
   model?: string;
   provider?: OperatorProvider;
   effort?: OperatorEffort;
+  // Omitting `model` keeps the conversation's stored pin, so it cannot also
+  // mean "drop it". This asks for the pin to be removed.
+  clearSelection?: boolean;
 }
 
 export interface OperatorTurnAccepted {

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -580,15 +580,42 @@ export interface OperatorConversationSnapshot {
   frames: OperatorFrame[];
 }
 
-/** Closed set: the value reaches a CLI argument on the daemon. */
-export const OPERATOR_MODELS = ["sonnet", "opus", "haiku"] as const;
-export type OperatorModel = (typeof OPERATOR_MODELS)[number];
+/** Provider each catalog model runs through; mirrors lionagi/studio/operator/catalog.py. */
+export type OperatorProvider = "claude_code" | "codex" | "gemini_code";
+
+/** Reasoning-effort vocabulary; which subset a given provider accepts is
+ * carried per-entry in OperatorModelCatalogEntry.efforts, not hardcoded here. */
+export type OperatorEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "ultra";
+
+/** One entry in the backend-served model catalog (GET /api/operator/models).
+ * The model reaches a CLI argument on the daemon, so the UI only ever offers
+ * ids the server actually named -- see fetchOperatorModelCatalog. */
+export interface OperatorModelCatalogEntry {
+  id: string;
+  label: string;
+  provider: OperatorProvider;
+  efforts: OperatorEffort[];
+}
+
+export interface OperatorModelCatalog {
+  models: OperatorModelCatalogEntry[];
+}
 
 export interface OperatorTurnRequest {
   instruction: string;
   context: OperatorContextSnapshot;
   expectedLastSequence: number;
-  model?: OperatorModel;
+  model?: string;
+  provider?: OperatorProvider;
+  effort?: OperatorEffort;
 }
 
 export interface OperatorTurnAccepted {

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "الجهد",
+      "default": "افتراضي"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "افتراضي"
     },
     "effort": {
       "label": "الجهد",

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "افتراضي"
+      "default": "افتراضي",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "الجهد",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "প্রচেষ্টা",
+      "default": "ডিফল্ট"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "ডিফল্ট"
     },
     "effort": {
       "label": "প্রচেষ্টা",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "ডিফল্ট"
+      "default": "ডিফল্ট",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "প্রচেষ্টা",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "Standard"
     },
     "effort": {
       "label": "Aufwand",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "Standard"
+      "default": "Standard",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Aufwand",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Aufwand",
+      "default": "Standard"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "Default"
     },
     "effort": {
       "label": "Effort",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Effort",
+      "default": "Default"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "Default"
+      "default": "Default",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Effort",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Esfuerzo",
+      "default": "Predeterminado"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "Predeterminado"
     },
     "effort": {
       "label": "Esfuerzo",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "Predeterminado"
+      "default": "Predeterminado",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Esfuerzo",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "Par défaut"
     },
     "effort": {
       "label": "Effort",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "Par défaut"
+      "default": "Par défaut",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Effort",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Effort",
+      "default": "Par défaut"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "डिफ़ॉल्ट"
     },
     "effort": {
       "label": "प्रयास",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "प्रयास",
+      "default": "डिफ़ॉल्ट"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "डिफ़ॉल्ट"
+      "default": "डिफ़ॉल्ट",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "प्रयास",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "Default"
+      "default": "Default",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Usaha",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Usaha",
+      "default": "Default"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "Default"
     },
     "effort": {
       "label": "Usaha",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "デフォルト"
     },
     "effort": {
       "label": "労力",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "労力",
+      "default": "デフォルト"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "デフォルト"
+      "default": "デフォルト",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "労力",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "노력",
+      "default": "기본값"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "기본값"
+      "default": "기본값",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "노력",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "기본값"
     },
     "effort": {
       "label": "노력",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Esforço",
+      "default": "Padrão"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "Padrão"
+      "default": "Padrão",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Esforço",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "Padrão"
     },
     "effort": {
       "label": "Esforço",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "По умолчанию"
+      "default": "По умолчанию",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Усилие",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Усилие",
+      "default": "По умолчанию"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "По умолчанию"
     },
     "effort": {
       "label": "Усилие",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Çaba",
+      "default": "Varsayılan"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "Varsayılan"
+      "default": "Varsayılan",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Çaba",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "Varsayılan"
     },
     "effort": {
       "label": "Çaba",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "پہلے سے طے شدہ"
     },
     "effort": {
       "label": "کوشش",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "کوشش",
+      "default": "پہلے سے طے شدہ"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "پہلے سے طے شدہ"
+      "default": "پہلے سے طے شدہ",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "کوشش",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -156,7 +156,8 @@
       "open": "Open run"
     },
     "model": {
-      "label": "Model"
+      "label": "Model",
+      "default": "Mặc định"
     },
     "effort": {
       "label": "Nỗ lực",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "Model",
-      "default": "Mặc định"
+      "default": "Mặc định",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "Nỗ lực",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "Model"
+    },
+    "effort": {
+      "label": "Nỗ lực",
+      "default": "Mặc định"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -157,7 +157,8 @@
     },
     "model": {
       "label": "模型",
-      "default": "默认"
+      "default": "默认",
+      "unavailable": "{model} (unavailable)"
     },
     "effort": {
       "label": "强度",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -157,6 +157,10 @@
     },
     "model": {
       "label": "模型"
+    },
+    "effort": {
+      "label": "强度",
+      "default": "默认"
     }
   },
   "playfield": {

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -156,7 +156,8 @@
       "open": "打开运行"
     },
     "model": {
-      "label": "模型"
+      "label": "模型",
+      "default": "默认"
     },
     "effort": {
       "label": "强度",

--- a/lionagi/studio/operator/catalog.py
+++ b/lionagi/studio/operator/catalog.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The Operator's model catalog: which models exist, which provider each runs
+through, and which reasoning-effort levels each accepts.
+
+This is the single source of truth the frontend renders from (``GET
+/operator/models``) and the coordinator validates a turn's selection against
+before it ever reaches a provider CLI. Model identifiers and effort ceilings
+are grounded in the provider request models themselves — see
+``lionagi/providers/anthropic/claude_code.py`` (``ClaudeEffort``),
+``lionagi/providers/openai/codex.py`` plus the codex effort-ceiling tables in
+``lionagi/service/providers.py``, and
+``lionagi/providers/google/gemini_code.py`` (effort folds into the model
+name via ``resolve_agy_model`` rather than a separate parameter).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+OperatorProvider = Literal["claude_code", "codex", "gemini_code"]
+OperatorEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+
+# Claude has no none/minimal tier and no ultra tier (ultra clamps to max).
+CLAUDE_EFFORTS: tuple[OperatorEffort, ...] = ("low", "medium", "high", "xhigh", "max")
+# Codex additionally accepts none/minimal; max/ultra are clamped per model at
+# request-build time (see _clamp_codex_effort in lionagi/service/providers.py).
+CODEX_EFFORTS: tuple[OperatorEffort, ...] = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+    "ultra",
+)
+# agy (the gemini-code CLI) has no effort kwarg at all -- effort folds into the
+# --model name as Low/Medium/High, so only those three tiers are meaningful.
+GEMINI_EFFORTS: tuple[OperatorEffort, ...] = ("low", "medium", "high")
+
+_PROVIDER_EFFORTS: dict[OperatorProvider, tuple[OperatorEffort, ...]] = {
+    "claude_code": CLAUDE_EFFORTS,
+    "codex": CODEX_EFFORTS,
+    "gemini_code": GEMINI_EFFORTS,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorModelSpec:
+    id: str
+    label: str
+    provider: OperatorProvider
+
+
+# Curated, not exhaustive: every id here is a model name a provider's CLI
+# request model or effort-ceiling table actually names (see module docstring).
+# Adding a model is a backend-only edit to this tuple.
+OPERATOR_MODEL_CATALOG: tuple[OperatorModelSpec, ...] = (
+    OperatorModelSpec("sonnet", "Claude Sonnet", "claude_code"),
+    OperatorModelSpec("opus", "Claude Opus", "claude_code"),
+    OperatorModelSpec("haiku", "Claude Haiku", "claude_code"),
+    OperatorModelSpec("claude-fable-5", "Claude Fable", "claude_code"),
+    OperatorModelSpec("gpt-5.3-codex", "Codex (gpt-5.3)", "codex"),
+    OperatorModelSpec("gpt-5.3-codex-spark", "Codex Spark (gpt-5.3)", "codex"),
+    OperatorModelSpec("gpt-5.4", "Codex (gpt-5.4)", "codex"),
+    OperatorModelSpec("gpt-5.5", "Codex (gpt-5.5)", "codex"),
+    OperatorModelSpec("gemini-3.6-flash", "Gemini 3.6 Flash", "gemini_code"),
+    OperatorModelSpec("gemini-3.5-flash", "Gemini 3.5 Flash", "gemini_code"),
+    OperatorModelSpec("gemini-3.1-pro", "Gemini 3.1 Pro", "gemini_code"),
+)
+
+_BY_ID: dict[str, OperatorModelSpec] = {spec.id: spec for spec in OPERATOR_MODEL_CATALOG}
+
+
+class OperatorSelectionError(ValueError):
+    """A requested provider/model/effort combination the Operator cannot honor."""
+
+
+def effort_choices(provider: str) -> tuple[OperatorEffort, ...]:
+    return _PROVIDER_EFFORTS.get(provider, ())  # type: ignore[arg-type]
+
+
+def catalog_entries() -> list[dict[str, object]]:
+    """The wire-serializable catalog: id/label/provider/efforts per model."""
+    return [
+        {
+            "id": spec.id,
+            "label": spec.label,
+            "provider": spec.provider,
+            "efforts": list(_PROVIDER_EFFORTS[spec.provider]),
+        }
+        for spec in OPERATOR_MODEL_CATALOG
+    ]
+
+
+def resolve_selection(
+    *,
+    provider: str | None,
+    model: str | None,
+    effort: str | None,
+) -> tuple[str | None, str | None, str | None]:
+    """Validate a client-requested (provider, model, effort) against the catalog.
+
+    Returns the resolved ``(provider, model, effort)`` -- ``None`` for any of
+    the three the caller did not specify, so the env-var/default fallback path
+    in ``build_operator_branch`` is unchanged for a turn that specifies none of
+    them. Raises ``OperatorSelectionError`` for an unknown model, an unknown
+    provider, a model that does not belong to an explicitly given provider, or
+    an effort the resolved provider cannot honor.
+    """
+    resolved_provider = provider
+    if model is not None:
+        spec = _BY_ID.get(model)
+        if spec is None:
+            raise OperatorSelectionError(f"Unknown Operator model '{model}'")
+        if provider is not None and provider != spec.provider:
+            raise OperatorSelectionError(
+                f"Model '{model}' belongs to provider '{spec.provider}', not '{provider}'"
+            )
+        resolved_provider = spec.provider
+    elif provider is not None and provider not in _PROVIDER_EFFORTS:
+        raise OperatorSelectionError(f"Unknown Operator provider '{provider}'")
+
+    if effort is not None:
+        if resolved_provider is None:
+            raise OperatorSelectionError("An effort selection requires a provider or model")
+        allowed = _PROVIDER_EFFORTS.get(resolved_provider)  # type: ignore[arg-type]
+        if allowed is None or effort not in allowed:
+            raise OperatorSelectionError(
+                f"Provider '{resolved_provider}' does not accept effort '{effort}'"
+            )
+
+    return resolved_provider, model, effort

--- a/lionagi/studio/operator/catalog.py
+++ b/lionagi/studio/operator/catalog.py
@@ -82,6 +82,50 @@ def effort_choices(provider: str) -> tuple[OperatorEffort, ...]:
     return _PROVIDER_EFFORTS.get(provider, ())  # type: ignore[arg-type]
 
 
+def model_effort_choices(model: str) -> tuple[OperatorEffort, ...]:
+    """The efforts a specific model actually honors, not the ones its provider
+    has a name for.
+
+    Effort ceilings are per model, and the request path enforces them by
+    silently clamping: a Claude model that is not Opus turns ``xhigh`` into
+    ``high``, most Codex models turn ``max`` and ``ultra`` into ``xhigh``, and
+    Gemini Pro has no Medium tier so ``medium`` becomes High. Offering a value
+    the request will change is worse than not offering it, because the operator
+    picks a level and the provider is asked for a different one with nothing
+    said.
+
+    So the choices are derived from the same clamp functions the request path
+    uses, rather than restated here: an effort is offered only when clamping it
+    for this model leaves it alone. Deriving rather than duplicating is the
+    point -- a new ceiling added to the provider tables narrows this catalog on
+    its own, and cannot drift away from what the request will do.
+    """
+    spec = _BY_ID.get(model)
+    if spec is None:
+        return ()
+    from lionagi.service.providers import (
+        _GEMINI_EFFORT_CLAMP,
+        _clamp_claude_effort,
+        _clamp_codex_effort,
+        _clamp_gemini_effort,
+    )
+
+    offered = _PROVIDER_EFFORTS[spec.provider]
+    if spec.provider == "claude_code":
+        return tuple(e for e in offered if _clamp_claude_effort(e, spec.id) == e)
+    if spec.provider == "codex":
+        return tuple(e for e in offered if _clamp_codex_effort(e, spec.id) == e)
+    if spec.provider == "gemini_code":
+        # Gemini has no effort kwarg: the level becomes part of the model name,
+        # so "honored" means the tier this effort names is the tier that gets
+        # requested.
+        is_pro = "pro" in spec.id
+        return tuple(
+            e for e in offered if _clamp_gemini_effort(e, is_pro) == _GEMINI_EFFORT_CLAMP.get(e)
+        )
+    return offered
+
+
 def catalog_entries() -> list[dict[str, object]]:
     """The wire-serializable catalog: id/label/provider/efforts per model."""
     return [
@@ -89,7 +133,7 @@ def catalog_entries() -> list[dict[str, object]]:
             "id": spec.id,
             "label": spec.label,
             "provider": spec.provider,
-            "efforts": list(_PROVIDER_EFFORTS[spec.provider]),
+            "efforts": list(model_effort_choices(spec.id)),
         }
         for spec in OPERATOR_MODEL_CATALOG
     ]
@@ -108,7 +152,11 @@ def resolve_selection(
     in ``build_operator_branch`` is unchanged for a turn that specifies none of
     them. Raises ``OperatorSelectionError`` for an unknown model, an unknown
     provider, a model that does not belong to an explicitly given provider, or
-    an effort the resolved provider cannot honor.
+    an effort the selection cannot honor. When a model is named, the effort is
+    checked against that model's own ceiling rather than its provider's whole
+    vocabulary: the catalog offers per-model choices, so accepting a value the
+    catalog does not offer would let a stale client pin an effort the request
+    path then quietly clamps.
     """
     resolved_provider = provider
     if model is not None:
@@ -126,10 +174,14 @@ def resolve_selection(
     if effort is not None:
         if resolved_provider is None:
             raise OperatorSelectionError("An effort selection requires a provider or model")
-        allowed = _PROVIDER_EFFORTS.get(resolved_provider)  # type: ignore[arg-type]
-        if allowed is None or effort not in allowed:
-            raise OperatorSelectionError(
-                f"Provider '{resolved_provider}' does not accept effort '{effort}'"
-            )
+        if model is not None:
+            if effort not in model_effort_choices(model):
+                raise OperatorSelectionError(f"Model '{model}' does not accept effort '{effort}'")
+        else:
+            allowed = _PROVIDER_EFFORTS.get(resolved_provider)  # type: ignore[arg-type]
+            if allowed is None or effort not in allowed:
+                raise OperatorSelectionError(
+                    f"Provider '{resolved_provider}' does not accept effort '{effort}'"
+                )
 
     return resolved_provider, model, effort

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -6,23 +6,25 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import time
 import uuid
 from contextlib import suppress
 from typing import Any
 
+from .catalog import OperatorSelectionError, resolve_selection
 from .engine import (
     BranchOperatorEngine,
     OperatorProviderUnavailableError,
     build_operator_branch,
     compile_operator_history,
+    resolve_operator_provider_model,
     write_resumable_operator_snapshot,
 )
 from .store import (
     OperatorAuditUnavailableError,
     OperatorConflictError,
     OperatorStore,
+    OperatorValidationError,
 )
 from .types import (
     CommandExecutor,
@@ -186,16 +188,27 @@ class OperatorCoordinator:
         context: dict[str, Any],
         expected_last_sequence: int,
         model: str | None = None,
+        provider: str | None = None,
+        effort: str | None = None,
     ) -> dict[str, Any]:
         await self.ensure_started()
-        if model:
+        try:
+            resolved_provider, resolved_model, resolved_effort = resolve_selection(
+                provider=provider, model=model, effort=effort
+            )
+        except OperatorSelectionError as exc:
+            raise OperatorValidationError(str(exc)) from exc
+        if resolved_provider is not None or resolved_model is not None:
             # Before the turn is accepted, so the run it builds already sees it.
-            await self.store.select_provider_model(conversation_id, model)
+            await self.store.select_provider_model(
+                conversation_id, provider=resolved_provider, model=resolved_model
+            )
         accepted = await self.store.submit_turn(
             conversation_id,
             instruction=instruction,
             context=context,
             expected_last_sequence=expected_last_sequence,
+            effort=resolved_effort,
         )
         request_id = accepted["requestId"]
         ready = asyncio.Event()
@@ -273,7 +286,9 @@ class OperatorCoordinator:
 
             conversation_row = await self.store.get_conversation(conversation_id)
             resumed_session_id = conversation_row.get("providerSessionId")
+            selected_provider = conversation_row.get("provider")
             selected_model = conversation_row.get("providerModel")
+            selected_effort = turn_row.get("effort")
             engine_turn = OperatorEngineTurn(
                 conversation_id=conversation_id,
                 request_id=request_id,
@@ -285,7 +300,9 @@ class OperatorCoordinator:
                 provider_session_id=(
                     resumed_session_id if isinstance(resumed_session_id, str) else None
                 ),
+                provider=selected_provider if isinstance(selected_provider, str) else None,
                 model=selected_model if isinstance(selected_model, str) else None,
+                effort=selected_effort if isinstance(selected_effort, str) else None,
             )
             run_branch = build_operator_branch(engine_turn)
             engine_turn = OperatorEngineTurn(
@@ -298,7 +315,9 @@ class OperatorCoordinator:
                 runtime_branch=run_branch,
                 store_path=engine_turn.store_path,
                 provider_session_id=engine_turn.provider_session_id,
+                provider=engine_turn.provider,
                 model=engine_turn.model,
+                effort=engine_turn.effort,
             )
             from lionagi.cli import _runs as cli_runs
 
@@ -311,14 +330,17 @@ class OperatorCoordinator:
             run_dir.ensure_state_dirs()
             run_dir.ensure_artifact_root()
             started_at = time.time()
+            # Same resolution build_operator_branch already applied to the Branch
+            # itself, so the manifest and persisted run record never disagree with
+            # what actually ran.
+            resolved_provider, resolved_model = resolve_operator_provider_model(engine_turn)
             run_dir.write_manifest(
                 {
                     "kind": "agent",
                     "agent_name": "Operator",
                     "branch_id": str(run_branch.id),
-                    "provider": os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code"),
-                    "model": engine_turn.model
-                    or os.environ.get("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet"),
+                    "provider": resolved_provider,
+                    "model": resolved_model,
                     "status": "running",
                     "started_at": started_at,
                     "ended_at": None,
@@ -328,16 +350,12 @@ class OperatorCoordinator:
             # canonical snapshot still exists before the run link is emitted.
             await write_resumable_operator_snapshot(run_branch, run_dir.branches_dir)
 
-            provider = os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
-            model_name = engine_turn.model or os.environ.get(
-                "LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet"
-            )
             live = await cli_runs.setup_agent_persist(
                 run_branch,
                 agent_name="Operator",
                 artifacts_path=str(run_dir.artifact_root),
-                model=model_name,
-                provider=provider,
+                model=resolved_model,
+                provider=resolved_provider,
                 project=turn_row["context"].get("project"),
                 run_id=run_dir.run_id,
                 share_db=False,
@@ -486,17 +504,15 @@ class OperatorCoordinator:
                     )
             if run_branch is not None and run_dir is not None:
                 with suppress(Exception):
+                    final_provider, final_model = resolve_operator_provider_model(engine_turn)
                     run_dir.write_manifest(
                         {
                             "kind": "agent",
                             "agent_name": "Operator",
                             "branch_id": str(run_branch.id),
                             "session_id": live["session_id"] if live is not None else None,
-                            "provider": os.environ.get(
-                                "LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code"
-                            ),
-                            "model": engine_turn.model
-                            or os.environ.get("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet"),
+                            "provider": final_provider,
+                            "model": final_model,
                             "status": terminal_status,
                             "started_at": started_at or time.time(),
                             "ended_at": time.time(),

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -200,21 +200,19 @@ class OperatorCoordinator:
             )
         except OperatorSelectionError as exc:
             raise OperatorValidationError(str(exc)) from exc
-        if clear_selection:
-            # Also before the turn is accepted, so this turn is the first one
-            # to run without the pin rather than the last one to run with it.
-            await self.store.clear_provider_model(conversation_id)
-        elif resolved_provider is not None or resolved_model is not None:
-            # Before the turn is accepted, so the run it builds already sees it.
-            await self.store.select_provider_model(
-                conversation_id, provider=resolved_provider, model=resolved_model
-            )
+        # The selection travels with the turn rather than being written first:
+        # a turn that is refused for an active turn or a stale cursor must
+        # leave the conversation exactly as it found it. It still applies to
+        # this turn, because the store commits it before the turn is readable.
         accepted = await self.store.submit_turn(
             conversation_id,
             instruction=instruction,
             context=context,
             expected_last_sequence=expected_last_sequence,
             effort=resolved_effort,
+            select_provider=resolved_provider,
+            select_model=resolved_model,
+            clear_selection=clear_selection,
         )
         request_id = accepted["requestId"]
         ready = asyncio.Event()

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -191,6 +191,7 @@ class OperatorCoordinator:
         model: str | None = None,
         provider: str | None = None,
         effort: str | None = None,
+        clear_selection: bool = False,
     ) -> dict[str, Any]:
         await self.ensure_started()
         try:
@@ -199,7 +200,11 @@ class OperatorCoordinator:
             )
         except OperatorSelectionError as exc:
             raise OperatorValidationError(str(exc)) from exc
-        if resolved_provider is not None or resolved_model is not None:
+        if clear_selection:
+            # Also before the turn is accepted, so this turn is the first one
+            # to run without the pin rather than the last one to run with it.
+            await self.store.clear_provider_model(conversation_id)
+        elif resolved_provider is not None or resolved_model is not None:
             # Before the turn is accepted, so the run it builds already sees it.
             await self.store.select_provider_model(
                 conversation_id, provider=resolved_provider, model=resolved_model

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -9,6 +9,7 @@ import logging
 import time
 import uuid
 from contextlib import suppress
+from dataclasses import replace
 from typing import Any
 
 from .catalog import OperatorSelectionError, resolve_selection
@@ -305,20 +306,7 @@ class OperatorCoordinator:
                 effort=selected_effort if isinstance(selected_effort, str) else None,
             )
             run_branch = build_operator_branch(engine_turn)
-            engine_turn = OperatorEngineTurn(
-                conversation_id=engine_turn.conversation_id,
-                request_id=engine_turn.request_id,
-                instruction=engine_turn.instruction,
-                context=engine_turn.context,
-                history=engine_turn.history,
-                request_permission=engine_turn.request_permission,
-                runtime_branch=run_branch,
-                store_path=engine_turn.store_path,
-                provider_session_id=engine_turn.provider_session_id,
-                provider=engine_turn.provider,
-                model=engine_turn.model,
-                effort=engine_turn.effort,
-            )
+            engine_turn = replace(engine_turn, runtime_branch=run_branch)
             from lionagi.cli import _runs as cli_runs
 
             file_run_id = f"operator-{uuid.uuid4().hex[:12]}"
@@ -392,19 +380,10 @@ class OperatorCoordinator:
             )
             ready.set()
             engine = self.engine_factory()
-            engine_turn = OperatorEngineTurn(
-                conversation_id=engine_turn.conversation_id,
-                request_id=engine_turn.request_id,
-                instruction=engine_turn.instruction,
-                context=engine_turn.context,
-                history=engine_turn.history,
-                request_permission=engine_turn.request_permission,
-                runtime_branch=engine_turn.runtime_branch,
-                store_path=engine_turn.store_path,
-                run_dir=run_dir,
-                provider_session_id=engine_turn.provider_session_id,
-                model=engine_turn.model,
-            )
+            # Only run_dir changes here. Copying field by field means every
+            # field added later has to be remembered at this call site, and one
+            # already was not: provider and effort were being dropped.
+            engine_turn = replace(engine_turn, run_dir=run_dir)
             async for event in engine.stream(engine_turn):
                 if not isinstance(event, OperatorEngineEvent):
                     raise TypeError("Operator engine yielded an invalid event")

--- a/lionagi/studio/operator/engine.py
+++ b/lionagi/studio/operator/engine.py
@@ -353,7 +353,11 @@ class BranchOperatorEngine:
         return self._stream(turn)
 
     async def _stream(self, turn: OperatorEngineTurn):
-        provider = os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
+        # Preflight the provider this turn will actually run on, not the
+        # environment default. Once a turn can carry its own selection, reading
+        # the environment here refuses a valid Codex or Gemini turn because an
+        # unselected Claude installation is missing.
+        provider, _ = resolve_operator_provider_model(turn)
         if provider == "claude_code":
             from lionagi.providers.anthropic.claude_code import CLAUDE_CLI
 

--- a/lionagi/studio/operator/engine.py
+++ b/lionagi/studio/operator/engine.py
@@ -477,15 +477,59 @@ class BranchOperatorEngine:
                 await task
 
 
+def resolve_operator_provider_model(turn: OperatorEngineTurn) -> tuple[str, str]:
+    """Resolve (provider, model) for a turn.
+
+    The turn's own selection wins; the environment variables remain the
+    default for a turn that specifies neither, so an unmigrated caller (or a
+    conversation that never chose a provider) keeps its old behavior exactly.
+    """
+    provider = turn.provider or os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
+    model_name = turn.model or os.environ.get("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet")
+    return provider, model_name
+
+
+def _apply_operator_effort(
+    provider: str, model_name: str, effort: str | None, model_kwargs: dict[str, Any]
+) -> str:
+    """Fold ``effort`` into ``model_kwargs`` (or the model name) the way each
+    provider actually accepts it; returns the (possibly rewritten) model name.
+
+    See ``lionagi/service/providers.py`` for the per-provider tables this
+    mirrors: Claude and Codex take effort as a request kwarg (with model-
+    dependent clamping); the gemini-code CLI has no effort kwarg at all and
+    instead folds it into the resolved ``--model`` display name.
+    """
+    if not effort:
+        return model_name
+    from lionagi.service.providers import (
+        PROVIDER_EFFORT_KWARG,
+        PROVIDERS_EFFORT_VIA_MODEL_NAME,
+        _clamp_claude_effort,
+        _clamp_codex_effort,
+    )
+
+    kwarg = PROVIDER_EFFORT_KWARG.get(provider)
+    if kwarg is not None:
+        if provider == "codex":
+            effort = _clamp_codex_effort(effort, model_name)
+        elif provider == "claude_code":
+            effort = _clamp_claude_effort(effort, model_name)
+        model_kwargs[kwarg] = effort
+        return model_name
+    if provider in PROVIDERS_EFFORT_VIA_MODEL_NAME:
+        from lionagi.providers.google.gemini_code import resolve_agy_model
+
+        return resolve_agy_model(model_name, effort=effort)
+    return model_name
+
+
 def build_operator_branch(turn: OperatorEngineTurn):
     """Build the real, permission-gated Branch used by a canonical turn run."""
     from lionagi.service.manager import iModel
     from lionagi.session.branch import Branch
 
-    provider = os.environ.get("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
-    # The conversation's own selection wins; the environment is the default for
-    # a conversation that has never chosen one.
-    model_name = turn.model or os.environ.get("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet")
+    provider, model_name = resolve_operator_provider_model(turn)
     model_kwargs: dict[str, Any] = {}
     if provider == "claude_code":
         from .store import OperatorStore
@@ -531,5 +575,21 @@ def build_operator_branch(turn: OperatorEngineTurn):
                 },
             },
         }
+    elif provider == "codex":
+        # Codex's CLI request model has no MCP-server / permission-prompt-tool
+        # fields (those are Claude Code CLI-specific) and no session-resume
+        # field either, so a Codex-backed turn starts fresh each time and
+        # runs without the Operator's application MCP tools.
+        model_kwargs = {"endpoint": "query_cli", "api_key": "dummy"}
+    elif provider == "gemini_code":
+        # Same MCP/permission-tool limitation as Codex; agy does support
+        # conversation resume via --conversation, so that continuity carries
+        # over even though tool access does not.
+        model_kwargs = {
+            "endpoint": "query_cli",
+            "api_key": "dummy",
+            **({"resume": turn.provider_session_id} if turn.provider_session_id else {}),
+        }
+    model_name = _apply_operator_effort(provider, model_name, turn.effort, model_kwargs)
     chat_model = iModel(provider=provider, model=model_name, **model_kwargs)
     return Branch(system=_SYSTEM_PROMPT, chat_model=chat_model)

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -463,10 +463,17 @@ class OperatorStore:
         else:
             next_provider = provider if provider is not None else row_provider
             next_model = model if model is not None else row_model
-            # A provider session belongs to the pair that created it, so it is
-            # only invalidated when the pair actually moves off a set value.
-            changed = (provider is not None and row_provider not in (None, provider)) or (
-                model is not None and row_model not in (None, model)
+            # A provider session belongs to the pair that created it, so any
+            # explicitly supplied value that differs from the stored one
+            # invalidates it. A stored NULL counts as a difference rather than
+            # as "nothing to invalidate": an unpinned conversation still ran on
+            # whatever the environment resolved to, and the session it holds
+            # belongs to that pair, so the first explicit pin is a change of
+            # pair like any other. Re-sending the value already stored is not a
+            # change, which is what keeps a session alive across the turns of a
+            # conversation whose composer submits its pin every time.
+            changed = (provider is not None and row_provider != provider) or (
+                model is not None and row_model != model
             )
         if changed:
             await db.execute(

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -487,6 +487,44 @@ class OperatorStore:
                 )
             await db.commit()
 
+    async def clear_provider_model(self, conversation_id: str) -> None:
+        """Drop this conversation's provider/model pin so it runs on the default again.
+
+        Omitting a model on a turn means "leave the pin alone", which is what
+        an unchanged composer sends, so it cannot also mean "remove the pin" --
+        without this there is no way back to the daemon's own default once a
+        conversation has been pinned. The provider session goes with it: a
+        session belongs to the pair that created it, and the next turn resolves
+        its provider from the environment rather than from that pair.
+
+        Clearing a conversation that has no pin does nothing at all. Dropping
+        the session is a consequence of the pin changing, so a repeated clear
+        must not keep discarding sessions that no pin is invalidating.
+        """
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT provider, provider_model FROM studio_operator_conversations "
+                    "WHERE id = ?",
+                    (conversation_id,),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
+            if row["provider"] is None and row["provider_model"] is None:
+                await db.rollback()
+                return
+            await db.execute(
+                "UPDATE studio_operator_conversations "
+                "SET provider = NULL, provider_model = NULL, provider_session_id = NULL, "
+                "updated_at = ? WHERE id = ?",
+                (time.time(), conversation_id),
+            )
+            await db.commit()
+
     async def archive_or_delete(self, conversation_id: str) -> None:
         await self.ensure_schema()
         now = time.time()

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -436,6 +436,52 @@ class OperatorStore:
             )
             await db.commit()
 
+    @staticmethod
+    async def _write_selection(
+        db: Any,
+        conversation_id: str,
+        *,
+        row_provider: str | None,
+        row_model: str | None,
+        provider: str | None,
+        model: str | None,
+    ) -> None:
+        """Apply a provider/model pin inside the caller's open transaction.
+
+        Takes the row's current values rather than re-reading them, so the
+        decision to drop the session is made against the same snapshot the
+        caller validated. Both ``provider`` and ``model`` as ``None`` means
+        clear the pin; otherwise a ``None`` leaves that column untouched.
+        """
+        clearing = provider is None and model is None
+        if clearing:
+            if row_provider is None and row_model is None:
+                return
+            next_provider: str | None = None
+            next_model: str | None = None
+            changed = True
+        else:
+            next_provider = provider if provider is not None else row_provider
+            next_model = model if model is not None else row_model
+            # A provider session belongs to the pair that created it, so it is
+            # only invalidated when the pair actually moves off a set value.
+            changed = (provider is not None and row_provider not in (None, provider)) or (
+                model is not None and row_model not in (None, model)
+            )
+        if changed:
+            await db.execute(
+                "UPDATE studio_operator_conversations "
+                "SET provider = ?, provider_model = ?, provider_session_id = NULL, "
+                "updated_at = ? WHERE id = ?",
+                (next_provider, next_model, time.time(), conversation_id),
+            )
+        else:
+            await db.execute(
+                "UPDATE studio_operator_conversations "
+                "SET provider = ?, provider_model = ?, updated_at = ? WHERE id = ?",
+                (next_provider, next_model, time.time(), conversation_id),
+            )
+
     async def select_provider_model(
         self,
         conversation_id: str,
@@ -467,24 +513,14 @@ class OperatorStore:
             if row is None:
                 await db.rollback()
                 raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
-            changed = (provider is not None and row["provider"] not in (None, provider)) or (
-                model is not None and row["provider_model"] not in (None, model)
+            await self._write_selection(
+                db,
+                conversation_id,
+                row_provider=row["provider"],
+                row_model=row["provider_model"],
+                provider=provider,
+                model=model,
             )
-            next_provider = provider if provider is not None else row["provider"]
-            next_model = model if model is not None else row["provider_model"]
-            if changed:
-                await db.execute(
-                    "UPDATE studio_operator_conversations "
-                    "SET provider = ?, provider_model = ?, provider_session_id = NULL, "
-                    "updated_at = ? WHERE id = ?",
-                    (next_provider, next_model, time.time(), conversation_id),
-                )
-            else:
-                await db.execute(
-                    "UPDATE studio_operator_conversations "
-                    "SET provider = ?, provider_model = ?, updated_at = ? WHERE id = ?",
-                    (next_provider, next_model, time.time(), conversation_id),
-                )
             await db.commit()
 
     async def clear_provider_model(self, conversation_id: str) -> None:
@@ -517,11 +553,13 @@ class OperatorStore:
             if row["provider"] is None and row["provider_model"] is None:
                 await db.rollback()
                 return
-            await db.execute(
-                "UPDATE studio_operator_conversations "
-                "SET provider = NULL, provider_model = NULL, provider_session_id = NULL, "
-                "updated_at = ? WHERE id = ?",
-                (time.time(), conversation_id),
+            await self._write_selection(
+                db,
+                conversation_id,
+                row_provider=row["provider"],
+                row_model=row["provider_model"],
+                provider=None,
+                model=None,
             )
             await db.commit()
 
@@ -655,7 +693,19 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
         context: dict[str, Any],
         expected_last_sequence: int,
         effort: str | None = None,
+        select_provider: str | None = None,
+        select_model: str | None = None,
+        clear_selection: bool = False,
     ) -> dict[str, Any]:
+        """Accept a turn, applying any provider/model change in the same transaction.
+
+        The selection rides here rather than being written before the call
+        because a turn that is refused must not leave the conversation
+        changed. Reserving the turn and moving the pin are decided against one
+        snapshot of the row: either both land or neither does. The pin still
+        applies to this turn, since it is committed before the turn is
+        readable.
+        """
         await self.ensure_schema()
         request_id = str(uuid.uuid4())
         now = time.time()
@@ -665,7 +715,7 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
             await db.execute("BEGIN IMMEDIATE")
             row = await (
                 await db.execute(
-                    "SELECT status, next_sequence, active_request_id "
+                    "SELECT status, next_sequence, active_request_id, provider, provider_model "
                     "FROM studio_operator_conversations WHERE id=?",
                     (conversation_id,),
                 )
@@ -692,6 +742,17 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
                         "expectedLastSequence": expected_last_sequence,
                         "actualLastSequence": actual_last,
                     },
+                )
+            # Past every rejection, so nothing below can refuse the turn after
+            # the pin has moved.
+            if clear_selection or select_provider is not None or select_model is not None:
+                await self._write_selection(
+                    db,
+                    conversation_id,
+                    row_provider=row["provider"],
+                    row_model=row["provider_model"],
+                    provider=None if clear_selection else select_provider,
+                    model=None if clear_selection else select_model,
                 )
             sequence = int(row["next_sequence"])
             await db.execute(

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -44,6 +44,9 @@ CREATE TABLE IF NOT EXISTS studio_operator_conversations (
   -- continues the first instead of starting a stranger.
   provider_session_id TEXT,
   provider_model      TEXT,
+  -- Provider the conversation is currently pinned to; NULL means "use the
+  -- env-var default" (see build_operator_branch), same as provider_model.
+  provider            TEXT,
   created_at         REAL NOT NULL,
   updated_at         REAL NOT NULL,
   archived_at        REAL,
@@ -59,6 +62,9 @@ CREATE TABLE IF NOT EXISTS studio_operator_turns (
   status              TEXT NOT NULL
                       CHECK(status IN ('queued', 'running', 'awaiting_confirmation',
                                        'completed', 'failed', 'cancelled')),
+  -- Effort is per-turn (unlike provider/model, it never invalidates a
+  -- resumed provider session), so it lives on the turn, not the conversation.
+  effort              TEXT,
   error_code          TEXT,
   created_at          REAL NOT NULL,
   started_at          REAL,
@@ -144,6 +150,10 @@ class OperatorConflictError(OperatorStoreError):
         self.details = details or {}
 
 
+class OperatorValidationError(OperatorStoreError):
+    code = "validation"
+
+
 class OperatorStore:
     def __init__(self, db_path: str | Path | None = None) -> None:
         self._db_path = Path(db_path) if db_path is not None else None
@@ -187,7 +197,12 @@ class OperatorStore:
                 await self._add_missing_columns(
                     db,
                     "studio_operator_conversations",
-                    {"provider_session_id": "TEXT", "provider_model": "TEXT"},
+                    {"provider_session_id": "TEXT", "provider_model": "TEXT", "provider": "TEXT"},
+                )
+                await self._add_missing_columns(
+                    db,
+                    "studio_operator_turns",
+                    {"effort": "TEXT"},
                 )
                 await db.commit()
             stat = path.stat()
@@ -267,6 +282,7 @@ class OperatorStore:
             "activeRequestId": row["active_request_id"],
             "providerSessionId": row["provider_session_id"],
             "providerModel": row["provider_model"],
+            "provider": row["provider"],
             "createdAt": row["created_at"],
             "updatedAt": row["updated_at"],
         }
@@ -420,38 +436,54 @@ class OperatorStore:
             )
             await db.commit()
 
-    async def select_provider_model(self, conversation_id: str, model: str) -> None:
-        """Record the model for this conversation, dropping a stale session.
+    async def select_provider_model(
+        self,
+        conversation_id: str,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        """Record the provider and/or model for this conversation, dropping a stale session.
 
-        A provider session belongs to the model that created it, so resuming
-        one under a different model is undefined. Switching models therefore
-        starts a fresh session on purpose rather than resuming into a mismatch.
+        A provider session belongs to the (provider, model) pair that created
+        it, so resuming one under a different provider or model is undefined.
+        Changing either therefore starts a fresh session on purpose rather
+        than resuming into a mismatch. A ``None`` argument leaves that column
+        untouched -- e.g. selecting only a model on a conversation that
+        already pinned a provider does not clear the provider pin.
         """
+        if provider is None and model is None:
+            return
         await self.ensure_schema()
         async with open_db(str(self.path())) as db:
             await db.execute("BEGIN IMMEDIATE")
             row = await (
                 await db.execute(
-                    "SELECT provider_model FROM studio_operator_conversations WHERE id = ?",
+                    "SELECT provider, provider_model FROM studio_operator_conversations "
+                    "WHERE id = ?",
                     (conversation_id,),
                 )
             ).fetchone()
             if row is None:
                 await db.rollback()
                 raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
-            changed = row["provider_model"] is not None and row["provider_model"] != model
+            changed = (provider is not None and row["provider"] not in (None, provider)) or (
+                model is not None and row["provider_model"] not in (None, model)
+            )
+            next_provider = provider if provider is not None else row["provider"]
+            next_model = model if model is not None else row["provider_model"]
             if changed:
                 await db.execute(
                     "UPDATE studio_operator_conversations "
-                    "SET provider_model = ?, provider_session_id = NULL, updated_at = ? "
-                    "WHERE id = ?",
-                    (model, time.time(), conversation_id),
+                    "SET provider = ?, provider_model = ?, provider_session_id = NULL, "
+                    "updated_at = ? WHERE id = ?",
+                    (next_provider, next_model, time.time(), conversation_id),
                 )
             else:
                 await db.execute(
                     "UPDATE studio_operator_conversations "
-                    "SET provider_model = ?, updated_at = ? WHERE id = ?",
-                    (model, time.time(), conversation_id),
+                    "SET provider = ?, provider_model = ?, updated_at = ? WHERE id = ?",
+                    (next_provider, next_model, time.time(), conversation_id),
                 )
             await db.commit()
 
@@ -584,6 +616,7 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
         instruction: str,
         context: dict[str, Any],
         expected_last_sequence: int,
+        effort: str | None = None,
     ) -> dict[str, Any]:
         await self.ensure_schema()
         request_id = str(uuid.uuid4())
@@ -626,8 +659,16 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
             await db.execute(
                 "INSERT INTO studio_operator_turns "
                 "(request_id, conversation_id, instruction, context_json, context_hash, "
-                "status, created_at) VALUES (?, ?, ?, ?, ?, 'queued', ?)",
-                (request_id, conversation_id, instruction, context_json, context_hash, now),
+                "status, effort, created_at) VALUES (?, ?, ?, ?, ?, 'queued', ?, ?)",
+                (
+                    request_id,
+                    conversation_id,
+                    instruction,
+                    context_json,
+                    context_hash,
+                    effort,
+                    now,
+                ),
             )
             await db.execute(
                 "UPDATE studio_operator_conversations SET active_request_id=?, "
@@ -689,6 +730,7 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
             "context": json.loads(row["context_json"]),
             "contextHash": row["context_hash"],
             "status": row["status"],
+            "effort": row["effort"],
             "errorCode": row["error_code"],
             "cancelRequestedAt": row["cancel_requested_at"],
         }

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -539,9 +539,23 @@ class OperatorStore:
 
             await db.execute(
                 "INSERT INTO studio_operator_conversations "
-                "(id, project, title, status, next_sequence, provider_model, "
-                "created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?, ?)",
-                (new_id, source["project"], new_title, source["providerModel"], now, now),
+                "(id, project, title, status, next_sequence, provider, provider_model, "
+                "created_at, updated_at) VALUES (?, ?, ?, 'active', 1, ?, ?, ?, ?)",
+                (
+                    new_id,
+                    source["project"],
+                    new_title,
+                    # A pin is the provider and the model together. Copying the
+                    # model alone would leave the fork resolving its provider
+                    # from the environment, so a conversation pinned to one
+                    # provider's model would fork into a conversation that runs
+                    # that model name against whatever provider the environment
+                    # names.
+                    source["provider"],
+                    source["providerModel"],
+                    now,
+                    now,
+                ),
             )
             next_sequence = 1
             if ordered_request_ids:

--- a/lionagi/studio/operator/types.py
+++ b/lionagi/studio/operator/types.py
@@ -65,16 +65,24 @@ class OperatorContextSnapshot(WireModel):
     filters: dict[str, Any] = Field(default_factory=dict)
 
 
-# Closed set: the model reaches a CLI argument, so an open string would let the
-# browser choose what the daemon executes.
-OperatorModel = Literal["sonnet", "opus", "haiku"]
+# The model still reaches a CLI argument, so it stays a closed set -- but the
+# set now lives in the backend catalog (catalog.py) instead of a literal here,
+# so a browser can only ever request a model the coordinator recognizes
+# (resolve_selection rejects anything else before the turn is accepted).
+OperatorProvider = Literal["claude_code", "codex", "gemini_code"]
+OperatorEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
 
 
 class OperatorTurnRequest(WireModel):
     instruction: str = Field(min_length=1, max_length=32_768)
     context: OperatorContextSnapshot
     expected_last_sequence: int = Field(ge=0)
-    model: OperatorModel | None = None
+    model: str | None = Field(default=None, max_length=128)
+    # Optional: an explicit provider disambiguates a model id and lets a turn
+    # pin a provider without changing model. Omitted, it is inferred from
+    # `model` (via the catalog) or falls back to the env-var default.
+    provider: OperatorProvider | None = None
+    effort: OperatorEffort | None = None
 
 
 class ConfirmProposalRequest(WireModel):
@@ -145,6 +153,8 @@ class OperatorEngineTurn:
     run_dir: Any | None = None
     provider_session_id: str | None = None
     model: str | None = None
+    provider: str | None = None
+    effort: str | None = None
 
 
 class OperatorEngine(Protocol):

--- a/lionagi/studio/operator/types.py
+++ b/lionagi/studio/operator/types.py
@@ -83,6 +83,18 @@ class OperatorTurnRequest(WireModel):
     # `model` (via the catalog) or falls back to the env-var default.
     provider: OperatorProvider | None = None
     effort: OperatorEffort | None = None
+    # Omitting `model` means "keep whatever this conversation is pinned to",
+    # so it cannot also mean "remove the pin". This asks for the pin to be
+    # dropped, returning the conversation to the daemon's own default.
+    clear_selection: bool = False
+
+    @model_validator(mode="after")
+    def _clear_is_not_also_a_pin(self) -> OperatorTurnRequest:
+        if self.clear_selection and (
+            self.model is not None or self.provider is not None or self.effort is not None
+        ):
+            raise ValueError("clearSelection cannot be combined with a provider, model, or effort")
+        return self
 
 
 class ConfirmProposalRequest(WireModel):

--- a/lionagi/studio/services/operator.py
+++ b/lionagi/studio/services/operator.py
@@ -15,6 +15,7 @@ from ..operator.store import (
     OperatorConflictError,
     OperatorNotFoundError,
     OperatorStoreError,
+    OperatorValidationError,
 )
 from ..operator.types import (
     AcknowledgeEffectRequest,
@@ -32,6 +33,8 @@ def _http_error(exc: OperatorStoreError) -> HTTPException:
         status = 404
     elif isinstance(exc, OperatorConflictError):
         status = 409
+    elif isinstance(exc, OperatorValidationError):
+        status = 400
     else:
         status = 503
     detail: dict[str, Any] = {
@@ -120,9 +123,20 @@ async def submit_operator_turn(conversation_id: str, body: OperatorTurnRequest) 
             context=body.context.model_dump(by_alias=True),
             expected_last_sequence=body.expected_last_sequence,
             model=body.model,
+            provider=body.provider,
+            effort=body.effort,
         )
     except OperatorStoreError as exc:
         raise _http_error(exc) from exc
+
+
+@studio_route("/operator/models", method="GET", area="operator")
+async def list_operator_models() -> dict[str, Any]:
+    """The Operator's model catalog: every model the daemon can actually drive,
+    grouped by provider, with the reasoning-effort levels each accepts."""
+    from ..operator.catalog import catalog_entries
+
+    return {"models": catalog_entries()}
 
 
 @studio_route(

--- a/lionagi/studio/services/operator.py
+++ b/lionagi/studio/services/operator.py
@@ -125,6 +125,7 @@ async def submit_operator_turn(conversation_id: str, body: OperatorTurnRequest) 
             model=body.model,
             provider=body.provider,
             effort=body.effort,
+            clear_selection=body.clear_selection,
         )
     except OperatorStoreError as exc:
         raise _http_error(exc) from exc

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -90,6 +90,7 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("GET", "/api/operator/conversations"),
     ("GET", "/api/operator/conversations/{conversation_id}"),
     ("GET", "/api/operator/conversations/{conversation_id}/stream"),
+    ("GET", "/api/operator/models"),
     ("GET", "/api/playbook-templates/"),
     ("GET", "/api/playbook-templates/{name}"),
     ("GET", "/api/playbooks/"),
@@ -255,7 +256,7 @@ def test_golden_route_table_matches_pinned_snapshot():
 
 
 def test_golden_route_count_pinned():
-    assert len(_GOLDEN_ROUTES) == 109
+    assert len(_GOLDEN_ROUTES) == 110
 
 
 def _compiled_match_shape(path_template: str) -> str:

--- a/tests/apps_studio_server/test_operator_conversation_lifecycle.py
+++ b/tests/apps_studio_server/test_operator_conversation_lifecycle.py
@@ -251,6 +251,29 @@ async def test_fork_copies_completed_turns_into_a_new_independent_conversation(
 
 
 @pytest.mark.asyncio
+async def test_fork_carries_the_whole_pin_not_just_the_model(tmp_path, monkeypatch):
+    """A fork of a pinned conversation resolves to the same provider and model.
+
+    The provider and the model are read as an independent pair when a turn is
+    built, and an absent provider falls back to the environment. A fork that
+    carried only the model would therefore run the source's model name against
+    a different provider rather than refusing.
+    """
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    store = OperatorStore(path)
+    cid = (await store.create_conversation(title="pinned"))["id"]
+    await store.select_provider_model(cid, provider="codex", model="gpt-5.4")
+
+    forked = await store.fork_conversation(cid)
+
+    assert forked["provider"] == "codex"
+    assert forked["providerModel"] == "gpt-5.4"
+    # The session belongs to the pair that opened it, so it is not inherited.
+    assert forked["providerSessionId"] is None
+
+
+@pytest.mark.asyncio
 async def test_fork_up_to_sequence_excludes_later_turns(tmp_path, monkeypatch):
     path = tmp_path / "state.db"
     _patch_state_db(monkeypatch, path)

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -386,3 +386,57 @@ async def test_provider_and_effort_columns_are_added_to_a_preexisting_store(tmp_
     conversation = await store.get_conversation(conversation_id)
     assert conversation["provider"] == "codex"
     assert conversation["providerModel"] == "gpt-5.3-codex"
+
+
+@pytest.mark.asyncio
+async def test_the_turn_handed_to_the_engine_keeps_the_selected_provider_and_effort(
+    tmp_path, monkeypatch
+):
+    """The coordinator rebuilds the engine turn twice on the way to streaming.
+    Both rebuilds must carry the whole selection, not the subset whoever wrote
+    the call site happened to list.
+
+    The built-in engine reads provider and effort off the Branch it was handed
+    rather than off the turn, so a dropped field is invisible until a different
+    engine is supplied through engine_factory -- which is exactly what this does.
+    """
+    import asyncio
+
+    captured: list = []
+
+    class CapturingEngine:
+        async def _stream(self, turn):
+            captured.append(turn)
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        def stream(self, turn):
+            return self._stream(turn)
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=CapturingEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="Selection"))["conversation"]["id"]
+    await coordinator.submit(
+        cid,
+        instruction="run it",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+        model="sonnet",
+        effort="high",
+    )
+
+    for _ in range(200):
+        if captured:
+            break
+        await asyncio.sleep(0.02)
+    assert captured, "the engine was never handed a turn"
+    turn = captured[0]
+    assert turn.model == "sonnet"
+    assert turn.provider == "claude_code"
+    assert turn.effort == "high"
+    # run_dir is what that last rebuild exists to attach; if it is missing the
+    # assertions above would pass on a turn that never went through it.
+    assert turn.run_dir is not None
+    await coordinator.shutdown()

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -1,0 +1,388 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Operator's backend-served model catalog and the provider/model/effort
+selection it validates before a turn is ever accepted -- see lionagi/studio/operator/catalog.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.studio.operator.catalog import (
+    OperatorSelectionError,
+    catalog_entries,
+    resolve_selection,
+)
+from lionagi.studio.operator.coordinator import OperatorCoordinator
+from lionagi.studio.operator.store import OperatorStore, OperatorValidationError
+
+
+class ScriptedEngine:
+    async def _stream(self, _turn):
+        yield
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
+def _patch_state_db(monkeypatch: pytest.MonkeyPatch, path) -> None:
+    import lionagi.cli._runs as runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.sessions as sessions_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", path)
+    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", path)
+    monkeypatch.setattr(sessions_mod, "_DB", str(path))
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", path.parent / "runs")
+
+
+# ── catalog_entries() ───────────────────────────────────────────────────────
+
+
+def test_catalog_entries_cover_claude_codex_and_gemini_with_a_fable_entry():
+    entries = catalog_entries()
+    by_id = {entry["id"]: entry for entry in entries}
+    assert by_id["claude-fable-5"]["provider"] == "claude_code"
+    assert "codex" in {entry["provider"] for entry in entries}
+    assert "gemini_code" in {entry["provider"] for entry in entries}
+    # Claude has no none/minimal/ultra tier.
+    assert set(by_id["sonnet"]["efforts"]) == {"low", "medium", "high", "xhigh", "max"}
+    # Codex additionally accepts none/minimal/ultra.
+    codex_entry = next(e for e in entries if e["provider"] == "codex")
+    assert {"none", "minimal", "ultra"} <= set(codex_entry["efforts"])
+    # gemini-code folds effort into the model name -- only 3 tiers are meaningful.
+    gemini_entry = next(e for e in entries if e["provider"] == "gemini_code")
+    assert set(gemini_entry["efforts"]) == {"low", "medium", "high"}
+
+
+# ── resolve_selection() ─────────────────────────────────────────────────────
+
+
+def test_resolve_selection_rejects_an_unknown_model():
+    with pytest.raises(OperatorSelectionError, match="Unknown Operator model"):
+        resolve_selection(provider=None, model="not-a-real-model", effort=None)
+
+
+def test_resolve_selection_rejects_an_unknown_provider():
+    with pytest.raises(OperatorSelectionError, match="Unknown Operator provider"):
+        resolve_selection(provider="not-a-real-provider", model=None, effort=None)
+
+
+def test_resolve_selection_rejects_a_provider_model_mismatch():
+    with pytest.raises(OperatorSelectionError, match="belongs to provider"):
+        resolve_selection(provider="codex", model="sonnet", effort=None)
+
+
+def test_resolve_selection_rejects_an_effort_the_providers_cannot_accept():
+    # gemini-code only accepts low/medium/high (folded into the --model name).
+    with pytest.raises(OperatorSelectionError, match="does not accept effort"):
+        resolve_selection(provider=None, model="gemini-3.6-flash", effort="xhigh")
+    # codex has no "ultra-plus" tier at all.
+    with pytest.raises(OperatorSelectionError, match="does not accept effort"):
+        resolve_selection(provider="codex", model=None, effort="not-a-real-effort")
+
+
+def test_resolve_selection_rejects_effort_with_no_provider_or_model():
+    with pytest.raises(OperatorSelectionError, match="requires a provider or model"):
+        resolve_selection(provider=None, model=None, effort="high")
+
+
+def test_resolve_selection_accepts_a_valid_codex_effort_and_infers_provider():
+    provider, model, effort = resolve_selection(
+        provider=None, model="gpt-5.3-codex", effort="xhigh"
+    )
+    assert (provider, model, effort) == ("codex", "gpt-5.3-codex", "xhigh")
+
+
+def test_resolve_selection_leaves_unspecified_fields_none_for_backward_compat():
+    # A turn that specifies nothing must resolve to (None, None, None) so the
+    # env-var default path in build_operator_branch is untouched.
+    assert resolve_selection(provider=None, model=None, effort=None) == (None, None, None)
+
+
+# ── coordinator.submit() rejects a bad selection before the turn is accepted ─
+
+
+@pytest.mark.asyncio
+async def test_submit_rejects_an_unknown_model_before_accepting_the_turn(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    snapshot = await coordinator.create_conversation(title="Bad model")
+    cid = snapshot["conversation"]["id"]
+
+    with pytest.raises(OperatorValidationError):
+        await coordinator.submit(
+            cid,
+            instruction="hello",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+            model="not-a-real-model",
+        )
+    # Rejected before acceptance: no active turn was created.
+    conversation = await coordinator.store.get_conversation(cid)
+    assert conversation["activeRequestId"] is None
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_submit_rejects_a_provider_model_mismatch(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    snapshot = await coordinator.create_conversation(title="Mismatch")
+    cid = snapshot["conversation"]["id"]
+
+    with pytest.raises(OperatorValidationError):
+        await coordinator.submit(
+            cid,
+            instruction="hello",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+            model="sonnet",
+            provider="codex",
+        )
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_submit_rejects_an_effort_the_selected_provider_cannot_honor(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    snapshot = await coordinator.create_conversation(title="Bad effort")
+    cid = snapshot["conversation"]["id"]
+
+    with pytest.raises(OperatorValidationError):
+        await coordinator.submit(
+            cid,
+            instruction="hello",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+            model="gemini-3.5-flash",
+            effort="xhigh",
+        )
+    await coordinator.shutdown()
+
+
+# ── build_operator_branch: provider now travels with the turn ──────────────
+
+
+def test_build_operator_branch_drives_the_selected_provider_not_just_the_env_default(
+    tmp_path, monkeypatch
+):
+    """The structural bug this feature fixes: selecting a non-Claude model in
+    the UI used to still hand it to the env-var-pinned provider (always
+    claude_code by default). The turn's own provider must now win."""
+    from lionagi.studio.operator.engine import build_operator_branch
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
+
+    async def request_permission(*_args):
+        raise AssertionError("branch construction cannot request permission")
+
+    branch = build_operator_branch(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="use codex please",
+            context={},
+            history=(),
+            request_permission=request_permission,
+            store_path=str(tmp_path / "state.db"),
+            provider="codex",
+            model="gpt-5.3-codex",
+        )
+    )
+    assert branch.chat_model.endpoint.config.provider == "codex"
+    assert branch.chat_model.endpoint.config.kwargs["model"] == "gpt-5.3-codex"
+    # Codex's CLI request model has no Claude-specific permission/MCP wiring.
+    assert "mcp_servers" not in branch.chat_model.endpoint.config.kwargs
+    assert "permission_prompt_tool_name" not in branch.chat_model.endpoint.config.kwargs
+
+
+def test_build_operator_branch_defaults_to_the_env_var_when_the_turn_specifies_nothing(
+    tmp_path, monkeypatch
+):
+    """Backward compat: a turn with no provider/model still resolves through
+    the environment defaults exactly as before this feature."""
+    from lionagi.studio.operator.engine import build_operator_branch
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_MODEL", "opus")
+
+    async def request_permission(*_args):
+        raise AssertionError("branch construction cannot request permission")
+
+    branch = build_operator_branch(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="hi",
+            context={},
+            history=(),
+            request_permission=request_permission,
+            store_path=str(tmp_path / "state.db"),
+        )
+    )
+    assert branch.chat_model.endpoint.config.provider == "claude_code"
+
+
+def test_build_operator_branch_selects_the_fable_model_through_the_claude_provider(
+    tmp_path, monkeypatch
+):
+    from lionagi.studio.operator.engine import build_operator_branch
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    monkeypatch.delenv("LIONAGI_STUDIO_OPERATOR_PROVIDER", raising=False)
+
+    async def request_permission(*_args):
+        raise AssertionError("branch construction cannot request permission")
+
+    branch = build_operator_branch(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="hi",
+            context={},
+            history=(),
+            request_permission=request_permission,
+            store_path=str(tmp_path / "state.db"),
+            model="claude-fable-5",
+        )
+    )
+    # Fable is served through the same claude_code provider path as sonnet/opus/haiku.
+    assert branch.chat_model.endpoint.config.provider == "claude_code"
+    assert "studio_permission" in branch.chat_model.endpoint.config.kwargs["mcp_servers"]
+
+
+def test_build_operator_branch_folds_codex_effort_into_the_reasoning_effort_kwarg(tmp_path):
+    from lionagi.studio.operator.engine import build_operator_branch
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("branch construction cannot request permission")
+
+    branch = build_operator_branch(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="hi",
+            context={},
+            history=(),
+            request_permission=request_permission,
+            store_path=str(tmp_path / "state.db"),
+            provider="codex",
+            model="gpt-5.3-codex",
+            effort="high",
+        )
+    )
+    assert branch.chat_model.endpoint.config.kwargs["reasoning_effort"] == "high"
+
+
+def test_build_operator_branch_folds_gemini_effort_into_the_model_name(tmp_path):
+    from lionagi.studio.operator.engine import build_operator_branch
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    async def request_permission(*_args):
+        raise AssertionError("branch construction cannot request permission")
+
+    branch = build_operator_branch(
+        OperatorEngineTurn(
+            conversation_id="conversation",
+            request_id="request",
+            instruction="hi",
+            context={},
+            history=(),
+            request_permission=request_permission,
+            store_path=str(tmp_path / "state.db"),
+            provider="gemini_code",
+            model="gemini-3.5-flash",
+            effort="high",
+        )
+    )
+    # gemini-code has no effort kwarg -- it is folded into the resolved model name.
+    assert "reasoning_effort" not in branch.chat_model.endpoint.config.kwargs
+    assert "effort" not in branch.chat_model.endpoint.config.kwargs
+    assert branch.chat_model.endpoint.config.kwargs["model"] == "Gemini 3.5 Flash (High)"
+
+
+# ── store: provider/model/effort persistence ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_select_provider_model_resets_the_session_when_provider_changes(tmp_path):
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    await store.select_provider_model(conversation_id, provider="claude_code", model="sonnet")
+    await store.set_provider_session_id(conversation_id, "session-1")
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["providerSessionId"] == "session-1"
+
+    await store.select_provider_model(conversation_id, provider="codex", model="gpt-5.3-codex")
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.3-codex"
+    assert conversation["providerSessionId"] is None
+
+
+@pytest.mark.asyncio
+async def test_select_provider_model_leaves_an_unspecified_field_untouched(tmp_path):
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    await store.select_provider_model(conversation_id, provider="codex", model="gpt-5.3-codex")
+    await store.set_provider_session_id(conversation_id, "session-1")
+
+    # Selecting only a model on a conversation that already pinned a provider
+    # must not clear that provider pin.
+    await store.select_provider_model(conversation_id, model="gpt-5.4")
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.4"
+    assert conversation["providerSessionId"] is None
+
+
+@pytest.mark.asyncio
+async def test_submit_turn_persists_effort_per_turn_not_per_conversation(tmp_path):
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    accepted = await store.submit_turn(
+        conversation_id,
+        instruction="hi",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+        effort="xhigh",
+    )
+    turn = await store.get_turn(accepted["requestId"])
+    assert turn["effort"] == "xhigh"
+
+
+@pytest.mark.asyncio
+async def test_provider_and_effort_columns_are_added_to_a_preexisting_store(tmp_path):
+    """Same additive-migration contract as provider_session_id/provider_model:
+    a pre-existing StateDB file predates the `provider` and `effort` columns."""
+    import aiosqlite
+
+    db_path = tmp_path / "state.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "CREATE TABLE studio_operator_conversations ("
+            "id TEXT PRIMARY KEY, project TEXT, title TEXT, "
+            "status TEXT NOT NULL DEFAULT 'active', "
+            "next_sequence INTEGER NOT NULL DEFAULT 1, active_request_id TEXT, "
+            "created_at REAL NOT NULL, updated_at REAL NOT NULL, "
+            "archived_at REAL, deleted_at REAL)"
+        )
+        await db.commit()
+
+    store = OperatorStore(db_path)
+    conversation_id = (await store.create_conversation())["id"]
+    await store.select_provider_model(conversation_id, provider="codex", model="gpt-5.3-codex")
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.3-codex"

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -15,7 +15,11 @@ from lionagi.studio.operator.catalog import (
     resolve_selection,
 )
 from lionagi.studio.operator.coordinator import OperatorCoordinator
-from lionagi.studio.operator.store import OperatorStore, OperatorValidationError
+from lionagi.studio.operator.store import (
+    OperatorConflictError,
+    OperatorStore,
+    OperatorValidationError,
+)
 
 
 class ScriptedEngine:
@@ -682,3 +686,158 @@ def test_a_clear_request_cannot_also_carry_a_pin():
 
     with pytest.raises(pydantic.ValidationError, match="cannot be combined"):
         OperatorTurnRequest.model_validate({**body, "clearSelection": True, "model": "sonnet"})
+
+
+# ── a refused turn must not move the pin ────────────────────────────────────
+
+
+async def _pin_and_reserve(store, *, provider="codex", model="gpt-5.4"):
+    """A conversation pinned to a pair, with a session, and a turn already running."""
+    conversation_id = (await store.create_conversation())["id"]
+    await store.select_provider_model(conversation_id, provider=provider, model=model)
+    await store.set_provider_session_id(conversation_id, "session-1")
+    await store.submit_turn(
+        conversation_id,
+        instruction="the turn already running",
+        context={},
+        expected_last_sequence=0,
+    )
+    return conversation_id
+
+
+@pytest.mark.asyncio
+async def test_a_clear_refused_for_an_active_turn_leaves_the_pin_alone(tmp_path):
+    """The 409 and the pin change are decided against one snapshot of the row.
+
+    A second client reversing a selection it cannot see gets refused, and the
+    conversation it did not get to run must be exactly as it was: a rejected
+    request that still drops the pin and the resumable session hands the
+    already-accepted turn a different provider than the one it was accepted
+    under.
+    """
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = await _pin_and_reserve(store)
+
+    with pytest.raises(OperatorConflictError):
+        await store.submit_turn(
+            conversation_id,
+            instruction="reverse it",
+            context={},
+            expected_last_sequence=1,
+            clear_selection=True,
+        )
+
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.4"
+    assert conversation["providerSessionId"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_a_selection_refused_for_an_active_turn_leaves_the_pin_alone(tmp_path):
+    """Same row state, the other direction: a changed pin is refused whole."""
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = await _pin_and_reserve(store)
+
+    with pytest.raises(OperatorConflictError):
+        await store.submit_turn(
+            conversation_id,
+            instruction="switch provider",
+            context={},
+            expected_last_sequence=1,
+            select_provider="claude_code",
+            select_model="sonnet",
+        )
+
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.4"
+    assert conversation["providerSessionId"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_a_selection_refused_for_a_stale_cursor_leaves_the_pin_alone(tmp_path):
+    """The cursor check rejects after the active-turn check, so it needs its own
+    case: a guard placed between the two would pass the tests above and still
+    let a stale-context rejection move the pin."""
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    await store.select_provider_model(conversation_id, provider="codex", model="gpt-5.4")
+    await store.set_provider_session_id(conversation_id, "session-1")
+
+    with pytest.raises(OperatorConflictError):
+        await store.submit_turn(
+            conversation_id,
+            instruction="submitted against an old cursor",
+            context={},
+            expected_last_sequence=41,
+            clear_selection=True,
+        )
+
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.4"
+    assert conversation["providerSessionId"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_turn_still_applies_the_selection(tmp_path):
+    """The control for all three above: moving the write inside the transaction
+    must not stop it happening. A guard that simply never applied the pin would
+    pass every rejection case."""
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    await store.select_provider_model(conversation_id, provider="codex", model="gpt-5.4")
+    await store.set_provider_session_id(conversation_id, "session-1")
+
+    await store.submit_turn(
+        conversation_id,
+        instruction="accepted",
+        context={},
+        expected_last_sequence=0,
+        clear_selection=True,
+    )
+
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] is None
+    assert conversation["providerModel"] is None
+    assert conversation["providerSessionId"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_refused_submit_does_not_move_the_pin_through_the_coordinator(
+    tmp_path, monkeypatch
+):
+    """The discriminating case for the whole selection-with-turn contract.
+
+    The store-level cases above cannot catch the defect this replaces: inside
+    ``submit_turn`` every rejection rolls its transaction back, so ordering
+    within it is not observable. The defect was that the coordinator committed
+    the pin through a separate store call before asking whether the turn was
+    acceptable at all, so the rejection could not undo it. Only a test that
+    goes through the coordinator sees that.
+    """
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="Pinned"))["conversation"]["id"]
+    await store.select_provider_model(cid, provider="codex", model="gpt-5.4")
+    await store.set_provider_session_id(cid, "session-1")
+    # Reserve the turn directly: the conversation now has one in flight.
+    await store.submit_turn(cid, instruction="running", context={}, expected_last_sequence=0)
+
+    with pytest.raises(OperatorConflictError):
+        await coordinator.submit(
+            cid,
+            instruction="reverse the pin while a turn is running",
+            context={},
+            expected_last_sequence=1,
+            clear_selection=True,
+        )
+
+    conversation = await store.get_conversation(cid)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.4"
+    assert conversation["providerSessionId"] == "session-1"

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -11,6 +11,7 @@ import pytest
 from lionagi.studio.operator.catalog import (
     OperatorSelectionError,
     catalog_entries,
+    model_effort_choices,
     resolve_selection,
 )
 from lionagi.studio.operator.coordinator import OperatorCoordinator
@@ -45,14 +46,20 @@ def test_catalog_entries_cover_claude_codex_and_gemini_with_a_fable_entry():
     assert by_id["claude-fable-5"]["provider"] == "claude_code"
     assert "codex" in {entry["provider"] for entry in entries}
     assert "gemini_code" in {entry["provider"] for entry in entries}
-    # Claude has no none/minimal/ultra tier.
-    assert set(by_id["sonnet"]["efforts"]) == {"low", "medium", "high", "xhigh", "max"}
-    # Codex additionally accepts none/minimal/ultra.
+    # Efforts are per model, not per provider: the catalog offers a level only
+    # when the request path will send that level unchanged. Claude has no
+    # none/minimal/ultra tier at all, and xhigh survives on Opus alone.
+    assert set(by_id["sonnet"]["efforts"]) == {"low", "medium", "high", "max"}
+    assert set(by_id["opus"]["efforts"]) == {"low", "medium", "high", "xhigh", "max"}
+    # Codex additionally accepts none/minimal; max and ultra clamp to xhigh on
+    # every Codex model this catalog lists, so they are not offered.
     codex_entry = next(e for e in entries if e["provider"] == "codex")
-    assert {"none", "minimal", "ultra"} <= set(codex_entry["efforts"])
-    # gemini-code folds effort into the model name -- only 3 tiers are meaningful.
-    gemini_entry = next(e for e in entries if e["provider"] == "gemini_code")
-    assert set(gemini_entry["efforts"]) == {"low", "medium", "high"}
+    assert {"none", "minimal"} <= set(codex_entry["efforts"])
+    assert {"max", "ultra"}.isdisjoint(codex_entry["efforts"])
+    # gemini-code folds effort into the model name -- only 3 tiers are
+    # meaningful, and Pro has no Medium tier.
+    assert set(by_id["gemini-3.5-flash"]["efforts"]) == {"low", "medium", "high"}
+    assert set(by_id["gemini-3.1-pro"]["efforts"]) == {"low", "high"}
 
 
 # ── resolve_selection() ─────────────────────────────────────────────────────
@@ -440,3 +447,238 @@ async def test_the_turn_handed_to_the_engine_keeps_the_selected_provider_and_eff
     # assertions above would pass on a turn that never went through it.
     assert turn.run_dir is not None
     await coordinator.shutdown()
+
+
+# ── per-model effort ceilings ───────────────────────────────────────────────
+
+
+def test_the_catalog_never_offers_an_effort_the_request_path_would_change():
+    """The whole point of the per-model list: every offered level must survive
+    the clamp that runs on the way to the provider. This walks the catalog
+    rather than spot-checking, so a model added later cannot quietly offer a
+    level that gets rewritten."""
+    from lionagi.service.providers import (
+        _GEMINI_EFFORT_CLAMP,
+        _clamp_claude_effort,
+        _clamp_codex_effort,
+        _clamp_gemini_effort,
+    )
+    from lionagi.studio.operator.catalog import OPERATOR_MODEL_CATALOG
+
+    checked = 0
+    for spec in OPERATOR_MODEL_CATALOG:
+        for effort in model_effort_choices(spec.id):
+            checked += 1
+            if spec.provider == "claude_code":
+                assert _clamp_claude_effort(effort, spec.id) == effort, (spec.id, effort)
+            elif spec.provider == "codex":
+                assert _clamp_codex_effort(effort, spec.id) == effort, (spec.id, effort)
+            else:
+                is_pro = "pro" in spec.id
+                assert _clamp_gemini_effort(effort, is_pro) == _GEMINI_EFFORT_CLAMP[effort], (
+                    spec.id,
+                    effort,
+                )
+    assert checked > 20, "sanity: the walk must actually have examined the catalog"
+
+
+def test_a_clamped_effort_is_rejected_rather_than_silently_downgraded():
+    """The three measured cases where the provider used to receive a level the
+    operator never chose."""
+    for model, effort in (("sonnet", "xhigh"), ("gpt-5.4", "ultra"), ("gemini-3.1-pro", "medium")):
+        with pytest.raises(OperatorSelectionError, match="does not accept effort"):
+            resolve_selection(provider=None, model=model, effort=effort)
+
+
+def test_a_model_that_does_honor_the_level_still_accepts_it():
+    """Rejecting must not become rejecting everything: each of the three above
+    has a sibling for which the same level is honored."""
+    assert resolve_selection(provider=None, model="opus", effort="xhigh") == (
+        "claude_code",
+        "opus",
+        "xhigh",
+    )
+    assert resolve_selection(provider=None, model="gpt-5.4", effort="xhigh") == (
+        "codex",
+        "gpt-5.4",
+        "xhigh",
+    )
+    assert resolve_selection(provider=None, model="gemini-3.5-flash", effort="medium") == (
+        "gemini_code",
+        "gemini-3.5-flash",
+        "medium",
+    )
+
+
+# ── availability preflight is per selected provider ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_codex_turn_is_not_refused_because_claude_is_the_env_default(tmp_path, monkeypatch):
+    """The availability check runs before the branch is built, so it has to ask
+    the turn which provider it selected. Reading the environment there refuses a
+    perfectly runnable Codex or Gemini turn whenever the machine happens to have
+    no Claude CLI installed.
+    """
+    import lionagi.providers.anthropic.claude_code as claude_mod
+    from lionagi.studio.operator.engine import (
+        BranchOperatorEngine,
+        OperatorProviderUnavailableError,
+    )
+    from lionagi.studio.operator.types import OperatorEngineTurn
+
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_PROVIDER", "claude_code")
+    monkeypatch.setattr(claude_mod, "CLAUDE_CLI", None)
+
+    def _turn(provider: str | None, model: str | None) -> OperatorEngineTurn:
+        return OperatorEngineTurn(
+            conversation_id="c1",
+            request_id="r1",
+            instruction="do it",
+            context={"space": "mission", "route": "/", "filters": {}},
+            history=[],
+            request_permission=None,
+            store_path=str(tmp_path / "state.db"),
+            provider=provider,
+            model=model,
+        )
+
+    engine = BranchOperatorEngine()
+
+    # The control: a turn that selects nothing still falls back to the
+    # environment, so the missing Claude CLI is still reported. Without this the
+    # test would pass just as well against a preflight that never fires.
+    with pytest.raises(OperatorProviderUnavailableError):
+        stream = engine.stream(_turn(None, None))
+        await stream.__anext__()
+
+    # The regression: a selected Codex turn must get past the preflight. It
+    # fails later for an unrelated reason (no codex binary, no network) or
+    # succeeds; what matters is that it is not the Claude-unavailable refusal.
+    stream = engine.stream(_turn("codex", "gpt-5.3-codex"))
+    try:
+        await stream.__anext__()
+    except OperatorProviderUnavailableError as exc:  # pragma: no cover - the defect
+        raise AssertionError(f"a codex turn was refused for a Claude reason: {exc}") from exc
+    except StopAsyncIteration:
+        pass
+    except Exception:
+        pass
+    finally:
+        await stream.aclose()
+
+
+# ── clearing a conversation's pin ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clearing_returns_a_pinned_conversation_to_the_default(tmp_path):
+    """Omitting a model means "keep the pin", so there has to be a separate way
+    to say "drop it" -- otherwise a conversation can never go back to the
+    daemon's own default once it has been pinned once.
+    """
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    await store.select_provider_model(conversation_id, provider="codex", model="gpt-5.4")
+    await store.set_provider_session_id(conversation_id, "session-1")
+
+    await store.clear_provider_model(conversation_id)
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] is None
+    assert conversation["providerModel"] is None
+    # The session belonged to the pair that is gone.
+    assert conversation["providerSessionId"] is None
+
+
+@pytest.mark.asyncio
+async def test_clearing_an_unpinned_conversation_keeps_its_session(tmp_path):
+    """A client that cannot see the store may repeat the clear. Dropping the
+    session is a consequence of a pin changing, so a repeat must not keep
+    discarding sessions that nothing is invalidating."""
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    await store.set_provider_session_id(conversation_id, "session-1")
+
+    await store.clear_provider_model(conversation_id)
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["providerSessionId"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_a_cleared_turn_reaches_the_engine_with_no_selection(tmp_path, monkeypatch):
+    """End to end through the coordinator: the pin is dropped before the turn is
+    accepted, so this turn is the first one to run without it rather than the
+    last one to run with it."""
+    import asyncio
+
+    captured: list = []
+
+    class CapturingEngine:
+        async def _stream(self, turn):
+            captured.append(turn)
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        def stream(self, turn):
+            return self._stream(turn)
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=CapturingEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="Clearing"))["conversation"]["id"]
+    await coordinator.submit(
+        cid,
+        instruction="pin it",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+        model="gpt-5.4",
+    )
+    for _ in range(200):
+        if captured:
+            break
+        await asyncio.sleep(0.02)
+    assert captured and captured[0].model == "gpt-5.4"
+    for _ in range(400):
+        conversation = await coordinator.store.get_conversation(cid)
+        if conversation["activeRequestId"] is None:
+            break
+        await asyncio.sleep(0.02)
+    assert conversation["activeRequestId"] is None, "the pinned turn never finished"
+    assert conversation["providerModel"] == "gpt-5.4"
+
+    captured.clear()
+    await coordinator.submit(
+        cid,
+        instruction="unpin it",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=int(conversation["nextSequence"]) - 1,
+        clear_selection=True,
+    )
+    for _ in range(200):
+        if captured:
+            break
+        await asyncio.sleep(0.02)
+    assert captured, "the engine was never handed the cleared turn"
+    assert captured[0].model is None
+    assert captured[0].provider is None
+    await coordinator.shutdown()
+
+
+def test_a_clear_request_cannot_also_carry_a_pin():
+    """Clearing and pinning in one turn is a contradiction, and silently
+    letting one win would make the wire ambiguous."""
+    import pydantic
+
+    from lionagi.studio.operator.types import OperatorTurnRequest
+
+    body = {
+        "instruction": "hi",
+        "context": {"space": "mission", "route": "/", "filters": {}},
+        "expectedLastSequence": 0,
+    }
+    # The control: the same body without a pin is accepted.
+    assert OperatorTurnRequest.model_validate({**body, "clearSelection": True}).clear_selection
+
+    with pytest.raises(pydantic.ValidationError, match="cannot be combined"):
+        OperatorTurnRequest.model_validate({**body, "clearSelection": True, "model": "sonnet"})

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -841,3 +841,98 @@ async def test_a_refused_submit_does_not_move_the_pin_through_the_coordinator(
     assert conversation["provider"] == "codex"
     assert conversation["providerModel"] == "gpt-5.4"
     assert conversation["providerSessionId"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_a_first_explicit_selection_drops_the_default_providers_session(tmp_path):
+    """A NULL pin does not mean "no session was created under a pair".
+
+    An unpinned conversation runs on whatever the environment resolves to, and
+    the session it gets belongs to that pair. Pinning a different pair for the
+    first time therefore invalidates the session exactly as changing an existing
+    pin does. Treating NULL as "unset, so nothing to invalidate" hands the new
+    provider a session id that another provider created, which the engine passes
+    straight through as its resume argument.
+    """
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    await store.set_provider_session_id(conversation_id, "default-provider-session")
+
+    await store.submit_turn(
+        conversation_id,
+        instruction="first explicit selection",
+        context={},
+        expected_last_sequence=0,
+        select_provider="gemini_code",
+        select_model="gemini-3.5-flash",
+    )
+
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] == "gemini_code"
+    assert conversation["providerModel"] == "gemini-3.5-flash"
+    assert conversation["providerSessionId"] is None
+
+
+@pytest.mark.asyncio
+async def test_resending_the_pin_already_stored_keeps_the_session(tmp_path):
+    """The control for the invalidation rule above.
+
+    A composer submits its selection on every turn, so the common case is the
+    stored pair being sent back unchanged. If that counted as a change, every
+    turn would discard the provider session and the conversation would never
+    resume anything. An invalidation rule that clears on NULL must still not
+    clear on equal.
+    """
+    store = OperatorStore(tmp_path / "state.db")
+    conversation_id = (await store.create_conversation())["id"]
+    await store.select_provider_model(conversation_id, provider="codex", model="gpt-5.4")
+    await store.set_provider_session_id(conversation_id, "session-1")
+
+    await store.submit_turn(
+        conversation_id,
+        instruction="same selection again",
+        context={},
+        expected_last_sequence=0,
+        select_provider="codex",
+        select_model="gpt-5.4",
+    )
+
+    conversation = await store.get_conversation(conversation_id)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.4"
+    assert conversation["providerSessionId"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_selection_does_not_move_the_pin_through_the_coordinator(
+    tmp_path, monkeypatch
+):
+    """The clear path and the select path both have to survive a refusal.
+
+    A regression covering only ``clearSelection`` passes against an
+    implementation that moved just the clear inside the accepting transaction
+    and left an ordinary model selection written ahead of it.
+    """
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="Pinned"))["conversation"]["id"]
+    await store.select_provider_model(cid, provider="codex", model="gpt-5.4")
+    await store.set_provider_session_id(cid, "session-1")
+    await store.submit_turn(cid, instruction="running", context={}, expected_last_sequence=0)
+
+    with pytest.raises(OperatorConflictError):
+        await coordinator.submit(
+            cid,
+            instruction="switch model while a turn is running",
+            context={},
+            expected_last_sequence=1,
+            model="sonnet",
+        )
+
+    conversation = await store.get_conversation(cid)
+    assert conversation["provider"] == "codex"
+    assert conversation["providerModel"] == "gpt-5.4"
+    assert conversation["providerSessionId"] == "session-1"


### PR DESCRIPTION
The Operator took its model from the turn but its provider from an environment variable, so choosing a model from another provider handed that name to the wrong client.

- The model catalog is served from the backend instead of a hardcoded frontend list.
- Provider travels with the model, so selecting a Codex or Gemini model routes to the matching provider.
- Reasoning effort is selectable per turn.

Route and locale pins are updated to this branch's own delta from `main`. Several sibling branches touch the same two pinned counters, so whichever lands second needs the sum of the deltas, not either branch's value.
