### PR TITLE
fix(cli): a run that asked for a terminal notice it can never get now says so

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -992,6 +992,26 @@ async def _run_agent(
     # auto-resume legs unregister without firing; the recursed leg registers anew.
     _notify_scope_name: str | None = None
     _notify_session_id = live.get("session_id") if live else None
+    if notify and _notify_session_id is None:
+        # Asked for a notifier that can never fire, and say so.
+        #
+        # The terminal notice is raised by a terminal transition on this run's
+        # session entity. Persistence setup failing leaves no session entity, so
+        # no transition can occur and nothing will call the adapter however well
+        # it resolves. That is the most complete refusal there is, and it is the
+        # one the registration below cannot report: on_rejection is passed into
+        # it, so it only speaks for runs that got far enough to register.
+        #
+        # Without this the run is silent in a way that reads as success. A
+        # caller waiting on a terminal notice sees what a caller that never
+        # asked for one sees, and the ones consuming these runs are automated:
+        # they conclude the process vanished, which is the opposite of what
+        # happened, since the run goes on to do all of its work.
+        from lionagi.state.lifecycle.notify_settings import (
+            record_notify_rejection_to_run,
+        )
+
+        record_notify_rejection_to_run(run, "run_has_no_persisted_session_to_notify_on")
     if notify and _notify_session_id is not None:
         from lionagi.cli.orchestrate._notify import (
             register_flow_notify_scope,

--- a/tests/cli/test_agent_notify_without_persistence.py
+++ b/tests/cli/test_agent_notify_without_persistence.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A run that asked for a terminal notice it can never get has to say so.
+
+`--notify` is delivered by a callback registered against this run's session
+entity and fired by that entity's terminal transition. When persistence setup
+fails there is no session entity, so no transition can happen and the adapter
+is never called, however well it resolves. The run then finishes its work and
+ends in silence, and silence is exactly what a run that never asked for a
+notifier produces.
+
+That matters because the consumers are automated. The lion MCP server wires
+`--notify` on every job it spawns and takes the resulting notice as the run's
+end; without one it eventually observes the process is gone with nothing
+recorded and publishes `outcome=indeterminate`, which is the opposite of what
+happened to a run that did all of its work.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _wire_agent_stubs(monkeypatch, tmp_path: Path, *, persist: dict | None):
+    """Stub _run_agent's external I/O, keeping a REAL run directory.
+
+    The run directory is the one thing not stubbed here: the refusal record is
+    a file this code writes into it, so a SimpleNamespace stand-in would make
+    the assertion about the stand-in. *persist* is what setup_agent_persist
+    returns, None being the failure this module is about.
+    """
+    import lionagi.cli._runs as runs_mod
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi.cli._runs import allocate_run
+    from lionagi.service.manager import iModelManager
+
+    monkeypatch.setattr(iModelManager, "shutdown", AsyncMock())
+    monkeypatch.setattr(agent_mod, "build_chat_model", lambda *a, **kw: "codex/model")
+    monkeypatch.setattr(agent_mod, "resolve_persisted_effort", lambda *a, **kw: None)
+
+    async def fake_setup(*a, **kw):
+        return persist
+
+    async def fake_teardown(
+        ctx,
+        *,
+        status="completed",
+        exception=None,
+        cwd=None,
+        engine_session_uid=None,
+        defer_terminal=False,
+    ):
+        return status
+
+    monkeypatch.setattr(agent_mod, "setup_agent_persist", fake_setup)
+    monkeypatch.setattr(agent_mod, "teardown_agent_persist", fake_teardown)
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        agent_mod,
+        "_provenance",
+        SimpleNamespace(
+            resolve_model_spec=lambda p, m: f"{p}/{m}",
+            agent_definition_hash=lambda n: "abc",
+        ),
+    )
+    monkeypatch.setattr(agent_mod, "resolve_artifact_contract", lambda **_: None)
+
+    monkeypatch.setattr(runs_mod, "RUNS_ROOT", tmp_path / "runs")
+    run = allocate_run(run_id="notify-without-persistence")
+    monkeypatch.setattr(agent_mod, "allocate_run", lambda: run)
+
+    async def fake_operate(self, instruction=None, **kw):
+        return "the work this run was asked to do"
+
+    monkeypatch.setattr(Branch, "operate", fake_operate)
+    return run
+
+
+@pytest.mark.asyncio
+async def test_notify_asked_for_without_a_session_records_the_refusal(monkeypatch, tmp_path):
+    """No session entity to fire on is recorded, not passed over in silence."""
+    run = _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("codex/model", "do the thing", notify="/some/notifier")
+
+    assert run.notify_outcome_path.exists(), (
+        "a notifier was asked for and can never fire; the run has to record that"
+    )
+    outcome = json.loads(run.notify_outcome_path.read_text())
+    assert outcome["ok"] is False
+    # The reason is what separates this from every other way a notice fails to
+    # arrive, so it is asserted by value rather than by being present.
+    assert outcome["reason"] == "run_has_no_persisted_session_to_notify_on"
+    # Nothing was launched, so there is no exit code and no captured stderr to
+    # point at. Asserting these keeps the record from growing a fabricated
+    # success shape later.
+    assert outcome["exit_code"] is None
+    assert outcome["stderr_path"] is None
+
+
+@pytest.mark.asyncio
+async def test_no_notifier_asked_for_writes_no_refusal(monkeypatch, tmp_path):
+    """The control that stops the record from meaning nothing.
+
+    Without this, a change that wrote the refusal unconditionally would pass
+    the test above while reporting a refused notifier on every run that never
+    wanted one, and the field would stop distinguishing anything.
+    """
+    run = _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("codex/model", "do the thing")
+
+    assert not run.notify_outcome_path.exists(), (
+        "a run that asked for nothing must look different from one that was refused"
+    )


### PR DESCRIPTION
## What happens today

`--notify` is delivered by a callback registered against the run's session
entity and fired by that entity's terminal transition. If persistence setup
fails, there is no session entity, so `_notify_session_id` is `None`, so the
registration is skipped entirely. Nothing will call the adapter however well it
resolves, and the run goes on to do all of its work and finish in silence.

Silence is precisely what a run that never asked for a notifier produces, so
from outside the two are the same.

The mechanism that exists to prevent that cannot reach this case. `on_rejection`
is an argument to `register_flow_notify_scope`, so it only ever speaks for runs
that got far enough to register. Its own docstring names the problem it solves:
"without it, asking for a notifier and being refused looks exactly like never
having asked". The most complete refusal there is was the one it could not
report.

## The change

When a notifier was asked for and there is no session entity to fire on, record
that into the run's own `notify_outcome.json` with a stable reason
(`run_has_no_persisted_session_to_notify_on`).

`record_notify_rejection_to_run` writes through the run directory rather than
the store, which matters here: the case being reported is the store being
unreachable, so a record that needed the store would be absent exactly when it
is needed.

## Why this is not cosmetic

The consumers are automated. The lion MCP server wires `--notify` on every job
it spawns and takes the resulting notice as the run's end. With no notice it
eventually observes that the process is gone with nothing recorded and publishes
`outcome=indeterminate`, so a run that completed and wrote its report reads to
the caller as a run that vanished. A caller then either re-runs work that was
already delivered or treats a real result as missing.

That is measurable rather than hypothetical: 44 job records on this machine
carry that outcome, and the case that prompted this had a full report on disk
roughly a second before its record was written.

Nothing here fixes the coupling itself. Making a terminal notice deliverable
without a persisted session is a design change to the callback registry and is
not attempted in this PR. This makes the failure loud where it was silent.

## Tests

Two arms, and the second is what stops the first from being satisfiable by a
change that always writes the record:

- a notifier asked for with no session entity writes the refusal, asserted by
  reason value and with `exit_code`/`stderr_path` pinned to null so the record
  cannot later grow a success shape
- a run that asked for nothing writes no file at all

The run directory is the one thing not stubbed in these tests. The record is a
file this code writes into it, so a stand-in would make the assertion about the
stand-in.