### PR TITLE
feat(studio): optional periodic all-thread stack dump, off by default

### DIFF
--- a/lionagi/studio/_traceback_dump.py
+++ b/lionagi/studio/_traceback_dump.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Periodic all-thread stack dumps, armed by an environment variable.
+
+A daemon that stops answering on one route is asking a question only a stack
+can answer, and the usual way to get one is to attach a sampling profiler to
+the live process. On macOS that needs root, which a rule against improvised
+elevation puts out of reach at exactly the moment the process is wedged.
+
+``faulthandler.dump_traceback_later`` answers the same question from inside:
+every thread's stack, written to a file on a timer, with no attach and no
+privileges. It is stdlib, it is already imported by nothing else here, and it
+costs a wedged process nothing it was doing anyway.
+
+It is off unless ``LIONAGI_STUDIO_TRACEBACK_DUMP`` names a path. Absent that
+variable this module arms no timer, opens no file, and changes no behaviour.
+
+Capture windows are operator-bounded. ``repeat=True`` appends every interval
+for as long as the process runs, so an armed daemon left running writes an
+unbounded file. Nothing here rotates or truncates it: the intended use is a
+short reproduction window, and a size cap that silently stopped writing would
+lose the frames the window exists to catch.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import os
+import sys
+from pathlib import Path
+from typing import TextIO
+
+_ENV_PATH = "LIONAGI_STUDIO_TRACEBACK_DUMP"
+_ENV_INTERVAL = "LIONAGI_STUDIO_TRACEBACK_DUMP_INTERVAL"
+_DEFAULT_INTERVAL_SECONDS = 20.0
+
+_handle: TextIO | None = None
+
+
+def _refuse(message: str) -> None:
+    """Say why the dump did not arm.
+
+    On stderr rather than through the logger: this runs before the daemon's
+    logging is necessarily useful to whoever set the variable, and an operator
+    who armed a capture and got nothing must not have to guess between "the
+    hook is not wired" and "the path was wrong".
+    """
+    print(f"{_ENV_PATH}: not armed: {message}", file=sys.stderr, flush=True)
+
+
+def _inside_a_git_tree(path: Path) -> Path | None:
+    """The nearest ancestor of *path* that is a git working tree, if any.
+
+    Dumps carry stack frames, local file paths and process detail, so a path
+    that lands inside a checkout is one ``git add -A`` away from being
+    committed. Refusing is cheaper than relying on an ignore rule that the
+    operator would have to have written first.
+    """
+    for candidate in (path, *path.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def arm_traceback_dump() -> bool:
+    """Arm the periodic dump if the environment asks for it. Returns whether it armed."""
+    global _handle
+
+    raw = os.environ.get(_ENV_PATH)
+    if not raw:
+        return False
+
+    path = Path(raw).expanduser()
+    tree = _inside_a_git_tree(path.parent if path.parent != path else path)
+    if tree is not None:
+        _refuse(f"{path} is inside the git tree at {tree}; choose a path outside any checkout")
+        return False
+
+    interval = _DEFAULT_INTERVAL_SECONDS
+    raw_interval = os.environ.get(_ENV_INTERVAL)
+    if raw_interval:
+        try:
+            interval = float(raw_interval)
+        except ValueError:
+            _refuse(f"{_ENV_INTERVAL}={raw_interval!r} is not a number")
+            return False
+        if interval <= 0:
+            _refuse(f"{_ENV_INTERVAL}={raw_interval!r} must be positive")
+            return False
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = path.open("a", encoding="utf-8")
+    except OSError as exc:
+        # %r, not %s: an argless OSError's str() is empty, and "not armed:"
+        # followed by nothing is the same silence this branch exists to break.
+        _refuse(f"{path} could not be opened for append: {exc!r}")
+        return False
+
+    faulthandler.dump_traceback_later(interval, repeat=True, file=handle)
+    _handle = handle
+    print(
+        f"{_ENV_PATH}: armed, every {interval}s, appending to {path}",
+        file=sys.stderr,
+        flush=True,
+    )
+    return True
+
+
+def disarm_traceback_dump() -> None:
+    """Cancel the timer and close the file. Safe to call when never armed."""
+    global _handle
+
+    faulthandler.cancel_dump_traceback_later()
+    if _handle is not None:
+        try:
+            _handle.close()
+        finally:
+            _handle = None

--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -18,6 +18,7 @@ from starlette.staticfiles import StaticFiles
 from lionagi._errors import LionError
 from lionagi.version import __version__
 
+from ._traceback_dump import arm_traceback_dump, disarm_traceback_dump
 from .config import CORS_ORIGINS, HOST
 from .registry import iter_studio_routes, load_studio_route_modules
 
@@ -185,6 +186,10 @@ async def lifespan(app_instance):
     # verdict on top.
     await asyncio.to_thread(snapshot_git_position)
 
+    # Off unless LIONAGI_STUDIO_TRACEBACK_DUMP names a path. Armed here rather
+    # than later so a hang anywhere in the rest of startup is still captured.
+    arm_traceback_dump()
+
     _emit_startup_warnings()
     # The second of the two settings-driven notify bootstrap points (CLI is the first).
     from lionagi.state.lifecycle.notify_settings import register_settings_terminal_callback
@@ -202,6 +207,7 @@ async def lifespan(app_instance):
     yield
     from .services.launches import shutdown_launches
 
+    disarm_traceback_dump()
     await _finalize_warmup(warmup_task)
     await _stop_claude_mirror(mirror_stop, mirror_task)
     await operator_shutdown()

--- a/tests/studio/test_traceback_dump.py
+++ b/tests/studio/test_traceback_dump.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The periodic stack dump is off unless asked for, and says why when it refuses.
+
+The disarmed arm is the load-bearing one. A diagnostic hook that costs anything
+when nobody asked for it is a worse problem than the hang it exists to
+diagnose, so "no timer, no file, no behaviour change" is asserted directly
+rather than inferred from the code path not being reached.
+
+Every refusal is asserted through the channel that carries it. The hook prints
+to stderr, so a test that only checked "it did not arm" would pass on a version
+that refuses silently, which is the shape the flag-says-whether-log-says-why
+rule exists to prevent.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import time
+from pathlib import Path
+
+import pytest
+
+from lionagi.studio import _traceback_dump as td
+
+
+@pytest.fixture(autouse=True)
+def _never_leave_a_timer_armed():
+    """A leaked timer would dump stacks into a closed file for the rest of the run."""
+    yield
+    td.disarm_traceback_dump()
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    """Record calls to the stdlib arming call instead of making them."""
+    calls: list[dict] = []
+
+    def fake(timeout, repeat=False, file=None, exit=False):  # noqa: A002
+        calls.append({"timeout": timeout, "repeat": repeat, "file": file, "exit": exit})
+
+    # td holds the module, not the function, so one patch covers both names.
+    monkeypatch.setattr(faulthandler, "dump_traceback_later", fake)
+    return calls
+
+
+def _outside_any_checkout(tmp_path: Path) -> Path:
+    """pytest's tmp_path is outside the repo, but assert it rather than assume."""
+    assert td._inside_a_git_tree(tmp_path) is None, (
+        f"{tmp_path} is inside a checkout, so it cannot stand in for an external path"
+    )
+    return tmp_path
+
+
+def test_it_does_not_arm_when_the_variable_is_absent(tmp_path, monkeypatch, spy, capsys):
+    monkeypatch.delenv(td._ENV_PATH, raising=False)
+    target = _outside_any_checkout(tmp_path) / "dump.txt"
+
+    assert td.arm_traceback_dump() is False
+    assert spy == [], "a timer was armed with nothing asking for one"
+    assert not target.exists()
+    assert capsys.readouterr().err == "", "the disarmed path must be silent as well as inert"
+
+
+def test_it_arms_on_the_variable_and_appends_to_the_named_path(tmp_path, monkeypatch, spy):
+    target = _outside_any_checkout(tmp_path) / "nested" / "dump.txt"
+    monkeypatch.setenv(td._ENV_PATH, str(target))
+
+    assert td.arm_traceback_dump() is True
+
+    assert len(spy) == 1
+    call = spy[0]
+    assert call["repeat"] is True, "a single dump cannot show whether a frame is stuck"
+    assert call["timeout"] == td._DEFAULT_INTERVAL_SECONDS
+    assert call["file"] is not None
+    assert target.exists(), "the file is opened at arm time, not at the first dump"
+    assert call["file"].mode == "a", "an overwriting handle loses every dump but the last"
+
+
+def test_the_interval_is_configurable(tmp_path, monkeypatch, spy):
+    target = _outside_any_checkout(tmp_path) / "dump.txt"
+    monkeypatch.setenv(td._ENV_PATH, str(target))
+    monkeypatch.setenv(td._ENV_INTERVAL, "3.5")
+
+    assert td.arm_traceback_dump() is True
+    assert spy[0]["timeout"] == 3.5
+
+
+@pytest.mark.parametrize("bad", ["not-a-number", "0", "-5"])
+def test_a_bad_interval_refuses_out_loud_rather_than_arming_a_default(
+    tmp_path, monkeypatch, spy, capsys, bad
+):
+    target = _outside_any_checkout(tmp_path) / "dump.txt"
+    monkeypatch.setenv(td._ENV_PATH, str(target))
+    monkeypatch.setenv(td._ENV_INTERVAL, bad)
+
+    assert td.arm_traceback_dump() is False
+    assert spy == []
+    err = capsys.readouterr().err
+    assert "not armed" in err, err
+    assert td._ENV_INTERVAL in err, err
+
+
+def test_it_refuses_a_path_inside_a_checkout(monkeypatch, spy, capsys):
+    """A dump under a tracked tree is one `git add -A` away from being committed.
+
+    The candidate path is a real one inside this checkout, because a fake one
+    would not exercise the check. Cleaned up unconditionally: a version that
+    creates the file before refusing would otherwise leave it in the working
+    tree, where the next run of this same test reads it as the earlier failure
+    rather than its own.
+    """
+    inside = Path(__file__).resolve().parent / "refused-dump.txt"
+    inside.unlink(missing_ok=True)
+    assert td._inside_a_git_tree(inside.parent) is not None, (
+        "this test's own directory is not in a checkout, so it proves nothing"
+    )
+    monkeypatch.setenv(td._ENV_PATH, str(inside))
+
+    assert td.arm_traceback_dump() is False
+    assert spy == []
+    assert not inside.exists(), "the refused path must not be created on the way to refusing"
+    err = capsys.readouterr().err
+    assert "not armed" in err and "git tree" in err, err
+    inside.unlink(missing_ok=True)
+
+
+def test_an_unwritable_path_refuses_out_loud_rather_than_arming_nothing(
+    tmp_path, monkeypatch, spy, capsys
+):
+    """The failure the operator is most likely to hit, and the one silence hides best."""
+    blocker = _outside_any_checkout(tmp_path) / "not-a-directory"
+    blocker.write_text("")
+    target = blocker / "dump.txt"  # parent is a regular file, so mkdir and open both fail
+    monkeypatch.setenv(td._ENV_PATH, str(target))
+
+    assert td.arm_traceback_dump() is False
+    assert spy == []
+    err = capsys.readouterr().err
+    assert "not armed" in err, err
+    assert str(target) in err, "the refusal must name the path the operator set"
+
+
+def test_disarm_is_safe_when_nothing_was_ever_armed(monkeypatch, spy):
+    monkeypatch.delenv(td._ENV_PATH, raising=False)
+
+    td.disarm_traceback_dump()
+    td.disarm_traceback_dump()
+
+
+def test_a_real_arm_writes_real_stacks(tmp_path, monkeypatch):
+    """One end-to-end pass with the stdlib call unmocked.
+
+    Every other test here spies on ``dump_traceback_later``, so all of them
+    would pass on a version that arms something which never writes anything.
+    """
+    target = _outside_any_checkout(tmp_path) / "real.txt"
+    monkeypatch.setenv(td._ENV_PATH, str(target))
+    monkeypatch.setenv(td._ENV_INTERVAL, "0.2")
+
+    assert td.arm_traceback_dump() is True
+    try:
+        deadline = time.time() + 5.0
+        while target.stat().st_size == 0 and time.time() < deadline:
+            time.sleep(0.05)
+        content = target.read_text()
+    finally:
+        td.disarm_traceback_dump()
+
+    assert "Thread" in content or "File " in content, (
+        f"the armed timer produced no stack text within the window: {content[:200]!r}"
+    )


### PR DESCRIPTION
## Why

A daemon that stops answering on one route is asking a question only a stack can answer. The usual instrument is a sampling profiler attached to the live process, and on macOS that requires root:

```
$ py-spy dump --pid <daemon>
This program requires root on OSX.
```

So the instrument is unavailable at exactly the moment the process is wedged, and the alternative is improvised privilege escalation on a production process.

`faulthandler.dump_traceback_later` answers the same question from inside the process: every thread's stack, on a timer, written to a file, with no attach and no privileges. It is stdlib, and it costs a wedged process nothing it was doing anyway.

## Off unless asked for

Armed only when `LIONAGI_STUDIO_TRACEBACK_DUMP` names a path. Absent that variable it arms no timer, opens no file, prints nothing, and changes no behaviour. That is **asserted directly** rather than inferred from a code path not being reached, because a diagnostic hook that costs anything when nobody asked for it is a worse problem than the hang it exists to diagnose.

`LIONAGI_STUDIO_TRACEBACK_DUMP_INTERVAL` overrides the 20 second default.

## Refuses out loud

| refused | why |
|---|---|
| a path inside any git working tree | a dump carries stack frames and local paths, and would be one `git add -A` from being committed |
| an unwritable path | the failure an operator is most likely to hit, and the one silence hides best |
| a non-numeric or non-positive interval | arming a default here would silently ignore what the operator asked for |

Each refusal names its reason on stderr. The flag says whether, the log says why: a version that refuses silently is indistinguishable from one that is not wired at all, and an operator who armed a capture and got nothing would have no way to tell which.

## Bounds, stated rather than built

`repeat=True` appends for as long as the process runs, so an armed daemon left running writes an unbounded file. Nothing here rotates or truncates it. Capture windows are operator-bounded, and a size cap that silently stopped writing would lose exactly the frames the window exists to catch.

## Testing

Five mutations, each turning the suite red:

| mutation | result |
|---|---|
| arm regardless of the variable | 1 failed |
| refuse silently | 5 failed |
| dump once instead of repeating | 1 failed |
| drop the git-tree refusal | 1 failed |
| open for overwrite instead of append | 1 failed |

One test runs the stdlib call **unmocked** and waits for real stack text to appear, because every spying test would pass on a version that arms something which never writes.

The checkout-path test cleans up unconditionally. An earlier probe run left a file in the working tree when the refusal was mutated away, and the next run read that leftover as its own failure.

`tests/studio` + `tests/apps_studio_server`: 2187 passed.
