### PR TITLE
fix(state): the threshold-metric comment claimed an invariant the code does not hold

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -3925,8 +3925,15 @@ class StateDB:
 
     # Threshold-alert metrics (studio-wide, not scoped to a single schedule's
     # own runs -- unlike sum_schedule_spend above, which sums a single
-    # schedule's spawned sessions). Keys must match
-    # lionagi.studio.scheduler.threshold.VALID_METRICS.
+    # schedule's spawned sessions).
+    #
+    # The members of lionagi.studio.scheduler.threshold.VALID_METRICS that one
+    # aggregate query answers, which is not all of them: p95_latency_ms needs a
+    # sorted sample (SQLite has no percentile function) and
+    # github_poll_healthy_age_minutes is a point-in-time gauge, so both are
+    # served by their own branches in metric_value below. The invariant is that
+    # every VALID_METRICS member is answered somewhere in metric_value, not
+    # that it is answered here.
     _THRESHOLD_METRIC_QUERIES: dict[str, str] = {
         "failed_sessions": (
             "SELECT COUNT(*) AS n FROM sessions "

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -1058,3 +1058,39 @@ async def test_schedule_round_trips_threshold_config_and_last_alert_at():
     assert row["last_alert_at"] == 123.0
 
     await state.close()
+
+
+# ---------------------------------------------------------------------------
+# VALID_METRICS and _THRESHOLD_METRIC_QUERIES, named in one place
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_valid_metric_is_answered_by_metric_value():
+    """A metric the scheduler accepts but the store cannot answer is a config
+    that validates and then raises at alert time, which is the worst moment.
+
+    Each metric already has its own test, but nothing named both symbols
+    together, so the two sets could drift apart: adding a member to
+    VALID_METRICS without a query or a branch broke nothing until a schedule
+    used it.
+    """
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.threshold import VALID_METRICS
+
+    state = StateDB(":memory:")
+    await state.open()
+    try:
+        for metric in sorted(VALID_METRICS):
+            assert isinstance(await state.metric_value(metric, window_start=0.0), float), metric
+    finally:
+        await state.close()
+
+
+def test_threshold_metric_queries_serve_only_metrics_the_scheduler_accepts():
+    """The other direction. A keyed query for a metric validate_threshold_config
+    rejects is dead code that reads as a supported feature."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.threshold import VALID_METRICS
+
+    assert set(StateDB._THRESHOLD_METRIC_QUERIES) <= VALID_METRICS


### PR DESCRIPTION
## Why

`_THRESHOLD_METRIC_QUERIES` in `lionagi/state/db.py` carried this:

```
# Keys must match lionagi.studio.scheduler.threshold.VALID_METRICS.
```

The dict has three keys. `VALID_METRICS` has five. A reader auditing the stated
invariant concludes two metrics are unserved and goes looking for the bug.

There is no bug. `p95_latency_ms` needs a sorted sample because SQLite has no
percentile function, and `github_poll_healthy_age_minutes` is a point-in-time
gauge rather than a `[window_start, now)` aggregate. Both have their own branches
in `metric_value` directly above the dict lookup. The code was right and the
sentence describing it was wrong, which is the more expensive of the two.

## What changed

The comment now states the invariant that actually holds, which is
one-directional: every `VALID_METRICS` member is answered somewhere in
`metric_value`, not necessarily by a query in this dict. It names the two
exceptions and why each one is an exception.

## The part that keeps it fixed

Every metric already had its own test. No test named both symbols, so nothing
tied the two sets together and they could drift apart silently. A member added to
`VALID_METRICS` with neither a query nor a branch passes config validation and
then raises `Unknown threshold metric` at alert time, which is the worst moment
to find out.

Two tests, one per direction:

- every `VALID_METRICS` member is answerable by `metric_value` against a real
  in-memory store
- the query dict serves only metrics `validate_threshold_config` accepts, so a
  keyed query cannot become dead code that reads as a supported feature

## Testing

Three mutations, each detected by the arm meant for it:

| mutation | detected by |
|---|---|
| add a member to `VALID_METRICS` with no query and no branch | every-metric-answerable |
| delete a served metric's query from the dict | every-metric-answerable |
| key a query on a metric the scheduler rejects | queries-serve-only-accepted |

`tests/studio/` and `tests/state/` both green.
