### PR TITLE
fix(state): share one sqlite busy_timeout between both connection layers

### DIFF
--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -17,9 +17,11 @@ from lionagi._paths import LIONAGI_HOME
 
 _log = logging.getLogger(__name__)
 
-# sqlite busy_timeout (ms) applied to every connection; kept low so tests that
-# deliberately hold a write lock fail fast instead of waiting the full default.
-_SQLITE_BUSY_TIMEOUT_MS = 5000
+# sqlite busy_timeout (ms) applied to every connection this process opens against
+# the store, whether through this engine or through the Studio connection helper;
+# kept low so tests that deliberately hold a write lock fail fast instead of
+# waiting the full default.
+SQLITE_BUSY_TIMEOUT_MS = 5000
 
 
 def has_wal_reset_fix(version_info: tuple[int, ...]) -> bool:
@@ -149,7 +151,7 @@ def make_engine(url: str, **overrides):
 
         def _apply_pragmas(dbapi_conn, _connection_record):
             cursor = dbapi_conn.cursor()
-            cursor.execute(f"PRAGMA busy_timeout = {_SQLITE_BUSY_TIMEOUT_MS}")
+            cursor.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
             cursor.execute("PRAGMA journal_mode = WAL")
             cursor.execute("PRAGMA synchronous = NORMAL")
             cursor.execute("PRAGMA foreign_keys = ON")
@@ -214,7 +216,7 @@ def make_readonly_engine(url: str, **overrides):
 
     def _apply_readonly_pragmas(dbapi_conn, _connection_record):
         cursor = dbapi_conn.cursor()
-        cursor.execute(f"PRAGMA busy_timeout = {_SQLITE_BUSY_TIMEOUT_MS}")
+        cursor.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
         cursor.execute("PRAGMA query_only = 1")
         cursor.close()
 

--- a/lionagi/studio/services/_db.py
+++ b/lionagi/studio/services/_db.py
@@ -9,6 +9,8 @@ from contextlib import asynccontextmanager
 
 import aiosqlite
 
+from lionagi.state.engine import SQLITE_BUSY_TIMEOUT_MS
+
 _log = logging.getLogger(__name__)
 
 _ACTIVE_CONNECTIONS: int = 0
@@ -20,14 +22,19 @@ def get_active_connection_count() -> int:
 
 @asynccontextmanager
 async def open_db(path: str) -> AsyncIterator[aiosqlite.Connection]:
-    """Studio-local SQLite connection with WAL mode and busy_timeout=5000ms,
-    preventing "database is locked" errors under modest concurrency."""
+    """Studio-local SQLite connection with WAL mode and a busy timeout,
+    preventing "database is locked" errors under modest concurrency.
+
+    The timeout is the same value the StateDB engine applies, imported rather
+    than restated: these are two connection layers onto one store file, and a
+    lock wait that differs between them is a difference nobody chose.
+    """
     global _ACTIVE_CONNECTIONS
     async with aiosqlite.connect(path) as db:
         _ACTIVE_CONNECTIONS += 1
         try:
             await db.execute("PRAGMA journal_mode = WAL")
