### PR TITLE
fix(khive): date each recalled memory and name the serving profile

### DIFF
--- a/lionagi/tools/khive_injection.py
+++ b/lionagi/tools/khive_injection.py
@@ -133,15 +133,44 @@ def _first_result_id(khive_response: Any) -> str | None:
 
 
 def _render_recall(khive_response: Any) -> str | None:
+    """Render recalled memories, each dated, under a header naming the serving
+    profile.
+
+    A bullet with no date is a claim a reader cannot place in time, and the
+    block it lands in is explicitly labelled untrusted, so an undated but
+    genuine record from a year ago reads exactly like something fabricated.
+    The date is what lets a reader weigh it; the profile is where it came
+    from. Both are already in the recall response, and neither used to be
+    carried across.
+
+    Fields are rendered when present rather than assumed: a store that does
+    not stamp a record must still produce a bullet, not a ``[None]``.
+    """
     op_result = _first_op_result(khive_response)
     if not op_result:
         return None
-    lines = ["# khive recall"]
+
+    served_by = ""
+    if isinstance(op_result, list):
+        profiles = {
+            item.get("served_by_profile_id")
+            for item in op_result
+            if isinstance(item, dict) and item.get("served_by_profile_id")
+        }
+        # One recall is served by one profile, so this is a header line rather
+        # than the same string repeated down every bullet. Rendered only when
+        # the response actually agrees on it.
+        if len(profiles) == 1:
+            served_by = f" (served by {profiles.pop()})"
+
+    lines = [f"# khive recall{served_by}"]
     for item in op_result:
-        if isinstance(item, dict):
-            lines.append(f"- {item.get('content', item)}")
-        else:
+        if not isinstance(item, dict):
             lines.append(f"- {item}")
+            continue
+        content = item.get("content", item)
+        created_at = item.get("created_at")
+        lines.append(f"- [{created_at}] {content}" if created_at else f"- {content}")
     return "\n".join(lines)
 
 

--- a/tests/tools/test_khive_injection.py
+++ b/tests/tools/test_khive_injection.py
@@ -719,3 +719,110 @@ def test_truncate_cap_semantics():
     assert _truncate("hello world", -1) == ""
     assert _truncate("", 5) == ""
     assert _truncate("hi", 10_000) == "hi"
