### PR TITLE
fix(state): refuse a store URL with credentials and no scheme

### DIFF
--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -72,6 +72,44 @@ def _dumps_with_uuid(value):
     return json.dumps(value, default=_json_serializer, allow_nan=False)
 
 
+# A value with no scheme is a filesystem path. That is the documented case and
+# almost always what was meant. But `user:secret@host/db` with the scheme left
+# off is also scheme-less, and resolving it as a path creates a database file
+# whose *name* carries the credential, at a location nobody chose, while the
+# server it was meant to reach is never contacted. Nothing about that failure
+# announces itself: the store opens, it is empty, and the daemon runs.
+#
+# The shape being matched is a URL's userinfo prefix, `something:something@`
+# before any slash. A filename may legally contain an `@` — `user@host.db` is
+# an odd but valid name — so the colon before it is what separates a credential
+# from a filename, and this must not fire on the latter.
+_CREDENTIALED_USERINFO = re.compile(r"^[^\s:/@]+:[^\s:/@]+@([^\s/@]+)")
+
+# Keyed by what the warning prints, which is the part after the credential, so
+# a repeated misconfiguration is logged once without the secret being what
+# makes two entries distinct.
+_schemeless_credential_targets: set[str] = set()
+
+
+def _warn_if_schemeless_credentials(value: str) -> None:
+    match = _CREDENTIALED_USERINFO.match(value)
+    if match is None:
+        return
+    target = match.group(1)
+    if target in _schemeless_credential_targets:
+        return
+    _schemeless_credential_targets.add(target)
+    _log.warning(
+        "The state store URL has no scheme, so it is being read as a filesystem "
+        "path and a SQLite file will be created from it. It has the shape of a "
+        "connection string to %s with credentials in front, which means those "
+        "credentials become part of a file name on disk and the server is never "
+        "contacted. Add the scheme (postgresql:// for a server) if that is what "
+        "was meant.",
+        target,
+    )
+
+
 def normalize_state_db_url(value: str | Path | None) -> str:
     """Resolve *value* to a fully-qualified async SQLAlchemy URL string."""
     if value is None:
@@ -87,6 +125,7 @@ def normalize_state_db_url(value: str | Path | None) -> str:
         return "sqlite+aiosqlite:///:memory:"
 
     if "://" not in s:
+        _warn_if_schemeless_credentials(s)
         return f"sqlite+aiosqlite:///{Path(s).resolve()}"
 
     if s.startswith("sqlite+aiosqlite://") or s.startswith("postgresql+asyncpg://"):

--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -82,31 +82,32 @@ def _dumps_with_uuid(value):
 # The shape being matched is a URL's userinfo prefix, `something:something@`
 # before any slash. A filename may legally contain an `@` — `user@host.db` is
 # an odd but valid name — so the colon before it is what separates a credential
-# from a filename, and this must not fire on the latter.
+# from a filename, and this must not fire on the latter. Nothing beginning with
+# `./` or `/` can match, which is the way to spell a path that really does look
+# like this.
 _CREDENTIALED_USERINFO = re.compile(r"^[^\s:/@]+:[^\s:/@]+@([^\s/@]+)")
 
-# Keyed by what the warning prints, which is the part after the credential, so
-# a repeated misconfiguration is logged once without the secret being what
-# makes two entries distinct.
-_schemeless_credential_targets: set[str] = set()
 
+def _reject_schemeless_credentials(value: str) -> None:
+    """Refuse a scheme-less value shaped like a credentialed connection string.
 
-def _warn_if_schemeless_credentials(value: str) -> None:
+    Refusing rather than warning, because there is no reading of this value
+    under which resolving it is the right thing to do. Every outcome of going
+    ahead is wrong: the server named in it is not contacted, the store that
+    does open is empty, and the credential is written into a file name where it
+    outlives the process that was misconfigured. A warning leaves all three in
+    place and asks somebody to be reading the log at the right moment.
+    """
     match = _CREDENTIALED_USERINFO.match(value)
     if match is None:
         return
