### PR TITLE
fix(cli): ask whether a runner drains controls instead of whether it owns a run

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1024,7 +1024,9 @@ async def _flush_pending_message_events(ctx: dict) -> None:
         await retry_queue.flush()
 
 
-async def _reopen_session_for_resume(db, session_id: str, existing_session: dict | None) -> bool:
+async def _reopen_session_for_resume(
+    db, session_id: str, existing_session: dict | None, *, drains_controls: bool = False
+) -> bool:
     """Return a resumed session to ``running`` so its next close is a real change.
 
     A session's closing transition only announces itself when the status
@@ -1077,7 +1079,21 @@ async def _reopen_session_for_resume(db, session_id: str, existing_session: dict
             expected_statuses=SESSION_TERMINAL_STATUSES,
             extra_fields={
                 "ended_at": None,
-                "node_metadata": json.dumps({**node_metadata, **current_pid_markers()}),
+                # The control-drain declaration rides this same write. It has to:
+                # it describes the leg that is executing now, and so do the
+                # process markers beside it. Written separately afterwards, it
+                # would be a read-modify-write over the row as it was read
+                # *before* this transition, which restores the exited leg's pid
+                # and pid_create_time and hands the stale-session doctor grounds
+                # to terminalize a live leg. One statement, one set of facts
+                # about one leg.
+                "node_metadata": json.dumps(
+                    {
+                        **node_metadata,
+                        **current_pid_markers(),
+                        "drains_controls": bool(drains_controls),
+                    }
+                ),
             },
             override=True,
             override_actor="cli.resume",
@@ -1147,7 +1163,10 @@ async def setup_agent_persist(
         if existing_branch:
             existing_session = await db.get_session(existing_branch["session_id"])
             if existing_session is not None and not await _reopen_session_for_resume(
-                db, existing_branch["session_id"], existing_session
+                db,
+                existing_branch["session_id"],
+                existing_session,
+                drains_controls=drains_controls,
             ):
                 # The reopen declines for three reasons and one of them is that
                 # the session is no longer there — maintenance removes old
@@ -1181,46 +1200,12 @@ async def setup_agent_persist(
 
             existing_msg_ids = set(await db.get_progression(branch_prog_id))
 
-            # Re-declare the drain on the adopted row. The declaration below is
-            # written when a session is created, so a session started before
-            # this existed, or started by a different runner, does not carry
-            # one — and the row would then refuse steers aimed at a leg that
-            # does drain them. It describes whoever is executing now, so the
-            # current caller's value wins in both directions rather than being
-            # merged with the previous leg's. Read-modify-write like every other
-            # node_metadata update on this path; a resume racing a live leg on
-            # the same branch can lose the other leg's concurrent marker write,
-            # which is bookkeeping rather than state the run depends on.
-            _adopted_meta = existing_session.get("node_metadata") or {}
-            if isinstance(_adopted_meta, str):
-                try:
-                    _adopted_meta = json.loads(_adopted_meta)
-                except (TypeError, ValueError):
-                    _adopted_meta = {}
-            if not isinstance(_adopted_meta, dict):
-                _adopted_meta = {}
-            if _adopted_meta.get("drains_controls") != bool(drains_controls):
-                # Held inside its own boundary rather than the enclosing one:
-                # everything else in this block is what persistence is made of,
-                # and failing it correctly disables persistence for the run. This
-                # is a steerability flag, and losing the run's entire record over
-                # it is the larger loss. Logged rather than swallowed, because
-                # the consequence is invisible from the outside — the leg runs
-                # normally and its steers are refused.
-                try:
-                    await db.update_session(
-                        session_id,
-                        node_metadata=json.dumps(
-                            {**_adopted_meta, "drains_controls": bool(drains_controls)}
-                        ),
-                    )
-                except Exception as _decl_exc:  # noqa: BLE001 — bookkeeping, not the run
-                    _log.warning(
-                        "session %s kept the previous leg's control-drain declaration "
-                        "(%r): operator steers aimed at this leg may be refused",
-                        session_id,
-                        _decl_exc,
-                    )
+            # The adopted row's drain declaration is rewritten by the reopen
+            # above, in the same statement that installs this leg's process
+            # markers. Nothing to do here. A resume that did not reopen — one
+            # racing a live leg on the same branch, which leaves the row running
+            # and untouched — keeps the running leg's declaration, which is the
+            # correct answer: that leg is the one a control would reach.
         else:
             session_prog_id = str(uuid.uuid4())
             branch_prog_id = str(uuid.uuid4())

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1205,23 +1205,31 @@ async def setup_agent_persist(
             # markers. Nothing to do here for a row that was terminal.
             #
             # A resume that did NOT reopen adopts a row still reading running,
-            # and that row keeps whatever the earlier leg declared. Two cases,
-            # and only one of them is benign. If that leg is genuinely alive,
-            # its declaration is the right answer: it is the one a control would
-            # reach. If it died without terminalizing, the row outlives it, and
-            # a declaration of True then admits a control for a drain that is
-            # gone. Nothing here can tell those apart — a row reading running is
-            # the only evidence available, and it is exactly the evidence a dead
-            # leg leaves behind. The stale-session doctor is what resolves it,
-            # after the fact.
+            # and that row keeps whatever the earlier leg declared. Three
+            # representations reach here, not two: explicit True, explicit
+            # False, and no declaration at all on a row written before this
+            # field existed. The last one refuses like False at the admission
+            # gate, but it is a third state and not a spelling of the second —
+            # it means nobody ever answered the question, where False means a
+            # runner answered no.
+            #
+            # Of the three, only True is not benign. If that leg is genuinely
+            # alive, its declaration is the right answer: it is the one a
+            # control would reach. If it died without terminalizing, the row
+            # outlives it, and a declaration of True then admits a control for
+            # a drain that is gone. Nothing here can tell those apart — a row
+            # reading running is the only evidence available, and it is exactly
+            # the evidence a dead leg leaves behind. The stale-session doctor is
+            # what resolves it, after the fact.
             #
             # So this path is not made correct by leaving it alone; it is left
             # alone because the alternative is worse. Writing the declaration
             # here would mean a read-modify-write against a row a live leg may
             # be updating, which is how the exited leg's process markers got
             # restored over the live leg's once already. The narrower cost is
-            # the other direction: a row reading False keeps refusing controls
-            # even though this leg would drain them.
+            # the other direction: a row reading False, or carrying no
+            # declaration at all, keeps refusing controls even though this leg
+            # would drain them.
         else:
             session_prog_id = str(uuid.uuid4())
             branch_prog_id = str(uuid.uuid4())

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1202,10 +1202,26 @@ async def setup_agent_persist(
 
             # The adopted row's drain declaration is rewritten by the reopen
             # above, in the same statement that installs this leg's process
-            # markers. Nothing to do here. A resume that did not reopen — one
-            # racing a live leg on the same branch, which leaves the row running
-            # and untouched — keeps the running leg's declaration, which is the
-            # correct answer: that leg is the one a control would reach.
+            # markers. Nothing to do here for a row that was terminal.
+            #
+            # A resume that did NOT reopen adopts a row still reading running,
+            # and that row keeps whatever the earlier leg declared. Two cases,
+            # and only one of them is benign. If that leg is genuinely alive,
+            # its declaration is the right answer: it is the one a control would
+            # reach. If it died without terminalizing, the row outlives it, and
+            # a declaration of True then admits a control for a drain that is
+            # gone. Nothing here can tell those apart — a row reading running is
+            # the only evidence available, and it is exactly the evidence a dead
+            # leg leaves behind. The stale-session doctor is what resolves it,
+            # after the fact.
+            #
+            # So this path is not made correct by leaving it alone; it is left
+            # alone because the alternative is worse. Writing the declaration
+            # here would mean a read-modify-write against a row a live leg may
+            # be updating, which is how the exited leg's process markers got
+            # restored over the live leg's once already. The narrower cost is
+            # the other direction: a row reading False keeps refusing controls
+            # even though this leg would drain them.
         else:
             session_prog_id = str(uuid.uuid4())
             branch_prog_id = str(uuid.uuid4())

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1126,6 +1126,7 @@ async def setup_agent_persist(
     project: str | None = None,
     run_id: str | None = None,
     share_db: bool = True,
+    drains_controls: bool = False,
 ) -> dict | None:
     from lionagi.session.session import Session
     from lionagi.state import provenance as _provenance
@@ -1179,6 +1180,47 @@ async def setup_agent_persist(
                 branch_prog_id = effective or candidate
 
             existing_msg_ids = set(await db.get_progression(branch_prog_id))
+
+            # Re-declare the drain on the adopted row. The declaration below is
+            # written when a session is created, so a session started before
+            # this existed, or started by a different runner, does not carry
+            # one — and the row would then refuse steers aimed at a leg that
+            # does drain them. It describes whoever is executing now, so the
+            # current caller's value wins in both directions rather than being
+            # merged with the previous leg's. Read-modify-write like every other
+            # node_metadata update on this path; a resume racing a live leg on
+            # the same branch can lose the other leg's concurrent marker write,
+            # which is bookkeeping rather than state the run depends on.
+            _adopted_meta = existing_session.get("node_metadata") or {}
+            if isinstance(_adopted_meta, str):
+                try:
+                    _adopted_meta = json.loads(_adopted_meta)
+                except (TypeError, ValueError):
+                    _adopted_meta = {}
+            if not isinstance(_adopted_meta, dict):
+                _adopted_meta = {}
+            if _adopted_meta.get("drains_controls") != bool(drains_controls):
+                # Held inside its own boundary rather than the enclosing one:
+                # everything else in this block is what persistence is made of,
+                # and failing it correctly disables persistence for the run. This
+                # is a steerability flag, and losing the run's entire record over
+                # it is the larger loss. Logged rather than swallowed, because
+                # the consequence is invisible from the outside — the leg runs
+                # normally and its steers are refused.
+                try:
+                    await db.update_session(
+                        session_id,
+                        node_metadata=json.dumps(
+                            {**_adopted_meta, "drains_controls": bool(drains_controls)}
+                        ),
+                    )
+                except Exception as _decl_exc:  # noqa: BLE001 — bookkeeping, not the run
+                    _log.warning(
+                        "session %s kept the previous leg's control-drain declaration "
+                        "(%r): operator steers aimed at this leg may be refused",
+                        session_id,
+                        _decl_exc,
+                    )
         else:
             session_prog_id = str(uuid.uuid4())
             branch_prog_id = str(uuid.uuid4())
@@ -1191,7 +1233,20 @@ async def setup_agent_persist(
             _proj, _proj_src = _resolve_project(project)
             from lionagi.cli.kill import current_pid_markers
 
-            _node_meta = {**(session_dict.get("node_metadata") or {}), **current_pid_markers()}
+            # Whether this session's runner consumes operator controls, declared
+            # by the caller that starts the run rather than inferred. The
+            # control writer refuses a session whose runner has no drain, and it
+            # has no other way to tell one agent-kind session from another:
+            # every runner that persists through here writes the same kind and
+            # a run_id, so run_id presence stopped distinguishing them the
+            # moment a second caller began supplying one. Default False so a
+            # new runner that forgets to declare it gets a visible refusal
+            # rather than a control nobody will ever read.
+            _node_meta = {
+                **(session_dict.get("node_metadata") or {}),
+                **current_pid_markers(),
+                "drains_controls": bool(drains_controls),
+            }
             await db.create_session(
                 {
                     "id": session_id,

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -979,6 +979,10 @@ async def _run_agent(
         provider=provider,
         effort=effort,
         project=project,
+        # This runner drains queued operator messages at turn end and
+        # tombstones whatever it did not take, so controls aimed at it have a
+        # consumer.
+        drains_controls=True,
     )
     if seed_injection_totals:
         await _seed_injection_stats(live, _injection_totals)

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 from typing import Any
 
 from .._logging import log_error
@@ -60,6 +61,23 @@ async def _resolve_session(db: Any, entity_id: str) -> dict[str, Any] | None:
     return await _resolve_primary_session(db, entity_type, row)
 
 
+def _runner_drains_controls(session: dict[str, Any]) -> bool:
+    """Whether this session's runner declared that it consumes operator controls.
+
+    The declaration is written into node_metadata when the run starts. Absence
+    reads as False on purpose: a runner that never said it drains is exactly the
+    case this exists to catch, and a control admitted for it would be delivered
+    by nobody.
+    """
+    meta = session.get("node_metadata") or {}
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta)
+        except (ValueError, TypeError):
+            return False
+    return bool(meta.get("drains_controls")) if isinstance(meta, dict) else False
+
+
 async def _enqueue_control_inner(
     *, entity_id: str, verb: str, payload: dict[str, Any] | None
 ) -> tuple[str, int]:
@@ -98,6 +116,21 @@ async def _enqueue_control_inner(
                 f"session {session_id[:8]} is a mirrored/imported agent "
                 "session (no lionagi run owns it), so no runner would ever "
                 "deliver the steer",
+                EXIT_UNKNOWN,
+            )
+        # Owning a run is not the same as consuming controls. The check above
+        # uses run_id as a proxy for "a lionagi runner owns this", and that
+        # proxy held only while the CLI agent runner was the sole caller that
+        # stamped one. Other callers persist through the same path, write the
+        # same kind, and supply their own run_id, so they pass that check while
+        # having no drain at all — the control would be admitted, never
+        # delivered, and never closed. Ask about the capability instead, and
+        # let the runner declare it when it starts the session.
+        if kind == "agent" and not _runner_drains_controls(session):
+            return (
+                f"session {session_id[:8]} is run by something that does not "
+                "consume operator controls, so the control would sit pending "
+                "forever with nobody to deliver or close it",
                 EXIT_UNKNOWN,
             )
         if kind not in allowed:

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -132,12 +132,13 @@ async def _enqueue_control_inner(
         # run_id and a real turn-end drain, and its control would have landed.
         # That is deliberate and it is not a migration that was skipped.
         #
-        # It is not bounded in time, and it would be convenient to say it was.
-        # Only a resume that REOPENS a terminal row writes a declaration; a
-        # resume adopting a row that still reads running writes nothing, by
-        # design, so an absent key stays absent however many times that row is
-        # adopted. The leg running it then declares, drains, and is refused
-        # anyway. Ending is what clears it, not resuming.
+        # Which transitions replace an absent declaration, and when that
+        # refusal ends, are not described here on purpose: every attempt to
+        # state it in prose has been wrong, in a different way each time, while
+        # the meaning below has held. The tests own that behaviour — see the
+        # resume cases in tests/cli/test_agent_steer.py, which pin each
+        # transition individually and cannot drift from the code the way a
+        # sentence can.
         #
         # Absence is still the right reading. Fields that happen to differ
         # between producers are not capability: the embedded runner's run_id

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -126,6 +126,18 @@ async def _enqueue_control_inner(
         # having no drain at all — the control would be admitted, never
         # delivered, and never closed. Ask about the capability instead, and
         # let the runner declare it when it starts the session.
+        #
+        # This refuses one row that used to be admitted and deserved to be: a
+        # CLI agent leg that was already running when this check landed. It has
+        # a run_id and a real turn-end drain, but its session row predates the
+        # declaration, so it is unsteerable until it ends or resumes. That is
+        # deliberate and it is not a migration that was skipped. A pre-existing
+        # row carries no field separating a CLI leg from an embedded runner —
+        # both are agent-kind with a run_id and no declaration — so reading the
+        # absent key as "capable" to spare the CLI leg would re-admit exactly
+        # the orphaned controls this exists to refuse. The window is bounded by
+        # the life of legs that started before the upgrade; every leg started
+        # after it declares.
         if kind == "agent" and not _runner_drains_controls(session):
             return (
                 f"session {session_id[:8]} is run by something that does not "

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -135,10 +135,11 @@ async def _enqueue_control_inner(
         # Which transitions replace an absent declaration, and when that
         # refusal ends, are not described here on purpose: every attempt to
         # state it in prose has been wrong, in a different way each time, while
-        # the meaning below has held. The tests own that behaviour — see the
-        # resume cases in tests/cli/test_agent_steer.py, which pin each
-        # transition individually and cannot drift from the code the way a
-        # sentence can.
+        # the meaning below has held. Read the resume cases in
+        # tests/cli/test_agent_steer.py instead. They are where that behaviour
+        # is stated in a form that fails when it stops being true, which a
+        # comment cannot do; they are not a claim that every transition is
+        # covered.
         #
         # Absence is still the right reading. Fields that happen to differ
         # between producers are not capability: the embedded runner's run_id

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -128,16 +128,25 @@ async def _enqueue_control_inner(
         # let the runner declare it when it starts the session.
         #
         # This refuses one row that used to be admitted and deserved to be: a
-        # CLI agent leg that was already running when this check landed. It has
-        # a run_id and a real turn-end drain, but its session row predates the
-        # declaration, so it is unsteerable until it ends or resumes. That is
-        # deliberate and it is not a migration that was skipped. A pre-existing
-        # row carries no field separating a CLI leg from an embedded runner —
-        # both are agent-kind with a run_id and no declaration — so reading the
-        # absent key as "capable" to spare the CLI leg would re-admit exactly
-        # the orphaned controls this exists to refuse. The window is bounded by
-        # the life of legs that started before the upgrade; every leg started
-        # after it declares.
+        # CLI agent leg whose session row predates the declaration. It has a
+        # run_id and a real turn-end drain, and its control would have landed.
+        # That is deliberate and it is not a migration that was skipped.
+        #
+        # It is not bounded in time, and it would be convenient to say it was.
+        # Only a resume that REOPENS a terminal row writes a declaration; a
+        # resume adopting a row that still reads running writes nothing, by
+        # design, so an absent key stays absent however many times that row is
+        # adopted. The leg running it then declares, drains, and is refused
+        # anyway. Ending is what clears it, not resuming.
+        #
+        # Absence is still the right reading. Fields that happen to differ
+        # between producers are not capability: the embedded runner's run_id
+        # carries a distinguishing prefix today, but a naming convention is not
+        # a contract, and keying admission on the shape of an id is the same
+        # move as keying it on the presence of one — the proxy this check
+        # exists to retire. There is no field on a pre-existing row that says
+        # what the runner will DO, and inventing one from a prefix would
+        # re-admit the orphaned controls as soon as a producer renamed a run.
         if kind == "agent" and not _runner_drains_controls(session):
             return (
                 f"session {session_id[:8]} is run by something that does not "

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -172,7 +172,14 @@ async def test_msg_refused_when_the_session_never_declared_a_drain(temp_db_path,
     """Absence is a refusal, not a pass. A session row written before the
     declaration existed, or by a runner that forgot to make one, says nothing
     about whether anything will read its controls — and admitting on silence
