### PR TITLE
fix(codex): report a failed session once, and set is_error on the chunk

### DIFF
--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -753,7 +753,17 @@ async def stream_codex_cli(
                 else:
                     if request.verbose_output:
                         log.error("Codex error: %s", session.result)
-                sc = StreamChunk(type="error", content=session.result, metadata=chunk_meta)
+                # The flag follows the classification above, so a consumer
+                # reading it sees the same verdict as one reading the metadata.
+                # Benign end-of-stream keeps `is_error` false: the type is
+                # "error" only because that is the event the CLI sends, and the
+                # three conditions above are what say it is not one.
+                sc = StreamChunk(
+                    type="error",
+                    content=session.result,
+                    is_error=not _is_benign_eos,
+                    metadata=chunk_meta,
+                )
                 session.chunks.append(sc)
                 yield sc
 
@@ -905,10 +915,16 @@ class CodexCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
         async with contextlib.aclosing(stream_codex_cli(request_obj, **handlers)) as gen:
             async for item in gen:
                 if isinstance(item, CLISession):
-                    if item.is_error:
+                    # The parser already yields an error chunk for a failed
+                    # turn, so without the guard a single failure is reported
+                    # twice — once as it happens and once as the session ends.
+                    # This is the session-terminal verdict; per-tool failures
+                    # have their own carriers and are not what this counts.
+                    if item.is_error and not any(c.type == "error" for c in item.chunks):
                         yield StreamChunk(
                             type="error",
                             content=item.result or "Codex session failed",
+                            is_error=True,
                         )
                     continue
                 yield item

--- a/tests/providers/openai/codex/test_session_error_chunk.py
+++ b/tests/providers/openai/codex/test_session_error_chunk.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""One session failure produces one error chunk, and the chunk says it is one.
+
+Two things reach a consumer when a codex session ends badly, and until now they
+disagreed. The parser yields an error chunk as the failing event arrives. The
+endpoint yields a second one as the session closes, unconditionally, so a real
+``turn.failed`` was reported twice by two objects describing the same failure.
+Neither carried ``is_error``, so a consumer reading the flag rather than the
+type saw no failure at all.
+
+The benign end-of-stream case is why the flag cannot simply be set on every
+error-typed chunk. A resumed session that ends normally emits ``{"type":
+"error"}`` with an empty payload, and that chunk is classified as *not* a
+failure on purpose. It keeps ``is_error`` false, and the test below pins that
+alongside the failure cases rather than in a separate file, because the two
+decisions are one decision and a change to either belongs beside the other.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lionagi.providers.openai.codex import CodexCLIEndpoint, CodexCodeRequest, stream_codex_cli
+from lionagi.service.types.stream_chunk import StreamChunk
+
+
+def _request() -> CodexCodeRequest:
+    return CodexCodeRequest(prompt="test", verbose_output=False)
+
+
+def _fake_events(events: list[dict]):
+    async def fake(request):
+        for event in events:
+            yield event
+
+    return patch(
+        "lionagi.providers.openai.codex.stream_codex_cli_events",
+        side_effect=fake,
+    )
+
+
+async def _parser_chunks(events: list[dict]) -> list[StreamChunk]:
+    """What the parser alone yields, which is one half of what a consumer sees."""
+    collected: list[StreamChunk] = []
+    with _fake_events(events):
+        async for item in stream_codex_cli(_request()):
+            if isinstance(item, StreamChunk):
+                collected.append(item)
+    return collected
+
+
+async def _endpoint_chunks(events: list[dict]) -> list[StreamChunk]:
+    """What a consumer of the endpoint actually receives: parser chunks plus
+    whatever the session-terminal branch adds on top."""
+    endpoint = CodexCLIEndpoint()
+    collected: list[StreamChunk] = []
+    with _fake_events(events):
+        async for chunk in endpoint.stream({"request": _request()}):
+            collected.append(chunk)
+    return collected
+
+
+FAILURES = [
+    pytest.param([{"type": "turn.failed", "error": {}}], id="turn-failed"),
+    pytest.param(
+        [{"type": "error", "error": {"code": "rate_limit"}}],
+        id="error-with-payload",
+    ),
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("events", FAILURES)
+async def test_a_failed_session_is_reported_exactly_once(events):
+    chunks = await _endpoint_chunks(events)
+    errors = [c for c in chunks if c.type == "error"]
+
+    assert len(errors) == 1, (
+        "one failure, one error chunk; a second describes the same failure again and a "
+        f"consumer counting failures counts two: {errors}"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("events", FAILURES)
+async def test_a_failed_session_says_so_on_the_flag_as_well_as_the_type(events):
+    """A consumer keying on ``is_error`` must not have to know the type vocabulary."""
+    errors = [c for c in await _endpoint_chunks(events) if c.type == "error"]
+
+    assert errors[0].is_error is True, (
+        f"the failure chunk does not carry is_error, so the flag reads as success: {errors[0]}"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("events", FAILURES)
+async def test_the_parser_chunk_carries_the_flag_too(events):
+    """The endpoint's guard means the parser's chunk is the one that survives, so
+    the flag has to be right on that one, not only on the one it replaced."""
+    errors = [c for c in await _parser_chunks(events) if c.type == "error"]
+
+    assert len(errors) == 1
+    assert errors[0].is_error is True, f"the surviving chunk reads as success: {errors[0]}"
+
+
+@pytest.mark.anyio
+async def test_a_benign_end_of_stream_still_reads_as_success():
+    """The bare empty-error sentinel a resumed session ends with.
+
+    Its type is "error" because that is the event the CLI sends. It is not a
+    failure, the classification says so in the metadata, and the flag must
+    agree with the classification rather than with the type.
+    """
+    chunks = await _endpoint_chunks([{"type": "error", "error": {}}])
+    errors = [c for c in chunks if c.type == "error"]
+
+    assert len(errors) == 1, f"the benign sentinel moved; this test describes nothing: {chunks}"
+    assert errors[0].metadata.get("benign_eos") is True, (
+        f"this arm is meant to exercise the benign path: {errors[0]}"
+    )
+    assert errors[0].is_error is False, (
+        "a normal end of stream now reports itself as a failure, which is the whole "
+        f"reason the flag could not be set on chunk type alone: {errors[0]}"
+    )
+
+
+@pytest.mark.anyio
+async def test_a_terminal_result_that_reports_failure_is_reported_by_the_endpoint():
+    """The path where the endpoint's chunk is the only one there is.
+
+    A terminal ``result`` event carrying ``is_error`` marks the session failed
+    without any error event having arrived, so the parser appends nothing and
+    the guard's condition is true. This is what stops the guard from being a
+    way to emit nothing at all, and it is the only arm that exercises the flag
+    on the endpoint's own chunk.
+    """
+    events = [{"type": "result", "result": "boom", "is_error": True}]
+
+    parser_errors = [c for c in await _parser_chunks(events) if c.type == "error"]
+    assert parser_errors == [], (
+        "the parser now reports this itself, so this arm no longer reaches the endpoint's "
+        f"branch and stops testing what it says it tests: {parser_errors}"
+    )
+
+    errors = [c for c in await _endpoint_chunks(events) if c.type == "error"]
+    assert len(errors) == 1, f"a failed session went unreported: {errors}"
+    assert errors[0].is_error is True, f"the endpoint's own chunk reads as success: {errors[0]}"
+    assert errors[0].content == "boom"
+
+
+@pytest.mark.anyio
+async def test_a_healthy_session_yields_no_error_chunk_at_all():
+    """The must-not-match arm: the guard must not be satisfiable by a version
+    that stops emitting, and a healthy session is where that would show."""
+    chunks = await _endpoint_chunks([{"type": "turn.completed"}])
+
+    assert [c for c in chunks if c.type == "error"] == [], (
+        f"a healthy session reported a failure: {chunks}"
+    )


### PR DESCRIPTION
## Why

Two objects described one codex session failure, and they disagreed about whether it was one.

The parser yields an error chunk as the failing event arrives and records it on the session. The endpoint then yielded a second one as the session closed, unconditionally:

```python
if item.is_error:
    yield StreamChunk(type="error", content=item.result or "Codex session failed")
```

So a real `turn.failed` reached a consumer twice. Neither chunk set `is_error`, so a consumer reading the flag instead of the type saw no failure at all.

`claude_code` and `gemini` already have both halves. This brings codex to the same shape:

```python
if item.is_error and not any(c.type == "error" for c in item.chunks):
```

## The flag cannot simply be set on every error-typed chunk

A resumed session that ends normally emits `{"type": "error"}` with an empty payload. That chunk is classified as *not* a failure on purpose, by three conditions a few lines up, and it has to keep reading as success. The flag follows the classification rather than the type:

```python
is_error=not _is_benign_eos,
```

## The guard is not vacuous here

`claude_code`'s equivalent guard is documented as currently unreachable. Codex's is not, in either direction:

- A `turn.failed` **does** produce a parser chunk, so the guard is what stops the second report. That is the defect being fixed, not a latent one.
- A terminal `result` event carrying `is_error` marks the session failed with **no** error event having arrived, so the parser appends nothing and the endpoint's chunk is the only report there is. That path has its own test, which first asserts the parser produced nothing — otherwise the test would silently stop exercising the branch it names.

## Testing

Six tests, and four mutations:

| mutation | result |
|---|---|
| drop the already-reported guard | 4 failed |
| drop `is_error` on the endpoint's chunk | 2 failed |
| set the parser flag unconditionally true | 2 failed |
| set the parser flag unconditionally false | 5 failed |

The second one was **not detected** on the first pass, which is how the terminal-`result` path got found: the endpoint's flag was unreachable from every event sequence the other tests used, so it was masked with nothing exercising it.

`tests/providers` + `tests/service`: 1831 passed. Full suite: 16992 passed, 8 skipped. Two failures in `tests/tools/test_coding_toolkit.py` come from a `docling` import chain and reproduce in a second, unrelated checkout of this repo.

The cross-adapter conformance suite in #2786 marks codex as an expected failure on exactly these two assertions. Those markers come off once both land; this PR does not touch that file.
