### PR TITLE
feat(state): the sqlite busy_timeout becomes a deployment property

### DIFF
--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import sqlite3
 import uuid
@@ -17,11 +18,48 @@ from lionagi._paths import LIONAGI_HOME
 
 _log = logging.getLogger(__name__)
 
+
+def _busy_timeout_from_env() -> int:
+    """The sqlite busy_timeout (ms) this deployment asked for, or the default.
+
+    The default of 5000 is sized for the test suite — a test that deliberately
+    holds a write lock should fail fast, not wait out a production-grade
+    timeout — and for years it was also silently the production value. On a
+    large store contended by more than one long-lived process, five seconds is
+    the difference between a write that waits and a write that reports
+    "database is locked" after having already waited as long as it was allowed
+    to. That is a deployment property, so it comes from the environment: a
+    daemon's launch config sets it high, the suite sets nothing and keeps the
+    fast failure.
+
+    An unusable value falls back to the default and says so. Refusing to start
+    over a malformed tuning knob would trade a slower lock wait for no daemon
+    at all, which is not a trade the knob's owner asked for. Zero and negative
+    values are refused the same way: busy_timeout=0 means "never wait", which
+    turns every momentary lock into an error and is never what a deployment
+    that bothered to set the variable wants.
+    """
+    raw = os.environ.get("LIONAGI_SQLITE_BUSY_TIMEOUT_MS")
+    if raw is None:
+        return 5000
+    try:
+        value = int(raw)
+    except ValueError:
+        value = -1
+    if value <= 0:
+        _log.warning(
+            "LIONAGI_SQLITE_BUSY_TIMEOUT_MS=%r is not a positive integer; using 5000",
+            raw,
+        )
+        return 5000
+    return value
+
+
 # sqlite busy_timeout (ms) applied to every connection this process opens against
-# the store, whether through this engine or through the Studio connection helper;
-# kept low so tests that deliberately hold a write lock fail fast instead of
-# waiting the full default.
-SQLITE_BUSY_TIMEOUT_MS = 5000
+# the store, whether through this engine or through the Studio connection helper.
+# A module attribute rather than a frozen local because the pragma listeners read
+# it at connection time — tests that need a different wait retune it here.
+SQLITE_BUSY_TIMEOUT_MS = _busy_timeout_from_env()
 
 
 def has_wal_reset_fix(version_info: tuple[int, ...]) -> bool:

--- a/lionagi/studio/services/_db.py
+++ b/lionagi/studio/services/_db.py
@@ -9,7 +9,11 @@ from contextlib import asynccontextmanager
 
 import aiosqlite
 
-from lionagi.state.engine import SQLITE_BUSY_TIMEOUT_MS
+# Module import, not a from-import of the value: the timeout is a module
+# attribute that deployments set via env and tests retune at runtime, and a
+# from-import would freeze a copy here at import time — two layers onto one
+# store file would then wait different lengths, a difference nobody chose.
+from lionagi.state import engine as _state_engine
 
 _log = logging.getLogger(__name__)
 
@@ -71,7 +75,7 @@ async def open_db(path: str) -> AsyncIterator[aiosqlite.Connection]:
         _ACTIVE_CONNECTIONS += 1
         try:
             await db.execute("PRAGMA journal_mode = WAL")
-            await db.execute(f"PRAGMA busy_timeout = {SQLITE_BUSY_TIMEOUT_MS}")
+            await db.execute(f"PRAGMA busy_timeout = {_state_engine.SQLITE_BUSY_TIMEOUT_MS}")
             await db.execute("PRAGMA foreign_keys = ON")
             db.row_factory = aiosqlite.Row
             yield db

