### PR TITLE
fix(cli,mcp): a child that lost its persistence now delivers its own terminal notice

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -134,6 +134,43 @@ terminal event now comes from the guarded lifecycle transition itself
 and letting the registry's own post-commit push fire it is what prevents
 double delivery.
 
+**`deliver_flow_notify_now`** — the direct-path sibling of
+`register_flow_notify_scope`, for the one case that registered path cannot
+cover: `setup_agent_persist` failing before a session entity exists (`li
+agent`, `agent.py`). With no session there is no terminal transition to
+register against, so the run delivers its own `--notify` adapter itself, at
+process end in the `finally` block, once its own terminal status is already
+known — same `resolve_notify_config` resolution, same legacy payload/argv/env
+shape (`_legacy_argv_env_builders`, shared with the registered path), just
+invoked against a synthesized `RunTerminalEnvelope` instead of one raised by
+a DB transition. This is why the MCP server's job-spawn `--notify` template
+(`lionagi/mcp/jobs.py`, `_notify_template`) still fires for a run whose
+persistence broke: the argv it invokes (`lionagi.mcp._notify_hook`) carries
+its own `run_id` and needs nothing from the session/StateDB path to record
+the job's end and attempt delivery — it is agnostic to which of the two
+notify paths called it.
+
+Idempotence is a single file check, not the per-run lock the MCP job record
+uses: `run.notify_outcome_path.exists()` before attempting delivery, skipping
+if something is already recorded there. This is sufficient (not merely
+convenient) because the two notify paths are mutually exclusive by
+construction within one process — whether a session entity exists is decided
+once, right after `setup_agent_persist` returns, and never changes for the
+rest of the run, so the registered path and the direct path can never both
+fire for the same run. The check exists for re-entrancy safety (a second
+pass through the same `finally` body), not to arbitrate a real race.
+
+The refusal record (`record_notify_rejection_to_run`, `notify_outcome.json`
+with `reason` set) that used to fire unconditionally the moment persistence
+failed now fires only when delivery is actually attempted and genuinely
+cannot be completed — nothing configured to run, or the configured adapter
+itself fails to resolve/build. A `--notify` adapter that resolves and builds
+but fails to *launch or exit cleanly* is recorded by `record_notify_outcome_
+to_run` instead (no `reason` key — see `lionagi/state/lifecycle/
+notify_settings.py`), which is what lets `lionagi/mcp/jobs.py`'s orphan
+reaper (see `docs/internals/mcp.md#reap-reason-code-split`) tell "this run
+said its notice never arrived" from "this run said nothing at all."
+
 ### `_orchestration.py` — team-mode worker/coordinator wiring
 
 `team_worker_system()`/`team_history_context()`: a worker never has both

--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -51,6 +51,46 @@ run ended. A mutation that cannot take that lock records nothing and says so —
 the record stays non-terminal and the next observation retries it, rather than a
 terminal fact being announced that no reader can find.
 
