### PR TITLE
fix(claude-code): report a session that ended in error on the streaming path

### DIFF
--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -858,6 +858,30 @@ class ClaudeCodeCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
         async with contextlib.aclosing(stream_claude_code_cli(request_obj, **handlers)) as gen:
             async for item in gen:
                 if isinstance(item, CLISession):
+                    # The session carries the run's terminal verdict and is not
+                    # itself yielded, so a failure recorded only there reaches
+                    # nobody on this path: the result chunk emitted beside it
+                    # carries usage, cost, turns and duration, never the error
+                    # flag. A run that ended in error then looks exactly like
+                    # one that succeeded, and that is the direction consumers
+                    # believe without checking.
+                    #
+                    # Per-tool failures already have their own carriers, so this
+                    # is only about the session-terminal verdict.
+                    #
+                    # The already-reported guard is vacuous today: nothing else
+                    # in this module constructs an error chunk, so the condition
+                    # is always true. It is kept because the emission it guards
+                    # belongs to this file, and the natural place to add a real
+                    # error chunk is a few lines up — at which point the guard
+                    # is what stops one failure being reported twice. Do not
+                    # read it as currently load-bearing.
+                    if item.is_error and not any(c.type == "error" for c in item.chunks):
+                        yield StreamChunk(
+                            type="error",
+                            content=item.result or "Claude Code session failed",
+                            is_error=True,
+                        )
                     continue
                 yield item
 

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -859,12 +859,21 @@ class ClaudeCodeCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
             async for item in gen:
                 if isinstance(item, CLISession):
                     # The session carries the run's terminal verdict and is not
-                    # itself yielded, so a failure recorded only there reaches
-                    # nobody on this path: the result chunk emitted beside it
-                    # carries usage, cost, turns and duration, never the error
-                    # flag. A run that ended in error then looks exactly like
-                    # one that succeeded, and that is the direction consumers
-                    # believe without checking.
+                    # itself yielded here, so a failure recorded only there
+                    # reaches nobody on this stream: the result chunk emitted
+                    # beside it carries usage, cost, turns and duration, never
+                    # the error flag. A run that ended in error then looks
+                    # exactly like one that succeeded, and that is the direction
+                    # consumers believe without checking.
+                    #
+                    # The scope is this stream and no wider. `_call()` below
+                    # drives the same generator itself and returns the session
+                    # as a dict, so the flag is present there and nothing
+                    # branches on it; the one-shot helpers built on `_call()`
+                    # still return an ordinary answer for a failed session.
+                    # Closing that is a separate change with a separate
+                    # compatibility question, and this comment is not a claim
+                    # that it is closed.
                     #
                     # Per-tool failures already have their own carriers, so this
                     # is only about the session-terminal verdict.

--- a/tests/providers/test_claude_code_session_error_chunk.py
+++ b/tests/providers/test_claude_code_session_error_chunk.py
@@ -113,6 +113,12 @@ async def test_a_failure_already_carrying_an_error_chunk_is_not_reported_twice()
     contract is pinned now because the emission being guarded lives in this file
     and a future error chunk added a few lines away would otherwise double-report.
     Read this as documenting intent, not as covering a reachable path.
