### PR TITLE
fix(mcp): name the notify refusal that has exactly one fix

### DIFF
--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -54,6 +54,14 @@ _FAILURE_CLASSES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("refused_by_policy", ("refused by", "blocked by", "denied by policy", "forbidden", "403")),
     ("target_unknown", ("unknown recipient", "no such actor", "unknown actor", "no such user")),
     ("invalid_usage", ("usage:", "unrecognized argument", "invalid argument", "unknown option")),
+    # A delivery command that verifies who it would be sending AS (kkernel's
+    # --expect-actor) refuses when the working directory resolves to a different
+    # identity than the record's sender. That is a producer-side configuration
+    # fact — the submit named a sender its own directory cannot sign for — and
+    # an operator reading "unknown" cannot tell it from a genuinely novel
+    # failure, though it has exactly one fix (make notify_sender match the
+    # submitting directory's actor, or omit it).
+    ("sender_identity_mismatch", ("expect-actor mismatch",)),
 )
 
 

--- a/tests/mcp/test_notify_failure_classification.py
+++ b/tests/mcp/test_notify_failure_classification.py
@@ -118,6 +118,21 @@ def test_a_network_refusal_is_not_read_as_a_policy_refusal():
     assert _classify_failure("request refused by the delivery gate") == "refused_by_policy"
 
 
+def test_an_identity_refusal_is_named_not_unknown():
+    """The needle is the delivery command's own verbatim refusal, not my paraphrase.
+
+    Measured: a notifier run under kkernel --expect-actor from a directory that
+    resolves to a different identity prints
+    '--expect-actor mismatch: expected "agent:x", resolved "lambda:y"' and exits 1.
+    The quoted identities stay out of the record — only the class name is stored —
+    and a text that merely talks about actors without that refusal phrase must
+    stay unknown, because "mismatch" alone appears in too many unrelated errors.
+    """
+    real = 'Error: --expect-actor mismatch: expected "agent:x", resolved "lambda:y"'
+    assert _classify_failure(real) == "sender_identity_mismatch"
+    assert _classify_failure("actor lambda:y sent a mismatched payload") == _FAILURE_UNKNOWN
+
+
 def test_a_delivery_that_says_nothing_useful_is_unknown_not_a_quote():
     out = _deliver(_py("import sys; sys.stderr.write('weird internal burble'); sys.exit(9)"), {})
     assert out["ok"] is False


### PR DESCRIPTION
A delivery command that verifies who it would send AS (kkernel `--expect-actor`) refuses when the working directory resolves to a different identity than the record's sender. That refusal was stored as `failure_class=unknown`, indistinguishable from a genuinely novel failure, though it is a producer-side configuration fact with exactly one fix: make `notify_sender` match the submitting directory's actor, or omit it.

New closed-set member `sender_identity_mismatch`, keyed on the command's own verbatim refusal phrase (`expect-actor mismatch`) rather than any broad word like "mismatch" that unrelated errors also use. The test asserts both arms: the real refusal line classifies, and a text that merely mentions actors and a mismatch stays `unknown`. The quoted identities in the refusal never reach the record; only the class name is stored, preserving the closed-set invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)