+#### reap-reason-code-split
+
+Three ways a run can end with nobody around to say what happened, each with
+its own `reason_code` — `_derive()` and `reap_orphan()` (`lionagi/mcp/jobs.py`):
+
+- **Spawn never started doing work** — `spawn_state == "failed"`, caught and
+  recorded synchronously by `_record_spawn_failure` before this run ever did
+  anything. `reason_code=spawn_failed` (`_SPAWN_FAILED_REASON`), `terminal`
+  true immediately; never reaches the orphan path at all. Already distinct
+  before the notice-survives-lost-persistence change — no new code needed
+  here, only documented as the first branch of the split.
+- **Notice recorded as undelivered** — the run's own directory carries a
+  `notify_outcome.json` with `ok: false` (the refusal `--notify` asked for
+  and never got, from `record_notify_rejection_to_run`, or a `--notify`
+  adapter that resolved but failed to deliver, from `record_notify_outcome_
+  to_run` — see `docs/internals/cli.md#_notifypy`). `reap_orphan()` checks
+  this (`_notice_recorded_undelivered`) only once every other admission gate
+  already holds (`spawn_state == "started"`, no `finished_at` yet, a
+  conclusive `process_gone` finding) — never as a substitute for those
+  checks, only as a refinement of which reason code the reap writes.
+  `reason_code=process_gone_notice_recorded_undelivered`
+  (`LOST_REASON_NOTICE_RECORDED_UNDELIVERED`).
+- **True silence** — no spawn failure, no recorded notice either way, process
+  conclusively gone. `reason_code=process_gone_without_outcome` (`LOST_
+  REASON`), unchanged from before.
+
+The file read for the second case is best-effort and one-directional: found
+and parseable with `ok: false` upgrades the reason code; anything else (file
+absent, unreadable, `ok: true`, wrong shape) falls through to `LOST_REASON`.
+An *absent* file is never evidence of true silence — run directories are
+pruned by retention, so "the file used to say undelivered and is gone now" is
+indistinguishable on disk from "nothing was ever recorded" — but the
+resulting reason code (`LOST_REASON`, the pre-existing default) is the
+correct one for both, so this never mislabels anything as more or less
+informative than it actually is. `ok: true` similarly falls through, but is
+moot in practice for an MCP-spawned run: a delivered `--notify` means
+`lionagi.mcp._notify_hook` ran and called `mark_terminal`, which sets
+`finished_at` and disqualifies the run from reaping before this check is
+ever reached.
+
 #### unresolved-spawn-window
 
 `UNRESOLVED_SPAWN_AFTER_SECONDS` (= `WAIT_MAX_SECONDS`) is a defensible default,

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -55,6 +55,7 @@ from ._runs import (
     allocate_run,
     find_branch,
     load_last_branch,
+    resolve_run_reason,
     save_last_branch_pointer,
     setup_agent_persist,
     teardown_agent_persist,
@@ -990,28 +991,19 @@ async def _run_agent(
     # Session-scoped: teardown_agent_persist terminalizes only the session;
     # invocation records are finalized externally and would never fire. Deferred
     # auto-resume legs unregister without firing; the recursed leg registers anew.
+    #
+    # Persistence setup failing leaves no session entity to fire a terminal
+    # transition on, so the registered path below (register_flow_notify_scope)
+    # cannot be used. That used to mean the notice was silently unreachable;
+    # this run now delivers it itself once its own terminal status is known,
+    # in the `finally` block below (see `deliver_flow_notify_now`) — same
+    # resolution, same payload, run directly instead of registered for a
+    # transition that will never happen. The refusal record this run can still
+    # write applies only once delivery is actually attempted and genuinely
+    # cannot be completed (nothing configured to run, or the config itself is
+    # unusable), never merely because persistence failed.
     _notify_scope_name: str | None = None
     _notify_session_id = live.get("session_id") if live else None
-    if notify and _notify_session_id is None:
-        # Asked for a notifier that can never fire, and say so.
-        #
-        # The terminal notice is raised by a terminal transition on this run's
-        # session entity. Persistence setup failing leaves no session entity, so
-        # no transition can occur and nothing will call the adapter however well
-        # it resolves. That is the most complete refusal there is, and it is the
-        # one the registration below cannot report: on_rejection is passed into
-        # it, so it only speaks for runs that got far enough to register.
-        #
-        # Without this the run is silent in a way that reads as success. A
-        # caller waiting on a terminal notice sees what a caller that never
-        # asked for one sees, and the ones consuming these runs are automated:
-        # they conclude the process vanished, which is the opposite of what
-        # happened, since the run goes on to do all of its work.
-        from lionagi.state.lifecycle.notify_settings import (
-            record_notify_rejection_to_run,
-        )
-
-        record_notify_rejection_to_run(run, "run_has_no_persisted_session_to_notify_on")
     if notify and _notify_session_id is not None:
         from lionagi.cli.orchestrate._notify import (
             register_flow_notify_scope,
@@ -1226,6 +1218,37 @@ async def _run_agent(
                 run_manifest["ended_at"] = time.time()
             if _write_run_manifest is not None:
                 _write_run_manifest(run_manifest)
+            # No session entity ever existed for this run (persistence setup
+            # failed), so register_flow_notify_scope above was never reached —
+            # this run's terminal status is now known, and delivering it here
+            # is the only chance this run gets. Same resolution, same payload
+            # shape as the registered path; see deliver_flow_notify_now.
+            if notify and _notify_session_id is None:
+                try:
+                    from lionagi.cli.orchestrate._notify import (
+                        deliver_flow_notify_now,
+                    )
+
+                    _reason_code, _, _ = resolve_run_reason(
+                        status=_terminal_status, exception=_terminal_exc
+                    )
+                    await deliver_flow_notify_now(
+                        override=notify,
+                        run=run,
+                        entity_kind="session",
+                        entity_id=branch_id,
+                        invocation_id=invocation_id,
+                        flow_kind="agent",
+                        playbook=None,
+                        save_dir=str(run.artifact_root),
+                        cwd=cwd or os.getcwd(),
+                        started_at=run_manifest["started_at"],
+                        terminal_status=_terminal_status,
+                        reason_code=_reason_code,
+                        occurred_at=time.time(),
+                    )
+                except Exception as _notify_exc:  # noqa: BLE001 — a notifier failure must never affect the run
+                    log_error(f"direct-path notify.on_terminal delivery failed: {_notify_exc!r}")
             # Unregister after teardown fires the terminal transition.
             if _notify_scope_name is not None:
                 unregister_flow_notify_scope(_notify_scope_name)

--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -9,20 +9,35 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import anyio.to_thread
 
 from lionagi.cli.status import _classify
+from lionagi.ln.concurrency import is_coro_func, maybe_await
 from lionagi.state.lifecycle.callbacks import (
     DEFAULT_TERMINAL_CALLBACKS,
+    EntityRef,
     RunTerminalEnvelope,
     TerminalCallbackRegistry,
 )
 from lionagi.state.lifecycle.notify_settings import (
     build_handler,
+    record_notify_outcome_to_run,
+    record_notify_rejection_to_run,
     resolve_notify_config,
 )
 
-__all__ = ("register_flow_notify_scope", "unregister_flow_notify_scope")
+if TYPE_CHECKING:
+    from lionagi.cli._runs import RunDir
+
+__all__ = (
+    "deliver_flow_notify_now",
+    "register_flow_notify_scope",
+    "unregister_flow_notify_scope",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +71,32 @@ def _legacy_payload_builder(
         }
 
     return _build
+
+
+def _legacy_argv_env_builders(payload_fn, *, invocation_id: str | None):
+    """The `{payload}`/`{status}`/`{invocation_id}` argv substitution and the
+    matching env vars, shared by every caller that launches the legacy
+    `--notify` adapter (registered or delivered directly)."""
+
+    def _argv_fn(argv: tuple[str, ...], envelope: RunTerminalEnvelope) -> list[str]:
+        payload_json = json.dumps(payload_fn(envelope))
+        status = envelope.terminal_status
+        inv_id = invocation_id or ""
+        return [
+            tok.replace("{payload}", payload_json)
+            .replace("{status}", status)
+            .replace("{invocation_id}", inv_id)
+            for tok in argv
+        ]
+
+    def _env_fn(envelope: RunTerminalEnvelope) -> dict[str, str]:
+        return {
+            _PAYLOAD_ENV: json.dumps(payload_fn(envelope)),
+            _STATUS_ENV: envelope.terminal_status,
+            _INVOCATION_ID_ENV: invocation_id or "",
+        }
+
+    return _argv_fn, _env_fn
 
 
 def register_flow_notify_scope(
@@ -111,23 +152,7 @@ def register_flow_notify_scope(
         started_at=started_at,
     )
 
-    def _argv_fn(argv: tuple[str, ...], envelope: RunTerminalEnvelope) -> list[str]:
-        payload_json = json.dumps(payload_fn(envelope))
-        status = envelope.terminal_status
-        inv_id = invocation_id or ""
-        return [
-            tok.replace("{payload}", payload_json)
-            .replace("{status}", status)
-            .replace("{invocation_id}", inv_id)
-            for tok in argv
-        ]
-
-    def _env_fn(envelope: RunTerminalEnvelope) -> dict[str, str]:
-        return {
-            _PAYLOAD_ENV: json.dumps(payload_fn(envelope)),
-            _STATUS_ENV: envelope.terminal_status,
-            _INVOCATION_ID_ENV: invocation_id or "",
-        }
+    _argv_fn, _env_fn = _legacy_argv_env_builders(payload_fn, invocation_id=invocation_id)
 
     handler = build_handler(
         resolved,
@@ -155,3 +180,101 @@ def unregister_flow_notify_scope(
 ) -> None:
     if name is not None:
         registry.unregister(name)
+
+
+async def deliver_flow_notify_now(
+    *,
+    override: str,
+    run: RunDir,
+    entity_kind: str,
+    entity_id: str,
+    invocation_id: str | None,
+    flow_kind: str,
+    playbook: str | None,
+    save_dir: str | None,
+    cwd: str,
+    started_at: float,
+    terminal_status: str,
+    reason_code: str,
+    occurred_at: float,
+) -> None:
+    """Deliver this run's `--notify` adapter directly, at process end, for a
+    run that never got a session entity to fire the registered callback path
+    on (``setup_agent_persist`` failed -- see docs/internals/cli.md). Same
+    resolution, same legacy payload/argv/env shape as
+    ``register_flow_notify_scope``, invoked immediately against a
+    process-local envelope instead of registered for a transition that can
+    never happen.
+
+    Idempotent: a run that already has a recorded notify outcome (an earlier
+    rejection, or an earlier direct-path attempt) is skipped rather than
+    notified twice -- see docs/internals/cli.md for why a file check is
+    sufficient here rather than the per-run lock the MCP job record uses.
+
+    A notifier that was never asked for is not this function's job to notice;
+    callers only reach here once they know an override was actually given.
+    """
+    if run.notify_outcome_path.exists():
+        return
+
+    def _report(reason: str) -> None:
+        try:
+            record_notify_rejection_to_run(run, reason)
+        except Exception:  # noqa: BLE001 -- bookkeeping must never affect the run
+            logger.debug("failed to record notify direct-delivery rejection", exc_info=True)
+
+    resolution = resolve_notify_config(override=override)
+    if resolution.reason is not None:
+        _report(resolution.reason)
+        return
+    resolved = resolution.handler
+    if resolved is None:
+        return
+
+    payload_fn = _legacy_payload_builder(
+        invocation_id=invocation_id,
+        kind=flow_kind,
+        playbook=playbook,
+        save_dir=save_dir,
+        cwd=cwd,
+        started_at=started_at,
+    )
+    _argv_fn, _env_fn = _legacy_argv_env_builders(payload_fn, invocation_id=invocation_id)
+
+    def _outcome_fn(*, ok: bool, exit_code: int | None, stderr_text: str | None) -> str | None:
+        return record_notify_outcome_to_run(
+            run, ok=ok, exit_code=exit_code, stderr_text=stderr_text
+        )
+
+    handler = build_handler(
+        resolved,
+        payload_fn=payload_fn,
+        argv_fn=_argv_fn,
+        env_fn=_env_fn,
+        outcome_fn=_outcome_fn,
+        on_build_failure=_report,
+    )
+    if handler is None:
+        return
+
+    envelope = RunTerminalEnvelope(
+        event_id=str(uuid.uuid4()),
+        entity=EntityRef(kind=entity_kind, id=entity_id),
+        previous_status=None,
+        terminal_status=terminal_status,
+        reason_code=reason_code,
+        occurred_at=occurred_at,
+    )
+    try:
+        if is_coro_func(handler):
+            await maybe_await(handler(envelope))
+        else:
+            # offloaded so a sync handler body never blocks the loop; see
+            # TerminalCallbackRegistry.emit, which this mirrors.
+            await maybe_await(
+                await anyio.to_thread.run_sync(handler, envelope, abandon_on_cancel=True)
+            )
+    except Exception:  # noqa: BLE001 -- a notifier failure must never affect the run
+        logger.warning(
+            "direct-path notify.on_terminal delivery failed for run %s", run.run_id, exc_info=True
+        )

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -89,6 +89,16 @@ _SPAWN_FAILED_REASON = "spawn_failed"
 OUTCOME_INDETERMINATE = "indeterminate"
 LOST_REASON = "process_gone_without_outcome"
 
+# A narrower sibling of LOST_REASON: the run's own directory carries a
+# notify_outcome.json recording that its terminal notice was never delivered
+# (persistence was unavailable, or a direct-delivery attempt itself failed —
+# see lionagi/cli/orchestrate/_notify.py). Unlike LOST_REASON this is not pure
+# silence — the run said something about its own end before going quiet — but
+# it is still not a recorded status, so it stays OUTCOME_INDETERMINATE. Never
+# assigned from the *absence* of that file: retention prunes run directories,
+# and an absent file is exactly what true silence also looks like.
+LOST_REASON_NOTICE_RECORDED_UNDELIVERED = "process_gone_notice_recorded_undelivered"
+
 # Outcome values valid to report back from a job record.
 _OUTCOMES = frozenset({"succeeded", "failed", "cancelled", OUTCOME_INDETERMINATE})
 
@@ -1501,6 +1511,22 @@ class ReapResult:
     reason: str
 
 
+def _notice_recorded_undelivered(run_id: str) -> bool:
+    """Whether *run_id*'s own run directory recorded its terminal notice as
+    never delivered (``notify_outcome.json`` with ``ok: false``).
+
+    Best-effort and evidence-only: a missing or unreadable file returns
+    False, the same as a run that never wrote one — see LOST_REASON_
+    NOTICE_RECORDED_UNDELIVERED for why absence must never be read as this.
+    """
+    try:
+        text = config.run_dir(run_id).joinpath("notify_outcome.json").read_text()
+        outcome = json.loads(text)
+    except (OSError, ValueError):
+        return False
+    return isinstance(outcome, dict) and outcome.get("ok") is False
+
+
 def reap_orphan(run_id: str, *, finding: str, observed_at: str) -> ReapResult:
     """Publish the end of a run whose process is conclusively gone.
 
@@ -1528,11 +1554,16 @@ def reap_orphan(run_id: str, *, finding: str, observed_at: str) -> ReapResult:
             return ReapResult(False, job, "spawn_state_is_not_started")
         if job.get("finished_at") is not None:
             return ReapResult(False, job, "already_ended")
+        reason_code = (
+            LOST_REASON_NOTICE_RECORDED_UNDELIVERED
+            if _notice_recorded_undelivered(run_id)
+            else LOST_REASON
+        )
         job.update(
             {
                 "status": "exited",
                 "outcome": OUTCOME_INDETERMINATE,
-                "reason_code": LOST_REASON,
+                "reason_code": reason_code,
                 "finished_at": observed_at,
                 "terminal_source": TERMINAL_SOURCE_ORPHAN_REAPER,
                 "terminal_evidence": {"kind": EVIDENCE_PROCESS_GONE, "finding": finding},

--- a/lionagi/state/lifecycle/notify_settings.py
+++ b/lionagi/state/lifecycle/notify_settings.py
@@ -41,6 +41,8 @@ __all__ = (
     "PayloadBuilder",
     "ResolvedNotifyHandler",
     "build_handler",
+    "record_notify_outcome_to_run",
+    "record_notify_rejection_to_run",
     "register_run_notify_outcome_scope",
     "register_settings_terminal_callback",
     "resolve_notify_config",
@@ -313,7 +315,7 @@ def _resolve_mapping(cfg: dict[str, Any], *, scope: str) -> NotifyConfigResoluti
 OutcomeFn = Callable[..., "str | None"]
 
 
-def _record_notify_outcome_to_run(
+def record_notify_outcome_to_run(
     run: RunDir, *, ok: bool, exit_code: int | None, stderr_text: str | None
 ) -> str | None:
     """Best-effort: record the exec adapter's outcome into *run*'s own
@@ -662,7 +664,7 @@ def register_run_notify_outcome_scope(
         return None
 
     def _outcome_fn(*, ok: bool, exit_code: int | None, stderr_text: str | None) -> str | None:
-        return _record_notify_outcome_to_run(
+        return record_notify_outcome_to_run(
             run, ok=ok, exit_code=exit_code, stderr_text=stderr_text
         )
 

--- a/tests/cli/test_agent_notify_without_persistence.py
+++ b/tests/cli/test_agent_notify_without_persistence.py
@@ -1,25 +1,34 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""A run that asked for a terminal notice it can never get has to say so.
+"""A run that asked for a terminal notice, and lost its persistence before it
+could register the callback that would normally deliver one, still gets it
+delivered.
 
-`--notify` is delivered by a callback registered against this run's session
-entity and fired by that entity's terminal transition. When persistence setup
-fails there is no session entity, so no transition can happen and the adapter
-is never called, however well it resolves. The run then finishes its work and
-ends in silence, and silence is exactly what a run that never asked for a
-notifier produces.
+`--notify` is ordinarily delivered by a callback registered against this
+run's session entity and fired by that entity's terminal transition. When
+persistence setup fails there is no session entity, so no transition can ever
+happen and the registered path can never fire, however well it resolves. This
+run instead delivers the notice itself, directly, once its own terminal
+status is known — see `deliver_flow_notify_now` in
+`lionagi/cli/orchestrate/_notify.py` and docs/internals/cli.md.
 
 That matters because the consumers are automated. The lion MCP server wires
 `--notify` on every job it spawns and takes the resulting notice as the run's
 end; without one it eventually observes the process is gone with nothing
 recorded and publishes `outcome=indeterminate`, which is the opposite of what
 happened to a run that did all of its work.
+
+Recording a refusal is not the same as delivering a notice: the refusal
+record (`notify_outcome.json` with a `reason`) is now written only when
+delivery is actually attempted and genuinely cannot be completed — nothing
+usable is configured — never merely because persistence broke.
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -84,25 +93,24 @@ def _wire_agent_stubs(monkeypatch, tmp_path: Path, *, persist: dict | None):
 
 
 @pytest.mark.asyncio
-async def test_notify_asked_for_without_a_session_records_the_refusal(monkeypatch, tmp_path):
-    """No session entity to fire on is recorded, not passed over in silence."""
+async def test_notify_unusable_config_without_a_session_records_the_refusal(monkeypatch, tmp_path):
+    """A notifier that was asked for and cannot even be resolved is refused
+    and recorded — the only case that still writes a bare refusal now that
+    delivery is attempted directly."""
     run = _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
 
     from lionagi.cli.agent import _run_agent
 
-    await _run_agent("codex/model", "do the thing", notify="/some/notifier")
+    # Shell features are never honored by any notify resolver; this is
+    # rejected before any delivery is attempted.
+    await _run_agent("codex/model", "do the thing", notify="echo hi | cat")
 
     assert run.notify_outcome_path.exists(), (
-        "a notifier was asked for and can never fire; the run has to record that"
+        "a notifier was asked for and could not even be resolved; the run has to record that"
     )
     outcome = json.loads(run.notify_outcome_path.read_text())
     assert outcome["ok"] is False
-    # The reason is what separates this from every other way a notice fails to
-    # arrive, so it is asserted by value rather than by being present.
-    assert outcome["reason"] == "run_has_no_persisted_session_to_notify_on"
-    # Nothing was launched, so there is no exit code and no captured stderr to
-    # point at. Asserting these keeps the record from growing a fabricated
-    # success shape later.
+    assert outcome["reason"] == "on_terminal_command_requires_shell_features"
     assert outcome["exit_code"] is None
     assert outcome["stderr_path"] is None
 
@@ -123,4 +131,69 @@ async def test_no_notifier_asked_for_writes_no_refusal(monkeypatch, tmp_path):
 
     assert not run.notify_outcome_path.exists(), (
         "a run that asked for nothing must look different from one that was refused"
+    )
+
+
+def _write_fake_notifier(tmp_path: Path) -> Path:
+    """A tiny script standing in for a real `--notify` adapter: argv[1] is
+    where it records that it ran, argv[2] (if given) is written into it — the
+    `{status}` placeholder, in the delivery test below, so the assertion is
+    on what the CLI actually substituted, not just that something ran."""
+    script = tmp_path / "fake_notifier.py"
+    script.write_text(
+        "import sys\n"
+        "path = sys.argv[1]\n"
+        "status = sys.argv[2] if len(sys.argv) > 2 else ''\n"
+        "with open(path, 'w') as f:\n"
+        "    f.write(status)\n"
+    )
+    return script
+
+
+@pytest.mark.asyncio
+async def test_direct_path_delivers_the_notice_when_persistence_is_lost(monkeypatch, tmp_path):
+    """The reproduced condition: persistence setup fails for a run submitted
+    with a notify template, and the notice is DELIVERED — the fake delivery
+    command records its own invocation, carrying the run's real terminal
+    status, not silence and not a bare refusal record."""
+    run = _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
+    marker = tmp_path / "delivered.txt"
+    script = _write_fake_notifier(tmp_path)
+    notify_cmd = f"{sys.executable} {script} {marker} {{status}}"
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("codex/model", "do the thing", notify=notify_cmd)
+
+    assert marker.exists(), "the fake delivery command was never invoked"
+    assert marker.read_text() == "completed"
+
+
+@pytest.mark.asyncio
+async def test_control_disabling_the_direct_path_delivers_nothing(monkeypatch, tmp_path):
+    """The pre-fix behaviour, reproduced as a control: with the direct-path
+    seam disabled, the identical arrangement above delivers nothing. This is
+    what proves the test above exercises the new code, not something that
+    would have passed anyway (a fake notifier that always runs, a marker file
+    that already existed, etc.)."""
+    run = _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
+    marker = tmp_path / "delivered.txt"
+    script = _write_fake_notifier(tmp_path)
+    notify_cmd = f"{sys.executable} {script} {marker} {{status}}"
+
+    import lionagi.cli.orchestrate._notify as notify_mod
+
+    async def _disabled(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(notify_mod, "deliver_flow_notify_now", _disabled)
+
+    from lionagi.cli.agent import _run_agent
+
+    await _run_agent("codex/model", "do the thing", notify=notify_cmd)
+
+    assert not marker.exists(), "the old (pre-fix) path must not deliver anything"
+    assert not run.notify_outcome_path.exists(), (
+        "the old path recorded nothing either — this is what made the run look "
+        "exactly like one that never asked for a notifier at all"
     )

--- a/tests/mcp/test_orphan_reaping.py
+++ b/tests/mcp/test_orphan_reaping.py
@@ -11,6 +11,7 @@ being checked is that the lock serializes — a doubled lock would prove nothing
 
 from __future__ import annotations
 
+import json
 import threading
 from typing import Any
 
@@ -694,3 +695,105 @@ def test_a_recorded_kill_names_the_kill_as_what_ended_the_run(sandbox, monkeypat
     on_disk = jobs._read_job(rid)
     assert on_disk["status"] == "killed"
     assert on_disk["terminal_source"] == jobs.TERMINAL_SOURCE_KILL
+
+
+# --- reap reason-code split (docs/internals/mcp.md#reap-reason-code-split) ----
+
+
+def test_reap_upgrades_the_reason_code_when_the_run_recorded_an_undelivered_notice(
+    sandbox, monkeypatch, no_delivery
+):
+    """A run whose own directory says its terminal notice never arrived is not
+    pure silence, and the reap it gets should say so.
+
+    This is the shape `deliver_flow_notify_now` (`lionagi/cli/orchestrate/
+    _notify.py`) and the pre-existing `record_notify_rejection_to_run` both
+    leave behind for a run that lost its persistence: `notify_outcome.json`
+    with `ok: false`.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    run_dir = config.run_dir(rid)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "notify_outcome.json").write_text(
+        json.dumps(
+            {
+                "ok": False,
+                "exit_code": None,
+                "stderr_path": None,
+                "reason": "run_has_no_persisted_session_to_notify_on",
+            }
+        )
+    )
+
+    st = jobs.status(rid)
+
+    assert st["terminal"] is True
+    assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
+    assert st["reason_code"] == jobs.LOST_REASON_NOTICE_RECORDED_UNDELIVERED
+
+
+def test_reap_keeps_true_silence_when_nothing_was_recorded(sandbox, monkeypatch, no_delivery):
+    """No file at all -- never wrote one, or retention pruned it -- reaps to
+    the pre-existing reason code. Absence is never read as evidence either
+    way; it is the same signal a genuinely silent run produces."""
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    st = jobs.status(rid)
+
+    assert st["reason_code"] == jobs.LOST_REASON
+
+
+def test_reap_ignores_a_delivered_outcome_file(sandbox, monkeypatch, no_delivery):
+    """`ok: true` never upgrades the reason code. Moot for a real MCP-spawned
+    run (a delivered `--notify` already set `finished_at` via `mark_terminal`,
+    disqualifying it from reaping before this file is even read) but must not
+    misclassify a record that somehow reaches here anyway."""
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    run_dir = config.run_dir(rid)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "notify_outcome.json").write_text(
+        json.dumps({"ok": True, "exit_code": 0, "stderr_path": None})
+    )
+
+    st = jobs.status(rid)
+
+    assert st["reason_code"] == jobs.LOST_REASON
+
+
+def test_a_child_recorded_end_wins_over_a_later_reaper_observation(
+    sandbox, monkeypatch, no_delivery
+):
+    """Ties the general hook-wins-over-reaper guarantee (see
+    ``test_a_hook_end_that_lands_first_survives_the_reaper`` above) to the
+    concrete mechanism the CLI's direct-path notice delivery depends on:
+    `--notify` for an MCP-spawned run always resolves to
+    `lionagi.mcp._notify_hook`, so calling it IS how a run records its own
+    end, whichever of the two CLI-side notify paths (registered callback, or
+    a run that lost its persistence and delivers directly) triggered it.
+
+    Ordering matters here specifically: the child's hook runs and wins the
+    write BEFORE the reaper ever observes this run, and the reap that follows
+    must decline rather than overwrite it with `indeterminate`.
+    """
+    _pid_absent(monkeypatch)
+    rid = _stranded()
+
+    terminal = _notify_hook.main(["--run-id", rid, "--status", "completed"])
+    assert terminal == 0
+    assert jobs._read_job(rid)["terminal_source"] == jobs.TERMINAL_SOURCE_HOOK
+    assert len(no_delivery) == 1, "the hook's own delivery attempt"
+
+    st = jobs.status(rid)
+
+    assert st["status"] == "completed"
+    assert st["terminal"] is True
+    assert st["outcome"] == "succeeded"
+    assert st["reason_code"] != jobs.LOST_REASON
+    assert st["reason_code"] != jobs.LOST_REASON_NOTICE_RECORDED_UNDELIVERED
+    assert st["terminal_source"] == jobs.TERMINAL_SOURCE_HOOK
+    assert len(no_delivery) == 1, "the reaper must not attempt its own delivery over a recorded end"

--- a/tests/state/lifecycle/test_notify_settings.py
+++ b/tests/state/lifecycle/test_notify_settings.py
@@ -395,10 +395,10 @@ async def test_exec_handler_swallows_nonzero_exit_and_timeout(monkeypatch, caplo
 
 
 def _outcome_fn_for(run):
-    from lionagi.state.lifecycle.notify_settings import _record_notify_outcome_to_run
+    from lionagi.state.lifecycle.notify_settings import record_notify_outcome_to_run
 
     def _fn(*, ok, exit_code, stderr_text):
-        return _record_notify_outcome_to_run(
+        return record_notify_outcome_to_run(
             run, ok=ok, exit_code=exit_code, stderr_text=stderr_text
         )
 


### PR DESCRIPTION
## What

When `setup_agent_persist` fails, `li agent` has no session entity to fire the registered `--notify` callback on, so the notice could never arrive even though the run went on to complete all of its work. A caller waiting on a terminal notice saw exactly what a vanished process looks like.

- `cli/orchestrate/_notify.py`: `deliver_flow_notify_now` — same resolution and legacy payload/argv/env shape as the registered path (shared via `_legacy_argv_env_builders`), invoked directly against a synthesized envelope once the run's real terminal status is known, instead of registered for a transition that can never happen. Idempotent via a per-run `notify_outcome.json` existence check; the two notify paths are mutually exclusive by construction within one process, so this guards re-entrancy rather than a race.
- `cli/agent.py`: the eager refusal record on the no-session branch is replaced by the deferred direct delivery in `finally`, carrying the same reason vocabulary (`resolve_run_reason`) a registered notice would. The refusal record now fires only when delivery genuinely cannot be attempted, never merely because persistence broke.
- `mcp/jobs.py`: the orphan reaper's reason code splits three ways for what remains unattributable — spawn rejected before starting (pre-existing, via `spawn_state == "failed"`), a run whose own directory recorded its notice as undelivered (new: `process_gone_notice_recorded_undelivered`), and true silence (`process_gone_without_outcome`, unchanged). Absence of the file is never read as evidence: retention prunes run directories, so a pruned record and true silence are indistinguishable on disk. A child-recorded end always wins: `mark_terminal` is first-writer-wins and the reaper's admission gate refuses once `finished_at` is set.

## Tests

- Positive: persistence-lost run delivers its notice with the run's real terminal status (a fake delivery script asserts it ran and what it received).
- Negative control: with the direct path disabled, nothing is written at all — the original bug's exact symptom.
- Ordering: a child-recorded end via the actual `_notify_hook.main` survives a later reaper observation.
- Reason split: undelivered-recorded picks the new code; a delivered (`ok: true`) file is never upgraded; absence stays `process_gone_without_outcome`.

`tests/cli` + `tests/state` + `tests/mcp` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)