### PR TITLE
fix(state): take the read-only open only where the backend supports it

### DIFF
--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -281,7 +281,7 @@ async def readonly_state_db() -> AsyncIterator[tuple[Any | None, dict[str, Any] 
     raised. The guard covers the open alone — the caller's own body runs outside
     it, and a bug in a reader still surfaces as the crash it is.
     """
-    from lionagi.state.db import StateDB, state_db_known_absent
+    from lionagi.state.db import StateDB, read_only_open_supported, state_db_known_absent
 
     # Asked of the configured store, not of the default path: the open below
     # honours LIONAGI_STATE_DB_URL, so a guard that consulted the file would
@@ -291,7 +291,7 @@ async def readonly_state_db() -> AsyncIterator[tuple[Any | None, dict[str, Any] 
         return
     async with AsyncExitStack() as stack:
         try:
-            db = await stack.enter_async_context(StateDB(readonly=True))
+            db = await stack.enter_async_context(StateDB(readonly=read_only_open_supported()))
             # The engine is lazy: it connects on the first statement, so without
             # this the store's refusal would surface in the middle of a caller's
             # query, where it is indistinguishable from that query being wrong.
@@ -582,7 +582,12 @@ def lifecycle_data(run_id: str) -> dict[str, Any]:
     opened.
     """
     from lionagi.ln.concurrency import run_async
-    from lionagi.state.db import StateDB, state_db_file, state_db_known_absent
+    from lionagi.state.db import (
+        StateDB,
+        read_only_open_supported,
+        state_db_file,
+        state_db_known_absent,
+    )
 
     if state_db_known_absent():
         # No store at all is absence of every record, not evidence about this
@@ -594,9 +599,11 @@ def lifecycle_data(run_id: str) -> dict[str, Any]:
         }
 
     async def _read() -> list[dict[str, Any]]:
-        # readonly=True: the ordinary open reconciles the schema (create_all,
-        # seed inserts), which would write to the store this is reporting on.
-        async with StateDB(readonly=True) as db:
+        # Read-only where the backend has it: the ordinary open reconciles the
+        # schema (create_all, seed inserts), which would write to the store this
+        # is reporting on. Where read-only is unavailable the ordinary open is
+        # the only open there is, and those writes are the price of the read.
+        async with StateDB(readonly=read_only_open_supported()) as db:
             return await db.get_sessions_for_run(run_id)
 
     try:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -164,6 +164,33 @@ def state_db_file() -> Path | None:
     return Path(database)
 
 
+def read_only_open_supported() -> bool:
+    """Whether ``StateDB(readonly=True)`` can open the configured store at all.
+
+    Read-only mode is SQLite-only by contract: it is an ``mode=ro`` URI open of
+    an existing file, and ``make_readonly_engine()`` rejects every other
+    dialect. ``StateDB.open()``'s read-only branch is not dialect-gated, so an
+    unconditional ``readonly=True`` does not degrade on a server-backed store,
+    it fails at open. Callers that want read-only as an optimisation, rather
+    than as a safety requirement, pass this instead of True and take the
+    ordinary open where read-only is unavailable.
+
+    Callers that need read-only for safety must NOT use this: it hands them a
+    writable connection on the stores it returns False for, which is the
+    opposite of what they asked for.
+
+    ``state_db_file()`` returns a path exactly when the configured store is an
+    on-disk SQLite file, which is the set read-only mode accepts for any URL an
+    async engine can be built from at all. It is not literally the same set:
+    ``make_readonly_engine()`` also requires the ``sqlite+aiosqlite:///``
+    spelling, and an unrecognised driver such as ``sqlite+pysqlite:///`` passes
+    ``normalize_state_db_url()`` untouched. Such a URL fails the ordinary open
+    too, since a sync driver cannot back an async engine, so it is broken
+    either way and only the exception differs.
+    """
+    return state_db_file() is not None
+
+
 def state_db_known_absent() -> bool:
     """Whether the store a default ``StateDB()`` would open is known not to exist.
 

--- a/lionagi/studio/services/run_resume.py
+++ b/lionagi/studio/services/run_resume.py
@@ -17,7 +17,7 @@ from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
 from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
-from lionagi.state.db import StateDB, state_db_known_absent
+from lionagi.state.db import StateDB, read_only_open_supported, state_db_known_absent
 
 from ..registry import studio_route
 from ..scheduler import subprocess as _subprocess
@@ -89,7 +89,7 @@ async def _resolve_branch(run_id: str, requested_branch_id: str | None) -> str:
     if state_db_known_absent():
         raise RunNotFoundError(f"Run {run_id!r} not found")
 
-    async with StateDB(readonly=True) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         session = await db.get_session(run_id)
         if session is None:
             raise RunNotFoundError(f"Run {run_id!r} not found")
@@ -113,7 +113,7 @@ async def _resolve_branch(run_id: str, requested_branch_id: str | None) -> str:
 
 
 async def _run_status(run_id: str) -> str:
-    async with StateDB(readonly=True) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         session = await db.get_session(run_id)
     if session is None:
         raise RunNotFoundError(f"Run {run_id!r} not found")
@@ -121,7 +121,7 @@ async def _run_status(run_id: str) -> str:
 
 
 async def _active_resume_for_branch(branch_id: str) -> dict[str, Any] | None:
-    async with StateDB(readonly=True) as db:
+    async with StateDB(readonly=read_only_open_supported()) as db:
         rows = await db.list_invocations(
             skill="resume:agent",
             status="running",

--- a/lionagi/studio/services/run_resume_worker.py
+++ b/lionagi/studio/services/run_resume_worker.py
@@ -14,7 +14,12 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-from lionagi.state.db import SESSION_TERMINAL_STATUSES, StateDB, state_db_file
+from lionagi.state.db import (
+    SESSION_TERMINAL_STATUSES,
+    StateDB,
+    read_only_open_supported,
+    state_db_file,
+)
 
 
 def _load_config(path: str) -> dict[str, Any]:
@@ -59,7 +64,7 @@ def _branch_resume_lock(branch_id: str):
 
 async def _wait_for_terminal(run_id: str) -> None:
     while True:
-        async with StateDB(readonly=True) as db:
+        async with StateDB(readonly=read_only_open_supported()) as db:
             session = await db.get_session(run_id)
         if session is None:
             raise RuntimeError("source run disappeared while its resume was queued")

--- a/tests/state/test_state_db_url_guards.py
+++ b/tests/state/test_state_db_url_guards.py
@@ -253,3 +253,90 @@ def test_a_store_with_no_file_reports_no_size_rather_than_zero(absent_default, m
     assert sizes["is_file"] is False
     assert sizes["size_bytes"] is None
     assert sizes["wal_size_bytes"] is None
+
+
+# ---------------------------------------------------------------------------
+# Read-only mode is SQLite-only, so asking for it unconditionally is not a
+# degradation on a server-backed store, it is a failure to open at all. These
+# pin the predicate and the two shapes the failure used to take.
+#
+# Note what an assertion here cannot be: `pytest.raises(Exception)` passes
+# whether the store refused the read-only MODE or refused the CONNECTION, and
+# only the first is the defect. Every test below asserts the failure REASON.
+
+
+def test_read_only_is_supported_for_an_on_disk_sqlite_store(moved_sqlite_url, tmp_path):
+    from lionagi.state.db import read_only_open_supported
+
+    assert read_only_open_supported() is True
+
+
+def test_read_only_is_not_supported_for_a_server_store(absent_default, monkeypatch):
+    from lionagi.state.db import read_only_open_supported
+
+    _set_url(monkeypatch, _SERVER_URL)
+
+    assert read_only_open_supported() is False
+
+
+def test_read_only_is_not_supported_for_an_in_memory_store(absent_default, monkeypatch):
+    # There is no file to reopen in mode=ro, so the read-only open has nothing
+    # to attach to even though the dialect is sqlite.
+    from lionagi.state.db import read_only_open_supported
+
+    _set_url(monkeypatch, "sqlite+aiosqlite:///:memory:")
+
+    assert read_only_open_supported() is False
+
+
+@pytest.mark.asyncio
+async def test_the_readonly_seam_on_a_server_url_fails_on_the_connection_not_the_mode(
+    absent_default, monkeypatch
+):
+    """A server store must fail to CONNECT here, never fail to open read-only.
+
+    The seam reports a failed open as an answer rather than raising, so an
+    unconditional read-only open turned every server-backed store into a
+    considered-looking "unreadable" verdict about a store that reads fine. The
+    sibling test above asserts the reason is not NOT_FOUND, which the defect
+    satisfied: it produced UNREADABLE. Only the detail separates them.
+
+    The assertion is on the exception TYPE because that is all the seam records:
+    its detail is the URL and ``type(exc).__name__``, with the message dropped.
+    So the two failures read as ``ValueError`` (the read-only engine refusing a
+    dialect it never supported, a fact about the flag) and
+    ``ConnectionRefusedError`` (a fact about the store). An earlier version of
+    this test asserted on the message text, which cannot appear in that channel
+    at all -- it passed with the defect restored, which is how it was caught.
+    """
+    from lionagi.cli.machine import readonly_state_db
+
+    _set_url(monkeypatch, _SERVER_URL)
+
+    async with readonly_state_db() as (db, why):
+        if db is None:
+            assert not why["detail"].endswith(": ValueError"), (
+                "the seam refused its own read-only flag and reported it as the store "
+                f"being unreadable: {why}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_resume_read_on_a_server_url_fails_on_the_connection_not_the_mode(
+    absent_default, monkeypatch
+):
+    """The same defect in its raising form, on the resume path.
+
+    Nothing reaches the database: the URL points at a closed port, so the open
+    fails either way. What it must not fail with is the read-only engine's own
+    refusal, which never touches the network and so cannot be a fact about the
+    store.
+    """
+    from lionagi.studio.services import run_resume
+
+    _set_url(monkeypatch, _SERVER_URL)
+
+    with pytest.raises(Exception) as excinfo:  # noqa: PT011 — the reason is the assertion
+        await run_resume._run_status("run-that-cannot-be-reached")
+
+    assert "only supports sqlite" not in str(excinfo.value)


### PR DESCRIPTION
## Why

Read-only mode is SQLite-only by contract. It is a `mode=ro` URI open of an existing file, and `make_readonly_engine()` raises on any other dialect. `StateDB.open()`'s read-only branch is not dialect-gated, so an unconditional `readonly=True` is not a degradation on a server-backed store, it is a failure to open.

Six call sites did that, in two shapes:

| site | shape |
|---|---|
| `run_resume.py` × 3, `run_resume_worker.py` × 1 (the last inside a poll loop) | raises |
| `cli/machine.py` × 2 | sits inside `except Exception` and answers "unreadable" |

The second is the worse one. A store that reads perfectly well was reported to the operator as unreadable, which is not a crash but a considered-looking verdict about the wrong thing.

## The change

`read_only_open_supported()` lives next to `state_db_file()`, the resolver it depends on, and returns True exactly when the configured store is an on-disk SQLite file. All six sites pass it instead of `True`.

The docstring carries the constraint that matters at a call site: **callers who want read-only for safety must not use this**, because it hands back a writable connection on the stores it returns False for, which is the opposite of what they asked for. It is for callers who want read-only as an optimisation, where the ordinary open is an acceptable fallback.

It is not literally `make_readonly_engine()`'s acceptance set: that also requires the `sqlite+aiosqlite:///` spelling, and an unrecognised driver such as `sqlite+pysqlite:///` passes `normalize_state_db_url()` untouched. Such a URL fails the ordinary open too, since a sync driver cannot back an async engine, so it is broken either way and only the exception differs.

## Testing the reason, not the failure

`pytest.raises(Exception)` cannot see this class. It passes whether the store refused the read-only **mode** or refused the **connection**, and only the first is the defect. Every test here asserts which.

Measured, on a URL pointing at a closed port:

```
readonly=True (the defect) : ValueError: make_readonly_engine() only supports sqlite, got dialect='postgresql'
readonly=guarded (the fix) : ConnectionRefusedError: [Errno 61] Connect call failed ('127.0.0.1', 1)
```

One of these tests first asserted on the message text and **passed with the defect restored**. The seam records only the URL and `type(exc).__name__`, so the message never reaches the channel being asserted on and the assertion was vacuous. It now asserts on the type, and the test says so in its own docstring.

Four mutations, each turning the suite red:

| mutation | result |
|---|---|
| resume call site back to unconditional | 1 failed |
| machine seam back to unconditional | 1 failed |
| predicate pinned to `True` | 4 failed |
| predicate pinned to `False` | 1 failed |

Per-site coverage is honest about its limits: the two mutated sites are directly covered, and the other four are covered through the shared predicate rather than individually.

## Results

`tests/state` + `tests/cli`: 3534 passed, 2 skipped. `tests/studio` + `tests/apps_studio_server`: 2177 passed.
