### PR TITLE
fix(studio): 501 the data routes a server-backed store cannot answer

### DIFF
--- a/lionagi/studio/app.py
+++ b/lionagi/studio/app.py
@@ -21,6 +21,7 @@ from lionagi.version import __version__
 from ._traceback_dump import arm_traceback_dump, disarm_traceback_dump
 from .config import CORS_ORIGINS, HOST
 from .registry import iter_studio_routes, load_studio_route_modules
+from .services._db import StoreNotAddressableError
 
 _log = logging.getLogger(__name__)
 
@@ -339,6 +340,31 @@ def create_app() -> FastAPI:
         return JSONResponse(
             status_code=exc.status_code,
             content={"detail": exc.message},
+        )
+
+    @application.exception_handler(StoreNotAddressableError)
+    async def _store_not_addressable_handler(
+        request: Request, exc: StoreNotAddressableError
+    ) -> JSONResponse:
+        """Map a route asking for rows it structurally cannot fetch to 501.
+
+        Handles exactly :class:`StoreNotAddressableError` and nothing wider --
+        a path-resolution bug raising something else must not land here and be
+        reported as this specific, permanent condition. Not 503: the store
+        being server-backed does not change while this process runs, so
+        retrying buys nothing and shouldn't be implied.
+        """
+        return JSONResponse(
+            status_code=501,
+            content={
+                "detail": (
+                    f"{request.url.path} cannot answer: the configured store "
+                    f"is {exc.backend}-backed, and this route can only read "
+                    "from a local SQLite file."
+                ),
+                "route": request.url.path,
+                "backend": exc.backend,
+            },
         )
 
     @application.middleware("http")

--- a/lionagi/studio/services/_db.py
+++ b/lionagi/studio/services/_db.py
@@ -57,6 +57,58 @@ def store_exists() -> bool:
     return Path(store_path()).exists()
 
 
