### PR TITLE
fix(state,cli): mask store credentials in every operator-facing string

### DIFF
--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -433,6 +433,7 @@ async def _writable_state_db() -> AsyncIterator[Any]:
     body's bug and surfaces as the crash it is.
     """
     from lionagi.state.db import StateDB, state_db_known_absent
+    from lionagi.state.engine import mask_credentials, mask_db_url
 
     from .machine import MachineError
 
@@ -441,7 +442,8 @@ async def _writable_state_db() -> AsyncIterator[Any]:
     # this command would not have written to.
     if state_db_known_absent():
         raise MachineError(
-            "not_found", f"{StateDB().url} does not exist; there are no dispatches to act on"
+            "not_found",
+            f"{mask_db_url(StateDB().url)} does not exist; there are no dispatches to act on",
         )
     async with AsyncExitStack() as stack:
         try:
@@ -453,7 +455,16 @@ async def _writable_state_db() -> AsyncIterator[Any]:
         except MachineError:
             raise
         except Exception as exc:  # noqa: BLE001 — an unopenable store is a refusal, not a crash
-            raise MachineError("unavailable", f"{StateDB().url}: {type(exc).__name__}") from exc
+            # The message goes in `detail` rather than into the refusal text,
+            # so what a reader parses today is unchanged and the discriminator
+            # between two failures sharing a type is still there. Masked on
+            # both channels: the message can quote the store as readily as the
+            # URL field does.
+            raise MachineError(
+                "unavailable",
+                f"{mask_db_url(StateDB().url)}: {type(exc).__name__}",
+                {"cause": mask_credentials(str(exc))},
+            ) from exc
         yield db
 
 

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -282,6 +282,7 @@ async def readonly_state_db() -> AsyncIterator[tuple[Any | None, dict[str, Any] 
     it, and a bug in a reader still surfaces as the crash it is.
     """
     from lionagi.state.db import StateDB, read_only_open_supported, state_db_known_absent
+    from lionagi.state.engine import mask_db_url
 
     # Asked of the configured store, not of the default path: the open below
     # honours LIONAGI_STATE_DB_URL, so a guard that consulted the file would
