### PR TITLE
fix(studio): resolve the store once, where the services open it

### DIFF
--- a/lionagi/studio/services/_db.py
+++ b/lionagi/studio/services/_db.py
@@ -20,6 +20,43 @@ def get_active_connection_count() -> int:
     return _ACTIVE_CONNECTIONS
 
 
+def store_path() -> str:
+    """The store file these services open.
+
+    Every service here used to name ``DEFAULT_DB_PATH`` directly, which is the
+    right file exactly when nothing has moved it. With
+    ``LIONAGI_STATE_DB_URL`` pointing at another file, a route would read a
+    database the daemon never opens and report on rows nobody is serving, and
+    ``aiosqlite`` would create that unrelated file on connect if it were not
+    already there.
+
+    This layer talks to SQLite directly, so the only store it can reach is one
+    with a file behind it. When the configured store is a server, there is no
+    file to name and this falls back to the default path, which is what these
+    services did before and is equally wrong for that deployment: a
+    server-backed store has rows no SQLite connection here can reach. What a
+    route should answer in that case is a question about the route's contract,
+    not about path resolution, and it is tracked separately.
+    """
+    from lionagi.state import db as db_mod
+
+    path = db_mod.state_db_file()
+    return str(path if path is not None else db_mod.DEFAULT_DB_PATH)
+
+
+def store_exists() -> bool:
+    """Whether the store file is there to read.
+
+    The direct analogue of the ``DEFAULT_DB_PATH.exists()`` checks these
+    services used to make, asked about the file they will actually open. It
+    stays in step with :func:`store_path` by construction, so a guard and the
+    connection it protects cannot disagree about which store is in play.
+    """
+    from pathlib import Path
+
+    return Path(store_path()).exists()
+
+
 @asynccontextmanager
 async def open_db(path: str) -> AsyncIterator[aiosqlite.Connection]:
     """Studio-local SQLite connection with WAL mode and a busy timeout,

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -21,13 +21,14 @@ from sqlalchemy.exc import OperationalError as _SAOperationalError
 from lionagi.cli._util import pid_alive as _pid_is_live
 from lionagi.ln import now_utc
 from lionagi.state.db import ADMIN_TRANSITION_TARGETS as _ADMIN_TRANSITION_TARGETS
-from lionagi.state.db import DEFAULT_DB_PATH, state_db_known_absent
+from lionagi.state.db import state_db_known_absent
 from lionagi.state.reasons import RunReasons, SessionReasons, validate_reason_code
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
+from ._db import store_exists, store_path
+from ._path_safety import public_path
 
-_DB = str(DEFAULT_DB_PATH)
 _log = logging.getLogger(__name__)
 
 # Fallback mapping for deprecated 'reason' field without reason_code.
@@ -76,7 +77,7 @@ class TransitionBody(BaseModel):
 
 
 def db_health() -> dict[str, int]:
-    db_path = DEFAULT_DB_PATH
+    db_path = Path(store_path())
     size_bytes = db_path.stat().st_size if db_path.exists() else 0
     wal_path = db_path.parent / (db_path.name + "-wal")
     wal_bytes = wal_path.stat().st_size if wal_path.exists() else 0
@@ -109,11 +110,11 @@ async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, 
         "detail": "",
         "latency_ms": None,
         "timeout_ms": timeout_ms,
-        "store_present": DEFAULT_DB_PATH.exists(),
+        "store_present": store_exists(),
         "checked_at": now_utc().isoformat(),
     }
     if not result["store_present"]:
-        result["detail"] = f"no store at {DEFAULT_DB_PATH}"
+        result["detail"] = f"no store at {public_path(Path(store_path()))}"
         return result
 
     started = time.perf_counter()
@@ -136,7 +137,7 @@ async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, 
         # remaining way for this to hang is a filesystem that will not answer,
         # which the `store_present` check above already stands in front of.
         with CancelScope(shield=True):
-            conn = aiosqlite.connect(str(DEFAULT_DB_PATH))
+            conn = aiosqlite.connect(store_path())
             db = await conn
         with move_on_after(timeout_ms / 1000) as scope:
             # The shared busy timeout is longer than this probe's own deadline,
@@ -320,12 +321,12 @@ def _classify_phantom(
 
 
 async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, Any]]:
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return []
     now = time.time()
     stale_seconds = stale_hours * 3600
     phantoms: list[dict[str, Any]] = []
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             """
             SELECT id, name, playbook_name, started_at, updated_at, artifacts_path,
@@ -405,7 +406,7 @@ async def health_report() -> dict[str, Any]:
     )
     from lionagi.studio.config import scheduler_timezone_report
 
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return {
             "sessions": {"total": 0, "by_status": {}, "by_health": {}, "unhealthy": []},
             "db": db_health(),
@@ -415,7 +416,7 @@ async def health_report() -> dict[str, Any]:
         }
 
     now = time.time()
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         total_cur = await db.execute("SELECT COUNT(*) AS n FROM sessions")
         total_row = await total_cur.fetchone()
         total_sessions = int(total_row["n"]) if total_row else 0
@@ -776,10 +777,10 @@ async def prune_sessions(session_ids: list[str]) -> int:
     for sid in session_ids:
         seen[sid] = None
     unique_ids = list(seen)
-    if not unique_ids or not DEFAULT_DB_PATH.exists():
+    if not unique_ids or not store_exists():
         return 0
     placeholders = ",".join("?" * len(unique_ids))
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             f"DELETE FROM sessions WHERE id IN ({placeholders})",  # noqa: S608
             unique_ids,

--- a/lionagi/studio/services/approvals.py
+++ b/lionagi/studio/services/approvals.py
@@ -18,12 +18,9 @@ from typing import Any, Literal
 from fastapi import HTTPException, Request
 from pydantic import BaseModel, Field, field_validator
 
-from lionagi.state.db import DEFAULT_DB_PATH
-
 from ..registry import studio_route
 from ._db import open_db as _open_db
-
-_DB = str(DEFAULT_DB_PATH)
+from ._db import store_path
 
 APPROVAL_TTL_SECONDS = 5 * 60
 
