### PR TITLE
feat(studio): scope, search, and cursor-page the fleet session list

### DIFF
--- a/apps/studio/frontend/src/components/fleet/FleetView.test.ts
+++ b/apps/studio/frontend/src/components/fleet/FleetView.test.ts
@@ -275,8 +275,48 @@ describe("selectedRunId validation", () => {
 
 // ─── Formatter helpers ────────────────────────────────────────────────────────
 
-import { formatElapsed, formatCompactCount } from "./FleetView";
+import { formatElapsed, formatCompactCount, patchSearch } from "./FleetView";
 import { resetDetailScrollPosition } from "./SessionDetail";
+
+// ─── patchSearch — URL search patching without smuggling `undefined` in ──────
+// FleetSearch's index signature is RetiredSearchValue (no `undefined`), so a
+// naive `{...search, key: undefined}` spread would type- and shape-mismatch;
+// patchSearch must delete the key instead.
+
+describe("patchSearch", () => {
+  it("adds a new key", () => {
+    expect(patchSearch({ s: "run-1" }, { project: "org/alpha" })).toEqual({
+      s: "run-1",
+      project: "org/alpha",
+    });
+  });
+
+  it("deletes a key when the patch value is undefined, rather than keeping it as literal undefined", () => {
+    const result = patchSearch({ s: "run-1", project: "org/alpha" }, { project: undefined });
+    expect(result).toEqual({ s: "run-1" });
+    expect("project" in result).toBe(false);
+  });
+
+  it("overwrites an existing key", () => {
+    expect(patchSearch({ project: "org/alpha" }, { project: "org/beta" })).toEqual({
+      project: "org/beta",
+    });
+  });
+
+  it("clearing project and project_null together removes both, keeping the rest", () => {
+    const result = patchSearch(
+      { s: "run-1", project: "org/alpha", project_null: true, q: "flaky" },
+      { project: undefined, project_null: undefined },
+    );
+    expect(result).toEqual({ s: "run-1", q: "flaky" });
+  });
+
+  it("does not mutate the base object", () => {
+    const base = { s: "run-1" };
+    patchSearch(base, { project: "org/alpha" });
+    expect(base).toEqual({ s: "run-1" });
+  });
+});
 
 describe("formatElapsed", () => {
   it("renders — for null, NaN, Infinity, and negative input", () => {

--- a/apps/studio/frontend/src/components/fleet/FleetView.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.tsx
@@ -708,8 +708,12 @@ export default function FleetView() {
     if (urlRunId) return; // URL already has a selection
     if (autoSelectedRef.current === first) return;
     autoSelectedRef.current = first;
-    void navigate({ search: { s: first }, replace: true });
-  }, [state.orgUnits, historyRows, urlRunId, navigate]);
+    // Patched onto the current search, not written over it: the router takes an
+    // object-valued search as the whole next search, so selecting a row with a
+    // bare `{ s }` would drop the project and text filters that produced the
+    // row in the first place, and the next poll would come back unscoped.
+    void navigate({ search: patchSearch(search, { s: first }), replace: true });
+  }, [state.orgUnits, historyRows, urlRunId, navigate, search]);
 
   // Resolved selected id: validated URL param, fallback to first (pre-auto-select)
   const selectedRunId: string | null = urlIdValid ? requestedRunId : null;
@@ -717,9 +721,9 @@ export default function FleetView() {
   const handleSelectAgent = useCallback(
     (id: string) => {
       setNarrowExplicit(true);
-      void navigate({ search: { s: id } });
+      void navigate({ search: patchSearch(search, { s: id }) });
     },
-    [navigate],
+    [navigate, search],
   );
 
   const handleBack = useCallback(() => {

--- a/apps/studio/frontend/src/components/fleet/FleetView.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
-import { listRuns } from "@/lib/api";
+import { listRuns, listRunProjects } from "@/lib/api";
+import type { RunProjectCount } from "@/lib/api";
 import { useFleet } from "./useFleet";
 import { createHistoryPager } from "./fleetReducer";
 import type { HistoryPager } from "./fleetReducer";
@@ -12,6 +13,7 @@ import SplitPane from "@/components/ui/SplitPane";
 import StatusDot from "@/components/ui/StatusDot";
 import { deriveDisplayStatus } from "@/lib/runStatus";
 import { Route } from "@/routes/fleet";
+import type { RetiredSearchValue } from "@/lib/retiredRoutes";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -415,7 +417,87 @@ function HistorySection({
   );
 }
 
+// ─── Filter bar (project scope + text search) ─────────────────────────────────
+
+function FilterBar({
+  searchDraft,
+  onSearchDraftChange,
+  project,
+  projectNull,
+  onProjectChange,
+  projectOptions,
+  onClear,
+}: {
+  searchDraft: string;
+  onSearchDraftChange: (v: string) => void;
+  project: string | null;
+  projectNull: boolean;
+  onProjectChange: (next: { project?: string; projectNull?: boolean }) => void;
+  projectOptions: RunProjectCount[];
+  onClear: () => void;
+}) {
+  const t = useTranslations("fleet");
+  const hasFilter = Boolean(searchDraft) || Boolean(project) || projectNull;
+  return (
+    <div className="flex items-center gap-2 border-b border-edge px-4 py-2">
+      <input
+        type="search"
+        value={searchDraft}
+        onChange={(e) => onSearchDraftChange(e.target.value)}
+        placeholder={t("filters.searchPlaceholder")}
+        aria-label={t("filters.searchAria")}
+        className="min-w-0 flex-1 rounded border border-edge bg-surface-base px-2 py-1 font-data text-[length:var(--t-xs)] text-content-primary placeholder:text-content-muted focus:border-accent/50 focus:outline-none"
+      />
+      <select
+        aria-label={t("filters.projectAria")}
+        value={projectNull ? "__none__" : (project ?? "")}
+        onChange={(e) => {
+          const v = e.target.value;
+          if (v === "") onProjectChange({});
+          else if (v === "__none__") onProjectChange({ projectNull: true });
+          else onProjectChange({ project: v });
+        }}
+        className="shrink-0 rounded border border-edge bg-surface-base px-2 py-1 font-data text-[length:var(--t-xs)] text-content-primary focus:border-accent/50 focus:outline-none"
+      >
+        <option value="">{t("filters.allProjects")}</option>
+        <option value="__none__">{t("filters.noProject")}</option>
+        {projectOptions
+          .filter((p): p is RunProjectCount & { project: string } => p.project != null)
+          .map((p) => (
+            <option key={p.project} value={p.project}>
+              {p.project} ({p.count})
+            </option>
+          ))}
+      </select>
+      {hasFilter && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="shrink-0 font-data text-[length:var(--t-xs)] text-content-muted transition-colors hover:text-content-secondary"
+        >
+          {t("filters.clear")}
+        </button>
+      )}
+    </div>
+  );
+}
+
 // ─── First agent id across all units ─────────────────────────────────────────
+
+// FleetSearch's index signature is `RetiredSearchValue` (no `undefined`), so
+// an explicit `undefined` in a patch must delete the key rather than be
+// assigned — otherwise the object no longer satisfies the router's search type.
+export function patchSearch(
+  base: Record<string, unknown>,
+  patch: Record<string, string | boolean | undefined>,
+): Record<string, RetiredSearchValue> {
+  const next = { ...base } as Record<string, RetiredSearchValue>;
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) delete next[key];
+    else next[key] = value;
+  }
+  return next;
+}
 
 function firstAgentId(orgUnits: OrgUnit[]): string | null {
   for (const unit of orgUnits) {
@@ -428,9 +510,8 @@ function firstAgentId(orgUnits: OrgUnit[]): string | null {
 
 export default function FleetView() {
   const t = useTranslations("fleet");
-  const state = useFleet();
 
-  // URL-synced selection: ?s=<runId>
+  // URL-synced selection and filters: ?s=<runId>&project=<name>&project_null=true&q=<text>
   const search = Route.useSearch();
   const navigate = Route.useNavigate();
   const urlRunId = (search as { s?: string }).s ?? null;
@@ -441,12 +522,78 @@ export default function FleetView() {
       : Array.isArray(rawInvocationId) && typeof rawInvocationId[0] === "string"
         ? rawInvocationId[0]
         : null;
+  const urlProject = (search as { project?: string }).project ?? null;
+  const urlProjectNull = (search as { project_null?: boolean }).project_null ?? false;
+  const urlSearchText = (search as { q?: string }).q ?? "";
+
+  const state = useFleet({
+    project: urlProject ?? undefined,
+    projectNull: urlProjectNull,
+    search: urlSearchText || undefined,
+  });
 
   // A deep link is already an explicit selection. This matters when the
   // Operator dock narrows Fleet below the split-pane breakpoint: opening a run
   // must reveal its detail instead of landing back on the master list.
   const [narrowExplicit, setNarrowExplicit] = useState(() => Boolean(urlRunId));
   const [histFilter, setHistFilter] = useState<HistFilter>("all");
+
+  // Text search is debounced into the URL (and from there into the poll and
+  // pager) so every keystroke doesn't fire a request — the input itself stays
+  // instant, only the committed value lags by SEARCH_DEBOUNCE_MS.
+  const SEARCH_DEBOUNCE_MS = 300;
+  const [searchDraft, setSearchDraft] = useState(urlSearchText);
+  useEffect(() => {
+    // Resync the draft from an external URL change (back/forward nav,
+    // Clear) — typing itself must not be fought by this effect on every
+    // keystroke, so urlSearchText is the sole dependency.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- external->local resync, not a derived-from-props computation the render body could do instead
+    setSearchDraft(urlSearchText);
+  }, [urlSearchText]);
+  useEffect(() => {
+    if (searchDraft === urlSearchText) return;
+    const timer = window.setTimeout(() => {
+      void navigate({
+        search: patchSearch(search, { q: searchDraft || undefined }),
+        replace: true,
+      });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchDraft]);
+
+  const handleProjectChange = useCallback(
+    (next: { project?: string; projectNull?: boolean }) => {
+      void navigate({
+        search: patchSearch(search, {
+          project: next.project,
+          project_null: next.projectNull || undefined,
+        }),
+      });
+    },
+    [navigate, search],
+  );
+  const handleClearFilters = useCallback(() => {
+    setSearchDraft("");
+    void navigate({
+      search: patchSearch(search, { project: undefined, project_null: undefined, q: undefined }),
+    });
+  }, [navigate, search]);
+
+  const [projectOptions, setProjectOptions] = useState<
+    Awaited<ReturnType<typeof listRunProjects>>["projects"]
+  >([]);
+  useEffect(() => {
+    let active = true;
+    listRunProjects()
+      .then((r) => {
+        if (active) setProjectOptions(r.projects);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // History pagination. The 3s poll covers page 1 (200 runs); older pages are
   // fetched on demand and kept here — polls never clobber them. The visible
@@ -462,11 +609,40 @@ export default function FleetView() {
   const [loadingMore, setLoadingMore] = useState(false);
   // The pager serializes fetches with a synchronous guard so a sentinel fire
   // and a click in the same tick can't fetch one page twice and skip the next.
+  // Rebuilt (via the effect below) whenever the filter scope changes, so an
+  // in-flight or already-fetched older page from a different filter can never
+  // be appended to the newly-filtered result set.
   const pagerRef = useRef<HistoryPager | null>(null);
   if (pagerRef.current === null) {
-    pagerRef.current = createHistoryPager((page) => listRuns({ page, per_page: HIST_PAGE_SIZE }));
+    pagerRef.current = createHistoryPager((page) =>
+      listRuns({
+        page,
+        per_page: HIST_PAGE_SIZE,
+        project: urlProject ?? undefined,
+        project_null: urlProjectNull,
+        search: urlSearchText || undefined,
+      }),
+    );
   }
   const pager = pagerRef.current;
+
+  useEffect(() => {
+    pagerRef.current = createHistoryPager((page) =>
+      listRuns({
+        page,
+        per_page: HIST_PAGE_SIZE,
+        project: urlProject ?? undefined,
+        project_null: urlProjectNull,
+        search: urlSearchText || undefined,
+      }),
+    );
+    // Filter scope changed - the previous page's older-history cache/cursor
+    // belongs to a different result set and must not be appended to this one.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- external filter change, not a render-derivable value
+    setOlderRows([]);
+    setPagedHasMore(null);
+    setHistVisible(HIST_VISIBLE_STEP);
+  }, [urlProject, urlProjectNull, urlSearchText]);
 
   // Polled rows win on id collision (fresher status); older pages fill the tail.
   const historyRows = useMemo(() => {
@@ -566,6 +742,19 @@ export default function FleetView() {
           />
         </div>
       </div>
+
+      {/* Filter bar — project scope + text search, both URL-persisted and
+          applied server-side so they compose with pagination instead of
+          filtering an already-truncated page. */}
+      <FilterBar
+        searchDraft={searchDraft}
+        onSearchDraftChange={setSearchDraft}
+        project={urlProject}
+        projectNull={urlProjectNull}
+        onProjectChange={handleProjectChange}
+        projectOptions={projectOptions}
+        onClear={handleClearFilters}
+      />
 
       {/* Counts strip */}
       {state.dataState !== "loading" && state.dataState !== "error" && (

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
@@ -55,12 +55,13 @@ function dispatchOk(
   runs: RunSummary[],
   nowSec = 1_000_000,
   scope?: { project?: string; projectNull?: boolean; search?: string },
+  runsHasNext = false,
 ): FleetState {
   return fleetReducer(state, {
     type: "DATA_OK",
     invocations,
     runs,
-    runsHasNext: false,
+    runsHasNext,
     nowSec,
     ...scope,
   });
@@ -266,7 +267,10 @@ describe("fleetReducer — invocation groups respect runs scope", () => {
     const unit = s.orgUnits.find((u) => u.id === "inv1");
     expect(unit).toBeDefined();
     expect(unit?.agents).toHaveLength(1);
-    expect(unit?.session_count).toBe(2);
+    // The scoped count, not the invocation's global session_count of 2: a
+    // filtered child list under a total that counts unfiltered children states
+    // a number belonging to a different question.
+    expect(unit?.session_count).toBe(1);
   });
 
   it("still shows a matching invocation under a search filter", () => {
@@ -280,6 +284,46 @@ describe("fleetReducer — invocation groups respect runs scope", () => {
     const unit = s.orgUnits.find((u) => u.id === "inv1");
     expect(unit).toBeDefined();
     expect(unit?.agents).toHaveLength(1);
+  });
+
+  it("keeps a childless invocation when the runs page is not the whole scoped set", () => {
+    // The runs page is bounded. With more scoped rows behind it, "no child
+    // here" is not "no child in scope": the matching child can be on a page
+    // nobody asked for. Suppressing an empty heading is cosmetic; hiding a
+    // running orchestration from the view that is supposed to include it is
+    // not, so the suppression only applies where the page is the whole set.
+    const s = dispatchOk(
+      initialFleetState(),
+      [makeInvocation({ id: "inv1", status: "running", skill: "review", session_count: 5 })],
+      [],
+      1_000_000,
+      { project: "alpha" },
+      true,
+    );
+    expect(s.orgUnits.find((u) => u.id === "inv1")).toBeDefined();
+  });
+
+  it("reports the scoped child count, not the global one, on a surviving group", () => {
+    const s = dispatchOk(
+      initialFleetState(),
+      [makeInvocation({ id: "inv1", status: "running", skill: "review", session_count: 5 })],
+      [makeRun({ run_id: "r1", status: "running", invocation_id: "inv1", project: "alpha" })],
+      1_000_000,
+      { project: "alpha" },
+    );
+    expect(s.orgUnits.find((u) => u.id === "inv1")?.session_count).toBe(1);
+  });
+
+  it("reports the invocation's own count when nothing is scoped", () => {
+    // Control: the scoped count must not become the count everywhere. With no
+    // filter, the group's total is the invocation's own, children beyond this
+    // page included.
+    const s = dispatchOk(
+      initialFleetState(),
+      [makeInvocation({ id: "inv1", status: "running", skill: "review", session_count: 5 })],
+      [makeRun({ run_id: "r1", status: "running", invocation_id: "inv1" })],
+    );
+    expect(s.orgUnits.find((u) => u.id === "inv1")?.session_count).toBe(5);
   });
 });
 

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
@@ -54,8 +54,16 @@ function dispatchOk(
   invocations: InvocationSummary[],
   runs: RunSummary[],
   nowSec = 1_000_000,
+  scope?: { project?: string; projectNull?: boolean; search?: string },
 ): FleetState {
-  return fleetReducer(state, { type: "DATA_OK", invocations, runs, runsHasNext: false, nowSec });
+  return fleetReducer(state, {
+    type: "DATA_OK",
+    invocations,
+    runs,
+    runsHasNext: false,
+    nowSec,
+    ...scope,
+  });
 }
 
 // ─── Data state transitions ───────────────────────────────────────────────────
@@ -164,7 +172,10 @@ describe("fleetReducer — invocation join", () => {
     expect(s.orgUnits[0].agents).toHaveLength(1);
   });
 
-  it("invocation without runs still appears", () => {
+  it("invocation without runs still appears when no scope is active", () => {
+    // Names the case that would have passed either way: no project/search
+    // filter is in play here, so this test exercises the same code path
+    // before and after the scoping fix below and cannot discriminate them.
     const s = dispatchOk(
       initialFleetState(),
       [makeInvocation({ id: "inv1", status: "running", skill: "review", session_count: 3 })],
@@ -187,6 +198,88 @@ describe("fleetReducer — invocation join", () => {
     const directUnit = s.orgUnits.find((u) => u.id === "__direct__");
     expect(invUnit?.agents).toHaveLength(1);
     expect(directUnit?.agents).toHaveLength(1);
+  });
+});
+
+// ─── Invocation groups respect the same scope as the runs projection ─────────
+// Reproduces: an active invocation with no child in the scoped runs page
+// previously still rendered a group (global session_count header + a "no
+// agents" row), under both a project scope and a search filter — because
+// buildOrgUnits created a unit for every active invocation regardless of
+// whether the (separately-scoped) runs page had anything under it.
+
+describe("fleetReducer — invocation groups respect runs scope", () => {
+  it("drops a non-matching invocation under a project scope", () => {
+    // inv1's own project is "beta"; the runs page is scoped to "alpha" and
+    // (correctly, since scoping is server-side on runs) contains no child of
+    // inv1. Before the fix this rendered anyway: FAILS on current head.
+    const s = dispatchOk(
+      initialFleetState(),
+      [
+        makeInvocation({
+          id: "inv1",
+          status: "running",
+          skill: "review",
+          session_count: 5,
+          project: "beta",
+        }),
+      ],
+      [],
+      1_000_000,
+      { project: "alpha" },
+    );
+    expect(s.orgUnits.find((u) => u.id === "inv1")).toBeUndefined();
+  });
+
+  it("drops a non-matching invocation under a search filter", () => {
+    // Same shape, but the active scope is a name/agent search instead of a
+    // project. inv1 has no child in the scoped runs page either way — the
+    // group must not render regardless of which filter produced the scope.
+    const s = dispatchOk(
+      initialFleetState(),
+      [makeInvocation({ id: "inv1", status: "running", skill: "review", session_count: 5 })],
+      [],
+      1_000_000,
+      { search: "cleanup" },
+    );
+    expect(s.orgUnits.find((u) => u.id === "inv1")).toBeUndefined();
+  });
+
+  it("still shows a matching invocation, with its count, under a project scope", () => {
+    // Positive direction: a suppress-everything implementation (e.g. "if
+    // scoped, always return []") fails this test.
+    const s = dispatchOk(
+      initialFleetState(),
+      [
+        makeInvocation({
+          id: "inv1",
+          status: "running",
+          skill: "review",
+          session_count: 2,
+          project: "alpha",
+        }),
+      ],
+      [makeRun({ run_id: "r1", status: "running", invocation_id: "inv1", project: "alpha" })],
+      1_000_000,
+      { project: "alpha" },
+    );
+    const unit = s.orgUnits.find((u) => u.id === "inv1");
+    expect(unit).toBeDefined();
+    expect(unit?.agents).toHaveLength(1);
+    expect(unit?.session_count).toBe(2);
+  });
+
+  it("still shows a matching invocation under a search filter", () => {
+    const s = dispatchOk(
+      initialFleetState(),
+      [makeInvocation({ id: "inv1", status: "running", skill: "review", session_count: 1 })],
+      [makeRun({ run_id: "r1", status: "running", invocation_id: "inv1" })],
+      1_000_000,
+      { search: "cleanup" },
+    );
+    const unit = s.orgUnits.find((u) => u.id === "inv1");
+    expect(unit).toBeDefined();
+    expect(unit?.agents).toHaveLength(1);
   });
 });
 

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -13,6 +13,15 @@
  *
  * Terminal/idle entries are excluded — Fleet is live-only.
  * History owns the past.
+ *
+ * Invocations carry no project/search scope of their own — only the runs
+ * projection is filtered server-side. So when a project or search filter is
+ * active, an invocation group is shown only if it has at least one matching
+ * child in the (already-scoped) runs page; otherwise the group is dropped
+ * rather than rendered empty. This is a client-side approximation: a live
+ * child that exists beyond the polled runs page (200 rows) can still be
+ * hidden. With no filter active, every active invocation renders as before,
+ * including one with zero children yet (e.g. just started).
  */
 
 import type { RunSummary } from "@/lib/types";
@@ -85,6 +94,11 @@ export type FleetAction =
       runs: RunSummary[];
       runsHasNext: boolean;
       nowSec: number;
+      /** Same filters just sent to listRuns() — determines whether an
+       *  invocation group with no matching child should be suppressed. */
+      project?: string;
+      projectNull?: boolean;
+      search?: string;
     }
   | { type: "DATA_ERROR"; message: string }
   | { type: "MARK_STALE" };
@@ -134,10 +148,17 @@ function needsAttention(row: AgentRow): boolean {
 
 // ─── Derivation ───────────────────────────────────────────────────────────────
 
+/** True when the runs projection is scoped to less than "everything live" —
+ *  the same condition useFleet uses to decide what to send listRuns(). */
+function isScopeActive(project?: string, projectNull?: boolean, search?: string): boolean {
+  return Boolean(project) || Boolean(projectNull) || Boolean(search);
+}
+
 function buildOrgUnits(
   invocations: InvocationSummary[],
   runs: RunSummary[],
   nowSec: number,
+  scoped: boolean,
 ): OrgUnit[] {
   const activeInvocations = invocations.filter((inv) => isActive(inv));
 
@@ -185,6 +206,10 @@ function buildOrgUnits(
   const units: OrgUnit[] = [];
 
   for (const unit of invMap.values()) {
+    // No child in the scoped runs page: the scope promised nothing unrelated
+    // would render, and the invocation has no scope of its own to fall back
+    // on — drop the group instead of showing a heading over a "no agents" row.
+    if (scoped && unit.agents.length === 0) continue;
     unit.needsAttention =
       ATTENTION_STATUSES.has(unit.status.toLowerCase()) ||
       unit.agents.some((a) => needsAttention(a));
@@ -311,8 +336,9 @@ export function fleetReducer(state: FleetState, action: FleetAction): FleetState
       return { ...state, nowSec: action.nowSec };
 
     case "DATA_OK": {
-      const { invocations, runs, runsHasNext, nowSec } = action;
-      const orgUnits = buildOrgUnits(invocations, runs, nowSec);
+      const { invocations, runs, runsHasNext, nowSec, project, projectNull, search } = action;
+      const scoped = isScopeActive(project, projectNull, search);
+      const orgUnits = buildOrgUnits(invocations, runs, nowSec, scoped);
       const counts = deriveCounts(orgUnits);
       return {
         ...state,

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -159,6 +159,7 @@ function buildOrgUnits(
   runs: RunSummary[],
   nowSec: number,
   scoped: boolean,
+  runsHasNext: boolean,
 ): OrgUnit[] {
   const activeInvocations = invocations.filter((inv) => isActive(inv));
 
@@ -205,11 +206,20 @@ function buildOrgUnits(
 
   const units: OrgUnit[] = [];
 
+  // Absence from the runs page is only evidence of absence when the page is the
+  // whole scoped set. The invocations request carries no scope of its own, so
+  // an invocation with no child here has either genuinely nothing in scope, or
+  // a matching child on a page we did not ask for -- and dropping it in the
+  // second case hides live work the filter was supposed to include. Suppressing
+  // an empty heading is a cosmetic win; hiding a running orchestration is not,
+  // so the cure only applies where the evidence actually supports it.
+  const runsAreExhaustive = !runsHasNext;
   for (const unit of invMap.values()) {
-    // No child in the scoped runs page: the scope promised nothing unrelated
-    // would render, and the invocation has no scope of its own to fall back
-    // on — drop the group instead of showing a heading over a "no agents" row.
-    if (scoped && unit.agents.length === 0) continue;
+    if (scoped && runsAreExhaustive && unit.agents.length === 0) continue;
+    // A scoped view reports the children it is showing. The invocation's own
+    // session_count is global, so rendering it beside a filtered child list
+    // states a total that belongs to a different question.
+    if (scoped) unit.session_count = unit.agents.length;
     unit.needsAttention =
       ATTENTION_STATUSES.has(unit.status.toLowerCase()) ||
       unit.agents.some((a) => needsAttention(a));
@@ -338,7 +348,7 @@ export function fleetReducer(state: FleetState, action: FleetAction): FleetState
     case "DATA_OK": {
       const { invocations, runs, runsHasNext, nowSec, project, projectNull, search } = action;
       const scoped = isScopeActive(project, projectNull, search);
-      const orgUnits = buildOrgUnits(invocations, runs, nowSec, scoped);
+      const orgUnits = buildOrgUnits(invocations, runs, nowSec, scoped, runsHasNext);
       const counts = deriveCounts(orgUnits);
       return {
         ...state,

--- a/apps/studio/frontend/src/components/fleet/useFleet.ts
+++ b/apps/studio/frontend/src/components/fleet/useFleet.ts
@@ -16,11 +16,20 @@ const POLL_INTERVAL_MS = 3_000;
 const STALE_THRESHOLD_MS = 5_000;
 const STABLE_RESUMPTION_COUNT = 2;
 
-export function useFleet(): FleetState {
+export interface FleetFilters {
+  project?: string;
+  projectNull?: boolean;
+  search?: string;
+}
+
+export function useFleet(filters?: FleetFilters): FleetState {
   const [state, dispatch] = useReducer(fleetReducer, undefined, initialFleetState);
 
   const successStreak = useRef(0);
   const wasStaleRef = useRef(false);
+  const project = filters?.project;
+  const projectNull = filters?.projectNull ?? false;
+  const search = filters?.search;
 
   useEffect(() => {
     let active = true;
@@ -46,7 +55,7 @@ export function useFleet(): FleetState {
         const nowSec = Math.floor(Date.now() / 1000);
         const [invsResp, runsResp] = await Promise.all([
           listInvocations({ limit: 200 }),
-          listRuns({ per_page: 200 }),
+          listRuns({ per_page: 200, project, project_null: projectNull, search }),
         ]);
         if (!active) return;
 
@@ -82,7 +91,10 @@ export function useFleet(): FleetState {
       clearInterval(ticker);
       clearInterval(poller);
     };
-  }, []);
+    // Changing a filter restarts polling immediately (via the effect's own
+    // teardown/setup) rather than waiting up to POLL_INTERVAL_MS for the next
+    // tick to pick up the new scope.
+  }, [project, projectNull, search]);
 
   return state;
 }

--- a/apps/studio/frontend/src/components/fleet/useFleet.ts
+++ b/apps/studio/frontend/src/components/fleet/useFleet.ts
@@ -70,6 +70,9 @@ export function useFleet(filters?: FleetFilters): FleetState {
             runs: runsResp.runs,
             runsHasNext: runsResp.has_next,
             nowSec,
+            project,
+            projectNull,
+            search,
           });
         }
       } catch (err) {

--- a/apps/studio/frontend/src/components/history/RunDetail.pagination.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.pagination.test.tsx
@@ -233,6 +233,57 @@ describe("RunDetail — cursor-based backward pagination", () => {
     expect(container.textContent).not.toContain("older messages");
   });
 
+  it("asks for a cursor page once when the scroll sentinel reports twice in the same turn", async () => {
+    // The sentinel above the message list fires whenever it scrolls into view,
+    // and two intersections can be delivered in a single turn. React state
+    // does not update between them, so an in-flight test that reads render
+    // state sees both callbacks as idle and sends the same cursor twice.
+    let notify: (() => void) | undefined;
+    class TwoShotObserver {
+      constructor(cb: (entries: { isIntersecting: boolean }[]) => void) {
+        notify = () => cb([{ isIntersecting: true }]);
+      }
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+    vi.stubGlobal("IntersectionObserver", TwoShotObserver);
+
+    getSessionMock.mockResolvedValueOnce(
+      baseSession({
+        message_next_cursor: "cursor-1",
+        branches: [
+          {
+            id: "b1",
+            name: "main",
+            created_at: 1,
+            message_total: 5,
+            message_has_older: true,
+            messages: [msg("m3", "three", 3), msg("m4", "four", 4), msg("m5", "five", 5)],
+          },
+        ],
+      }),
+    );
+    await mount();
+    expect(getSessionMock).toHaveBeenCalledTimes(1);
+
+    // The page never resolves during the two intersections, so the only thing
+    // that can suppress the second request is a synchronous guard.
+    getSessionMock.mockReturnValueOnce(new Promise(() => {}));
+
+    await act(async () => {
+      notify?.();
+      notify?.();
+      await Promise.resolve();
+    });
+
+    expect(
+      getSessionMock,
+      "a second intersection in the same turn must not re-send the cursor already in flight",
+    ).toHaveBeenCalledTimes(2);
+    expect(getSessionMock).toHaveBeenNthCalledWith(2, "s1", { messageCursor: "cursor-1" });
+  });
+
   it("shows a visible recovery, not a dead control, when the held anchor is rejected as stale", async () => {
     getSessionMock.mockResolvedValueOnce(
       baseSession({

--- a/apps/studio/frontend/src/components/history/RunDetail.pagination.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.pagination.test.tsx
@@ -95,7 +95,8 @@ describe("RunDetail — cursor-based backward pagination", () => {
 
   function findButton(text: string): HTMLButtonElement | undefined {
     return [...container.querySelectorAll("button")].find((b) => b.textContent?.includes(text)) as
-      HTMLButtonElement | undefined;
+      | HTMLButtonElement
+      | undefined;
   }
 
   it("pages older messages by cursor (not offset), merging with no skip and no duplicate even as the tail grows between fetches", async () => {
@@ -171,6 +172,65 @@ describe("RunDetail — cursor-based backward pagination", () => {
     expect(container.textContent).not.toContain("/4");
     expect(container.textContent).not.toContain("/6");
     expect(container.textContent).not.toContain("/7");
+  });
+
+  it("retires the load-older control when the last page arrives, even though tail growth leaves messages unloaded", async () => {
+    // Same shape as the merge test above, isolated on what the control says
+    // afterwards. The final older page carries message_next_cursor: null, so
+    // there is no older history left to ask for, while message_total has
+    // grown to 7 against 5 loaded messages because two newer ones landed at
+    // the tail. Counting those two as older history renders a control that
+    // is enabled and returns without doing anything, every time it is
+    // pressed, for the rest of the session.
+    getSessionMock.mockResolvedValueOnce(
+      baseSession({
+        message_next_cursor: "cursor-1",
+        branches: [
+          {
+            id: "b1",
+            name: "main",
+            created_at: 1,
+            message_total: 5,
+            message_has_older: true,
+            messages: [msg("m3", "three", 3), msg("m4", "four", 4), msg("m5", "five", 5)],
+          },
+        ],
+      }),
+    );
+    await mount();
+
+    const loadOlder = findButton("Load older messages");
+    expect(loadOlder).not.toBeUndefined();
+
+    getSessionMock.mockResolvedValueOnce(
+      baseSession({
+        message_next_cursor: null,
+        branches: [
+          {
+            id: "b1",
+            name: "main",
+            created_at: 1,
+            message_total: 7,
+            message_has_older: false,
+            messages: [msg("m1", "one", 1), msg("m2", "two", 2)],
+          },
+        ],
+      }),
+    );
+    await act(async () => {
+      loadOlder?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The unloaded count is still positive here (7 total, 5 loaded), which is
+    // what made the old arithmetic keep the control alive.
+    expect(container.textContent).toContain("/5");
+    expect(
+      findButton("Load older messages"),
+      "no cursor means nothing older to fetch, so the control must not be offered",
+    ).toBeUndefined();
+    expect(container.textContent).not.toContain("older messages");
   });
 
   it("shows a visible recovery, not a dead control, when the held anchor is rejected as stale", async () => {

--- a/apps/studio/frontend/src/components/history/RunDetail.pagination.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.pagination.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * RunDetail — backward message-cursor pagination.
+ *
+ * The server windows a branch's messages from the tail and returns a stable
+ * per-branch anchor cursor for "load older" (services/sessions.py
+ * _window_message_ids / _encode_message_cursor). The discriminating scenario
+ * this file covers: a "load older" fetch lands *after* new messages have
+ * already landed at the tail of the same branch. An offset-based "load
+ * older" (the code this replaces) would shift under that tail growth and
+ * either skip or repeat rows; a cursor-based one must not, because the
+ * anchor is a message id, not a position.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import enMessages from "@/messages/en.json";
+import type { SessionDetail } from "@/lib/api";
+
+class MockApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+const getSessionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({
+  ApiError: MockApiError,
+  getSession: getSessionMock,
+  getInvocation: vi.fn().mockRejectedValue(new Error("no invocation in this test")),
+  streamSession: vi.fn(() => () => {}),
+  streamSignals: vi.fn(() => () => {}),
+  resumeRun: vi.fn(),
+}));
+
+const { default: RunDetail } = await import("./RunDetail");
+
+function msg(id: string, text: string, ts: number) {
+  return {
+    id,
+    role: "user",
+    content: { instruction: text },
+    sender: "operator",
+    timestamp: ts,
+    lion_class: "Instruction",
+  };
+}
+
+function baseSession(overrides: Partial<SessionDetail> = {}): SessionDetail {
+  return {
+    id: "s1",
+    name: "session one",
+    created_at: 1,
+    updated_at: 1,
+    status: "completed",
+    branches: [],
+    ...overrides,
+  } as SessionDetail;
+}
+
+describe("RunDetail — cursor-based backward pagination", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    // jsdom does not implement scrollIntoView; RunDetail calls it on load.
+    Element.prototype.scrollIntoView = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function mount() {
+    await act(async () => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <RunDetail id="s1" />
+        </IntlProvider>,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  function findButton(text: string): HTMLButtonElement | undefined {
+    return [...container.querySelectorAll("button")].find((b) => b.textContent?.includes(text)) as
+      HTMLButtonElement | undefined;
+  }
+
+  it("pages older messages by cursor (not offset), merging with no skip and no duplicate even as the tail grows between fetches", async () => {
+    // Initial page: newest 3 of 5 messages, with a next-page anchor.
+    getSessionMock.mockResolvedValueOnce(
+      baseSession({
+        message_next_cursor: "cursor-1",
+        branches: [
+          {
+            id: "b1",
+            name: "main",
+            created_at: 1,
+            message_total: 5,
+            message_has_older: true,
+            messages: [msg("m3", "three", 3), msg("m4", "four", 4), msg("m5", "five", 5)],
+          },
+        ],
+      }),
+    );
+
+    await mount();
+
+    expect(getSessionMock).toHaveBeenCalledTimes(1);
+    expect(getSessionMock).toHaveBeenCalledWith("s1");
+
+    // RunStepCard's own "N/total" counter reflects branch.messages.length —
+    // the merge-correctness signal: a skip undercounts, a duplicate
+    // overcounts, only an exact match proves neither happened.
+    expect(container.textContent).toContain("/3");
+
+    const loadOlder = findButton("Load older messages");
+    expect(
+      loadOlder,
+      "load-older control must be visible when a branch has hidden history",
+    ).not.toBeUndefined();
+
+    // Between the initial load and this fetch, two more messages (m6, m7)
+    // landed at the tail server-side — message_total grows accordingly. The
+    // older page must still resolve relative to the m3 anchor, unaffected by
+    // that tail growth.
+    getSessionMock.mockResolvedValueOnce(
+      baseSession({
+        message_next_cursor: null,
+        branches: [
+          {
+            id: "b1",
+            name: "main",
+            created_at: 1,
+            message_total: 7,
+            message_has_older: false,
+            messages: [msg("m1", "one", 1), msg("m2", "two", 2)],
+          },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      loadOlder?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getSessionMock).toHaveBeenCalledTimes(2);
+    // The second call must carry the anchor cursor, never an offset — an
+    // offset here is exactly the bug this pagination replaces.
+    expect(getSessionMock).toHaveBeenNthCalledWith(2, "s1", { messageCursor: "cursor-1" });
+
+    // Merged branch now carries exactly 5 messages (3 initial + 2 older, 0
+    // overlap) — not 4 (a skip) and not 6+ (a duplicate). The newly-landed
+    // tail messages (server total went to 7) are correctly excluded: neither
+    // fetched window ever included them.
+    expect(container.textContent).toContain("/5");
+    expect(container.textContent).not.toContain("/4");
+    expect(container.textContent).not.toContain("/6");
+    expect(container.textContent).not.toContain("/7");
+  });
+
+  it("shows a visible recovery, not a dead control, when the held anchor is rejected as stale", async () => {
+    getSessionMock.mockResolvedValueOnce(
+      baseSession({
+        message_next_cursor: "cursor-1",
+        branches: [
+          {
+            id: "b1",
+            name: "main",
+            created_at: 1,
+            message_total: 5,
+            message_has_older: true,
+            messages: [msg("m3", "three", 3), msg("m4", "four", 4), msg("m5", "five", 5)],
+          },
+        ],
+      }),
+    );
+    await mount();
+
+    const loadOlder = findButton("Load older messages");
+    getSessionMock.mockRejectedValueOnce(
+      new MockApiError(400, "message_cursor anchor not found in branch progression"),
+    );
+
+    await act(async () => {
+      loadOlder?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(findButton("Load older messages")).toBeUndefined();
+    expect(container.textContent).toContain("Older history could not be loaded");
+    const reload = findButton("Reload conversation");
+    expect(
+      reload,
+      "a reload affordance must replace the dead load-older button",
+    ).not.toBeUndefined();
+
+    // The reload action re-fetches from scratch (no cursor) and clears the
+    // stuck state.
+    getSessionMock.mockResolvedValueOnce(
+      baseSession({
+        message_next_cursor: "cursor-2",
+        branches: [
+          {
+            id: "b1",
+            name: "main",
+            created_at: 1,
+            message_total: 6,
+            message_has_older: true,
+            messages: [msg("m4", "four", 4), msg("m5", "five", 5), msg("m6", "six", 6)],
+          },
+        ],
+      }),
+    );
+    await act(async () => {
+      reload?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getSessionMock).toHaveBeenNthCalledWith(3, "s1");
+    expect(container.textContent).not.toContain("Older history could not be loaded");
+    expect(findButton("Load older messages")).not.toBeUndefined();
+  });
+});

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -857,7 +857,10 @@ export default function RunDetail({ id }: RunDetailProps) {
   // reconversation reload instead of a dead retry loop.
   const [olderLoadFailed, setOlderLoadFailed] = useState(false);
   const [resumeWatch, setResumeWatch] = useState<RunResumeResponse | null>(null);
-  const olderCursorRef = useRef<string | null>(null);
+  // State rather than a ref because the affordance for loading older history
+  // is rendered from it: a cursor the server stopped handing back means there
+  // is nothing older left to ask for, and the reader has to see that.
+  const [olderCursor, setOlderCursor] = useState<string | null>(null);
   const suppressAutoScrollRef = useRef(false);
   const initialScrollDoneRef = useRef(false);
   const olderSentinelRef = useRef<HTMLDivElement>(null);
@@ -873,12 +876,12 @@ export default function RunDetail({ id }: RunDetailProps) {
     setSignalEvents([]);
     setLoadingOlder(false);
     setOlderLoadFailed(false);
-    olderCursorRef.current = null;
+    setOlderCursor(null);
     initialScrollDoneRef.current = false;
     getSession(id)
       .then((s) => {
         setSession(s);
-        olderCursorRef.current = s.message_next_cursor ?? null;
+        setOlderCursor(s.message_next_cursor ?? null);
         const ss = (s.status ?? "").toLowerCase();
         if (
           ss === "completed" ||
@@ -899,7 +902,9 @@ export default function RunDetail({ id }: RunDetailProps) {
           }
         }
         const graph = (s as unknown as Record<string, unknown>).graph as
-          { nodes: WorkerGraph["nodes"]; edges?: WorkerGraph["edges"] | null } | null | undefined;
+          | { nodes: WorkerGraph["nodes"]; edges?: WorkerGraph["edges"] | null }
+          | null
+          | undefined;
         if (graph && graph.nodes && graph.nodes.length > 0) {
           setRunGraph({
             name: s.name || id,
@@ -1033,21 +1038,28 @@ export default function RunDetail({ id }: RunDetailProps) {
   }, []);
 
   const hiddenOlderCount = useMemo(() => {
-    if (!session) return 0;
+    // The cursor gates the arithmetic instead of sitting beside it. The
+    // per-branch subtraction counts every message not loaded, which is older
+    // history only until the tail grows: after that it also counts newer
+    // messages, which arrive on their own and are not reachable through this
+    // cursor at all. Offering those as older history renders a control that
+    // is enabled and can never do anything, so once the server stops handing
+    // back a cursor there is nothing older to load and the count is zero.
+    if (!session || olderCursor === null) return 0;
     return session.branches.reduce((n, b) => {
       const total = b.message_total ?? b.messages.length;
       return n + Math.max(0, total - b.messages.length);
     }, 0);
-  }, [session]);
+  }, [session, olderCursor]);
 
   const handleLoadOlder = useCallback(() => {
-    const cursor = olderCursorRef.current;
+    const cursor = olderCursor;
     if (!id || loadingOlder || olderLoadFailed || !cursor) return;
     setLoadingOlder(true);
     suppressAutoScrollRef.current = true;
     getSession(id, { messageCursor: cursor })
       .then((older) => {
-        olderCursorRef.current = older.message_next_cursor ?? null;
+        setOlderCursor(older.message_next_cursor ?? null);
         setSession((prev) => {
           if (!prev) return prev;
           const olderById = new Map(older.branches.map((b) => [b.id, b]));
@@ -1079,7 +1091,7 @@ export default function RunDetail({ id }: RunDetailProps) {
         setError(String(e));
       })
       .finally(() => setLoadingOlder(false));
-  }, [id, loadingOlder, olderLoadFailed]);
+  }, [id, loadingOlder, olderLoadFailed, olderCursor]);
 
   const handleReloadConversation = useCallback(() => {
     if (!id) return;
@@ -1088,7 +1100,7 @@ export default function RunDetail({ id }: RunDetailProps) {
     setLoadingOlder(true);
     getSession(id)
       .then((fresh) => {
-        olderCursorRef.current = fresh.message_next_cursor ?? null;
+        setOlderCursor(fresh.message_next_cursor ?? null);
         setSession(fresh);
       })
       .catch((e: unknown) => setError(String(e)))
@@ -1292,11 +1304,17 @@ export default function RunDetail({ id }: RunDetailProps) {
     toolCallCount,
     errorCount,
     showTopic: (session as unknown as Record<string, unknown>).show_topic as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
     showPlayName: (session as unknown as Record<string, unknown>).show_play_name as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
     playbookName: (session as unknown as Record<string, unknown>).playbook_name as
-      string | null | undefined,
+      | string
+      | null
+      | undefined,
   };
 
   const content = (

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -15,13 +15,7 @@ import ExpectedArtifacts from "@/components/runs/ExpectedArtifacts";
 import ResumeRun from "@/components/history/ResumeRun";
 import RunStepCard, { extractFilePaths } from "@/components/RunStepCard";
 import { IconChevronDown, IconChevronRight } from "@/components/ui/icons";
-import {
-  getInvocation,
-  getSession,
-  streamSession,
-  streamSignals,
-  SESSION_MESSAGE_PAGE,
-} from "@/lib/api";
+import { ApiError, getInvocation, getSession, streamSession, streamSignals } from "@/lib/api";
 import type { SessionDetail, SessionBranch, SessionMessage, SignalEvent } from "@/lib/api";
 import { buildNodeStatusesByName, buildOperationGraph, laneFor } from "@/lib/operationGraph";
 import type { LaneSignal, OperationStatus } from "@/lib/operationGraph";
@@ -856,10 +850,17 @@ export default function RunDetail({ id }: RunDetailProps) {
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
   const [signalEvents, setSignalEvents] = useState<SignalEvent[]>([]);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  // Set when the server rejects the held anchor as no longer present in the
+  // branch's progression (HTTP 400 MessageCursorError) — the anchor points at
+  // a message id that aged out. Loading older history from this point on is
+  // unrecoverable for the current session load; the reader is offered a full
+  // reconversation reload instead of a dead retry loop.
+  const [olderLoadFailed, setOlderLoadFailed] = useState(false);
   const [resumeWatch, setResumeWatch] = useState<RunResumeResponse | null>(null);
-  const olderOffsetRef = useRef(SESSION_MESSAGE_PAGE);
+  const olderCursorRef = useRef<string | null>(null);
   const suppressAutoScrollRef = useRef(false);
   const initialScrollDoneRef = useRef(false);
+  const olderSentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!id) return;
@@ -871,11 +872,13 @@ export default function RunDetail({ id }: RunDetailProps) {
     setError(null);
     setSignalEvents([]);
     setLoadingOlder(false);
-    olderOffsetRef.current = SESSION_MESSAGE_PAGE;
+    setOlderLoadFailed(false);
+    olderCursorRef.current = null;
     initialScrollDoneRef.current = false;
     getSession(id)
       .then((s) => {
         setSession(s);
+        olderCursorRef.current = s.message_next_cursor ?? null;
         const ss = (s.status ?? "").toLowerCase();
         if (
           ss === "completed" ||
@@ -896,9 +899,7 @@ export default function RunDetail({ id }: RunDetailProps) {
           }
         }
         const graph = (s as unknown as Record<string, unknown>).graph as
-          | { nodes: WorkerGraph["nodes"]; edges?: WorkerGraph["edges"] | null }
-          | null
-          | undefined;
+          { nodes: WorkerGraph["nodes"]; edges?: WorkerGraph["edges"] | null } | null | undefined;
         if (graph && graph.nodes && graph.nodes.length > 0) {
           setRunGraph({
             name: s.name || id,
@@ -1040,13 +1041,13 @@ export default function RunDetail({ id }: RunDetailProps) {
   }, [session]);
 
   const handleLoadOlder = useCallback(() => {
-    if (!id || loadingOlder) return;
+    const cursor = olderCursorRef.current;
+    if (!id || loadingOlder || olderLoadFailed || !cursor) return;
     setLoadingOlder(true);
     suppressAutoScrollRef.current = true;
-    const offset = olderOffsetRef.current;
-    getSession(id, { messageOffset: offset })
+    getSession(id, { messageCursor: cursor })
       .then((older) => {
-        olderOffsetRef.current = offset + SESSION_MESSAGE_PAGE;
+        olderCursorRef.current = older.message_next_cursor ?? null;
         setSession((prev) => {
           if (!prev) return prev;
           const olderById = new Map(older.branches.map((b) => [b.id, b]));
@@ -1067,9 +1068,45 @@ export default function RunDetail({ id }: RunDetailProps) {
           };
         });
       })
+      .catch((e: unknown) => {
+        // A stale anchor (HTTP 400) means the branch's progression moved on
+        // and this cursor no longer resolves — surface the dead-end instead
+        // of retrying the same broken request on every scroll-up tick.
+        if (e instanceof ApiError && e.status === 400) {
+          setOlderLoadFailed(true);
+          return;
+        }
+        setError(String(e));
+      })
+      .finally(() => setLoadingOlder(false));
+  }, [id, loadingOlder, olderLoadFailed]);
+
+  const handleReloadConversation = useCallback(() => {
+    if (!id) return;
+    suppressAutoScrollRef.current = true;
+    setOlderLoadFailed(false);
+    setLoadingOlder(true);
+    getSession(id)
+      .then((fresh) => {
+        olderCursorRef.current = fresh.message_next_cursor ?? null;
+        setSession(fresh);
+      })
       .catch((e: unknown) => setError(String(e)))
       .finally(() => setLoadingOlder(false));
-  }, [id, loadingOlder]);
+  }, [id]);
+
+  // Scroll-up trigger: an always-mounted sentinel just above the message
+  // list. handleLoadOlder no-ops without a cursor or mid-flight, so this can
+  // fire freely as the sentinel scrolls in and out of view.
+  useEffect(() => {
+    const el = olderSentinelRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const io = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) handleLoadOlder();
+    });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [handleLoadOlder]);
 
   const handleResumed = useCallback(
     async (result: RunResumeResponse) => {
@@ -1255,17 +1292,11 @@ export default function RunDetail({ id }: RunDetailProps) {
     toolCallCount,
     errorCount,
     showTopic: (session as unknown as Record<string, unknown>).show_topic as
-      | string
-      | null
-      | undefined,
+      string | null | undefined,
     showPlayName: (session as unknown as Record<string, unknown>).show_play_name as
-      | string
-      | null
-      | undefined,
+      string | null | undefined,
     playbookName: (session as unknown as Record<string, unknown>).playbook_name as
-      | string
-      | null
-      | undefined,
+      string | null | undefined,
   };
 
   const content = (
@@ -1324,17 +1355,34 @@ export default function RunDetail({ id }: RunDetailProps) {
           </div>
         )
       )}
-      {hiddenOlderCount > 0 && (
-        <button
-          type="button"
-          onClick={handleLoadOlder}
-          disabled={loadingOlder}
-          className="self-start rounded border border-edge bg-surface-raised px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary disabled:opacity-50"
-        >
-          {loadingOlder
-            ? "…"
-            : `${t("loadOlder")} · ${t("olderRemaining", { count: hiddenOlderCount })}`}
-        </button>
+      {/* Scroll-up trigger: reaching the top of the conversation loads the
+          next older page, same handler as the explicit button below. */}
+      <div ref={olderSentinelRef} aria-hidden="true" className="h-px" />
+      {olderLoadFailed ? (
+        <div className="flex items-center gap-2 self-start rounded border border-edge bg-surface-raised px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary">
+          <span>{t("olderUnavailable")}</span>
+          <button
+            type="button"
+            onClick={handleReloadConversation}
+            disabled={loadingOlder}
+            className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50 disabled:opacity-50"
+          >
+            {t("reloadConversation")}
+          </button>
+        </div>
+      ) : (
+        hiddenOlderCount > 0 && (
+          <button
+            type="button"
+            onClick={handleLoadOlder}
+            disabled={loadingOlder}
+            className="self-start rounded border border-edge bg-surface-raised px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary disabled:opacity-50"
+          >
+            {loadingOlder
+              ? "…"
+              : `${t("loadOlder")} · ${t("olderRemaining", { count: hiddenOlderCount })}`}
+          </button>
+        )
       )}
       <BranchesSection
         steps={steps}

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -850,6 +850,7 @@ export default function RunDetail({ id }: RunDetailProps) {
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
   const [signalEvents, setSignalEvents] = useState<SignalEvent[]>([]);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const loadingOlderRef = useRef(false);
   // Set when the server rejects the held anchor as no longer present in the
   // branch's progression (HTTP 400 MessageCursorError) — the anchor points at
   // a message id that aged out. Loading older history from this point on is
@@ -875,6 +876,7 @@ export default function RunDetail({ id }: RunDetailProps) {
     setError(null);
     setSignalEvents([]);
     setLoadingOlder(false);
+    loadingOlderRef.current = false;
     setOlderLoadFailed(false);
     setOlderCursor(null);
     initialScrollDoneRef.current = false;
@@ -1054,7 +1056,14 @@ export default function RunDetail({ id }: RunDetailProps) {
 
   const handleLoadOlder = useCallback(() => {
     const cursor = olderCursor;
-    if (!id || loadingOlder || olderLoadFailed || !cursor) return;
+    // The in-flight test reads a ref, not the `loadingOlder` state beside it.
+    // The scroll sentinel can deliver two intersections within a single turn,
+    // and React state does not update between them, so both callbacks would
+    // see this handler as idle and issue the same cursor request twice. The
+    // state is still what the UI renders from; only the exclusion has to be
+    // synchronous.
+    if (!id || loadingOlderRef.current || olderLoadFailed || !cursor) return;
+    loadingOlderRef.current = true;
     setLoadingOlder(true);
     suppressAutoScrollRef.current = true;
     getSession(id, { messageCursor: cursor })
@@ -1090,8 +1099,11 @@ export default function RunDetail({ id }: RunDetailProps) {
         }
         setError(String(e));
       })
-      .finally(() => setLoadingOlder(false));
-  }, [id, loadingOlder, olderLoadFailed, olderCursor]);
+      .finally(() => {
+        loadingOlderRef.current = false;
+        setLoadingOlder(false);
+      });
+  }, [id, olderLoadFailed, olderCursor]);
 
   const handleReloadConversation = useCallback(() => {
     if (!id) return;

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -194,8 +194,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 786 leaves", () => {
-    expect(EN_LEAVES.size).toBe(786);
+  it("en.json has 794 leaves", () => {
+    expect(EN_LEAVES.size).toBe(794);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/api.test.ts
+++ b/apps/studio/frontend/src/lib/api.test.ts
@@ -475,3 +475,98 @@ describe("engine defs API", () => {
     expect(body.action_prompt).toBe("build a crawler");
   });
 });
+
+// ─── Runs/sessions query construction (Fleet filters, cursor pagination) ─────
+
+describe("runs/sessions query construction", () => {
+  type FetchCall = { url: string; init?: RequestInit };
+
+  function stubFetch(response: unknown, status = 200): FetchCall[] {
+    const calls: FetchCall[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return Promise.resolve(
+          new Response(JSON.stringify(response), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }),
+    );
+    return calls;
+  }
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.stubGlobal("window", {
+      ...window,
+      __STUDIO_API_BASE__: undefined,
+      location: { ...window.location, port: "8765", hostname: "localhost", protocol: "http:" },
+    });
+  });
+
+  it("listRuns sends search and project_null (project_null wins over project)", async () => {
+    const calls = stubFetch({
+      runs: [],
+      page: 1,
+      per_page: 20,
+      total: 0,
+      total_pages: 0,
+      has_next: false,
+      has_prev: false,
+    });
+    const { listRuns } = await import("./api");
+    await listRuns({ search: "50%off", project: "org/alpha", project_null: true });
+    const url = new URL(calls[0]!.url, "http://localhost");
+    expect(url.searchParams.get("search")).toBe("50%off");
+    expect(url.searchParams.get("project_null")).toBe("true");
+    expect(url.searchParams.has("project")).toBe(false);
+  });
+
+  it("listRuns sends project when project_null is not set", async () => {
+    const calls = stubFetch({
+      runs: [],
+      page: 1,
+      per_page: 20,
+      total: 0,
+      total_pages: 0,
+      has_next: false,
+      has_prev: false,
+    });
+    const { listRuns } = await import("./api");
+    await listRuns({ project: "org/alpha" });
+    const url = new URL(calls[0]!.url, "http://localhost");
+    expect(url.searchParams.get("project")).toBe("org/alpha");
+    expect(url.searchParams.has("project_null")).toBe(false);
+  });
+
+  it("listRunProjects — GET /api/runs/projects", async () => {
+    const payload = { projects: [{ project: "org/alpha", count: 3, last_activity: 1 }], total: 3 };
+    const calls = stubFetch(payload);
+    const { listRunProjects } = await import("./api");
+    const result = await listRunProjects();
+    expect(result).toEqual(payload);
+    expect(calls[0]?.url).toMatch(/\/api\/runs\/projects/);
+  });
+
+  it("getSession sends message_cursor, not message_offset, when a cursor is given", async () => {
+    const calls = stubFetch({ id: "s1", name: "s", created_at: 1, updated_at: 1, branches: [] });
+    const { getSession } = await import("./api");
+    await getSession("s1", { messageCursor: "cursor-1", messageLimit: 50 });
+    const url = new URL(calls[0]!.url, "http://localhost");
+    expect(url.searchParams.get("message_cursor")).toBe("cursor-1");
+    expect(url.searchParams.get("message_limit")).toBe("50");
+    expect(url.searchParams.has("message_offset")).toBe(false);
+  });
+
+  it("getSession omits message_cursor entirely when not given (first page)", async () => {
+    const calls = stubFetch({ id: "s1", name: "s", created_at: 1, updated_at: 1, branches: [] });
+    const { getSession } = await import("./api");
+    await getSession("s1");
+    const url = new URL(calls[0]!.url, "http://localhost");
+    expect(url.searchParams.has("message_cursor")).toBe(false);
+  });
+});

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -383,11 +383,7 @@ export async function cancelOperatorRequest(
 }
 
 export type OperatorEffectRejectionCode =
-  | "unsupported"
-  | "invalid_params"
-  | "stale_context"
-  | "not_visible"
-  | "client_error";
+  "unsupported" | "invalid_params" | "stale_context" | "not_visible" | "client_error";
 
 export async function acknowledgeOperatorEffect(
   conversationId: string,
@@ -611,6 +607,8 @@ export interface RunListParams {
   status?: string[];
   playbook?: string;
   project?: string;
+  project_null?: boolean;
+  search?: string;
 }
 
 export interface RunListResponse {
@@ -628,7 +626,12 @@ export async function listRuns(params?: RunListParams): Promise<RunListResponse>
   if (params?.page != null) query.set("page", String(params.page));
   if (params?.per_page != null) query.set("per_page", String(params.per_page));
   if (params?.playbook) query.set("playbook", params.playbook);
-  if (params?.project) query.set("project", params.project);
+  if (params?.project_null) {
+    query.set("project_null", "true");
+  } else if (params?.project) {
+    query.set("project", params.project);
+  }
+  if (params?.search) query.set("search", params.search);
   for (const value of params?.status ?? []) query.append("status", value);
   const suffix = query.toString() ? `?${query.toString()}` : "";
   // The daemon registers this list route with a trailing slash (unlike
@@ -636,6 +639,23 @@ export async function listRuns(params?: RunListParams): Promise<RunListResponse>
   // absolute-Location, which the browser then blocks as cross-origin
   // whenever the frontend is served from a different origin than the daemon.
   return fetchJson<RunListResponse>(`/api/runs/${suffix}`);
+}
+
+export interface RunProjectCount {
+  project: string | null;
+  count: number;
+  last_activity: number | null;
+}
+
+export interface RunProjectsResponse {
+  projects: RunProjectCount[];
+  total: number;
+}
+
+/** Per-project run counts, sorted by last activity — feeds the fleet project
+ * filter's option list without requiring a full unfiltered run scan. */
+export async function listRunProjects(): Promise<RunProjectsResponse> {
+  return fetchJson<RunProjectsResponse>("/api/runs/projects");
 }
 
 export async function getRun(runId: string): Promise<RunDetail> {
@@ -661,8 +681,7 @@ export interface RunFileContent {
 }
 
 export type RunFileResult =
-  | { ok: true; data: RunFileContent }
-  | { ok: false; status: number; detail?: string };
+  { ok: true; data: RunFileContent } | { ok: false; status: number; detail?: string };
 
 /** Read-only fetch of a run artifact's content, for the message-renderer's
  * file viewer. Reports status/detail on failure (rather than throwing) so
@@ -1036,6 +1055,10 @@ export interface SessionBranch {
   /** Full progression length; messages is a tail window of it. */
   message_total?: number;
   message_offset?: number;
+  /** Whether this branch has messages older than the current window — the
+   * server's own signal, independent of the message_total/messages.length
+   * diff the client also computes. */
+  message_has_older?: boolean;
   model?: string | null;
   provider?: string | null;
   agent_name?: string | null;
@@ -1050,6 +1073,10 @@ export interface SessionDetail {
   started_at?: number | null;
   ended_at?: number | null;
   branches: SessionBranch[];
+  // Opaque anchor cursor for the "load older" page, one page further back
+  // than what `branches[].messages` currently carries. Absent/null once every
+  // branch's progression has been fully paged.
+  message_next_cursor?: string | null;
   // ADR-0022: provenance disclosure — mirrors what list_sessions() exposes.
   model?: string | null;
   provider?: string | null;
@@ -1085,13 +1112,18 @@ export async function listSessions(): Promise<{ sessions: SessionSummary[] }> {
 
 export const SESSION_MESSAGE_PAGE = 200;
 
+// message_cursor pages backward from the tail (server: services/sessions.py
+// _window_message_ids) — each older page's anchor is stable against new
+// messages landing at the tail, unlike a fixed offset that shifts under a
+// live session. The offset param still exists server-side for legacy callers
+// but this client only ever asks for a page by cursor.
 export async function getSession(
   id: string,
-  params?: { messageLimit?: number; messageOffset?: number },
+  params?: { messageLimit?: number; messageCursor?: string },
 ): Promise<SessionDetail> {
   const query = new URLSearchParams();
   if (params?.messageLimit != null) query.set("message_limit", String(params.messageLimit));
-  if (params?.messageOffset != null) query.set("message_offset", String(params.messageOffset));
+  if (params?.messageCursor != null) query.set("message_cursor", params.messageCursor);
   const qs = query.toString();
   return fetchJson<SessionDetail>(`/api/sessions/${encodeURIComponent(id)}${qs ? `?${qs}` : ""}`);
 }

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "استدعاءات الأدوات (الأخيرة)",
       "statErrorsRecent": "الأخطاء (الأخيرة)",
       "noBranchErrorsPartial": "لا توجد أخطاء في الرسائل المحمّلة.",
-      "noFilesPartial": "لم تُكتشف عمليات على الملفات في الرسائل المحمّلة."
+      "noFilesPartial": "لم تُكتشف عمليات على الملفات في الرسائل المحمّلة.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "قائمة السجل",
     "detailAria": "تفاصيل العنصر"
@@ -724,6 +726,14 @@
       "empty": "لا توجد جلسات سابقة تطابق هذا العامل.",
       "loadMore": "تحميل المزيد",
       "loadingMore": "جارٍ التحميل…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "টুল কল (সাম্প্রতিক)",
       "statErrorsRecent": "ত্রুটি (সাম্প্রতিক)",
       "noBranchErrorsPartial": "লোড করা মেসেজে কোনো ত্রুটি নেই।",
-      "noFilesPartial": "লোড করা মেসেজে কোনো ফাইল অপারেশন শনাক্ত হয়নি।"
+      "noFilesPartial": "লোড করা মেসেজে কোনো ফাইল অপারেশন শনাক্ত হয়নি।",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "হিস্ট্রি তালিকা",
     "detailAria": "আইটেমের বিস্তারিত"
@@ -724,6 +726,14 @@
       "empty": "এই ফিল্টারের সঙ্গে কোনো পুরনো সেশন মেলে না।",
       "loadMore": "আরও লোড করুন",
       "loadingMore": "লোড হচ্ছে…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "Toolaufrufe (aktuell)",
       "statErrorsRecent": "Fehler (aktuell)",
       "noBranchErrorsPartial": "Keine Fehler in den geladenen Nachrichten.",
-      "noFilesPartial": "Keine Dateioperationen in den geladenen Nachrichten erkannt."
+      "noFilesPartial": "Keine Dateioperationen in den geladenen Nachrichten erkannt.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "Verlaufsliste",
     "detailAria": "Elementdetails"
@@ -724,6 +726,14 @@
       "empty": "Keine vergangenen Sessions entsprechen diesem Filter.",
       "loadMore": "Mehr laden",
       "loadingMore": "Wird geladen…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "Tool calls (recent)",
       "statErrorsRecent": "Errors (recent)",
       "noBranchErrorsPartial": "No errors in the loaded messages.",
-      "noFilesPartial": "No file operations detected in the loaded messages."
+      "noFilesPartial": "No file operations detected in the loaded messages.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "History list",
     "detailAria": "Item detail"
@@ -724,6 +726,14 @@
       "empty": "No past sessions match this filter.",
       "loadMore": "Load more",
       "loadingMore": "Loading…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "Llamadas a herramienta (recientes)",
       "statErrorsRecent": "Errores (recientes)",
       "noBranchErrorsPartial": "No hay errores en los mensajes cargados.",
-      "noFilesPartial": "No se detectaron operaciones de archivo en los mensajes cargados."
+      "noFilesPartial": "No se detectaron operaciones de archivo en los mensajes cargados.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "Lista de historial",
     "detailAria": "Detalle del elemento"
@@ -724,6 +726,14 @@
       "empty": "Ninguna sesión anterior coincide con este filtro.",
       "loadMore": "Cargar más",
       "loadingMore": "Cargando…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "Appels d’outil (récents)",
       "statErrorsRecent": "Erreurs (récentes)",
       "noBranchErrorsPartial": "Aucune erreur dans les messages chargés.",
-      "noFilesPartial": "Aucune opération de fichier détectée dans les messages chargés."
+      "noFilesPartial": "Aucune opération de fichier détectée dans les messages chargés.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "Liste d’historique",
     "detailAria": "Détail de l’élément"
@@ -724,6 +726,14 @@
       "empty": "Aucune session passée ne correspond à ce filtre.",
       "loadMore": "Charger plus",
       "loadingMore": "Chargement…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "टूल कॉल (हाल के)",
       "statErrorsRecent": "त्रुटियाँ (हाल की)",
       "noBranchErrorsPartial": "लोड किए गए मैसेज में कोई त्रुटि नहीं।",
-      "noFilesPartial": "लोड किए गए मैसेज में कोई फ़ाइल ऑपरेशन नहीं मिला।"
+      "noFilesPartial": "लोड किए गए मैसेज में कोई फ़ाइल ऑपरेशन नहीं मिला।",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "इतिहास सूची",
     "detailAria": "आइटम विवरण"
@@ -724,6 +726,14 @@
       "empty": "कोई पिछला सेशन इस फ़िल्टर से मेल नहीं खाता।",
       "loadMore": "और लोड करें",
       "loadingMore": "लोड हो रहा है…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "Pemanggilan alat (terbaru)",
       "statErrorsRecent": "Kesalahan (terbaru)",
       "noBranchErrorsPartial": "Tidak ada kesalahan dalam pesan yang dimuat.",
-      "noFilesPartial": "Tidak ada operasi file terdeteksi dalam pesan yang dimuat."
+      "noFilesPartial": "Tidak ada operasi file terdeteksi dalam pesan yang dimuat.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "Daftar riwayat",
     "detailAria": "Detail item"
@@ -724,6 +726,14 @@
       "empty": "Tidak ada sesi lampau yang cocok dengan filter ini.",
       "loadMore": "Muat lebih banyak",
       "loadingMore": "Memuat…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "直近のツール呼び出し",
       "statErrorsRecent": "エラー (最近)",
       "noBranchErrorsPartial": "読み込まれたメッセージにエラーはありません。",
-      "noFilesPartial": "読み込まれたメッセージにファイル操作は検出されていません。"
+      "noFilesPartial": "読み込まれたメッセージにファイル操作は検出されていません。",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "履歴一覧",
     "detailAria": "項目の詳細"
@@ -724,6 +726,14 @@
       "empty": "このフィルターに一致する過去のセッションはありません。",
       "loadMore": "さらに読み込む",
       "loadingMore": "読み込み中…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "도구 호출(최근)",
       "statErrorsRecent": "오류(최근)",
       "noBranchErrorsPartial": "로드된 메시지에 오류가 없습니다.",
-      "noFilesPartial": "로드된 메시지에서 감지된 파일 작업이 없습니다."
+      "noFilesPartial": "로드된 메시지에서 감지된 파일 작업이 없습니다.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "기록 목록",
     "detailAria": "항목 세부 정보"
@@ -724,6 +726,14 @@
       "empty": "이 필터와 일치하는 과거 세션이 없습니다.",
       "loadMore": "더 로드",
       "loadingMore": "로드 중…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "Chamadas de ferramenta (recentes)",
       "statErrorsRecent": "Erros (recentes)",
       "noBranchErrorsPartial": "Nenhum erro nas mensagens carregadas.",
-      "noFilesPartial": "Nenhuma operação de arquivo detectada nas mensagens carregadas."
+      "noFilesPartial": "Nenhuma operação de arquivo detectada nas mensagens carregadas.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "Lista do histórico",
     "detailAria": "Detalhes do item"
@@ -724,6 +726,14 @@
       "empty": "Nenhuma sessão passada corresponde a este filtro.",
       "loadMore": "Carregar mais",
       "loadingMore": "Carregando…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "Вызовы инструментов (последние)",
       "statErrorsRecent": "Ошибки (последние)",
       "noBranchErrorsPartial": "В загруженных сообщениях ошибок нет.",
-      "noFilesPartial": "В загруженных сообщениях операции с файлами не обнаружены."
+      "noFilesPartial": "В загруженных сообщениях операции с файлами не обнаружены.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "Список истории",
     "detailAria": "Сведения об элементе"
@@ -724,6 +726,14 @@
       "empty": "Нет прошлых сессий, соответствующих фильтру.",
       "loadMore": "Загрузить еще",
       "loadingMore": "Загрузка…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "araç çağrıları (son)",
       "statErrorsRecent": "hatalar (son)",
       "noBranchErrorsPartial": "yüklenen mesajlarda hata yok.",
-      "noFilesPartial": "yüklenen mesajlarda dosya işlemi algılanmadı."
+      "noFilesPartial": "yüklenen mesajlarda dosya işlemi algılanmadı.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "geçmiş listesi",
     "detailAria": "öğe ayrıntısı"
@@ -724,6 +726,14 @@
       "empty": "bu filtreyle eşleşen geçmiş oturum yok.",
       "loadMore": "daha fazla yükle",
       "loadingMore": "yükleniyor…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "ٹول کالز (حالیہ)",
       "statErrorsRecent": "خرابیاں (حالیہ)",
       "noBranchErrorsPartial": "لوڈ شدہ پیغامات میں کوئی خرابی نہیں۔",
-      "noFilesPartial": "لوڈ شدہ پیغامات میں کوئی فائل آپریشن نہیں ملا۔"
+      "noFilesPartial": "لوڈ شدہ پیغامات میں کوئی فائل آپریشن نہیں ملا۔",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "ہسٹری فہرست",
     "detailAria": "آئٹم تفصیل"
@@ -724,6 +726,14 @@
       "empty": "کوئی پچھلا سیشن اس فلٹر سے میل نہیں کھاتا۔",
       "loadMore": "مزید لوڈ کریں",
       "loadingMore": "لوڈ ہو رہا ہے…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "lệnh gọi công cụ (gần đây)",
       "statErrorsRecent": "lỗi (gần đây)",
       "noBranchErrorsPartial": "không có lỗi trong các tin nhắn đã tải.",
-      "noFilesPartial": "không phát hiện thao tác tệp trong các tin nhắn đã tải."
+      "noFilesPartial": "không phát hiện thao tác tệp trong các tin nhắn đã tải.",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "danh sách lịch sử",
     "detailAria": "chi tiết mục"
@@ -724,6 +726,14 @@
       "empty": "không có phiên cũ nào khớp với bộ lọc này.",
       "loadMore": "tải thêm",
       "loadingMore": "đang tải…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -374,7 +374,9 @@
       "statToolCallsRecent": "工具调用（近期）",
       "statErrorsRecent": "错误（近期）",
       "noBranchErrorsPartial": "已加载的消息中没有错误。",
-      "noFilesPartial": "已加载的消息中未检测到文件操作。"
+      "noFilesPartial": "已加载的消息中未检测到文件操作。",
+      "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
+      "reloadConversation": "Reload conversation"
     },
     "masterAria": "历史列表",
     "detailAria": "条目详情"
@@ -724,6 +726,14 @@
       "empty": "没有符合该过滤条件的历史会话。",
       "loadMore": "加载更多",
       "loadingMore": "加载中…"
+    },
+    "filters": {
+      "searchPlaceholder": "Search sessions…",
+      "searchAria": "Search sessions by name or agent",
+      "allProjects": "All projects",
+      "noProject": "No project",
+      "projectAria": "Filter by project",
+      "clear": "Clear filters"
     }
   },
   "mission": {

--- a/apps/studio/frontend/src/routes/-fleet.test.ts
+++ b/apps/studio/frontend/src/routes/-fleet.test.ts
@@ -58,4 +58,40 @@ describe("validateFleetSearch", () => {
   it("returns an empty object for no search", () => {
     expect(validateFleetSearch({})).toEqual({});
   });
+
+  // ─── project / project_null / q — Fleet filter state (URL-persisted) ──────
+
+  it("parses a project filter to a clean string", () => {
+    expect(validateFleetSearch({ project: "org/alpha" })).toEqual({ project: "org/alpha" });
+  });
+
+  it("takes the first non-empty string when project arrives as an array", () => {
+    expect(validateFleetSearch({ project: ["", "org/alpha", "org/beta"] })).toEqual({
+      project: "org/alpha",
+    });
+  });
+
+  it("parses project_null from a real boolean or the string 'true'", () => {
+    expect(validateFleetSearch({ project_null: true })).toEqual({ project_null: true });
+    expect(validateFleetSearch({ project_null: "true" })).toEqual({ project_null: true });
+  });
+
+  it("drops project_null when false or absent", () => {
+    expect(validateFleetSearch({ project_null: false })).toEqual({});
+    expect(validateFleetSearch({})).not.toHaveProperty("project_null");
+  });
+
+  it("parses the search text as q", () => {
+    expect(validateFleetSearch({ q: "flaky login" })).toEqual({ q: "flaky login" });
+  });
+
+  it("drops an empty q rather than carrying an empty-string filter", () => {
+    expect(validateFleetSearch({ q: "" })).toEqual({});
+  });
+
+  it("combines s, project, project_null, and q together", () => {
+    expect(
+      validateFleetSearch({ s: "run-1", project: "org/alpha", project_null: true, q: "flaky" }),
+    ).toEqual({ s: "run-1", project: "org/alpha", project_null: true, q: "flaky" });
+  });
 });

--- a/apps/studio/frontend/src/routes/fleet.tsx
+++ b/apps/studio/frontend/src/routes/fleet.tsx
@@ -14,7 +14,12 @@ export type FleetSearch = RetiredSearch & {
   s?: string;
   status?: RetiredSearchValue;
   playbook?: RetiredSearchValue;
-  project?: RetiredSearchValue;
+  // `project`/`project_null`/`q` are actively read by FleetView to scope and
+  // search the session list — unlike the other retired-route leftovers below,
+  // these are load-bearing, not just preserved for old bookmarks.
+  project?: string;
+  project_null?: boolean;
+  q?: string;
   page?: RetiredSearchValue;
   skill?: RetiredSearchValue;
   sessions?: RetiredSearchValue;
@@ -26,9 +31,23 @@ export function validateFleetSearch(search: Record<string, unknown>): FleetSearc
   const s = firstSearchString(search.s);
   if (!s) {
     delete preserved.s;
-    return preserved;
+  } else {
+    preserved.s = s;
   }
-  return { ...preserved, s };
+
+  // project/project_null/q are parsed to clean scalar types (not the raw
+  // RetiredSearchValue passthrough) since the view reads them directly.
+  delete preserved.project;
+  delete preserved.project_null;
+  delete preserved.q;
+  const out: FleetSearch = preserved;
+  const project = firstSearchString(search.project);
+  if (project) out.project = project;
+  if (search.project_null === true || search.project_null === "true") out.project_null = true;
+  const q = firstSearchString(search.q);
+  if (q) out.q = q;
+
+  return out;
 }
 
 export const Route = createFileRoute("/fleet")({

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -509,6 +509,7 @@ async def list_runs(
     project_null: bool = False,
     tag: list[str] | None = None,
     *,
+    search: str | None = None,
     limit: int = _sessions_svc.MAX_SESSION_PAGE,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
@@ -523,6 +524,7 @@ async def list_runs(
         project=project,
         project_null=project_null,
         tags=tag,
+        search=search,
     )
     sessions = await _sessions_svc.list_sessions(limit=limit, offset=offset, where=where)
     now = time.time()
@@ -715,6 +717,10 @@ async def list_runs_route(
     tag: list[str] | None = Query(  # noqa: B008
         default=None, description="Repeated tag filter (AND-composed)"
     ),
+    search: str | None = Query(
+        default=None,
+        description="Case-insensitive contains match on session name or agent name",
+    ),
 ) -> dict[str, Any]:
     where = _sessions_svc.SessionFilter(
         playbook=playbook,
@@ -722,6 +728,7 @@ async def list_runs_route(
         project=project,
         project_null=project_null,
         tags=tag,
+        search=search,
     )
     runs = await list_runs(
         playbook=playbook,
@@ -729,6 +736,7 @@ async def list_runs_route(
         project=project,
         project_null=project_null,
         tag=tag,
+        search=search,
         limit=per_page,
         offset=(page - 1) * per_page,
     )

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -104,6 +104,22 @@ def _format_message(row: aiosqlite.Row | dict[str, Any]) -> dict[str, Any]:
 MAX_SESSION_PAGE = 500
 
 
+# SQLite LIKE's own wildcards, '%' and '_', are otherwise live inside a
+# contains-filter value: a search for "50%" would match every row instead of
+# rows containing the literal substring "50%". Escaping is applied to every
+# LIKE operand this module builds, not just search — a stray '%'/'_' in a
+# playbook-name filter has the same bug.
+_LIKE_ESCAPE_CHAR = "\\"
+
+
+def _escape_like(value: str) -> str:
+    return (
+        value.replace(_LIKE_ESCAPE_CHAR, _LIKE_ESCAPE_CHAR * 2)
+        .replace("%", f"{_LIKE_ESCAPE_CHAR}%")
+        .replace("_", f"{_LIKE_ESCAPE_CHAR}_")
+    )
+
+
 class SessionFilter:
     """Filters the runs/sessions listings share, pushed into SQL so they select
     the page rather than discard rows after the whole store has been read."""
@@ -116,19 +132,33 @@ class SessionFilter:
         project: str | None = None,
         project_null: bool = False,
         tags: list[str] | None = None,
+        search: str | None = None,
     ) -> None:
         self.playbook = playbook
         self.statuses = statuses
         self.project = project
         self.project_null = project_null
         self.tags = list(dict.fromkeys(tags)) if tags else None
+        self.search = search
 
     def where(self) -> tuple[str, list[Any]]:
         clauses: list[str] = []
         params: list[Any] = []
         if self.playbook:
-            clauses.append("LOWER(COALESCE(s.playbook_name, '')) LIKE '%' || LOWER(?) || '%'")
-            params.append(self.playbook)
+            clauses.append(
+                "LOWER(COALESCE(s.playbook_name, '')) LIKE '%' || LOWER(?) || '%' "
+                f"ESCAPE '{_LIKE_ESCAPE_CHAR}'"
+            )
+            params.append(_escape_like(self.playbook))
+        if self.search:
+            escaped = _escape_like(self.search)
+            clauses.append(
+                "(LOWER(COALESCE(s.name, '')) LIKE '%' || LOWER(?) || '%' "
+                f"ESCAPE '{_LIKE_ESCAPE_CHAR}' "
+                "OR LOWER(COALESCE(s.agent_name, '')) LIKE '%' || LOWER(?) || '%' "
+                f"ESCAPE '{_LIKE_ESCAPE_CHAR}')"
+            )
+            params.extend([escaped, escaped])
         if self.statuses:
             ordered = sorted(self.statuses)
             placeholders = ",".join("?" for _ in ordered)

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -34,6 +34,7 @@ async def _seed_sessions(db_path: Path, sessions: list[dict]) -> None:
                 "name": s.get("name"),
                 "status": s.get("status", "completed"),
                 "playbook_name": s.get("playbook_name"),
+                "agent_name": s.get("agent_name"),
                 "started_at": s.get("started_at", time.time()),
                 "project": s.get("project"),
             }
@@ -199,6 +200,124 @@ def test_runs_list_project_null_filter(tmp_path, monkeypatch):
     # A positive project filter returns only that project's runs.
     r2 = client.get("/api/runs?project=org/alpha")
     assert r2.json()["total"] == 2
+
+
+# ─── GET /api/runs?search= — session/agent name contains filter ─────────────
+
+
+def test_runs_list_search_matches_name_or_agent_name(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    sessions = [
+        {"id": str(uuid.uuid4()), "name": "fix flaky login test"},
+        {"id": str(uuid.uuid4()), "name": "unrelated", "agent_name": "flaky-hunter"},
+        {"id": str(uuid.uuid4()), "name": "totally different"},
+    ]
+    _run(_seed_sessions(db_path, sessions))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs?search=flaky")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 2
+    names = {run["name"] for run in data["runs"]}
+    assert names == {"fix flaky login test", "unrelated"}
+
+
+def test_runs_list_search_is_case_insensitive(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    sessions = [{"id": str(uuid.uuid4()), "name": "Deploy Pipeline"}]
+    _run(_seed_sessions(db_path, sessions))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs?search=DEPLOY")
+    assert r.json()["total"] == 1
+
+
+def test_runs_list_search_no_match_returns_empty(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    sessions = [{"id": str(uuid.uuid4()), "name": "alpha"}]
+    _run(_seed_sessions(db_path, sessions))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs?search=zzz-no-such-thing")
+    assert r.status_code == 200
+    assert r.json()["total"] == 0
+    assert r.json()["runs"] == []
+
+
+def test_runs_list_search_escapes_percent_wildcard(tmp_path, monkeypatch):
+    """A literal '%' in the query must not act as a SQL LIKE wildcard — searching
+    for "50%" should match only names containing that literal substring, not
+    every row in the store."""
+    db_path = tmp_path / "state.db"
+    sessions = [
+        {"id": str(uuid.uuid4()), "name": "hit rate 50% today"},
+        {"id": str(uuid.uuid4()), "name": "completely unrelated"},
+    ]
+    _run(_seed_sessions(db_path, sessions))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs", params={"search": "50%"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["runs"][0]["name"] == "hit rate 50% today"
+
+
+def test_runs_list_search_escapes_underscore_wildcard(tmp_path, monkeypatch):
+    """A literal '_' must match only itself, not SQL LIKE's any-single-char
+    wildcard — "job_1" must not also match "jobX1"."""
+    db_path = tmp_path / "state.db"
+    sessions = [
+        {"id": str(uuid.uuid4()), "name": "job_1 run"},
+        {"id": str(uuid.uuid4()), "name": "jobX1 run"},
+    ]
+    _run(_seed_sessions(db_path, sessions))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs", params={"search": "job_1"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["runs"][0]["name"] == "job_1 run"
+
+
+def test_runs_list_playbook_filter_also_escapes_wildcards(tmp_path, monkeypatch):
+    """The pre-existing playbook contains-filter shares the same LIKE-building
+    code path and had the same unescaped-wildcard hole — covering it here so a
+    future refactor can't silently reopen it."""
+    db_path = tmp_path / "state.db"
+    sessions = [
+        {"id": str(uuid.uuid4()), "playbook_name": "release_50%"},
+        {"id": str(uuid.uuid4()), "playbook_name": "unrelated-playbook"},
+    ]
+    _run(_seed_sessions(db_path, sessions))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs", params={"playbook": "50%"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert data["runs"][0]["playbook_name"] == "release_50%"
+
+
+def test_runs_list_search_composes_with_pagination(tmp_path, monkeypatch):
+    """Search must be applied in SQL before paging, not to an already-truncated
+    page — seed more matches than one page and confirm total/pagination reflect
+    the full filtered result set."""
+    db_path = tmp_path / "state.db"
+    matching = [{"id": str(uuid.uuid4()), "name": f"target-{i}"} for i in range(25)]
+    noise = [{"id": str(uuid.uuid4()), "name": f"noise-{i}"} for i in range(10)]
+    _run(_seed_sessions(db_path, matching + noise))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs?search=target&per_page=20")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 25
+    assert len(data["runs"]) == 20
+    assert data["has_next"] is True
+    assert all("target" in run["name"] for run in data["runs"])
 
 
 # ─── ADR-0057/FIX-1: UNRESPONSIVE maps to 'stale' in runs list ───────────────


### PR DESCRIPTION
The fleet session list had no way to narrow itself, and its conversation scrollback could silently skip messages.

- Sessions can be searched by name or agent and scoped by project. LIKE wildcards in the search term are escaped.
- Conversation history pages backward by the stable cursor the backend already returned. The previous button paged by offset, which on a live session repeats rows (hidden by an id dedupe) or skips them (hidden by nothing).
- A scoped view no longer drops an invocation whose children were all filtered out unless the runs page it is reading is the whole scoped set, and a surviving group reports the children it is showing rather than a global total that answers a different question.
- Selecting a row patches the current URL search instead of replacing it, so the project and text filters that produced the row survive the selection.
- The load-older control is driven by the pagination cursor rather than by the difference between a branch's total and its loaded messages. After messages land at the tail that difference counts newer messages the cursor cannot reach, which left an enabled control that did nothing. Its in-flight guard is a ref rather than render state, because the scroll sentinel can fire twice in one turn and render state does not update between those two callbacks.

The paging test asserts an exact count while messages land during the fetch: not fewer, which would be a skip, and not more, which would be a duplicate.

### On the pinned counters

The locale leaf pin and the route-table pin count things that several branches add to at once. Both are re-derived by running the pinned test against the merged tree and reading the measured value, never by adding the two sides' deltas together. Those two happen to agree whenever the sides' additions are disjoint, which makes agreement worthless as a check: only the measurement establishes the number.

### Correction to a claim in this branch's merge commit

The merge commit that brings `main` into this branch says two union types in the frontend API client were committed to the base branch in a shape the formatter does not produce. That is wrong. The base branch's copy is correctly formatted; the single-line shape was introduced on this branch and the pre-commit formatter was restoring it, not surfacing anything pre-existing. The original claim came from running the formatter on a copy of the file outside the project tree, where it silently used its own defaults instead of the repository's configuration.

Closes #2737
Closes #2739
