### PR TITLE
feat(studio): agent create and delete with role, mode, and protections

### DIFF
--- a/apps/studio/frontend/src/components/AgentProfileForm.tsx
+++ b/apps/studio/frontend/src/components/AgentProfileForm.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Button from "@/components/ui/Button";
 import SectionLabel from "@/components/ui/SectionLabel";
 import { FieldLabel, Input, Select, TextArea } from "@/components/ui/Field";
+import { getCasts } from "@/lib/api";
+import type { CastMode, CastRole } from "@/lib/api";
 import type { AgentProfile } from "@/lib/types";
 
 interface AgentProfileFormProps {
@@ -75,6 +77,28 @@ export default function AgentProfileForm({
   errors = [],
 }: AgentProfileFormProps) {
   const [form, setForm] = useState<AgentProfile>(initial ? normalizeForm(initial) : emptyForm());
+  const [roles, setRoles] = useState<CastRole[]>([]);
+  const [modes, setModes] = useState<CastMode[]>([]);
+  const [castsError, setCastsError] = useState<string | null>(null);
+
+  // The role/mode dropdowns must reflect what lionagi/casts/roles and
+  // lionagi/casts/roles/modes actually ship, not a hardcoded guess -- fetch
+  // the live catalog once per mount.
+  useEffect(() => {
+    let alive = true;
+    getCasts()
+      .then((catalog) => {
+        if (!alive) return;
+        setRoles(catalog.roles);
+        setModes(catalog.modes);
+      })
+      .catch((e) => {
+        if (alive) setCastsError(e instanceof Error ? e.message : "Failed to load casts catalog");
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   const provider = isProvider(form.provider) ? form.provider : "claude_code";
   const availableModels = MODEL_OPTIONS[provider];
@@ -135,6 +159,60 @@ export default function AgentProfileForm({
             placeholder="What does this agent do?"
           />
         </FieldLabel>
+      </section>
+
+      {/* Section 1b: Cast role & mode — multiple named versions of the same role are
+          expected (e.g. two differently-configured "critic" agents), so role/mode
+          are independent per-agent settings, not part of the agent's identity. */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <SectionLabel className="text-label font-semibold text-content-primary">
+            Cast role & mode
+          </SectionLabel>
+          <p className="text-meta text-content-muted">
+            Optionally base this agent on a built-in cast role and cognitive mode
+          </p>
+        </div>
+
+        {castsError ? (
+          <p className="text-meta text-status-error">{castsError}</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <FieldLabel label="Role">
+              <Select
+                id="agent-role"
+                value={form.role ?? ""}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, role: e.target.value || undefined }))
+                }
+              >
+                <option value="">— none —</option>
+                {roles.map((r) => (
+                  <option key={r.name} value={r.name}>
+                    {r.name}
+                  </option>
+                ))}
+              </Select>
+            </FieldLabel>
+
+            <FieldLabel label="Mode">
+              <Select
+                id="agent-mode"
+                value={form.mode ?? ""}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, mode: e.target.value || undefined }))
+                }
+              >
+                <option value="">— none —</option>
+                {modes.map((m) => (
+                  <option key={m.name} value={m.name}>
+                    {m.name}
+                  </option>
+                ))}
+              </Select>
+            </FieldLabel>
+          </div>
+        )}
       </section>
 
       {/* Section 2: Provider & Model */}

--- a/apps/studio/frontend/src/components/library/AgentDetail.tsx
+++ b/apps/studio/frontend/src/components/library/AgentDetail.tsx
@@ -1,8 +1,15 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "use-intl";
 import { IconArrowLeft } from "@/components/ui/icons";
-import { getDefinition, saveDefinition, rollbackDefinition, getDefinitionVersion } from "@/lib/api";
-import type { DefinitionDetail, DefinitionVersion } from "@/lib/api";
+import {
+  getDefinition,
+  saveDefinition,
+  rollbackDefinition,
+  getDefinitionVersion,
+  getCasts,
+  deleteAgent,
+} from "@/lib/api";
+import type { CastMode, DefinitionDetail, DefinitionVersion } from "@/lib/api";
 import type { AgentProfileSummary } from "@/lib/types";
 import SectionLabel from "@/components/ui/SectionLabel";
 import Button from "@/components/ui/Button";
@@ -53,9 +60,11 @@ interface Props {
   agent: AgentProfileSummary;
   /** Rendered in collapsed (narrow) mode — show a back affordance. */
   onBack?: () => void;
+  /** Called after a successful delete so the caller can drop the selection. */
+  onDeleted?: () => void;
 }
 
-export function AgentDetail({ agent, onBack }: Props) {
+export function AgentDetail({ agent, onBack, onDeleted }: Props) {
   const t = useTranslations("library.drawer");
   const [def, setDef] = useState<DefinitionDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -71,6 +80,43 @@ export function AgentDetail({ agent, onBack }: Props) {
 
   const [previewVer, setPreviewVer] = useState<DefinitionDetail | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const [modes, setModes] = useState<CastMode[]>([]);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    getCasts()
+      .then((catalog) => {
+        if (alive) setModes(catalog.modes);
+      })
+      .catch(() => {
+        /* mode selector degrades to free text below if this fails */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const isProtected = agent.protected === true;
+  const isDefault = agent.is_default === true;
+  const canDelete = !isProtected && !isDefault;
+
+  const handleDelete = useCallback(async () => {
+    if (!canDelete || deleting) return;
+    if (!window.confirm(`Delete agent "${agent.name}"? This cannot be undone.`)) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteAgent(agent.name);
+      onDeleted?.();
+    } catch (e) {
+      setDeleteError(e instanceof Error ? e.message : "Delete failed");
+    } finally {
+      setDeleting(false);
+    }
+  }, [agent.name, canDelete, deleting, onDeleted]);
 
   useEffect(() => {
     let alive = true;
@@ -279,8 +325,39 @@ export function AgentDetail({ agent, onBack }: Props) {
               <span className="font-data text-[length:var(--t-xs)] text-content-muted">
                 v{def.version}
               </span>
-              <Button size="sm" variant="secondary" onClick={startEdit}>
+              {isProtected && (
+                <span
+                  title="System agent — not editable or deletable"
+                  className="rounded border border-edge bg-surface-overlay px-1.5 py-0.5 text-[length:var(--t-xs)] uppercase tracking-[0.08em] text-content-muted"
+                >
+                  system
+                </span>
+              )}
+              {!isProtected && isDefault && (
+                <span
+                  title="Default agent — not deletable"
+                  className="rounded border border-edge bg-surface-overlay px-1.5 py-0.5 text-[length:var(--t-xs)] uppercase tracking-[0.08em] text-content-muted"
+                >
+                  default
+                </span>
+              )}
+              <Button size="sm" variant="secondary" onClick={startEdit} disabled={isProtected}>
                 {t("edit")}
+              </Button>
+              <Button
+                size="sm"
+                variant="danger"
+                onClick={() => void handleDelete()}
+                disabled={!canDelete || deleting}
+                title={
+                  isProtected
+                    ? "System agents cannot be deleted"
+                    : isDefault
+                      ? "The default agent cannot be deleted"
+                      : undefined
+                }
+              >
+                {deleting ? "Deleting…" : "Delete"}
               </Button>
             </>
           )}
@@ -290,6 +367,12 @@ export function AgentDetail({ agent, onBack }: Props) {
       {saveError && (
         <div className="shrink-0 border-b border-edge px-4 py-2 text-[length:var(--t-xs)] text-status-failure">
           {saveError}
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="shrink-0 border-b border-edge px-4 py-2 text-[length:var(--t-xs)] text-status-failure">
+          {deleteError}
         </div>
       )}
 
@@ -335,6 +418,21 @@ export function AgentDetail({ agent, onBack }: Props) {
                 ))}
               </select>
             </label>
+            <label className="flex flex-col gap-1">
+              <SectionLabel>Mode</SectionLabel>
+              <select
+                value={typeof fm.mode === "string" ? fm.mode : ""}
+                onChange={(e) => setFmField("mode", e.target.value || undefined)}
+                className="rounded border border-edge bg-surface-overlay px-2 py-1 text-[length:var(--t-xs)] text-content-primary"
+              >
+                <option value="">—</option>
+                {modes.map((m) => (
+                  <option key={m.name} value={m.name}>
+                    {m.name}
+                  </option>
+                ))}
+              </select>
+            </label>
             <label className="flex cursor-pointer select-none items-center gap-1.5">
               <input
                 type="checkbox"
@@ -366,6 +464,18 @@ export function AgentDetail({ agent, onBack }: Props) {
                 <span className="font-data text-content-primary">
                   {String(dispFm.permission_mode)}
                 </span>
+              </div>
+            )}
+            {dispFm.role && (
+              <div className="flex items-center gap-1.5 text-[length:var(--t-xs)]">
+                <span className="text-content-muted">role</span>
+                <span className="font-data text-content-primary">{String(dispFm.role)}</span>
+              </div>
+            )}
+            {dispFm.mode && (
+              <div className="flex items-center gap-1.5 text-[length:var(--t-xs)]">
+                <span className="text-content-muted">mode</span>
+                <span className="font-data text-content-primary">{String(dispFm.mode)}</span>
               </div>
             )}
             {dispFm.yolo === true && (

--- a/apps/studio/frontend/src/components/library/AgentDetail.tsx
+++ b/apps/studio/frontend/src/components/library/AgentDetail.tsx
@@ -92,7 +92,10 @@ export function AgentDetail({ agent, onBack, onDeleted }: Props) {
         if (alive) setModes(catalog.modes);
       })
       .catch(() => {
-        /* mode selector degrades to free text below if this fails */
+        /* Leaves the mode list empty, so the selector below offers only the
+           clear option. Deliberately not a free-text fallback: mode is looked
+           up by exact name, so a field that accepts anything would let a failed
+           catalog fetch produce a profile nothing can resolve. */
       });
     return () => {
       alive = false;

--- a/apps/studio/frontend/src/components/library/CreateAgentPanel.tsx
+++ b/apps/studio/frontend/src/components/library/CreateAgentPanel.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import AgentProfileForm from "@/components/AgentProfileForm";
+import { createAgent } from "@/lib/api";
+import type { AgentProfile } from "@/lib/types";
+
+interface CreateAgentPanelProps {
+  onCreated: (name: string) => void;
+  onCancel: () => void;
+}
+
+export function CreateAgentPanel({ onCreated, onCancel }: CreateAgentPanelProps) {
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const handleSave = useCallback(
+    async (data: AgentProfile) => {
+      const name = data.name.trim();
+      if (!name) {
+        setErrors(["Name is required"]);
+        return;
+      }
+      setSaving(true);
+      setErrors([]);
+      try {
+        await createAgent(name, data);
+        onCreated(name);
+      } catch (e) {
+        setErrors([e instanceof Error ? e.message : "Failed to create agent"]);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [onCreated],
+  );
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between border-b border-edge px-4 py-3">
+        <span className="font-medium text-[length:var(--t-md)] text-content-primary">
+          New agent
+        </span>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-[length:var(--t-xs)] text-content-muted"
+        >
+          Cancel
+        </button>
+      </div>
+      <div className="flex-1 overflow-auto p-4">
+        <AgentProfileForm mode="create" onSave={handleSave} saving={saving} errors={errors} />
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -977,6 +977,12 @@ export async function updateAgent(name: string, data: AgentProfile): Promise<unk
   });
 }
 
+export async function deleteAgent(name: string): Promise<{ deleted: boolean; name: string }> {
+  return fetchJson<{ deleted: boolean; name: string }>(`/api/agents/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
+}
+
 // ─── Shows ────────────────────────────────────────────────────────────────────
 
 export async function listShows(): Promise<ShowSummary[]> {

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -272,6 +272,14 @@ export interface AgentProfileSummary {
   description?: string;
   provider: string;
   model: string;
+  /** Cast role this agent wraps (e.g. "critic"), if any -- see /api/casts/. */
+  role?: string;
+  /** Cognitive mode overlay (e.g. "terse"), if any -- see /api/casts/. */
+  mode?: string;
+  /** True for a catalog-sourced/hand-marked agent: not editable or deletable. */
+  protected?: boolean;
+  /** True for the single always-present fallback agent: not deletable. */
+  is_default?: boolean;
 }
 
 export interface AgentProfile {
@@ -284,6 +292,10 @@ export interface AgentProfile {
   permission_mode?: string;
   reasoning_effort?: string;
   description?: string;
+  role?: string;
+  mode?: string;
+  protected?: boolean;
+  is_default?: boolean;
 }
 
 // ─── Model config ─────────────────────────────────────────────────────────────

--- a/apps/studio/frontend/src/routes/library.tsx
+++ b/apps/studio/frontend/src/routes/library.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { useTranslations } from "use-intl";
 import { AgentDetail } from "@/components/library/AgentDetail";
+import { CreateAgentPanel } from "@/components/library/CreateAgentPanel";
 import { WorkflowDetail, CreateWorkflowPanel } from "@/components/library/WorkflowDetail";
 import { PlaybookTemplateDetail } from "@/components/library/PlaybookTemplateDetail";
 import { KindBadge } from "@/components/library/KindBadge";
@@ -421,7 +422,7 @@ function LibraryPage() {
             });
           }}
         >
-          + {t("newWorkflow")}
+          + {kindFilter === "agent" ? "New Agent" : t("newWorkflow")}
         </Button>
       </div>
 
@@ -546,7 +547,24 @@ function LibraryPage() {
 
   let detailPane: ReactNode;
 
-  if (showCreate) {
+  if (showCreate && kindFilter === "agent") {
+    detailPane = (
+      <CreateAgentPanel
+        onCreated={(name) => {
+          setShowCreate(false);
+          void reload();
+          void navigate({
+            search: (prev) => ({ ...prev, sel: encodeSel("agent", name) }),
+            replace: false,
+          });
+        }}
+        onCancel={() => {
+          setShowCreate(false);
+          setDetailActive(false);
+        }}
+      />
+    );
+  } else if (showCreate) {
     detailPane = (
       <div className="flex h-full flex-col overflow-hidden">
         <CreateWorkflowPanel
@@ -566,7 +584,24 @@ function LibraryPage() {
       </div>
     );
   } else if (parsed?.kind === "agent" && selectedAgent) {
-    detailPane = <AgentDetail agent={selectedAgent} onBack={handleBack} />;
+    detailPane = (
+      <AgentDetail
+        agent={selectedAgent}
+        onBack={handleBack}
+        onDeleted={() => {
+          setDetailActive(false);
+          void reload();
+          void navigate({
+            search: (prev) => {
+              const next = { ...prev };
+              delete next.sel;
+              return next;
+            },
+            replace: false,
+          });
+        }}
+      />
+    );
   } else if (parsed?.kind === "workflow" && selectedWorkflowId) {
     detailPane = <WorkflowDetail id={selectedWorkflowId} onBack={handleBack} />;
   } else if (parsed?.kind === "playbook") {

--- a/lionagi/studio/services/agents.py
+++ b/lionagi/studio/services/agents.py
@@ -9,13 +9,45 @@ import yaml
 from fastapi import Body, HTTPException
 
 from lionagi._paths import LIONAGI_HOME
+from lionagi.casts.pattern import list_modes as _list_modes
+from lionagi.casts.pattern import list_roles as _list_roles
 from lionagi.libs.frontmatter import parse_frontmatter as _parse_frontmatter
 
 from ..registry import studio_route
-from ._path_safety import public_path, safe_path_join
+from ._path_safety import public_path, safe_path_join, validate_name_component
 
 _AGENTS_ROOT = LIONAGI_HOME / "agents"
 _log = logging.getLogger(__name__)
+
+# The one agent Studio treats as the always-present fallback profile: not
+# deletable, but (unlike a system agent) editable like any other agent.
+DEFAULT_AGENT_NAME = "default"
+
+
+def _is_protected_system(fm: dict[str, Any]) -> bool:
+    """True only when a file explicitly opts into ``lion_system: true``.
+
+    ``lion_system`` already exists as a frontmatter flag (get_agent() has always
+    surfaced it, defaulting True, for CLI parity -- see
+    ``AgentProfile``/``AgentSpec.compose`` in ``lionagi/cli``). Write-protection
+    reuses that same flag rather than inventing a new one, but only the explicit
+    ``true`` value counts: treating an *absent* key as protected would silently
+    lock down every agent file that predates this feature (plain markdown with
+    no frontmatter at all is common -- see the generic definitions save path),
+    which is not what "the system agent cannot be edited" means. Agents created
+    through the Studio API stamp ``lion_system: false`` explicitly, so they are
+    unambiguously editable/deletable by their owner.
+    """
+    return fm.get("lion_system") is True
+
+
+def _read_frontmatter(path) -> dict[str, Any]:
+    try:
+        text = path.read_text()
+    except OSError:
+        return {}
+    fm, _ = _parse_frontmatter(text)
+    return _normalize_frontmatter(fm)
 
 
 def _normalize_frontmatter(fm: dict[str, Any]) -> dict[str, Any]:
@@ -58,6 +90,8 @@ def list_agents() -> list[dict[str, Any]]:
             "description": str(fm.get("description") or ""),
             **{k: v for k, v in fm.items() if k not in ("model", "description", "provider")},
         }
+        entry["protected"] = _is_protected_system(fm)
+        entry["is_default"] = path.stem == DEFAULT_AGENT_NAME
         if path.is_symlink():
             try:
                 entry["symlink_target"] = public_path(path.resolve())
@@ -92,9 +126,13 @@ def get_agent(name: str) -> dict[str, Any] | None:
 
     result["yolo"] = bool(fm.get("yolo", False))
     result["fast_mode"] = bool(fm.get("fast_mode", False))
+    # CLI-parity display default (absent key reads as True) -- distinct from
+    # the stricter, explicit-only check _is_protected_system() uses to gate writes.
     result["lion_system"] = bool(fm.get("lion_system", True))
+    result["protected"] = _is_protected_system(fm)
+    result["is_default"] = stem == DEFAULT_AGENT_NAME
 
-    for optional_key in ("permission_mode", "effort", "description"):
+    for optional_key in ("permission_mode", "effort", "description", "role", "mode"):
         if optional_key in fm:
             result[optional_key] = fm[optional_key]
 
@@ -117,7 +155,96 @@ _KNOWN_FRONTMATTER_KEYS = (
     "yolo",
     "fast_mode",
     "lion_system",
+    "role",
+    "mode",
 )
+
+
+class AgentExistsError(Exception):
+    """Raised by create_agent() when the target name already has a file on disk."""
+
+
+class AgentProtectedError(Exception):
+    """Raised when a write targets the system agent or the default agent's delete guard."""
+
+
+def _validate_role(role: Any) -> None:
+    role_s = str(role or "").strip()
+    if role_s and role_s not in _list_roles():
+        raise ValueError(f"Unknown cast role: {role_s!r}")
+
+
+def _validate_mode(mode: Any) -> None:
+    mode_s = str(mode or "").strip()
+    if mode_s and mode_s not in _list_modes():
+        raise ValueError(f"Unknown cast mode: {mode_s!r}")
+
+
+def create_agent(name: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Create a new agent profile file. Refuses to overwrite an existing name so that
+    creating a second, differently-configured version of a role always requires its own
+    name. Agents created through this route are never system-owned: ``lion_system`` is
+    always stamped false so the new agent is immediately editable and deletable."""
+    validate_name_component(name, label="name")
+    safe_path_join(_AGENTS_ROOT, name)
+    stem = name.removesuffix(".md")
+    path = _AGENTS_ROOT / f"{stem}.md"
+    if path.exists():
+        raise AgentExistsError(f"Agent '{stem}' already exists")
+
+    incoming = _normalize_frontmatter(data)
+    _validate_role(incoming.get("role"))
+    _validate_mode(incoming.get("mode"))
+
+    fm: dict[str, Any] = {}
+    for key in _KNOWN_FRONTMATTER_KEYS:
+        if key not in incoming:
+            continue
+        value = incoming[key]
+        if value not in (None, ""):
+            fm[key] = value
+
+    fm["lion_system"] = False
+
+    if "model" in fm:
+        model = _canonical_model(fm.get("model"), fm.get("provider"))
+        if model:
+            fm["model"] = model
+        else:
+            fm.pop("model", None)
+
+    body = (data.get("system_prompt") or "").strip()
+
+    _AGENTS_ROOT.mkdir(parents=True, exist_ok=True)
+    if fm:
+        fm_text = yaml.safe_dump(fm, sort_keys=False, allow_unicode=True).rstrip()
+        new_text = f"---\n{fm_text}\n---\n\n{body}\n" if body else f"---\n{fm_text}\n---\n"
+    else:
+        new_text = f"{body}\n" if body else ""
+
+    path.write_text(new_text)
+    return get_agent(stem)
+
+
+def delete_agent(name: str) -> bool:
+    """Delete an agent profile file. Refuses the default agent (name match) and any
+    system agent (``lion_system`` true, the pre-existing default). Returns False if the
+    agent does not exist so the route can 404 instead of raising."""
+    safe_path_join(_AGENTS_ROOT, name)
+    stem = name.removesuffix(".md")
+    path = _AGENTS_ROOT / f"{stem}.md"
+    if not path.exists():
+        return False
+
+    if stem == DEFAULT_AGENT_NAME:
+        raise AgentProtectedError(f"Agent '{stem}' is the default agent and cannot be deleted")
+
+    fm = _read_frontmatter(path)
+    if _is_protected_system(fm):
+        raise AgentProtectedError(f"Agent '{stem}' is a system agent and cannot be deleted")
+
+    path.unlink()
+    return True
 
 
 def update_agent(name: str, data: dict[str, Any]) -> dict[str, Any] | None:
@@ -135,8 +262,13 @@ def update_agent(name: str, data: dict[str, Any]) -> dict[str, Any] | None:
     existing_fm, existing_body = _parse_frontmatter(existing_text)
     existing_fm = _normalize_frontmatter(existing_fm)
 
+    if _is_protected_system(existing_fm):
+        raise AgentProtectedError(f"Agent '{stem}' is a system agent and cannot be edited")
+
     fm: dict[str, Any] = dict(existing_fm)
     incoming = _normalize_frontmatter(data)
+    _validate_role(incoming.get("role"))
+    _validate_mode(incoming.get("mode"))
     for key in _KNOWN_FRONTMATTER_KEYS:
         if key not in incoming:
             continue
@@ -183,26 +315,42 @@ async def get_agent_route(name: str) -> dict[str, Any]:
     return agent
 
 
-@studio_route("/agents/{name}", method="POST", area="agents")
-async def create_agent(name: str) -> dict[str, Any]:
-    # TODO(lift-backend-writes)
-    raise HTTPException(status_code=501, detail="Not implemented")
+@studio_route("/agents/{name}", method="POST", area="agents", name="create_agent")
+async def create_agent_route(
+    name: str, body: Annotated[dict[str, Any], Body(default_factory=dict)]
+) -> dict[str, Any]:
+    try:
+        return await anyio.to_thread.run_sync(partial(create_agent, name, body))
+    except AgentExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
 
 
 @studio_route("/agents/{name}", method="PUT", area="agents", name="update_agent")
 async def update_agent_route(
     name: str, body: Annotated[dict[str, Any], Body(...)]
 ) -> dict[str, Any]:
-    updated = await anyio.to_thread.run_sync(partial(update_agent, name, body))
+    try:
+        updated = await anyio.to_thread.run_sync(partial(update_agent, name, body))
+    except AgentProtectedError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
     if updated is None:
         raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
     return updated
 
 
-@studio_route("/agents/{name}", method="DELETE", area="agents")
-async def delete_agent(name: str) -> dict[str, Any]:
-    # TODO(lift-backend-writes)
-    raise HTTPException(status_code=501, detail="Not implemented")
+@studio_route("/agents/{name}", method="DELETE", area="agents", name="delete_agent")
+async def delete_agent_route(name: str) -> dict[str, Any]:
+    try:
+        deleted = await anyio.to_thread.run_sync(partial(delete_agent, name))
+    except AgentProtectedError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
+    return {"deleted": True, "name": name}
 
 
 @studio_route("/agents/{name}/validate", method="POST", area="agents")

--- a/lionagi/studio/services/agents.py
+++ b/lionagi/studio/services/agents.py
@@ -25,20 +25,30 @@ DEFAULT_AGENT_NAME = "default"
 
 
 def _is_protected_system(fm: dict[str, Any]) -> bool:
-    """True only when a file explicitly opts into ``lion_system: true``.
+    """True when a file's frontmatter carries a present, truthy ``lion_system``.
 
     ``lion_system`` already exists as a frontmatter flag (get_agent() has always
     surfaced it, defaulting True, for CLI parity -- see
     ``AgentProfile``/``AgentSpec.compose`` in ``lionagi/cli``). Write-protection
-    reuses that same flag rather than inventing a new one, but only the explicit
-    ``true`` value counts: treating an *absent* key as protected would silently
-    lock down every agent file that predates this feature (plain markdown with
-    no frontmatter at all is common -- see the generic definitions save path),
-    which is not what "the system agent cannot be edited" means. Agents created
-    through the Studio API stamp ``lion_system: false`` explicitly, so they are
-    unambiguously editable/deletable by their owner.
+    reuses that same flag rather than inventing a new one. Two things matter here:
+
+    - Present and truthy counts, whatever its YAML type -- ``true``, ``"true"``,
+      or any other value Python considers truthy -- so this agrees with the
+      runtime's own ``bool(frontmatter.get("lion_system", True))`` check in
+      ``lionagi/cli/_providers.py`` for every value that's actually there.
+    - An *absent* key does not count as protected: treating a missing key as
+      protected would silently lock down every agent file that predates this
+      feature (plain markdown with no frontmatter at all is common -- see the
+      generic definitions save path), which is not what "the system agent
+      cannot be edited" means. Agents created through the Studio API stamp
+      ``lion_system: false`` explicitly, so they are unambiguously
+      editable/deletable by their owner.
+
+    This is the single place both write-protection call sites (this module and
+    ``definitions.py``'s agent save path) resolve the predicate, so they cannot
+    drift apart from each other or from the runtime again.
     """
-    return fm.get("lion_system") is True
+    return "lion_system" in fm and bool(fm["lion_system"])
 
 
 def _read_frontmatter(path) -> dict[str, Any]:

--- a/lionagi/studio/services/agents.py
+++ b/lionagi/studio/services/agents.py
@@ -178,16 +178,37 @@ class AgentProtectedError(Exception):
     """Raised when a write targets the system agent or the default agent's delete guard."""
 
 
-def _validate_role(role: Any) -> None:
+def _canonical_role(role: Any) -> str:
+    """Validate a role and return the exact value that should be stored.
+
+    The stored value is what the runtime looks up, and that lookup is exact
+    (``AgentSpec.coding()``). Validating a stripped copy while writing the
+    original back would accept ``" critic "`` here and fail to launch it later,
+    so the canonical form is what both the check and the write use.
+    """
     role_s = str(role or "").strip()
     if role_s and role_s not in _list_roles():
         raise ValueError(f"Unknown cast role: {role_s!r}")
+    return role_s
 
 
-def _validate_mode(mode: Any) -> None:
+def _canonical_mode(mode: Any) -> str:
+    """Validate a mode and return the exact value that should be stored. Same
+    reasoning as ``_canonical_role``."""
     mode_s = str(mode or "").strip()
     if mode_s and mode_s not in _list_modes():
         raise ValueError(f"Unknown cast mode: {mode_s!r}")
+    return mode_s
+
+
+def _canonicalize_casts(incoming: dict[str, Any]) -> None:
+    """Validate role and mode in place, so every write path stores the same
+    form it validated. Absent keys stay absent -- an omitted role is not the
+    same request as an empty one."""
+    if "role" in incoming:
+        incoming["role"] = _canonical_role(incoming.get("role"))
+    if "mode" in incoming:
+        incoming["mode"] = _canonical_mode(incoming.get("mode"))
 
 
 def create_agent(name: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -203,8 +224,7 @@ def create_agent(name: str, data: dict[str, Any]) -> dict[str, Any]:
         raise AgentExistsError(f"Agent '{stem}' already exists")
 
     incoming = _normalize_frontmatter(data)
-    _validate_role(incoming.get("role"))
-    _validate_mode(incoming.get("mode"))
+    _canonicalize_casts(incoming)
 
     fm: dict[str, Any] = {}
     for key in _KNOWN_FRONTMATTER_KEYS:
@@ -277,8 +297,7 @@ def update_agent(name: str, data: dict[str, Any]) -> dict[str, Any] | None:
 
     fm: dict[str, Any] = dict(existing_fm)
     incoming = _normalize_frontmatter(data)
-    _validate_role(incoming.get("role"))
-    _validate_mode(incoming.get("mode"))
+    _canonicalize_casts(incoming)
     for key in _KNOWN_FRONTMATTER_KEYS:
         if key not in incoming:
             continue

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -16,6 +16,7 @@ from lionagi.state.db import DEFAULT_DB_PATH
 from ..registry import studio_route
 from ._db import open_db as _open_db
 from ._path_safety import validate_name_component
+from .agents import _is_protected_system
 
 # Per-(kind, name) concurrency lock, shared across all requests in this process.
 # Spans both the DB write and the disk write so a crash between them cannot leave disk ahead of history.
@@ -238,10 +239,7 @@ async def save_definition(
 
             existing_text = await anyio.to_thread.run_sync(disk_file.read_text)
             existing_fm, _ = _parse_fm(existing_text)
-            # Explicit-only: an absent key must not retroactively lock down every
-            # agent file that predates this protection (see agents.py's
-            # _is_protected_system for the full rationale -- kept in sync here).
-            if existing_fm.get("lion_system") is True:
+            if _is_protected_system(existing_fm):
                 raise PermissionError(f"Agent '{name}' is a system agent and cannot be edited")
 
         now = time.time()

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -227,6 +227,22 @@ async def save_definition(
         disk_file = await anyio.to_thread.run_sync(partial(_find_definition_file, base, name))
         if not disk_file:
             disk_file = base / f"{name}{_DEFAULT_EXT.get(kind, '.md')}"
+        elif kind == "agent":
+            # This route upserts blindly by design (ADR-0077), so it's the other write
+            # path onto agent files besides PUT /agents/{name} -- the same "system
+            # agent is not editable" rule (lionagi/studio/services/agents.py) has to
+            # hold here too, or it's a bypass. Read straight off disk_file rather than
+            # calling into agents.py, since that module resolves its own _AGENTS_ROOT
+            # independently of this module's (test-patchable) AGENTS_DIR/KIND_DIRS.
+            from lionagi.libs.frontmatter import parse_frontmatter as _parse_fm
+
+            existing_text = await anyio.to_thread.run_sync(disk_file.read_text)
+            existing_fm, _ = _parse_fm(existing_text)
+            # Explicit-only: an absent key must not retroactively lock down every
+            # agent file that predates this protection (see agents.py's
+            # _is_protected_system for the full rationale -- kept in sync here).
+            if existing_fm.get("lion_system") is True:
+                raise PermissionError(f"Agent '{name}' is a system agent and cannot be edited")
 
         now = time.time()
 
@@ -405,6 +421,8 @@ async def save_definition_route(kind: str, name: str, body: SaveBody) -> dict[st
     # service layer; catch it and return 422 instead of propagating a 500.
     try:
         return await save_definition(kind, name, body.content, body.message)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 

--- a/tests/apps_studio_server/test_agents_protections.py
+++ b/tests/apps_studio_server/test_agents_protections.py
@@ -1,0 +1,412 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Studio agent create/delete and the system/default agent protections.
+
+lionagi/studio/services/agents.py previously left POST and DELETE unimplemented
+(501). These tests exercise the create/delete/update paths added to support
+multiple, independently-configured agent versions per cast role, and verify the
+protection rules run in both directions: a protected agent refuses the write,
+and an ordinary agent accepts it (a test that would pass even if every write
+were blocked proves nothing)."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+pytest.importorskip("yaml", reason="PyYAML not installed")
+
+
+def _write_agent_md(path, content: str) -> None:
+    path.write_text(textwrap.dedent(content))
+
+
+def _make_agents_root(tmp_path, monkeypatch):
+    import lionagi.studio.services.agents as agents_mod
+
+    root = tmp_path / "agents"
+    root.mkdir()
+    monkeypatch.setattr(agents_mod, "_AGENTS_ROOT", root)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# create_agent()
+# ---------------------------------------------------------------------------
+
+
+def test_create_agent_writes_file_and_defaults_to_editable(tmp_path, monkeypatch):
+    """A freshly created agent is never system-owned, regardless of what's posted."""
+    from lionagi.studio.services.agents import create_agent, get_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+
+    created = create_agent(
+        "my-critic",
+        {
+            "provider": "claude",
+            "model": "claude-sonnet-4-6",
+            "role": "critic",
+            "system_prompt": "Be harsh.",
+            "lion_system": True,  # client-supplied; must be ignored
+        },
+    )
+
+    assert created["name"] == "my-critic"
+    assert created["lion_system"] is False
+    assert created["role"] == "critic"
+    assert created["system_prompt"] == "Be harsh."
+
+    fresh = get_agent("my-critic")
+    assert fresh is not None
+    assert fresh["lion_system"] is False
+
+
+def test_create_agent_rejects_duplicate_name(tmp_path, monkeypatch):
+    from lionagi.studio.services.agents import AgentExistsError, create_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+
+    create_agent("dup", {"provider": "claude", "model": "claude-sonnet-4-6"})
+    with pytest.raises(AgentExistsError):
+        create_agent("dup", {"provider": "claude", "model": "claude-sonnet-4-6"})
+
+
+def test_create_agent_rejects_unknown_role(tmp_path, monkeypatch):
+    from lionagi.studio.services.agents import create_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="Unknown cast role"):
+        create_agent("bogus-role-agent", {"role": "not-a-real-role"})
+
+
+def test_create_agent_rejects_unknown_mode(tmp_path, monkeypatch):
+    from lionagi.studio.services.agents import create_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="Unknown cast mode"):
+        create_agent("bogus-mode-agent", {"mode": "not-a-real-mode"})
+
+
+def test_create_two_versions_of_the_same_role(tmp_path, monkeypatch):
+    """Two independently named, independently configured agents can both wrap 'critic'."""
+    from lionagi.casts.pattern import list_modes
+    from lionagi.studio.services.agents import create_agent, list_agents
+
+    _make_agents_root(tmp_path, monkeypatch)
+    modes = list_modes()
+    assert len(modes) >= 2, "need at least two real modes to prove they aren't invented"
+
+    create_agent(
+        "critic-fast",
+        {"role": "critic", "model": "claude-haiku-4-5", "effort": "low", "mode": modes[0]},
+    )
+    create_agent(
+        "critic-deep",
+        {"role": "critic", "model": "claude-opus-5", "effort": "xhigh", "mode": modes[1]},
+    )
+
+    agents = {a["name"]: a for a in list_agents()}
+    assert agents["critic-fast"]["role"] == "critic"
+    assert agents["critic-deep"]["role"] == "critic"
+    assert agents["critic-fast"]["mode"] == modes[0]
+    assert agents["critic-deep"]["mode"] == modes[1]
+    assert agents["critic-fast"]["model"] != agents["critic-deep"]["model"]
+
+
+def test_every_cast_role_can_become_an_agent_template(tmp_path, monkeypatch):
+    """Every built-in role name is accepted by create_agent's role validation."""
+    from lionagi.casts.pattern import list_roles
+    from lionagi.studio.services.agents import _validate_role
+
+    _make_agents_root(tmp_path, monkeypatch)
+    roles = list_roles()
+    assert len(roles) > 5, "sanity: the built-in role catalog should not be near-empty"
+    for role in roles:
+        _validate_role(role)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# delete_agent() protections
+# ---------------------------------------------------------------------------
+
+
+def test_delete_ordinary_agent_succeeds(tmp_path, monkeypatch):
+    from lionagi.studio.services.agents import create_agent, delete_agent, get_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+    create_agent("throwaway", {"provider": "claude", "model": "claude-sonnet-4-6"})
+
+    assert delete_agent("throwaway") is True
+    assert get_agent("throwaway") is None
+
+
+def test_delete_missing_agent_returns_false(tmp_path, monkeypatch):
+    from lionagi.studio.services.agents import delete_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+    assert delete_agent("never-existed") is False
+
+
+def test_delete_agent_without_lion_system_key_is_not_protected(tmp_path, monkeypatch):
+    """A plain file with no lion_system key at all (common for hand-authored profiles
+    and the generic definitions save path) is NOT treated as a system agent -- only an
+    explicit lion_system: true is. get_agent() still displays lion_system: true for such
+    a file (CLI-parity default), but that display default must not gate deletion."""
+    from lionagi.studio.services.agents import delete_agent, get_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    _write_agent_md(
+        root / "hand-authored.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        role: critic
+        ---
+        No lion_system key at all.
+        """,
+    )
+
+    assert get_agent("hand-authored")["lion_system"] is True  # display default
+    assert get_agent("hand-authored")["protected"] is False  # but not write-protected
+    assert delete_agent("hand-authored") is True
+
+
+def test_delete_explicit_system_agent_refused(tmp_path, monkeypatch):
+    from lionagi.studio.services.agents import AgentProtectedError, delete_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    _write_agent_md(
+        root / "sysagent.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        lion_system: true
+        ---
+        System prompt.
+        """,
+    )
+
+    with pytest.raises(AgentProtectedError):
+        delete_agent("sysagent")
+
+
+def test_delete_default_agent_refused_even_when_user_owned(tmp_path, monkeypatch):
+    """The 'default' agent cannot be deleted even though it is otherwise a normal,
+    editable (lion_system: false) agent -- name-based protection, not system-based."""
+    from lionagi.studio.services.agents import (
+        DEFAULT_AGENT_NAME,
+        AgentProtectedError,
+        create_agent,
+        delete_agent,
+        get_agent,
+    )
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    assert DEFAULT_AGENT_NAME == "default"
+    create_agent(DEFAULT_AGENT_NAME, {"provider": "claude", "model": "claude-sonnet-4-6"})
+    assert get_agent(DEFAULT_AGENT_NAME)["lion_system"] is False  # editable, not system
+
+    with pytest.raises(AgentProtectedError):
+        delete_agent(DEFAULT_AGENT_NAME)
+    assert (root / "default.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# update_agent() protections
+# ---------------------------------------------------------------------------
+
+
+def test_edit_system_agent_refused(tmp_path, monkeypatch):
+    from lionagi.studio.services.agents import AgentProtectedError, update_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    _write_agent_md(
+        root / "sysagent.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        lion_system: true
+        ---
+        Original prompt.
+        """,
+    )
+
+    with pytest.raises(AgentProtectedError):
+        update_agent("sysagent", {"model": "claude-opus-5"})
+
+    # Untouched on disk.
+    assert "Original prompt." in (root / "sysagent.md").read_text()
+    assert "claude-opus-5" not in (root / "sysagent.md").read_text()
+
+
+def test_edit_ordinary_agent_succeeds(tmp_path, monkeypatch):
+    from lionagi.studio.services.agents import create_agent, update_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+    create_agent("editable", {"provider": "claude", "model": "claude-sonnet-4-6"})
+
+    updated = update_agent("editable", {"effort": "high"})
+    assert updated is not None
+    assert updated["effort"] == "high"
+
+
+def test_edit_default_agent_succeeds(tmp_path, monkeypatch):
+    """Delete-protected, but editing the default agent is allowed."""
+    from lionagi.studio.services.agents import DEFAULT_AGENT_NAME, create_agent, update_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+    create_agent(DEFAULT_AGENT_NAME, {"provider": "claude", "model": "claude-sonnet-4-6"})
+
+    updated = update_agent(DEFAULT_AGENT_NAME, {"effort": "medium"})
+    assert updated is not None
+    assert updated["effort"] == "medium"
+
+
+# ---------------------------------------------------------------------------
+# HTTP route wiring (protection status codes)
+# ---------------------------------------------------------------------------
+
+
+def _make_patched_client(tmp_path, monkeypatch):
+    import lionagi.studio.services.agents as agents_mod
+
+    root = tmp_path / "agents"
+    root.mkdir()
+    monkeypatch.setattr(agents_mod, "_AGENTS_ROOT", root)
+
+    from fastapi.testclient import TestClient
+
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765"), root
+
+
+def test_route_create_then_duplicate_conflicts(tmp_path, monkeypatch):
+    client, _ = _make_patched_client(tmp_path, monkeypatch)
+
+    r1 = client.post(
+        "/api/agents/route-agent", json={"provider": "claude", "model": "claude-sonnet-4-6"}
+    )
+    assert r1.status_code == 200, r1.text
+
+    r2 = client.post(
+        "/api/agents/route-agent", json={"provider": "claude", "model": "claude-sonnet-4-6"}
+    )
+    assert r2.status_code == 409, r2.text
+
+
+def test_route_delete_system_agent_is_403(tmp_path, monkeypatch):
+    client, root = _make_patched_client(tmp_path, monkeypatch)
+    _write_agent_md(
+        root / "sysagent.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        lion_system: true
+        ---
+        System prompt.
+        """,
+    )
+
+    r = client.delete("/api/agents/sysagent")
+    assert r.status_code == 403, r.text
+
+
+def test_route_delete_ordinary_agent_is_200(tmp_path, monkeypatch):
+    client, _ = _make_patched_client(tmp_path, monkeypatch)
+    client.post(
+        "/api/agents/route-throwaway", json={"provider": "claude", "model": "claude-sonnet-4-6"}
+    )
+
+    r = client.delete("/api/agents/route-throwaway")
+    assert r.status_code == 200, r.text
+
+    r2 = client.get("/api/agents/route-throwaway")
+    assert r2.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# The generic /definitions/agent/{name} save route is the other write path onto
+# agent files (Studio's own AgentDetail editor uses it, not PUT /agents/{name}).
+# It must honour the same "system agent is not editable" rule or the protection
+# added above is a no-op in practice.
+# ---------------------------------------------------------------------------
+
+
+def _make_definitions_client(tmp_path, monkeypatch):
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.agents as agents_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    agents_dir = fake_home / "agents"
+    playbooks_dir = fake_home / "playbooks"
+    agents_dir.mkdir()
+    playbooks_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
+    monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
+    # Keep agents.py's own root in sync so both write paths agree in the test.
+    monkeypatch.setattr(agents_mod, "_AGENTS_ROOT", agents_dir)
+
+    from fastapi.testclient import TestClient
+
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765"), agents_dir
+
+
+def test_definitions_save_route_refuses_system_agent(tmp_path, monkeypatch):
+    client, agents_dir = _make_definitions_client(tmp_path, monkeypatch)
+    _write_agent_md(
+        agents_dir / "sysagent.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        lion_system: true
+        ---
+        Original prompt.
+        """,
+    )
+
+    r = client.post("/api/definitions/agent/sysagent", json={"content": "# hijacked"})
+    assert r.status_code == 403, r.text
+    assert "Original prompt." in (agents_dir / "sysagent.md").read_text()
+
+
+def test_definitions_save_route_allows_ordinary_agent(tmp_path, monkeypatch):
+    client, agents_dir = _make_definitions_client(tmp_path, monkeypatch)
+    _write_agent_md(
+        agents_dir / "useragent.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        lion_system: false
+        ---
+        Original prompt.
+        """,
+    )
+
+    r = client.post("/api/definitions/agent/useragent", json={"content": "# updated"})
+    assert r.status_code == 200, r.text
+    assert (agents_dir / "useragent.md").read_text().strip() == "# updated"

--- a/tests/apps_studio_server/test_agents_protections.py
+++ b/tests/apps_studio_server/test_agents_protections.py
@@ -198,6 +198,30 @@ def test_delete_explicit_system_agent_refused(tmp_path, monkeypatch):
         delete_agent("sysagent")
 
 
+def test_delete_quoted_truthy_lion_system_is_protected(tmp_path, monkeypatch):
+    """YAML permits ``lion_system: "true"`` (a quoted string) as well as the bare
+    boolean. The runtime (lionagi/cli/_providers.py) treats both as system-owned via
+    bool(...), so the delete guard must refuse both too, not just the unquoted form."""
+    from lionagi.studio.services.agents import AgentProtectedError, delete_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    _write_agent_md(
+        root / "quotedsys.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        lion_system: "true"
+        ---
+        System prompt.
+        """,
+    )
+
+    with pytest.raises(AgentProtectedError):
+        delete_agent("quotedsys")
+    assert (root / "quotedsys.md").exists()
+
+
 def test_delete_default_agent_refused_even_when_user_owned(tmp_path, monkeypatch):
     """The 'default' agent cannot be deleted even though it is otherwise a normal,
     editable (lion_system: false) agent -- name-based protection, not system-based."""
@@ -246,6 +270,53 @@ def test_edit_system_agent_refused(tmp_path, monkeypatch):
     # Untouched on disk.
     assert "Original prompt." in (root / "sysagent.md").read_text()
     assert "claude-opus-5" not in (root / "sysagent.md").read_text()
+
+
+def test_edit_quoted_truthy_lion_system_is_protected(tmp_path, monkeypatch):
+    """Same quoted-string case as the delete guard, for the update path."""
+    from lionagi.studio.services.agents import AgentProtectedError, update_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    _write_agent_md(
+        root / "quotedsys.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        lion_system: "true"
+        ---
+        Original prompt.
+        """,
+    )
+
+    with pytest.raises(AgentProtectedError):
+        update_agent("quotedsys", {"model": "claude-opus-5"})
+
+    assert "Original prompt." in (root / "quotedsys.md").read_text()
+    assert "claude-opus-5" not in (root / "quotedsys.md").read_text()
+
+
+def test_edit_agent_without_lion_system_key_is_not_protected(tmp_path, monkeypatch):
+    """Pins the deliberate exception on the update path: a profile with no
+    lion_system key at all is still editable (see the delete-path equivalent,
+    test_delete_agent_without_lion_system_key_is_not_protected, for the rationale)."""
+    from lionagi.studio.services.agents import update_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    _write_agent_md(
+        root / "hand-authored.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        ---
+        No lion_system key at all.
+        """,
+    )
+
+    updated = update_agent("hand-authored", {"effort": "high"})
+    assert updated is not None
+    assert updated["effort"] == "high"
 
 
 def test_edit_ordinary_agent_succeeds(tmp_path, monkeypatch):
@@ -391,6 +462,27 @@ def test_definitions_save_route_refuses_system_agent(tmp_path, monkeypatch):
     r = client.post("/api/definitions/agent/sysagent", json={"content": "# hijacked"})
     assert r.status_code == 403, r.text
     assert "Original prompt." in (agents_dir / "sysagent.md").read_text()
+
+
+def test_definitions_save_route_refuses_quoted_truthy_lion_system(tmp_path, monkeypatch):
+    """Same quoted-string case as the PUT/DELETE guards, for the generic definitions
+    save path -- it must resolve the same predicate, not a hand-rolled copy of it."""
+    client, agents_dir = _make_definitions_client(tmp_path, monkeypatch)
+    _write_agent_md(
+        agents_dir / "quotedsys.md",
+        """\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        lion_system: "true"
+        ---
+        Original prompt.
+        """,
+    )
+
+    r = client.post("/api/definitions/agent/quotedsys", json={"content": "# hijacked"})
+    assert r.status_code == 403, r.text
+    assert "Original prompt." in (agents_dir / "quotedsys.md").read_text()
 
 
 def test_definitions_save_route_allows_ordinary_agent(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_agents_protections.py
+++ b/tests/apps_studio_server/test_agents_protections.py
@@ -122,13 +122,84 @@ def test_create_two_versions_of_the_same_role(tmp_path, monkeypatch):
 def test_every_cast_role_can_become_an_agent_template(tmp_path, monkeypatch):
     """Every built-in role name is accepted by create_agent's role validation."""
     from lionagi.casts.pattern import list_roles
-    from lionagi.studio.services.agents import _validate_role
+    from lionagi.studio.services.agents import _canonical_role
 
     _make_agents_root(tmp_path, monkeypatch)
     roles = list_roles()
     assert len(roles) > 5, "sanity: the built-in role catalog should not be near-empty"
     for role in roles:
-        _validate_role(role)  # must not raise
+        assert _canonical_role(role) == role  # must not raise, must not alter
+
+
+def test_create_agent_stores_the_role_it_validated(tmp_path, monkeypatch):
+    """Padded input must be stored stripped: the runtime's role lookup is exact, so
+    persisting ' critic ' after validating 'critic' writes a profile that passes the
+    API and then fails to launch."""
+    from lionagi.casts.pattern import list_roles
+    from lionagi.studio.services.agents import create_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    roles = list_roles()
+    assert "critic" in roles, "sanity: this test's padded value must wrap a real role"
+
+    created = create_agent("padded-role", {"role": "  critic  "})
+
+    assert created["role"] == "critic"
+    assert created["role"] in roles
+    assert "role: critic\n" in (root / "padded-role.md").read_text()
+
+
+def test_create_agent_stores_the_mode_it_validated(tmp_path, monkeypatch):
+    from lionagi.casts.pattern import list_modes
+    from lionagi.studio.services.agents import create_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    modes = list_modes()
+    assert modes, "sanity: the built-in mode catalog should not be empty"
+    mode = modes[0]
+
+    created = create_agent("padded-mode", {"mode": f"  {mode}  "})
+
+    assert created["mode"] == mode
+    assert created["mode"] in modes
+    assert f"mode: {mode}\n" in (root / "padded-mode.md").read_text()
+
+
+def test_update_agent_stores_the_role_and_mode_it_validated(tmp_path, monkeypatch):
+    """The PUT path canonicalises for the same reason the create path does."""
+    from lionagi.casts.pattern import list_modes, list_roles
+    from lionagi.studio.services.agents import create_agent, get_agent, update_agent
+
+    root = _make_agents_root(tmp_path, monkeypatch)
+    roles = list_roles()
+    modes = list_modes()
+    assert "critic" in roles and modes
+    mode = modes[0]
+
+    create_agent("edited", {"provider": "claude", "model": "claude-sonnet-4-6"})
+    updated = update_agent("edited", {"role": "\tcritic ", "mode": f" {mode}\n"})
+
+    assert updated is not None
+    assert updated["role"] == "critic"
+    assert updated["mode"] == mode
+
+    text = (root / "edited.md").read_text()
+    assert "role: critic\n" in text
+    assert f"mode: {mode}\n" in text
+
+    fresh = get_agent("edited")
+    assert fresh["role"] in roles
+    assert fresh["mode"] in modes
+
+
+def test_padded_unknown_role_is_still_rejected(tmp_path, monkeypatch):
+    """Canonicalising must not become a way to smuggle an unknown role past the check."""
+    from lionagi.studio.services.agents import create_agent
+
+    _make_agents_root(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="Unknown cast role"):
+        create_agent("padded-bogus-role", {"role": "  not-a-real-role  "})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_agents_roundtrip.py
+++ b/tests/apps_studio_server/test_agents_roundtrip.py
@@ -208,6 +208,7 @@ def test_update_agent_writes_yolo_field(tmp_path, monkeypatch):
         provider: claude
         model: claude-sonnet-4-6
         yolo: true
+        lion_system: false
         ---
         System prompt here.
         """,
@@ -305,6 +306,7 @@ def test_update_agent_canonicalises_model_with_provider(tmp_path, monkeypatch):
         ---
         provider: claude
         model: claude-sonnet-4-6
+        lion_system: false
         ---
         Agent body.
         """,


### PR DESCRIPTION
Agent create and delete returned 501 from Studio. This implements them, with protections on the agents that must not be removed.

- Create an agent with a role and mode; delete ordinary agents.
- The system agent cannot be edited or deleted and the default agent cannot be deleted, enforced at the write routes on the existing flag rather than a second notion of "system".
- Role and mode are validated against the cast catalog on the structured agent routes, and the value that was validated is the value stored. Validating a stripped copy while writing the original back accepted `role: "  critic  "` and produced a profile that could not be launched, since the runtime's role lookup is exact.
- Tests run both directions: the refusals hold, and editing or deleting an ordinary agent still succeeds, so a block-everything implementation fails.

Scope note on that validation: it covers the structured routes (`POST`/`PUT /api/agents/{name}`). The definitions route writes agent frontmatter verbatim by design, as a versioned content store, so it does not canonicalise. That gap predates this branch and is tracked in #2774, which also records why the obvious fix is not free: `save_definition` is the writer behind version rollback and snapshot-from-disk import, so a strict rejection there would make an already-malformed historical version un-rollbackable.

Known follow-up: the new panel uses plain string literals rather than translated keys, which is inconsistent with the rest of the Library surface. Filed separately rather than left silent.

Closes #2738
Closes #2740
