### PR TITLE
docs(mcp): name the notify negative sweep where a caller would look for it

### DIFF
--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -276,6 +276,19 @@ Inconclusive (settle nothing about death):
   `"unreadable"`/`"wrong_shape"` mean a file is on disk and damaged — reporting
   either as unknown would send an operator away from a file that exists.
 
+#### listing-negative-sweep
+
+A caller who suspects nothing still needs to find the run whose terminal
+notice never arrived — by construction that run announced itself to nobody.
+`job.list` is that surface: every row carries `notify_delivery_state`
+(`none` / `delivered` / `delivered_unverified` / `failed`, collapsed from the
+full `notify_delivery` object `status()` reports for one-run detail), so the
+sweep is "list, act on `failed`" with no per-run reads. `none` covers both
+not-terminal-yet and no-notifier-configured — silence is the documented
+default there, never a failure — and `delivered_unverified` is deliberately
+not collapsed into either neighbor (a zero exit from a command shape whose
+zero exit doesn't prove a send supports neither claim).
+
 #### signal-leader-group-safety
 
 `_signal_leader_group()` (`lionagi/mcp/jobs.py`) signals a process group only

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -422,7 +422,13 @@ _REGISTERED: tuple[Verb, ...] = (
     ),
     Verb(
         name="job.list",
-        summary="Recent background jobs, newest first, optionally filtered by status.",
+        summary=(
+            "Recent background jobs, newest first, optionally filtered by status. "
+            "Each row carries notify_delivery_state (none/delivered/"
+            "delivered_unverified/failed) — sweeping for terminal notices that "
+            "never arrived means reading this column and acting on 'failed'; no "
+            "prior suspicion about any particular run is needed."
+        ),
         executor="job",
         own_schema=_JOB_LIST_SCHEMA,
     ),


### PR DESCRIPTION
## What

Two documentation landings, no behavior change:

- `job.list` verb help now says each row carries `notify_delivery_state` and that sweeping for terminal notices that never arrived means reading that column and acting on `failed` — no prior suspicion about any particular run needed.
- `docs/internals/mcp.md` gains `#### listing-negative-sweep` under `mcp/jobs.py`, documenting the four-value vocabulary (`none` / `delivered` / `delivered_unverified` / `failed`), why `none` is never a failure, and why `delivered_unverified` is deliberately not collapsed into either neighbor.

## Why

The run whose terminal notice never arrived announced itself to nobody, so the caller who needs to find it has no run id to ask about. The listing column that answers this has existed since the field landed, but nothing at the surface said so — consumers were building per-run polling they did not need.

## Verification

- `uv run pytest tests/mcp/` green at rc=0
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)