-    target = match.group(1)
-    if target in _schemeless_credential_targets:
-        return
-    _schemeless_credential_targets.add(target)
-    _log.warning(
-        "The state store URL has no scheme, so it is being read as a filesystem "
-        "path and a SQLite file will be created from it. It has the shape of a "
-        "connection string to %s with credentials in front, which means those "
-        "credentials become part of a file name on disk and the server is never "
-        "contacted. Add the scheme (postgresql:// for a server) if that is what "
-        "was meant.",
-        target,
+    raise ValueError(
+        "The state store URL has no scheme, so it would be read as a filesystem "
+        f"path and a SQLite file created from it. It has the shape of a connection "
+        f"string to {match.group(1)} with credentials in front, so the credentials "
+        "would become part of a file name on disk and the server would never be "
+        "contacted. Add the scheme (postgresql:// for a server), or prefix the "
+        "value with ./ if it really is a relative path."
     )
 
 
@@ -125,7 +126,7 @@ def normalize_state_db_url(value: str | Path | None) -> str:
         return "sqlite+aiosqlite:///:memory:"
 
     if "://" not in s:
-        _warn_if_schemeless_credentials(s)
+        _reject_schemeless_credentials(s)
         return f"sqlite+aiosqlite:///{Path(s).resolve()}"
 
     if s.startswith("sqlite+aiosqlite://") or s.startswith("postgresql+asyncpg://"):

--- a/tests/state/test_schemeless_credentialed_store_url.py
+++ b/tests/state/test_schemeless_credentialed_store_url.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A store URL with credentials but no scheme is read as a path, and says so.
+
+``LIONAGI_STATE_DB_URL=user:secret@db.internal/lionagi`` is a connection string
+with the scheme left off. Nothing rejects it: it has no ``://``, so it resolves
+as a filesystem path, and a SQLite database appears at a path built out of the
+credential while the server it named is never contacted. The store opens, it is
+empty, and everything downstream reports on it as if it were the store.
+
+The warning does not change that resolution, because a file name may legally
+contain the characters involved. It makes the silent case audible.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lionagi.state import engine as engine_mod
+from lionagi.state.engine import normalize_state_db_url
+
+PASSWORD = "hunter2-correct-horse"
+TARGET = "db.internal"
+CREDENTIALED = f"dbuser:{PASSWORD}@{TARGET}/lionagi"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warning_state(monkeypatch):
+    """The once-per-target memo is module state; each test starts empty."""
+    monkeypatch.setattr(engine_mod, "_schemeless_credential_targets", set())
+
+
+def _warnings(caplog) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_a_schemeless_connection_string_warns_and_names_the_target(caplog, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+        normalize_state_db_url(CREDENTIALED)
+
+    messages = _warnings(caplog)
+    assert len(messages) == 1, messages
+    assert TARGET in messages[0], (
+        f"the warning does not say which target was meant, so it cannot be acted on: {messages[0]!r}"
+    )
+    assert "scheme" in messages[0]
+
+
+def test_the_warning_does_not_carry_the_credential(caplog, tmp_path, monkeypatch):
+    """A warning about a leaked secret must not be the thing that logs it."""
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+        normalize_state_db_url(CREDENTIALED)
+
+    messages = _warnings(caplog)
+    assert messages, "no warning at all, so this asserts nothing about its content"
+    assert PASSWORD not in messages[0]
+    assert "dbuser" not in messages[0]
+
+
+def test_resolution_is_unchanged(tmp_path, monkeypatch):
+    """The warning is a warning. What the URL resolves to is what it was."""
+    monkeypatch.chdir(tmp_path)
+    resolved = normalize_state_db_url(CREDENTIALED)
+    assert resolved.startswith("sqlite+aiosqlite:///")
+    assert resolved.endswith(f"{TARGET}/lionagi")
+
+
+def test_it_warns_once_per_target(caplog, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+        normalize_state_db_url(CREDENTIALED)
+        normalize_state_db_url(CREDENTIALED)
+        normalize_state_db_url(f"other:{PASSWORD}@{TARGET}/lionagi")
+
+    assert len(_warnings(caplog)) == 1
+
+
+def test_a_second_target_is_its_own_warning(caplog, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+        normalize_state_db_url(CREDENTIALED)
+        normalize_state_db_url(f"dbuser:{PASSWORD}@other.internal/lionagi")
+
+    assert len(_warnings(caplog)) == 2
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "state.db",
+        "/var/lib/lionagi/state.db",
+        "./nested/state.db",
+        # An '@' in a file name is legal and odd, and refusing or warning on it
+        # would be a breaking change against a valid path. The colon before the
+        # '@' is what distinguishes a credential from a name.
+        "user@host.db",
+        "backup@2026-08-03.db",
+        # A drive letter is a colon with no '@' anywhere after it.
+        "C:/data/state.db",
+        ":memory:",
+    ],
+)
+def test_ordinary_paths_do_not_warn(value, caplog, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+        normalize_state_db_url(value)
+
+    assert _warnings(caplog) == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        f"postgresql://dbuser:{PASSWORD}@{TARGET}/lionagi",
+        f"postgres://dbuser:{PASSWORD}@{TARGET}/lionagi",
+        f"postgresql+asyncpg://dbuser:{PASSWORD}@{TARGET}/lionagi",
+    ],
+)
+def test_a_url_with_its_scheme_does_not_warn(value, caplog):
+    """These are correct configurations. The warning is about the missing scheme,
+    not about credentials existing."""
+    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+        normalize_state_db_url(value)
+
+    assert _warnings(caplog) == []

--- a/tests/state/test_schemeless_credentialed_store_url.py
+++ b/tests/state/test_schemeless_credentialed_store_url.py
@@ -1,25 +1,24 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""A store URL with credentials but no scheme is read as a path, and says so.
+"""A store URL with credentials but no scheme is refused.
 
 ``LIONAGI_STATE_DB_URL=user:secret@db.internal/lionagi`` is a connection string
-with the scheme left off. Nothing rejects it: it has no ``://``, so it resolves
-as a filesystem path, and a SQLite database appears at a path built out of the
-credential while the server it named is never contacted. The store opens, it is
-empty, and everything downstream reports on it as if it were the store.
+with the scheme left off. Nothing used to reject it: it has no ``://``, so it
+resolved as a filesystem path, and a SQLite database appeared at a path built
+out of the credential while the server it named was never contacted. The store
+opened, it was empty, and everything downstream reported on it as if it were
+the store.
 
-The warning does not change that resolution, because a file name may legally
-contain the characters involved. It makes the silent case audible.
+There is no reading of that value under which resolving it is right, so it is
+refused rather than logged. A value that really is a path of this shape is
+spelled ``./`` first, which the pattern cannot match.
 """
 
 from __future__ import annotations
 
-import logging
-
 import pytest
 
-from lionagi.state import engine as engine_mod
 from lionagi.state.engine import normalize_state_db_url
 
 PASSWORD = "hunter2-correct-horse"
@@ -27,66 +26,56 @@ TARGET = "db.internal"
 CREDENTIALED = f"dbuser:{PASSWORD}@{TARGET}/lionagi"
 
 
-@pytest.fixture(autouse=True)
-def _fresh_warning_state(monkeypatch):
-    """The once-per-target memo is module state; each test starts empty."""
-    monkeypatch.setattr(engine_mod, "_schemeless_credential_targets", set())
-
-
-def _warnings(caplog) -> list[str]:
-    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
-
-
-def test_a_schemeless_connection_string_warns_and_names_the_target(caplog, tmp_path, monkeypatch):
+def test_a_schemeless_connection_string_is_refused(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+    with pytest.raises(ValueError) as excinfo:
         normalize_state_db_url(CREDENTIALED)
 
-    messages = _warnings(caplog)
-    assert len(messages) == 1, messages
-    assert TARGET in messages[0], (
-        f"the warning does not say which target was meant, so it cannot be acted on: {messages[0]!r}"
+    assert TARGET in str(excinfo.value), (
+        f"the error does not say which target was meant, so it cannot be acted on: {excinfo.value}"
     )
-    assert "scheme" in messages[0]
+    assert "scheme" in str(excinfo.value)
 
 
-def test_the_warning_does_not_carry_the_credential(caplog, tmp_path, monkeypatch):
-    """A warning about a leaked secret must not be the thing that logs it."""
+def test_nothing_is_written_when_it_is_refused(tmp_path, monkeypatch):
+    """The point of refusing is that the credential never reaches the disk."""
     monkeypatch.chdir(tmp_path)
-    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
+    with pytest.raises(ValueError):
         normalize_state_db_url(CREDENTIALED)
 
-    messages = _warnings(caplog)
-    assert messages, "no warning at all, so this asserts nothing about its content"
-    assert PASSWORD not in messages[0]
-    assert "dbuser" not in messages[0]
+    on_disk = [p.name for p in tmp_path.iterdir()]
+    assert on_disk == [], f"refusing still left something behind: {on_disk}"
+    assert not any(PASSWORD in name for name in on_disk)
 
 
-def test_resolution_is_unchanged(tmp_path, monkeypatch):
-    """The warning is a warning. What the URL resolves to is what it was."""
+def test_the_error_does_not_carry_the_credential(tmp_path, monkeypatch):
+    """An error about a leaked secret must not be the thing that logs it.
+
+    Exception text reaches tracebacks, log aggregators and crash reporters, so
+    it is subject to the same rule as any other output.
+    """
     monkeypatch.chdir(tmp_path)
-    resolved = normalize_state_db_url(CREDENTIALED)
+    with pytest.raises(ValueError) as excinfo:
+        normalize_state_db_url(CREDENTIALED)
+
+    message = str(excinfo.value)
+    assert PASSWORD not in message
+    assert "dbuser" not in message
+
+
+def test_the_error_names_the_escape_for_a_path_that_really_looks_like_this(tmp_path, monkeypatch):
+    """A refusal that does not say how to proceed is a dead end.
+
+    Tied to the behaviour rather than to the wording: whatever prefix the
+    message names must be one that actually resolves.
+    """
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        normalize_state_db_url(CREDENTIALED)
+
+    assert "./" in str(excinfo.value)
+    resolved = normalize_state_db_url(f"./{CREDENTIALED}")
     assert resolved.startswith("sqlite+aiosqlite:///")
-    assert resolved.endswith(f"{TARGET}/lionagi")
-
-
-def test_it_warns_once_per_target(caplog, tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
-        normalize_state_db_url(CREDENTIALED)
-        normalize_state_db_url(CREDENTIALED)
-        normalize_state_db_url(f"other:{PASSWORD}@{TARGET}/lionagi")
-
-    assert len(_warnings(caplog)) == 1
-
-
-def test_a_second_target_is_its_own_warning(caplog, tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
-        normalize_state_db_url(CREDENTIALED)
-        normalize_state_db_url(f"dbuser:{PASSWORD}@other.internal/lionagi")
-
-    assert len(_warnings(caplog)) == 2
 
 
 @pytest.mark.parametrize(
@@ -95,22 +84,25 @@ def test_a_second_target_is_its_own_warning(caplog, tmp_path, monkeypatch):
         "state.db",
         "/var/lib/lionagi/state.db",
         "./nested/state.db",
-        # An '@' in a file name is legal and odd, and refusing or warning on it
-        # would be a breaking change against a valid path. The colon before the
-        # '@' is what distinguishes a credential from a name.
+        # An '@' in a file name is legal and odd, and refusing on it would be a
+        # breaking change against a valid path. The colon before the '@' is
+        # what distinguishes a credential from a name.
         "user@host.db",
         "backup@2026-08-03.db",
         # A drive letter is a colon with no '@' anywhere after it.
         "C:/data/state.db",
         ":memory:",
+        # The escape from the error message, and an absolute spelling of the
+        # same thing. Both are paths that would otherwise match the shape.
+        f"./{CREDENTIALED}",
+        f"/tmp/{CREDENTIALED}",
     ],
 )
-def test_ordinary_paths_do_not_warn(value, caplog, tmp_path, monkeypatch):
+def test_ordinary_paths_still_resolve(value, tmp_path, monkeypatch):
+    """Over-refusal is invisible to a suite made only of must-refuse checks."""
     monkeypatch.chdir(tmp_path)
-    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
-        normalize_state_db_url(value)
-
-    assert _warnings(caplog) == []
+    resolved = normalize_state_db_url(value)
+    assert resolved.startswith("sqlite+aiosqlite:///")
 
 
 @pytest.mark.parametrize(
@@ -121,10 +113,15 @@ def test_ordinary_paths_do_not_warn(value, caplog, tmp_path, monkeypatch):
         f"postgresql+asyncpg://dbuser:{PASSWORD}@{TARGET}/lionagi",
     ],
 )
-def test_a_url_with_its_scheme_does_not_warn(value, caplog):
-    """These are correct configurations. The warning is about the missing scheme,
-    not about credentials existing."""
-    with caplog.at_level(logging.WARNING, logger=engine_mod.__name__):
-        normalize_state_db_url(value)
+def test_a_url_with_its_scheme_is_accepted(value):
+    """These are correct configurations. The refusal is about the missing
+    scheme, not about credentials existing."""
+    resolved = normalize_state_db_url(value)
+    assert resolved.startswith("postgresql+asyncpg://")
 
-    assert _warnings(caplog) == []
+
+def test_a_path_object_is_never_subject_to_this(tmp_path):
+    """A caller who passed a Path has already said what it is."""
+    weird = tmp_path / CREDENTIALED.replace("/", "_")
+    resolved = normalize_state_db_url(weird)
+    assert resolved.startswith("sqlite+aiosqlite:///")


### PR DESCRIPTION
## Why

`LIONAGI_STATE_DB_URL=user:secret@db.internal/lionagi` is a connection string
with the scheme left off. Nothing rejected it. It has no `://`, so it resolved
as a filesystem path, and a real SQLite database was created at a path built out
of the credential while the server it named was never contacted. The store
opened, it was empty, and everything downstream reported on it as if it were the
store.

Measured, not reasoned about: this produces a 634KB database in a directory
named after the plaintext credential, and the ordinary open succeeds silently.
Reproduced twice.

Three things are wrong at once, and they are separable:

1. the server the operator meant is not contacted,
2. the store that opens instead is empty and is treated as authoritative,
3. the credential is written into a file name, where it outlives the process
   that was misconfigured and is not covered by any output masking, because it
   is a credential at rest rather than one in a string.

## What changed

The value is refused.

This branch first added a warning and left the resolution alone. That was the
wrong call and this replaces it: a warning closes none of the three outcomes
above and asks somebody to be reading the log at the right moment. There is no
reading of this value under which resolving it as a path is what was wanted, so
there is nothing to preserve by continuing.

The error names the target it was aimed at and never the credential, because
exception text reaches tracebacks, log aggregators and crash reporters and is
subject to the same rule as any other output.

It also names the escape. A file name may legally contain a colon and an `@`, so
a path that genuinely has this shape is spelled `./` first, which the pattern
cannot match by construction.

## The consequence, stated rather than buried

A daemon configured this way now fails to start, and routes that resolve the
store return an error instead of serving an empty one.

That is the intended trade and not a regression to be softened later. The store
that would otherwise be served is not the store anyone asked for, and every
number read out of it is wrong in a way nothing downstream can detect.

## Testing

Seventeen cases. The must-accept half is the half that matters here, because
over-refusal is invisible to a suite made only of must-refuse checks: ordinary
paths, absolute paths, `user@host.db` and `backup@2026-08-03.db` (an `@` in a
file name is legal), a Windows drive letter, `:memory:`, a `Path` object, fully
qualified `postgresql://` URLs with credentials in them, and the `./` escape
that the error message names.

The escape is asserted against behaviour rather than wording: whatever prefix
the message names has to be one that actually resolves.

Two mutations:

| mutation | caught by |
|---|---|
| refusal made a no-op | the four must-refuse arms fail, all thirteen must-accept arms still pass |
| pattern broadened to `^[^\s/@]*@` | `user@host.db` and `backup@2026-08-03.db` are refused |

Restored by writing back the bytes read before each mutation, green after.
`tests/state`, `tests/studio`, `tests/cli`, `tests/apps_studio_server`: 5723
passed, 2 skipped.

## Note for whoever merges this

The branch carries the warning commit and the commit replacing it. The squash
message must be hand-written to describe the end state only; taking it from the
commit messages would put both the warning's rationale and its retraction into
the public history as if they were one change.
