### PR TITLE
fix(studio): serve schedule reads without taking a write lock

### DIFF
--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
-from lionagi.state.db import StateDB, state_db_known_absent
+from lionagi.state.db import StateDB, state_db_file, state_db_known_absent
 
 from ..registry import studio_route
 from . import run_view
@@ -405,70 +405,18 @@ def _validate_flow_yaml_spec(yaml_text: str) -> str | None:
     return None
 
 
-_ENSURE_SCHEDULES_SQL = """
-CREATE TABLE IF NOT EXISTS schedules (
-    id                  TEXT    PRIMARY KEY,
-    name                TEXT    NOT NULL UNIQUE,
-    description         TEXT,
-    enabled             INTEGER NOT NULL DEFAULT 1,
-    trigger_type        TEXT    NOT NULL,
-    cron_expr           TEXT,
-    interval_sec        INTEGER,
-    github_repo         TEXT,
-    github_filter       JSON,
-    github_cursor       TEXT,
-    poll_interval_sec   INTEGER,
-    action_kind         TEXT    NOT NULL,
-    action_model        TEXT,
-    action_prompt       TEXT,
-    action_agent        TEXT,
-    action_playbook     TEXT,
-    action_project      TEXT,
-    action_extra_args   JSON    DEFAULT '[]',
-    on_success          JSON,
-    on_fail             JSON,
-    last_fired_at       REAL,
-    next_fire_at        REAL,
-    missed_fire_policy  TEXT    NOT NULL DEFAULT 'skip',
-    overlap_policy      TEXT    NOT NULL DEFAULT 'skip',
-    max_runs            INTEGER,
-    budget_usd          REAL,
-    budget_tokens       INTEGER,
-    rate_limit          JSON,
-    project             TEXT,
-    created_at          REAL    NOT NULL,
-    updated_at          REAL    NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_schedules_enabled
-    ON schedules(enabled, next_fire_at) WHERE enabled = 1;
-CREATE INDEX IF NOT EXISTS idx_schedules_name
-    ON schedules(name);
+def _read_only_ok() -> bool:
+    """Whether a read route may take the read-only open.
 
