### PR TITLE
fix(cli): a late poller must not overwrite an outcome someone else recorded

### DIFF
--- a/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
+++ b/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
@@ -7,7 +7,8 @@
 - **Relations**: supersedes v0-0085, v0-0088; amended by ADR-0108, which widens the
   `message` verb's consumer set to the `agent` invocation kind, so this document's
   rule that an invocation kind outside `{"flow", "play"}` fails without inserting a
-  row no longer holds for that verb
+  row no longer holds for that verb, and widens the terminal `result` vocabulary
+  below, which is no longer a closed list of three
 
 ## Context
 
@@ -123,6 +124,29 @@ Exact addressing and queue semantics:
 Terminal `result` values are `applied`, `applying`, or `rejected:<reason>`. The poller records a
 compact control log in session `node_metadata`, but `session_controls` remains the authoritative
 request/application row.
+
+**This list is no longer closed — ADR-0108 extends it, and a reader checking equality against
+the three values above will miss rows.** The current stored forms, taken from the code rather
+than from this list:
+
+| form | written by |
+|---|---|
+| `applying` | a claimant that named no owner |
+| `applying:<owner>` | a claimant that named one, so a second consumer can tell "someone else holds this" from "I hold this" |
+| `applied` | an ordinary successful apply |
+| `rejected:no-pending-ops`, `rejected:unsupported-verb:<verb>`, `rejected:error:<exc>` | the flow poller |
+| `rejected: <sentence>` | run teardown, prose after the colon rather than a token |
+| `<applied\|abandoned>: resolved by <who> after the claim '<prior>' was taken and never reported back` | `li o ctl resolve`, a person closing a control whose claimant never came back |
+
+Two consequences for anyone reading this column. **Match by prefix, not equality**: every
+consumer of the claim check in the tree uses `startswith("applying")` for exactly this reason,
+and equality would stop matching the claims that identify who holds them. And `abandoned` is a
+terminal outcome that this ADR never contemplated, reachable only through a human resolution.
+
+Unrelated despite the name: `lionagi/state/lifecycle/` carries its own `result` with the values
+`applied`, `rejected`, and `conflict`. That is the session-status transition service and it never
+touches `session_controls`; the shared field name is a coincidence and the vocabularies are not
+the same one.
 
 Why this way: a database row lets a separate CLI process address a live flow without a process-wide
 handle registry. Restricting insertion to running flow/play sessions prevents controls from sitting

--- a/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
+++ b/docs/adr/ADR-0069-reactive-flow-steering-and-recovery.md
@@ -60,7 +60,7 @@ Out of scope:
 
 ### D1 — Ordered session-control rows are the live transport
 
-The public writers are:
+The public writers that create rows are:
 
 ```python
 # lionagi/cli/orchestrate/_control.py
@@ -72,6 +72,18 @@ async def _enqueue_control_inner(
     *, entity_id: str, verb: str, payload: dict[str, Any] | None
 ) -> tuple[str, int]: ...
 ```
+
+One further public writer does not create rows but closes them, and a reader who takes the
+list above as the whole set will not find it:
+
+```python
+# lionagi/cli/orchestrate/_control.py
+def run_ctl_resolve(args: argparse.Namespace) -> int: ...
+```
+
+It is how a person records the outcome of a control whose claimant never came back. It is
+covered in the result-vocabulary table below and in ADR-0108; it is named here because this
+is the section a reader consults for the set of writers.
 
 Their persisted contract is:
 
@@ -121,7 +133,9 @@ Exact addressing and queue semantics:
 - If a successful effect cannot be terminally stamped, the poller stops that tick so a later
   control cannot overtake the unstamped row.
 
-Terminal `result` values are `applied`, `applying`, or `rejected:<reason>`. The poller records a
+Terminal `result` values are `applied` or `rejected:<reason>`. `applying` is not one of them:
+it is a claim, written to say a consumer has taken the row and not yet reported an outcome, and
+a row still carrying it is a row whose result nobody knows. The poller records a
 compact control log in session `node_metadata`, but `session_controls` remains the authoritative
 request/application row.
 