@@ -299,7 +300,18 @@ async def readonly_state_db() -> AsyncIterator[tuple[Any | None, dict[str, Any] 
             # claims the store is open, which is what the claim has to mean.
             await db.fetch_all("SELECT 1")
         except Exception as exc:  # noqa: BLE001 — an unopenable store is an answer, not a crash
-            yield None, unavailable(REASON_UNREADABLE, f"{StateDB().url}: {type(exc).__name__}")
+            # The exception's own message is dropped here, as it always was:
+            # the availability wrapper's key set is a published contract with
+            # a test enumerating it, so there is nowhere to put the message
+            # that does not change the shape of an answer every reader parses.
+            # It is masked at its producers instead, which is where the leak
+            # was; what is lost is a diagnostic, not a control.
+            yield (
+                None,
+                unavailable(
+                    REASON_UNREADABLE, f"{mask_db_url(StateDB().url)}: {type(exc).__name__}"
+                ),
+            )
             return
         yield db, None
 
@@ -309,12 +321,15 @@ def state_db_absent() -> dict[str, Any]:
 
     Names the store that was actually consulted. Naming the default path while a
     URL is configured sends the reader to a file that is not the one their
-    command would have read.
+    command would have read. Naming it in full would print its password, so the
+    name it gives is the masked one.
     """
     from lionagi.state.db import StateDB
+    from lionagi.state.engine import mask_db_url
 
     return unavailable(
-        REASON_NOT_FOUND, f"{StateDB().url} does not exist; nothing has been recorded yet"
+        REASON_NOT_FOUND,
+        f"{mask_db_url(StateDB().url)} does not exist; nothing has been recorded yet",
     )
 
 
@@ -588,6 +603,7 @@ def lifecycle_data(run_id: str) -> dict[str, Any]:
         state_db_file,
         state_db_known_absent,
     )
+    from lionagi.state.engine import mask_credentials
 
     if state_db_known_absent():
         # No store at all is absence of every record, not evidence about this
@@ -595,7 +611,10 @@ def lifecycle_data(run_id: str) -> dict[str, Any]:
         # moves under LIONAGI_STATE_DB_URL), not the default path.
         return {
             "run_id": run_id,
-            "lifecycle": unavailable(REASON_NOT_FOUND, f"{state_db_file()} does not exist"),
+            "lifecycle": unavailable(
+                REASON_NOT_FOUND,
+                f"{mask_credentials(str(state_db_file()))} does not exist",
+            ),
         }
 
     async def _read() -> list[dict[str, Any]]:
@@ -611,7 +630,10 @@ def lifecycle_data(run_id: str) -> dict[str, Any]:
     except Exception as exc:  # noqa: BLE001 — an unreadable store is an answer, not a crash
         return {
             "run_id": run_id,
-            "lifecycle": unavailable(REASON_UNREADABLE, f"{type(exc).__name__}: {exc}"),
+            "lifecycle": unavailable(
+                REASON_UNREADABLE,
+                mask_credentials(f"{type(exc).__name__}: {exc}"),
+            ),
         }
     return {"run_id": run_id, "lifecycle": available(_lifecycle_summary(rows))}
 
@@ -746,7 +768,12 @@ def dispatch_machine(argv: list[str]) -> int:
                 raise
             channel.emit(failure("internal", "a required module is not installed"))
         except Exception as exc:  # noqa: BLE001 — a crash with no envelope is unreadable
-            channel.emit(failure("internal", f"{type(exc).__name__}: {exc}"))
+            from lionagi.state.engine import mask_credentials
+
+            # The only sink that prints a message from code we do not own. The
+            # producers we do own mask at the source; a driver that quotes the
+            # connection string it was handed has nowhere else to be caught.
+            channel.emit(failure("internal", mask_credentials(f"{type(exc).__name__}: {exc}")))
         else:
             channel.emit(ok(data))
     return 0

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -15,6 +15,8 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
+from lionagi.state.engine import mask_credentials
+
 from ._project import detect_project
 from ._runs import RUNS_ROOT
 from ._util import AmbiguousIdError, fetch_unique_row, resolve_entity
@@ -897,7 +899,9 @@ async def _run_table(
             )
         return _format_table(rows)
     except Exception as exc:  # noqa: BLE001
-        return _red(f"error reading state.db: {exc}")
+        # A catch-all around a store open, so the message can be one that names
+        # the store. Masked here for the same reason the envelope sinks are.
+        return _red(f"error reading state.db: {mask_credentials(str(exc))}")
 
 
 async def _run_detail(entity_id: str) -> str:
@@ -925,7 +929,7 @@ async def _run_detail(entity_id: str) -> str:
         # turn into a non-success exit code, not a rendered detail body.
         raise
     except Exception as exc:  # noqa: BLE001
-        return _red(f"error: {exc}")
+        return _red(f"error: {mask_credentials(str(exc))}")
 
 
 # ── Watch loop ────────────────────────────────────────────────────────────────

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -441,11 +441,15 @@ def _db_sizes() -> dict[str, Any]:
     answerable" and can never be read as "empty".
     """
     from lionagi.state.db import StateDB, state_db_file
+    from lionagi.state.engine import mask_credentials, mask_db_url
 
     db_path = state_db_file()
     if db_path is None:
+        # A store with no file behind it is a server URL, so this name is the
+        # one that most obviously carries a password. `is_file` is already
+        # false here, so nothing downstream treats it as a path to open.
         return {
-            "path": StateDB().url,
+            "path": mask_db_url(StateDB().url),
             "is_file": False,
             "exists": False,
             "size_bytes": None,
@@ -453,7 +457,11 @@ def _db_sizes() -> dict[str, Any]:
         }
     wal_path = db_path.with_name(db_path.name + "-wal")
     return {
-        "path": str(db_path),
+        # And so is this one, less obviously. A store URL with no scheme is
+        # read as a filesystem path, credential and all, which puts a password
+        # in the name of a real file and sends it down the branch that looks
+        # like it has nothing to hide.
+        "path": mask_credentials(str(db_path)),
         "is_file": True,
         "exists": db_path.exists(),
         "size_bytes": db_path.stat().st_size if db_path.exists() else 0,

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -28,6 +28,8 @@ from lionagi.state.engine import (
     dialect_of,
     make_engine,
     make_readonly_engine,
+    mask_credentials,
+    mask_db_url,
     normalize_state_db_url,
 )
 from lionagi.state.lifecycle import LifecycleNotFoundError as _LifecycleNotFoundError
@@ -712,9 +714,15 @@ class StateDB:
             if p is not None and str(p) != ":memory:":
                 if self.readonly:
                     if not p.exists():
+                        # A store URL with no scheme is read as a filesystem
+                        # path, so this path is where a mis-set credentialed
+                        # URL ends up, verbatim. Masked here rather than only
+                        # where it is printed, because an exception travels to
+                        # readers this module does not know about.
                         raise FileNotFoundError(
-                            f"state.db not found at {p} — read-only open requires an "
-                            "existing database file (it will never be created)"
+                            f"state.db not found at {mask_credentials(str(p))} — read-only "
+                            "open requires an existing database file (it will never be "
+                            "created)"
                         )
                 else:
                     ensure_lionagi_dir(p.parent)
@@ -876,7 +884,15 @@ class StateDB:
             return
         if recorded_n <= int(SCHEMA_VERSION):
             return
-        where = self.path if self.dialect == "sqlite" and self.path is not None else self.url
+        # Named for an operator, so masked: on a server-backed store this is
+        # the connection URL, and this refusal fires on an ordinary open of a
+        # database a newer release wrote, which is a routine upgrade order
+        # mistake rather than a rare one.
+        where = (
+            mask_credentials(str(self.path))
+            if self.dialect == "sqlite" and self.path is not None
+            else mask_db_url(self.url)
+        )
         raise SchemaTooNewError(
             f"{where} records schema version {recorded} but this version of lionagi "
             f"applies schema version {SCHEMA_VERSION}. It was written by a later "

--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -185,10 +185,13 @@ def mask_db_url(url: str) -> str:
     """Return *url* with any password replaced by the first-6-chars mask.
 
     The structured pass comes first, and text scanning is the fallback for the
-    URLs it cannot decompose. A string with no scheme, which is what a
-    mis-set store URL usually is, parses as a path rather than as a URL, so
-    ``urlparse`` reports no password for it and the credential would otherwise
-    be returned verbatim by the function whose whole job is to remove it.
+    URLs it cannot decompose. A string with no scheme parses as a path rather
+    than as a URL, so ``urlparse`` reports no password for it and the
+    credential would otherwise be returned verbatim by the function whose whole
+    job is to remove it. Such a value is refused as a store setting, which is
+    not a reason to drop the arm: what reaches here is whatever a caller was
+    handed, including a driver quoting its own connection string, an older log
+    line, and the ``./``-prefixed path that spelling makes acceptable.
     """
     try:
         parsed = urlparse(url)

--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -145,15 +145,56 @@ def normalize_state_db_url(value: str | Path | None) -> str:
     return s
 
 
+# A `user:secret@` credential, wherever it appears. The secret runs to the
+# first `@` and may not contain whitespace, a slash, a quote or a second colon,
+# which is what keeps this off `sqlite:///path` (no `@`) and off an ordinary
+# `scheme://host` (no colon before the host).
+_CREDENTIAL_IN_TEXT = re.compile(r"(?<![\w.+~%-])([\w.+~%-]+):([^\s:@/\\'\"]+)@")
+
+
+def _mask_secret(secret: str) -> str:
+    """The one mask token. Long secrets keep a 6-char prefix so an operator can
+    tell two of them apart; short ones show nothing but their length, because a
+    prefix of a short secret is most of it."""
+    prefix = secret[:6] if len(secret) >= 12 else ""
+    return f"{prefix}…[{len(secret)} chars]"
+
+
+def mask_credentials(text: str) -> str:
+    """Return *text* with the secret in every ``user:secret@`` masked.
+
+    For prose rather than for a URL: an error message that quotes the store it
+    failed to open carries the credential just as plainly as the URL field
+    beside it, and masking only the field closes one of two channels onto the
+    same secret.
+
+    Text is scanned rather than parsed because the strings that reach here are
+    not URLs and cannot be made into them. Two consequences worth stating: a
+    password containing a literal ``@`` is masked only up to that character,
+    and a secret passed as a bare argument rather than inside a URL is not
+    matched at all. Both are under-masking, so neither is a reason to skip the
+    pass, and both are why this is a backstop rather than the only control.
+
+    Masking is idempotent: the token it writes contains a space, and a space
+    cannot appear inside a secret this pattern will match.
+    """
+    return _CREDENTIAL_IN_TEXT.sub(lambda m: f"{m.group(1)}:{_mask_secret(m.group(2))}@", text)
+
+
 def mask_db_url(url: str) -> str:
-    """Return *url* with any password replaced by the first-6-chars mask."""
+    """Return *url* with any password replaced by the first-6-chars mask.
+
+    The structured pass comes first, and text scanning is the fallback for the
+    URLs it cannot decompose. A string with no scheme, which is what a
+    mis-set store URL usually is, parses as a path rather than as a URL, so
+    ``urlparse`` reports no password for it and the credential would otherwise
+    be returned verbatim by the function whose whole job is to remove it.
+    """
     try:
         parsed = urlparse(url)
         if not parsed.password:
-            return url
-        pw = parsed.password
-        prefix = pw[:6] if len(pw) >= 12 else ""
-        masked = f"{prefix}…[{len(pw)} chars]"
+            return mask_credentials(url)
+        masked = _mask_secret(parsed.password)
         user_info = f"{parsed.username}:{masked}"
         host_part = parsed.hostname or ""
         if parsed.port:

--- a/tests/cli/test_store_url_masking.py
+++ b/tests/cli/test_store_url_masking.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""No operator-facing string names the store with its password still in it.
+
+A store URL is a credential when the store is a server. Every command that
+reports which store it consulted, and every refusal that says why it could not
+open one, prints that URL, and those strings land in terminal scrollback, CI
+logs and machine-mode JSON that gets stored.
+
+Two channels carry the same secret and both are asserted here. The URL is the
+obvious one. The other is an exception's own message, which is a separate
+string built by separate code and is unaffected by masking the field beside it.
+
+The end-to-end tests run the real CLI in a subprocess and read **stdout and
+stderr separately**, because "it did not appear" is only worth something once
+you have said where you looked. Each of them also asserts the masked form is
+present, which is what distinguishes a command that ran and masked from a
+command that never reached the store at all: an early probe of this fix
+mistyped the invocation, got a clean password check from six commands that all
+answered "no such command", and read as a pass.
+
+The scheme-less URL is not a contrived shape. A store URL with no scheme is
+read as a filesystem path, so a mis-set variable puts the credential in a real
+path — which is both how it evades a masker that only parses URLs, and why the
+branch that looks like it has nothing to hide is the one that leaked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+import lionagi.state.db as db_mod
+
+PASSWORD = "hunter2-correct-horse"
+MASKED = "hunter…[21 chars]"
+
+SERVER_URL = f"postgresql://dbuser:{PASSWORD}@127.0.0.1:59999/lionagi"
+SCHEMELESS_URL = f"dbuser:{PASSWORD}@127.0.0.1/x"
+
+
+def _set_url(monkeypatch, url: str) -> None:
+    """Settings are frozen, so redirect the whole object the module reads."""
+    monkeypatch.setattr(
+        db_mod, "settings", db_mod.settings.model_copy(update={"LIONAGI_STATE_DB_URL": url})
+    )
+
+
+def _assert_masked(text: str, where: str) -> None:
+    assert PASSWORD not in text, f"the password reached {where}: {text!r}"
+    assert MASKED in text, (
+        f"{where} does not name the store at all, so it asserts nothing: {text!r}"
+    )
+
+
+# ── the masker itself ────────────────────────────────────────────────────────
+
+
+def test_a_url_with_no_scheme_is_masked_too():
+    """The shape ``urlparse`` cannot decompose, and the one a real mistake makes."""
+    from lionagi.state.engine import mask_db_url
+
+    _assert_masked(mask_db_url(SCHEMELESS_URL), "mask_db_url of a scheme-less URL")
+
+
+def test_credentials_are_masked_inside_prose():
+    from lionagi.state.engine import mask_credentials
+
+    message = f"state.db not found at /var/lib/{SCHEMELESS_URL} — nothing was created"
+    _assert_masked(mask_credentials(message), "mask_credentials of a message")
+
+
+def test_masking_is_idempotent():
+    """The sinks compose these, so masking an already-masked string must not re-mask it."""
+    from lionagi.state.engine import mask_credentials, mask_db_url
+
+    once = mask_db_url(SERVER_URL)
+    assert mask_credentials(once) == once
+    assert mask_credentials(mask_credentials(once)) == once
+
+
+@pytest.mark.parametrize(
+    "untouched",
+    [
+        "sqlite+aiosqlite:////var/lib/state.db",
+        "postgresql://dbuser@127.0.0.1/lionagi",
+        "[Errno 61] Connect call failed ('127.0.0.1', 59999)",
+        "mail alice@example.com about the 12:30 window",
+    ],
+)
+def test_strings_with_no_credential_are_returned_unchanged(untouched):
+    """Over-masking would corrupt paths and messages, so the must-not-match arm
+    matters as much as the must-match one."""
+    from lionagi.state.engine import mask_credentials, mask_db_url
+
+    assert mask_credentials(untouched) == untouched
+    assert mask_db_url(untouched) == untouched
+
+
+# ── per sink ─────────────────────────────────────────────────────────────────
+
+
+def test_the_absent_store_refusal_names_a_masked_store(monkeypatch):
+    from lionagi.cli.machine import state_db_absent
+
+    _set_url(monkeypatch, SERVER_URL)
+    _assert_masked(state_db_absent()["detail"], "the not-found detail")
+
+
+def _raise_quoting_the_store(monkeypatch) -> None:
+    """Make the open fail with a message that quotes the store, credential and all.
+
+    The exception a closed port produces does not name the store, so asserting
+    a password's absence from it asserts nothing: the string could not contain
+    it under any condition. What is under test here is the sink's handling of a
+    message that *does* carry the URL, so the message is supplied rather than
+    hoped for. Our own store raises exactly this shape when a read-only open
+    finds no file, and a driver that quotes its connection string is the case
+    we do not control at all.
+    """
+    from lionagi.state.db import StateDB
+
+    async def failing_open(self) -> None:
+        raise RuntimeError(f"could not open {SERVER_URL}")
+
+    monkeypatch.setattr(StateDB, "open", failing_open)
+
+
+@pytest.mark.anyio
+async def test_the_readonly_seam_masks_the_store_it_names(monkeypatch):
+    from lionagi.cli.machine import readonly_state_db
+
+    _set_url(monkeypatch, SERVER_URL)
+    async with readonly_state_db() as (db, why):
+        assert db is None, "this store cannot open, so the refusal is the thing under test"
+        _assert_masked(why["detail"], "the seam's detail")
+
+
+@pytest.mark.anyio
+async def test_the_availability_wrapper_keeps_its_four_keys(monkeypatch):
+    """Its key set is a published contract with its own test enumerating it.
+
+    Pinned again from this side because the obvious home for an exception's
+    message is a fifth key here, and the cost of putting one there is not
+    visible from the code that would add it.
+    """
+    from lionagi.cli.machine import readonly_state_db
+
+    _set_url(monkeypatch, SERVER_URL)
+    async with readonly_state_db() as (db, why):
+        assert set(why) == {"available", "value", "reason_code", "detail"}
+
+
+@pytest.mark.anyio
+async def test_the_writable_guard_masks_its_refusal(monkeypatch):
+    from lionagi.cli.dispatch import _writable_state_db
+    from lionagi.cli.machine import MachineError
+
+    _set_url(monkeypatch, SERVER_URL)
+    with pytest.raises(MachineError) as caught:
+        async with _writable_state_db():
+            pass
+
+    _assert_masked(str(caught.value), "the write refusal's message")
+    assert (caught.value.detail or {}).get("cause"), (
+        f"the refusal carries no message, so the discriminator is not there: {caught.value.detail}"
+    )
+    # A refusal is an exception, not the availability wrapper, so its detail is
+    # a free-form dict and carrying the message here costs no contract.
+
+
+@pytest.mark.anyio
+async def test_the_writable_guard_masks_a_message_that_quotes_the_store(monkeypatch):
+    from lionagi.cli.dispatch import _writable_state_db
+    from lionagi.cli.machine import MachineError
+
+    _set_url(monkeypatch, SERVER_URL)
+    _raise_quoting_the_store(monkeypatch)
+    with pytest.raises(MachineError) as caught:
+        async with _writable_state_db():
+            pass
+
+    _assert_masked((caught.value.detail or {}).get("cause", ""), "the write refusal's cause")
+
+
+@pytest.mark.anyio
+async def test_a_read_only_open_with_no_file_masks_the_path_it_names(monkeypatch, tmp_path):
+    """The producer of the message that started this: a scheme-less store URL
+    is read as a path, so the refusal names a path with a password in it."""
+    from lionagi.state.db import StateDB
+
+    monkeypatch.chdir(tmp_path)
+    _set_url(monkeypatch, SCHEMELESS_URL)
+    with pytest.raises(FileNotFoundError) as caught:
+        await StateDB(readonly=True).open()
+
+    _assert_masked(str(caught.value), "the read-only open refusal")
+
+
+def test_the_size_report_masks_a_server_url(monkeypatch):
+    from lionagi.cli.state import _db_sizes
+
+    _set_url(monkeypatch, SERVER_URL)
+    sizes = _db_sizes()
+    assert sizes["is_file"] is False
+    _assert_masked(sizes["path"], "the size report's path")
+
+
+def test_the_size_report_masks_a_credential_that_became_a_file_path(monkeypatch, tmp_path):
+    """The branch that looks like it cannot carry a secret, and does.
+
+    ``is_file`` is true here, so nothing about this answer suggests a
+    credential is in it. That is exactly why masking only the server branch
+    left the leak in place.
+    """
+    from lionagi.cli.state import _db_sizes
+
+    monkeypatch.chdir(tmp_path)
+    _set_url(monkeypatch, SCHEMELESS_URL)
+    sizes = _db_sizes()
+    assert sizes["is_file"] is True, "this arm is meant to take the file branch"
+    _assert_masked(sizes["path"], "the size report's path")
+
+
+def test_a_newer_schema_refusal_names_a_masked_store(monkeypatch):
+    """Raised on an ordinary open of a store a later release wrote, which is a
+    routine upgrade-order mistake rather than a rare one."""
+    from lionagi.state.db import SchemaTooNewError, StateDB
+
+    _set_url(monkeypatch, SERVER_URL)
+    db = StateDB()
+    with pytest.raises(SchemaTooNewError) as caught:
+        db._raise_if_schema_too_new("999999")
+
+    _assert_masked(str(caught.value), "the schema-too-new refusal")
+
+
+@pytest.mark.anyio
+async def test_the_writable_guard_masks_the_store_it_reports_absent(monkeypatch, tmp_path):
+    """The absent branch, which a credentialed URL reaches whenever the file it
+    was misread as does not exist."""
+    from lionagi.cli.dispatch import _writable_state_db
+    from lionagi.cli.machine import MachineError
+
+    monkeypatch.chdir(tmp_path)
+    _set_url(monkeypatch, SCHEMELESS_URL)
+    with pytest.raises(MachineError) as caught:
+        async with _writable_state_db():
+            pass
+
+    assert caught.value.kind == "not_found", f"this arm wanted the absent branch: {caught.value}"
+    _assert_masked(str(caught.value), "the absent-store refusal")
+
+
+def test_the_machine_dispatcher_masks_a_crash_that_quotes_the_store(monkeypatch, capfd):
+    """The last sink before the envelope, and the only one that prints a message
+    from code we do not own. A driver that quotes its connection string has
+    nowhere else to be caught.
+
+    ``capfd``, not ``capsys``: this dispatcher reserves stdout at the file
+    descriptor level, so the envelope never passes through the object
+    ``capsys`` replaces and the read comes back empty."""
+    from lionagi.cli import machine
+
+    def crash(argv):
+        raise RuntimeError(f"could not reach {SERVER_URL}")
+
+    monkeypatch.setattr(machine, "_run_machine_command", crash)
+    assert machine.dispatch_machine(["handshake"]) == 0
+
+    envelope = json.loads(capfd.readouterr().out)
+    assert envelope["error"]["kind"] == "internal"
+    _assert_masked(envelope["error"]["message"], "the crash envelope's message")
+
+
+def test_the_lifecycle_read_masks_a_message_that_quotes_the_store(monkeypatch):
+    from lionagi.cli.machine import lifecycle_data
+
+    _set_url(monkeypatch, SERVER_URL)
+    _raise_quoting_the_store(monkeypatch)
+    why = lifecycle_data("run-that-does-not-matter")["lifecycle"]
+
+    assert why["available"] is False
+    _assert_masked(why["detail"], "the lifecycle detail")
+
+
+def test_the_lifecycle_absent_answer_masks_the_path_it_names(monkeypatch, tmp_path):
+    """``state_db_file()`` is a path, and a scheme-less store URL is how a
+    password gets into one."""
+    from lionagi.cli.machine import lifecycle_data
+
+    monkeypatch.chdir(tmp_path)
+    _set_url(monkeypatch, SCHEMELESS_URL)
+    why = lifecycle_data("run-that-does-not-matter")["lifecycle"]
+
+    assert why["reason_code"] == "not_found", f"this arm wanted the absent branch: {why}"
+    _assert_masked(why["detail"], "the lifecycle absent detail")
+
+
+@pytest.mark.anyio
+async def test_the_monitor_table_masks_a_message_that_quotes_the_store(monkeypatch):
+    from lionagi.cli.monitor import _run_table
+
+    _set_url(monkeypatch, SERVER_URL)
+    _raise_quoting_the_store(monkeypatch)
+    _assert_masked(
+        await _run_table(since=None, entity_type=None, project=None),
+        "the monitor table's error line",
+    )
+
+
+@pytest.mark.anyio
+async def test_the_monitor_detail_masks_a_message_that_quotes_the_store(monkeypatch):
+    from lionagi.cli.monitor import _run_detail
+
+    _set_url(monkeypatch, SERVER_URL)
+    _raise_quoting_the_store(monkeypatch)
+    _assert_masked(await _run_detail("some-entity"), "the monitor detail's error line")
+
+
+# ── end to end, both channels named ──────────────────────────────────────────
+
+
+def _run_cli(args: list[str], url: str, cwd) -> subprocess.CompletedProcess:
+    env = {**os.environ, "LIONAGI_STATE_DB_URL": url}
+    return subprocess.run(
+        [sys.executable, "-m", "lionagi.cli.main", *args],
+        env=env,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+@pytest.mark.parametrize("url", [SERVER_URL, SCHEMELESS_URL], ids=["server", "scheme-less"])
+@pytest.mark.parametrize("args", [["--machine", "dispatch", "ls"], ["--machine", "stats", "runs"]])
+def test_machine_mode_prints_the_password_on_neither_channel(tmp_path, url, args):
+    """Machine mode is the channel that gets stored: its JSON lands in logs."""
+    proc = _run_cli(args, url, tmp_path)
+
+    assert PASSWORD not in proc.stdout, f"the password reached STDOUT: {proc.stdout!r}"
+    assert PASSWORD not in proc.stderr, f"the password reached STDERR: {proc.stderr!r}"
+
+    envelope = json.loads(proc.stdout)
+    assert envelope["ok"] is True, f"the command did not run, so it masked nothing: {envelope}"
+    assert MASKED in proc.stdout, (
+        "no masked store name in the output, so this command never consulted the store and "
+        f"the password check above is vacuous: {proc.stdout!r}"
+    )
+
+
+@pytest.mark.parametrize("url", [SERVER_URL, SCHEMELESS_URL], ids=["server", "scheme-less"])
+def test_the_human_size_report_prints_the_password_on_neither_channel(tmp_path, url):
+    proc = _run_cli(["state", "stats"], url, tmp_path)
+
+    assert PASSWORD not in proc.stdout, f"the password reached STDOUT: {proc.stdout!r}"
+    assert PASSWORD not in proc.stderr, f"the password reached STDERR: {proc.stderr!r}"
+    assert MASKED in proc.stdout, (
+        "the report does not name the store at all, so it never reached the code under "
+        f"test: {proc.stdout!r}"
+    )

--- a/tests/cli/test_store_url_masking.py
+++ b/tests/cli/test_store_url_masking.py
@@ -20,10 +20,14 @@ command that never reached the store at all: an early probe of this fix
 mistyped the invocation, got a clean password check from six commands that all
 answered "no such command", and read as a pass.
 
-The scheme-less URL is not a contrived shape. A store URL with no scheme is
-read as a filesystem path, so a mis-set variable puts the credential in a real
-path — which is both how it evades a masker that only parses URLs, and why the
-branch that looks like it has nothing to hide is the one that leaked.
+A store URL with no scheme is read as a filesystem path, so a credential in
+one puts a password in a real path. That is both how it evades a masker that
+only parses URLs, and why the branch that looks like it has nothing to hide is
+the one that leaked. The shape reaches a store setting only through the ``./``
+spelling now, since a bare ``user:secret@host/db`` is refused before it
+resolves, so that is the spelling the store-setting arms use. The masker is
+still asked about the bare form directly: it is handed strings built by
+drivers and by older logs, not only strings that passed our own validation.
 """
 
 from __future__ import annotations
@@ -42,6 +46,11 @@ MASKED = "hunter…[21 chars]"
 
 SERVER_URL = f"postgresql://dbuser:{PASSWORD}@127.0.0.1:59999/lionagi"
 SCHEMELESS_URL = f"dbuser:{PASSWORD}@127.0.0.1/x"
+# The same shape as a store setting. `./` is what says "this really is a path"
+# to the check that otherwise refuses a scheme-less credential outright, and it
+# changes nothing about what lands on disk: the credential is still in the name
+# of a real file, which is the leak these arms are about.
+CREDENTIALED_PATH = f"./{SCHEMELESS_URL}"
 
 
 def _set_url(monkeypatch, url: str) -> None:
@@ -62,7 +71,12 @@ def _assert_masked(text: str, where: str) -> None:
 
 
 def test_a_url_with_no_scheme_is_masked_too():
-    """The shape ``urlparse`` cannot decompose, and the one a real mistake makes."""
+    """The shape ``urlparse`` cannot decompose.
+
+    Refused as a store setting, and still reaching this function from every
+    other direction: a driver quoting what it was handed, an older log line,
+    a path spelled with the ``./`` that makes it acceptable.
+    """
     from lionagi.state.engine import mask_db_url
 
     _assert_masked(mask_db_url(SCHEMELESS_URL), "mask_db_url of a scheme-less URL")
@@ -190,12 +204,13 @@ async def test_the_writable_guard_masks_a_message_that_quotes_the_store(monkeypa
 
 @pytest.mark.anyio
 async def test_a_read_only_open_with_no_file_masks_the_path_it_names(monkeypatch, tmp_path):
-    """The producer of the message that started this: a scheme-less store URL
-    is read as a path, so the refusal names a path with a password in it."""
+    """The producer of the message that started this: a store URL with no
+    scheme is read as a path, so the refusal names a path with a password in
+    it."""
     from lionagi.state.db import StateDB
 
     monkeypatch.chdir(tmp_path)
-    _set_url(monkeypatch, SCHEMELESS_URL)
+    _set_url(monkeypatch, CREDENTIALED_PATH)
     with pytest.raises(FileNotFoundError) as caught:
         await StateDB(readonly=True).open()
 
@@ -221,7 +236,7 @@ def test_the_size_report_masks_a_credential_that_became_a_file_path(monkeypatch,
     from lionagi.cli.state import _db_sizes
 
     monkeypatch.chdir(tmp_path)
-    _set_url(monkeypatch, SCHEMELESS_URL)
+    _set_url(monkeypatch, CREDENTIALED_PATH)
     sizes = _db_sizes()
     assert sizes["is_file"] is True, "this arm is meant to take the file branch"
     _assert_masked(sizes["path"], "the size report's path")
@@ -242,13 +257,13 @@ def test_a_newer_schema_refusal_names_a_masked_store(monkeypatch):
 
 @pytest.mark.anyio
 async def test_the_writable_guard_masks_the_store_it_reports_absent(monkeypatch, tmp_path):
-    """The absent branch, which a credentialed URL reaches whenever the file it
-    was misread as does not exist."""
+    """The absent branch, which a credentialed path reaches whenever the file
+    it names does not exist."""
     from lionagi.cli.dispatch import _writable_state_db
     from lionagi.cli.machine import MachineError
 
     monkeypatch.chdir(tmp_path)
-    _set_url(monkeypatch, SCHEMELESS_URL)
+    _set_url(monkeypatch, CREDENTIALED_PATH)
     with pytest.raises(MachineError) as caught:
         async with _writable_state_db():
             pass
@@ -290,12 +305,12 @@ def test_the_lifecycle_read_masks_a_message_that_quotes_the_store(monkeypatch):
 
 
 def test_the_lifecycle_absent_answer_masks_the_path_it_names(monkeypatch, tmp_path):
-    """``state_db_file()`` is a path, and a scheme-less store URL is how a
+    """``state_db_file()`` is a path, and a store URL with no scheme is how a
     password gets into one."""
     from lionagi.cli.machine import lifecycle_data
 
     monkeypatch.chdir(tmp_path)
-    _set_url(monkeypatch, SCHEMELESS_URL)
+    _set_url(monkeypatch, CREDENTIALED_PATH)
     why = lifecycle_data("run-that-does-not-matter")["lifecycle"]
 
     assert why["reason_code"] == "not_found", f"this arm wanted the absent branch: {why}"
@@ -338,7 +353,9 @@ def _run_cli(args: list[str], url: str, cwd) -> subprocess.CompletedProcess:
     )
 
 
-@pytest.mark.parametrize("url", [SERVER_URL, SCHEMELESS_URL], ids=["server", "scheme-less"])
+@pytest.mark.parametrize(
+    "url", [SERVER_URL, CREDENTIALED_PATH], ids=["server", "credentialed-path"]
+)
 @pytest.mark.parametrize("args", [["--machine", "dispatch", "ls"], ["--machine", "stats", "runs"]])
 def test_machine_mode_prints_the_password_on_neither_channel(tmp_path, url, args):
     """Machine mode is the channel that gets stored: its JSON lands in logs."""
@@ -355,7 +372,9 @@ def test_machine_mode_prints_the_password_on_neither_channel(tmp_path, url, args
     )
 
 
-@pytest.mark.parametrize("url", [SERVER_URL, SCHEMELESS_URL], ids=["server", "scheme-less"])
+@pytest.mark.parametrize(
+    "url", [SERVER_URL, CREDENTIALED_PATH], ids=["server", "credentialed-path"]
+)
 def test_the_human_size_report_prints_the_password_on_neither_channel(tmp_path, url):
     proc = _run_cli(["state", "stats"], url, tmp_path)
 


### PR DESCRIPTION
## Why

`mask_db_url()` has existed since the Postgres backend landed and had **no production callers**. Meanwhile every command that reports which store it consulted printed `StateDB().url` verbatim, into terminal scrollback, CI logs and machine-mode JSON that gets stored:

```python
yield None, unavailable(REASON_UNREADABLE, f"{StateDB().url}: {type(exc).__name__}")
```

On SQLite that URL is a path. On a server-backed store it is a credential.

## Two things the obvious fix does not cover

**A store URL with no scheme is read as a filesystem path.** `urlparse` finds no password in `dbuser:secret@host/db`, so `mask_db_url()` returned it *unchanged* — the function whose whole job is removing the credential handed it back intact. That is also the shape a real mistake makes (a variable set to a bare connection string), and it puts the password into a real path, which then flows through the branches that look like they have nothing to hide. `li state stats` printed it in full from the `is_file: True` branch.

`mask_db_url()` now falls back to scanning text when it cannot decompose a URL. `mask_credentials()` is that scan, exposed for the second case:

**An exception's message is a separate string built by separate code.** Masking the URL field beside it closes one of two channels onto the same secret. This store raises `state.db not found at <path>` on a read-only open, and by the paragraph above that path can contain a password. Masked at the producer, so it stays masked wherever the exception travels.

## Where it is applied

Source, so the string is safe wherever it goes:

| | |
|---|---|
| `state/db.py` read-only open refusal | names the path it looked at |
| `state/db.py` newer-schema refusal | names the connection URL, and fires on an ordinary open of a store a later release wrote |

Sinks, for messages from code we do not own — a driver that quotes its connection string has nowhere else to be caught:

`machine.py` (read-only seam, absent-store answer, lifecycle read, machine-mode crash envelope) · `dispatch.py` (both write-guard refusals) · `state.py` (both size-report branches) · `monitor.py` (both store-read catch-alls).

## Surface

Unchanged. `mask_db_url()` is a no-op on any string with no credential in it, so SQLite output is byte-identical; only a credentialed URL renders differently, and it renders as `dbuser:hunte…[21 chars]@host`.

The availability wrapper keeps its four keys. Its key set is a published contract with a test enumerating it, so an exception's message has nowhere to go there without changing the shape of an answer every reader parses — a second test pins that from this side, because the obvious home for the message is a fifth key and the cost of adding one is not visible from the code that would add it. `MachineError.detail` is a free-form dict and does carry it.

`li state doctor` crashes with an unhandled traceback on a server-backed store. Pre-existing, unrelated, no credential in the traceback; left alone.

## Testing

36 tests. 15 mutations, each reverting one masking call, **all 15 detected**, with the baseline run as an arm at both ends. Two of them were not detected on the first pass and are the reason the count is 36 rather than 34: the machine-mode crash envelope and the absent-store write refusal were masked with nothing exercising them.

The end-to-end tests run the real CLI in a subprocess and read **stdout and stderr separately**. Each also asserts the masked form is *present*, because an early probe of this fix mistyped the invocation, got a clean password check from six commands that all answered `no such command`, and read as a pass.

Acceptance sweep, 10 commands × 2 URL shapes: 20 rows, **0 leaking on either channel**, 0 that failed to reach the CLI, 13 that named the store in masked form. The other 7 print nothing about the store in that state, so their clean result is weaker evidence and is not counted as coverage.

Full suite: 17010 passed, 8 skipped. Two failures in `tests/tools/test_coding_toolkit.py` come from a `docling` import chain in this checkout's virtualenv and touch none of the six files here.