+
+    Deleting the guard does make this fail, so it is not passing vacuously. Those
+    are two independent things and only the first one holds: the guard expression
+    cannot be silently removed, and the guard is still never reached by a real
+    event sequence. Seeing this go red is not evidence that it fires in
+    production, which is the inference it cannot support.
     """
     session = CLISession()
     session.is_error = True

--- a/tests/providers/test_claude_code_session_error_chunk.py
+++ b/tests/providers/test_claude_code_session_error_chunk.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: a Claude Code session that ended in error looked exactly like one
+that succeeded.
+
+The CLI's terminal "result" event sets ``is_error`` on the CLISession, and the
+endpoint's ``stream()`` drops the session rather than yielding it. The result
+chunk emitted alongside it carries usage, cost, turns and duration and never the
+error flag, so nothing a streaming consumer receives distinguishes a failed run
+from a good one -- and the one consumer that inspects ``chunk.is_error`` could
+never observe a session-terminal failure. Per-tool failures were unaffected;
+they already have their own chunk carriers.
+
+These tests pin the contract: a result event carrying ``is_error=True`` must
+produce an error chunk on the streaming path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lionagi.providers.anthropic.claude_code import (
+    ClaudeCodeCLIEndpoint,
+    ClaudeCodeRequest,
+)
+from lionagi.service.types.cli_session import CLISession
+from lionagi.service.types.stream_chunk import StreamChunk
+
+
+def _result_event(**over) -> dict:
+    ev = {
+        "type": "result",
+        "result": "the model refused",
+        "usage": {"input_tokens": 10, "output_tokens": 2},
+        "total_cost_usd": 0.001,
+        "num_turns": 1,
+        "duration_ms": 100,
+        "duration_api_ms": 90,
+        "is_error": True,
+    }
+    ev.update(over)
+    return ev
+
+
+async def _endpoint_chunks(events: list[dict]) -> list[StreamChunk]:
+    """Drive the ENDPOINT, not the underlying generator.
+
+    The generator yields the CLISession; the endpoint is what decides whether
+    anything downstream ever learns what was on it, so a test against the
+    generator would pass while the defect was live.
+    """
+
+    async def fake_events(_request):
+        for ev in events:
+            yield ev
+
+    endpoint = ClaudeCodeCLIEndpoint()
+    request = ClaudeCodeRequest(prompt="test", verbose_output=False)
+    collected: list[StreamChunk] = []
+    with patch(
+        "lionagi.providers.anthropic.claude_code.stream_cc_cli_events",
+        side_effect=fake_events,
+    ):
+        async for chunk in endpoint.stream({"request": request}):
+            collected.append(chunk)
+    return collected
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_ends_in_error_yields_an_error_chunk():
+    chunks = await _endpoint_chunks([_result_event(), {"type": "done"}])
+    errors = [c for c in chunks if c.type == "error"]
+    assert len(errors) == 1, "a failed session produced nothing a consumer can branch on"
+    assert errors[0].is_error is True
+    assert errors[0].content == "the model refused", (
+        "the error chunk must carry the provider's own reason, not a generic string"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_error_chunk_falls_back_to_a_named_reason_when_the_provider_gave_none():
+    """An empty result must not produce an error chunk with empty content.
+
+    A consumer branching on the chunk gets nothing to report, which is how a
+    real failure ends up logged as a blank line.
+    """
+    chunks = await _endpoint_chunks([_result_event(result=""), {"type": "done"}])
+    errors = [c for c in chunks if c.type == "error"]
+    assert len(errors) == 1
+    assert errors[0].content == "Claude Code session failed"
+
+
+@pytest.mark.asyncio
+async def test_a_successful_session_yields_no_error_chunk():
+    """The other direction. A fix that emits unconditionally would turn every
+    healthy run into a reported failure, which is worse than the defect."""
+    chunks = await _endpoint_chunks([_result_event(is_error=False), {"type": "done"}])
+    assert [c for c in chunks if c.type == "error"] == []
+    assert [c for c in chunks if c.type == "result"], (
+        "the result chunk stopped being emitted, so this asserts nothing about the error path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failure_already_carrying_an_error_chunk_is_not_reported_twice():
+    """Pins the guard, which is vacuous on the current event set.
+
+    Nothing in the module constructs an error chunk today, so no sequence of
+    real events reaches this branch; the session is built directly instead. The
+    contract is pinned now because the emission being guarded lives in this file
+    and a future error chunk added a few lines away would otherwise double-report.
+    Read this as documenting intent, not as covering a reachable path.
+    """
+    session = CLISession()
+    session.is_error = True
+    session.result = "already reported"
+    session.chunks.append(StreamChunk(type="error", content="already reported", is_error=True))
+
+    async def only_the_session(_request, **_kwargs):
+        yield session
+
+    endpoint = ClaudeCodeCLIEndpoint()
+    request = ClaudeCodeRequest(prompt="test", verbose_output=False)
+    collected: list[StreamChunk] = []
+    with patch(
+        "lionagi.providers.anthropic.claude_code.stream_claude_code_cli",
+        side_effect=only_the_session,
+    ):
+        async for chunk in endpoint.stream({"request": request}):
+            collected.append(chunk)
+
+    assert [c for c in collected if c.type == "error"] == [], (
+        "the session already carried an error chunk, so the endpoint added a second report"
+    )


### PR DESCRIPTION
## What

A Claude Code session that terminates with `is_error` set now emits an error chunk on the endpoint's stream. Previously the flag was recorded on the session object and nothing on that stream read it.

## Why

`CLISession.is_error` is populated from the terminal result event. The chunk yielded alongside it is built from usage, cost, turn count and duration, so the error flag is not in it, and the session object itself is not yielded on that path. Consumers of the stream therefore had no carrier for a session-terminal failure at all: an errored session was indistinguishable from a successful one.

Per-tool errors were already covered and are unchanged. The gap was specific to the session-terminal flag.

## How

In the endpoint's `stream()`, when a `CLISession` arrives carrying `is_error` and no error chunk has already been emitted, yield a `StreamChunk(type="error", is_error=True)` carrying the session's result text, falling back to a fixed reason when that text is empty.

The already-reported guard cannot fire today, since nothing else in this module constructs an error chunk. It is kept with a comment saying so, rather than left to imply work it does not do.

## Scope, and what this does not reach

The change is scoped to `stream()`. The non-streaming `_call()` drives the same generator itself and returns the session as a dict, so the flag is present there and nothing branches on it. One-shot helpers built on that path still return an ordinary answer for a failed session. Closing that changes what a one-shot call returns for every consumer, which is a separate compatibility question, so it is not done here and the in-file comment says so.

## Behaviour change for stream consumers

This is not purely additive for callers. `run()` treats an error chunk as a real failure: it flushes any text already delivered and then raises a classified provider error. So a Claude Code session that ends in error after producing partial text now raises through `run()`, `run_and_collect()` and `operate()`, where it previously returned the accumulated text as an ordinary result. That is the intended effect, since the previous result was indistinguishable from success, but it is a visible change for anyone relying on the partial return.

The final-answer turn of `ReAct()` catches broadly and substitutes the last response, so it continues to return partial text rather than surfacing the failure. That behaviour predates this change and is not altered by it.

## Comparison with the other CLI adapters

The Gemini adapter does exactly this, including the already-reported guard and the `is_error` flag on the chunk. The Codex adapter emits a terminal-session error chunk too, but unconditionally and without setting `is_error` on it; the consumers in this repository key on the chunk type rather than that flag, so the difference is a consistency gap rather than a live defect. The Pi adapter records an error on its session and translates it into no error chunk at all, so it still has the gap this change closes.

## Tests

Four cases drive the endpoint rather than the generator, covering both directions:

- an error chunk is emitted when the session ends in error
- a fallback reason is used when the session's result text is empty
- no error chunk is emitted on a healthy run
- an error already reported on the stream is not reported twice

The healthy-run case is there deliberately: an implementation that yields an error chunk unconditionally passes every test that only exercises the failing side.

These stub the raw event source and drive the real parser and endpoint wrapper. They do not exercise any downstream consumer, so they do not cover the `run()` behaviour described above.

The no-double-report case is worth one more sentence, since the guard it covers cannot fire in production today. Deleting the guard makes that test fail on its own assertion, so it is not passing vacuously. It does construct the already-reported state by hand rather than reaching it through the parser, because no current event sequence produces it: it tests the guard expression, not a reachable sequence.
