### PR TITLE
fix(agent): a control that cannot answer is not a policy verdict

### DIFF
--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -718,6 +718,16 @@ guard_paths, and the session-level gate into that shape. Legacy hooks signal den
 treated as an evaluator failure and turned into a fail-closed deny rather than propagating
 uncaught.
 
+A control that cannot reach a verdict at all — misconfigured, or its backend unreachable —
+raises `ControlUnavailableError`, which subclasses `PermissionError` so existing callers keep
+failing closed on it unchanged. The gate catches it ahead of `PermissionError` and sets
+`GateResult.errored`, which separates "your configuration cannot answer this" from "the answer
+is no": both refuse the call, and an operator acts on them differently. `errored` has two
+readers, the pass logging at error level where a plain denial logs nothing, and
+`GateDeniedError`'s message. `PermissionPolicy.to_pre_hook` raises it for an escalate decision
+with no `on_escalate` configured; an escalation a configured handler *declined* is an ordinary
+denial and says so.
+
 ### `agent/hooks.py`
 
 `_resolve_against_any_root()` / `guard_paths()` — multi-root path-containment contract: a

--- a/lionagi/agent/gate.py
+++ b/lionagi/agent/gate.py
@@ -17,6 +17,7 @@ from typing import Any
 from lionagi.ln.concurrency import maybe_await
 
 __all__ = (
+    "ControlUnavailableError",
     "GateDeniedError",
     "GateEvaluator",
     "GateResult",
@@ -44,11 +45,29 @@ class GateResult:
 GateEvaluator = Callable[[str, str, dict], Awaitable[GateResult]]
 
 
+class ControlUnavailableError(PermissionError):
+    """A control could not reach a verdict about this call.
+
+    Raised when the thing standing in the way is the control's own
+    configuration rather than anything about the call: no escalation handler
+    where a decision needs one, a backend that is not reachable, a rule set
+    that could not be loaded. The call is still refused, because a control
+    that cannot answer must not be read as an approval.
+
+    It subclasses ``PermissionError`` so that everything already failing
+    closed on that keeps doing so unchanged. What it adds is a way to tell
+    "your configuration cannot answer this" from "the answer is no", which
+    an operator acts on differently and which the two are otherwise
+    indistinguishable in.
+    """
+
+
 class GateDeniedError(PermissionError):
     """Raised when a gate evaluation pass denies a call; carries the verdict."""
 
     def __init__(self, result: GateResult) -> None:
-        super().__init__(f"{result.control}: {result.reason}")
+        prefix = f"{result.control} could not evaluate" if result.errored else result.control
+        super().__init__(f"{prefix}: {result.reason}")
         self.result = result
 
 
@@ -62,6 +81,12 @@ def adapt_legacy_hook(control: str, hook: Callable) -> GateEvaluator:
     async def evaluate(tool_name: str, action: str, args: dict) -> GateResult:
         try:
             result = await maybe_await(hook(tool_name, action, args))
+        except ControlUnavailableError as e:
+            # Caught before PermissionError, which it subclasses: a control
+            # saying it cannot answer is a fault, and reporting it as a
+            # verdict is what makes a misconfiguration look like policy.
+            logger.warning("gate control %r could not evaluate: %s", control, e)
+            return GateResult(False, control, tool_name, action, str(e), errored=True)
         except PermissionError as e:
             return GateResult(False, control, tool_name, action, str(e))
         except Exception as e:  # noqa: BLE001 - fail-closed on any evaluator error
@@ -117,6 +142,18 @@ async def run_gate_pass(
     for evaluate in evaluators:
         result = await evaluate(tool_name, action, args)
         if not result.allowed:
+            if result.errored:
+                # The pass is where a refusal becomes final, so it is where the
+                # difference between a broken control and a working one has to
+                # be visible. A denial is routine and logs nothing; a control
+                # that could not answer is an operator's problem.
+                logger.error(
+                    "gate control %r refused %s.%s without reaching a verdict: %s",
+                    result.control,
+                    tool_name,
+                    action,
+                    result.reason,
+                )
             return args, result
         if result.mutated_args is not None:
             args = result.mutated_args

--- a/lionagi/agent/permissions.py
+++ b/lionagi/agent/permissions.py
@@ -13,6 +13,8 @@ from typing import Any
 
 from lionagi.tools._subprocess import _SHELL_CONTROL
 
+from .gate import ControlUnavailableError
+
 __all__ = (
     "PermissionDecision",
     "PermissionPolicy",
@@ -160,7 +162,16 @@ class PermissionPolicy:
                         return None
                     if isinstance(result, dict):
                         return result
-                raise PermissionError(
+                    # A handler ran and turned it down. That is an answer, and
+                    # the same one a deny rule gives.
+                    raise PermissionError(
+                        f"Permission escalation for {tool_name}.{action} was declined: "
+                        f"{decision.reason}"
+                    )
+                # Nobody can be asked, so there is no answer to have. Refused
+                # either way, but as a configuration fault rather than as a
+                # decision about this call.
+                raise ControlUnavailableError(
                     f"Permission escalation required for {tool_name}.{action}: "
                     f"{decision.reason}. No escalation handler configured."
                 )

--- a/tests/agent/test_gate_fault_is_not_a_verdict.py
+++ b/tests/agent/test_gate_fault_is_not_a_verdict.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A control that cannot answer must not be reported as having decided.
+
+``GateResult.errored`` exists to separate an evaluator FAULT from a policy
+VERDICT. Both refuse the call, which is correct, and an operator does entirely
+different things about them: a denial means the policy is working, a fault
+means the policy is not running.
+
+The case that made this concrete: ``PermissionPolicy.to_pre_hook`` raised a
+plain ``PermissionError`` both for a deny rule and for an escalate decision
+with no handler configured. The second is a configuration mistake, and it
+arrived at every consumer as a clean policy verdict, recoverable only by
+reading the message text.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lionagi.agent.gate import (
+    ControlUnavailableError,
+    GateDeniedError,
+    GateResult,
+    adapt_legacy_hook,
+    run_gate_pass,
+)
+from lionagi.agent.permissions import PermissionPolicy
+
+
+def _policy(**kw) -> PermissionPolicy:
+    return PermissionPolicy(mode="rules", **kw)
+
+
+# --------------------------------------------------------------------------
+# the escalate decision, which is where the two were conflated
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalate_without_a_handler_is_a_fault():
+    hook = _policy(escalate={"bash": ["*"]}).to_pre_hook()
+
+    with pytest.raises(ControlUnavailableError) as exc:
+        await hook("bash", "run", {"command": "ls"})
+
+    assert "No escalation handler configured" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_a_fault_is_still_a_refusal():
+    """Subclassing PermissionError is what keeps every existing consumer
+    failing closed; a caller that only knows the base class sees no change."""
+    hook = _policy(escalate={"bash": ["*"]}).to_pre_hook()
+
+    with pytest.raises(PermissionError):
+        await hook("bash", "run", {"command": "ls"})
+
+
+@pytest.mark.asyncio
+async def test_escalate_declined_by_a_handler_is_a_verdict():
+    """A handler that ran and said no is an answer, and reads as one."""
+
+    async def decline(decision, args):
+        return False
+
+    hook = _policy(escalate={"bash": ["*"]}, on_escalate=decline).to_pre_hook()
+
+    with pytest.raises(PermissionError) as exc:
+        await hook("bash", "run", {"command": "ls"})
+
+    assert not isinstance(exc.value, ControlUnavailableError)
+    assert "declined" in str(exc.value)
+    assert "No escalation handler configured" not in str(exc.value), (
+        "a handler was configured and ran, so saying otherwise is false"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_deny_rule_is_a_verdict():
+    hook = _policy(deny={"bash": ["rm *"]}).to_pre_hook()
+
+    with pytest.raises(PermissionError) as exc:
+        await hook("bash", "run", {"command": "rm -rf /"})
+
+    assert not isinstance(exc.value, ControlUnavailableError)
+
+
+@pytest.mark.asyncio
+async def test_an_allowed_call_is_untouched():
+    hook = _policy(allow={"bash": ["ls*"]}).to_pre_hook()
+    assert await hook("bash", "run", {"command": "ls -la"}) is None
+
+
+# --------------------------------------------------------------------------
+# what the gate layer does with each
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_gate_marks_a_declared_fault_errored():
+    hook = _policy(escalate={"bash": ["*"]}).to_pre_hook()
+    evaluate = adapt_legacy_hook("permission_check", hook)
+
+    result = await evaluate("bash", "run", {"command": "ls"})
+
+    assert result.allowed is False
+    assert result.errored is True
+
+
+@pytest.mark.asyncio
+async def test_the_gate_does_not_mark_a_denial_errored():
+    hook = _policy(deny={"bash": ["*"]}).to_pre_hook()
+    evaluate = adapt_legacy_hook("permission_check", hook)
+
+    result = await evaluate("bash", "run", {"command": "ls"})
+
+    assert result.allowed is False
+    assert result.errored is False
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_exception_stays_errored():
+    """The pre-existing fail-closed path keeps its behaviour and its wording."""
+
+    async def broken(tool_name, action, args):
+        raise RuntimeError("boom")
+
+    result = await adapt_legacy_hook("broken", broken)("bash", "run", {})
+
+    assert result.allowed is False
+    assert result.errored is True
+    assert "evaluator error" in result.reason
+
+
+# --------------------------------------------------------------------------
+# the flag has readers, which is the other half of the row
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_pass_logs_a_fault_and_says_nothing_about_a_denial(caplog):
+    async def faulty(tool_name, action, args):
+        raise ControlUnavailableError("backend unreachable")
+
+    async def denying(tool_name, action, args):
+        raise PermissionError("denied by rule: *")
+
+    with caplog.at_level(logging.ERROR, logger="lionagi.agent.gate"):
+        await run_gate_pass([adapt_legacy_hook("denies", denying)], "bash", "run", {})
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR, logger="lionagi.agent.gate"):
+        await run_gate_pass([adapt_legacy_hook("faulty", faulty)], "bash", "run", {})
+    errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(errors) == 1, errors
+    assert "faulty" in errors[0]
+    assert "backend unreachable" in errors[0]
+
+
+def test_the_raised_error_says_which_of_the_two_it_was():
+    denial = GateResult(False, "policy", "bash", "run", "denied by rule: rm *")
+    fault = GateResult(False, "policy", "bash", "run", "backend unreachable", errored=True)
+
+    assert str(GateDeniedError(denial)) == "policy: denied by rule: rm *"
+    assert "could not evaluate" in str(GateDeniedError(fault))
+    assert GateDeniedError(fault).result.errored is True
+
+
+@pytest.mark.asyncio
+async def test_a_fault_still_stops_the_pass():
+    """Whatever it is called, the call does not proceed."""
+    ran = []
+
+    async def faulty(tool_name, action, args):
+        raise ControlUnavailableError("no handler")
+
+    async def later(tool_name, action, args):
+        ran.append(tool_name)
+        return None
+
+    args, deny = await run_gate_pass(
+        [adapt_legacy_hook("faulty", faulty), adapt_legacy_hook("later", later)],
+        "bash",
+        "run",
+        {},
+    )
+
+    assert deny is not None and deny.allowed is False
+    assert ran == [], "a control that could not answer must not let the pass continue"


### PR DESCRIPTION
## Why

`GateResult.errored` exists to separate an evaluator **fault** from a policy **verdict**. Both refuse the call, which is right, and an operator does entirely different things about them: a denial means the policy is working, a fault means the policy is not running.

It was written at two sites and read at none.

The case that makes it concrete is `PermissionPolicy.to_pre_hook`, which raised a plain `PermissionError` for two unrelated things:

```python
raise PermissionError(
    f"Permission escalation required for {tool_name}.{action}: "
    f"{decision.reason}. No escalation handler configured."
)
...
raise PermissionError(f"Permission denied for {tool_name}.{action}: {decision.reason}")
```

The gate adapter catches `PermissionError` and returns `GateResult(False, ..., str(e))` with `errored` defaulting to False. So "you configured an escalate rule and no handler to answer it" arrived at every consumer as a clean policy verdict, recoverable only by reading the message text.

Reading that block turned up a second one: when `on_escalate` **is** configured and returns something other than `True` or a `dict`, control falls through to the same raise. A handler that ran and declined was reported as no handler being configured, which is false.

## What changed

`ControlUnavailableError` in `agent/gate.py`, for a control that cannot reach a verdict about the call: no handler where a decision needs one, a backend that is not reachable, a rule set that would not load.

It subclasses `PermissionError`, so everything already failing closed on that keeps doing so unchanged, including consumers outside this repo. The gate catches it ahead of `PermissionError` and sets `errored=True`.

In `permissions.py`, the escalate branch now distinguishes its three cases: approved, declined by a handler that ran (an ordinary denial, and the message says declined), and no handler at all (the fault).

`errored` gets two readers, chosen because they are the two places the distinction is actually needed:

- `run_gate_pass` logs at error level when the refusal that ends the pass came from a control that could not answer. An ordinary denial logs nothing, because an ordinary denial is the system working.
- `GateDeniedError`'s message reads `"<control> could not evaluate: ..."` rather than `"<control>: ..."`.

Nothing about failing closed changes. A fault still stops the pass, still refuses the call, and still stops later controls from running.

## Testing

13 tests, and six mutations, all detected:

| mutation | detected |
|---|---|
| gate stops recognising a declared fault (falls to the verdict arm) | yes |
| the no-handler case goes back to a plain `PermissionError` | yes |
| a handler that declined is reported as no handler configured | yes |
| the pass stops logging a fault | yes |
| the raised error stops distinguishing the two | yes |
| the fault stops subclassing `PermissionError` | yes |

The last one is the arm that matters for the compatibility claim: if `ControlUnavailableError` stopped being a `PermissionError`, a caller that only knows the base class would stop failing closed on it, and a test asserts that it does not.

`tests/agent`: green, including the two existing tests that assert on the `evaluator error` wording, which is unchanged. Full suite: see the checks.

`docs/internals/runtime.md` carries the contract.
