### PR TITLE
feat(studio): stable creation-ordered mission board with a bounded table view

### DIFF
--- a/apps/studio/frontend/src/components/mission/LiveBoard.test.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.test.tsx
@@ -8,13 +8,33 @@
  * covers what actually reaches the DOM: StatusDot status + stale label.
  */
 
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import * as React from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { IntlProvider } from "use-intl";
 import enMessages from "@/messages/en.json";
 import type { RunSummary } from "@/lib/types";
+import type { InvocationSummary } from "@/lib/api";
+
+// jsdom's built-in `window.localStorage` in this vitest environment is a
+// stub with no Storage methods (no --localstorage-file wired up) — mounting
+// LiveBoard now reads a view preference from it, so tests need a working
+// implementation, same as a real browser provides.
+function installLocalStorageStub() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+      setItem: (key: string, value: string) => {
+        store.set(key, String(value));
+      },
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+    },
+  });
+}
 
 // LiveBoard cards route through <Link> for deep-linking, which needs a full
 // RouterProvider tree to resolve `useLinkProps`. These tests only assert on
@@ -58,6 +78,10 @@ describe("LiveBoard — RunCard dead-health rendering", () => {
   let container: HTMLDivElement;
   let root: Root;
 
+  beforeEach(() => {
+    installLocalStorageStub();
+  });
+
   afterEach(() => {
     act(() => {
       root.unmount();
@@ -100,5 +124,149 @@ describe("LiveBoard — RunCard dead-health rendering", () => {
     const dot = container.querySelector('[aria-hidden="true"].rounded-full');
     expect(dot?.className).toContain("live-pulse-dot");
     expect(container.textContent).not.toContain("quiet — check?");
+  });
+});
+
+// ─── Board rendering: interleaved order, view toggle, persistence ────────────
+
+function invocation(overrides: Partial<InvocationSummary> = {}): InvocationSummary {
+  return {
+    id: "inv-0000000000000001",
+    skill: "code-review",
+    plugin: null,
+    prompt: null,
+    started_at: 0,
+    ended_at: null,
+    status: "running",
+    session_count: 1,
+    created_at: 0,
+    updated_at: 0,
+    node_metadata: null,
+    ...overrides,
+  };
+}
+
+describe("LiveBoard — combined card order and view switching", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    installLocalStorageStub();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function mount(runs: RunSummary[], invocations: InvocationSummary[] = []) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <LiveBoard activeRuns={runs} activeInvocations={invocations} nowSec={1000} />
+        </IntlProvider>,
+      );
+    });
+  }
+
+  it("interleaves runs and invocations into one creation-ordered board, not two separate groups", () => {
+    mount(
+      [
+        run({ run_id: "run-a", started_at: 300, playbook_name: "run-a" }),
+        run({ run_id: "run-b", started_at: 100, playbook_name: "run-b" }),
+      ],
+      [invocation({ id: "inv-a", started_at: 200, skill: "inv-a" })],
+    );
+    // Grid renders a flat sequence of cards — the DOM order is the read
+    // order. Sorted by started_at: run-b (100), inv-a (200), run-a (300).
+    // A card query that grabs each card's <span> name in document order
+    // proves the merge, not two concatenated per-kind lists.
+    const names = container.querySelectorAll(".group span.truncate");
+    const text = Array.from(names).map((n) => n.textContent);
+    expect(text[0]).toBe("run-b");
+    expect(text.some((_, i) => text[i] === "inv-a")).toBe(true);
+    const order = ["run-b", "inv-a", "run-a"];
+    const positions = order.map((name) => text.indexOf(name));
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it("defaults to the cards view and switches to the table view on click", () => {
+    mount([run({ run_id: "r1", started_at: 100, playbook_name: "solo-run" })]);
+    expect(container.querySelector("table")).toBeNull();
+    const tableButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Table",
+    );
+    expect(tableButton).toBeDefined();
+    act(() => {
+      tableButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.textContent).toContain("solo-run");
+  });
+
+  it("table view renders one row per card with name, status, uptime, last-activity, kind, and id", () => {
+    mount([run({ run_id: "run-abcdef0123456789", started_at: 900, playbook_name: "table-run" })]);
+    const tableButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Table",
+    );
+    act(() => {
+      tableButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows).toHaveLength(1);
+    const cells = rows[0].querySelectorAll("td");
+    expect(cells).toHaveLength(6);
+    expect(rows[0].textContent).toContain("table-run");
+    expect(rows[0].textContent).toContain("run");
+    expect(rows[0].textContent).toContain("run-abcdef0123456789".slice(-16));
+  });
+
+  it("persists the view choice across remounts via localStorage", () => {
+    mount([run({ run_id: "r1", started_at: 100 })]);
+    const tableButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Table",
+    );
+    act(() => {
+      tableButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(window.localStorage.getItem("studio:mission-board-view")).toBe("table");
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    // Remount fresh — the stored preference (not the component default)
+    // decides what's on screen first.
+    mount([run({ run_id: "r1", started_at: 100 })]);
+    expect(container.querySelector("table")).not.toBeNull();
+  });
+
+  it("bounds the board's footprint with an internally-scrolling container in both views", () => {
+    mount([run({ run_id: "r1", started_at: 100 })]);
+    const cardsRegion = container.querySelector('[class*="max-h-"]');
+    expect(cardsRegion).not.toBeNull();
+    expect(cardsRegion?.className).toContain("overflow-y-auto");
+
+    const tableButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Table",
+    );
+    act(() => {
+      tableButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const tableRegion = container.querySelector('[class*="max-h-"]');
+    expect(tableRegion).not.toBeNull();
+    expect(tableRegion?.className).toMatch(/overflow-(y-)?auto/);
+  });
+
+  it("empty board shows no cards, no table, and no view toggle", () => {
+    mount([], []);
+    expect(container.querySelector("table")).toBeNull();
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+    expect(container.textContent).toContain("No active runs or invocations.");
   });
 });

--- a/apps/studio/frontend/src/components/mission/LiveBoard.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.tsx
@@ -12,6 +12,7 @@
  * "quiet — check?" flag; duration alone never does.
  */
 
+import { useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 import SectionLabel from "@/components/ui/SectionLabel";
@@ -21,6 +22,7 @@ import Skeleton from "@/components/ui/Skeleton";
 import type { RunSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
 import { runDeepLink, invocationDeepLink } from "@/lib/runDeepLink";
+import { runCreationKey, invocationCreationKey } from "./boardReducer";
 
 /**
  * Health states meaning the process is gone even though the run is
@@ -193,9 +195,172 @@ export function LiveBoardSkeleton() {
   );
 }
 
+// The board is one grid of cards, not "runs, then invocations" — a card's
+// position is its creation order regardless of which kind it is, so a run
+// that started a minute ago sits before an invocation that started just now,
+// not after every run. Both key functions live in boardReducer.ts (the same
+// rule that orders activeRuns/activeInvocations individually), so the merge
+// below can't drift from the per-list order the reducer already guarantees.
+type LiveCard =
+  | { kind: "run"; id: string; sortKey: number; run: RunSummary }
+  | { kind: "invocation"; id: string; sortKey: number; invocation: InvocationSummary };
+
+function buildLiveCards(runs: RunSummary[], invocations: InvocationSummary[]): LiveCard[] {
+  const cards: LiveCard[] = [
+    ...runs.map((run) => ({
+      kind: "run" as const,
+      id: run.run_id,
+      sortKey: runCreationKey(run),
+      run,
+    })),
+    ...invocations.map((inv) => ({
+      kind: "invocation" as const,
+      id: inv.id,
+      sortKey: invocationCreationKey(inv),
+      invocation: inv,
+    })),
+  ];
+  cards.sort((a, b) => a.sortKey - b.sortKey || a.id.localeCompare(b.id));
+  return cards;
+}
+
+// ─── View preference (cards / table) ───────────────────────────────────────
+// Same direct-localStorage pattern as lib/theme.ts / SplitPane / AppShell —
+// no separate persistence mechanism for one more UI toggle.
+
+type BoardView = "cards" | "table";
+
+const BOARD_VIEW_STORAGE_KEY = "studio:mission-board-view";
+
+function getStoredBoardView(): BoardView {
+  if (typeof window === "undefined") return "cards";
+  return window.localStorage.getItem(BOARD_VIEW_STORAGE_KEY) === "table" ? "table" : "cards";
+}
+
+function BoardViewToggle({
+  view,
+  onChange,
+}: {
+  view: BoardView;
+  onChange: (view: BoardView) => void;
+}) {
+  const t = useTranslations("mission");
+  const seg = (v: BoardView, label: string) => (
+    <button
+      type="button"
+      onClick={() => onChange(v)}
+      aria-pressed={view === v}
+      className={[
+        "h-6 shrink-0 rounded px-2 font-data text-[length:var(--t-xs)] font-medium transition-colors duration-100",
+        view === v
+          ? "bg-surface-overlay text-content-primary"
+          : "text-content-muted hover:text-content-primary",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+  return (
+    <div className="flex shrink-0 items-center gap-0.5 rounded border border-edge p-0.5">
+      {seg("cards", t("liveBoard.viewCards"))}
+      {seg("table", t("liveBoard.viewTable"))}
+    </div>
+  );
+}
+
+// Bounds the board's footprint regardless of how many runs are active — the
+// board scrolls internally instead of pushing Pulse/Recent Runs off screen.
+const BOARD_MAX_HEIGHT = "max-h-[420px]";
+
+function BoardTableRow({ card, nowSec }: { card: LiveCard; nowSec: number }) {
+  const t = useTranslations("mission");
+  const isRun = card.kind === "run";
+  const name = isRun
+    ? (card.run.playbook_name ?? card.run.agent_name ?? card.run.run_id.slice(-12))
+    : card.invocation.skill;
+  const startedAt = isRun ? (card.run.started_at ?? undefined) : card.invocation.started_at;
+  const elapsed = elapsedSec(startedAt, nowSec);
+  const lastActivityAt = isRun
+    ? (card.run.last_message_at ?? card.run.started_at ?? undefined)
+    : (card.invocation.updated_at ?? card.invocation.started_at);
+  const lastActivity = elapsedSec(lastActivityAt, nowSec);
+  const dead = isRun && isDeadHealth(card.run.effective_health);
+  const status = isRun ? card.run.status : card.invocation.status;
+  const linkProps = isRun ? runDeepLink(card.run.run_id) : invocationDeepLink();
+
+  return (
+    <tr className="border-b border-edge transition-colors duration-100 hover:bg-surface-overlay/60">
+      <td className="max-w-0 px-3 py-2">
+        <Link
+          {...linkProps}
+          className="block truncate font-data text-[length:var(--t-sm)] font-medium text-content-primary hover:opacity-80"
+        >
+          {name}
+        </Link>
+      </td>
+      <td className="px-3 py-2">
+        <span className="flex items-center gap-1.5">
+          <StatusDot status={dead ? "stale" : status} />
+          <span className="font-data text-[length:var(--t-xs)] text-content-secondary">
+            {dead ? t("liveBoard.staleLabel") : status}
+          </span>
+        </span>
+      </td>
+      <td className="px-3 py-2 font-data tabular-nums text-[length:var(--t-xs)] text-content-secondary">
+        {formatElapsed(elapsed)}
+      </td>
+      <td className="px-3 py-2 font-data tabular-nums text-[length:var(--t-xs)] text-content-secondary">
+        {formatElapsed(lastActivity)}
+      </td>
+      <td className="px-3 py-2">
+        <Chip mono>{isRun ? "run" : "invoke"}</Chip>
+      </td>
+      <td className="px-3 py-2 font-data text-[length:var(--t-xs)] text-content-muted">
+        {card.id.slice(-16)}
+      </td>
+    </tr>
+  );
+}
+
+function BoardTable({ cards, nowSec }: { cards: LiveCard[]; nowSec: number }) {
+  const t = useTranslations("mission");
+  return (
+    <div className={`${BOARD_MAX_HEIGHT} overflow-auto rounded border border-edge`}>
+      <table className="w-full text-left" style={{ borderCollapse: "collapse" }}>
+        <thead>
+          <tr
+            className="border-b border-edge bg-surface-raised text-[length:var(--t-xs)] uppercase tracking-[0.08em] text-content-muted"
+            style={{ position: "sticky", top: 0, zIndex: 1 }}
+          >
+            <th className="px-3 py-2 font-medium">{t("liveBoard.table.colName")}</th>
+            <th className="px-3 py-2 font-medium">{t("liveBoard.table.colStatus")}</th>
+            <th className="px-3 py-2 font-medium">{t("liveBoard.table.colUptime")}</th>
+            <th className="px-3 py-2 font-medium">{t("liveBoard.table.colLastActivity")}</th>
+            <th className="px-3 py-2 font-medium">{t("liveBoard.table.colKind")}</th>
+            <th className="px-3 py-2 font-medium">{t("liveBoard.table.colId")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cards.map((card) => (
+            <BoardTableRow key={card.id} card={card} nowSec={nowSec} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export default function LiveBoard({ activeRuns, activeInvocations, nowSec }: Props) {
   const t = useTranslations("mission");
   const total = activeRuns.length + activeInvocations.length;
+  const [view, setView] = useState<BoardView>(getStoredBoardView);
+
+  function changeView(next: BoardView) {
+    setView(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(BOARD_VIEW_STORAGE_KEY, next);
+    }
+  }
 
   return (
     <section aria-labelledby="live-board-heading">
@@ -214,6 +379,7 @@ export default function LiveBoard({ activeRuns, activeInvocations, nowSec }: Pro
                   {total}
                 </span>
               )}
+              {total > 0 && <BoardViewToggle view={view} onChange={changeView} />}
               <Link
                 to="/fleet"
                 className="font-data text-[length:var(--t-xs)] text-content-muted transition-colors duration-100"
@@ -233,14 +399,19 @@ export default function LiveBoard({ activeRuns, activeInvocations, nowSec }: Pro
             {t("liveBoard.empty")} {t("liveBoard.emptyHint")}
           </p>
         </div>
+      ) : view === "table" ? (
+        <BoardTable cards={buildLiveCards(activeRuns, activeInvocations)} nowSec={nowSec} />
       ) : (
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
-          {activeRuns.map((run) => (
-            <RunCard key={run.run_id} run={run} nowSec={nowSec} />
-          ))}
-          {activeInvocations.map((inv) => (
-            <InvocationCard key={inv.id} inv={inv} nowSec={nowSec} />
-          ))}
+        <div
+          className={`${BOARD_MAX_HEIGHT} grid grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4`}
+        >
+          {buildLiveCards(activeRuns, activeInvocations).map((card) =>
+            card.kind === "run" ? (
+              <RunCard key={card.id} run={card.run} nowSec={nowSec} />
+            ) : (
+              <InvocationCard key={card.id} inv={card.invocation} nowSec={nowSec} />
+            ),
+          )}
         </div>
       )}
     </section>

--- a/apps/studio/frontend/src/components/mission/boardReducer.test.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.test.ts
@@ -338,6 +338,104 @@ describe("boardReducer — active/recent derivation", () => {
   });
 });
 
+// ─── Live board ordering — creation order, oldest first, never recency ───────
+//
+// The bug this closes: the board reordered every few seconds because it
+// inherited the API's `ORDER BY updated_at DESC`, and updated_at bumps on
+// every message. These tests assert the properties the fix must hold, not
+// just "sorted ascending" (a recency sort would also pass an ascending
+// check on already-sorted input — it only fails once the same runs arrive
+// in a *different* API order, or one of them gets a message in between).
+
+describe("boardReducer — active board creation order", () => {
+  it("orders active runs by started_at ascending, oldest first", () => {
+    const s = dispatchOk(initialBoardState(), [
+      makeRun({ run_id: "newest", status: "running", started_at: 300 }),
+      makeRun({ run_id: "oldest", status: "running", started_at: 100 }),
+      makeRun({ run_id: "middle", status: "running", started_at: 200 }),
+    ]);
+    expect(s.activeRuns.map((r) => r.run_id)).toEqual(["oldest", "middle", "newest"]);
+  });
+
+  it("derives an identical order from the same runs fed in a different API order — order is not inherited array position", () => {
+    const runs = [
+      makeRun({ run_id: "a", status: "running", started_at: 300 }),
+      makeRun({ run_id: "b", status: "running", started_at: 100 }),
+      makeRun({ run_id: "c", status: "running", started_at: 200 }),
+    ];
+    const forward = dispatchOk(initialBoardState(), runs);
+    const shuffled = dispatchOk(initialBoardState(), [runs[2], runs[0], runs[1]]);
+    const reversed = dispatchOk(initialBoardState(), [...runs].reverse());
+    const order = forward.activeRuns.map((r) => r.run_id);
+    expect(order).toEqual(["b", "c", "a"]);
+    expect(shuffled.activeRuns.map((r) => r.run_id)).toEqual(order);
+    expect(reversed.activeRuns.map((r) => r.run_id)).toEqual(order);
+  });
+
+  it("a run's position does not move when it receives a message (updated_at/last_message_at churn only)", () => {
+    const runs = [
+      makeRun({ run_id: "a", status: "running", started_at: 100, last_message_at: 100 }),
+      makeRun({ run_id: "b", status: "running", started_at: 200, last_message_at: 200 }),
+    ];
+    const before = dispatchOk(initialBoardState(), runs);
+    // "b" just talked — a recency sort would now put it first.
+    const chatty = runs.map((r) => (r.run_id === "b" ? { ...r, last_message_at: 9_999_999 } : r));
+    const after = dispatchOk(before, chatty);
+    expect(before.activeRuns.map((r) => r.run_id)).toEqual(["a", "b"]);
+    expect(after.activeRuns.map((r) => r.run_id)).toEqual(["a", "b"]);
+  });
+
+  it("breaks a tied started_at deterministically by run_id, not array order", () => {
+    const tied = [
+      makeRun({ run_id: "z-run", status: "running", started_at: 500 }),
+      makeRun({ run_id: "a-run", status: "running", started_at: 500 }),
+    ];
+    const forward = dispatchOk(initialBoardState(), tied);
+    const reversed = dispatchOk(initialBoardState(), [...tied].reverse());
+    expect(forward.activeRuns.map((r) => r.run_id)).toEqual(["a-run", "z-run"]);
+    expect(reversed.activeRuns.map((r) => r.run_id)).toEqual(["a-run", "z-run"]);
+  });
+
+  it("a run with no started_at yet falls back to created_at rather than losing its place", () => {
+    const s = dispatchOk(initialBoardState(), [
+      makeRun({ run_id: "has-started", status: "running", started_at: 200 }),
+      makeRun({ run_id: "not-started-yet", status: "running", started_at: null, created_at: 50 }),
+    ]);
+    // created_at (50) predates the started run's started_at (200) — the
+    // undated-by-started_at run sorts first, not last-by-default and not
+    // wherever the API happened to place it.
+    expect(s.activeRuns.map((r) => r.run_id)).toEqual(["not-started-yet", "has-started"]);
+  });
+
+  it("runs with neither started_at nor created_at still produce a total, stable order (tiebreak by id)", () => {
+    const s = dispatchOk(initialBoardState(), [
+      makeRun({ run_id: "z", status: "running", started_at: null }),
+      makeRun({ run_id: "a", status: "running", started_at: null }),
+      makeRun({ run_id: "m", status: "running", started_at: 10 }),
+    ]);
+    // Dated run sorts before the undated pair; the undated pair is ordered
+    // by id, not left to whatever position the API returned them in.
+    expect(s.activeRuns.map((r) => r.run_id)).toEqual(["m", "a", "z"]);
+  });
+
+  it("orders active invocations by started_at ascending, oldest first, independent of API order", () => {
+    const invs = [
+      makeInvocation({ id: "i-new", status: "running", skill: "s", started_at: 300 }),
+      makeInvocation({ id: "i-old", status: "running", skill: "s", started_at: 100 }),
+    ];
+    const forward = dispatchOk(initialBoardState(), [], invs);
+    const reversed = dispatchOk(initialBoardState(), [], [...invs].reverse());
+    expect(forward.activeInvocations.map((i) => i.id)).toEqual(["i-old", "i-new"]);
+    expect(reversed.activeInvocations.map((i) => i.id)).toEqual(["i-old", "i-new"]);
+  });
+
+  it("empty board: no runs or invocations produces empty, stable arrays", () => {
+    const s = dispatchOk(initialBoardState(), [], []);
+    expect(s.activeRuns).toEqual([]);
+    expect(s.activeInvocations).toEqual([]);
+  });
+});
+
 // ─── TICK action ─────────────────────────────────────────────────────────────
 
 describe("boardReducer — TICK", () => {

--- a/apps/studio/frontend/src/components/mission/boardReducer.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.ts
@@ -228,8 +228,28 @@ function buildAttentionItems(
   });
 }
 
+// Board order (Running now): creation order, oldest first — never recency.
+// The API sorts by updated_at (recency), which is right for Recent Runs but
+// wrong here — updated_at bumps on every message, so a recency-ordered board
+// reshuffles mid-conversation. started_at is the moment a run actually began
+// and never changes afterward, so it's the stable key; a run can in principle
+// read "running" before started_at has landed (see the QUEUED/GATED aliases
+// and the unrecognized-status fallback in deriveDisplayStatus), so it falls
+// back to created_at, which the sessions table guarantees is always present.
+// Equal keys (same second, or two undated rows) fall back to id so the order
+// is total, not "whatever the array happened to hold."
+export function runCreationKey(run: RunSummary): number {
+  return run.started_at ?? run.created_at ?? Number.POSITIVE_INFINITY;
+}
+
+export function invocationCreationKey(inv: InvocationSummary): number {
+  return inv.started_at ?? inv.created_at ?? Number.POSITIVE_INFINITY;
+}
+
 function deriveActiveRuns(runs: RunSummary[]): RunSummary[] {
-  return runs.filter((r) => deriveDisplayStatus(r) === "running");
+  return runs
+    .filter((r) => deriveDisplayStatus(r) === "running")
+    .sort((a, b) => runCreationKey(a) - runCreationKey(b) || a.run_id.localeCompare(b.run_id));
 }
 
 function deriveRecentRuns(runs: RunSummary[]): RunSummary[] {
@@ -243,7 +263,11 @@ function deriveRecentRuns(runs: RunSummary[]): RunSummary[] {
 }
 
 function deriveActiveInvocations(invocations: InvocationSummary[]): InvocationSummary[] {
-  return invocations.filter((i) => RUNNING_STATUSES.has(i.status.toLowerCase()));
+  return invocations
+    .filter((i) => RUNNING_STATUSES.has(i.status.toLowerCase()))
+    .sort(
+      (a, b) => invocationCreationKey(a) - invocationCreationKey(b) || a.id.localeCompare(b.id),
+    );
 }
 
 // ─── Initial state ────────────────────────────────────────────────────────────

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -194,8 +194,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 786 leaves", () => {
-    expect(EN_LEAVES.size).toBe(786);
+  it("en.json has 794 leaves", () => {
+    expect(EN_LEAVES.size).toBe(794);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -754,7 +754,17 @@
       "durationStatus": "قيد التشغيل منذ {duration} · آخر نشاط منذ {age}",
       "empty": "لا توجد تشغيلات أو استدعاءات نشطة.",
       "emptyHint": "شغّل واحدًا باستخدام li CLI، أو اضغط ⌘K للانتقال إلى أي مكان.",
-      "fleetLink": "أسطول الوكلاء ←"
+      "fleetLink": "أسطول الوكلاء ←",
+      "viewCards": "بطاقات",
+      "viewTable": "جدول",
+      "table": {
+        "colName": "الاسم",
+        "colStatus": "الحالة",
+        "colUptime": "مدة التشغيل",
+        "colLastActivity": "آخر نشاط",
+        "colKind": "النوع",
+        "colId": "المعرف"
+      }
     },
     "recent": {
       "title": "الأخيرة",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -754,7 +754,17 @@
       "durationStatus": "{duration} ধরে চলছে · সর্বশেষ কার্যকলাপ {age} আগে",
       "empty": "কোনো সক্রিয় রান বা ইনভোকেশন নেই।",
       "emptyHint": "li CLI দিয়ে একটি লঞ্চ করুন, বা যেকোনো জায়গায় যেতে ⌘K চাপুন।",
-      "fleetLink": "এজেন্ট ফ্লিট →"
+      "fleetLink": "এজেন্ট ফ্লিট →",
+      "viewCards": "কার্ড",
+      "viewTable": "টেবিল",
+      "table": {
+        "colName": "নাম",
+        "colStatus": "অবস্থা",
+        "colUptime": "আপটাইম",
+        "colLastActivity": "সর্বশেষ কার্যকলাপ",
+        "colKind": "ধরন",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "সাম্প্রতিক",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -754,7 +754,17 @@
       "durationStatus": "läuft seit {duration} · letzte Aktivität vor {age}",
       "empty": "Keine aktiven Ausführungen oder Aufrufe.",
       "emptyHint": "Starte eine mit der li CLI, oder drücke ⌘K, um überallhin zu springen.",
-      "fleetLink": "Flotte →"
+      "fleetLink": "Flotte →",
+      "viewCards": "Karten",
+      "viewTable": "Tabelle",
+      "table": {
+        "colName": "Name",
+        "colStatus": "Status",
+        "colUptime": "Laufzeit",
+        "colLastActivity": "Letzte Aktivität",
+        "colKind": "Art",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "Letzte",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -754,7 +754,17 @@
       "durationStatus": "up {duration} · last activity {age} ago",
       "empty": "No active runs or invocations.",
       "emptyHint": "Launch one with the li CLI, or press ⌘K to jump anywhere.",
-      "fleetLink": "Fleet →"
+      "fleetLink": "Fleet →",
+      "viewCards": "Cards",
+      "viewTable": "Table",
+      "table": {
+        "colName": "Name",
+        "colStatus": "Status",
+        "colUptime": "Uptime",
+        "colLastActivity": "Last activity",
+        "colKind": "Kind",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "Recent",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -754,7 +754,17 @@
       "durationStatus": "activo {duration} · última actividad hace {age}",
       "empty": "No hay ejecuciones ni invocaciones activas.",
       "emptyHint": "Lanza una con la li CLI o pulsa ⌘K para saltar a cualquier lugar.",
-      "fleetLink": "Flota →"
+      "fleetLink": "Flota →",
+      "viewCards": "Tarjetas",
+      "viewTable": "Tabla",
+      "table": {
+        "colName": "Nombre",
+        "colStatus": "Estado",
+        "colUptime": "Tiempo activo",
+        "colLastActivity": "Última actividad",
+        "colKind": "Tipo",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "Reciente",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -754,7 +754,17 @@
       "durationStatus": "actif depuis {duration} · dernière activité il y a {age}",
       "empty": "Aucune exécution ou invocation active.",
       "emptyHint": "Lancez-en une avec la CLI li, ou appuyez sur ⌘K pour aller n’importe où.",
-      "fleetLink": "Flotte →"
+      "fleetLink": "Flotte →",
+      "viewCards": "Cartes",
+      "viewTable": "Tableau",
+      "table": {
+        "colName": "Nom",
+        "colStatus": "Statut",
+        "colUptime": "Durée active",
+        "colLastActivity": "Dernière activité",
+        "colKind": "Type",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "Récent",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -754,7 +754,17 @@
       "durationStatus": "{duration} से चालू · अंतिम गतिविधि {age} पहले",
       "empty": "कोई सक्रिय रन या इनवोकेशन नहीं।",
       "emptyHint": "li CLI से एक लॉन्च करें, या कहीं भी जाने के लिए ⌘K दबाएँ।",
-      "fleetLink": "फ़्लीट →"
+      "fleetLink": "फ़्लीट →",
+      "viewCards": "कार्ड",
+      "viewTable": "तालिका",
+      "table": {
+        "colName": "नाम",
+        "colStatus": "स्थिति",
+        "colUptime": "अपटाइम",
+        "colLastActivity": "अंतिम गतिविधि",
+        "colKind": "प्रकार",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "हाल का",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -754,7 +754,17 @@
       "durationStatus": "aktif {duration} · aktivitas terakhir {age} lalu",
       "empty": "Tidak ada eksekusi atau invokasi aktif.",
       "emptyHint": "Luncurkan satu dengan CLI li, atau tekan ⌘K untuk lompat ke mana saja.",
-      "fleetLink": "Armada agen →"
+      "fleetLink": "Armada agen →",
+      "viewCards": "Kartu",
+      "viewTable": "Tabel",
+      "table": {
+        "colName": "Nama",
+        "colStatus": "Status",
+        "colUptime": "Waktu aktif",
+        "colLastActivity": "Aktivitas terakhir",
+        "colKind": "Jenis",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "Terbaru",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -754,7 +754,17 @@
       "durationStatus": "稼働 {duration} · 最終アクティビティ {age} 前",
       "empty": "アクティブな実行または呼び出しはありません。",
       "emptyHint": "li CLIで起動するか、⌘Kで任意の場所へ移動できます。",
-      "fleetLink": "エージェントフリート →"
+      "fleetLink": "エージェントフリート →",
+      "viewCards": "カード",
+      "viewTable": "テーブル",
+      "table": {
+        "colName": "名前",
+        "colStatus": "ステータス",
+        "colUptime": "稼働時間",
+        "colLastActivity": "最終アクティビティ",
+        "colKind": "種類",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "最近",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -754,7 +754,17 @@
       "durationStatus": "{duration} 동안 실행 중 · 마지막 활동 {age} 전",
       "empty": "활성 실행 또는 호출이 없습니다.",
       "emptyHint": "li CLI로 하나를 실행하거나 ⌘K를 눌러 어디로든 이동하세요.",
-      "fleetLink": "에이전트 플릿 →"
+      "fleetLink": "에이전트 플릿 →",
+      "viewCards": "카드",
+      "viewTable": "표",
+      "table": {
+        "colName": "이름",
+        "colStatus": "상태",
+        "colUptime": "가동 시간",
+        "colLastActivity": "마지막 활동",
+        "colKind": "종류",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "최근",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -754,7 +754,17 @@
       "durationStatus": "ativo há {duration} · última atividade há {age}",
       "empty": "Nenhuma execução ou invocação ativa.",
       "emptyHint": "Inicie uma com a CLI li, ou pressione ⌘K para ir a qualquer lugar.",
-      "fleetLink": "Frota →"
+      "fleetLink": "Frota →",
+      "viewCards": "Cartões",
+      "viewTable": "Tabela",
+      "table": {
+        "colName": "Nome",
+        "colStatus": "Status",
+        "colUptime": "Tempo ativo",
+        "colLastActivity": "Última atividade",
+        "colKind": "Tipo",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "Recentes",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -754,7 +754,17 @@
       "durationStatus": "работает {duration} · последняя активность {age} назад",
       "empty": "Нет активных запусков или вызовов.",
       "emptyHint": "Запустите через li CLI или нажмите ⌘K, чтобы перейти куда угодно.",
-      "fleetLink": "Пул агентов →"
+      "fleetLink": "Пул агентов →",
+      "viewCards": "Карточки",
+      "viewTable": "Таблица",
+      "table": {
+        "colName": "Имя",
+        "colStatus": "Статус",
+        "colUptime": "Время работы",
+        "colLastActivity": "Последняя активность",
+        "colKind": "Тип",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "Недавние",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -754,7 +754,17 @@
       "durationStatus": "{duration} süredir açık · son etkinlik {age} önce",
       "empty": "aktif çalıştırma veya çağrı yok.",
       "emptyHint": "li CLI ile bir tane başlat veya herhangi bir yere atlamak için ⌘K’ye bas.",
-      "fleetLink": "ajan filosu →"
+      "fleetLink": "ajan filosu →",
+      "viewCards": "Kartlar",
+      "viewTable": "Tablo",
+      "table": {
+        "colName": "Ad",
+        "colStatus": "Durum",
+        "colUptime": "Çalışma süresi",
+        "colLastActivity": "Son etkinlik",
+        "colKind": "Tür",
+        "colId": "Kimlik"
+      }
     },
     "recent": {
       "title": "son",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -754,7 +754,17 @@
       "durationStatus": "{duration} سے چل رہا ہے · آخری سرگرمی {age} پہلے",
       "empty": "کوئی فعال رن یا انووکیشن نہیں۔",
       "emptyHint": "li CLI سے ایک لانچ کریں، یا کہیں بھی جانے کے لیے ⌘K دبائیں۔",
-      "fleetLink": "ایجنٹ فلیٹ →"
+      "fleetLink": "ایجنٹ فلیٹ →",
+      "viewCards": "کارڈز",
+      "viewTable": "جدول",
+      "table": {
+        "colName": "نام",
+        "colStatus": "حیثیت",
+        "colUptime": "اپ ٹائم",
+        "colLastActivity": "آخری سرگرمی",
+        "colKind": "قسم",
+        "colId": "آئی ڈی"
+      }
     },
     "recent": {
       "title": "حالیہ",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -754,7 +754,17 @@
       "durationStatus": "chạy {duration} · hoạt động gần nhất {age} trước",
       "empty": "không có lần chạy hoặc lần gọi đang hoạt động.",
       "emptyHint": "khởi chạy một lần bằng li CLI, hoặc nhấn ⌘K để nhảy tới bất kỳ đâu.",
-      "fleetLink": "nhóm tác nhân →"
+      "fleetLink": "nhóm tác nhân →",
+      "viewCards": "Thẻ",
+      "viewTable": "Bảng",
+      "table": {
+        "colName": "Tên",
+        "colStatus": "Trạng thái",
+        "colUptime": "Thời gian hoạt động",
+        "colLastActivity": "Hoạt động gần nhất",
+        "colKind": "Loại",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "gần đây",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -754,7 +754,17 @@
       "durationStatus": "运行 {duration} · 最近活动 {age} 前",
       "empty": "当前无活跃运行或调用。",
       "emptyHint": "可用 li CLI 启动，或按 ⌘K 快速跳转。",
-      "fleetLink": "智能体监控 →"
+      "fleetLink": "智能体监控 →",
+      "viewCards": "卡片",
+      "viewTable": "表格",
+      "table": {
+        "colName": "名称",
+        "colStatus": "状态",
+        "colUptime": "运行时长",
+        "colLastActivity": "最近活动",
+        "colKind": "类型",
+        "colId": "ID"
+      }
     },
     "recent": {
       "title": "近期",


### PR DESCRIPTION
Cards on the control overview reshuffled while the user was reading them.

The board only filtered its runs and inherited the API's `ORDER BY updated_at DESC`, and `updated_at` bumps on every message while the page polls every few seconds. The fix is at the display layer: changing the query would have fixed this board and broken Recent Runs, which reads the same endpoint.

- Stable creation-ordered board; position does not move when a run receives a message.
- A bounded table view for when the card grid gets long.

The ordering test feeds the same runs shuffled and reversed and asserts identical output, so a sort that happens to look right on one input fails.
