### PR TITLE
fix(cli): give the steer tombstone a handle that is still open

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -1169,8 +1169,19 @@ async def _run_agent(
             # having written it, which is why the sweep re-reads the stored
             # session and declines a non-terminal one rather than trusting the
             # call order.
-            if not will_auto_resume:
-                await _tombstone_pending_steers(live)
+            # That ordering also means the handle in `live` is gone by now:
+            # teardown closes it in its own `finally`. The sweep is given a
+            # fresh one rather than the corpse, because a sweep that fails on a
+            # closed engine fails into its own must-not-raise catch, which turns
+            # the entire tombstone path into one log line on every run while the
+            # rows it exists to close stay pending forever. The connection is
+            # opened here rather than inside the sweep so callers that hand it a
+            # handle of their own, including the tests, keep doing so.
+            if not will_auto_resume and live:
+                from lionagi.state.db import StateDB
+
+                async with StateDB() as _sweep_db:
+                    await _tombstone_pending_steers({**live, "db": _sweep_db})
             if effective_status != _terminal_status:
                 _terminal_status = effective_status
             from lionagi.state.db import SESSION_TERMINAL_STATUSES

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -1177,11 +1177,22 @@ async def _run_agent(
             # rows it exists to close stay pending forever. The connection is
             # opened here rather than inside the sweep so callers that hand it a
             # handle of their own, including the tests, keep doing so.
+            # Opening it is inside the same best-effort boundary as the sweep,
+            # not outside it. The sweep swallows its own failures on purpose so
+            # a finished run is not turned into an error by bookkeeping, and
+            # acquiring the connection can fail for exactly the reasons the
+            # sweep already tolerates: another writer holding the lock, a busy
+            # timeout, a migration. StateDB re-raises out of __aenter__, so an
+            # unguarded `async with` here would escape this teardown and report
+            # an infrastructure exception for a run that actually completed.
             if not will_auto_resume and live:
                 from lionagi.state.db import StateDB
 
-                async with StateDB() as _sweep_db:
-                    await _tombstone_pending_steers({**live, "db": _sweep_db})
+                try:
+                    async with StateDB() as _sweep_db:
+                        await _tombstone_pending_steers({**live, "db": _sweep_db})
+                except Exception as _sweep_exc:  # noqa: BLE001 — teardown must not raise
+                    log_error(f"steer tombstone write failed: {_sweep_exc!r}")
             if effective_status != _terminal_status:
                 _terminal_status = effective_status
             from lionagi.state.db import SESSION_TERMINAL_STATUSES

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import time
 import uuid
 from pathlib import Path
@@ -1281,4 +1282,113 @@ async def test_the_sweep_survives_the_teardown_closing_the_handle_it_was_given(
         assert row["applied_at"] is not None
     finally:
         if not closed:
+            await db.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_a_run_still_finishes_when_the_sweep_cannot_get_a_connection(
+    temp_db_path, tmp_path, monkeypatch, caplog
+):
+    """Acquiring the sweep's connection is bookkeeping, and bookkeeping does not
+    get to fail a run that completed.
+
+    The sweep swallows its own errors deliberately, but the connection is opened
+    before the sweep is entered, so an open that raises would sail past that
+    catch and out of the teardown block. StateDB re-raises out of __aenter__,
+    and the reasons it does so are the ones the sweep already tolerates: another
+    writer holding the lock, a busy timeout, a migration. The run must still end
+    normally, and the row must stay visibly pending rather than being recorded
+    as anything.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    import lionagi.cli.agent as agent_mod
+    import lionagi.state.db as db_mod
+    from lionagi import Branch
+    from lionagi.cli.agent import _run_agent
+    from lionagi.service.manager import iModelManager
+
+    db = StateDB()
+    await db.__aenter__()
+    try:
+        sid = await _make_agent_session(db)
+        cid = await db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "never swept"}
+        )
+
+        real_aenter = db_mod.StateDB.__aenter__
+        opened_after_teardown = False
+
+        async def refusing_aenter(self):
+            # Only the sweep's own acquisition is refused; the run's setup
+            # handle above was opened before this patch went in.
+            if opened_after_teardown:
+                raise RuntimeError("database is locked")
+            return await real_aenter(self)
+
+        async def fake_operate(self, instruction=None, **kw):
+            return "done"
+
+        async def fake_setup(*a, **kw):
+            return {"db": db, "session_id": sid}
+
+        async def fake_teardown(ctx, *, status="completed", **kw):
+            nonlocal opened_after_teardown
+            await _terminalize(db, sid)
+            await db.close()
+            opened_after_teardown = True
+            return status
+
+        async def no_drain(*a, **kw):
+            return None
+
+        monkeypatch.setattr(db_mod.StateDB, "__aenter__", refusing_aenter)
+        monkeypatch.setattr(Branch, "operate", fake_operate)
+        monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+        monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+        monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+        monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+        monkeypatch.setattr(agent_mod, "_drain_pending_steers", no_drain)
+        monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+        monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+        monkeypatch.setattr(
+            agent_mod,
+            "_provenance",
+            SimpleNamespace(
+                resolve_model_spec=lambda p, m: f"{p}/{m}",
+                agent_definition_hash=lambda n: "abc",
+            ),
+        )
+        monkeypatch.setattr(
+            agent_mod,
+            "allocate_run",
+            lambda: SimpleNamespace(
+                run_id="20260802T000000-lockedrun",
+                artifact_root=tmp_path / "artifacts",
+                stream_dir=tmp_path / "stream",
+                branches_dir=tmp_path / "branches",
+            ),
+        )
+
+        with caplog.at_level("ERROR"):
+            # The assertion is that this returns at all.
+            await _run_agent("claude", "do the thing")
+
+        assert opened_after_teardown, "the refusal never armed, so this proves nothing"
+        assert "tombstone write failed" in caplog.text, (
+            f"the refused acquisition was not reported: {caplog.text!r}"
+        )
+        assert "database is locked" in caplog.text, (
+            f"the log does not say why it failed: {caplog.text!r}"
+        )
+
+        monkeypatch.setattr(db_mod.StateDB, "__aenter__", real_aenter)
+        async with StateDB() as check:
+            row = await check.get_session_control(cid)
+        assert row["result"] is None, (
+            f"a row was recorded by a sweep that never ran: {row['result']!r}"
+        )
+    finally:
+        with contextlib.suppress(Exception):
             await db.__aexit__(None, None, None)

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -1185,3 +1185,100 @@ async def test_a_refused_finalize_after_delivery_is_reported_not_swallowed(temp_
     assert any("delivered" in m for m in reported), (
         f"the report does not say the message went out anyway: {reported!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_survives_the_teardown_closing_the_handle_it_was_given(
+    temp_db_path, tmp_path, monkeypatch
+):
+    """The real teardown closes the run's database handle in its own `finally`,
+    and the sweep is called after it, deliberately, because the terminal
+    transition has to land before pending rows can be judged.
+
+    So the sweep cannot use the handle it was set up with: it is already
+    closed. Nothing about that fails loudly. The sweep's own must-not-raise
+    catch swallows it, which leaves the entire tombstone path dead on every run
+    with one log line as the only symptom, and the row it exists to close
+    pending forever.
+
+    The sibling ordering test above wires a teardown double that does NOT close
+    the handle, so it passes either way. That divergence between the double and
+    the real teardown is what hid this.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.cli.agent import _run_agent
+    from lionagi.service.manager import iModelManager
+
+    db = StateDB()
+    await db.__aenter__()
+    closed = False
+    try:
+        sid = await _make_agent_session(db)
+        cid = await db.insert_session_control(
+            session_id=sid, verb="message", payload={"text": "queued at the wire"}
+        )
+
+        async def fake_operate(self, instruction=None, **kw):
+            return "done"
+
+        async def fake_setup(*a, **kw):
+            return {"db": db, "session_id": sid}
+
+        async def fake_teardown(ctx, *, status="completed", **kw):
+            # Both halves of what the real teardown does to this path: the
+            # terminal transition, and then closing the handle on the way out.
+            nonlocal closed
+            await _terminalize(db, sid)
+            await db.close()
+            closed = True
+            return status
+
+        async def no_drain(*a, **kw):
+            return None
+
+        monkeypatch.setattr(Branch, "operate", fake_operate)
+        monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+        monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+        monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+        monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+        monkeypatch.setattr(agent_mod, "_drain_pending_steers", no_drain)
+        monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+        monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+        monkeypatch.setattr(
+            agent_mod,
+            "_provenance",
+            SimpleNamespace(
+                resolve_model_spec=lambda p, m: f"{p}/{m}",
+                agent_definition_hash=lambda n: "abc",
+            ),
+        )
+        monkeypatch.setattr(
+            agent_mod,
+            "allocate_run",
+            lambda: SimpleNamespace(
+                run_id="20260802T000000-closedrun",
+                artifact_root=tmp_path / "artifacts",
+                stream_dir=tmp_path / "stream",
+                branches_dir=tmp_path / "branches",
+            ),
+        )
+
+        await _run_agent("claude", "do the thing")
+
+        assert closed, "the teardown double did not close the handle, so this proves nothing"
+
+        async with StateDB() as check:
+            row = await check.get_session_control(cid)
+        assert row["result"] is not None, (
+            "the control was left pending: the sweep ran against the handle the "
+            "teardown had already closed"
+        )
+        assert row["result"].startswith("rejected:")
+        assert row["applied_at"] is not None
+    finally:
+        if not closed:
+            await db.__aexit__(None, None, None)


### PR DESCRIPTION
## What breaks

The run teardown closes the database handle it was given, in its own `finally` block. The tombstone sweep for never-drained operator steers runs *after* that teardown, deliberately: the terminal transition has to land before a pending control can be judged, because the writer only admits a control while the session reads `running`.

That ordering means the sweep was handed an already-closed connection on every ordinary agent run.

Nothing failed loudly. The sweep has a teardown-must-not-raise catch, so the entire path collapsed to one logged line:

```
steer tombstone write failed: AttributeError("'NoneType' object has no attribute 'connect'")
```

while the controls it exists to close stayed pending forever. A steer enqueued against a run that ended before draining it sits unresolved with no outcome recorded, which is precisely the state the sweep was built to prevent.

## The fix

The sweep gets its own connection, opened at the call site. It is opened there rather than inside the sweep so that callers passing a handle of their own keep working.

The ordering is unchanged. The sweep still runs after the terminal transition and still re-reads the stored session and declines a non-terminal one.

## Why no existing test caught it

The existing ordering test wires a teardown double that terminalizes the session but does not close the handle, which is half of what the real teardown does. It passes with or without this bug.

The new test closes the handle the way the real teardown does, and asserts that it did, so the double cannot silently drift back to the easier behaviour. Reverting the fix turns it red with `the control was left pending: the sweep ran against the handle the teardown had already closed`.

## Verification

- `tests/cli/` and `tests/state/`: 3518 tests, zero failures
- `ruff check` and `ruff format` clean