-            await db.execute("PRAGMA busy_timeout = 5000")
+            await db.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
             await db.execute("PRAGMA foreign_keys = ON")
             db.row_factory = aiosqlite.Row
             yield db

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -139,8 +139,8 @@ async def store_probe(*, timeout_ms: int = STORE_PROBE_TIMEOUT_MS) -> dict[str, 
             conn = aiosqlite.connect(str(DEFAULT_DB_PATH))
             db = await conn
         with move_on_after(timeout_ms / 1000) as scope:
-            # The shared connection helper waits 5s on a lock, which would
-            # outlast this probe's own deadline; the probe would rather
+            # The shared busy timeout is longer than this probe's own deadline,
+            # so waiting it out would outlast the answer; the probe would rather
             # report "slow" than sit in SQLite's retry loop.
             await db.execute(f"PRAGMA busy_timeout = {timeout_ms}")
             cur = await db.execute(_STORE_PROBE_SQL)

--- a/tests/apps_studio_server/test_admin_maintenance_api.py
+++ b/tests/apps_studio_server/test_admin_maintenance_api.py
@@ -320,7 +320,7 @@ def test_maintenance_lock_contention_returns_409(tmp_path, monkeypatch, action):
 
     # Shorten the per-connection busy_timeout so the contended open/write fails
     # fast (every pooled connection reads this at connect time).
-    monkeypatch.setattr(engine_mod, "_SQLITE_BUSY_TIMEOUT_MS", 100)
+    monkeypatch.setattr(engine_mod, "SQLITE_BUSY_TIMEOUT_MS", 100)
 
     # Hold an exclusive write lock with a raw sqlite3 connection.
     lock_conn = sqlite3.connect(str(db_path), timeout=0)

--- a/tests/apps_studio_server/test_db_helper_batch2.py
+++ b/tests/apps_studio_server/test_db_helper_batch2.py
@@ -36,7 +36,8 @@ class TestOpenDb:
 
     @pytest.mark.integration
     def test_open_db_sets_busy_timeout(self, tmp_path):
-        """open_db() must set busy_timeout = 5000 ms."""
+        """open_db() must set a busy_timeout, and the shared one."""
+        from lionagi.state.engine import SQLITE_BUSY_TIMEOUT_MS
         from lionagi.studio.services._db import open_db
 
         db_path = str(tmp_path / "test.db")
@@ -48,7 +49,42 @@ class TestOpenDb:
             return row[0]
 
         timeout = _run(_check())
-        assert timeout == 5000, f"Expected busy_timeout=5000, got {timeout!r}"
+        assert timeout == SQLITE_BUSY_TIMEOUT_MS, (
+            f"Expected busy_timeout={SQLITE_BUSY_TIMEOUT_MS}, got {timeout!r}"
+        )
+
+    @pytest.mark.integration
+    def test_open_db_waits_as_long_as_the_state_engine_does(self, tmp_path):
+        """The two connection layers onto one store file must wait the same time
+        on a lock.
+
+        Asserted between two live connections rather than against the constant,
+        so that re-hardcoding a number in either layer fails here even if it
+        happens to be spelled the same as the constant's current value.
+        """
+        pytest.importorskip("sqlalchemy", reason="sqlalchemy not installed")
+        from lionagi.state.engine import make_engine
+        from lionagi.studio.services._db import open_db
+
+        db_path = tmp_path / "test.db"
+
+        async def _check():
+            async with open_db(str(db_path)) as db:
+                cur = await db.execute("PRAGMA busy_timeout")
+                helper_value = (await cur.fetchone())[0]
+            engine = make_engine(f"sqlite+aiosqlite:///{db_path}")
+            try:
+                async with engine.connect() as conn:
+                    result = await conn.exec_driver_sql("PRAGMA busy_timeout")
+                    engine_value = result.scalar()
+            finally:
+                await engine.dispose()
+            return helper_value, engine_value
+
+        helper_value, engine_value = _run(_check())
+        assert helper_value == engine_value, (
+            f"Studio helper waits {helper_value}ms, StateDB engine waits {engine_value}ms"
+        )
 
     @pytest.mark.integration
     def test_open_db_sets_row_factory(self, tmp_path):

--- a/tests/state/test_check_rebuild_concurrency.py
+++ b/tests/state/test_check_rebuild_concurrency.py
@@ -117,7 +117,7 @@ def _open_state_db_worker_synchronized_begin(
     # A shorter-than-production busy_timeout makes lock contention surface
     # as an OperationalError within this test's patience instead of quietly
     # blocking it out. Tuned to 500ms (vs. production's 5000ms default,
-    # engine.py:_SQLITE_BUSY_TIMEOUT_MS): low enough that the barrier-forced
+    # engine.py:SQLITE_BUSY_TIMEOUT_MS): low enough that the barrier-forced
     # pileup on the sessions rebuild's write lock can still exceed it under
     # load, but high enough to stay clear of a separate, pre-existing
     # SQLite characteristic — a bare SELECT against sqlite_master can itself
@@ -128,7 +128,7 @@ def _open_state_db_worker_synchronized_begin(
     # (this fix only guards the mutations); at very aggressive timeouts it
     # was observed to fail the harness on those unrelated reads rather than
     # on the write path this test targets.
-    state_engine_module._SQLITE_BUSY_TIMEOUT_MS = 500
+    state_engine_module.SQLITE_BUSY_TIMEOUT_MS = 500
 
     original_make_engine = state_db_module.make_engine
 
@@ -180,7 +180,7 @@ def test_concurrent_statedb_opens_rebuild_session_status_check(tmp_path: Path) -
     another process winning the rebuild race instead of crashing.
 
     Against the unguarded rebuild (no catch-and-reinspect guard), lowering
-    ``_SQLITE_BUSY_TIMEOUT_MS`` far enough (~50ms, well below this test's
+    ``SQLITE_BUSY_TIMEOUT_MS`` far enough (~50ms, well below this test's
     500ms) reliably reproduces the bug this fix closes: N processes racing
     the same DROP/CREATE/INSERT/RENAME transaction see a loser surface an
     OperationalError that isn't caught, failing that worker's whole


### PR DESCRIPTION
## Why

Two layers open SQLite connections onto the same store file. The StateDB engine
applies its pragmas through a `connect` listener; the Studio services share a
small `open_db` helper. Both set `busy_timeout`, one from a named constant and
one from a literal that happened to be spelled the same way.

They agreed by coincidence. Nothing tied them together, so an edit to either
would have moved one layer's lock wait and left the other where it was, and the
symptom of that is a "database is locked" error appearing on one code path and
not another for reasons no reader can see from either file.

## What changed

The constant is public and the helper imports it. That is the whole behaviour
change: the value is unchanged at 5000ms.

## What is deliberately not changed

The two layers also differ on `synchronous` (the engine sets NORMAL, the helper
leaves the default), and the engine alone sets `cache_size` and
`wal_autocheckpoint`. Those are not the same kind of difference.

`synchronous = NORMAL` under WAL is a durability-against-write-cost trade, not a
defect, and it is the deliberate choice for a store that ingests continuously.
Reading the difference as drift and "harmonizing" it upward would tax every
commit to close a hazard nobody has measured. Making these agree needs a written
intent for what this store should promise, which is a sentence someone decides
on, not a cleanup. So the constant is shared now and the semantics are left
where they are.

The surviving hazard is not addressed here and should be said plainly: there are
still two connection layers, and the next writer inherits whichever one they
happen to touch.

## Testing

The cross-layer test opens a live connection from each layer and compares what
each one reports, rather than comparing either against the constant. A test that
asserted `== SQLITE_BUSY_TIMEOUT_MS` on one layer would pass while the other
layer sat on a stale literal that no longer matched.

Mutation: restore the literal in the helper and move the constant to 4000. Both
arms fail, with the message naming both values (`Studio helper waits 5000ms,
StateDB engine waits 4000ms`). Restored by writing back the bytes read before
the mutation, and the suite is green again after.

`tests/state`, `tests/studio`, `tests/apps_studio_server`: 3075 passed.
