### PR TITLE
fix(operator): a resumed provider session must follow what ran, not what was pinned

### DIFF
--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -289,7 +289,6 @@ class OperatorCoordinator:
                     await asyncio.sleep(0.05)
 
             conversation_row = await self.store.get_conversation(conversation_id)
-            resumed_session_id = conversation_row.get("providerSessionId")
             selected_provider = conversation_row.get("provider")
             selected_model = conversation_row.get("providerModel")
             selected_effort = turn_row.get("effort")
@@ -301,12 +300,28 @@ class OperatorCoordinator:
                 history=compiled.frames,
                 request_permission=request_permission,
                 store_path=str(self.store.path()),
-                provider_session_id=(
-                    resumed_session_id if isinstance(resumed_session_id, str) else None
-                ),
+                # Filled in below, once the store has said whether the session
+                # still belongs to what this turn is about to run on.
+                provider_session_id=None,
                 provider=selected_provider if isinstance(selected_provider, str) else None,
                 model=selected_model if isinstance(selected_model, str) else None,
                 effort=selected_effort if isinstance(selected_effort, str) else None,
+            )
+            # Resolve once, here, and hand the same pair to the store, the
+            # branch and the manifest. The environment is re-read on every
+            # resolution, so two calls a few lines apart are two chances to
+            # disagree about what ran.
+            resolved_provider, resolved_model = resolve_operator_provider_model(engine_turn)
+            resumed_session_id = await self.store.claim_resolved_pair(
+                conversation_id,
+                provider=resolved_provider,
+                model=resolved_model,
+            )
+            engine_turn = replace(
+                engine_turn,
+                provider_session_id=(
+                    resumed_session_id if isinstance(resumed_session_id, str) else None
+                ),
             )
             run_branch = build_operator_branch(engine_turn)
             engine_turn = replace(engine_turn, runtime_branch=run_branch)
@@ -321,10 +336,6 @@ class OperatorCoordinator:
             run_dir.ensure_state_dirs()
             run_dir.ensure_artifact_root()
             started_at = time.time()
-            # Same resolution build_operator_branch already applied to the Branch
-            # itself, so the manifest and persisted run record never disagree with
-            # what actually ran.
-            resolved_provider, resolved_model = resolve_operator_provider_model(engine_turn)
             run_dir.write_manifest(
                 {
                     "kind": "agent",

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -47,6 +47,13 @@ CREATE TABLE IF NOT EXISTS studio_operator_conversations (
   -- Provider the conversation is currently pinned to; NULL means "use the
   -- env-var default" (see build_operator_branch), same as provider_model.
   provider            TEXT,
+  -- What the last turn actually ran on, which is not the same fact as the pin
+  -- above: an unpinned conversation has no pin and still ran on whatever the
+  -- environment resolved to. The provider session belongs to this pair, so
+  -- this is the pair the resume path compares against. NULL means no turn has
+  -- recorded a resolution yet, which is not the same as "it changed".
+  resolved_provider   TEXT,
+  resolved_model      TEXT,
   pinned             INTEGER NOT NULL DEFAULT 0,
   created_at         REAL NOT NULL,
   updated_at         REAL NOT NULL,
@@ -206,6 +213,8 @@ class OperatorStore:
                         "provider_session_id": "TEXT",
                         "provider_model": "TEXT",
                         "provider": "TEXT",
+                        "resolved_provider": "TEXT",
+                        "resolved_model": "TEXT",
                         "pinned": "INTEGER NOT NULL DEFAULT 0",
                     },
                 )
@@ -294,6 +303,11 @@ class OperatorStore:
             "providerSessionId": row["provider_session_id"],
             "providerModel": row["provider_model"],
             "provider": row["provider"],
+            # Served beside the pin because a session that resets has to be
+            # explainable: without these, "my conversation started over" has no
+            # visible cause anywhere in the UI or the API.
+            "resolvedProvider": row["resolved_provider"],
+            "resolvedModel": row["resolved_model"],
             "createdAt": row["created_at"],
             "updatedAt": row["updated_at"],
         }