--- a/tests/state/test_busy_timeout_env.py
+++ b/tests/state/test_busy_timeout_env.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The sqlite busy_timeout is a deployment property, resolved from the env.
+
+The default is sized for the test suite (a test holding a write lock should
+fail fast), so a production daemon has to be able to ask for more without the
+suite inheriting it. The resolver refuses unusable values toward the default
+rather than toward a crash or toward "never wait": a daemon that fails to
+start over a malformed tuning knob, or one whose every momentary lock becomes
+an error because 0 slipped through, are both worse than a slower lock wait.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from lionagi.state.engine import _busy_timeout_from_env
+
+_VAR = "LIONAGI_SQLITE_BUSY_TIMEOUT_MS"
+
+
+def test_unset_returns_the_suite_default(monkeypatch):
+    monkeypatch.delenv(_VAR, raising=False)
+    assert _busy_timeout_from_env() == 5000
+
+
+def test_a_deployment_value_is_used_verbatim(monkeypatch):
+    monkeypatch.setenv(_VAR, "30000")
+    assert _busy_timeout_from_env() == 30000
+
+
+def test_garbage_falls_back_and_says_so(monkeypatch, caplog):
+    monkeypatch.setenv(_VAR, "thirty seconds")
+    with caplog.at_level(logging.WARNING, logger="lionagi.state.engine"):
+        assert _busy_timeout_from_env() == 5000
+    # The warning names the rejected value: an operator reading the log has to
+    # be able to tell WHICH knob was ignored without reproducing the env.
+    assert any("thirty seconds" in r.getMessage() for r in caplog.records)
+
+
+def test_zero_and_negative_are_refused_like_garbage(monkeypatch, caplog):
+    # busy_timeout=0 means "never wait", turning every momentary lock into an
+    # error — never what a deployment that set the variable wanted.
+    for bad in ("0", "-1"):
+        caplog.clear()
+        monkeypatch.setenv(_VAR, bad)
+        with caplog.at_level(logging.WARNING, logger="lionagi.state.engine"):
+            assert _busy_timeout_from_env() == 5000
+        assert caplog.records, f"refusing {bad!r} must be logged, not silent"
+
+
+def test_the_connection_pragma_reads_the_module_attribute_at_connect_time(monkeypatch):
+    """Tests retune the module attribute; a frozen copy would ignore them.
+
+    Asserted against a real connection because the coupling under test is
+    between the attribute and the pragma actually applied, not between two
+    Python names.
+    """
+    import asyncio
+
+    import lionagi.state.engine as engine_mod
+    from lionagi.state.engine import make_engine
+
+    monkeypatch.setattr(engine_mod, "SQLITE_BUSY_TIMEOUT_MS", 1234)
+
+    async def _applied_timeout() -> int:
+        from sqlalchemy import text
+
+        engine = make_engine("sqlite+aiosqlite:///:memory:")
+        try:
+            async with engine.connect() as conn:
+                row = (await conn.execute(text("PRAGMA busy_timeout"))).first()
+                return int(row[0])
+        finally:
+            await engine.dispose()
+
+    assert asyncio.run(_applied_timeout()) == 1234


### PR DESCRIPTION
## The constant and what it silently governed

`SQLITE_BUSY_TIMEOUT_MS = 5000` in `lionagi/state/engine.py` carried its own
justification: kept low so tests that deliberately hold a write lock fail fast
instead of waiting the full default. That is the right value for the suite. It
was also, with nothing deciding it, the production value — applied to every
connection any process opens against the store.

On a large store contended by more than one long-lived process, five seconds is
the difference between a write that waits and a write that reports
`database is locked` after having already waited as long as it was allowed to.
A worked example is in the linked observability changes from today: a child
process lost that race at startup and its whole run's persistence was disabled
by it.

## The change

- `LIONAGI_SQLITE_BUSY_TIMEOUT_MS` resolves the value at import, default 5000.
  A daemon's launch config sets it high; the suite sets nothing and keeps the
  fast failure.
- Unusable values (non-integer, zero, negative) fall back to the default with a
  warning naming the rejected value. Refusing to start over a malformed tuning
  knob trades a slower lock wait for no daemon at all, and `busy_timeout=0`
  means "never wait" — every momentary lock becomes an error, which no
  deployment that bothered to set the variable wants.
- The value stays a **module attribute** read by the pragma listeners at
  connection time, because tests retune it at runtime
  (`tests/state/test_check_rebuild_concurrency.py`,
  `tests/apps_studio_server/test_admin_maintenance_api.py`).
- The studio connection helper now reads the attribute through the module. Its
  previous from-import froze a copy at import time, while its own docstring
  promised the two connection layers wait the same length. Now they do under
  runtime retuning as well.

## Tests

- Resolver: unset → 5000; a deployment value used verbatim; garbage → 5000 with
  the rejected value named in the warning; zero and negative refused the same
  way, loudly.
- The coupling under test — attribute to applied pragma — is asserted against a
  real connection (`PRAGMA busy_timeout` read back), not between two Python
  names.
- Full `tests/state`, `tests/apps_studio_server`, `tests/studio` green locally.