### PR TITLE
fix(studio): record what a WAL checkpoint actually drained

### DIFF
--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1717,6 +1717,11 @@ export interface MaintenanceResult {
   busy?: number | null;
   log_pages?: number | null;
   checkpointed?: number | null;
+  // How much WAL the checkpoint was asked to drain and how long it took. The
+  // three counters above read zero on every successful TRUNCATE regardless of
+  // size, so they cannot separate a long drain from an idle one.
+  wal_bytes_before?: number | null;
+  elapsed_ms?: number | null;
   // prune
   sessions_pruned?: number;
   runs_pruned?: number;

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -13,7 +13,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from lionagi._errors import LionError
-from lionagi.state.db import StateDB, state_db_known_absent
+from lionagi.state.db import StateDB, state_db_file, state_db_known_absent
 
 _log = logging.getLogger(__name__)
 
@@ -114,25 +114,78 @@ def _session_retention_predicate(cutoff: float) -> tuple[str, tuple[Any, ...]]:
     )
 
 
+def _wal_bytes_now() -> int | None:
+    """Size of the store's WAL sidecar at this moment, or None if unmeasurable.
+
+    ``None`` means the question does not apply or could not be answered: a
+    server-backed or in-memory store has no sidecar, and a file we are not
+    allowed to stat gives no size. A missing sidecar beside a real store file
+    is 0 rather than None, because that is a genuine answer: SQLite removes
+    the WAL on a clean close and on a successful TRUNCATE checkpoint, and both
+    mean there is nothing there to drain.
+    """
+    path = state_db_file()
+    if path is None:
+        return None
+    try:
+        return path.with_name(path.name + "-wal").stat().st_size
+    except FileNotFoundError:
+        return 0
+    except OSError:
+        return None
+
+
 async def checkpoint_state_db(
     mode: str = "TRUNCATE",
     *,
     actor: str = "studio_db_maintenance",
-) -> dict[str, int | None]:
+) -> dict[str, Any]:
     """Run ``PRAGMA wal_checkpoint(<mode>)`` and write an audit event.
 
-    Returns the PRAGMA result dict: busy, log_pages, checkpointed.
+    Returns the PRAGMA result (busy, log_pages, checkpointed) plus the size of
+    the WAL going in and how long the whole thing took.
+
+    Those last two are here because the PRAGMA counters cannot answer the
+    question an operator brings to this record. For TRUNCATE a successful
+    checkpoint reports busy, log_pages and checkpointed all zero by
+    definition, whether it drained one page or a hundred thousand: the frames
+    are gone and the log has been reset, so there is nothing left for the
+    counters to describe. All zeros is the success signature, not evidence
+    that there was nothing to do, and reading it as the latter is the natural
+    mistake. Four consecutive rows of zeros say only that four checkpoints
+    succeeded.
+
+    ``wal_bytes_before`` is read before the connection is opened, so it is the
+    WAL this checkpoint was actually asked to deal with rather than whatever
+    is left after opening did its own work. ``elapsed_ms`` covers opening the
+    connection as well as the PRAGMA, because a checkpoint that waits can wait
+    in either place and the split cannot be recovered from the row afterwards.
+
+    Both are bounded by the same limit: the event is written after the
+    checkpoint returns, so this records a slow checkpoint and can never record
+    a hung one. A stall that never ends leaves no row at all.
     """
     if state_db_known_absent():
-        return {"mode": mode, "busy": None, "log_pages": None, "checkpointed": None}
+        return {
+            "mode": mode,
+            "busy": None,
+            "log_pages": None,
+            "checkpointed": None,
+            "wal_bytes_before": None,
+            "elapsed_ms": None,
+        }
 
+    wal_before = _wal_bytes_now()
+    started = time.perf_counter()
     async with StateDB() as db:
         row = await db.checkpoint(mode)