--- a/docs/adr/ADR-0108-agent-run-steering-at-turn-end.md
+++ b/docs/adr/ADR-0108-agent-run-steering-at-turn-end.md
@@ -161,10 +161,27 @@ steer landing as a warm continuation turn at the run's next turn boundary.
    Two things follow, and both are now the design. **The claim is returned by the code
    that writes it** rather than rebuilt by callers: a guard only guards while the
    expression that produces it and the expression that stored it agree, and two copies
-   of a string are what stop agreeing. **A guarded write that lands nowhere says so**,
-   and its caller reports the row as untouched rather than returning the outcome it
-   failed to record — a receipt for a write that did not happen is the same defect as
-   the overwrite, one level up.
+   of a string are what stop agreeing. **A guarded write that lands nowhere says so**:
+   the drain reports the refusal instead of discarding it, because a receipt for a
+   write that did not happen is the same defect as the overwrite, one level up.
+
+   **What this guarantees, and what it does not.** The guarantee is about the record
+   only: a row's outcome is written by whoever still holds the claim, and no writer
+   silently replaces an outcome it does not own. It is not a guarantee about the
+   effect. The effect and the record are not written together, and on the agent drain
+   the effect comes first: the operator message is handed to the branch, the
+   continuation turn runs, and the finalize happens after it returns. A hand
+   resolution landing inside that window is refused nothing — it owns the row, so it
+   wins — and the result is a row reading `abandoned` for a message that was already
+   delivered to the model. The drain reports that disagreement rather than hiding it,
+   which is all it can do from where it stands; the delivery cannot be recalled. The
+   flow poller has the same shape, with the delivery written into executor context
+   before its own finalize.
+
+   Closing that gap means fencing the effect against the claim, so a delivery whose
+   claim has been revoked cannot land. That is a larger change than this decision
+   makes, it belongs to the transport rather than to either consumer, and it is
+   deliberately out of scope here rather than absent by oversight.
 
 5. **Receipt visibility without mid-turn delivery.** The runner's 60-second heartbeat
    reports a queued steer ("lands at end of current turn") so the operator knows it

--- a/docs/adr/ADR-0108-agent-run-steering-at-turn-end.md
+++ b/docs/adr/ADR-0108-agent-run-steering-at-turn-end.md
@@ -1,6 +1,7 @@
 # ADR-0108: Agent-run steering at the turn-end boundary
 