@@ -647,6 +661,69 @@ class OperatorStore:
                 (session_id, time.time(), conversation_id),
             )
             await db.commit()
+
+    async def claim_resolved_pair(
+        self,
+        conversation_id: str,
+        *,
+        provider: str,
+        model: str,
+    ) -> str | None:
+        """Record what this turn will run on and return the session it may resume.
+
+        A provider session belongs to the (provider, model) pair that created
+        it, and until now the only thing that could invalidate one was an
+        explicit pin change. An unpinned conversation has no pin to change: it
+        runs on whatever the environment resolves to, which is re-read every
+        turn, so moving the default silently resumed a session that belonged to
+        the old pair. This compares the pair that is about to run against the
+        pair that last ran, which is the comparison the pin check could never
+        make.
+
+        Returns the session id to resume with, or ``None`` when the pair moved
+        and the stored session no longer belongs to this turn.
+
+        A stored pair of ``NULL`` returns the session unchanged. It means no
+        turn has recorded a resolution yet, which is not evidence that anything
+        changed, and every conversation alive when this ships is in exactly
+        that state -- reading it as a mismatch would drop every live session
+        once, at upgrade, and would look like the check working.
+        """
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT provider_session_id, resolved_provider, resolved_model "
+                    "FROM studio_operator_conversations WHERE id = ?",
+                    (conversation_id,),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
+            session_id = row["provider_session_id"]
+            known = row["resolved_provider"] is not None
+            moved = known and (row["resolved_provider"], row["resolved_model"]) != (
+                provider,
+                model,
+            )
+            if moved:
+                await db.execute(
+                    "UPDATE studio_operator_conversations "
+                    "SET resolved_provider = ?, resolved_model = ?, "
+                    "provider_session_id = NULL, updated_at = ? WHERE id = ?",
+                    (provider, model, time.time(), conversation_id),
+                )
+            else:
+                await db.execute(
+                    "UPDATE studio_operator_conversations "
+                    "SET resolved_provider = ?, resolved_model = ?, updated_at = ? "
+                    "WHERE id = ?",
+                    (provider, model, time.time(), conversation_id),
+                )
+            await db.commit()
+        return None if moved else session_id
 
     @staticmethod
     async def _write_selection(

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -1049,6 +1049,12 @@ async def test_a_conversation_that_predates_this_check_keeps_its_session(tmp_pat
     Every conversation alive when this ships is in that state, so reading NULL
     as a mismatch would drop every live session once, at upgrade, and would look
     like the check working.
+
+    The grace is one turn wide, and that is what the last assertion is for. The
+    same call records the resolution it just let through, so the conversation is
+    governed from its next turn onward. Without that write the exemption would
+    never end, and the conversations it exempted permanently would be exactly the
+    long-lived ones this check exists for.
     """
     store = OperatorStore(tmp_path / "state.db")
     cid = (await store.create_conversation())["id"]
@@ -1058,7 +1064,14 @@ async def test_a_conversation_that_predates_this_check_keeps_its_session(tmp_pat
     kept = await store.claim_resolved_pair(cid, provider="claude_code", model="sonnet")
 
     assert kept == "session-from-before"
-    assert (await store.get_conversation(cid))["providerSessionId"] == "session-from-before"
+    conversation = await store.get_conversation(cid)
+    assert conversation["providerSessionId"] == "session-from-before"
+    assert (conversation["resolvedProvider"], conversation["resolvedModel"]) == (
+        "claude_code",
+        "sonnet",
+    )
+    # Governed from here: the next turn on a different pair drops the session.
+    assert await store.claim_resolved_pair(cid, provider="claude_code", model="opus") is None
 
 
 @pytest.mark.asyncio

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -936,3 +936,151 @@ async def test_a_refused_selection_does_not_move_the_pin_through_the_coordinator
     assert conversation["provider"] == "codex"
     assert conversation["providerModel"] == "gpt-5.4"
     assert conversation["providerSessionId"] == "session-1"
+
+
+# ── a provider session belongs to what ran, not to what was pinned ──────────
+
+
+class _CapturingEngine:
+    """Records the turn it is handed instead of streaming it.
+
+    The built-in engine reads provider and model off the Branch, so whether a
+    resume was passed is only observable from the turn itself.
+    """
+
+    captured: list = []
+
+    async def _stream(self, turn):
+        type(self).captured.append(turn)
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
+async def _run_one_turn(coordinator, cid: str, *, expect: int):
+    import asyncio
+
+    before = len(_CapturingEngine.captured)
+    await coordinator.submit(
+        cid,
+        instruction="go",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=expect,
+    )
+    for _ in range(200):
+        if len(_CapturingEngine.captured) > before:
+            break
+        await asyncio.sleep(0.02)
+    assert len(_CapturingEngine.captured) > before, "the engine was never handed a turn"
+    return _CapturingEngine.captured[-1]
+
+
+@pytest.mark.asyncio
+async def test_an_unpinned_conversation_stops_resuming_when_the_default_model_moves(
+    tmp_path, monkeypatch
+):
+    """The case the pin check could never see.
+
+    An unpinned conversation has no pin to change, so nothing used to compare
+    anything: it ran on whatever the environment resolved to, kept the session
+    that pair produced, and resumed it under a different pair after the default
+    moved.
+    """
+    _CapturingEngine.captured = []
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet")
+
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=_CapturingEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="Unpinned"))["conversation"]["id"]
+
+    await _run_one_turn(coordinator, cid, expect=0)
+    conversation = await coordinator.store.get_conversation(cid)
+    # The conversation is genuinely unpinned, which is the whole premise: if a
+    # pin were set the existing check would already cover this.
+    assert conversation["providerModel"] is None
+    assert conversation["resolvedModel"] == "sonnet"
+    await coordinator.store.set_provider_session_id(cid, "session-from-sonnet")
+
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_MODEL", "opus")
+    turn = await _run_one_turn(
+        coordinator, cid, expect=(await coordinator.store.get_conversation(cid))["nextSequence"] - 1
+    )
+
+    assert turn.provider_session_id is None
+    assert (await coordinator.store.get_conversation(cid))["resolvedModel"] == "opus"
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_an_unpinned_conversation_keeps_resuming_while_the_default_holds_still(
+    tmp_path, monkeypatch
+):
+    """The over-firing arm. A check that drops the session every turn also
+    passes the test above, and it would silently end resuming for everyone."""
+    _CapturingEngine.captured = []
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_MODEL", "sonnet")
+
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=_CapturingEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="Steady"))["conversation"]["id"]
+
+    await _run_one_turn(coordinator, cid, expect=0)
+    await coordinator.store.set_provider_session_id(cid, "session-from-sonnet")
+
+    turn = await _run_one_turn(
+        coordinator, cid, expect=(await coordinator.store.get_conversation(cid))["nextSequence"] - 1
+    )
+
+    assert turn.provider_session_id == "session-from-sonnet"
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_a_conversation_that_predates_this_check_keeps_its_session(tmp_path):
+    """A stored resolution of NULL means no turn ever recorded one, which is not
+    evidence that anything changed.
+
+    Every conversation alive when this ships is in that state, so reading NULL
+    as a mismatch would drop every live session once, at upgrade, and would look
+    like the check working.
+    """
+    store = OperatorStore(tmp_path / "state.db")
+    cid = (await store.create_conversation())["id"]
+    await store.set_provider_session_id(cid, "session-from-before")
+    assert (await store.get_conversation(cid))["resolvedModel"] is None
+
+    kept = await store.claim_resolved_pair(cid, provider="claude_code", model="sonnet")
+
+    assert kept == "session-from-before"
+    assert (await store.get_conversation(cid))["providerSessionId"] == "session-from-before"
+
+
+@pytest.mark.asyncio
+async def test_the_resolved_columns_are_added_to_a_preexisting_store(tmp_path):
+    """Same additive-migration contract the provider and effort columns carry."""
+    import aiosqlite
+
+    db_path = tmp_path / "state.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "CREATE TABLE studio_operator_conversations ("
+            "id TEXT PRIMARY KEY, project TEXT, title TEXT, "
+            "status TEXT NOT NULL DEFAULT 'active', "
+            "next_sequence INTEGER NOT NULL DEFAULT 1, active_request_id TEXT, "
+            "created_at REAL NOT NULL, updated_at REAL NOT NULL, "
+            "archived_at REAL, deleted_at REAL)"
+        )
+        await db.commit()
+
+    store = OperatorStore(db_path)
+    cid = (await store.create_conversation())["id"]
+    assert await store.claim_resolved_pair(cid, provider="codex", model="gpt-5.3-codex") is None
+    conversation = await store.get_conversation(cid)
+    assert conversation["resolvedProvider"] == "codex"
+    assert conversation["resolvedModel"] == "gpt-5.3-codex"

--- a/tests/apps_studio_server/test_operator_model_catalog.py
+++ b/tests/apps_studio_server/test_operator_model_catalog.py
@@ -959,21 +959,37 @@ class _CapturingEngine:
         return self._stream(turn)
 
 
-async def _run_one_turn(coordinator, cid: str, *, expect: int):
+async def _run_one_turn(coordinator, cid: str):
+    """Submit one turn and return only once that turn has finished.
+
+    Both halves matter. The cursor is read here rather than by the caller
+    because a turn's own completion writes bump ``nextSequence``, so a cursor
+    read while a turn is still running is already stale by the time the next
+    submit checks it. And waiting for ``activeRequestId`` to clear is what makes
+    the read at the top of the next call safe: being handed to the engine is the
+    middle of a turn, not the end of one.
+    """
     import asyncio
 
+    conversation = await coordinator.store.get_conversation(cid)
     before = len(_CapturingEngine.captured)
     await coordinator.submit(
         cid,
         instruction="go",
         context={"space": "mission", "route": "/", "filters": {}},
-        expected_last_sequence=expect,
+        expected_last_sequence=int(conversation["nextSequence"]) - 1,
     )
     for _ in range(200):
         if len(_CapturingEngine.captured) > before:
             break
         await asyncio.sleep(0.02)
     assert len(_CapturingEngine.captured) > before, "the engine was never handed a turn"
+    for _ in range(400):
+        conversation = await coordinator.store.get_conversation(cid)
+        if conversation["activeRequestId"] is None:
+            break
+        await asyncio.sleep(0.02)
+    assert conversation["activeRequestId"] is None, "the turn never finished"
     return _CapturingEngine.captured[-1]
 
 
@@ -997,7 +1013,7 @@ async def test_an_unpinned_conversation_stops_resuming_when_the_default_model_mo
     await coordinator.startup()
     cid = (await coordinator.create_conversation(title="Unpinned"))["conversation"]["id"]
 
-    await _run_one_turn(coordinator, cid, expect=0)
+    await _run_one_turn(coordinator, cid)
     conversation = await coordinator.store.get_conversation(cid)
     # The conversation is genuinely unpinned, which is the whole premise: if a
     # pin were set the existing check would already cover this.
@@ -1006,9 +1022,7 @@ async def test_an_unpinned_conversation_stops_resuming_when_the_default_model_mo
     await coordinator.store.set_provider_session_id(cid, "session-from-sonnet")
 
     monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_MODEL", "opus")
-    turn = await _run_one_turn(
-        coordinator, cid, expect=(await coordinator.store.get_conversation(cid))["nextSequence"] - 1
-    )
+    turn = await _run_one_turn(coordinator, cid)
 
     assert turn.provider_session_id is None
     assert (await coordinator.store.get_conversation(cid))["resolvedModel"] == "opus"
@@ -1030,12 +1044,10 @@ async def test_an_unpinned_conversation_keeps_resuming_while_the_default_holds_s
     await coordinator.startup()
     cid = (await coordinator.create_conversation(title="Steady"))["conversation"]["id"]
 
-    await _run_one_turn(coordinator, cid, expect=0)
+    await _run_one_turn(coordinator, cid)
     await coordinator.store.set_provider_session_id(cid, "session-from-sonnet")
 
-    turn = await _run_one_turn(
-        coordinator, cid, expect=(await coordinator.store.get_conversation(cid))["nextSequence"] - 1
-    )
+    turn = await _run_one_turn(coordinator, cid)
 
     assert turn.provider_session_id == "session-from-sonnet"
     await coordinator.shutdown()


### PR DESCRIPTION
## Why

A provider session belongs to the `(provider, model)` pair that created it, and
resuming one under a different pair is undefined. The store knew that: changing a
conversation's pin drops the session.

An unpinned conversation has no pin to change. It runs on whatever
`LIONAGI_STUDIO_OPERATOR_PROVIDER` and `LIONAGI_STUDIO_OPERATOR_MODEL` resolve
to, those are re-read on every turn, and the frontend sends a model only when the
user actually picked one. The invalidation runs only when a caller supplied a
selection, so on that path it was not a weak check, it was never invoked. Move
the default between two turns and the second turn resumed a session belonging to
the old pair, with nothing comparing anything and nothing to see afterwards.

The root is a category slip. The row recorded the **request**, a pin that may be
absent. The session belongs to the **resolution**, what actually ran. The
coordinator already computed the resolved pair for the run manifest and threw it
away.

## What changed

Two columns, `resolved_provider` and `resolved_model`, record what the last turn
ran on. They sit **beside** the pin rather than replacing it: the pin is what the
user asked for, the resolution is what happened, and the API already serves the
pin.

The resume path claims that pair in one transaction before the session id ever
reaches the branch. Same pair, resume as before. Different pair, drop the session
and start fresh.

Both values are served beside the pin, because a conversation that quietly starts
over needs a visible cause.

## The arm that looks wrong and is load-bearing

A stored pair of `NULL` returns the session **unchanged**.

`NULL` means no turn has recorded a resolution yet. That is not evidence that
anything changed, and every conversation alive when this ships is in exactly that
state. Reading `NULL` as a mismatch would drop every live session once, at
upgrade, and it would look like the check working.

The grace is one turn wide. The same call records the resolution it just let
through, so the conversation is governed from its next turn onward. Without that
write the exemption would never end, and the conversations it exempted forever
would be exactly the long-lived ones the check exists for. That is the difference
between a grace and a hole, so it is asserted rather than described.

## Also

The resolution is computed once and handed to the store, the branch and the
manifest, instead of twice a few lines apart with the environment re-read in
between.

Deliberately not addressed: the final turn record resolves the pair a third time,
so an environment change *during* a turn can still make the recorded model
disagree with what ran. Pre-existing and separate.

Not closed, and stated rather than left implicit: the comparison is string
equality on a model name, so an alias whose upstream target moves under a fixed
string stays invisible. Nothing local can see that.

## Testing

Four tests, five mutations, each caught by the arm meant for it:

| mutation | caught by |
|---|---|
| return the stored session unconditionally | default moves, session must be dropped |
| treat a `NULL` stored pair as a mismatch | a conversation from before this check keeps its session |
| always clear the session | default holds still, session must survive |
| coordinator ignores what the store returned | default holds still, session must survive |
| stop recording on the let-through path, so the grace never ends | a conversation from before this check keeps its session |

The over-firing arm matters as much as the under-firing one: a check that drops
the session every turn passes the headline test and silently ends resuming for
everybody.

`tests/apps_studio_server/` and `tests/studio/` both green.