@@ -158,7 +155,7 @@ def _row_to_dict(row: Any) -> dict[str, Any]:
 
 
 async def _fetch_row(approval_id: str) -> dict[str, Any] | None:
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         cur = await db.execute(
             "SELECT id, action_kind, params_hash, session_id, status, "
@@ -258,7 +255,7 @@ async def verify_evidence_chain() -> dict[str, Any]:
     """Replay the evidence chain end to end and report whether it is intact."""
     errors: list[str] = []
     total = 0
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_evidence_table(db)
         cur = await db.execute(
             "SELECT id, sequence, event_type, approval_id, action_kind, status_from, "
@@ -323,7 +320,7 @@ async def _lazy_expire(approval_id: str, row: dict[str, Any], *, now: float) -> 
     """CAS the row to 'expired' if it is past its TTL and still pending/granted."""
     if row["status"] not in ("pending", "granted") or now <= row["expires_at"]:
         return row
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_evidence_table(db)
         await db.execute("BEGIN IMMEDIATE")
         cur = await db.execute(
@@ -360,7 +357,7 @@ async def create_approval(
     now = time.time()
     approval_id = uuid.uuid4().hex
     params_hash = compute_params_hash(params)
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         await _ensure_evidence_table(db)
         await db.execute("BEGIN IMMEDIATE")
@@ -396,7 +393,7 @@ async def grant_approval(approval_id: str) -> dict[str, Any]:
             detail=f"approval {approval_id!r} is not pending (status={row['status']!r})",
         )
     now = time.time()
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         await _ensure_evidence_table(db)
         await db.execute("BEGIN IMMEDIATE")
@@ -440,7 +437,7 @@ async def deny_approval(
             status_code=409,
             detail=f"approval {approval_id!r} is not pending (status={row['status']!r})",
         )
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         await _ensure_evidence_table(db)
         await db.execute("BEGIN IMMEDIATE")
@@ -499,7 +496,7 @@ async def require_approval(
             detail=f"approval {approval_id!r} params do not match the action being executed",
         )
     now = time.time()
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         await _ensure_evidence_table(db)
         await db.execute("BEGIN IMMEDIATE")

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -11,10 +11,10 @@ from fastapi import HTTPException, Query
 from pydantic import BaseModel
 
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
-from lionagi.state.db import DEFAULT_DB_PATH
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
+from ._db import store_exists, store_path
 from ._path_safety import validate_name_component
 from .agents import _is_protected_system
 
@@ -30,8 +30,6 @@ async def _lock_for(kind: str, name: str) -> asyncio.Lock:
     async with _DEFINITION_LOCKS_GUARD:
         return _DEFINITION_LOCKS.setdefault((kind, name), asyncio.Lock())
 
-
-_DB = str(DEFAULT_DB_PATH)
 
 AGENTS_DIR = LIONAGI_HOME / "agents"
 PLAYBOOKS_DIR = LIONAGI_HOME / "playbooks"
@@ -59,7 +57,7 @@ def _relative_path(full_path: Path) -> str:
 
 
 async def _ensure_db() -> bool:
-    return DEFAULT_DB_PATH.exists()
+    return store_exists()
 
 
 async def list_definitions(kind: str | None = None) -> list[dict[str, Any]]:
@@ -111,7 +109,7 @@ async def list_definitions(kind: str | None = None) -> list[dict[str, Any]]:
     if result and await _ensure_db():
         conditions = " OR ".join("(kind = ? AND name = ?)" for _ in result)
         params = [value for item in result for value in (item["kind"], item["name"])]
-        async with _open_db(_DB) as db:
+        async with _open_db(store_path()) as db:
             cur = await db.execute(
                 f"SELECT kind, name, MAX(version) AS v, MAX(created_at) AS ts"  # noqa: S608
                 f" FROM definitions WHERE {conditions} GROUP BY kind, name",
@@ -147,7 +145,7 @@ async def get_definition(kind: str, name: str) -> dict[str, Any] | None:
 
     versions: list[dict[str, Any]] = []
     if await _ensure_db():
-        async with _open_db(_DB) as db:
+        async with _open_db(store_path()) as db:
             cur = await db.execute(
                 "SELECT id, version, created_at, message FROM definitions WHERE kind = ? AND name = ? ORDER BY version DESC",
                 (kind, name),
@@ -185,7 +183,7 @@ async def get_version(kind: str, name: str, version: int) -> dict[str, Any] | No
     if not await _ensure_db():
         return None
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             "SELECT id, content, version, created_at, message FROM definitions"
             " WHERE kind = ? AND name = ? AND version = ?",
@@ -280,7 +278,7 @@ async def rollback_definition(kind: str, name: str, target_version: int) -> dict
 
     current_version = 0
     if await _ensure_db():
-        async with _open_db(_DB) as db:
+        async with _open_db(store_path()) as db:
             cur = await db.execute(
                 "SELECT MAX(version) AS v FROM definitions WHERE kind = ? AND name = ?",
                 (kind, name),

--- a/lionagi/studio/services/projects.py
+++ b/lionagi/studio/services/projects.py
@@ -10,12 +10,9 @@ from typing import Any
 from fastapi import HTTPException
 from pydantic import BaseModel
 
-from lionagi.state.db import DEFAULT_DB_PATH
-
 from ..registry import studio_route
 from ._db import open_db as _open_db
-
-_DB = str(DEFAULT_DB_PATH)
+from ._db import store_exists, store_path
 
 
 class NameConflictError(Exception):
@@ -44,10 +41,10 @@ async def _ensure_table(db) -> None:
 
 async def list_projects() -> dict[str, Any]:
     """Return all known projects with session counts and an unassigned count."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return {"projects": [], "unassigned_count": 0}
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         cur = await db.execute(
             """SELECT p.name, p.source, p.path, p.github, p.description,
@@ -91,10 +88,10 @@ async def list_projects() -> dict[str, Any]:
 
 async def get_project(name: str) -> dict[str, Any] | None:
     """Return a single project with session counts and usage summaries."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return None
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         cur = await db.execute(
             """SELECT p.name, p.source, p.path, p.github, p.description,
@@ -170,7 +167,7 @@ async def create_project(
 
     clean_name = name.strip()
     now = time.time()
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         try:
             await db.execute(
@@ -194,7 +191,7 @@ async def update_project(name: str, fields: dict[str, Any]) -> bool:
     allowed = {"description", "github", "path"}
     clean = {k: v for k, v in fields.items() if k in allowed}
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         if not clean:
             cur = await db.execute("SELECT 1 FROM projects WHERE name = ?", (name,))
@@ -219,7 +216,7 @@ async def assign_sessions_to_project(
     all_unassigned: bool = False,
 ) -> int:
     """Assign sessions to a project. Returns count of updated rows."""
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         if session_ids:
             placeholders = ",".join("?" for _ in session_ids)
@@ -253,7 +250,7 @@ async def assign_sessions_to_project(
 
 async def delete_project(name: str) -> bool:
     """Delete a Studio-managed project. Returns True when deleted."""
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         cur = await db.execute(
             "DELETE FROM projects WHERE name = ? AND source = 'studio'",

--- a/lionagi/studio/services/run_tags.py
+++ b/lionagi/studio/services/run_tags.py
@@ -10,12 +10,11 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 
 from lionagi._errors import NotFoundError
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB
+from lionagi.state.db import StateDB
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
-
-_DB = str(DEFAULT_DB_PATH)
+from ._db import store_exists, store_path
 
 # Keep each IN(...) bind list under SQLite's default SQLITE_MAX_VARIABLE_NUMBER
 # (999 on builds older than 3.32) so tag hydration cannot overflow it.
@@ -42,7 +41,7 @@ async def add_tag(session_id: str, tag: str) -> None:
     if not clean:
         raise HTTPException(status_code=422, detail="tag must not be empty")
 
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         # Apply the full schema first so a tag write never leaves a partial
         # db behind (only run_tags, no sessions/etc).
         _db = StateDB()
@@ -50,7 +49,7 @@ async def add_tag(session_id: str, tag: str) -> None:
         await _db.close()
 
     now = time.time()
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         await db.execute(
             "INSERT OR IGNORE INTO run_tags (session_id, tag, created_at) VALUES (?, ?, ?)",
@@ -61,11 +60,11 @@ async def add_tag(session_id: str, tag: str) -> None:
 
 async def remove_tag(session_id: str, tag: str) -> None:
     """Detach a tag from a run (session)."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         # Nothing to detach; a delete must never create the db file (a bare
         # _ensure_table would leave a run_tags-only db behind).
         return
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         await db.execute(
             "DELETE FROM run_tags WHERE session_id = ? AND tag = ?",
@@ -77,7 +76,7 @@ async def remove_tag(session_id: str, tag: str) -> None:
 async def tags_for_sessions(session_ids: list[str]) -> dict[str, list[str]]:
     """Batch-fetch tags for many sessions in ONE query (no N+1). Returns
     {session_id: [tags...]}; sessions with no tags are absent from the result."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return {}
     if not session_ids:
         return {}
@@ -85,7 +84,7 @@ async def tags_for_sessions(session_ids: list[str]) -> dict[str, list[str]]:
     # Chunk the IN(...) list so a large run history cannot exceed SQLite's
     # bound-variable limit (SQLITE_MAX_VARIABLE_NUMBER, 999 on older builds).
     out: dict[str, list[str]] = {}
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         for i in range(0, len(session_ids), _MAX_SQL_VARS):
             chunk = session_ids[i : i + _MAX_SQL_VARS]
@@ -104,14 +103,14 @@ async def session_ids_with_tags(tags: list[str]) -> set[str] | None:
     """The F8 SQL pre-filter: session_ids carrying ALL of `tags` (AND-composed).
     Contract: empty/None `tags` returns None ("no filter"), not "no matches" —
     callers must treat None as pass-through."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return None
     if not tags:
         return None
 
     unique_tags = list(dict.fromkeys(tags))
     placeholders = ",".join("?" for _ in unique_tags)
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         await _ensure_table(db)
         cur = await db.execute(
             f"SELECT session_id FROM run_tags "  # noqa: S608

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -11,14 +11,13 @@ from fastapi import HTTPException, Query
 
 from lionagi._errors import NotFoundError
 from lionagi.state.claude_mirror import session_db_id
-from lionagi.state.db import DEFAULT_DB_PATH, SESSION_TERMINAL_STATUSES
+from lionagi.state.db import SESSION_TERMINAL_STATUSES
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
+from ._db import store_exists, store_path
 from ._io import parse_json_col as _parse_json_col
 from .artifact_verification import resolve_artifact_verification
-
-_DB = str(DEFAULT_DB_PATH)
 
 SESSION_DONE_STABLE_SECS = 60.0
 
@@ -185,10 +184,10 @@ class SessionFilter:
 
 async def count_sessions(where: SessionFilter | None = None) -> int:
     """Total matching sessions, without reading a single branch or progression."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return 0
     clause, params = (where or SessionFilter()).where()
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             f"SELECT COUNT(*) AS n FROM sessions s {clause}",  # noqa: S608
             params,
@@ -205,14 +204,14 @@ async def list_sessions(
 ) -> list[dict[str, Any]]:
     """One page of sessions, newest first. Cost is proportional to `limit`, not
     to the size of the store."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return []
 
     limit = max(1, min(int(limit), MAX_SESSION_PAGE))
     offset = max(0, int(offset))
     clause, params = (where or SessionFilter()).where()
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         # run_tags is created lazily on first tag write, so a tag filter would
         # fail on a store that has never been tagged.
         if (where or SessionFilter()).tags:
@@ -334,9 +333,9 @@ async def list_sessions(
 
 async def list_project_counts() -> list[dict[str, Any]]:
     """Per-project run counts via a cheap GROUP BY (no branch/message join)."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return []
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             """
             SELECT project,
@@ -628,7 +627,7 @@ async def get_session(
     message_offset: int = 0,
     message_cursor: str | None = None,
 ) -> dict[str, Any] | None:
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return None
 
     message_limit = max(1, min(message_limit, MAX_MESSAGE_LIMIT))
@@ -639,7 +638,7 @@ async def get_session(
         else None
     )
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             # Include lifecycle and provenance columns (model/provider/effort/agent_hash).
             """SELECT id, name, created_at, updated_at,
@@ -838,10 +837,10 @@ async def get_session(
 
 async def get_session_by_cc_id(cc_uid: str) -> dict[str, Any] | None:
     """Return a mirrored Claude Code session, including legacy unbackfilled rows."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return None
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             "SELECT id FROM sessions WHERE cc_session_id = ? LIMIT 1",
             (cc_uid,),
@@ -855,10 +854,10 @@ async def get_session_messages_after(session_id: str, after_ts: float) -> list[d
     """Poll-friendly tail read for the SSE stream/signals endpoints. Joins via
     json_each rather than binding every message id into an IN (...) clause,
     which would blow past SQLite's 999 bound-variable limit at scale."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return []
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             """
             SELECT m.id, m.created_at, m.content, m.sender, m.role,
@@ -884,10 +883,10 @@ async def get_session_messages_after(session_id: str, after_ts: float) -> list[d
 
 
 async def session_exists(session_id: str) -> bool:
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return False
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             "SELECT 1 FROM sessions WHERE id = ? LIMIT 1",
             (session_id,),
@@ -898,10 +897,10 @@ async def session_exists(session_id: str) -> bool:
 
 async def get_session_stream_state(session_id: str) -> dict[str, Any] | None:
     """Scalar read for the SSE done-condition check — avoids the full get_session() round-trip."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return None
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             "SELECT updated_at, status FROM sessions WHERE id = ?",
             (session_id,),

--- a/lionagi/studio/services/shows.py
+++ b/lionagi/studio/services/shows.py
@@ -12,18 +12,16 @@ from typing import Any
 from fastapi import HTTPException
 
 from lionagi.libs.path_safety import safe_join
-from lionagi.state.db import DEFAULT_DB_PATH
 
 from ..config import SHOWS_ROOT
 from ..registry import studio_route
 from ._db import open_db as _open_db
+from ._db import store_exists, store_path
 from ._io import read_json_file as _read_json
 from ._path_safety import public_path, safe_path_join
 from ._sse import sse_response
 
 _log = __import__("logging").getLogger(__name__)
-
-_DB = str(DEFAULT_DB_PATH)
 
 
 def _read_text(path: Path) -> str | None:
@@ -68,7 +66,7 @@ def _extract_repo_and_branches(show_md: str | None) -> tuple[str | None, str | N
 
 
 async def _db_available() -> bool:
-    return DEFAULT_DB_PATH.exists()
+    return store_exists()
 
 
 async def list_shows() -> list[dict[str, Any]]:
@@ -81,7 +79,7 @@ async def list_shows() -> list[dict[str, Any]]:
 
 
 async def _list_shows_db() -> list[dict[str, Any]]:
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute("""
             SELECT s.id, s.topic, s.goal, s.status, s.show_dir,
                    s.created_at, s.updated_at,
@@ -158,7 +156,7 @@ async def get_show(topic: str) -> dict[str, Any] | None:
     show_row: dict[str, Any] | None = None
     if await _db_available():
         try:
-            async with _open_db(_DB) as db:
+            async with _open_db(store_path()) as db:
                 cur = await db.execute("SELECT * FROM shows WHERE topic = ?", (topic,))
                 row = await cur.fetchone()
                 if row:
@@ -563,7 +561,7 @@ async def watch_show(topic: str) -> AsyncGenerator[str]:
             show_status: str | None = None
             if await _db_available():
                 try:
-                    async with _open_db(_DB) as db:
+                    async with _open_db(store_path()) as db:
                         cur = await db.execute("SELECT status FROM shows WHERE topic = ?", (topic,))
                         row = await cur.fetchone()
                         if row:

--- a/lionagi/studio/services/signals.py
+++ b/lionagi/studio/services/signals.py
@@ -7,11 +7,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from lionagi.state.db import DEFAULT_DB_PATH
-
 from ._db import open_db as _open_db
-
-_DB = str(DEFAULT_DB_PATH)
+from ._db import store_exists, store_path
 
 
 async def get_signals_after(
@@ -21,10 +18,10 @@ async def get_signals_after(
     limit: int = 500,
 ) -> list[dict[str, Any]]:
     """Return signal rows for *session_id* with seq > *after_seq*, ordered by seq."""
-    if not DEFAULT_DB_PATH.exists():
+    if not store_exists():
         return []
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         cur = await db.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='session_signals'"
         )

--- a/lionagi/studio/services/stats.py
+++ b/lionagi/studio/services/stats.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from typing import Any
 
 from fastapi import HTTPException, Query
 
-from lionagi.state.db import DEFAULT_DB_PATH, StateDB, state_db_known_absent
+from lionagi.state.db import StateDB, state_db_known_absent
 
 from ..registry import studio_route
 from . import agents as agents_svc
@@ -14,11 +15,9 @@ from . import plugins as plugins_svc
 from . import sessions as sessions_svc
 from . import shows as shows_svc
 from . import skills as skills_svc
-from ._db import get_active_connection_count
+from ._db import get_active_connection_count, store_path
 from ._db import open_db as _open_db
 from ._path_safety import public_path
-
-_DB = str(DEFAULT_DB_PATH)
 
 # ADR-0057 D1 defines the seven-value session status vocabulary; the Pulse
 # sparkline folds it into four buckets (timed_out→failed, aborted→cancelled).
@@ -158,7 +157,7 @@ async def _pragmas(db: Any) -> dict[str, Any]:
 async def get_db_stats() -> dict[str, Any]:
     from .db_maintenance import get_db_size_alert, get_last_checkpoint_at
 
-    db_path = DEFAULT_DB_PATH
+    db_path = Path(store_path())
     size_bytes = db_path.stat().st_size if db_path.exists() else 0
     wal_path = db_path.parent / (db_path.name + "-wal")
     wal_bytes = wal_path.stat().st_size if wal_path.exists() else 0
@@ -194,7 +193,7 @@ async def get_db_stats() -> dict[str, Any]:
 
     last_checkpoint_at = await get_last_checkpoint_at()
 
-    async with _open_db(_DB) as db:
+    async with _open_db(store_path()) as db:
         tables = await _table_counts(db)
         by_status = await _sessions_by_status(db)
         pragmas = await _pragmas(db)

--- a/tests/apps_studio_server/test_activity_stats.py
+++ b/tests/apps_studio_server/test_activity_stats.py
@@ -40,11 +40,8 @@ async def _seed_session(
 
 def _make_client(monkeypatch, db_path: Path) -> TestClient:
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.stats as stats_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(stats_mod, "_DB", str(db_path))
 
     from lionagi.studio.app import app
 

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -56,14 +56,8 @@ async def _seed_running_session(
 
 def _make_client(tmp_path, monkeypatch, db_path: Path) -> TestClient:
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
 
     from lionagi.studio.app import app
 

--- a/tests/apps_studio_server/test_admin_maintenance_api.py
+++ b/tests/apps_studio_server/test_admin_maintenance_api.py
@@ -22,16 +22,8 @@ import lionagi.state.db as state_db_mod
 
 def _make_client(tmp_path, monkeypatch):
     """Return (client, db_path) with all relevant service modules pointed at db_path."""
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.db_maintenance as maint_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app

--- a/tests/apps_studio_server/test_admin_transition.py
+++ b/tests/apps_studio_server/test_admin_transition.py
@@ -51,14 +51,8 @@ async def _seed_stale_session(
 
 def _make_admin_client(tmp_path, monkeypatch, db_path):
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
 
     from fastapi.testclient import TestClient
 
@@ -94,8 +88,6 @@ def test_transition_refused_when_heartbeat_changes_health(tmp_path, monkeypatch)
     import lionagi.studio.services.admin as adm
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(adm, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(adm, "_DB", str(db_path))
 
     # Synchronous fake classifier bumps last_message_at via sqlite3 directly
     # (aiosqlite is a thread-executor wrapper; sqlite3 write here is safe because
@@ -194,8 +186,6 @@ def test_transition_sessions_leaves_already_terminal_session_untouched(tmp_path,
     import lionagi.studio.services.admin as adm
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(adm, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(adm, "_DB", str(db_path))
 
     result = _run(
         adm.transition_sessions(

--- a/tests/apps_studio_server/test_adversarial_reapers.py
+++ b/tests/apps_studio_server/test_adversarial_reapers.py
@@ -21,12 +21,7 @@ from ._helpers import run_async  # noqa: E402
 
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.lifecycle as lifecycle_mod
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
@@ -355,7 +350,6 @@ def test_1173_prune_does_not_touch_running_old_sessions(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     ancient = time.time() - 365 * 86400  # 1 year old
 
@@ -389,7 +383,6 @@ def test_1173_prune_status_transitions_cleanup(tmp_path, monkeypatch):
 
     db_path = tmp_path / "state.db"
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     old_ts = time.time() - 40 * 86400
@@ -440,7 +433,6 @@ def test_1173_prune_preserves_recent_terminal_sessions(tmp_path, monkeypatch):
 
     db_path = tmp_path / "state.db"
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     recent_ts = time.time() - 5 * 86400  # 5 days ago, within 30-day keep window

--- a/tests/apps_studio_server/test_agents_protections.py
+++ b/tests/apps_studio_server/test_agents_protections.py
@@ -501,8 +501,6 @@ def _make_definitions_client(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})

--- a/tests/apps_studio_server/test_approvals.py
+++ b/tests/apps_studio_server/test_approvals.py
@@ -27,11 +27,8 @@ def _run(coro):
 
 def _patch_db(monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.approvals as approvals_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(approvals_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(approvals_mod, "_DB", str(db_path))
 
 
 def _make_client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:

--- a/tests/apps_studio_server/test_async_fs_io.py
+++ b/tests/apps_studio_server/test_async_fs_io.py
@@ -42,13 +42,9 @@ def _make_client(
     import lionagi.state.db as state_db_mod
     import lionagi.studio.config as config_mod
     import lionagi.studio.services.agents as agents_mod
-    import lionagi.studio.services.definitions as defs_mod
     import lionagi.studio.services.playbooks as playbooks_mod
-    import lionagi.studio.services.runs as runs_mod
-    import lionagi.studio.services.sessions as sessions_mod
     import lionagi.studio.services.shows as shows_mod
     import lionagi.studio.services.skills as skills_mod
-    import lionagi.studio.services.stats as stats_mod
 
     monkeypatch.setattr(config_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
@@ -57,14 +53,6 @@ def _make_client(
     monkeypatch.setattr(skills_mod, "SKILLS_ROOT", skills_root)
     monkeypatch.setattr(cli_runs_mod, "RUNS_ROOT", runs_root)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(sessions_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(shows_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
     if with_run:
         run_dir = runs_root / "20240101T000000-abc123"
@@ -146,10 +134,9 @@ def test_run_detail_reads_from_statedb(tmp_path: Path, monkeypatch: pytest.Monke
     finally:
         loop.close()
 
-    import lionagi.studio.services.sessions as sessions_mod
+    import lionagi.state.db as state_db_mod
 
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     client = _make_client(tmp_path, monkeypatch)
     r = client.get(f"/api/runs/{run_id}")

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -28,11 +28,9 @@ def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
     shared lionagi.studio.app.app singleton other code still imports.
     """
     import lionagi.studio.app as app_mod
-    import lionagi.studio.services.stats as stats_mod
 
     if fake_db is not None:
-        monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-        monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
+        monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     app = app_mod.create_app()
     return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
@@ -778,11 +776,9 @@ def _real_svc_client(monkeypatch, tmp_path: Path) -> TestClient:
     """Return a TestClient backed by the real service layer + temp DB."""
     from fastapi.testclient import TestClient
 
-    import lionagi.studio.services.schedules as sched_svc_mod
     from lionagi.studio.app import app
 
     db_file = tmp_path / "test_state.db"
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
     return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
@@ -1206,10 +1202,8 @@ class TestGithubRepoRealServiceValidation:
 
         # 1. Build the temp DB and wire the app to it.
         db_file = tmp_path / "test_state.db"
-        import lionagi.studio.services.schedules as sched_svc_mod
         from lionagi.studio.app import app
 
-        monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
         monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_file)
 
         # 2. Use the real service to create the schema (create a throw-away schedule).

--- a/tests/apps_studio_server/test_batch3_logic.py
+++ b/tests/apps_studio_server/test_batch3_logic.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
@@ -83,8 +85,7 @@ class TestIsSessionStreamDone:
 class TestGetSessionStreamState:
     def _patch_db(self, monkeypatch, svc, db_path: Path):
         """Patch both the string path and the Path sentinel used by the exists() check."""
-        monkeypatch.setattr(svc, "_DB", str(db_path))
-        monkeypatch.setattr(svc, "DEFAULT_DB_PATH", db_path)
+        monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     def test_returns_none_when_db_missing(self, tmp_path, monkeypatch):
         """When the DB file does not exist, return None (keep stream alive)."""

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -381,10 +381,6 @@ def test_api_prefix_appears_exactly_once_in_every_route_path():
 
 def _patch_db(monkeypatch, db_path: Path) -> None:
     """Point every service module's DB reference at a fresh temp path; must run before any seeding call since StateDB() re-reads DEFAULT_DB_PATH fresh per instantiation, and admin.py/sessions.py additionally cache the path in their own module-level `_DB`."""
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.db_maintenance as db_maintenance_mod
-    import lionagi.studio.services.schedules as schedules_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     # An environment with LIONAGI_STUDIO_AUTH_TOKEN set (a dev machine, CI)
     # would make every unauthenticated request in this file 401 before it
@@ -402,11 +398,6 @@ def _patch_db(monkeypatch, db_path: Path) -> None:
         "settings",
         state_db_mod.settings.model_copy(update={"LIONAGI_STATE_DB_URL": None}),
     )
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     # db_maintenance imports DEFAULT_DB_PATH by value, so the state_db_mod
     # patch above never reaches its own module-level binding.

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -66,7 +66,6 @@ def _patch_db(monkeypatch, db_path: Path) -> None:
     from lionagi.studio.services import db_maintenance as maint
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
 # ── checkpoint tests ──────────────────────────────────────────────────────────
@@ -137,16 +136,9 @@ def test_stats_endpoint_exposes_checkpoint_and_size_fields(tmp_path, monkeypatch
     pytest.importorskip("fastapi", reason="studio extra not installed")
     from fastapi.testclient import TestClient
 
-    import lionagi.studio.services.sessions as sessions_mod
-    import lionagi.studio.services.stats as stats_mod
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(stats_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     run_async(_make_session_in(db_path, status="running", started_at=time.time()))
@@ -669,16 +661,9 @@ def test_prune_old_data_endpoint(tmp_path, monkeypatch):
     pytest.importorskip("fastapi", reason="studio extra not installed")
     from fastapi.testclient import TestClient
 
-    import lionagi.studio.services.sessions as sessions_mod
-    import lionagi.studio.services.stats as stats_mod
     from lionagi.studio.services import db_maintenance as maint
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(stats_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     run_async(_make_session_in(db_path, status="completed", started_at=time.time() - 40 * 86400))

--- a/tests/apps_studio_server/test_definitions.py
+++ b/tests/apps_studio_server/test_definitions.py
@@ -40,8 +40,6 @@ async def test_save_definition_creates_db_row_and_file(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -97,8 +95,6 @@ async def test_save_definition_increments_version(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -131,8 +127,6 @@ async def test_save_new_playbook_definition_lands_in_playbook_catalog(tmp_path, 
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -193,8 +187,6 @@ def _make_patched_client(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -293,8 +285,6 @@ async def test_save_definition_accepts_safe_names(name, tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", fake_home / "playbooks")
     monkeypatch.setattr(
@@ -325,8 +315,6 @@ async def test_save_definition_accepts_valid_kinds(kind, tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -364,8 +352,6 @@ async def test_concurrent_save_disk_reflects_highest_version(tmp_path, monkeypat
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -424,8 +410,6 @@ async def test_save_definition_db_failure_does_not_write_file(tmp_path, monkeypa
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -462,8 +446,6 @@ def test_save_definition_db_failure_returns_500_from_router(tmp_path, monkeypatc
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -526,8 +508,6 @@ async def test_get_definition_follows_symlink(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -570,8 +550,6 @@ async def test_save_definition_writes_through_symlink(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -651,8 +629,6 @@ async def test_get_definition_finds_nested_dir_listed_by_list_definitions(tmp_pa
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
@@ -688,8 +664,6 @@ async def test_save_definition_fresh_home_no_kind_dir(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
     monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
     monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})

--- a/tests/apps_studio_server/test_definitions_batch2.py
+++ b/tests/apps_studio_server/test_definitions_batch2.py
@@ -61,10 +61,8 @@ class TestListDefinitionsNPlusOne:
         monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
         monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", fake_home / "playbooks")
         monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir})
-        monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
         # Patch DEFAULT_DB_PATH on BOTH the source module and definitions'
         # local import — _ensure_db() uses the latter (from-import binding).
-        monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
         monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
         return defs_mod
@@ -123,8 +121,6 @@ class TestListDefinitionsNPlusOne:
         monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
         monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", fake_home / "playbooks")
         monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir})
-        monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
-        monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
         monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
         class _RowLike:

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
@@ -26,11 +28,9 @@ def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
     shared lionagi.studio.app.app singleton other code still imports.
     """
     import lionagi.studio.app as app_mod
-    import lionagi.studio.services.stats as stats_mod
 
     if fake_db is not None:
-        monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-        monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
+        monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     app = app_mod.create_app()
     return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")

--- a/tests/apps_studio_server/test_leo.py
+++ b/tests/apps_studio_server/test_leo.py
@@ -27,20 +27,8 @@ def _make_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     fake_db = tmp_path / "state.db"
 
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.definitions as defs_mod
-    import lionagi.studio.services.sessions as sessions_mod
-    import lionagi.studio.services.shows as shows_mod
-    import lionagi.studio.services.stats as stats_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(sessions_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(shows_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
     from lionagi.studio.app import create_app
 

--- a/tests/apps_studio_server/test_lifecycle_play_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_play_reaper.py
@@ -20,12 +20,7 @@ from ._helpers import run_async
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
     """Point all relevant modules at a temp DB path."""
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.lifecycle as lifecycle_mod
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -22,12 +22,7 @@ from ._helpers import run_async
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
     """Point all relevant modules at a temp DB path."""
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.lifecycle as lifecycle_mod
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 
@@ -630,10 +625,6 @@ def test_admin_prune_all_phantom_transitions_not_deletes(tmp_path, monkeypatch):
 
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
-    import lionagi.studio.services.sessions as sessions_mod
-
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
 
     missing_dir = str(tmp_path / "ghost_arts")
     stale_time = time.time() - 7200
@@ -674,11 +665,7 @@ def test_stats_includes_phantom_count(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
 
-    import lionagi.studio.services.sessions as sessions_mod
-
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
 
     from lionagi.studio.app import app
 

--- a/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
@@ -24,12 +24,7 @@ from ._helpers import run_async
 
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.lifecycle as lifecycle_mod
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 

--- a/tests/apps_studio_server/test_lifecycle_show_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_show_reaper.py
@@ -21,12 +21,7 @@ from ._helpers import run_async
 
 def _monkey_db(monkeypatch, db_path: Path) -> None:
     """Point all relevant modules at a temp DB path."""
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.lifecycle as lifecycle_mod
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin_mod, "_DB", str(db_path))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
 

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -91,16 +91,9 @@ def _hold_the_write_lock(db_path):
 def seeded(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     ids = _seed(db_path, sessions=25)
-    for mod in ("sessions", "runs", "admin", "run_tags", "stats"):
-        module = pytest.importorskip(f"lionagi.studio.services.{mod}")
-        monkeypatch.setattr(module, "_DB", str(db_path), raising=False)
     import lionagi.state.db as db_mod
 
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
-    for mod in ("sessions", "runs", "admin", "run_tags"):
-        module = pytest.importorskip(f"lionagi.studio.services.{mod}")
-        if hasattr(module, "DEFAULT_DB_PATH"):
-            monkeypatch.setattr(module, "DEFAULT_DB_PATH", db_path)
     return db_path, ids
 
 
@@ -137,8 +130,6 @@ class TestPageBoundsTheWork:
         from lionagi.studio.services import sessions as sessions_svc
 
         monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
-        monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
-        monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
 
         rows = asyncio.run(sessions_svc.list_sessions(limit=5))
         assert [r["id"] for r in rows] == ids[:5]
@@ -285,9 +276,9 @@ class TestStoreProbe:
         assert body["latency_ms"] >= 0
 
     def test_missing_store_reports_unavailable_not_healthy(self, client, tmp_path, monkeypatch):
-        from lionagi.studio.services import admin as admin_svc
+        import lionagi.state.db as db_mod
 
-        monkeypatch.setattr(admin_svc, "DEFAULT_DB_PATH", tmp_path / "gone.db")
+        monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", tmp_path / "gone.db")
         body = client.get("/api/admin/readiness").json()
         assert body["status"] == "unavailable"
         assert body["store_present"] is False

--- a/tests/apps_studio_server/test_operator_conversation_lifecycle.py
+++ b/tests/apps_studio_server/test_operator_conversation_lifecycle.py
@@ -51,11 +51,8 @@ async def _wait_done(store: OperatorStore, conversation_id: str, *, timeout: flo
 def _patch_state_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
     import lionagi.cli._runs as runs_mod
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", path)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(path))
     monkeypatch.setattr(runs_mod, "RUNS_ROOT", path.parent / "runs")
 
 

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -33,11 +33,8 @@ class ScriptedEngine:
 def _patch_state_db(monkeypatch: pytest.MonkeyPatch, path) -> None:
     import lionagi.cli._runs as runs_mod
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", path)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(path))
     monkeypatch.setattr(runs_mod, "RUNS_ROOT", path.parent / "runs")
 
 

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -536,11 +536,8 @@ async def _audit_decisions(proposal_id: str) -> list[str]:
 def _patch_state_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
     import lionagi.cli._runs as runs_mod
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", path)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(path))
     monkeypatch.setattr(runs_mod, "RUNS_ROOT", path.parent / "runs")
 
 

--- a/tests/apps_studio_server/test_projects.py
+++ b/tests/apps_studio_server/test_projects.py
@@ -18,12 +18,9 @@ def _make_client(
 ) -> TestClient:
     """Wire a TestClient with a real temp state.db and patched paths."""
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.projects as projects_mod
 
     fake_db = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(projects_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(projects_mod, "_DB", str(fake_db))
 
     # Ensure schema is applied to the temp DB.
     import asyncio

--- a/tests/apps_studio_server/test_run_file.py
+++ b/tests/apps_studio_server/test_run_file.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
@@ -38,11 +40,9 @@ async def seed_session(db_path: Path, *, session_id: str, artifacts_path: str) -
 
 @pytest.fixture
 def patched_runs_svc(tmp_path: Path, monkeypatch: Any):
-    import lionagi.studio.services.sessions as sessions_mod
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     import lionagi.studio.services.runs as runs_svc
 
@@ -377,10 +377,8 @@ async def test_open_helper_refuses_intermediate_dir_swapped_to_symlink(tmp_path)
 
 
 def _make_client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    import lionagi.studio.services.sessions as sessions_mod
 
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
 

--- a/tests/apps_studio_server/test_run_tags.py
+++ b/tests/apps_studio_server/test_run_tags.py
@@ -28,14 +28,8 @@ def _run(coro):
 
 def _patch_db(monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.run_tags as run_tags_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(run_tags_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(run_tags_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
 
 
 def _make_client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
@@ -414,13 +408,13 @@ def test_pruning_a_session_cascades_its_tags(tmp_path, monkeypatch):
     _patch_db(monkeypatch, db_path)
     _run(_init_db(db_path))
 
+    # admin freezes its own _DB / DEFAULT_DB_PATH at import; _patch_db does not
+    # touch them, so point prune at the tmp db too.
+    import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin
     import lionagi.studio.services.run_tags as run_tags
 
-    # admin freezes its own _DB / DEFAULT_DB_PATH at import; _patch_db does not
-    # touch them, so point prune at the tmp db too.
-    monkeypatch.setattr(admin, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(admin, "_DB", str(db_path))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     sid = str(uuid.uuid4())
     _run(_seed_session(db_path, sid))

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
@@ -91,11 +93,9 @@ async def seed_branch(
 @pytest.fixture
 def patched_runs_svc(tmp_path: Path, monkeypatch: Any):
     """Patch sessions service to point at a tmp DB; return (svc, db_path)."""
-    import lionagi.studio.services.sessions as sessions_mod
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     import lionagi.studio.services.runs as runs_svc
 
@@ -314,11 +314,8 @@ async def test_get_run_steps_is_none_with_no_branches(patched_runs_svc):
 def test_get_run_endpoint_returns_404_for_missing(tmp_path, monkeypatch):
     fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
-    import lionagi.studio.services.sessions as sessions_mod
-
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from fastapi.testclient import TestClient
 

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -47,11 +47,8 @@ async def _seed_sessions(db_path: Path, sessions: list[dict]) -> None:
 
 def _make_client(tmp_path, monkeypatch, db_path: Path) -> TestClient:
     import lionagi.state.db as state_db_mod
-    import lionagi.studio.services.sessions as sessions_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
 
     from lionagi.studio.app import app
 

--- a/tests/apps_studio_server/test_security_batch1.py
+++ b/tests/apps_studio_server/test_security_batch1.py
@@ -85,8 +85,6 @@ class TestDefinitionsDiskPath:
 
         monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
         monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-        monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-        monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
         monkeypatch.setattr(defs_mod, "LIONAGI_HOME", fake_home)
         monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
         monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", fake_home / "playbooks")
@@ -279,11 +277,11 @@ class TestBearerTokenAuth:
         shared lionagi.studio.app.app singleton other code still imports.
         """
         import lionagi.studio.app as app_mod
-        import lionagi.studio.services.stats as stats_mod
 
         if fake_db is not None:
-            monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-            monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
+            import lionagi.state.db as state_db_mod
+
+            monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
         app = app_mod.create_app()
         return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")

--- a/tests/apps_studio_server/test_services_store_resolution.py
+++ b/tests/apps_studio_server/test_services_store_resolution.py
@@ -1,0 +1,133 @@
+"""The studio services open the store the daemon serves.
+
+Every service in this layer used to name ``DEFAULT_DB_PATH`` at import. That is
+the right file until ``LIONAGI_STATE_DB_URL`` moves the store, and then it is a
+different database from the one the daemon writes: the routes report on rows
+nobody is serving, and SQLite creates the unrelated file on connect if it is
+not already there.
+
+Two things are worth pinning. The first is that nothing changes for a
+deployment that has not moved anything, since that is what makes changing every
+service at once safe. The second is that a health answer and a data answer come
+from the same store, because two services resolving separately is the defect
+this replaces rather than a smaller version of it.
+
+The default path is present and wrong in these tests, not absent. A service
+still reading it would then answer from an empty database instead of raising,
+which is the failure that has to be visible here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+import lionagi.state.db as state_db_mod  # noqa: E402
+from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.studio.services._db import store_exists, store_path  # noqa: E402
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+async def _seed(db_path: Path, name: str, count: int = 1) -> list[str]:
+    ids = []
+    async with StateDB(db_path) as db:
+        for i in range(count):
+            session_id = str(uuid.uuid4())
+            pid = str(uuid.uuid4())
+            await db.create_progression(pid)
+            await db.create_session(
+                {
+                    "id": session_id,
+                    "progression_id": pid,
+                    "name": name if count == 1 else f"{name}-{i}",
+                    "status": "completed",
+                    "started_at": time.time(),
+                }
+            )
+            ids.append(session_id)
+    return ids
+
+
+def _configure(monkeypatch, *, default: Path, url: str | None) -> None:
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", default)
+    monkeypatch.setattr(
+        state_db_mod,
+        "settings",
+        state_db_mod.settings.model_copy(update={"LIONAGI_STATE_DB_URL": url}),
+    )
+
+
+def test_unconfigured_deployment_resolves_the_default_path(tmp_path, monkeypatch):
+    """With nothing configured, this is the path the services always used."""
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url=None)
+
+    assert store_path() == str(default)
+    assert store_exists() is False
+
+    _run(_seed(default, "s"))
+    assert store_path() == str(default)
+    assert store_exists() is True
+
+
+def test_configured_store_moves_the_path_the_services_open(tmp_path, monkeypatch):
+    default = tmp_path / "default_state.db"
+    configured = tmp_path / "configured_state.db"
+    _run(_seed(default, "in-the-default-store"))
+    _run(_seed(configured, "in-the-configured-store"))
+
+    _configure(monkeypatch, default=default, url=str(configured))
+
+    assert store_path() == str(configured)
+
+
+def test_health_and_data_answers_come_from_the_same_store(tmp_path, monkeypatch):
+    """A configured store is one store: the size reported and the rows listed
+    are both about it, and neither is about the default path.
+
+    The configured store is seeded heavily enough that the two files differ in
+    size. Two stores holding one row each come out byte-identical, so a size
+    assertion between them passes whichever file was measured, which is worth
+    less than no assertion at all.
+    """
+    import lionagi.studio.services.admin as admin_mod
+    import lionagi.studio.services.sessions as sessions_mod
+
+    default = tmp_path / "default_state.db"
+    configured = tmp_path / "configured_state.db"
+    _run(_seed(default, "in-the-default-store"))
+    configured_ids = _run(_seed(configured, "in-the-configured-store", count=120))
+    assert configured.stat().st_size != default.stat().st_size
+
+    _configure(monkeypatch, default=default, url=str(configured))
+
+    health = admin_mod.db_health()
+    assert health["size_bytes"] == configured.stat().st_size
+
+    rows = _run(sessions_mod.list_sessions(limit=200))
+    assert sorted(r["id"] for r in rows) == sorted(configured_ids)
+
+
+def test_a_configured_store_is_never_created_by_reading_it(tmp_path, monkeypatch):
+    """Resolution alone must not bring a store into existence."""
+    default = tmp_path / "default_state.db"
+    configured = tmp_path / "not_there_yet.db"
+    _run(_seed(default, "in-the-default-store"))
+
+    _configure(monkeypatch, default=default, url=str(configured))
+
+    assert store_exists() is False
+    assert not configured.exists()

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
 from lionagi.state.claude_mirror import session_db_id  # noqa: E402
@@ -43,8 +45,7 @@ def patched_sessions_db(tmp_path, monkeypatch):
     import lionagi.studio.services.sessions as svc
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(svc, "_DB", str(db_path))
-    monkeypatch.setattr(svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     return svc, db_path
 
 

--- a/tests/apps_studio_server/test_shows.py
+++ b/tests/apps_studio_server/test_shows.py
@@ -43,8 +43,6 @@ def patched_app(shows_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(config_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "_DB", str(fake_db))
 
     from lionagi.studio.app import app
 
@@ -180,8 +178,6 @@ def sqlite_patched_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(config_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "_DB", str(fake_db))
 
     # Create the show directory on disk so safe_path_join() passes and
     # show_dir.is_dir() is True inside get_show().
@@ -258,8 +254,6 @@ def docker_patched_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(config_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "_DB", str(fake_db))
 
     topic = "overnight-sweep"
     # Deliberately do NOT create shows_root / topic on disk.

--- a/tests/apps_studio_server/test_signals_sse.py
+++ b/tests/apps_studio_server/test_signals_sse.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
 from lionagi.state.db import StateDB  # noqa: E402
@@ -153,8 +155,7 @@ def patched_signals_db(tmp_path, monkeypatch):
     import lionagi.studio.services.signals as svc
 
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(svc, "_DB", str(db_path))
-    monkeypatch.setattr(svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     return svc, db_path
 
 
@@ -230,14 +231,8 @@ def patched_app(tmp_path, monkeypatch):
     pytest.importorskip("fastapi", reason="studio extra not installed")
     httpx = pytest.importorskip("httpx", reason="httpx not installed")
 
-    import lionagi.studio.services.sessions as sessions_svc
-    import lionagi.studio.services.signals as signals_svc
-
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(signals_svc, "_DB", str(db_path))
-    monkeypatch.setattr(signals_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
 
@@ -714,14 +709,8 @@ def test_signals_endpoint_requires_bearer_auth(tmp_path, monkeypatch):
     pytest.importorskip("fastapi", reason="studio extra not installed")
     from fastapi.testclient import TestClient
 
-    import lionagi.studio.services.sessions as sessions_svc
-    import lionagi.studio.services.signals as signals_svc
-
     db_path = tmp_path / "state.db"
-    monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(signals_svc, "_DB", str(db_path))
-    monkeypatch.setattr(signals_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setenv("LIONAGI_STUDIO_AUTH_TOKEN", "secret-token")
 
     from lionagi.studio.app import app
@@ -761,9 +750,6 @@ async def test_signals_generator_cancellation_on_disconnect(tmp_path, monkeypatc
     pytest.importorskip("fastapi", reason="studio extra not installed")
     pytest.importorskip("httpx", reason="httpx not installed")
 
-    import lionagi.studio.services.sessions as sessions_svc
-    import lionagi.studio.services.signals as signals_svc
-
     db_path = tmp_path / "state.db"
     session_id = "cancel-test-sess"
 
@@ -782,10 +768,7 @@ async def test_signals_generator_cancellation_on_disconnect(tmp_path, monkeypatc
             }
         )
 
-    monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
-    monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(signals_svc, "_DB", str(db_path))
-    monkeypatch.setattr(signals_svc, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     # Import the handler directly from the service module.
     from lionagi.studio.services.sessions import stream_signals

--- a/tests/apps_studio_server/test_smoke.py
+++ b/tests/apps_studio_server/test_smoke.py
@@ -39,12 +39,8 @@ def _make_client(
     import lionagi.state.db as state_db_mod
     import lionagi.studio.config as config_mod
     import lionagi.studio.services.agents as agents_mod
-    import lionagi.studio.services.definitions as defs_mod
     import lionagi.studio.services.playbooks as playbooks_mod
-    import lionagi.studio.services.runs as runs_mod
-    import lionagi.studio.services.sessions as sessions_mod
     import lionagi.studio.services.shows as shows_mod
-    import lionagi.studio.services.stats as stats_mod
 
     monkeypatch.setattr(config_mod, "SHOWS_ROOT", shows_root)
     monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
@@ -56,14 +52,6 @@ def _make_client(
     # sessions/shows/defs import DEFAULT_DB_PATH at module load; patch both the
     # Path object and the _DB string so .exists() and aiosqlite.connect() both
     # see the fake path.
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(sessions_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(shows_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(shows_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(defs_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(defs_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
 
     if with_run:
         run_dir = runs_root / "20240101T000000-abc123"
@@ -246,10 +234,9 @@ def test_run_detail_contract_fields(tmp_path, monkeypatch):
     finally:
         loop.close()
 
-    import lionagi.studio.services.sessions as sessions_mod
+    import lionagi.state.db as state_db_mod
 
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     client = _make_client(tmp_path, monkeypatch)
     r = client.get(f"/api/runs/{run_id}")

--- a/tests/apps_studio_server/test_spa_serving.py
+++ b/tests/apps_studio_server/test_spa_serving.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from fastapi.testclient import TestClient  # noqa: E402
@@ -48,13 +50,7 @@ def spa_client(
     """
     fake_db = tmp_path / "state.db"
 
-    import lionagi.studio.services.sessions as sessions_mod
-    import lionagi.studio.services.stats as stats_mod
-
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(sessions_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
     monkeypatch.setenv("LIONAGI_STUDIO_FRONTEND_DIST", str(dist_dir))
 
     import lionagi.studio.app as app_mod
@@ -71,13 +67,7 @@ def no_dist_client(
     """TestClient in API-only mode (no dist dir), backed by a fresh app instance."""
     fake_db = tmp_path / "state.db"
 
-    import lionagi.studio.services.sessions as sessions_mod
-    import lionagi.studio.services.stats as stats_mod
-
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(sessions_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
     # Ensure no dist is resolved (env var must be absent so _resolve_frontend_dist
     # returns None and the 404 exception handler is not registered).
     monkeypatch.delenv("LIONAGI_STUDIO_FRONTEND_DIST", raising=False)

--- a/tests/apps_studio_server/test_startup_warnings.py
+++ b/tests/apps_studio_server/test_startup_warnings.py
@@ -20,6 +20,8 @@ from typing import NamedTuple
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 import anyio  # noqa: E402
@@ -103,11 +105,9 @@ def _lifespan_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generat
     Bare TestClient(app, base_url="http://127.0.0.1:8765") construction does NOT trigger the lifespan.
     """
     import lionagi.studio.app as app_mod
-    import lionagi.studio.services.stats as stats_mod
 
     fake_db = tmp_path / "state.db"
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     # A fresh app instance (via create_app()) instead of importlib.reload(app_mod):
     # reload mutates the shared module singleton every other importer holds a
@@ -131,11 +131,9 @@ def _bare_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generator[T
     response headers.
     """
     import lionagi.studio.app as app_mod
-    import lionagi.studio.services.stats as stats_mod
 
     fake_db = tmp_path / "state.db"
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(stats_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     app = app_mod.create_app()
     client = TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")

--- a/tests/apps_studio_server/test_stats_db_health.py
+++ b/tests/apps_studio_server/test_stats_db_health.py
@@ -42,14 +42,8 @@ async def _seed_two_sessions(db_path: Path) -> None:
 
 
 def _make_client(tmp_path, monkeypatch, db_path: Path) -> TestClient:
-    import lionagi.studio.services.sessions as sessions_mod
-    import lionagi.studio.services.stats as stats_mod
 
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(stats_mod, "_DB", str(db_path))
 
     from lionagi.studio.app import app
 
@@ -92,27 +86,31 @@ def test_stats_db_health_missing_db_returns_zeroes(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# stats DB path delegation: size_bytes must reflect stats.DEFAULT_DB_PATH
+# stats reports the store the daemon serves, not a path of its own
 # ---------------------------------------------------------------------------
 
 
-def test_stats_size_comes_from_stats_db_path(tmp_path, monkeypatch):
-    """size_bytes must reflect stats.DEFAULT_DB_PATH, not admin.DEFAULT_DB_PATH."""
-    small_db = tmp_path / "small_state.db"
-    _run(_seed_two_sessions(small_db))
+def test_stats_size_comes_from_the_configured_store(tmp_path, monkeypatch):
+    """The reported size belongs to the store in play, whichever file that is.
 
-    import lionagi.studio.services.admin as admin_mod
-    import lionagi.studio.services.sessions as sessions_mod
-    import lionagi.studio.services.stats as stats_mod
+    Each service used to hold its own copy of the default path, so this asked
+    whether stats read stats' copy rather than admin's. There is one
+    resolution now, and the question that replaces it is whether that
+    resolution follows the configuration: the default path exists here and is
+    the wrong answer, so a service still reading it reports a size of zero.
+    """
+    configured = tmp_path / "configured_state.db"
+    _run(_seed_two_sessions(configured))
 
-    # Patch stats to the small DB; leave admin pointing at a nonexistent path
-    admin_db = tmp_path / "admin_state.db"
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", small_db)
-    monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", small_db)
-    monkeypatch.setattr(sessions_mod, "_DB", str(small_db))
-    monkeypatch.setattr(stats_mod, "DEFAULT_DB_PATH", small_db)
-    monkeypatch.setattr(stats_mod, "_DB", str(small_db))
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", admin_db)
+    default_path = tmp_path / "default_state.db"
+    default_path.write_bytes(b"")
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", default_path)
+    monkeypatch.setattr(
+        state_db_mod,
+        "settings",
+        state_db_mod.settings.model_copy(update={"LIONAGI_STATE_DB_URL": str(configured)}),
+    )
 
     from lionagi.studio.app import app
 
@@ -120,8 +118,7 @@ def test_stats_size_comes_from_stats_db_path(tmp_path, monkeypatch):
     r = client.get("/api/stats")
     assert r.status_code == 200
     db = r.json()["db"]
-    # The stats endpoint must report the size of small_db, which exists and has content
-    assert db["size_bytes"] > 0, "size_bytes must reflect the patched stats DB, not admin's DB"
+    assert db["size_bytes"] == configured.stat().st_size
     assert db["tables"]["sessions"] == 2
 
 
@@ -145,13 +142,11 @@ async def _seed_invocation_with_bad_metadata(db_path: Path, inv_id: str) -> None
 
 def test_invocation_bad_metadata_becomes_none(tmp_path, monkeypatch):
     """Corrupted node_metadata must be None, not the raw invalid string."""
-    import lionagi.studio.services.invocations as inv_mod
 
     db_path = tmp_path / "state.db"
     inv_id = str(uuid.uuid4())
     _run(_seed_invocation_with_bad_metadata(db_path, inv_id))
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app
@@ -167,13 +162,11 @@ def test_invocation_bad_metadata_becomes_none(tmp_path, monkeypatch):
 
 def test_invocation_list_bad_metadata_becomes_none(tmp_path, monkeypatch):
     """Corrupted node_metadata in list endpoint must also be None."""
-    import lionagi.studio.services.invocations as inv_mod
 
     db_path = tmp_path / "state.db"
     inv_id = str(uuid.uuid4())
     _run(_seed_invocation_with_bad_metadata(db_path, inv_id))
 
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
 
     from lionagi.studio.app import app

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -108,18 +108,14 @@ def _mock_chat_branch(name: str = "workflow-default"):
 def patched_env(tmp_path: Path, monkeypatch):
     import lionagi.state.db as db_mod
     import lionagi.studio.services.engine_defs as engine_defs_svc
-    import lionagi.studio.services.sessions as sessions_svc
     import lionagi.studio.services.workflow_defs as wf_svc
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
     # sessions.py freezes `_DB = str(DEFAULT_DB_PATH)` at import time (module
     # constant, not re-read per call) — both attrs need patching, matching the
     # convention already established in test_admin.py.
-    monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
 
     import lionagi.cli.engine as cli_engine
 

--- a/tests/apps_studio_server/test_workflow_run_transcript_persist.py
+++ b/tests/apps_studio_server/test_workflow_run_transcript_persist.py
@@ -123,15 +123,11 @@ def _mock_chat_branch(name: str = "workflow-default"):
 def patched_env(tmp_path: Path, monkeypatch):
     import lionagi.state.db as db_mod
     import lionagi.studio.services.engine_defs as engine_defs_svc
-    import lionagi.studio.services.sessions as sessions_svc
     import lionagi.studio.services.workflow_defs as wf_svc
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
 
     import lionagi.cli.engine as cli_engine
 

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -4255,15 +4255,11 @@ async def test_run_workflow_def_delegates_to_session_flow_with_progress_wrapper(
 
     import lionagi.state.db as db_mod
     import lionagi.studio.services.engine_defs as engine_defs_svc
-    import lionagi.studio.services.sessions as sessions_svc
     import lionagi.studio.services.workflow_defs as wf_svc
 
     db_path = tmp_path / "state.db"
     monkeypatch.setattr(db_mod, "DEFAULT_DB_PATH", db_path)
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_svc, "DEFAULT_DB_PATH", db_path)
-    monkeypatch.setattr(sessions_svc, "_DB", str(db_path))
 
     import lionagi.cli.engine as cli_engine
     from tests.apps_studio_server.test_workflow_run import _FakeEngine, _mock_chat_branch, _spec

--- a/tests/studio/test_admin_health_code_identity.py
+++ b/tests/studio/test_admin_health_code_identity.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from fastapi.testclient import TestClient  # noqa: E402
@@ -30,11 +32,9 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 def _make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
     import lionagi.studio.app as app_mod
-    import lionagi.studio.services.admin as admin_mod
 
     fake_db = tmp_path / "state.db"
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(admin_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     app = app_mod.create_app()
     return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")

--- a/tests/studio/test_admin_health_timezone.py
+++ b/tests/studio/test_admin_health_timezone.py
@@ -21,6 +21,8 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+import lionagi.state.db as state_db_mod
+
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from fastapi.testclient import TestClient  # noqa: E402
@@ -42,11 +44,9 @@ def _install_resolution(monkeypatch: pytest.MonkeyPatch) -> config.TimezoneResol
 
 def _make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
     import lionagi.studio.app as app_mod
-    import lionagi.studio.services.admin as admin_mod
 
     fake_db = tmp_path / "state.db"
-    monkeypatch.setattr(admin_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(admin_mod, "_DB", str(fake_db))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     app = app_mod.create_app()
     return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")

--- a/tests/studio/test_auth.py
+++ b/tests/studio/test_auth.py
@@ -43,18 +43,10 @@ _DATA_GET_PREFIXES = [
 
 def _make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
     import lionagi.studio.app as app_mod
-    import lionagi.studio.services.invocations as inv_mod
-    import lionagi.studio.services.sessions as sess_mod
-    import lionagi.studio.services.stats as stats_mod
 
     fake_db = tmp_path / "state.db"
 
     # Redirect all DB-backed services to the throw-away path so the app stays hermetic.
-    for mod in (stats_mod, inv_mod, sess_mod):
-        if hasattr(mod, "DEFAULT_DB_PATH"):
-            monkeypatch.setattr(mod, "DEFAULT_DB_PATH", fake_db)
-        if hasattr(mod, "_DB"):
-            monkeypatch.setattr(mod, "_DB", str(fake_db))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     # A fresh app instance (via create_app()) instead of importlib.reload(app_mod):

--- a/tests/studio/test_hosted_hardening.py
+++ b/tests/studio/test_hosted_hardening.py
@@ -58,16 +58,8 @@ def make_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     other code still imports.
     """
     import lionagi.studio.app as app_mod
-    import lionagi.studio.services.invocations as inv_mod
-    import lionagi.studio.services.sessions as sess_mod
-    import lionagi.studio.services.stats as stats_mod
 
     fake_db = tmp_path / "state.db"
-    for mod in (stats_mod, inv_mod, sess_mod):
-        if hasattr(mod, "DEFAULT_DB_PATH"):
-            monkeypatch.setattr(mod, "DEFAULT_DB_PATH", fake_db)
-        if hasattr(mod, "_DB"):
-            monkeypatch.setattr(mod, "_DB", str(fake_db))
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
     stack = ExitStack()
@@ -282,16 +274,8 @@ class TestJsonContentTypeEnforcement:
         httpx = pytest.importorskip("httpx", reason="httpx not installed")
 
         import lionagi.studio.app as app_mod
-        import lionagi.studio.services.invocations as inv_mod
-        import lionagi.studio.services.sessions as sess_mod
-        import lionagi.studio.services.stats as stats_mod
 
         fake_db = tmp_path / "state.db"
-        for mod in (stats_mod, inv_mod, sess_mod):
-            if hasattr(mod, "DEFAULT_DB_PATH"):
-                monkeypatch.setattr(mod, "DEFAULT_DB_PATH", fake_db)
-            if hasattr(mod, "_DB"):
-                monkeypatch.setattr(mod, "_DB", str(fake_db))
         monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
         app = app_mod.create_app()
 


### PR DESCRIPTION
## Why

Every service in `lionagi/studio/services/` opened the store like this:

```python
_DB = str(DEFAULT_DB_PATH)
...
async with _open_db(_DB) as db:
```

`DEFAULT_DB_PATH` is the right file until `LIONAGI_STATE_DB_URL` moves the store. After that the daemon writes one database and these routes read another, so `/api/stats`, `/api/admin/readiness`, the session lists and everything else report on rows nobody is serving. SQLite makes it quieter than it sounds: `aiosqlite.connect` creates the file it was given, so the wrong answer arrives as an empty store rather than as an error.

The guards had the same shape, `if not DEFAULT_DB_PATH.exists()`, so a route could also decide there was no store by checking a file that was never involved.

## What changed

One resolution, in `services/_db.py`:

```python
def store_path() -> str:      # the file to open
def store_exists() -> bool:   # whether it is there to read
```

`store_exists` is defined as `Path(store_path()).exists()`, so a guard and the connection it protects cannot disagree about which store is in play.

Everything in the layer now goes through it: 37 `_open_db(_DB)` call sites, 17 `DEFAULT_DB_PATH.exists()` guards, 2 availability predicates, and 6 places that named the path directly (`db_health`, the store probe's presence check, connect and detail string, the prune guard, and the stats size reporter). No `DEFAULT_DB_PATH` reference is left anywhere under `lionagi/studio/`.

Open semantics are unchanged. This is resolution only: no readonly flags, no new guards, no route answering anything it did not answer before.

One response field does change. `/api/admin/readiness` used to interpolate the absolute default path into its detail string; it now renders the resolved store through `public_path`, the same helper `/api/stats` already used for the same purpose.

## The limit this does not remove

This layer talks to SQLite directly. When the configured store is a **server**, there is no file to open, and `store_path()` falls back to the default path. That is exactly what these services did before and it is equally wrong for that deployment: a server-backed store has rows no SQLite connection here can reach.

What a route should answer in that case is a third state, *not answerable here*, and that is a contract change across nine service modules and the frontend rather than a path resolution. It is tracked separately and deliberately not improvised into this PR.

So: this fixes a **moved SQLite file**. It does not fix a server-backed store, and it does not pretend to.

## Tests

The per-service seam is gone, and with it the reason tests had to know about it. Redirecting the store used to mean patching three attributes per service module:

```python
monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
monkeypatch.setattr(sessions_mod, "DEFAULT_DB_PATH", db_path)
monkeypatch.setattr(sessions_mod, "_DB", str(db_path))
```

Now it means patching the first line. Across 44 test files that is 351 lines removed against 72 added, where the additions are the places the service patch was the *only* redirect a function had and became the `state_db_mod` one instead.

New coverage in `tests/apps_studio_server/test_services_store_resolution.py`:

- an unconfigured deployment resolves the default path, before and after the file exists, since a no-op for default deployments is what makes changing every service at once safe;
- a configured store moves the path the services open;
- a health answer and a data answer come from the same store;
- resolving a configured store that does not exist yet does not create it.

`test_stats_size_comes_from_stats_db_path` asked whether stats read stats' copy of the path rather than admin's. There is one copy now, so it asks the question that replaces it: whether the reported size follows the configuration when the default path exists and is the wrong answer.

One note on that pair of tests. The first version of the coherence test asserted the reported size differed from the default store's size, and it failed: two stores seeded with one row each come out byte-identical, so the assertion passed or failed on file layout rather than on which file was measured. The configured store is now seeded heavily enough for the two to differ, and the test asserts that difference before it asserts anything about the response.

`tests/apps_studio_server` + `tests/studio` + `tests/cli` + the graph entrypoint conformance file: 4896 passed, 3 skipped. Full suite: 16978 passed, 8 skipped. Two failures in `tests/tools/test_coding_toolkit.py` come from a `docling` import chain and reproduce in a second, unrelated checkout of this repo.
