### PR TITLE
fix(studio): stop reporting a WAL pending count that was the file size

### DIFF
--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -195,8 +195,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 859 leaves", () => {
-    expect(EN_LEAVES.size).toBe(859);
+  it("en.json has 858 leaves", () => {
+    expect(EN_LEAVES.size).toBe(858);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -195,8 +195,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 860 leaves", () => {
-    expect(EN_LEAVES.size).toBe(860);
+  it("en.json has 859 leaves", () => {
+    expect(EN_LEAVES.size).toBe(859);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1683,7 +1683,6 @@ export interface AdminDoctorResponse {
   db_health: {
     size_bytes: number;
     wal_bytes: number;
-    wal_pending: number;
   };
   diagnostic_run_at: string;
 }

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL معلّق",
-      "walPendingSuffix": "WAL معلّق",
       "phantoms": "الجلسات الوهمية",
       "phantomsNone": "لم يُكتشف شيء",
       "manageLink": "إدارة في الصيانة ←",

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "قاعدة بيانات الحالة",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL معلّق",
       "phantoms": "الجلسات الوهمية",
       "phantomsNone": "لم يُكتشف شيء",
       "manageLink": "إدارة في الصيانة ←",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL পেন্ডিং",
-      "walPendingSuffix": "WAL পেন্ডিং",
       "phantoms": "ফ্যান্টম সেশন",
       "phantomsNone": "কিছু শনাক্ত হয়নি",
       "manageLink": "মেইনটেন্যান্সে ম্যানেজ করুন →",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "স্টেট DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL পেন্ডিং",
       "phantoms": "ফ্যান্টম সেশন",
       "phantomsNone": "কিছু শনাক্ত হয়নি",
       "manageLink": "মেইনটেন্যান্সে ম্যানেজ করুন →",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL ausstehend",
-      "walPendingSuffix": "WAL ausstehend",
       "phantoms": "Phantom-Sessions",
       "phantomsNone": "Keine erkannt",
       "manageLink": "In Wartung verwalten →",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "Status-DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL ausstehend",
       "phantoms": "Phantom-Sessions",
       "phantomsNone": "Keine erkannt",
       "manageLink": "In Wartung verwalten →",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL pending",
-      "walPendingSuffix": "WAL pending",
       "phantoms": "Phantom sessions",
       "phantomsNone": "None detected",
       "manageLink": "Manage in Maintenance →",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "state DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL pending",
       "phantoms": "Phantom sessions",
       "phantomsNone": "None detected",
       "manageLink": "Manage in Maintenance →",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL pendiente",
-      "walPendingSuffix": "WAL pendiente",
       "phantoms": "Sesiones fantasma",
       "phantomsNone": "No se detectó nada",
       "manageLink": "Gestionar en Mantenimiento →",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "DB de estado",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL pendiente",
       "phantoms": "Sesiones fantasma",
       "phantomsNone": "No se detectó nada",
       "manageLink": "Gestionar en Mantenimiento →",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "DB d’état",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL en attente",
       "phantoms": "Sessions fantômes",
       "phantomsNone": "Aucune détectée",
       "manageLink": "Gérer dans Maintenance →",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL en attente",
-      "walPendingSuffix": "WAL en attente",
       "phantoms": "Sessions fantômes",
       "phantomsNone": "Aucune détectée",
       "manageLink": "Gérer dans Maintenance →",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL लंबित",
-      "walPendingSuffix": "WAL लंबित",
       "phantoms": "फ़ैंटम सेशन",
       "phantomsNone": "कोई नहीं मिला",
       "manageLink": "मेंटेनेंस में मैनेज करें →",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "स्टेट DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL लंबित",
       "phantoms": "फ़ैंटम सेशन",
       "phantomsNone": "कोई नहीं मिला",
       "manageLink": "मेंटेनेंस में मैनेज करें →",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL tertunda",
-      "walPendingSuffix": "WAL tertunda",
       "phantoms": "Sesi phantom",
       "phantomsNone": "Tidak ada yang terdeteksi",
       "manageLink": "Kelola di Pemeliharaan →",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "DB state",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL tertunda",
       "phantoms": "Sesi phantom",
       "phantomsNone": "Tidak ada yang terdeteksi",
       "manageLink": "Kelola di Pemeliharaan →",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "状態DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL保留",
       "phantoms": "ファントムセッション",
       "phantomsNone": "検出なし",
       "manageLink": "メンテナンスで管理 →",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL保留",
-      "walPendingSuffix": "WAL保留",
       "phantoms": "ファントムセッション",
       "phantomsNone": "検出なし",
       "manageLink": "メンテナンスで管理 →",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "보류 중인 WAL",
-      "walPendingSuffix": "보류 중인 WAL",
       "phantoms": "팬텀 세션",
       "phantomsNone": "감지되지 않음",
       "manageLink": "유지 관리에서 관리 →",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "state DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "보류 중인 WAL",
       "phantoms": "팬텀 세션",
       "phantomsNone": "감지되지 않음",
       "manageLink": "유지 관리에서 관리 →",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL pendente",
-      "walPendingSuffix": "WAL pendente",
       "phantoms": "Sessões fantasma",
       "phantomsNone": "Nenhuma detectada",
       "manageLink": "Gerenciar em manutenção →",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "DB de estado",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL pendente",
       "phantoms": "Sessões fantasma",
       "phantomsNone": "Nenhuma detectada",
       "manageLink": "Gerenciar em manutenção →",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "БД состояния",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "Записи WAL в ожидании",
       "phantoms": "Фантомные сессии",
       "phantomsNone": "Не обнаружено",
       "manageLink": "Управлять в обслуживании →",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "Записи WAL в ожидании",
-      "walPendingSuffix": "WAL ожидает",
       "phantoms": "Фантомные сессии",
       "phantomsNone": "Не обнаружено",
       "manageLink": "Управлять в обслуживании →",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "state DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "bekleyen WAL",
       "phantoms": "phantom oturumlar",
       "phantomsNone": "algılanmadı",
       "manageLink": "bakımda yönet →",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "bekleyen WAL",
-      "walPendingSuffix": "bekleyen WAL",
       "phantoms": "phantom oturumlar",
       "phantomsNone": "algılanmadı",
       "manageLink": "bakımda yönet →",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL زیر التوا",
-      "walPendingSuffix": "WAL زیر التوا",
       "phantoms": "فینٹم سیشنز",
       "phantomsNone": "کوئی نہیں ملا",
       "manageLink": "مینٹیننس میں مینیج کریں →",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "state DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL زیر التوا",
       "phantoms": "فینٹم سیشنز",
       "phantomsNone": "کوئی نہیں ملا",
       "manageLink": "مینٹیننس میں مینیج کریں →",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -461,7 +461,6 @@
       "wal": "WAL",
       "walSuffix": "WAL",
       "walPending": "WAL đang chờ",
-      "walPendingSuffix": "WAL đang chờ",
       "phantoms": "phiên phantom",
       "phantomsNone": "không phát hiện",
       "manageLink": "quản lý trong bảo trì →",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "state DB",
       "wal": "WAL",
       "walSuffix": "WAL",
-      "walPending": "WAL đang chờ",
       "phantoms": "phiên phantom",
       "phantomsNone": "không phát hiện",
       "manageLink": "quản lý trong bảo trì →",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -460,7 +460,6 @@
       "stateDbSuffix": "状态数据库",
       "wal": "预写日志",
       "walSuffix": "WAL",
-      "walPending": "待处理 WAL",
       "phantoms": "幽灵会话",
       "phantomsNone": "未检测到",
       "manageLink": "在维护中管理 →",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -461,7 +461,6 @@
       "wal": "预写日志",
       "walSuffix": "WAL",
       "walPending": "待处理 WAL",
-      "walPendingSuffix": "WAL 待写回",
       "phantoms": "幽灵会话",
       "phantomsNone": "未检测到",
       "manageLink": "在维护中管理 →",

--- a/apps/studio/frontend/src/routes/system.tsx
+++ b/apps/studio/frontend/src/routes/system.tsx
@@ -81,10 +81,6 @@ function HealthSection({ doctor }: { doctor: AdminDoctorResponse }) {
           <span className="font-mono text-content-primary">{formatBytes(h.wal_bytes)}</span>{" "}
           {t("health.walSuffix")}
         </span>
-        <span>
-          <span className="font-mono text-content-primary">{h.wal_pending}</span>{" "}
-          {t("health.walPendingSuffix")}
-        </span>
         <span className="text-content-muted">
           {t("health.checked")} <Timestamp value={doctor.diagnostic_run_at} exact />
         </span>

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -80,7 +80,7 @@ def db_health() -> dict[str, int]:
     size_bytes = db_path.stat().st_size if db_path.exists() else 0
     wal_path = db_path.parent / (db_path.name + "-wal")
     wal_bytes = wal_path.stat().st_size if wal_path.exists() else 0
-    return {"size_bytes": size_bytes, "wal_bytes": wal_bytes, "wal_pending": wal_bytes}
+    return {"size_bytes": size_bytes, "wal_bytes": wal_bytes}
 
 
 # How long the store probe waits before calling the store slow. Well under any

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -103,7 +103,33 @@ def test_admin_doctor_no_db_returns_empty_health(tmp_path, monkeypatch):
     assert data["phantom_sessions"] == []
     assert data["db_health"]["size_bytes"] == 0
     assert data["db_health"]["wal_bytes"] == 0
-    assert data["db_health"]["wal_pending"] == 0
+
+
+def test_db_health_reports_only_numbers_it_can_actually_measure(tmp_path, monkeypatch):
+    """The payload carries no field that merely duplicates another.
+
+    ``wal_pending`` used to be returned as a second copy of ``wal_bytes``. A
+    field named for pending WAL frames invites exactly one inference, that
+    frames are waiting, and the WAL file's size cannot support it: SQLite
+    leaves a checkpointed WAL at its allocated size, so a fully checkpointed
+    store reported a large pending count forever, in the alarming direction.
+
+    It is dropped rather than populated because the only source for the number
+    is ``PRAGMA wal_checkpoint``, which does not read the pending count, it
+    performs a checkpoint. Populating the field would turn a health read into a
+    writer against the store it reports on.
+
+    Pinning the whole key set, not just the absence of that one name, is
+    deliberate: the defect was a duplicate, and the next duplicate will have a
+    different name.
+    """
+    from lionagi.studio.services.admin import db_health
+
+    health = db_health()
+
+    assert set(health) == {"size_bytes", "wal_bytes"}, (
+        f"db_health grew a field; if it reports a real measurement, say so here: {health}"
+    )
 
 
 def test_admin_prune_selected_sessions(tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

```python
return {"size_bytes": size_bytes, "wal_bytes": wal_bytes, "wal_pending": wal_bytes}
```

`wal_pending` was a second copy of `wal_bytes`. A field named for pending WAL frames invites exactly one inference, that frames are waiting, and the WAL file's size cannot support it: SQLite leaves a checkpointed WAL at its allocated size, so a fully checkpointed store reported a large pending count forever.

The error runs in the **alarming** direction, which is the direction that gets acted on. A field that can only ever equal its sibling is worse than an absent field, because absence prompts a measurement and a duplicate prompts a conclusion.

## Dropped, not populated

The only source for a real pending-frame count is `PRAGMA wal_checkpoint`, and that pragma does not read the count, it **performs a checkpoint**. Populating the field would turn a health read into a writer against the store it reports on, which is the wrong trade for a diagnostic endpoint.

Removed from the response, the frontend type, the system view, and all 16 locale files.

`get_db_stats()` was cross-checked: it reports only `wal_bytes`, the one honest number, so nothing else carried this shape.

## The test

It pins the whole key set rather than the absence of that one name, because the defect was a duplicate and the next duplicate will have a different name:

```python
assert set(health) == {"size_bytes", "wal_bytes"}
```

Mutation-checked: restoring the field turns it red.

The locale leaf-count invariant moves from 860 to 859. Parity across the 16 locales is unaffected, since all 16 lost the same key.

## Results

`tests/apps_studio_server` + `tests/studio`: 2178 passed. Frontend: typecheck clean, eslint clean, prettier clean, 1017 vitest tests passed.