-- **Status**: Accepted (2026-08-02, PR #2773)
+- **Status**: Accepted (2026-08-02, PR #2773); amended 2026-08-02 — the claim
+  condition binds every consumer of a claimed row, not only the agent drain
 - **Kind**: Aspirational
 - **Area**: scheduling-control-plane
 - **Date**: 2026-08-01
@@ -145,6 +146,26 @@ steer landing as a warm continuation turn at the run's next turn boundary.
    from a shared database can do better, and the honest scope of the guarantee is the
    accidental case rather than the adversarial one.
 
+   **The condition binds every consumer of a claimed row, and originally it did not.**
+   The paragraph above describes the protocol the agent drain follows; the flow poller
+   did not follow it. Its finalize calls on the already-claimed path carried no
+   condition, which is `WHERE id = :id` with no predicate on the outcome, so a poller
+   returning late overwrote whatever the row had come to hold. The ordering that
+   exposes this is the one `ctl resolve` is built for rather than an exotic race: the
+   verb exists for a claimant that has not reported back, so the case it serves is a
+   slow claimant, which is exactly the state a person resolves by hand. Claim, resolve,
+   claimant wakes and stamps over the resolution. The reject paths were the worse half,
+   turning a delivery a person recorded as applied into one the record says never
+   arrived.
+
+   Two things follow, and both are now the design. **The claim is returned by the code
+   that writes it** rather than rebuilt by callers: a guard only guards while the
+   expression that produces it and the expression that stored it agree, and two copies
+   of a string are what stop agreeing. **A guarded write that lands nowhere says so**,
+   and its caller reports the row as untouched rather than returning the outcome it
+   failed to record — a receipt for a write that did not happen is the same defect as
+   the overwrite, one level up.
+
 5. **Receipt visibility without mid-turn delivery.** The runner's 60-second heartbeat
    reports a queued steer ("lands at end of current turn") so the operator knows it
    was received while the turn is still executing. The heartbeat is armed
@@ -221,6 +242,20 @@ steer landing as a warm continuation turn at the run's next turn boundary.
   receipt for a write that never landed. Locking the row on that read instead was tried
   and removed, because the UPDATE takes the same row lock a moment later and the lock
   therefore changed no outcome.
+
+  **Why the verb is not on the MCP surface**, where it is catalogued as unavailable with
+  a reason rather than simply omitted. Every other control verb reports something the
+  system can observe: a queue read, a status, an enqueue. This one records a finding
+  about a delivery the system explicitly cannot determine — that is the whole reason the
+  row was left standing. A machine caller reaching for it would not be reporting that
+  finding, it would be manufacturing it, because it holds exactly the knowledge the row
+  is waiting for, which is none. The verb would still write, the row would still close,
+  and the resulting record would read the same as one a person stood behind. The cost of
+  the omission is that an agent noticing a wedged control must surface it to a person
+  instead of clearing it, which is the intended cost: an operator's judgement is the
+  input, and a surface that accepts a substitute for it produces confident rows nobody
+  checked. It is catalogued rather than hidden so a caller that goes looking finds the
+  reason instead of an absence it has to interpret.
 - **Forced-consumer honesty.** The tombstone's failure path logs, but that log has no
   forced consumer and is not the guarantee. The guarantee is state-shaped and computed
   at read time: the status surface renders an unclaimed pending control on a terminal

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -428,7 +428,7 @@ async def _drain_pending_steers(
         return None
     import time as _time
 
-    from lionagi.cli._logging import hint, log_error
+    from lionagi.cli._logging import hint, log_error, warn
 
     db = live.get("db")
     if db is None:
@@ -498,7 +498,21 @@ async def _drain_pending_steers(
             # a skipped finalize would leave a delivered message on record as
             # undelivered. The claim token is the guard here instead: this write
             # lands only while the row still carries this leg's claim.
-            await db.finalize_session_control(row["id"], result="applied", expect_claim=claim_token)
+            stamped = await db.finalize_session_control(
+                row["id"], result="applied", expect_claim=claim_token
+            )
+            if not stamped:
+                # Somebody resolved the row while the continuation was running.
+                # Their outcome stands, which is the point of the guard, but the
+                # message was already delivered to the branch by then, so the
+                # record now disagrees with what happened. Say so: the delivery
+                # cannot be taken back, and a silent refusal here is the same
+                # defect as the overwrite, one level up.
+                warn(
+                    f"operator message {row['id']} was delivered, but the control row "
+                    f"was resolved by someone else first and now records their outcome "
+                    f"instead of 'applied'. The message reached the agent."
+                )
     return last_res
 
 

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -466,12 +466,15 @@ async def _drain_pending_steers(
                 break
         texts = []
         claimed = []
-        claim_token = f"applying:{owner}" if owner else "applying"
         for row in steers:
-            if not await db.mark_session_control_applying(row["id"], owner=owner):
+            # Carry the claim the database actually wrote rather than rebuilding
+            # it here: the finalize below is only guarded if the two agree, and
+            # two copies of the same expression are what stop agreeing.
+            claim_token = await db.mark_session_control_applying(row["id"], owner=owner)
+            if claim_token is None:
                 # Another consumer claimed it between the read and here.
                 continue
-            claimed.append(row)
+            claimed.append((row, claim_token))
             payload = row.get("payload") or {}
             texts.append(str(payload.get("text") or ""))
         if not claimed:
@@ -488,7 +491,7 @@ async def _drain_pending_steers(
             instruction=_AGENT_STEER_TEMPLATE.format(lines=joined),
             **kwargs,
         )
-        for row in claimed:
+        for row, claim_token in claimed:
             # Unconditional on the clock, deliberately. The deadline gates when
             # new provider work may start, which the recheck above enforces;
             # recording the outcome of work already performed is exempt, because

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -162,6 +162,13 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
     poller crash). Never raises — failures are recorded as rejected."""
     control_id = row["id"]
     verb = row["verb"]
+    # Set only once this poller has actually claimed the row. Every finalize
+    # below passes it, so a write from this function can never land on an
+    # outcome somebody else recorded while the apply was in flight — including
+    # a hand resolution, which is the one outcome here that nothing can rebuild.
+    # It stays None for the idempotent verbs, which take no claim and want the
+    # unconditional write.
+    claim: str | None = None
     try:
         if verb == "pause":
             executor.pause()
@@ -179,7 +186,8 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
                 # owner ('applying:<run id>'), and an equality check would stop
                 # recognising exactly the claims that identify who holds them.
                 return None
-            if not await db.mark_session_control_applying(control_id):
+            claim = await db.mark_session_control_applying(control_id)
+            if claim is None:
                 # The row above said unclaimed; this says it is claimed now.
                 # Only the stamp that actually wrote may go on to inject, since
                 # the losing side proceeding is the double-injection the check
@@ -195,7 +203,10 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
             )
             if not has_pending_op:
                 result = "rejected:no-pending-ops"
-                await db.finalize_session_control(control_id, result=result)
+                if not await db.finalize_session_control(
+                    control_id, result=result, expect_claim=claim
+                ):
+                    return None
                 return result
 
             from lionagi.libs.nested import deep_update  # noqa: PLC0415
@@ -204,18 +215,22 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
             existing = executor.context.content.get("operator_messages", [])
             entry = {"ts": time.time(), "text": payload.get("text", "")}
             deep_update(executor.context.content, {"operator_messages": [*existing, entry]})
-            return await _finalize_applied(db, control_id)
+            return await _finalize_applied(db, control_id, claim)
 
         # 'stop' is schema-reserved for a later slice (checkpoint writer);
         # reject other verbs loudly instead of polling them forever.
         result = f"rejected:unsupported-verb:{verb}"
-        await db.finalize_session_control(control_id, result=result)
+        await db.finalize_session_control(control_id, result=result, expect_claim=claim)
         return result
     except Exception as exc:  # noqa: BLE001 — the poller must never crash the run
         result = f"rejected:error:{exc}"[:500]
         logger.warning("control %s (%s) failed to apply: %s", control_id, verb, exc)
         try:
-            await db.finalize_session_control(control_id, result=result)
+            if not await db.finalize_session_control(control_id, result=result, expect_claim=claim):
+                # The claim moved while this apply was failing, so the row
+                # already carries somebody else's outcome. Recording our error
+                # over it would replace a settled answer with a worse one.
+                return None
         except Exception:  # noqa: BLE001
             # Still pending: signal the poller to end the tick so a later
             # control isn't overtaken by this one re-applying next tick.
@@ -223,13 +238,18 @@ async def _apply_session_control(db, executor, row: dict) -> str | None:
         return result
 
 
-async def _finalize_applied(db, control_id: str) -> str:
+async def _finalize_applied(db, control_id: str, claim: str | None = None) -> str | None:
     """Stamp 'applied' after a successful apply; on finalize failure, retry
-    once then return the unstamped sentinel for the next poller tick."""
+    once then return the unstamped sentinel for the next poller tick.
+
+    Returns None when *claim* is given and the row no longer carries it: the
+    apply happened, but somebody else has since recorded the outcome, and
+    theirs stands. Callers read None as "left untouched by us"."""
     for _ in range(2):
         try:
-            await db.finalize_session_control(control_id, result="applied")
-            return "applied"
+            if await db.finalize_session_control(control_id, result="applied", expect_claim=claim):
+                return "applied"
+            return None
         except Exception as exc:  # noqa: BLE001 — the poller must never crash the run
             logger.warning("control %s applied but finalize failed: %s", control_id, exc)
     return _CONTROL_UNSTAMPED

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -5726,15 +5726,22 @@ class StateDB:
 
     async def mark_session_control_applying(
         self, control_id: str, *, owner: str | None = None
-    ) -> bool:
+    ) -> str | None:
         """Claim a non-idempotent (message) control as mid-apply, before attempting it.
 
         The stamp is a compare-and-set: only a row no consumer has claimed
-        (``result IS NULL``) moves to 'applying', and the return value says
-        whether this caller is the one that took it. Two consumers that read the
-        same pending row therefore cannot both apply it; the loser sees False and
-        leaves the row alone. A bool rather than an exception keeps the ordinary
-        "someone else got there first" case off the error path.
+        (``result IS NULL``) moves to 'applying'. Returns the claim string this
+        call wrote, or None if another consumer got there first. Two consumers
+        that read the same pending row therefore cannot both apply it; the loser
+        sees None and leaves the row alone. Returning a value rather than raising
+        keeps the ordinary "someone else got there first" case off the error path.
+
+        **The claim comes back because the claimant needs it to finish safely.**
+        finalize_session_control(expect_claim=...) is what stops a slow consumer
+        from overwriting an outcome that someone else recorded while it was
+        working, and a caller can only pass a claim it holds. Rebuilding the
+        string at the call site instead is how the two drift apart, so this is
+        the only place it is constructed.
 
         *owner* names the claimant, and the claim is stored as ``applying:<owner>``.
         Naming it is what lets a second consumer tell "someone else is mid-apply"
@@ -5745,6 +5752,7 @@ class StateDB:
         applied_at stays NULL — the row remains "pending" until finalize_session_control()
         runs, so a poller crash right after this stamp is visible, not silently lost.
         """
+        claim = f"applying:{owner}" if owner else "applying"
         async with self._tx() as conn:
             result = await conn.execute(
                 text(
@@ -5752,12 +5760,12 @@ class StateDB:
                     "WHERE id = :id AND result IS NULL"
                 ),
                 {
-                    "claim": f"applying:{owner}" if owner else "applying",
+                    "claim": claim,
                     "now": time.time(),
                     "id": control_id,
                 },
             )
-            return bool(result.rowcount)
+            return claim if result.rowcount else None
 
     async def finalize_session_control(
         self,

--- a/tests/cli/orchestrate/test_control_poller.py
+++ b/tests/cli/orchestrate/test_control_poller.py
@@ -263,6 +263,106 @@ async def test_message_stamped_applying_but_unapplied_is_not_reapplied(tmp_path:
         assert still_row["result"] == "applying"
 
 
+class _ResolvedByHandRightAfterTheClaim:
+    """Puts a hand resolution in the one window where it can be overwritten.
+
+    `ctl resolve` exists for a claimant that never reported back, so the
+    dangerous ordering is not a rare race: it is a slow claimant, which is
+    exactly the state a human resolves. Injecting the resolution rather than
+    racing for it makes that ordering the only one the test can produce.
+    """
+
+    def __init__(self, db, *, outcome: str, actor: str) -> None:
+        self._db = db
+        self._outcome = outcome
+        self._actor = actor
+        self.resolution: str | None = None
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+    async def mark_session_control_applying(self, control_id, **kwargs):
+        claim = await self._db.mark_session_control_applying(control_id, **kwargs)
+        if claim is not None:
+            self.resolution = await self._db.resolve_claimed_session_control(
+                control_id, outcome=self._outcome, actor=self._actor
+            )
+        return claim
+
+
+async def test_the_poller_does_not_overwrite_a_hand_resolution(tmp_path: Path) -> None:
+    """A human's finding about a delivery is the one outcome here that nothing
+    can reconstruct, so a poller that comes back late must lose to it."""
+    async with StateDB(tmp_path / "state.db") as real_db:
+        sid = await _make_session(real_db)
+        control_id = await real_db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "steer"}
+        )
+        row = await real_db.get_session_control(control_id)
+        nodes = Pile(item_type={Operation})
+        nodes.include(_pending_operation())
+        executor = _FakeExecutor(nodes=nodes)
+        db = _ResolvedByHandRightAfterTheClaim(real_db, outcome="applied", actor="ops@example.com")
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert db.resolution is not None, "the injected hand resolution did not land"
+        assert result is None, "the poller reported an outcome it did not record"
+        final = await real_db.get_session_control(control_id)
+        assert final["result"] == db.resolution, (
+            "the poller overwrote the hand resolution: "
+            f"{final['result']!r} replaced {db.resolution!r}"
+        )
+        assert "resolved by ops@example.com" in final["result"]
+
+
+async def test_the_poller_does_not_reject_over_a_hand_resolution(tmp_path: Path) -> None:
+    """The worse direction of the same defect. Here the poller's own answer is a
+    rejection, so an unguarded write would flip a delivery a person recorded as
+    applied into one the record says never happened."""
+    async with StateDB(tmp_path / "state.db") as real_db:
+        sid = await _make_session(real_db)
+        control_id = await real_db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "steer"}
+        )
+        row = await real_db.get_session_control(control_id)
+        # No pending operation, so the poller's verdict is rejected:no-pending-ops.
+        executor = _FakeExecutor()
+        db = _ResolvedByHandRightAfterTheClaim(real_db, outcome="applied", actor="ops@example.com")
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert db.resolution is not None, "the injected hand resolution did not land"
+        assert result is None
+        final = await real_db.get_session_control(control_id)
+        assert final["result"] == db.resolution
+        assert "rejected" not in final["result"]
+
+
+async def test_the_poller_still_records_its_own_outcome_when_nobody_intervenes(
+    tmp_path: Path,
+) -> None:
+    """The guard must not cost the ordinary path its stamp. Without this arm,
+    a finalize that never writes anything would pass the test above."""
+    async with StateDB(tmp_path / "state.db") as db:
+        sid = await _make_session(db)
+        control_id = await db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "steer"}
+        )
+        row = await db.get_session_control(control_id)
+        nodes = Pile(item_type={Operation})
+        nodes.include(_pending_operation())
+        executor = _FakeExecutor(nodes=nodes)
+
+        result = await _apply_session_control(db, executor, row)
+
+        assert result == "applied"
+        final = await db.get_session_control(control_id)
+        assert final["result"] == "applied"
+        assert final["applied_at"] is not None
+        assert executor.context.content["operator_messages"][-1]["text"] == "steer"
+
+
 # ── unsupported verb / stop (schema-reserved, no CLI verb emits it) ────────
 
 