-    is how the queue fills with rows nobody closes."""
+    is how the queue fills with rows nobody closes.
+
+    This pins a cost as well as a guarantee, and the cost is real: a CLI agent
+    leg that was already running when this landed matches this row exactly, and
+    it does have a drain, so it loses steering until it ends or resumes. Read
+    that as accepted rather than as overlooked. Nothing on a pre-existing row
+    separates that leg from an embedded runner with no drain at all, so the
+    only way to keep steering it is to admit the orphaned controls too."""
     async with StateDB() as db:
         sid = uuid.uuid4().hex[:12]
         pid = uuid.uuid4().hex
@@ -1525,12 +1532,18 @@ async def test_a_resumed_session_takes_the_declaration_of_the_leg_running_it_now
         # it. Refusing is the side to be wrong on.
         (False, True, False),
     ],
-    ids=["stale-true-still-admits", "stale-false-now-refuses"],
+    ids=["KNOWN-GAP-stale-true-still-admits", "GUARANTEE-stale-false-refuses"],
 )
-async def test_a_resume_that_does_not_reopen_keeps_the_declaration_already_on_the_row(
+async def test_a_resume_that_does_not_reopen_keeps_the_row_declaration_one_gap_one_guarantee(
     temp_db_path, monkeypatch, declared_by_the_first_leg, declared_by_the_resumer, admits
 ):
     """A resume only rewrites the declaration when it reopens a terminal row.
+
+    The two parameters are NOT both guarantees, and the ids say which is which.
+    KNOWN-GAP pins behaviour that is wrong and not fixed here: a control admitted
+    for a drain that is gone. It is in the suite so it cannot be lost, not
+    because it is correct. GUARANTEE pins behaviour this change is responsible
+    for. Read the first as coverage of the defect and you have it backwards.
 
     Adopting a row that still reads running leaves it alone, deliberately: a
     write here is a read-modify-write against a row a live leg may be updating,

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -1684,6 +1684,85 @@ async def test_a_row_that_never_declared_stays_undeclared_across_a_resume_that_d
 
 
 @pytest.mark.asyncio
+async def test_a_row_that_never_declared_is_repaired_by_a_resume_that_reopens_it(
+    temp_db_path, monkeypatch
+):
+    """The repair path for a row written before the declaration existed.
+
+    Its sibling above pins that adopting such a row while it still reads running
+    leaves it undeclared and refusing. This pins the other end: once the row is
+    terminal, a resume reopens it and the reopening write records the declaration
+    of the leg running it now, so the session becomes steerable again.
+
+    Absent is a third representation and this is where that matters. The terminal
+    reopen is tested elsewhere starting from an explicit False; starting from no
+    key at all is a different write, and without this the suite would still pass
+    if a change repaired only rows that had once declared something.
+    """
+    import json as _json
+
+    import lionagi.cli._runs as runs_mod
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist
+
+    monkeypatch.setattr(runs_mod, "active_run_id", lambda: "20260802T000000-repaired")
+    exited_leg = {"pid": 303, "pid_create_time": 3.0}
+    live_leg = {"pid": 404, "pid_create_time": 4.0}
+    monkeypatch.setattr(runs_mod, "current_pid_markers", lambda: dict(exited_leg), raising=False)
+    monkeypatch.setattr("lionagi.cli.kill.current_pid_markers", lambda: dict(exited_leg))
+
+    branch = Branch(name="predates-the-field-then-ends")
+    first = await setup_agent_persist(
+        branch, agent_name="claude", share_db=False, drains_controls=True
+    )
+    assert first is not None
+    session_id = first["session_id"]
+    await first["db"].close()
+
+    # A row from before the field existed, then ended: no key at all, terminal.
+    async with StateDB() as db:
+        meta = dict((await db.get_session(session_id)).get("node_metadata") or {})
+        meta.pop("drains_controls", None)
+        await db.update_session(session_id, node_metadata=_json.dumps(meta))
+        await _terminalize(db, session_id)
+        row = await db.get_session(session_id)
+        assert "drains_controls" not in (row["node_metadata"] or {}), (
+            "the row still declares, so this does not start from the absent state"
+        )
+        assert row["status"] != "running", "not terminal, so the resume would not reopen"
+
+    monkeypatch.setattr("lionagi.cli.kill.current_pid_markers", lambda: dict(live_leg))
+
+    second = await setup_agent_persist(
+        Branch.from_dict(branch.to_dict()),
+        agent_name="claude",
+        share_db=False,
+        drains_controls=True,
+    )
+    assert second is not None
+    assert second["session_id"] == session_id, "this did not resume, so it proves nothing"
+    await second["db"].close()
+
+    async with StateDB() as db:
+        row = await db.get_session(session_id)
+    assert _runner_drains_controls(row), (
+        "the reopen did not record the resuming leg's declaration, so a row that "
+        "predates the field can never become steerable again"
+    )
+    assert row["status"] == "running"
+    # Same invariant the explicit-False reopen pins: the declaration rides the
+    # transition, so the live leg's identity is not overwritten by the exited
+    # leg's markers.
+    assert row["node_metadata"]["pid"] == 404
+    assert row["node_metadata"]["pid_create_time"] == 4.0
+
+    message, exit_code = await _enqueue_control_inner(
+        entity_id=session_id, verb="message", payload={"text": "steer the repaired leg"}
+    )
+    assert exit_code == 0, message
+
+
+@pytest.mark.asyncio
 async def test_a_run_still_finishes_when_the_sweep_cannot_get_a_connection(
     temp_db_path, tmp_path, monkeypatch, caplog
 ):

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -1507,6 +1507,82 @@ async def test_a_resumed_session_takes_the_declaration_of_the_leg_running_it_now
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("declared_by_the_first_leg", "declared_by_the_resumer", "admits"),
+    [
+        # The row outlives the leg that wrote it. If that leg declared a drain
+        # and then died without terminalizing, the row still says so, and a
+        # control is admitted for a drain that is gone. This is what the status
+        # column costs: a row reading running is the only evidence available,
+        # and a dead leg leaves exactly that evidence behind. Unchanged by the
+        # capability predicate — the previous rule admitted this row too, on the
+        # run_id every agent leg stamps — so it is pinned here as a known gap
+        # rather than claimed as solved.
+        (True, False, True),
+        # The other direction costs availability instead of safety: the row
+        # keeps the first leg's False and refuses controls the resuming leg
+        # would have drained. This one IS a change; the previous rule admitted
+        # it. Refusing is the side to be wrong on.
+        (False, True, False),
+    ],
+    ids=["stale-true-still-admits", "stale-false-now-refuses"],
+)
+async def test_a_resume_that_does_not_reopen_keeps_the_declaration_already_on_the_row(
+    temp_db_path, monkeypatch, declared_by_the_first_leg, declared_by_the_resumer, admits
+):
+    """A resume only rewrites the declaration when it reopens a terminal row.
+
+    Adopting a row that still reads running leaves it alone, deliberately: a
+    write here is a read-modify-write against a row a live leg may be updating,
+    which is how an exited leg's process markers were restored over a live one's
+    once already. Both consequences are pinned so neither can be lost to a
+    comment.
+    """
+    import lionagi.cli._runs as runs_mod
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist
+
+    monkeypatch.setattr(runs_mod, "active_run_id", lambda: "20260802T000000-noreopen")
+
+    branch = Branch(name="not-reopened")
+    first = await setup_agent_persist(
+        branch,
+        agent_name="claude",
+        share_db=False,
+        drains_controls=declared_by_the_first_leg,
+    )
+    assert first is not None
+    session_id = first["session_id"]
+    await first["db"].close()
+
+    # Deliberately NOT terminalized: the row still reads running, which is both
+    # what a live leg looks like and what a leg that died leaves behind.
+    async with StateDB() as db:
+        assert (await db.get_session(session_id))["status"] == "running"
+
+    second = await setup_agent_persist(
+        Branch.from_dict(branch.to_dict()),
+        agent_name="claude",
+        share_db=False,
+        drains_controls=declared_by_the_resumer,
+    )
+    assert second is not None
+    assert second["session_id"] == session_id, "this did not adopt the row, so it proves nothing"
+    await second["db"].close()
+
+    async with StateDB() as db:
+        row = await db.get_session(session_id)
+    assert _runner_drains_controls(row) is declared_by_the_first_leg, (
+        "the row was rewritten; this path is supposed to leave it alone"
+    )
+
+    _message, exit_code = await _enqueue_control_inner(
+        entity_id=session_id, verb="message", payload={"text": "steer"}
+    )
+    assert (exit_code == 0) is admits, _message
+
+
+@pytest.mark.asyncio
 async def test_a_run_still_finishes_when_the_sweep_cannot_get_a_connection(
     temp_db_path, tmp_path, monkeypatch, caplog
 ):

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -1657,17 +1657,30 @@ async def test_a_row_that_never_declared_stays_undeclared_across_a_resume_that_d
     await second["db"].close()
 
     async with StateDB() as db:
-        after = (await db.get_session(session_id))["node_metadata"] or {}
+        row = await db.get_session(session_id)
+    after = row["node_metadata"] or {}
     assert "drains_controls" not in after, (
         "the non-reopening path wrote a declaration; it is documented as writing nothing"
     )
+    # The owner gate runs first and returns the same nonzero code, so without
+    # this the whole test passes on a row that lost its run_id and never
+    # reached the predicate under test. Verified by mutation: stripping run_id
+    # at creation leaves every other assertion here satisfied.
+    assert row["run_id"] == "20260802T000000-undeclared", (
+        "the row lost its run_id, so a refusal below proves nothing about the declaration"
+    )
 
-    _message, exit_code = await _enqueue_control_inner(
+    message, exit_code = await _enqueue_control_inner(
         entity_id=session_id, verb="message", payload={"text": "steer"}
     )
     assert exit_code != 0, (
         "a row carrying no declaration must refuse however capable the leg adopting it is"
     )
+    assert "does not consume operator controls" in message, (
+        f"refused by a different gate than the one under test: {message}"
+    )
+    async with StateDB() as db:
+        assert await db.list_pending_session_controls(session_id) == []
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -23,7 +23,13 @@ from pathlib import Path
 import pytest
 
 from lionagi.cli.agent import _drain_pending_steers, _tombstone_pending_steers
-from lionagi.cli.orchestrate._control import run_ctl_msg, run_ctl_pause, run_ctl_resume
+from lionagi.cli.orchestrate._control import (
+    _enqueue_control_inner,
+    _runner_drains_controls,
+    run_ctl_msg,
+    run_ctl_pause,
+    run_ctl_resume,
+)
 from lionagi.cli.status import EXIT_UNKNOWN
 from lionagi.state.db import StateDB
 
@@ -41,10 +47,14 @@ async def _make_agent_session(
     status: str = "running",
     run_id: str | None = "20260801T000000-testrun",
     cc_session_id: str | None = None,
+    drains_controls: bool = True,
 ) -> str:
-    """A native `li agent` session carries a run_id (the runner stamps one);
-    a mirrored Claude Code / Codex session is also invocation_kind='agent'
-    but has no run_id and no runner to drain its controls."""
+    """A native `li agent` session carries a run_id (the runner stamps one)
+    and declares that it drains operator controls; a mirrored Claude Code /
+    Codex session is also invocation_kind='agent' but has neither. Other
+    embedded runners persist through the same path and do stamp a run_id, so
+    the declaration is what separates them: `drains_controls=False` here is a
+    session whose runner never reads the controls queued against it."""
     sid = uuid.uuid4().hex[:12]
     pid = uuid.uuid4().hex
     await db.create_progression(pid)
@@ -54,6 +64,7 @@ async def _make_agent_session(
         "status": status,
         "invocation_kind": "agent",
         "started_at": time.time(),
+        "node_metadata": {"drains_controls": drains_controls},
     }
     if run_id is not None:
         row["run_id"] = run_id
@@ -133,6 +144,53 @@ async def test_msg_refused_for_mirrored_agent_session(temp_db_path, caplog):
         rc = run_ctl_msg(argparse.Namespace(id=sid, text="redirect"))
     assert rc == EXIT_UNKNOWN
     assert "mirrored/imported" in caplog.text
+    async with StateDB() as db:
+        assert await db.list_pending_session_controls(sid) == []
+
+
+@pytest.mark.anyio
+async def test_msg_refused_when_the_runner_does_not_drain_controls(temp_db_path, caplog):
+    """An embedded runner persists through the same path as `li agent`: same
+    invocation kind, same running status, and a run_id of its own. It has no
+    turn-end drain, so a steer queued against it is delivered by nobody and
+    closed by nobody. Owning a run and consuming controls are different
+    properties, and only the second one answers this question."""
+    async with StateDB() as db:
+        sid = await _make_agent_session(
+            db, run_id="20260801T060606-embedded", drains_controls=False
+        )
+    with caplog.at_level("ERROR"):
+        rc = run_ctl_msg(argparse.Namespace(id=sid, text="redirect"))
+    assert rc == EXIT_UNKNOWN
+    assert "does not consume operator controls" in caplog.text
+    async with StateDB() as db:
+        assert await db.list_pending_session_controls(sid) == []
+
+
+@pytest.mark.anyio
+async def test_msg_refused_when_the_session_never_declared_a_drain(temp_db_path, caplog):
+    """Absence is a refusal, not a pass. A session row written before the
+    declaration existed, or by a runner that forgot to make one, says nothing
+    about whether anything will read its controls — and admitting on silence
+    is how the queue fills with rows nobody closes."""
+    async with StateDB() as db:
+        sid = uuid.uuid4().hex[:12]
+        pid = uuid.uuid4().hex
+        await db.create_progression(pid)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": pid,
+                "status": "running",
+                "invocation_kind": "agent",
+                "started_at": time.time(),
+                "run_id": "20260801T070707-undeclared",
+            }
+        )
+    with caplog.at_level("ERROR"):
+        rc = run_ctl_msg(argparse.Namespace(id=sid, text="redirect"))
+    assert rc == EXIT_UNKNOWN
+    assert "does not consume operator controls" in caplog.text
     async with StateDB() as db:
         assert await db.list_pending_session_controls(sid) == []
 
@@ -1283,6 +1341,187 @@ async def test_the_sweep_survives_the_teardown_closing_the_handle_it_was_given(
     finally:
         if not closed:
             await db.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_the_cli_runner_declares_its_drain_so_its_own_runs_stay_steerable(
+    temp_db_path, tmp_path, monkeypatch
+):
+    """The writer now refuses any agent session that has not declared a drain,
+    and the runner that has one has to say so or it locks itself out.
+
+    Wired through the real `setup_agent_persist` and the real admission
+    predicate rather than a recorded keyword, because the keyword is not what
+    matters: what matters is that a control aimed at a live `li agent` run is
+    still accepted. The enqueue runs inside the turn, which is when an operator
+    would actually issue it and the only point at which the session reads
+    running.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    import lionagi.cli._runs as runs_mod
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.cli.agent import _run_agent
+    from lionagi.service.manager import iModelManager
+
+    run_id = "20260802T000000-steerablerun"
+    admitted: list[tuple[str, int]] = []
+
+    async def fake_operate(self, instruction=None, **kw):
+        # Mid-turn: the session row the real setup just wrote is live, and this
+        # is the same call `li o ctl msg` makes.
+        admitted.append(
+            await _enqueue_control_inner(entity_id=run_id, verb="message", payload={"text": "hi"})
+        )
+        return "done"
+
+    async def no_drain(*a, **kw):
+        # The drain would consume the row and end the turn loop; this test is
+        # about admission, not delivery.
+        return None
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "_drain_pending_steers", no_drain)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(
+        agent_mod,
+        "allocate_run",
+        lambda: SimpleNamespace(
+            run_id=run_id,
+            artifact_root=tmp_path / "artifacts",
+            stream_dir=tmp_path / "stream",
+            branches_dir=tmp_path / "branches",
+        ),
+    )
+    # The real allocator sets the process-wide run pointer as a side effect, and
+    # that pointer is what stamps run_id onto the session row. The stand-in above
+    # writes nothing outside tmp_path, so the pointer is set here instead; without
+    # it the persisted session carries no run_id and would be refused as a
+    # mirrored session, which is a property of the stand-in rather than of the
+    # runner under test.
+    monkeypatch.setattr(runs_mod, "active_run_id", lambda: run_id)
+
+    await _run_agent("claude", "do the thing")
+
+    assert admitted, "the turn never ran, so nothing was admitted or refused"
+    message, exit_code = admitted[0]
+    assert exit_code == 0, f"a live `li agent` run refused its own steer: {message}"
+    assert "queued message" in message
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_session_takes_the_declaration_of_the_leg_running_it_now(
+    temp_db_path, monkeypatch
+):
+    """The declaration is written when a session is created, and a resume does
+    not create one — it adopts a row another leg wrote.
+
+    So a session started before this existed, or started by a runner without a
+    drain, would keep saying so while a leg that does drain is the one actually
+    executing, and every steer aimed at that live leg would be refused. The
+    declaration describes whoever is running now, which means the resuming
+    caller's value replaces the adopted one rather than merging with it.
+    """
+    import lionagi.cli._runs as runs_mod
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist
+
+    monkeypatch.setattr(runs_mod, "active_run_id", lambda: "20260802T000000-resumedrun")
+
+    branch = Branch(name="resumed")
+    first = await setup_agent_persist(branch, agent_name="claude", share_db=False)
+    assert first is not None, "the first persist failed, so there is nothing to resume into"
+    session_id = first["session_id"]
+    await first["db"].close()
+
+    async with StateDB() as db:
+        await _terminalize(db, session_id)
+        assert not _runner_drains_controls(await db.get_session(session_id))
+
+    # A resume rebuilds the branch from its snapshot rather than reusing the
+    # object, which is why the second call is a resume at all: same branch id,
+    # new instance, and not still owned by the first session.
+    resumed_branch = Branch.from_dict(branch.to_dict())
+    assert str(resumed_branch.id) == str(branch.id)
+
+    second = await setup_agent_persist(
+        resumed_branch, agent_name="claude", share_db=False, drains_controls=True
+    )
+    assert second is not None
+    assert second["session_id"] == session_id, "this did not resume, so it proves nothing"
+    await second["db"].close()
+
+    async with StateDB() as db:
+        assert _runner_drains_controls(await db.get_session(session_id))
+        # And the row the resume adopted is admissible again, which is the point.
+        assert (await db.get_session(session_id))["status"] == "running"
+    message, exit_code = await _enqueue_control_inner(
+        entity_id=session_id, verb="message", payload={"text": "steer the resumed leg"}
+    )
+    assert exit_code == 0, message
+
+
+@pytest.mark.asyncio
+async def test_a_resume_keeps_its_persistence_when_the_declaration_write_fails(
+    temp_db_path, monkeypatch, caplog
+):
+    """Re-declaring the drain is bookkeeping, and everything around it in that
+    block is persistence itself. A failure here must not take the run's records
+    down with it, and must not pass unremarked either: the leg goes on running
+    normally while its steers are refused, which is invisible from outside."""
+    import lionagi.cli._runs as runs_mod
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist
+
+    monkeypatch.setattr(runs_mod, "active_run_id", lambda: "20260802T000000-declfail")
+
+    branch = Branch(name="decl-fail")
+    first = await setup_agent_persist(branch, agent_name="claude", share_db=False)
+    assert first is not None
+    session_id = first["session_id"]
+    await first["db"].close()
+
+    async with StateDB() as db:
+        await _terminalize(db, session_id)
+
+    from lionagi.state.db import StateDB as _StateDB
+
+    real_update = _StateDB.update_session
+
+    async def refusing_update(self, sid, **fields):
+        if "node_metadata" in fields:
+            raise RuntimeError("database is locked")
+        return await real_update(self, sid, **fields)
+
+    monkeypatch.setattr(_StateDB, "update_session", refusing_update)
+
+    with caplog.at_level("WARNING"):
+        second = await setup_agent_persist(
+            Branch.from_dict(branch.to_dict()),
+            agent_name="claude",
+            share_db=False,
+            drains_controls=True,
+        )
+
+    assert second is not None, "a failed declaration write disabled persistence for the run"
+    assert second["session_id"] == session_id
+    await second["db"].close()
+
+    assert "control-drain declaration" in caplog.text
+    assert "database is locked" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -1369,23 +1369,23 @@ async def test_the_cli_runner_declares_its_drain_so_its_own_runs_stay_steerable(
     run_id = "20260802T000000-steerablerun"
     admitted: list[tuple[str, int]] = []
 
-    async def fake_operate(self, instruction=None, **kw):
-        # Mid-turn: the session row the real setup just wrote is live, and this
-        # is the same call `li o ctl msg` makes.
-        admitted.append(
-            await _enqueue_control_inner(entity_id=run_id, verb="message", payload={"text": "hi"})
-        )
-        return "done"
+    turns: list[str] = []
 
-    async def no_drain(*a, **kw):
-        # The drain would consume the row and end the turn loop; this test is
-        # about admission, not delivery.
-        return None
+    async def fake_operate(self, instruction=None, **kw):
+        turns.append(str(instruction))
+        # Enqueued once, on the first turn only. The real drain runs after this
+        # returns, so a second enqueue here would feed itself forever.
+        if len(turns) == 1:
+            admitted.append(
+                await _enqueue_control_inner(
+                    entity_id=run_id, verb="message", payload={"text": "hi"}
+                )
+            )
+        return "done"
 
     monkeypatch.setattr(Branch, "operate", fake_operate)
     monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
     monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
-    monkeypatch.setattr(agent_mod, "_drain_pending_steers", no_drain)
     monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
     monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
     monkeypatch.setattr(
@@ -1421,6 +1421,16 @@ async def test_the_cli_runner_declares_its_drain_so_its_own_runs_stay_steerable(
     assert exit_code == 0, f"a live `li agent` run refused its own steer: {message}"
     assert "queued message" in message
 
+    # The declaration is a claim about this runner, so the test has to check the
+    # claim and not just that it was written down. The real drain runs here: the
+    # steer came back as a second turn carrying its text, and the control row it
+    # came from is closed rather than left pending.
+    assert len(turns) == 2, f"the steer did not come back as a continuation turn: {turns}"
+    assert "hi" in turns[1]
+    async with StateDB() as db:
+        sid = (await db.get_sessions_for_run(run_id))[0]["id"]
+        assert await db.list_pending_session_controls(sid) == []
+
 
 @pytest.mark.asyncio
 async def test_a_resumed_session_takes_the_declaration_of_the_leg_running_it_now(
@@ -1433,13 +1443,25 @@ async def test_a_resumed_session_takes_the_declaration_of_the_leg_running_it_now
     drain, would keep saying so while a leg that does drain is the one actually
     executing, and every steer aimed at that live leg would be refused. The
     declaration describes whoever is running now, which means the resuming
-    caller's value replaces the adopted one rather than merging with it.
+    caller's value replaces the adopted one.
+
+    It has to replace it in the *same* write that installs this leg's process
+    markers. The two legs get different markers here for that reason: a
+    declaration written separately afterwards would carry the row as it was read
+    before the reopen, restoring the exited leg's pid and pid_create_time over
+    the live leg's. The stale-session doctor reads exactly those two fields to
+    decide whether a row belongs to a process that is gone.
     """
     import lionagi.cli._runs as runs_mod
     from lionagi import Branch
     from lionagi.cli._runs import setup_agent_persist
 
     monkeypatch.setattr(runs_mod, "active_run_id", lambda: "20260802T000000-resumedrun")
+
+    exited_leg = {"pid": 101, "pid_create_time": 1.0}
+    live_leg = {"pid": 202, "pid_create_time": 2.0}
+    monkeypatch.setattr(runs_mod, "current_pid_markers", lambda: dict(exited_leg), raising=False)
+    monkeypatch.setattr("lionagi.cli.kill.current_pid_markers", lambda: dict(exited_leg))
 
     branch = Branch(name="resumed")
     first = await setup_agent_persist(branch, agent_name="claude", share_db=False)
@@ -1449,13 +1471,17 @@ async def test_a_resumed_session_takes_the_declaration_of_the_leg_running_it_now
 
     async with StateDB() as db:
         await _terminalize(db, session_id)
-        assert not _runner_drains_controls(await db.get_session(session_id))
+        row = await db.get_session(session_id)
+        assert not _runner_drains_controls(row)
+        assert row["node_metadata"]["pid"] == 101, "the first leg's markers did not land"
 
     # A resume rebuilds the branch from its snapshot rather than reusing the
     # object, which is why the second call is a resume at all: same branch id,
     # new instance, and not still owned by the first session.
     resumed_branch = Branch.from_dict(branch.to_dict())
     assert str(resumed_branch.id) == str(branch.id)
+
+    monkeypatch.setattr("lionagi.cli.kill.current_pid_markers", lambda: dict(live_leg))
 
     second = await setup_agent_persist(
         resumed_branch, agent_name="claude", share_db=False, drains_controls=True
@@ -1465,63 +1491,19 @@ async def test_a_resumed_session_takes_the_declaration_of_the_leg_running_it_now
     await second["db"].close()
 
     async with StateDB() as db:
-        assert _runner_drains_controls(await db.get_session(session_id))
+        row = await db.get_session(session_id)
+        assert _runner_drains_controls(row)
         # And the row the resume adopted is admissible again, which is the point.
-        assert (await db.get_session(session_id))["status"] == "running"
+        assert row["status"] == "running"
+        # The live leg's identity survived the declaration. If these read 101,
+        # the declaration was written over a pre-reopen copy of the row and the
+        # doctor would be judging this live leg by a dead process's pid.
+        assert row["node_metadata"]["pid"] == 202
+        assert row["node_metadata"]["pid_create_time"] == 2.0
     message, exit_code = await _enqueue_control_inner(
         entity_id=session_id, verb="message", payload={"text": "steer the resumed leg"}
     )
     assert exit_code == 0, message
-
-
-@pytest.mark.asyncio
-async def test_a_resume_keeps_its_persistence_when_the_declaration_write_fails(
-    temp_db_path, monkeypatch, caplog
-):
-    """Re-declaring the drain is bookkeeping, and everything around it in that
-    block is persistence itself. A failure here must not take the run's records
-    down with it, and must not pass unremarked either: the leg goes on running
-    normally while its steers are refused, which is invisible from outside."""
-    import lionagi.cli._runs as runs_mod
-    from lionagi import Branch
-    from lionagi.cli._runs import setup_agent_persist
-
-    monkeypatch.setattr(runs_mod, "active_run_id", lambda: "20260802T000000-declfail")
-
-    branch = Branch(name="decl-fail")
-    first = await setup_agent_persist(branch, agent_name="claude", share_db=False)
-    assert first is not None
-    session_id = first["session_id"]
-    await first["db"].close()
-
-    async with StateDB() as db:
-        await _terminalize(db, session_id)
-
-    from lionagi.state.db import StateDB as _StateDB
-
-    real_update = _StateDB.update_session
-
-    async def refusing_update(self, sid, **fields):
-        if "node_metadata" in fields:
-            raise RuntimeError("database is locked")
-        return await real_update(self, sid, **fields)
-
-    monkeypatch.setattr(_StateDB, "update_session", refusing_update)
-
-    with caplog.at_level("WARNING"):
-        second = await setup_agent_persist(
-            Branch.from_dict(branch.to_dict()),
-            agent_name="claude",
-            share_db=False,
-            drains_controls=True,
-        )
-
-    assert second is not None, "a failed declaration write disabled persistence for the run"
-    assert second["session_id"] == session_id
-    await second["db"].close()
-
-    assert "control-drain declaration" in caplog.text
-    assert "database is locked" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_agent_steer.py
+++ b/tests/cli/test_agent_steer.py
@@ -174,12 +174,16 @@ async def test_msg_refused_when_the_session_never_declared_a_drain(temp_db_path,
     about whether anything will read its controls — and admitting on silence
     is how the queue fills with rows nobody closes.
 
-    This pins a cost as well as a guarantee, and the cost is real: a CLI agent
-    leg that was already running when this landed matches this row exactly, and
-    it does have a drain, so it loses steering until it ends or resumes. Read
-    that as accepted rather than as overlooked. Nothing on a pre-existing row
-    separates that leg from an embedded runner with no drain at all, so the
-    only way to keep steering it is to admit the orphaned controls too."""
+    What this body asserts is narrow: an agent row with a run_id and no
+    declaration is refused and leaves no pending control. That is the whole
+    check. It does not start a CLI runner and does not establish that a real
+    pre-declaration leg would have drained, so do not read it as measuring the
+    cost of the refusal.
+
+    The cost is real and it is recorded next to the predicate rather than here,
+    because it is a property of the design and not of this row: a leg whose
+    session predates the declaration does have a drain, and it is refused
+    anyway. Accepted, not overlooked."""
     async with StateDB() as db:
         sid = uuid.uuid4().hex[:12]
         pid = uuid.uuid4().hex
@@ -1593,6 +1597,77 @@ async def test_a_resume_that_does_not_reopen_keeps_the_row_declaration_one_gap_o
         entity_id=session_id, verb="message", payload={"text": "steer"}
     )
     assert (exit_code == 0) is admits, _message
+
+
+@pytest.mark.asyncio
+async def test_a_row_that_never_declared_stays_undeclared_across_a_resume_that_does_not_reopen(
+    temp_db_path, monkeypatch
+):
+    """KNOWN GAP: the refusal is not bounded by the life of the leg that predates it.
+
+    A row written before the declaration existed carries no key at all. A resume
+    that adopts such a row while it still reads running writes nothing, on
+    purpose, so the key stays absent however many times it is adopted. The leg
+    running it now has a real turn-end drain and declares True, and is refused
+    anyway.
+
+    This is pinned because the boundary is easy to describe as time-limited and
+    it is not: nothing about the original leg ending clears the row, and only a
+    resume that REOPENS a terminal row ever replaces the declaration. It is the
+    third representation the adoption path names — absent is not a spelling of
+    False, and this is the case that separates them.
+    """
+    import json as _json
+
+    import lionagi.cli._runs as runs_mod
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist
+
+    monkeypatch.setattr(runs_mod, "active_run_id", lambda: "20260802T000000-undeclared")
+
+    branch = Branch(name="predates-the-field")
+    first = await setup_agent_persist(
+        branch, agent_name="claude", share_db=False, drains_controls=True
+    )
+    assert first is not None
+    session_id = first["session_id"]
+    await first["db"].close()
+
+    # Turn it into a row that predates the field. Removing the key is the point:
+    # writing False instead would test the case the parametrized test already
+    # covers, and absent is the state this one exists to distinguish.
+    async with StateDB() as db:
+        meta = dict((await db.get_session(session_id)).get("node_metadata") or {})
+        meta.pop("drains_controls", None)
+        await db.update_session(session_id, node_metadata=_json.dumps(meta))
+        checked = await db.get_session(session_id)
+        assert checked["status"] == "running"
+        assert "drains_controls" not in (checked["node_metadata"] or {}), (
+            "the row still declares, so the rest of this test would prove nothing"
+        )
+
+    second = await setup_agent_persist(
+        Branch.from_dict(branch.to_dict()),
+        agent_name="claude",
+        share_db=False,
+        drains_controls=True,
+    )
+    assert second is not None
+    assert second["session_id"] == session_id, "this did not adopt the row, so it proves nothing"
+    await second["db"].close()
+
+    async with StateDB() as db:
+        after = (await db.get_session(session_id))["node_metadata"] or {}
+    assert "drains_controls" not in after, (
+        "the non-reopening path wrote a declaration; it is documented as writing nothing"
+    )
+
+    _message, exit_code = await _enqueue_control_inner(
+        entity_id=session_id, verb="message", payload={"text": "steer"}
+    )
+    assert exit_code != 0, (
+        "a row carrying no declaration must refuse however capable the leg adopting it is"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The defect

`li o ctl msg` admits a control only when something will read it. For agent-kind
sessions it decided that by asking whether the session carries a `run_id`, using
that as a proxy for "a lionagi runner owns this and drains the queue at turn end".

The proxy held while the CLI agent runner was the only caller that stamped one.
It no longer is. Other callers persist through the same function, write the same
`invocation_kind`, and supply a `run_id` of their own. They satisfy the check and
have no drain, so a control aimed at them is admitted, never delivered, and never
closed — it sits pending for the life of the row, and the operator is told it was
queued.

## The change

Ask about the capability rather than inferring it.

- `setup_agent_persist` takes `drains_controls`, stored on the session at start.
- The CLI agent runner declares `True`: it drains queued messages at turn end and
  tombstones whatever it did not take.
- `_enqueue_control_inner` refuses any agent session that has not declared one,
  and says which property is missing.

Absence is a refusal, not a pass. A runner added later that forgets to declare
gets a visible error rather than a queue nobody reads.

A resume adopts a session that another leg created, so the declaration is
rewritten on the adopted row: it describes whoever is executing now. It is
written in the same statement that returns the session to `running` and installs
this leg's process markers, because all three describe the same leg and none is
true without the others. An earlier revision of this PR wrote it separately and
got both halves of that wrong; see the second commit.

A resume that does not reopen — one adopting a row that still reads `running` —
leaves the declaration alone. That is a deliberate limit rather than a property,
and it is pinned by tests in both directions:

- The row keeps an earlier `True` while the leg that wrote it is gone, so a
  control is admitted for a drain that no longer exists. **This is unchanged by
  this PR**: the previous rule admitted the same row on the `run_id` every agent
  leg stamps, so a stale running row accepted controls before and accepts them
  after. Checked against `main` rather than assumed.
- The row keeps an earlier `False` while this leg would have drained, so a
  control is refused. **This one is new** — the previous rule admitted it. It
  costs availability rather than safety.

Neither is written into a comment and left there. A row reading `running` is the
only evidence available and it is exactly what a leg that died leaves behind, so
this path cannot tell the two apart; writing the declaration on adoption would
be a read-modify-write against a row a live leg may be updating, which is the
shape that restored an exited leg's process markers over a live one's earlier in
this PR. Resolving a row that outlived its process belongs to the stale-session
sweep.

## What this does not reach

- **Only new admissions.** Controls already queued against a runner with no drain
  are not delivered and not closed by this change. Closing them is the teardown
  sweep's job, and a runner without a drain does not run one.
- **No runner gains a drain.** An embedded runner that wants to be steerable
  still has to consume and close controls; this only stops the writer from
  promising an operator that it will.
- **A session that predates the declaration is refused, and not only until it
  ends.** For an embedded runner that is the hole being closed. For a CLI agent
  leg it is a real cost rather than a side effect worth glossing: that leg does
  have a turn-end drain, and its control would have landed.

  How long that refusal lasts is deliberately not described in prose here or in
  the code. Three attempts to state it were each wrong in a different way, while
  the definitions around them held, so the transitions are owned by tests that
  pin each one separately: a resume that does not reopen leaves the declaration
  exactly as it found it, including when there is none, and a resume that
  reopens a terminal row writes the declaration of the leg running it now.

  Absence is still the right reading, for a different reason than "the producers
  are indistinguishable" — they are not, the embedded runner's run ids carry a
  prefix. A naming convention is not a contract, and keying admission on the
  shape of an id is the same move as keying it on the presence of one, which is
  the proxy being retired here. No pre-existing row carries a field saying what
  its runner will do.

## Tests

Seven new cases in `tests/cli/test_agent_steer.py`:

- a session whose runner declared no drain is refused, and the reason names the
  missing property
- a session that declared nothing at all is refused (absence is not consent)
- a live run started by the CLI agent runner still admits its own steer, wired
  through the real persist path and the real admission predicate rather than a
  recorded keyword, with the enqueue issued mid-turn
- a resumed session takes the declaration of the leg running it now, and the
  live leg's process identity survives it — the two legs are given different
  markers, because a version of this that ran both under one process could not
  see the defect it was meant to catch

Each was mutation-probed: disabling the check, flipping the runner's declaration,
dropping the declaration from the resume's transition, and reintroducing the
separate post-reopen write each turn the corresponding test red.

The end-to-end case does not stub the drain. It enqueues once, lets the real
drain run, and asserts the steer returned as a continuation turn carrying its
text with the control row closed, so it tests whether the declaration is true
rather than only whether it was written.

`tests/cli`, `tests/state`, `tests/apps_studio_server`, `tests/studio` and
`tests/mcp` pass.