+
+
+# ---------------------------------------------------------------------------
+# Provenance in the rendered block: a bullet a reader can date
+# ---------------------------------------------------------------------------
+
+# Captured from a live `memory.recall`, trimmed to the fields the renderer
+# reads. The dates are in the two forms the store actually returns: an
+# absolute stamp for an older record and a relative one for a recent record.
+_LIVE_RECALL_RESULT = [
+    {
+        "id": "5abc601f",
+        "content": "governance records tool preprocessors as separate local controls",
+        "created_at": "2026-07-09T21:11",
+        "memory_type": "semantic",
+        "salience": 0.9,
+        "served_by_profile_id": "lionagi-recall-v1",
+    },
+    {
+        "id": "b465f64c",
+        "content": "the scope of an identity comparison must match the scope of the binding",
+        "created_at": "20m ago",
+        "memory_type": "semantic",
+        "salience": 0.72,
+        "served_by_profile_id": "lionagi-recall-v1",
+    },
+]
+
+
+def _live_recall_response(result=None):
+    return json.dumps(
+        {
+            "results": [
+                {
+                    "ok": True,
+                    "tool": "memory.recall",
+                    "result": _LIVE_RECALL_RESULT if result is None else result,
+                }
+            ],
+            "summary": {"total": 1, "succeeded": 1, "failed": 0},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_injected_block_dates_every_bullet(patched_transport):
+    """Read the text that reaches the model, not the template that builds it.
+
+    An undated bullet inside a block labelled untrusted gives a reader no way
+    to tell a genuine year-old record from something invented, so the date has
+    to survive all the way into the injected string.
+    """
+    patched_transport.return_value = _mcp_result(_live_recall_response())
+    provider = KhiveInjectionProvider(KhiveInjectionPolicy(profile_id="lionagi-recall-v1"))
+
+    text = await provider.provide(_FakeBranch(), _FakeInstruction("do the thing"))
+
+    bullets = [line for line in text.splitlines() if line.startswith("- ")]
+    assert len(bullets) == 2, text
+    assert all(re.match(r"- \[[^\]]+\] ", line) for line in bullets), bullets
+    assert "[2026-07-09T21:11]" in text
+    assert "[20m ago]" in text
+
+
+@pytest.mark.asyncio
+async def test_injected_block_names_the_serving_profile(patched_transport):
+    patched_transport.return_value = _mcp_result(_live_recall_response())
+    provider = KhiveInjectionProvider(KhiveInjectionPolicy(profile_id="lionagi-recall-v1"))
+
+    text = await provider.provide(_FakeBranch(), _FakeInstruction("do the thing"))
+
+    assert "# khive recall (served by lionagi-recall-v1)" in text
+    assert text.count("lionagi-recall-v1") == 1, (
+        "the serving profile is one fact about the response, not one per bullet"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_record_with_no_date_still_renders(patched_transport):
+    """A store that does not stamp a record must produce a bullet, not '[None]'."""
+    patched_transport.return_value = _mcp_result(
+        _live_recall_response([{"id": "x", "content": "undated lesson"}])
+    )
+    provider = KhiveInjectionProvider(KhiveInjectionPolicy(profile_id="lionagi-recall-v1"))
+
+    text = await provider.provide(_FakeBranch(), _FakeInstruction("do the thing"))
+
+    assert "- undated lesson" in text
+    assert "None" not in text
+
+
+@pytest.mark.asyncio
+async def test_no_profile_header_when_the_response_does_not_agree_on_one(patched_transport):
+    patched_transport.return_value = _mcp_result(
+        _live_recall_response(
+            [
+                {"id": "a", "content": "one", "served_by_profile_id": "p1"},
+                {"id": "b", "content": "two", "served_by_profile_id": "p2"},
+            ]
+        )
+    )
+    provider = KhiveInjectionProvider(KhiveInjectionPolicy(profile_id="lionagi-recall-v1"))
+
+    text = await provider.provide(_FakeBranch(), _FakeInstruction("do the thing"))
+
+    assert "# khive recall\n" in text
+    assert "served by" not in text


### PR DESCRIPTION
## Why

The khive recall block injected into an agent's prompt rendered one bullet per memory and nothing else:

```python
lines.append(f"- {item.get('content', item)}")
```

That block is deliberately wrapped as untrusted context, and correctly so. But an undated bullet inside a block labelled untrusted gives the reader no way to tell a genuine record written a year ago from something invented, so a true old memory reads as suspect. The safety half was already right; the provenance half was missing.

`created_at` and `served_by_profile_id` are both in the recall response already. Neither was carried across.

## What changed

```
# khive recall (served by lionagi-recall-v1)
- [2026-07-09T21:11] governance records tool preprocessors as separate local controls
- [20m ago] the scope of an identity comparison must match the scope of the binding
```

The date goes on each bullet, since it varies per record. The serving profile goes in the header, because one recall is served by one profile and repeating the same string down every bullet spends tokens in every injected prompt to say one thing. If a response does not agree on a single profile, the header omits it rather than picking one.

Both are rendered only when present. A store that does not stamp a record produces `- content`, never `- [None] content`.

## Verified at the rendered text, not at the template

The failure mode for a change like this is a template edit that never reaches what the model is handed, so the tests read the output of `provide()` — the full injected string, wrapper and all — rather than the renderer.

The fixture is a response captured from a live `memory.recall`, trimmed to the fields the renderer reads and kept in the two date forms the store actually returns: an absolute stamp for an older record and a relative one for a recent one. A hand-written fixture here would have agreed with my idea of the response shape by construction.

## Testing

Four tests added to the existing suite, and five mutations, all detected:

| mutation | detected |
|---|---|
| drop the date from the bullet | yes |
| render the date unconditionally, so a missing one prints `None` | yes |
| drop the serving-profile header | yes |
| repeat the profile on every bullet instead of the header | yes |
| name a profile even when the response does not agree on one | yes |

`tests/tools/test_khive_injection.py` plus the two agent-side wiring suites: 59 passed. Full suite: see the checks.

One local note so nobody chases it. Running the whole suite under xdist on this machine crashes a worker in `tests/agent/test_factory.py`, a different test in the `forward_mcp` family each run. It reproduces on a detached checkout of clean main in the same worktree and the same virtualenv, so it is a property of this machine rather than of this change. Local docling failures likewise.