--- a/tests/cli/orchestrate/test_control_poller_lifecycle.py
+++ b/tests/cli/orchestrate/test_control_poller_lifecycle.py
@@ -81,10 +81,15 @@ async def test_ctl_task_applies_a_queued_control_during_a_live_run(tmp_path, mon
         control_finalized = asyncio.Event()
         finalize_session_control = StateDB.finalize_session_control
 
-        async def finalize_and_signal(self, control_id, *, result):
-            await finalize_session_control(self, control_id, result=result)
+        async def finalize_and_signal(self, control_id, **kwargs):
+            # Forward whatever the caller passes rather than naming the
+            # arguments here: this double only exists to observe the call, so
+            # pinning a signature to it turns any change to the real one into
+            # a timeout in a test that is not about signatures.
+            stamped = await finalize_session_control(self, control_id, **kwargs)
             if control_id == control["id"]:
                 control_finalized.set()
+            return stamped
 
         monkeypatch.setattr(StateDB, "finalize_session_control", finalize_and_signal)
 

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -1126,3 +1126,62 @@ async def test_a_hand_resolution_falls_back_to_the_os_account_not_a_placeholder(
     async with StateDB() as db:
         stored = (await db.get_session_control(cid))["result"]
     assert getpass.getuser() in stored, f"no real identity was recorded: {stored!r}"
+
+
+@pytest.mark.anyio
+async def test_a_refused_finalize_after_delivery_is_reported_not_swallowed(temp_db_path, caplog):
+    """Somebody resolves the row while the continuation turn is running.
+
+    The guard is doing its job: the other writer's outcome stands and the drain
+    does not overwrite it. But the message was already handed to the branch
+    before that happened, so the row now records an outcome that disagrees with
+    what the run did. That disagreement is the whole reason to look at the
+    record, and it is invisible if the refusal returns quietly, since the drain
+    hands its caller the continuation's result either way.
+    """
+
+    class _ResolvingBranch:
+        """Resolves the control by hand during the continuation turn, which is
+        the exact window the claim guard exists to cover."""
+
+        def __init__(self, db, control_id):
+            self._db = db
+            self._control_id = control_id
+            self.calls: list[str] = []
+
+        async def operate(self, *, instruction: str, **kwargs):
+            self.calls.append(instruction)
+            await self._db.finalize_session_control(
+                self._control_id, result="abandoned:ops@example.com"
+            )
+            return "turn-1"
+
+    async with StateDB() as db:
+        sid = await _make_agent_session(db)
+        cid = await db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "still relevant?"}
+        )
+
+        branch = _ResolvingBranch(db, cid)
+        res = await _drain_pending_steers(
+            {"db": db, "session_id": sid}, branch, operate_kwargs={}, deadline=None
+        )
+
+        # Delivery happened. The drain cannot take it back and does not pretend
+        # otherwise: the continuation's result is still what it returns.
+        assert len(branch.calls) == 1, "the operator message was never delivered"
+        assert res == "turn-1"
+
+        # The other writer's outcome stands. This is the guard working.
+        stored = (await db.get_session_control(cid))["result"]
+        assert stored == "abandoned:ops@example.com", (
+            f"the drain overwrote a resolution it did not own: {stored!r}"
+        )
+
+    # And the disagreement reached somebody. Without this the caller has no way
+    # to tell a landed finalize from a refused one.
+    reported = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any(cid in m for m in reported), f"the refused finalize named no control: {reported!r}"
+    assert any("delivered" in m for m in reported), (
+        f"the report does not say the message went out anyway: {reported!r}"
+    )

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -437,10 +437,29 @@ async def test_claiming_a_control_twice_only_succeeds_once(temp_db_path):
         cid = await db.insert_session_control(
             session_id=sid, verb="message", payload={"text": "once"}
         )