-        details: dict[str, int | None] = {
+        details: dict[str, Any] = {
             "mode": mode,
             "busy": int(row[0]) if row else None,
             "log_pages": int(row[1]) if row else None,
             "checkpointed": int(row[2]) if row else None,
+            "wal_bytes_before": wal_before,
+            "elapsed_ms": round((time.perf_counter() - started) * 1000, 3),
         }
         await db.insert_admin_event(action="checkpoint", details=details, actor=actor)
 

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -526,7 +526,15 @@ def test_admin_maintenance_checkpoint_response_shape(tmp_path, monkeypatch):
 
     r = client.post("/api/admin/maintenance", json={"action": "checkpoint"})
     assert r.status_code == 200
-    assert sorted(r.json().keys()) == ["action", "busy", "checkpointed", "log_pages", "mode"]
+    assert sorted(r.json().keys()) == [
+        "action",
+        "busy",
+        "checkpointed",
+        "elapsed_ms",
+        "log_pages",
+        "mode",
+        "wal_bytes_before",
+    ]
 
 
 def test_admin_maintenance_malformed_action_422_shape(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -108,6 +108,110 @@ def test_checkpoint_missing_db_is_noop(tmp_path, monkeypatch):
     assert run_async(maint.get_last_checkpoint_at()) is None
 
 
+def test_checkpoint_result_shape_is_the_same_with_and_without_a_store(tmp_path, monkeypatch):
+    """Both return paths report the same fields.
+
+    The no-store path builds its dict by hand instead of running the PRAGMA,
+    so it is the one that silently falls behind when a field is added. It
+    reaches the admin maintenance API unchanged, and a response that drops a
+    field depending on whether the store happens to exist is a shape a caller
+    cannot rely on.
+    """
+    from lionagi.studio.services import db_maintenance as maint
+
+    _patch_db(monkeypatch, tmp_path / "absent.db")
+    absent = run_async(maint.checkpoint_state_db())
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    run_async(_make_session_in(db_path, status="running", started_at=time.time()))
+    present = run_async(maint.checkpoint_state_db(actor="test"))
+
+    assert sorted(absent) == sorted(present)
+
+
+def test_checkpoint_event_records_the_wal_size_and_the_time_it_took(tmp_path, monkeypatch):
+    """The stored row carries what the PRAGMA counters cannot say.
+
+    A TRUNCATE checkpoint that succeeds reports busy, log_pages and
+    checkpointed all zero however much it drained, so those three cannot
+    separate a long stall from an idle tick. Asserted on the admin_events row
+    rather than on the return value because the row is what an operator reads
+    afterwards; a field that was returned but never stored would satisfy a
+    return-value check and still leave the record useless.
+    """
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    run_async(_make_session_in(db_path, status="running", started_at=time.time()))
+
+    async def _grow_a_wal_then_checkpoint_it():
+        """Hold a connection open so the WAL is still there when we look.
+
+        SQLite checkpoints and removes the WAL when the last connection
+        closes, so a fixture that writes and then lets go leaves nothing
+        behind to drain and the size going in is zero however much was
+        written. Keeping this connection open is what makes the number under
+        test a real one.
+        """
+        async with StateDB() as db:
+            for i in range(200):
+                await db.insert_admin_event(
+                    action="grow", details={"i": i, "pad": "x" * 400}, actor="fixture"
+                )
+            standing = db_path.with_name(db_path.name + "-wal").stat().st_size
+            await maint.checkpoint_state_db(actor="test")
+            events = await db.list_admin_events(action="checkpoint", limit=5)
+        return standing, _details(events[0])
+
+    standing_wal, details = run_async(_grow_a_wal_then_checkpoint_it())
+
+    # The fixture is what makes this an assertion rather than a formality:
+    # if the WAL were empty the recorded size would be zero either way, and
+    # a checkpoint that never read it would pass.
+    assert standing_wal > 0
+    assert details["wal_bytes_before"] == standing_wal
+
+    # Opening a connection and running a PRAGMA is never free, so a zero here
+    # would mean the clock was never read rather than that the work was fast.
+    assert details["elapsed_ms"] > 0
+
+
+def test_wal_size_is_read_from_the_sidecar_that_is_there(tmp_path, monkeypatch):
+    """Three answers, and the difference between the two that look alike.
+
+    Zero and None both read as "no bytes to drain" at a glance and mean
+    different things: zero is a store whose WAL is genuinely empty, None is a
+    store where the question does not apply. An operator seeing None knows to
+    stop asking about the WAL; one seeing zero knows the checkpoint had
+    nothing to do.
+    """
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+
+    # Nothing beside the store yet.
+    assert maint._wal_bytes_now() == 0
+
+    # The size comes off the file, so the expected value is the number of
+    # bytes actually written rather than anything this test decided.
+    payload = b"x" * 4096
+    db_path.with_name(db_path.name + "-wal").write_bytes(payload)
+    assert maint._wal_bytes_now() == len(payload)
+
+    # A store with no local file at all.
+    monkeypatch.setattr(
+        state_db_mod,
+        "settings",
+        state_db_mod.settings.model_copy(
+            update={"LIONAGI_STATE_DB_URL": "postgresql+asyncpg://u:p@127.0.0.1:5432/lionagi"}
+        ),
+    )
+    assert maint._wal_bytes_now() is None
+
+
 # ── size alert tests ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## The problem

`PRAGMA wal_checkpoint(TRUNCATE)` returns `busy`, `log_pages` and `checkpointed`
all zero on every success. That is by definition: a successful TRUNCATE moves
every frame into the database and resets the log, so there is nothing left for
the counters to describe. One page or a hundred thousand, the row reads the
same.

Those three numbers are the entire audit event the daemon writes after each
checkpoint. On a live instance four consecutive rows, one from startup and
three from hourly scheduler ticks, all read `busy 0, log_pages 0,
checkpointed 0`. The only thing that record can tell you is that four
checkpoints succeeded. Someone investigating a checkpoint stall reads it as
"there was nothing to drain", which the row does not say and cannot say.

## The change

Record the WAL size going in and the elapsed wall time in the same event.

- `wal_bytes_before` is read before the connection is opened, so it is the WAL
  this checkpoint was asked to deal with rather than whatever opening left
  behind. It is `None` when the store has no local WAL to measure (a server or
  in-memory store) and `0` when the sidecar is genuinely absent, which are
  different answers.
- `elapsed_ms` covers opening the connection as well as the PRAGMA, because a
  checkpoint that waits can wait in either place and the split cannot be
  recovered from the row afterwards.

Both carry the same limit, written where they are set: the event is stored
after the checkpoint returns, so this records a slow checkpoint and can never
record a hung one. A stall that never ends still leaves no row.

The early-return branch for a store that does not exist builds its dict by
hand, so it gets the new fields too. Otherwise the `/api/admin/maintenance`
response would gain or lose fields depending on whether the store happened to
exist yet.

## Tests

- The stored `admin_events` row carries both fields, asserted on the row rather
  than the return value, since a field that is returned but never stored would
  pass a return-value check and leave the record just as useless.
- The WAL fixture holds a connection open while it writes. SQLite checkpoints
  and removes the WAL when the last connection closes, so a fixture that writes
  and lets go leaves an empty WAL and the assertion would hold trivially. The
  recorded size is compared against the size measured independently while that
  connection is still open, which also pins the ordering: reading the sidecar
  after the checkpoint instead of before gives zero and fails.
- Zero, a real size, and `None` are covered separately, because the first two
  both read as "no bytes" at a glance and mean different things.
- Both return paths are asserted to report the same field names.