-CREATE TABLE IF NOT EXISTS schedule_runs (
-    id                  TEXT    PRIMARY KEY,
-    schedule_id         TEXT    NOT NULL REFERENCES schedules(id) ON DELETE CASCADE,
-    invocation_id       TEXT,
-    trigger_context     JSON    NOT NULL,
-    action_kind         TEXT    NOT NULL,
-    action_args         JSON    NOT NULL,
-    status              TEXT    NOT NULL DEFAULT 'running',
-    exit_code           INTEGER,
-    chain_parent_id     TEXT,
-    chain_depth         INTEGER NOT NULL DEFAULT 0,
-    fired_at            REAL    NOT NULL,
-    ended_at            REAL,
-    error_detail        TEXT,
-    created_at          REAL    NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_sched_runs_schedule
-    ON schedule_runs(schedule_id, fired_at DESC);
-CREATE INDEX IF NOT EXISTS idx_sched_runs_status
-    ON schedule_runs(status) WHERE status = 'running';
-"""
-
-
-async def _ensure_table(db) -> None:
-    await db.executescript(_ENSURE_SCHEDULES_SQL)
+    Serving a read through the ordinary open costs a schema reconciliation and
+    a BEGIN IMMEDIATE write lock per request, neither of which a read needs.
+    Read-only mode removes both, but it is SQLite-only by contract — Postgres
+    has no side-effect-free connect mode to fake at this layer and wants a
+    read-only role instead. ``state_db_file()`` returns a path exactly when the
+    configured store is an on-disk SQLite file, which is the same set
+    ``make_readonly_engine()`` accepts, so other stores take the normal open.
+    """
+    return state_db_file() is not None
 
 
 async def list_schedules(
@@ -479,7 +427,7 @@ async def list_schedules(
 ) -> list[dict[str, Any]]:
     if state_db_known_absent():
         return []
-    async with StateDB() as db:
+    async with StateDB(readonly=_read_only_ok()) as db:
         rows = await db.list_schedules(enabled=enabled, trigger_type=trigger_type, project=project)
         ids = [row["id"] for row in rows]
         used_by_id = await db.count_schedule_runs_batch(ids, chain_depth=0)
@@ -496,7 +444,7 @@ async def list_schedules(
 async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
     if state_db_known_absent():
         return None
-    async with StateDB() as db:
+    async with StateDB(readonly=_read_only_ok()) as db:
         row = await db.get_schedule(schedule_id)
         if not row:
             return None
@@ -514,7 +462,7 @@ async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
 async def get_schedule_by_name(name: str) -> dict[str, Any] | None:
     if state_db_known_absent():
         return None
-    async with StateDB() as db:
+    async with StateDB(readonly=_read_only_ok()) as db:
         return await db.get_schedule_by_name(name)
 
 
@@ -746,7 +694,7 @@ async def list_schedule_runs(
 ) -> list[dict[str, Any]]:
     if state_db_known_absent():
         return []
-    async with StateDB() as db:
+    async with StateDB(readonly=_read_only_ok()) as db:
         return await db.list_schedule_runs(schedule_id, status=status, limit=limit, offset=offset)
 
 
@@ -760,7 +708,7 @@ async def list_schedule_run_views(
     """RunView list — each row additionally carries a reconciled ``outcome``."""
     if state_db_known_absent():
         return []
-    async with StateDB() as db:
+    async with StateDB(readonly=_read_only_ok()) as db:
         return await run_view.list_run_views(
             db, schedule_id, status=status, limit=limit, offset=offset
         )
@@ -769,7 +717,7 @@ async def list_schedule_run_views(
 async def get_schedule_run(run_id: str) -> dict[str, Any] | None:
     if state_db_known_absent():
         return None
-    async with StateDB() as db:
+    async with StateDB(readonly=_read_only_ok()) as db:
         run = await db.get_schedule_run(run_id)
         if not run:
             return None
@@ -793,7 +741,7 @@ async def get_schedule_status(schedule_id: str) -> dict[str, Any] | None:
     """'Did it work?' view: schedule header + latest RunView + shared exit code."""
     if state_db_known_absent():
         return None
-    async with StateDB() as db:
+    async with StateDB(readonly=_read_only_ok()) as db:
         return await run_view.get_schedule_status_view(db, schedule_id)
 
 

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
-from lionagi.state.db import StateDB, state_db_file, state_db_known_absent
+from lionagi.state.db import StateDB, read_only_open_supported, state_db_known_absent
 
 from ..registry import studio_route
 from . import run_view
@@ -405,29 +405,6 @@ def _validate_flow_yaml_spec(yaml_text: str) -> str | None:
     return None
 
 
-def _read_only_ok() -> bool:
-    """Whether a read route may take the read-only open.
-
-    Serving a read through the ordinary open costs a schema reconciliation and
-    a BEGIN IMMEDIATE write lock per request, neither of which a read needs.
-    Read-only mode removes both, but it is SQLite-only by contract — Postgres
-    has no side-effect-free connect mode to fake at this layer and wants a
-    read-only role instead. ``state_db_file()`` returns a path exactly when the
-    configured store is an on-disk SQLite file, so every other store takes the
-    normal open.
-
-    That is the set ``make_readonly_engine()`` accepts for any URL an async
-    engine can be built from at all, which is the only case that matters here.
-    It is not literally the same set: ``make_readonly_engine()`` also requires
-    the ``sqlite+aiosqlite:///`` spelling, and ``normalize_state_db_url()``
-    passes an unrecognised driver such as ``sqlite+pysqlite:///`` through
-    untouched. Such a URL fails the ordinary open too, since a sync driver
-    cannot back an async engine, so it is broken either way and only the
-    exception differs.
-    """
-    return state_db_file() is not None
-
-
 async def list_schedules(
     *,
     enabled: bool | None = None,
@@ -436,7 +413,7 @@ async def list_schedules(
 ) -> list[dict[str, Any]]:
     if state_db_known_absent():
         return []
-    async with StateDB(readonly=_read_only_ok()) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         rows = await db.list_schedules(enabled=enabled, trigger_type=trigger_type, project=project)
         ids = [row["id"] for row in rows]
         used_by_id = await db.count_schedule_runs_batch(ids, chain_depth=0)
@@ -453,7 +430,7 @@ async def list_schedules(
 async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
     if state_db_known_absent():
         return None
-    async with StateDB(readonly=_read_only_ok()) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         row = await db.get_schedule(schedule_id)
         if not row:
             return None
@@ -471,7 +448,7 @@ async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
 async def get_schedule_by_name(name: str) -> dict[str, Any] | None:
     if state_db_known_absent():
         return None
-    async with StateDB(readonly=_read_only_ok()) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         return await db.get_schedule_by_name(name)
 
 
@@ -703,7 +680,7 @@ async def list_schedule_runs(
 ) -> list[dict[str, Any]]:
     if state_db_known_absent():
         return []
-    async with StateDB(readonly=_read_only_ok()) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         return await db.list_schedule_runs(schedule_id, status=status, limit=limit, offset=offset)
 
 
@@ -717,7 +694,7 @@ async def list_schedule_run_views(
     """RunView list — each row additionally carries a reconciled ``outcome``."""
     if state_db_known_absent():
         return []
-    async with StateDB(readonly=_read_only_ok()) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         return await run_view.list_run_views(
             db, schedule_id, status=status, limit=limit, offset=offset
         )
@@ -726,7 +703,7 @@ async def list_schedule_run_views(
 async def get_schedule_run(run_id: str) -> dict[str, Any] | None:
     if state_db_known_absent():
         return None
-    async with StateDB(readonly=_read_only_ok()) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         run = await db.get_schedule_run(run_id)
         if not run:
             return None
@@ -750,7 +727,7 @@ async def get_schedule_status(schedule_id: str) -> dict[str, Any] | None:
     """'Did it work?' view: schedule header + latest RunView + shared exit code."""
     if state_db_known_absent():
         return None
-    async with StateDB(readonly=_read_only_ok()) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         return await run_view.get_schedule_status_view(db, schedule_id)
 
 

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -413,8 +413,17 @@ def _read_only_ok() -> bool:
     Read-only mode removes both, but it is SQLite-only by contract — Postgres
     has no side-effect-free connect mode to fake at this layer and wants a
     read-only role instead. ``state_db_file()`` returns a path exactly when the
-    configured store is an on-disk SQLite file, which is the same set
-    ``make_readonly_engine()`` accepts, so other stores take the normal open.
+    configured store is an on-disk SQLite file, so every other store takes the
+    normal open.
+
+    That is the set ``make_readonly_engine()`` accepts for any URL an async
+    engine can be built from at all, which is the only case that matters here.
+    It is not literally the same set: ``make_readonly_engine()`` also requires
+    the ``sqlite+aiosqlite:///`` spelling, and ``normalize_state_db_url()``
+    passes an unrecognised driver such as ``sqlite+pysqlite:///`` through
+    untouched. Such a URL fails the ordinary open too, since a sync driver
+    cannot back an async engine, so it is broken either way and only the
+    exception differs.
     """
     return state_db_file() is not None
 

--- a/tests/apps_studio_server/test_schedule_streaks.py
+++ b/tests/apps_studio_server/test_schedule_streaks.py
@@ -194,12 +194,16 @@ async def test_list_schedules_issues_constant_queries_not_per_row(temp_db_path):
         and "sqlite_master" not in s
         and "pragma" not in s.lower()
     ]
-    # list_schedules() opens its own StateDB, and a writable open reads the
-    # recorded schema version once before applying anything -- so that read,
-    # one SELECT for the schedules themselves, one batched count, and one
-    # batched streak query. All four are per-open or per-call: the count moves
-    # only when the path gains a query, never when it gains a row.
-    assert len(select_statements) == 4, select_statements
+    # One SELECT for the schedules themselves, one batched count, one batched
+    # streak query. All three are per-call: the count moves only when the path
+    # gains a query, never when it gains a row.
+    #
+    # A writable open would add a fourth, reading the recorded schema version
+    # before applying anything. list_schedules() is a read route and opens
+    # read-only on an on-disk SQLite store, which skips the schema step
+    # entirely -- so on this fixture the schema read is absent by design, and
+    # its reappearance would mean a read route went back to a writable open.
+    assert len(select_statements) == 3, select_statements
 
     for sid in sids:
         row = next(r for r in rows if r["id"] == sid)

--- a/tests/state/test_state_db_url_guards.py
+++ b/tests/state/test_state_db_url_guards.py
@@ -233,6 +233,59 @@ def test_the_absent_reason_names_the_store_that_was_consulted(moved_sqlite_url, 
     assert "moved" in detail
 
 
+# ── the open mode a schedules read route asks for ─────────────────────────────
+# Read-only mode exists so a read does not pay schema reconciliation and a
+# BEGIN IMMEDIATE write lock per request. It is SQLite-only: asked for on any
+# other store it fails the open outright, which would turn every working read
+# route into a hard error the moment the store moves to a server. So the flag is
+# conditional, and what the condition answers is checked here rather than
+# inferred from the fact that a SQLite run passes.
+
+
+def test_a_read_route_takes_read_only_mode_on_an_on_disk_sqlite_store(moved_sqlite_url, tmp_path):
+    from lionagi.studio.services.schedules import _read_only_ok
+
+    (tmp_path / "moved" / "state.db").touch()
+    assert _read_only_ok() is True
+
+
+def test_a_read_route_does_not_ask_for_read_only_mode_on_a_server_store(
+    absent_default, monkeypatch
+):
+    from lionagi.studio.services.schedules import _read_only_ok
+
+    _set_url(monkeypatch, _SERVER_URL)
+    assert _read_only_ok() is False
+
+
+def test_a_read_route_does_not_ask_for_read_only_mode_on_an_in_memory_store(
+    absent_default, monkeypatch
+):
+    from lionagi.studio.services.schedules import _read_only_ok
+
+    _set_url(monkeypatch, "sqlite+aiosqlite:///:memory:")
+    assert _read_only_ok() is False
+
+
+async def test_a_server_url_read_fails_on_the_connection_not_on_the_open_mode(
+    absent_default, monkeypatch
+):
+    """The failure a server URL produces here must stay the one it produced
+    before the read routes changed open mode: the driver is absent or the host
+    refuses. If a read route asks for read-only mode on a server store the open
+    is rejected before any connection is attempted, and that rejection would
+    reach a real Postgres deployment as a total outage of the route rather than
+    as the connection error this asserts.
+    """
+    _set_url(monkeypatch, _SERVER_URL)
+    from lionagi.studio.services import schedules as svc
+
+    with pytest.raises(Exception) as excinfo:  # noqa: B017 — the message is the assertion
+        await svc.list_schedules()
+
+    assert "only supports sqlite" not in str(excinfo.value)
+
+
 def test_reported_sizes_describe_the_configured_store(moved_sqlite_url, tmp_path):
     from lionagi.cli.state import _db_sizes
 

--- a/tests/state/test_state_db_url_guards.py
+++ b/tests/state/test_state_db_url_guards.py
@@ -234,37 +234,10 @@ def test_the_absent_reason_names_the_store_that_was_consulted(moved_sqlite_url, 
 
 
 # ── the open mode a schedules read route asks for ─────────────────────────────
-# Read-only mode exists so a read does not pay schema reconciliation and a
-# BEGIN IMMEDIATE write lock per request. It is SQLite-only: asked for on any
-# other store it fails the open outright, which would turn every working read
-# route into a hard error the moment the store moves to a server. So the flag is
-# conditional, and what the condition answers is checked here rather than
-# inferred from the fact that a SQLite run passes.
-
-
-def test_a_read_route_takes_read_only_mode_on_an_on_disk_sqlite_store(moved_sqlite_url, tmp_path):
-    from lionagi.studio.services.schedules import _read_only_ok
-
-    (tmp_path / "moved" / "state.db").touch()
-    assert _read_only_ok() is True
-
-
-def test_a_read_route_does_not_ask_for_read_only_mode_on_a_server_store(
-    absent_default, monkeypatch
-):
-    from lionagi.studio.services.schedules import _read_only_ok
-
-    _set_url(monkeypatch, _SERVER_URL)
-    assert _read_only_ok() is False
-
-
-def test_a_read_route_does_not_ask_for_read_only_mode_on_an_in_memory_store(
-    absent_default, monkeypatch
-):
-    from lionagi.studio.services.schedules import _read_only_ok
-
-    _set_url(monkeypatch, "sqlite+aiosqlite:///:memory:")
-    assert _read_only_ok() is False
+# Which stores the predicate answers True for is pinned above, beside the
+# predicate. What is left to check here is that a schedules read route actually
+# routes through it, since a route that hardcoded True would pass every one of
+# those tests and still be a total outage on a server-backed store.
 
 
 async def test_a_server_url_read_fails_on_the_connection_not_on_the_open_mode(


### PR DESCRIPTION
## What

The seven read routes in the schedules service opened the state store the ordinary way. That open reconciles the schema and takes a `BEGIN IMMEDIATE` write lock before a single row is read, and both costs are paid on every request.

They now open read-only when the configured store is an on-disk SQLite file: SQLite's own `mode=ro` URI, no schema step, no write lock, and none of the connect-time pragmas that persist into the file. The five write routes are unchanged.

## The flag is conditional, not constant

Read-only mode is SQLite-only by contract. Postgres has no side-effect-free connect mode to fake at this layer and wants a read-only role instead, so `make_readonly_engine()` rejects any other dialect. Asking for read-only unconditionally would therefore have taken all seven routes out on a Postgres-backed deployment, turning working reads into a hard error at open.

The condition is `state_db_file() is not None`, which is true exactly for an on-disk SQLite store.

That is the set `make_readonly_engine()` accepts for any URL an async engine can be built from at all. It is not literally the same set: `make_readonly_engine()` also requires the `sqlite+aiosqlite:///` spelling, and `normalize_state_db_url()` passes an unrecognised driver such as `sqlite+pysqlite:///` through untouched, so for that URL the predicate returns `True` while the read-only open is rejected. Such a URL fails the ordinary open too (`InvalidRequestError`: a sync driver cannot back an async engine), so it is broken either way and only the exception differs. The predicate is left alone and the docstring now says so.

## Dead code removed

The module carried a table-creation SQL constant and an `_ensure_table` helper. The helper had no callers, and both tables plus their indexes are already declared in the canonical schema. Left in place next to the new read-only opens it would read as a dependency of the read path, which it never was.

## Tests

- Both arms of the dialect condition, plus the in-memory case.
- A server URL still fails on the connection rather than on the open mode. That is the assertion that catches the flag being made constant.
- The existing query-count test on the listing path drops from four selects to three. The fourth was the schema-version read a writable open performs, which the test's own comment already named.

Mutation-checked in both directions: making the flag constant `True` fails three tests, constant `False` fails two including the query-count test.

`tests/studio`, `tests/apps_studio_server`, `tests/state`, `tests/mcp` run green (3920 tests, no failures). The Postgres dual-backend tests ran rather than skipped.

## Scope

This removes a mechanism consistent with the symptoms of a hang reported against the schedules listing route. It is not established as the cause, and this change does not claim to close it.