-        assert await db.mark_session_control_applying(cid) is True
-        assert await db.mark_session_control_applying(cid) is False, (
+        assert await db.mark_session_control_applying(cid) == "applying"
+        assert await db.mark_session_control_applying(cid) is None, (
             "a second consumer claimed a control that was already claimed"
         )
+
+
+@pytest.mark.anyio
+async def test_the_claim_comes_back_so_the_claimant_can_guard_its_own_finalize(temp_db_path):
+    """The winner is handed the exact string it wrote. Rebuilding that string at
+    the call site is how a guard stops matching the row it is supposed to guard,
+    so the only copy lives in the claimer."""
+    async with StateDB() as db:
+        sid = await _make_agent_session(db)
+        cid = await db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "hi"}
+        )
+        claim = await db.mark_session_control_applying(cid, owner="leg-a")
+        assert claim == "applying:leg-a"
+        # The returned value is usable as-is: it matches the stored row, so a
+        # finalize carrying it lands.
+        assert (await db.get_session_control(cid))["result"] == claim
+        assert await db.finalize_session_control(cid, result="applied", expect_claim=claim)
+        assert (await db.get_session_control(cid))["result"] == "applied"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Finalizing a session control without a guard is `WHERE id = :id` with no
predicate on the outcome, and the flow poller finalized that way at four sites
on the path where it had already claimed the row. A poller that came back late
therefore overwrote whatever was there, including the one outcome in that
system nothing can reconstruct: a person's finding about a delivery.