+class StoreNotAddressableError(RuntimeError):
+    """The configured store has no file this layer can open.
+
+    Raised by :func:`require_file_store` for a route that reads or writes rows
+    straight through a SQLite connection. A server-backed store (or an
+    in-memory one) has no file behind it, so ``store_path()`` would have to
+    fall back to a path the daemon never writes -- reading it back would
+    report a store nobody is serving, and connecting to write would create a
+    file whose rows nothing else will ever see. The route has no honest answer
+    against that connection, and this says so instead of giving one.
+    """
+
+    def __init__(self, backend: str) -> None:
+        self.backend = backend
+        super().__init__(
+            f"this route reads from a local SQLite file, but the configured "
+            f"store is {backend}-backed and has no such file"
+        )
+
+
+def require_file_store() -> None:
+    """Raise :class:`StoreNotAddressableError` when the configured store is
+    not a SQLite file this layer can open directly.
+
+    Call this where a route or service function currently guards with
+    ``if not store_exists(): return []`` (or opens the connection
+    unconditionally): it slots in front of that check. A path that exists or a
+    path that is merely absent both pass through unchanged -- the second case
+    still means "no store yet", answered the same empty way as before. Only a
+    resolution with no path at all (a server URL, or ``:memory:``) raises,
+    because that is the one condition this layer cannot ever satisfy by
+    waiting or by creating the file.
+    """
+    from lionagi.state import db as db_mod
+
+    if db_mod.state_db_file() is not None:
+        return
+
+    from lionagi.state.engine import dialect_of, normalize_state_db_url
+
+    raw = db_mod.settings.LIONAGI_STATE_DB_URL
+    if raw is None:
+        raw = db_mod.DEFAULT_DB_PATH
+    url = normalize_state_db_url(raw)
+    dialect = dialect_of(url)
+    from sqlalchemy.engine import make_url
+
+    database = make_url(url).database
+    backend = "in-memory sqlite" if (not database or database == ":memory:") else dialect
+    raise StoreNotAddressableError(backend)
+
+
 @asynccontextmanager
 async def open_db(path: str) -> AsyncIterator[aiosqlite.Connection]:
     """Studio-local SQLite connection with WAL mode and a busy timeout,

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -26,7 +26,7 @@ from lionagi.state.reasons import RunReasons, SessionReasons, validate_reason_co
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
-from ._db import store_exists, store_path
+from ._db import require_file_store, store_exists, store_path
 from ._path_safety import public_path
 
 _log = logging.getLogger(__name__)
@@ -321,6 +321,7 @@ def _classify_phantom(
 
 
 async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, Any]]:
+    require_file_store()
     if not store_exists():
         return []
     now = time.time()
@@ -406,6 +407,7 @@ async def health_report() -> dict[str, Any]:
     )
     from lionagi.studio.config import scheduler_timezone_report
 
+    require_file_store()
     if not store_exists():
         return {
             "sessions": {"total": 0, "by_status": {}, "by_health": {}, "unhealthy": []},
@@ -773,6 +775,7 @@ async def list_admin_events(
 
 async def prune_sessions(session_ids: list[str]) -> int:
     """Delete sessions by explicit ID list."""
+    require_file_store()
     seen: dict[str, None] = {}
     for sid in session_ids:
         seen[sid] = None

--- a/lionagi/studio/services/approvals.py
+++ b/lionagi/studio/services/approvals.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
-from ._db import store_path
+from ._db import require_file_store, store_path
 
 APPROVAL_TTL_SECONDS = 5 * 60
 
@@ -155,6 +155,7 @@ def _row_to_dict(row: Any) -> dict[str, Any]:
 
 
 async def _fetch_row(approval_id: str) -> dict[str, Any] | None:
+    require_file_store()
     async with _open_db(store_path()) as db:
         await _ensure_table(db)
         cur = await db.execute(
@@ -253,6 +254,7 @@ async def _write_evidence(
 
 async def verify_evidence_chain() -> dict[str, Any]:
     """Replay the evidence chain end to end and report whether it is intact."""
+    require_file_store()
     errors: list[str] = []
     total = 0
     async with _open_db(store_path()) as db:
@@ -354,6 +356,7 @@ async def create_approval(
     *, action_kind: str, params: dict[str, Any], session_id: str | None = None
 ) -> dict[str, Any]:
     """Propose a mutating action; returns the pending approval row."""
+    require_file_store()
     now = time.time()
     approval_id = uuid.uuid4().hex
     params_hash = compute_params_hash(params)

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -14,7 +14,7 @@ from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
-from ._db import store_exists, store_path
+from ._db import require_file_store, store_exists, store_path
 from ._path_safety import validate_name_component
 from .agents import _is_protected_system
 
@@ -180,6 +180,7 @@ async def get_version(kind: str, name: str, version: int) -> dict[str, Any] | No
     validate_name_component(kind, label="kind")
     validate_name_component(name, label="name")
 
+    require_file_store()
     if not await _ensure_db():
         return None
 

--- a/lionagi/studio/services/projects.py
+++ b/lionagi/studio/services/projects.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
-from ._db import store_exists, store_path
+from ._db import require_file_store, store_exists, store_path
 
 
 class NameConflictError(Exception):
@@ -41,6 +41,7 @@ async def _ensure_table(db) -> None:
 
 async def list_projects() -> dict[str, Any]:
     """Return all known projects with session counts and an unassigned count."""
+    require_file_store()
     if not store_exists():
         return {"projects": [], "unassigned_count": 0}
 
@@ -88,6 +89,7 @@ async def list_projects() -> dict[str, Any]:
 
 async def get_project(name: str) -> dict[str, Any] | None:
     """Return a single project with session counts and usage summaries."""
+    require_file_store()
     if not store_exists():
         return None
 
@@ -167,6 +169,7 @@ async def create_project(
 
     clean_name = name.strip()
     now = time.time()
+    require_file_store()
     async with _open_db(store_path()) as db:
         await _ensure_table(db)
         try:
@@ -191,6 +194,7 @@ async def update_project(name: str, fields: dict[str, Any]) -> bool:
     allowed = {"description", "github", "path"}
     clean = {k: v for k, v in fields.items() if k in allowed}
 
+    require_file_store()
     async with _open_db(store_path()) as db:
         await _ensure_table(db)
         if not clean:
@@ -216,6 +220,7 @@ async def assign_sessions_to_project(
     all_unassigned: bool = False,
 ) -> int:
     """Assign sessions to a project. Returns count of updated rows."""
+    require_file_store()
     async with _open_db(store_path()) as db:
         await _ensure_table(db)
         if session_ids:
@@ -250,6 +255,7 @@ async def assign_sessions_to_project(
 
 async def delete_project(name: str) -> bool:
     """Delete a Studio-managed project. Returns True when deleted."""
+    require_file_store()
     async with _open_db(store_path()) as db:
         await _ensure_table(db)
         cur = await db.execute(

--- a/lionagi/studio/services/run_tags.py
+++ b/lionagi/studio/services/run_tags.py
@@ -14,7 +14,7 @@ from lionagi.state.db import StateDB
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
-from ._db import store_exists, store_path
+from ._db import require_file_store, store_exists, store_path
 
 # Keep each IN(...) bind list under SQLite's default SQLITE_MAX_VARIABLE_NUMBER
 # (999 on builds older than 3.32) so tag hydration cannot overflow it.
@@ -41,6 +41,7 @@ async def add_tag(session_id: str, tag: str) -> None:
     if not clean:
         raise HTTPException(status_code=422, detail="tag must not be empty")
 
+    require_file_store()
     if not store_exists():
         # Apply the full schema first so a tag write never leaves a partial
         # db behind (only run_tags, no sessions/etc).
@@ -60,6 +61,7 @@ async def add_tag(session_id: str, tag: str) -> None:
 
 async def remove_tag(session_id: str, tag: str) -> None:
     """Detach a tag from a run (session)."""
+    require_file_store()
     if not store_exists():
         # Nothing to detach; a delete must never create the db file (a bare
         # _ensure_table would leave a run_tags-only db behind).

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -506,11 +506,20 @@ async def create_schedule(data: dict[str, Any]) -> dict[str, Any]:
     # changes can't move this schedule's spawn cwd out from under it.
     action_cwd = data.get("action_cwd")
     if not action_cwd and data.get("action_project"):
+        from lionagi.studio.services._db import StoreNotAddressableError
         from lionagi.studio.services.projects import get_project
 
         from ..scheduler.engine import _is_usable_execution_root
 
-        project = await get_project(data["action_project"])
+        # This lookup is a best-effort cwd snapshot on an otherwise
+        # StateDB-only write (server-reachable). The projects catalog is
+        # SQLite-only, so a server-backed store makes it unreadable here --
+        # same as the project simply not being found, not a reason to refuse
+        # a schedule create that does not itself need SQLite.
+        try:
+            project = await get_project(data["action_project"])
+        except StoreNotAddressableError:
+            project = None
         project_path = project.get("path") if project else None
         # The same rule the resolver applies, so a root is never persisted here
         # that the resolver would refuse to honor later. Registered project

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -15,7 +15,7 @@ from lionagi.state.db import SESSION_TERMINAL_STATUSES
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
-from ._db import store_exists, store_path
+from ._db import require_file_store, store_exists, store_path
 from ._io import parse_json_col as _parse_json_col
 from .artifact_verification import resolve_artifact_verification
 
@@ -184,6 +184,7 @@ class SessionFilter:
 
 async def count_sessions(where: SessionFilter | None = None) -> int:
     """Total matching sessions, without reading a single branch or progression."""
+    require_file_store()
     if not store_exists():
         return 0
     clause, params = (where or SessionFilter()).where()
@@ -204,6 +205,7 @@ async def list_sessions(
 ) -> list[dict[str, Any]]:
     """One page of sessions, newest first. Cost is proportional to `limit`, not
     to the size of the store."""
+    require_file_store()
     if not store_exists():
         return []
 
@@ -333,6 +335,7 @@ async def list_sessions(
 
 async def list_project_counts() -> list[dict[str, Any]]:
     """Per-project run counts via a cheap GROUP BY (no branch/message join)."""
+    require_file_store()
     if not store_exists():
         return []
     async with _open_db(store_path()) as db:
@@ -627,6 +630,7 @@ async def get_session(
     message_offset: int = 0,
     message_cursor: str | None = None,
 ) -> dict[str, Any] | None:
+    require_file_store()
     if not store_exists():
         return None
 
@@ -837,6 +841,7 @@ async def get_session(
 
 async def get_session_by_cc_id(cc_uid: str) -> dict[str, Any] | None:
     """Return a mirrored Claude Code session, including legacy unbackfilled rows."""
+    require_file_store()
     if not store_exists():
         return None
 
@@ -883,6 +888,7 @@ async def get_session_messages_after(session_id: str, after_ts: float) -> list[d
 
 
 async def session_exists(session_id: str) -> bool:
+    require_file_store()
     if not store_exists():
         return False
 

--- a/tests/apps_studio_server/test_not_answerable.py
+++ b/tests/apps_studio_server/test_not_answerable.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The third state a data route needs when the configured store has no file.
+
+``require_file_store`` distinguishes three conditions from ``state_db_file()``
+alone: a store path that exists (answer the rows), one that does not exist yet
+(answer empty, unchanged), and no path at all -- a server-backed or in-memory
+store this SQLite-direct layer cannot open. Only the third one raises.
+
+The suite below pins all three, plus the one thing a must-refuse-only suite
+would miss: a route in front of an *existing* store must still answer with its
+real rows, not get swept into the refusal by an over-eager guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import lionagi.state.db as state_db_mod  # noqa: E402
+from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.studio.services._db import (  # noqa: E402
+    StoreNotAddressableError,
+    require_file_store,
+)
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _configure(monkeypatch, *, default: Path, url: str | None) -> None:
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", default)
+    monkeypatch.setattr(
+        state_db_mod,
+        "settings",
+        state_db_mod.settings.model_copy(update={"LIONAGI_STATE_DB_URL": url}),
+    )
+
+
+def _client(*, raise_server_exceptions: bool = True) -> TestClient:
+    from lionagi.studio.app import app
+
+    return TestClient(
+        app, base_url="http://127.0.0.1:8765", raise_server_exceptions=raise_server_exceptions
+    )
+
+
+# ── require_file_store(): the three states ──────────────────────────────────
+
+
+def test_existing_store_path_does_not_raise(tmp_path, monkeypatch):
+    """The accept arm: an existing file-backed store is left alone."""
+    default = tmp_path / "state.db"
+    _run(StateDB(default).open())
+    _configure(monkeypatch, default=default, url=None)
+
+    require_file_store()  # must not raise
+
+
+def test_missing_store_file_does_not_raise(tmp_path, monkeypatch):
+    """A store that simply has not been created yet is not the same as one
+    this layer cannot reach -- the existing empty-result behavior stays."""
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url=None)
+    assert not default.exists()
+
+    require_file_store()  # must not raise
+
+
+def test_server_backed_store_raises(tmp_path, monkeypatch):
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@host/db")
+
+    with pytest.raises(StoreNotAddressableError) as exc_info:
+        require_file_store()
+    assert exc_info.value.backend == "postgresql"
+
+
+def test_in_memory_store_raises(tmp_path, monkeypatch):
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url=":memory:")
+
+    with pytest.raises(StoreNotAddressableError) as exc_info:
+        require_file_store()
+    assert "memory" in exc_info.value.backend
+
+
+# ── The app-level 501 handler, on a representative route ────────────────────
+
+
+def test_data_route_is_501_when_store_is_server_backed(tmp_path, monkeypatch):
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@host/db")
+
+    r = _client().get("/api/projects/")
+
+    assert r.status_code == 501
+    body = r.json()
+    assert body["route"] == "/api/projects/"
+    assert body["backend"] == "postgresql"
+    assert "detail" in body and "postgresql" in body["detail"]
+
+
+def test_same_route_is_200_empty_when_store_file_is_merely_absent(tmp_path, monkeypatch):
+    """Same route, same shape of "nothing here" -- but this time the store is
+    a local file that just has not been created, so the pre-existing empty
+    answer must survive untouched."""
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url=None)
+    assert not default.exists()
+
+    r = _client().get("/api/projects/")
+
+    assert r.status_code == 200
+    assert r.json() == {"projects": [], "unassigned_count": 0}
+
+
+def test_same_route_still_answers_rows_against_an_existing_store(tmp_path, monkeypatch):
+    """The over-refusal arm: a guard that fires on every request would pass
+    every must-refuse test above and still be wrong. A route in front of a
+    store that genuinely exists must keep answering with real rows."""
+    default = tmp_path / "state.db"
+    _run(StateDB(default).open())
+    _configure(monkeypatch, default=default, url=None)
+
+    client = _client()
+    created = client.post("/api/projects/", json={"name": "demo-project"})
+    assert created.status_code == 201
+
+    r = client.get("/api/projects/")
+    assert r.status_code == 200
+    names = [p["name"] for p in r.json()["projects"]]
+    assert names == ["demo-project"]
+
+
+# ── Readiness stays 200 no matter what (it is asked about the store, not for rows) ──
+
+
+def test_readiness_route_stays_200_when_store_is_server_backed(tmp_path, monkeypatch):
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@host/db")
+
+    r = _client().get("/api/admin/readiness")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] in {"unavailable", "healthy", "slow"}


### PR DESCRIPTION
## What

The Studio services layer opens SQLite files directly. When the configured store is server-backed, `state_db_file()` returns `None` and every route in that layer answered as if there were no store at all: an empty list indistinguishable from "genuinely no rows".

- `services/_db.py`: `StoreNotAddressableError` (carries `.backend`) and `require_file_store()`. It raises only when there is no file path at all (server URL or `:memory:`); an existing or merely-absent file passes through unchanged.
- `app.py`: a dedicated exception handler maps exactly that type to HTTP 501 with `{detail, route, backend}`. Not 503: the backend does not change while the process runs, so retrying should not be implied.
- Guards added across admin, approvals, definitions (`get_version` only), projects, run_tags, sessions. `/admin/readiness` deliberately unguarded: the store's condition is that route's subject, so a 200 body naming the condition is the correct answer.
- Mixed-source routes keep degrading honestly instead of hard-refusing: `definitions` list/get answer from disk with DB-only enrichment skipped; `shows` falls back to its filesystem tree. `schedules.create_schedule` catches the error from its incidental project lookup so a fully server-capable write is not swept into the refusal.
- `/runs/*` routes get the behaviour transitively through the guarded `sessions` helpers, with no edit to any runs file.

## Tests

`tests/apps_studio_server/test_not_answerable.py`: the three resolver states, the 501 body shape on a representative route, absent-file still 200-empty, a seeded store still returns real rows (no over-refusal), and the readiness carve-out. Full `tests/apps_studio_server` + `tests/studio` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)