The ordering is not exotic. `li o ctl resolve` exists for a claimant that never
reported back, so the case it is built for is a slow claimant, which is exactly
the state a person resolves by hand. Claim, resolve, claimant wakes and stamps
over the resolution.

## What changed

`mark_session_control_applying` returns the claim string it wrote rather than a
bool, and every finalize on the claimed path passes it back. A write whose claim
has moved on lands nowhere and reports that it did, which callers read as "left
untouched by us" — the return contract they already had for a row they declined
to touch. The idempotent verbs (`pause`, `resume`) take no claim and keep the
unconditional write.

Returning the claim also removes its second copy. The agent drain was rebuilding
`applying:<owner>` at the call site to pass as its own guard, so two expressions
had to agree by hand for that guard to match the row it guarded. There is now
one, in the code that writes it.

## Tests

Both directions, because the reject paths are the worse half: a poller writing
`rejected:...` over a resolution recorded as applied turns a delivered message
into one the record says never arrived.

- a hand resolution injected between the claim and the finalize survives, on
  both the applied and the rejected path
- the ordinary path still records its own outcome, so a finalize that simply
  never wrote could not pass the two above
- the claim returned by the claimer matches the stored row and a finalize
  carrying it lands

The interleave is injected rather than raced, so the ordering under test is the
only ordering the test can produce.

Both guards were mutation-probed: reverting either site to an unguarded write
fails the corresponding test while the ordinary-path arm keeps passing.
