### PR TITLE
docs(adr): ADR-0110 deterministic manifest fan-out — legs from briefs, no planner

### DIFF
--- a/docs/adr/ADR-0066-li-mcp-v2-verb-surface.md
+++ b/docs/adr/ADR-0066-li-mcp-v2-verb-surface.md
@@ -4,13 +4,32 @@
 - **Kind**: Aspirational
 - **Area**: cli-surface
 - **Date**: 2026-07-24 (amended 2026-07-25 twice — D1, D2, D3 and D7; amended 2026-07-27 —
-  D6, see Amendment history)
+  D6; amended 2026-08-03 — D6, see Amendment history)
 - **Relations**: builds on ADR-0095 (run-terminal callbacks — the `notify.on_terminal`
   layer the MCP submits ride) and ADR-0104 (`li kill` transitive play reaping and
   terminal-notify on kill, whose semantics the kill verb must inherit rather than
   re-implement); none superseded
 
 ## Amendment history
+
+**2026-08-03 — Amendment 4: D6's wait contract catches up with the observed surface.**
+Three changes, all already true of the implementation, recorded under this document's own
+rule that a non-terminal classification is added to a list a caller can read, never left
+to the classifier alone.
+
+1. **The partition is four-way.** An aged `preparing` record has no process to prove
+   absent, so it is neither `pending` (waiting has stopped changing its answer) nor
+   `stopped_without_end` (nothing observable stopped); it is returned in its own list,
+   `unresolved_spawn`, with the age threshold echoed in the result. `stopped_without_end`
+   is also now stated by evidence rather than phase: it holds records that stopped or
+   cannot be shown to be progressing, including a conclusive finding whose transition
+   could not be published and a record from before the spawn phase was recorded.
+2. **The one-poll floor keys on either special list**, since neither resolves by waiting.
+3. **Observation purity gains its one fenced exception.** The first reader of a
+   conclusively-gone `started` run may durably reap it where the fenced write publishes;
+   a refused write leaves the record untouched. ADR-0106 D10 and ADR-0107 carry the full
+   statement; it is recorded here so a verb-surface reader is not told purity is
+   unconditional.
 
 **2026-07-27 — Amendment 3: D6 states four things it previously left to the reader.** All
 four were already true of the implementation and none was findable in this document, which
@@ -450,8 +469,13 @@ unrecognised failure as a success.
 
 **The result partitions the observed ids, and the partition is exhaustive.** Every id that
 was observed without a per-id error is exactly one of: terminal; still `pending`, meaning
-further waiting can still change its answer; or in `stopped_without_end`, meaning its process
-is gone with no end recorded and waiting cannot. The three are disjoint and together cover
+further waiting can still change its answer; in `stopped_without_end`, meaning the record
+stopped or cannot be shown to be progressing — its process gone with no end recorded, a
+conclusive finding whose transition could not be published, or a record with no recorded
+spawn phase — and waiting cannot change it; or in `unresolved_spawn`, meaning the record
+still says `preparing` past the producer's stated age threshold (echoed in the result), so
+there is no process to prove absent and waiting has stopped meaning anything. The four are
+disjoint and together cover
 every observed id, so a caller can hold a policy for each and know it has covered them all.
 An id that is not resolved and is not named anywhere is a defect in the implementation, not
 a caller's problem to infer: the duty to have a policy for an unresolved run is only
@@ -459,9 +483,10 @@ dischargeable if every unresolved run arrives somewhere it can be read. A future
 non-terminal classification is therefore added to a list at the same time it is added to the
 classifier, never to the classifier alone.
 
-Because an id in `stopped_without_end` resolves nothing by waiting, a caller looping until
+Because an id in `stopped_without_end` or `unresolved_spawn` resolves nothing by waiting, a
+caller looping until
 `all_terminal` would otherwise re-ask as fast as it could send. So a call that would return
-without having waited at all, while at least one id is in that list, first waits one poll
+without having waited at all, while at least one id is in either list, first waits one poll
 interval — bounded by whatever is left of the window — and observes again. This is a floor
 on the call rather than a charge added to it: a call that already waited on a running id has
 met it, and a snapshot request has no window to spend and pays nothing. Pacing sits here
@@ -475,8 +500,13 @@ other ids from being observed. Those errors are a separate channel from the pend
 do not define it: they are for ids that could not be observed at all, so an id that *was*
 observed is placed by the partition above rather than by what the error channel excludes.
 
-**Observing does not touch the run.** A wait that expires, that is signalled, or whose caller
-disconnects leaves the durable record exactly as it was. Cancelling an observation is not
+**Observing does not touch the run — with one deliberate, fenced exception.** A wait that
+expires, that is signalled, or whose caller
+disconnects leaves the durable record exactly as it was. The exception: the first reader of
+a `started` run whose process is conclusively established gone may durably reap it to an
+attributable terminal where the fenced write publishes; a refused write leaves the record
+exactly as every other observation does (ADR-0106 D10 and ADR-0107 specify the evidence and
+the fence). Cancelling an observation is not
 cancelling the work, and no implementation may make the two the same operation — a caller
 that walks away from a bounded wait has said nothing about whether the work should continue,
 and the only safe reading of silence is that it should.

--- a/docs/adr/ADR-0066-li-mcp-v2-verb-surface.md
+++ b/docs/adr/ADR-0066-li-mcp-v2-verb-surface.md
@@ -23,7 +23,8 @@ to the classifier alone.
    `unresolved_spawn`, with the age threshold echoed in the result. `stopped_without_end`
    is also now stated by evidence rather than phase: it holds records that stopped or
    cannot be shown to be progressing, including a conclusive finding whose transition
-   could not be published and a record from before the spawn phase was recorded.
+   could not be published and a not-shown-alive record from before the spawn phase was
+   recorded (a live pre-field record is classified running and stays in `pending`).
 2. **The one-poll floor keys on either special list**, since neither resolves by waiting.
 3. **Observation purity gains its one fenced exception.** The first reader of a
    conclusively-gone `started` run may durably reap it where the fenced write publishes;
@@ -472,7 +473,8 @@ was observed without a per-id error is exactly one of: terminal; still `pending`
 further waiting can still change its answer; in `stopped_without_end`, meaning the record
 stopped or cannot be shown to be progressing — its process gone with no end recorded, a
 conclusive finding whose transition could not be published, or a record with no recorded
-spawn phase — and waiting cannot change it; or in `unresolved_spawn`, meaning the record
+spawn phase that is not shown alive (a live one is classified running and stays
+`pending`) — and waiting cannot change it; or in `unresolved_spawn`, meaning the record
 still says `preparing` past the producer's stated age threshold (echoed in the result), so
 there is no process to prove absent and waiting has stopped meaning anything. The four are
 disjoint and together cover

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -99,7 +99,7 @@ wake it. A consumer restart across a successful delivery loses it the same way.
 | Distinguishing absence from failure | D7: every read-derived field carries its own availability and reason |
 | Process-level faults | D8: a valid envelope is authoritative; exit status is the transport-level answer, with a defined precedence |
 | Terminal notification | D9: a notification is a prompt to read state, never proof and never the only path |
-| Bounded observation | D10: `wait` is bounded, returns partial results, and takes ADR-0066 D6 with two marked extensions and one clause D6 leaves open decided here |
+| Bounded observation | D10: `wait` is bounded, returns partial results, and shares ADR-0066 D6's wait contract — first stated here as extensions, since adopted into D6 by its 2026-07-27 and 2026-08-03 amendments; this ADR carries the fuller statement |
 
 Out of scope:
 
@@ -575,7 +575,7 @@ is configured, sends a terminal notice.
 - Artifacts are written before the notice is sent, so a consumer woken by the notice
   finds the outputs already present.
 
-### D10 — Bounded observation, taken from ADR-0066 D6, extended in two places and completed in one
+### D10 — Bounded observation, shared with ADR-0066 D6, stated here in full
 
 `wait` takes ids, a maximum wait, and a poll interval; both numbers are clamped to
 documented bounds and the effective values are echoed back. `0` is a legal snapshot
@@ -604,7 +604,11 @@ request.
   is nicer is not the point. Every status-bearing path in this contract resolves through one
   authority, and an orphan is terminal on all of them or on none.
 
-**Three additions this ADR makes, which ADR-0066 does not state.** They are marked as
+**Three additions this ADR made when its text froze, which ADR-0066 then did not state.**
+ADR-0066's amendments have since adopted all three (`outcome` on every entry and the
+partition on 2026-07-27; the four-way partition, either-list floor, and fenced purity
+exception on 2026-08-03), so they are shared rules now and this section carries the fuller
+rationale. They were marked as
 extensions rather than folded into the list above, because presenting a new decision as an
 existing one tells every reader there is nothing left to reconcile, which is the most
 effective way to prevent it being reconciled:
@@ -616,13 +620,16 @@ effective way to prevent it being reconciled:
   where the fenced write publishes — an attributable terminal written under a fenced
   claim, before notification and wait aggregation — repairing a record no writer survived
   to finish, never mutating live work. A refused or unpublishable write leaves the run
-  exactly as every other observation does; the retry belongs to the next reader. ADR-0066 D6 is silent on signal and disconnect, so an MCP
-  implementer reading only that ADR could let request cancellation propagate into the
-  operation while an external consumer assumes it cannot — the two surfaces then behave
-  differently after the identical event.
+  exactly as every other observation does; the retry belongs to the next reader. ADR-0066
+  D6 as first written was silent on signal and disconnect, so an MCP
+  implementer reading only that ADR could have let request cancellation propagate into the
+  operation while an external consumer assumed it could not; its 2026-07-27 amendment
+  states the purity rule and its 2026-08-03 amendment adds this same fenced exception.
 - **Every entry carries `outcome`** as well as `terminal`, per D4. ADR-0066 D6's entry
-  contract lists kind, status, terminality and reason code, so a conforming ADR-0066
-  implementation would omit the field this contract requires for reporting a result.
+  contract as first written listed kind, status, terminality and reason code, so a
+  conforming implementation could have omitted the field this contract requires for
+  reporting a result; the 2026-07-27 amendment added `outcome` and both documents now
+  require it.
 - **An id that waiting cannot resolve does not hold the window open, and the producer pays
   a floor for it.** A run whose process is gone with no end recorded has stopped, and both
   original writers of an end are past it. Where that finding is conclusive for a `started`
@@ -681,16 +688,17 @@ ADR-0066 D6 was amended on 2026-08-03 to state the same partition, the same eith
 floor, and the same fenced-reap exception, so the two documents agree; where the level of
 detail differs, this ADR carries the fuller statement.
 
-**The third is a definition of something ADR-0066 D6 leaves open**, and it is the clause to
-read carefully. D6 states the result as the entries plus `all_terminal`, `timed_out`, and
-the list of ids still pending. It names that key and nowhere says which ids qualify for it,
-so it does not by itself decide where a run that stopped without an end belongs. A reading
-is available on which it does: D6 names a per-id error channel for ids that could not be
+**The third was a definition of something ADR-0066 D6 as first written left open**, and it
+is the clause whose history is worth keeping. D6 then stated the result as the entries plus
+`all_terminal`, `timed_out`, and
+the list of ids still pending. It named that key and nowhere said which ids qualify for it,
+so it did not by itself decide where a run that stopped without an end belongs. A reading
+was available on which it did: D6 names a per-id error channel for ids that could not be
 observed, and naming one exclusion can be read as ruling out others. That reading is
-recorded here because it was argued seriously, not because it is adopted. It is not
+recorded here because it was argued seriously, not because it was adopted. It was not
 adopted — the error channel is for ids observation could not resolve, while a stopped id
 was observed and classified, so naming that channel does not settle the pending rule by
-exclusion. The honest conclusion is that D6 underdetermines this, and an underdetermined
+exclusion. The honest conclusion was that D6 underdetermined this, and an underdetermined
 clause is settled by amending it rather than by either document assuming its own reading.
 ADR-0066's 2026-08-03 amendment therefore states the partition outright: `pending`,
 `stopped_without_end`, `unresolved_spawn` and terminal are disjoint and exhaustive over
@@ -861,12 +869,13 @@ own tests will not catch it.
 **Cost of reversal.** D3, D4 and D7 are cheap to extend and expensive to retract. D2 is
 the escape hatch: a breaking change is expressible as a version increment rather than a
 negotiation. D8 could be dropped without touching the envelope, at the cost of P7
-returning. D10 cannot be dropped without re-opening the contradiction with ADR-0066, and
-its two marked extensions cannot be dropped without leaving the two documents disagreeing
-about what a wait entry contains and what a disconnect does. The clause it decides where
-D6 is silent is the opposite case: nothing forces it, an implementation could have put
-stopped ids in `pending` and stayed conforming, and it is reversible only until a consumer
-has been written against it. The producer floor attached to it is cheaper to reverse than
+returning. D10's rules are now stated in ADR-0066 D6 as well, so dropping them here would
+not create disagreement; it would leave the verb surface carrying the rules with none of
+the rationale, and reversing any of them is a coordinated amendment of both documents. The
+partition clause had a window in which it was cheap to reverse — before ADR-0066's
+2026-08-03 amendment an implementation could have put
+stopped ids in `pending` and stayed conforming — and that window is closed: both documents
+now state where every unresolved id belongs, and consumers may be written against it. The producer floor attached to it is cheaper to reverse than
 to introduce, since removing a minimum call duration cannot break a caller that was
 tolerating it.
 

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -627,15 +627,19 @@ effective way to prevent it being reconciled:
   a floor for it.** A run whose process is gone with no end recorded has stopped, and both
   original writers of an end are past it. Where that finding is conclusive for a `started`
   run and the fenced reap publishes, the status read resolves it before aggregation
-  (ADR-0107): it comes back terminal and never appears in this list. The list holds the
-  `started` cases that stopped and could not be resolved — an inconclusive finding, or a
-  conclusive one whose transition could not be published, retried on the next
-  observation. A `preparing` record is never in it: fresh, it stays in `pending`; aged
-  past the producer's stated threshold, it is returned in its own fourth bucket,
-  `unresolved_spawn`, with that threshold reported beside it (there is no process to
-  prove absent, so it is a different fact than a stopped run). The stopped ids are
-  returned in their own list, `stopped_without_end`, rather than in `pending`, and the call
-  stops re-observing once every remaining id is either terminal or in that list. It is a
+  (ADR-0107): it comes back terminal and never appears in this list. The list is keyed on
+  what is known, not on a phase name: it holds every observed record that stopped, or
+  cannot be shown to be progressing, and could not be resolved — a `started` case with an
+  inconclusive finding, one whose conclusive transition could not be published (retried
+  on the next observation), and a record written before the spawn phase existed, whose
+  phase is unknown and which lands here by the same absence of evidence. The only records
+  kept out are the ones the producer explicitly marked `preparing`: fresh, such a record
+  stays in `pending`; aged past the producer's stated threshold, it is returned in its
+  own fourth bucket, `unresolved_spawn`, with that threshold reported beside it (there is
+  no process to prove absent, so it is a different fact than a stopped run). The stopped
+  ids are returned in their own list, `stopped_without_end`, rather than in `pending`,
+  and the call stops re-observing once every remaining id is either terminal or in one of
+  those two lists. It is a
   separate list and not a per-id error, because observing them succeeded. For those entries
   nothing about the
   record changes: the entry stays non-terminal with a null outcome, and a run that does
@@ -648,7 +652,9 @@ effective way to prevent it being reconciled:
   resolves. Dropping such ids from `pending` removes the second, and a consumer looping
   until `all_terminal` with no backoff of its own would turn a visible stall into a hot
   loop, which is worse than the stall it removes. So a call that would return without having
-  waited at all, while at least one id is in `stopped_without_end`, first sleeps one poll
+  waited at all, while at least one id is in `stopped_without_end` or `unresolved_spawn` —
+  the floor keys on either list, since an aged `preparing` record resolves nothing by
+  waiting either — first sleeps one poll
   interval — bounded by whatever is left of the window — and observes once more. The trigger
   is a property of the observation the call is about to return, not of any history, so it
   applies on a first observation as much as a later one.
@@ -671,9 +677,9 @@ effective way to prevent it being reconciled:
   boundary whose safety depends on N independent clients continuing to behave is not a
   boundary.
 
-The first two extensions need a forward amendment to ADR-0066 D6 to keep the two documents
-in agreement; until that lands, this ADR is the stricter of the two on them and an
-implementation satisfying it also satisfies ADR-0066.
+ADR-0066 D6 was amended on 2026-08-03 to state the same partition, the same either-list
+floor, and the same fenced-reap exception, so the two documents agree; where the level of
+detail differs, this ADR carries the fuller statement.
 
 **The third is a definition of something ADR-0066 D6 leaves open**, and it is the clause to
 read carefully. D6 states the result as the entries plus `all_terminal`, `timed_out`, and
@@ -686,7 +692,7 @@ adopted — the error channel is for ids observation could not resolve, while a 
 was observed and classified, so naming that channel does not settle the pending rule by
 exclusion. The honest conclusion is that D6 underdetermines this, and an underdetermined
 clause is settled by amending it rather than by either document assuming its own reading.
-The forward amendment therefore states the partition outright: `pending`,
+ADR-0066's 2026-08-03 amendment therefore states the partition outright: `pending`,
 `stopped_without_end`, `unresolved_spawn` and terminal are disjoint and exhaustive over
 every observed id (2026-08-03: the fourth bucket — an aged `preparing` record — is
 corrected into the partition here; the implementation and its tests already enforce the
@@ -795,7 +801,8 @@ being asked of them in one place.
    finish, or three integrators each inventing a different timeout behaviour, which is
    the divergence removed from the specification arriving back through the consumers.
 
-   On pacing, this obligation describes rather than requires. A `stopped_without_end` id
+   On pacing, this obligation describes rather than requires. A `stopped_without_end` or
+   `unresolved_spawn` id
    does not consume the window, so the window is not backpressure for it — the producer
    spends a one-interval floor instead (D10), and the correctness of the boundary does not
    depend on you. A backoff of your own is still recommended, because a floor set by the
@@ -829,7 +836,7 @@ non-terminal for as long as its record existed. Since ADR-0107 the first case cl
 the evidence is conclusive and the fenced reap publishes — a `started` orphan is reaped
 to an attributable terminal — while producer-death-before-spawn (`preparing`) and
 inconclusive findings still stay non-terminal. A consumer's bounded wait reports the
-inconclusive or unpublishable `started` cases as stopped without an end every time, and
+inconclusive or unpublishable cases as stopped without an end every time, and
 an aged `preparing` record in its own `unresolved_spawn` bucket, never as finished. Two earlier revisions tried to close this with a rule
 every reader would apply, and both produced worse failures than the one they removed: a
 healthy child reported as terminally failed, and two hosts disagreeing about one unchanged

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -277,7 +277,11 @@ another copy of our rules living in code we do not control.
   failure (D5) — never by matching `status` against a set, and never computed by a reader.
   In v1 those are the only two sources; the deferred reconciler in D6 would be a third.
 - `outcome` answers **"did the work come out right"**. It is a **closed** vocabulary,
-  `succeeded | failed | indeterminate`, and it is **`null` whenever `terminal` is false**.
+  `succeeded | failed | cancelled | indeterminate`, and it is **`null` whenever `terminal`
+  is false**. (`cancelled` added by the 2026-08-03 amendment carried by ADR-0110 D6: the
+  implementation emitted it before this text froze — the drift ADR-0107's Notes recorded
+  as a pending amendment item — so the correction records shipped behavior and moves no
+  version.)
   Stated against `terminal` rather than against "the run is still going", because v1 has a
   state that is neither: an orphan has stopped and is still not terminal (D6), and a rule
   phrased around being in flight would leave that case undefined. Being closed, `outcome`

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -553,8 +553,11 @@ is configured, sends a terminal notice.
   reading, so nothing wakes it to learn that nothing will wake it (P8). A consumer
   restart across a successful delivery loses it identically. Reconciliation is D10's
   bounded wait, or a poll; the notice is an optimisation over that floor, not a
-  replacement for it. That floor is bounded observation and not eventual resolution: an
-  orphan under D6 sends no notice, because it never reaches a terminal status, and it does
+  replacement for it. That floor is bounded observation, and it is eventual resolution
+  only for the case ADR-0107 closed: a conclusive `started` orphan is reaped to a
+  terminal, and the reap winner attempts the same configured delivery the dead child's
+  hook would have sent. A `preparing` or inconclusive orphan sends no notice, because it
+  never reaches a terminal status, and it does
   not resolve under polling either. A consumer that reads this decision as "the poll always
   gets there in the end" has the right fallback and the wrong stopping condition, which is
   what the consumer obligation on an unresolved bounded wait is for. D10 names such a run
@@ -602,9 +605,13 @@ extensions rather than folded into the list above, because presenting a new deci
 existing one tells every reader there is nothing left to reconcile, which is the most
 effective way to prevent it being reconciled:
 
-- **Observing does not touch the run.** A wait that times out, is signalled, or whose
-  caller disconnects leaves the durable run exactly as it was. Cancelling an observation is
-  not cancelling the work. ADR-0066 D6 is silent on signal and disconnect, so an MCP
+- **Observing does not touch the run — with one deliberate, fenced exception.** A wait
+  that times out, is signalled, or whose caller disconnects leaves the durable run exactly
+  as it was; cancelling an observation is not cancelling the work. The exception is the
+  one ADR-0107 added: the first reader of a conclusively-gone `started` orphan durably
+  reaps it — an attributable terminal written under a fenced claim, before notification
+  and wait aggregation — repairing a record no writer survived to finish, never mutating
+  live work. ADR-0066 D6 is silent on signal and disconnect, so an MCP
   implementer reading only that ADR could let request cancellation propagate into the
   operation while an external consumer assumes it cannot — the two surfaces then behave
   differently after the identical event.
@@ -613,10 +620,14 @@ effective way to prevent it being reconciled:
   implementation would omit the field this contract requires for reporting a result.
 - **An id that waiting cannot resolve does not hold the window open, and the producer pays
   a floor for it.** A run whose process is gone with no end recorded has stopped, and both
-  writers of an end are past it, so further polling cannot change its answer. Such ids are
+  original writers of an end are past it. Where that finding is conclusive for a `started`
+  run, the status read reaps it before aggregation (ADR-0107): it comes back terminal and
+  never appears in this list. The `preparing` and inconclusive cases are what the list is
+  for: such ids are
   returned in their own list, `stopped_without_end`, rather than in `pending`, and the call
   stops re-observing once every remaining id is either terminal or in that list. It is a
-  separate list and not a per-id error, because observing them succeeded. Nothing about the
+  separate list and not a per-id error, because observing them succeeded. For those entries
+  nothing about the
   record changes: the entry stays non-terminal with a null outcome, and a run that does
   record an end afterwards is classified terminal by the next observation exactly as
   before. `all_terminal` stays false while any id is in the list, because a run that stopped

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -109,10 +109,10 @@ Out of scope:
   Owned by the consumer; see D1 on why we nonetheless state a requirement about the
   binary path.
 - **The MCP tool surface itself.** ADR-0066 decides that. This ADR constrains what
-  those tools return, which is a strictly smaller question, and D10 takes ADR-0066 D6
-  as written rather than re-deciding it, marking its two additions as additions and
-  saying plainly where D6 underdetermines a rule that an implementation must nonetheless
-  settle.
+  those tools return, which is a strictly smaller question. D10 shares ADR-0066 D6's
+  wait contract — the rules D10 first stated as additions were adopted into D6 by its
+  2026-07-27 and 2026-08-03 amendments, so neither document re-decides the other; D10
+  carries the fuller rationale.
 - **Hosted / multi-tenant concerns.** No tenancy appears in this contract; a hosted
   join is built above it, not inside it.
 - **Playbook and flow semantics.** What a flow *does* is unchanged here.
@@ -454,9 +454,11 @@ li job kill <run_id> --machine
   decision, not a gap, and it is stated here so that a consumer can plan for it rather than
   discover it. A run whose process died without its terminal hook running, and a run whose
   producer died before it ever spawned, both remain `terminal: false` for as long as their
-  records exist. A consumer's bounded wait will keep returning them as pending until its own
-  window closes; what it does then is the consumer's policy, and this contract does not
-  pretend to make that decision for it.
+  records exist. As frozen, a consumer's bounded wait kept returning them as pending until
+  its own window closed (today D10's amended contract returns the stopped cases in
+  `stopped_without_end` and an aged `preparing` record in `unresolved_spawn`, at once
+  rather than at window close); what the consumer does then is its own policy, and this
+  contract does not pretend to make that decision for it.
 - **Why not simply specify the reconciler here.** Two earlier revisions tried, in opposite
   directions, and both failed for the same underlying reason: terminalising a run you did
   not run requires evidence that a run *ended*, and neither a missing pid nor an
@@ -638,8 +640,9 @@ effective way to prevent it being reconciled:
   what is known, not on a phase name: it holds every observed record that stopped, or
   cannot be shown to be progressing, and could not be resolved — a `started` case with an
   inconclusive finding, one whose conclusive transition could not be published (retried
-  on the next observation), and a record written before the spawn phase existed, whose
-  phase is unknown and which lands here by the same absence of evidence. The only records
+  on the next observation), and a record written before the spawn phase existed that is
+  not shown alive — phase absence alone is never stopped evidence, so a live pre-field
+  record is classified running and stays in `pending`. The only records
   kept out are the ones the producer explicitly marked `preparing`: fresh, such a record
   stays in `pending`; aged past the producer's stated threshold, it is returned in its
   own fourth bucket, `unresolved_spawn`, with that threshold reported beside it (there is

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -276,12 +276,17 @@ another copy of our rules living in code we do not control.
   state, derived by lionagi from a recorded end — `finished_at`, a producer-written spawn
   failure (D5) — never by matching `status` against a set, and never computed by a reader.
   In v1 those are the only two sources; the deferred reconciler in D6 would be a third.
+  (2026-08-03: ADR-0107 has since implemented that reconciler — its orphan reaper is now
+  the third source.)
 - `outcome` answers **"did the work come out right"**. It is a **closed** vocabulary,
   `succeeded | failed | cancelled | indeterminate`, and it is **`null` whenever `terminal`
-  is false**. (`cancelled` added by the 2026-08-03 amendment carried by ADR-0110 D6: the
-  implementation emitted it before this text froze — the drift ADR-0107's Notes recorded
-  as a pending amendment item — so the correction records shipped behavior and moves no
-  version.)
+  is false**. (`cancelled` added by the 2026-08-03 erratum carried by ADR-0110 D6.
+  Timing, recorded because D2 makes it matter: this text froze on 2026-07-25 with three
+  values; the wire began emitting `cancelled` hours later that same day and has shipped
+  it since. That unversioned expansion violated D2 when it happened; this
+  correction documents the wire as it ships and moves no version, because the breaking
+  event was the 2026-07-25 code change, not the text catching up to it. ADR-0107's Notes
+  recorded the drift.)
   Stated against `terminal` rather than against "the run is still going", because v1 has a
   state that is neither: an orphan has stopped and is still not terminal (D6), and a rule
   phrased around being in flight would leave that case undefined. Being closed, `outcome`
@@ -292,10 +297,13 @@ another copy of our rules living in code we do not control.
   `completed_empty` is `terminal: true, outcome: "failed"`. A consumer given only
   `terminal` must either invent the forbidden vocabulary or call every finished run a
   success, which is P2 recreated one level up (P2b).
-- **`indeterminate` is reserved in v1 and emitted by no path in it.** It is the value for a
-  run that can be established to have ended but whose result cannot be established, and the
-  only component that would produce it is the reconciler deferred in D6. It is defined now
-  anyway, and deliberately: `outcome` is a closed vocabulary that consumers branch on, so
+- **`indeterminate` was reserved at freeze and is emitted today.** (2026-08-03: ADR-0107
+  implemented the producer this paragraph deferred — its orphan reaper writes
+  `indeterminate` with an attributable reason; the reservation strategy below worked as
+  intended.) It is the value for a run that can be established to have ended but whose
+  result cannot be established, and the component that produces it is the reconciler D6
+  deferred and ADR-0107 then implemented. It was defined before any path emitted it, and
+  deliberately: `outcome` is a closed vocabulary that consumers branch on, so
   adding a third value later would be a breaking change under D2 and would cost a contract
   version. Defining an unused value costs one sentence; introducing it in v2 costs every
   consumer an upgrade. A two-valued field would also force `failed` for the unknowable case,

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -283,10 +283,15 @@ another copy of our rules living in code we do not control.
   is false**. (`cancelled` added by the 2026-08-03 erratum carried by ADR-0110 D6.
   Timing, recorded because D2 makes it matter: this text froze on 2026-07-25 with three
   values; the wire began emitting `cancelled` hours later that same day and has shipped
-  it since. That unversioned expansion violated D2 when it happened; this
-  correction documents the wire as it ships and moves no version, because the breaking
-  event was the 2026-07-25 code change, not the text catching up to it. ADR-0107's Notes
-  recorded the drift.)
+  it since. Envelope stamping itself began at 20:11 that day, so stamped v1 envelopes
+  spoke three values for under three hours, four ever since. That unversioned expansion
+  violated D2 when it happened; this correction documents the wire as it ships and moves
+  no version, because the breaking event was the 2026-07-25 code change, not the text
+  catching up to it. ADR-0107's Notes recorded the drift. Consumer notice and migration
+  policy, normative: a consumer exhaustively matching three values has been exposed to an
+  unlisted `cancelled` since 2026-07-25 22:54; add the `cancelled` branch, and until it is
+  added treat an out-of-vocabulary `outcome` the way `indeterminate` is treated — result
+  not establishable, never success and never failure.)
   Stated against `terminal` rather than against "the run is still going", because v1 has a
   state that is neither: an orphan has stopped and is still not terminal (D6), and a rule
   phrased around being in flight would leave that case undefined. Being closed, `outcome`
@@ -435,7 +440,11 @@ li job kill <run_id> --machine
   owns it, so a reused pid makes a dead run look alive, and the same unchanged record reads
   differently from two hosts. A lifecycle transition resting on that is a transition that
   depends on who asked.
-- **In v1, nothing terminalises an orphan. It stays non-terminal indefinitely.** This is a
+- **In v1 as frozen, nothing terminalised an orphan.** (2026-08-03: ADR-0107 has since
+  implemented the guarded reaper — a `started` run whose process is conclusively gone now
+  receives an attributable terminal with `outcome: indeterminate`; a `preparing` record
+  stays non-terminal exactly as described below.) The paragraph that follows records the
+  decision as frozen. This is a
   decision, not a gap, and it is stated here so that a consumer can plan for it rather than
   discover it. A run whose process died without its terminal hook running, and a run whose
   producer died before it ever spawned, both remain `terminal: false` for as long as their
@@ -692,7 +701,9 @@ starts from the constraints rather than rediscovering them:
 Everything in this list is a constraint on a future design, not a requirement on a v1
 implementation. Nothing here is normative: a v1 implementation has no reconciler, and the
 list exists so that whoever builds one starts from the constraints rather than
-rediscovering them. Adding it later is additive under D2 only because `outcome`'s
+rediscovering them. (2026-08-03: ADR-0107 built the `started`-phase reconciler within
+exactly these constraints — incarnation identity, host boundary, fenced ownership,
+per-phase eligibility; `preparing` remains unresolved, as this list predicted.) Adding it later is additive under D2 only because `outcome`'s
 vocabulary and the terminal fields are defined now, which is why they are.
 
 **DEFERRED: usage and cost accounting** — tokens, duration, and whatever else a metered
@@ -724,14 +735,15 @@ being asked of them in one place.
    actually tolerates it.
 3. **Never map `status` onto a local set** (D4). Record and display it verbatim; branch
    on `terminal` and `outcome`.
-4. **Branch on `outcome` totally, including `indeterminate`** (D4). All four cases —
-   `null`, `succeeded`, `failed`, `indeterminate` — need a defined behaviour. This is the
-   obligation that makes D4's reservation of `indeterminate` worth anything: the value is
-   defined now so that a reconciler can be added later without a version increment, and
-   that additivity is real only if consumers already have somewhere to put it. No v1 path
-   emits it, so a consumer cannot find the missing branch by testing against a producer,
-   and a two-way branch written against v1 behaviour looks complete for as long as v1 is
-   what it talks to. Test the branch against a hand-written envelope.
+4. **Branch on `outcome` totally** (D4). All five cases — `null`, `succeeded`, `failed`,
+   `cancelled`, `indeterminate` — need a defined behaviour (2026-08-03 erratum:
+   `cancelled` joined the documented set, and ADR-0107's reaper now emits
+   `indeterminate`, so neither formerly-theoretical branch is theoretical any longer).
+   This is the obligation that made D4's reservation of `indeterminate` worth anything:
+   the value was defined before any path emitted it, so its producer was added without a
+   version increment — which is exactly what then happened. A branch written against the
+   pre-reaper wire looks complete for as long as that wire is what it talks to. Test the
+   branch against a hand-written envelope.
 5. **Never render `available: false` as "none"** (D7). Absence of evidence is not
    evidence of absence, and the whole wrapper exists to stop those sharing an encoding.
 6. **Check the exit status before parsing stdout, and do not parse it at all on 78**

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -95,7 +95,7 @@ wake it. A consumer restart across a successful delivery loses it the same way.
 | The envelope every machine call returns | D3: one envelope shape — `ok`, `contract_version`, `data`, `error` |
 | Run status | D4: `status` is opaque and verbatim; the producer also publishes `terminal` and `outcome`, on every status-bearing response |
 | Submit | D5: submit returns a handle; the spawn phase is recorded rather than inferred from a missing pid |
-| Reads | D6: one lifecycle authority for every path; liveness is advisory; in v1 an orphaned run stays non-terminal |
+| Reads | D6: one lifecycle authority for every path; liveness is advisory; a conclusively-gone `started` orphan is reaped terminal (ADR-0107), a `preparing` or inconclusive one stays non-terminal |
 | Distinguishing absence from failure | D7: every read-derived field carries its own availability and reason |
 | Process-level faults | D8: a valid envelope is authoritative; exit status is the transport-level answer, with a defined precedence |
 | Terminal notification | D9: a notification is a prompt to read state, never proof and never the only path |
@@ -432,7 +432,12 @@ li job kill <run_id> --machine
   extra information carried beside it with its own reliability.
 - A run whose recorded pid is gone with no terminal recorded is an **orphan**. It is
   reported as `status: "exited"`, `terminal: false`, `outcome: null`, with `alive: false`
-  and an advisory flag that it may be orphaned. In v1 it never becomes terminal.
+  and an advisory flag that it may be orphaned. As frozen, it never became terminal;
+  since ADR-0107, a `started` orphan whose process is CONCLUSIVELY established gone —
+  process-incarnation evidence under a fenced claim, never the advisory pid probe the
+  next bullet warns about — is reaped to an attributable terminal
+  (`outcome: indeterminate`); a `preparing` record or an inconclusive finding stays
+  non-terminal exactly as before.
 - **Liveness may not be the fact that establishes terminality**, and an earlier revision
   had it both ways: this decision declares the pid probe advisory because a pid can be
   reused or denied, and the next paragraph then derived a terminal outcome from that same
@@ -757,9 +762,10 @@ being asked of them in one place.
    expires, and an id in `stopped_without_end`, which comes back at once and comes back
    every time. This is the obligation created by v1's liveness choice, and it is the one
    most likely to be skipped, because most runs resolve and the case looks like an edge.
-   It is not an edge: v1 states that nothing terminalises an orphan, so a consumer that
-   runs long enough **will** meet a run that never resolves, and this contract does not
-   supply the policy for it. Give up after N attempts, escalate to a human, mark it
+   It is not an edge: v1 as frozen terminalised no orphan, and although ADR-0107 now
+   reaps the conclusive `started` cases, a `preparing` or inconclusive orphan still never
+   resolves on its own — so a consumer that runs long enough **will** meet a run that
+   never resolves, and this contract does not supply the policy for it. Give up after N attempts, escalate to a human, mark it
    abandoned in your own store — any of those is conforming. Having no policy is not,
    because the failure mode is a consumer that waits forever on a run nobody will ever
    finish, or three integrators each inventing a different timeout behaviour, which is
@@ -793,15 +799,19 @@ a local change: it must also be classified, on every status-bearing response.
 it. Additive change stays free under the narrowed rule in D2; anything else costs a
 version increment and a coordinated update.
 
-**Accepted in v1, and stated rather than discovered.** A run whose process dies without
-recording a terminal, or whose producer dies before spawning it, stays non-terminal for as
-long as its record exists. A consumer's bounded wait reports it as stopped without an end
-every time, and never as finished. Two earlier revisions tried to close this with a rule
+**Accepted in v1, and stated rather than discovered.** As frozen: a run whose process
+died without recording a terminal, or whose producer died before spawning it, stayed
+non-terminal for as long as its record existed. Since ADR-0107 the first case closes when
+the evidence is conclusive — a `started` orphan is reaped to an attributable terminal —
+while producer-death-before-spawn (`preparing`) and inconclusive findings still stay
+non-terminal, and a consumer's bounded wait reports those as stopped without an end every
+time, never as finished. Two earlier revisions tried to close this with a rule
 every reader would apply, and both produced worse failures than the one they removed: a
 healthy child reported as terminally failed, and two hosts disagreeing about one unchanged
 record. Closing it properly needs a fenced reconciler with process-incarnation evidence,
 which is a protocol with its own failure modes rather than a clause, so it is written out
-in the deferred section instead of half-specified here. Naming the run is not resolving it:
+in the deferred section instead of half-specified here — and was then built to exactly
+that specification, for the `started` phase, by ADR-0107. Naming the run is not resolving it:
 the caller learns at once that nobody will finish this run, and still has to decide what to
 do about it, which is what consumer obligation 8 is for.
 

--- a/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
+++ b/docs/adr/ADR-0106-lion-machine-result-contract-v1.md
@@ -95,7 +95,7 @@ wake it. A consumer restart across a successful delivery loses it the same way.
 | The envelope every machine call returns | D3: one envelope shape — `ok`, `contract_version`, `data`, `error` |
 | Run status | D4: `status` is opaque and verbatim; the producer also publishes `terminal` and `outcome`, on every status-bearing response |
 | Submit | D5: submit returns a handle; the spawn phase is recorded rather than inferred from a missing pid |
-| Reads | D6: one lifecycle authority for every path; liveness is advisory; a conclusively-gone `started` orphan is reaped terminal (ADR-0107), a `preparing` or inconclusive one stays non-terminal |
+| Reads | D6: one lifecycle authority for every path; liveness is advisory; a conclusively-gone `started` orphan is reaped terminal where the fenced reap publishes (ADR-0107); a `preparing` or inconclusive one, or a reap whose write was refused, stays non-terminal |
 | Distinguishing absence from failure | D7: every read-derived field carries its own availability and reason |
 | Process-level faults | D8: a valid envelope is authoritative; exit status is the transport-level answer, with a defined precedence |
 | Terminal notification | D9: a notification is a prompt to read state, never proof and never the only path |
@@ -436,8 +436,9 @@ li job kill <run_id> --machine
   since ADR-0107, a `started` orphan whose process is CONCLUSIVELY established gone —
   process-incarnation evidence under a fenced claim, never the advisory pid probe the
   next bullet warns about — is reaped to an attributable terminal
-  (`outcome: indeterminate`); a `preparing` record or an inconclusive finding stays
-  non-terminal exactly as before.
+  (`outcome: indeterminate`) where the fenced write publishes; a refused write leaves
+  it non-terminal until a later observation retries, and a `preparing` record or an
+  inconclusive finding stays non-terminal exactly as before.
 - **Liveness may not be the fact that establishes terminality**, and an earlier revision
   had it both ways: this decision declares the pid probe advisory because a pid can be
   reused or denied, and the next paragraph then derived a terminal outcome from that same
@@ -447,8 +448,8 @@ li job kill <run_id> --machine
   depends on who asked.
 - **In v1 as frozen, nothing terminalised an orphan.** (2026-08-03: ADR-0107 has since
   implemented the guarded reaper — a `started` run whose process is conclusively gone now
-  receives an attributable terminal with `outcome: indeterminate`; a `preparing` record
-  stays non-terminal exactly as described below.) The paragraph that follows records the
+  receives an attributable terminal with `outcome: indeterminate` where the fenced reap
+  publishes; a `preparing` record stays non-terminal exactly as described below.) The paragraph that follows records the
   decision as frozen. This is a
   decision, not a gap, and it is stated here so that a consumer can plan for it rather than
   discover it. A run whose process died without its terminal hook running, and a run whose
@@ -554,9 +555,12 @@ is configured, sends a terminal notice.
   restart across a successful delivery loses it identically. Reconciliation is D10's
   bounded wait, or a poll; the notice is an optimisation over that floor, not a
   replacement for it. That floor is bounded observation, and it is eventual resolution
-  only for the case ADR-0107 closed: a conclusive `started` orphan is reaped to a
-  terminal, and the reap winner attempts the same configured delivery the dead child's
-  hook would have sent. A `preparing` or inconclusive orphan sends no notice, because it
+  only for the case ADR-0107 closed: a conclusive `started` orphan whose fenced reap
+  PUBLISHES durably is terminal, and the reap winner attempts the same configured
+  delivery the dead child's hook would have sent. A reap that cannot publish — the lock
+  or the write refused — leaves the record non-terminal and advisory-flagged, sends no
+  notice, and is retried by the next observation. A `preparing` or inconclusive orphan
+  sends no notice, because it
   never reaches a terminal status, and it does
   not resolve under polling either. A consumer that reads this decision as "the poll always
   gets there in the end" has the right fallback and the wrong stopping condition, which is
@@ -608,10 +612,11 @@ effective way to prevent it being reconciled:
 - **Observing does not touch the run — with one deliberate, fenced exception.** A wait
   that times out, is signalled, or whose caller disconnects leaves the durable run exactly
   as it was; cancelling an observation is not cancelling the work. The exception is the
-  one ADR-0107 added: the first reader of a conclusively-gone `started` orphan durably
-  reaps it — an attributable terminal written under a fenced claim, before notification
-  and wait aggregation — repairing a record no writer survived to finish, never mutating
-  live work. ADR-0066 D6 is silent on signal and disconnect, so an MCP
+  one ADR-0107 added: the first reader of a conclusively-gone `started` orphan reaps it
+  where the fenced write publishes — an attributable terminal written under a fenced
+  claim, before notification and wait aggregation — repairing a record no writer survived
+  to finish, never mutating live work. A refused or unpublishable write leaves the run
+  exactly as every other observation does; the retry belongs to the next reader. ADR-0066 D6 is silent on signal and disconnect, so an MCP
   implementer reading only that ADR could let request cancellation propagate into the
   operation while an external consumer assumes it cannot — the two surfaces then behave
   differently after the identical event.
@@ -621,9 +626,14 @@ effective way to prevent it being reconciled:
 - **An id that waiting cannot resolve does not hold the window open, and the producer pays
   a floor for it.** A run whose process is gone with no end recorded has stopped, and both
   original writers of an end are past it. Where that finding is conclusive for a `started`
-  run, the status read reaps it before aggregation (ADR-0107): it comes back terminal and
-  never appears in this list. The `preparing` and inconclusive cases are what the list is
-  for: such ids are
+  run and the fenced reap publishes, the status read resolves it before aggregation
+  (ADR-0107): it comes back terminal and never appears in this list. The list holds the
+  `started` cases that stopped and could not be resolved — an inconclusive finding, or a
+  conclusive one whose transition could not be published, retried on the next
+  observation. A `preparing` record is never in it: fresh, it stays in `pending`; aged
+  past the producer's stated threshold, it is returned in its own fourth bucket,
+  `unresolved_spawn`, with that threshold reported beside it (there is no process to
+  prove absent, so it is a different fact than a stopped run). The stopped ids are
   returned in their own list, `stopped_without_end`, rather than in `pending`, and the call
   stops re-observing once every remaining id is either terminal or in that list. It is a
   separate list and not a per-id error, because observing them succeeded. For those entries
@@ -677,9 +687,11 @@ was observed and classified, so naming that channel does not settle the pending 
 exclusion. The honest conclusion is that D6 underdetermines this, and an underdetermined
 clause is settled by amending it rather than by either document assuming its own reading.
 The forward amendment therefore states the partition outright: `pending`,
-`stopped_without_end` and terminal are disjoint and exhaustive over every observed id.
-That is the invariant this contract's implementation already tests, so the amendment
-records a rule that is enforced rather than adding one that is not.
+`stopped_without_end`, `unresolved_spawn` and terminal are disjoint and exhaustive over
+every observed id (2026-08-03: the fourth bucket — an aged `preparing` record — is
+corrected into the partition here; the implementation and its tests already enforce the
+four-way form). The amendment records a rule that is enforced rather than adding one
+that is not.
 
 **Why this is taken up rather than deferred.** An earlier draft deferred bounded wait on
 the grounds that timeout, signal and disconnect had no v1 answer. That was wrong about
@@ -768,14 +780,15 @@ being asked of them in one place.
 7. **Never treat a terminal notice as proof, or as the only discovery path** (D9).
    Delivery can fail, and the record of that failure lives in state a non-polling
    consumer is not reading.
-8. **Have a defined policy for a run a bounded wait does not resolve** (D10, D6). Two
-   shapes reach you and both need the policy: an id still in `pending` when the window
-   expires, and an id in `stopped_without_end`, which comes back at once and comes back
-   every time. This is the obligation created by v1's liveness choice, and it is the one
+8. **Have a defined policy for a run a bounded wait does not resolve** (D10, D6). Three
+   shapes reach you and all need the policy: an id still in `pending` when the window
+   expires; an id in `stopped_without_end`, which comes back at once and comes back
+   every time; and an id in `unresolved_spawn` — an aged `preparing` record with no
+   process to prove absent, which likewise returns every time. This is the obligation created by v1's liveness choice, and it is the one
    most likely to be skipped, because most runs resolve and the case looks like an edge.
    It is not an edge: v1 as frozen terminalised no orphan, and although ADR-0107 now
-   reaps the conclusive `started` cases, a `preparing` or inconclusive orphan still never
-   resolves on its own — so a consumer that runs long enough **will** meet a run that
+   reaps the conclusive `started` cases whose fenced write publishes, a `preparing` or
+   inconclusive orphan still never resolves on its own — so a consumer that runs long enough **will** meet a run that
    never resolves, and this contract does not supply the policy for it. Give up after N attempts, escalate to a human, mark it
    abandoned in your own store — any of those is conforming. Having no policy is not,
    because the failure mode is a consumer that waits forever on a run nobody will ever
@@ -813,10 +826,11 @@ version increment and a coordinated update.
 **Accepted in v1, and stated rather than discovered.** As frozen: a run whose process
 died without recording a terminal, or whose producer died before spawning it, stayed
 non-terminal for as long as its record existed. Since ADR-0107 the first case closes when
-the evidence is conclusive — a `started` orphan is reaped to an attributable terminal —
-while producer-death-before-spawn (`preparing`) and inconclusive findings still stay
-non-terminal, and a consumer's bounded wait reports those as stopped without an end every
-time, never as finished. Two earlier revisions tried to close this with a rule
+the evidence is conclusive and the fenced reap publishes — a `started` orphan is reaped
+to an attributable terminal — while producer-death-before-spawn (`preparing`) and
+inconclusive findings still stay non-terminal. A consumer's bounded wait reports the
+inconclusive or unpublishable `started` cases as stopped without an end every time, and
+an aged `preparing` record in its own `unresolved_spawn` bucket, never as finished. Two earlier revisions tried to close this with a rule
 every reader would apply, and both produced worse failures than the one they removed: a
 healthy child reported as terminally failed, and two hosts disagreeing about one unchanged
 record. Closing it properly needs a fenced reconciler with process-incarnation evidence,

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -188,8 +188,9 @@ concurrency caps compose the same way they do for the planner fanout.
   termination escalating to hard kill, and its harvest runs only after its
   process's death is confirmed. The quiescence invariant (D3) is
   path-independent: `round_state: complete` is never published while any
-  process that can write a leg's scratch is alive, on cooperative and reap
-  paths alike.
+  member of the run's recorded process-control domain survives, on
+  cooperative and reap paths alike. D3 states that domain exactly and names
+  the one residual it cannot close.
 
 ### D3 — Durable records, ordering, and the two-stage end
 
@@ -296,11 +297,26 @@ OBSERVABLE, never silent.
   acquiring the lock — which a dead owner cannot still hold, the kernel
   released it with the process — does it proceed, and its FIRST act on the
   claim is quiescence, not harvest: a hard kill of the run's recorded
-  process group (`os.killpg`, a primitive the server-side reaper already
-  holds; identity-verified against the recorded pgid and the group marker
-  every member inherits), then verification that no member survives.
-  `round_state: complete` is never published while any process that can
-  write a scratch directory is alive. Only then the manifest-aware reap:
+  process group (the raw `os.killpg` primitive, identity-verified against
+  the recorded pgid and the group marker every member inherits — not the
+  existing plain-kill helper, whose killed-marking record write belongs to
+  ordinary kills; the reaper's single terminal write comes later, after
+  harvest), then verification that no member of that group survives.
+  `round_state: complete` is never published while any member of the
+  recorded group is alive. The recorded group is the quiescence domain,
+  stated exactly: it is the strongest control the launch primitive
+  establishes portably — the initial child receives its own session, and
+  nothing prevents a descendant from leaving that session. A leg that
+  deliberately detaches into a new session while keeping the scratch path
+  can therefore still write after `complete`; that residual is accepted
+  and named rather than papered over. Such an escapee is the caller's own
+  agent executing the caller's own brief, so it crosses no privilege
+  boundary and sabotages only its author's round: D4's harvest copies
+  defensively, so the published record describes the harvested copies and
+  stays internally consistent — writes made after recorded-domain
+  quiescence simply miss the round. A mechanically non-escapable process
+  domain would close the residual; that is platform-specific hardening
+  this ADR names and does not adopt. Only then the manifest-aware reap:
   harvest each leg's scratch from disk as D4
   specifies, write each leg record with what could be established
   (`harvest_failed` with a reason where a scratch is unreadable — never an

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -5,119 +5,300 @@
 - **Area**: orchestration
 - **Date**: 2026-08-03
 - **Relations**: extends ADR-0106 (machine result contract); composes with the
-  MCP job surface (`job.status` artifact listing)
+  MCP job surface (`job.output` is the artifact listing read)
 
 ## Context
 
 Every orchestrating surface this package ships puts a planner model between the
 caller's task statement and the legs that execute it. `li o fanout` runs a
-decomposition phase first — "orchestrator decomposing task into ≤N assignments"
-(`lionagi/cli/orchestrate/fanout.py:254`) — and the assignments the workers
-receive are the planner's text, not the caller's. `li o flow` has the
+decomposition phase first (`lionagi/cli/orchestrate/fanout.py`, phase 1:
+"orchestrator decomposing task into ≤N assignments") and the assignments the
+workers receive are the planner's text, not the caller's. `li o flow` has the
 orchestrator compose the DAG. Playbooks template the planner's prompt; they do
 not remove the planner.
 
-That is the right shape for a prose task. It is the wrong shape for a class of
-work that is common and currently unserved: the caller already holds N
-pre-written briefs — review instructions, audit scopes, per-module checklists —
-and each brief IS the contract for its leg. A planner that can rephrase,
-merge, or re-scope those briefs is not adding intelligence; it is corrupting
-the input. Multi-round document review is the sharpest instance: the brief
-states what the reviewer must check, so any surface that lets another model
-rewrite it disqualifies itself.
+That is the right shape for a prose task and the wrong shape for a class of
+work that is common and currently unserved. The problems, concretely:
 
-Callers in this position today fall back to submitting N independent agent
-runs. That works — it is the only deterministic form — but the costs compound
-with round count:
+- **P1 — planner interposition corrupts fixed inputs.** When the caller
+  already holds N pre-written briefs — review instructions, audit scopes,
+  per-module checklists — each brief IS the contract for its leg. A planner
+  that can rephrase, merge, or re-scope them is not adding intelligence; it is
+  corrupting the input. Multi-round document review is the sharpest instance.
+  A prompt telling the planner "do not rewrite" is not a fix: prompt
+  prohibitions are requests, not controls.
+- **P2 — the deterministic fallback costs N of everything.** Callers in this
+  position submit N independent agent runs: N handles to track, N terminal
+  notices when one answer to "is the round done" was wanted, and artifact
+  harvest by hand.
+- **P3 — sandboxed legs contort output paths.** CLI legs under a
+  workspace-write sandbox cannot write outside their own cwd tree, so briefs
+  must smuggle output paths that land inside it. Meanwhile every run already
+  has an artifacts directory listed by `job.output`
+  (`lionagi/mcp/jobs.py`, `output()` returns `artifacts` + `artifacts_state`)
+  — but a leg is never told where it is and could not write there if it were.
+  `job.status` deliberately carries no artifact fields; the artifact read is
+  and stays `job.output`.
+- **P4 — per-leg working directories are the norm.** One round may span two
+  repositories, and PR-review rounds are per-worktree by construction. A
+  single run-level cwd excludes the most common round shapes.
 
-- N run handles to track and N terminal notices to receive, when the caller
-  wants one answer to "is the round done".
-- Artifact harvest by hand: each brief must name output paths, and sandboxed
-  CLI legs (workspace-write) cannot write outside their own cwd tree, so the
-  paths must be contorted to land inside it. Meanwhile every run already has
-  an artifacts directory that `job.status` lists (`lionagi/mcp/jobs.py:736-750`,
-  `:1740-1741`) — but a leg is never told where it is and could not write
-  there if it were.
-- Per-leg working directories are the norm, not the exception: one round may
-  span two repositories, and PR-review rounds are per-worktree by
-  construction. Any surface with a single run-level cwd excludes the most
-  common round shapes.
+| Concern | Decision |
+|---------|----------|
+| Input format and validation | D1: closed manifest schema v1, file-path-only, snapshotted at submit |
+| Execution and aggregation | D2: independent parallel legs; per-leg timeout from spawn; parent outcome table |
+| Durable per-leg record and ordering | D3: per-leg record persisted before parent terminalization and its one notice |
+| Leg artifact channel | D4: scratch dir inside leg cwd, env-announced, harvested as bounded regular-file copy |
+| Planner absence | D5: no-planner is a tested invariant with the profile-default drift vector as a named failure case |
+
+**Out of scope**: dependencies between legs (the flow surface's job);
+scheduling recurring rounds (`li schedule` composes on top); any change to the
+planner surfaces themselves; artifact content conventions (a verdict file's
+format is the caller's contract with its own legs).
 
 ## Decision
 
-Add a deterministic fan-out mode: legs are built one-per-brief from a caller
-manifest, verbatim, with no planner phase.
+### D1 — Manifest contract v1
 
-**1. Manifest in, one run out.** A YAML/JSON manifest declares the legs:
+A round is declared by a manifest file (YAML or JSON), passed by absolute
+path. The manifest is read and snapshotted at submit, same rule as
+`prompt_file` on the agent surface: editing the file afterwards cannot change
+what an already-submitted round executes. Every brief file is likewise read
+and snapshotted at submit, and each snapshot's content hash is recorded in the
+run directory as durable evidence of what was dispatched.
 
 ```yaml
-defaults:
-  model: gpt/large-effort-spec   # any model spec or agent profile name
-  timeout: 1200
-legs:
-  - brief: /abs/path/briefs/module-a.md
-    cwd: /abs/path/worktrees/module-a
-    label: review-module-a
-  - brief: /abs/path/briefs/module-b.md
-    cwd: /abs/path/worktrees/module-b
-    label: review-module-b
-    model: other/spec            # per-leg override wins over defaults
+manifest_version: 1            # required, exactly 1
+defaults:                      # optional; every key below optional
+  model: <model spec>          # XOR agent, at each level
+  agent: <profile name>
+  timeout: 1200                # seconds, positive, <= 86400
+legs:                          # required, 1..64 entries
+  - brief: /abs/path/briefs/module-a.md    # required
+    cwd: /abs/path/worktrees/module-a      # required
+    label: review-module-a                 # required
+    model: <model spec>        # optional per-leg override
+    timeout: 900               # optional per-leg override
 ```
 
-Each leg's prompt is the brief file's text, unmodified. `brief`, `cwd`, and
-`label` are per-leg; `model`/`agent`, `timeout`, and other run knobs may be
-set in `defaults` and overridden per leg. Brief files are read and snapshotted
-at submit time (same rule as `prompt_file` on the agent surface: editing the
-file afterwards cannot change what an already-submitted run executes).
+Exact semantics, refuse-early at submit (nothing spawns, no job record is
+created — the pattern `lionagi/mcp/dispatch.py` already applies to
+would-be-refused submissions):
 
-**2. One run id, one terminal notice.** The manifest run is a single job. Legs
-execute in parallel under the existing worker concurrency machinery; the
-terminal notice fires once, when the last leg ends, and carries per-leg
-outcomes. Per-leg status remains observable mid-run through the job surface.
+- **Unknown keys anywhere are refused by name.** The schema is closed; v1
+  accepts exactly the fields above. A misspelled knob must fail the submit,
+  not silently configure nothing.
+- **`brief`**: absolute path to an existing regular file, resolved through
+  symlinks at read time and then treated as bytes; empty (after strip) is
+  refused. Snapshot + BLAKE-family content hash recorded per leg.
+- **`cwd`**: absolute path to an existing directory.
+- **`label`**: required, matching `[a-z0-9][a-z0-9._-]{0,63}` after
+  lowercasing, unique across the manifest after normalization. The label is
+  an artifact-directory component (D4), so path separators, `..`, and
+  empty/dot-only names are unrepresentable by the pattern rather than
+  filtered by a check.
+- **`model` XOR `agent`** at each level. A leg naming either uses its own and
+  ignores both defaults (no cross-level merging of the pair — merging `model`
+  from one level with `agent` from another would construct a configuration
+  nobody wrote).
+- **`timeout`**: positive integer seconds, at most 86400. The ceiling is a
+  sanity bound, not a derivation: a leg that needs more than a day is not a
+  round leg.
+- **Leg count 1..64.** The floor is definitional. The ceiling is one order of
+  magnitude above the largest observed round (13) — a bound that exists so a
+  generated manifest with a bug cannot fan out unbounded, chosen loose enough
+  that no legitimate round has to think about it.
+- **File-path-only in v1.** An inline manifest object in the MCP call is
+  DEFERRED (see Alternatives): the file path gives snapshot semantics,
+  a natural durable-evidence story, and parity with `prompt_file`, and the
+  consuming workflow already produces brief files on disk.
 
-**3. A sanctioned leg artifact channel, without widening any sandbox.** For
-each leg the runner creates a scratch directory inside that leg's own cwd tree
-and exports its absolute path to the leg process as `LIONAGI_LEG_ARTIFACTS`.
-A sandboxed leg can always write there — it is inside the tree the sandbox
-already permits. When the leg reaches a terminal state, the runner harvests
-the scratch directory's contents into the run's artifacts directory under the
-leg's label and removes the scratch. `job.status` then lists every leg's
-artifacts with zero new read surface, and briefs stop carrying output-path
-contortions.
+### D2 — Round execution: independence, clocks, aggregation
 
-**4. Same surface everywhere.** The mode ships as a CLI command and as an MCP
-verb beside `fanout.submit`, taking the manifest as a file path. Submission
-validation follows the existing refuse-early pattern (`lionagi/mcp/dispatch.py:600-617`):
-a manifest that would be refused on start — unreadable brief, relative path,
-empty legs — is refused at submit, before a job record exists.
+Legs execute in parallel under the existing worker concurrency machinery;
+concurrency caps compose the same way they do for the planner fanout.
 
-## What this is not
+- **Legs are independent by construction.** A leg failing, timing out, or
+  being killed never cancels a sibling. For the motivating workload every
+  completed verdict has value regardless of a sibling's fate. Fail-fast is a
+  rejected alternative, not an option flag, in v1.
+- **Per-leg timeout clock starts at leg process spawn**, not at submit and not
+  at queue admission — queue wait under a concurrency cap is not the leg's
+  time. What a timeout interrupts is the leg's own execution.
+- **An optional round timeout** (defaults key `timeout` does double duty: it
+  is the per-leg default; a future `round_timeout` is deliberately NOT in v1
+  — one knob until a consumer demonstrates the second is needed).
+- **Parent terminalization**: the parent run becomes terminal only when every
+  leg has a durable per-leg record including its harvest state (D3). Parent
+  `outcome` derives from the leg records:
 
-- Not a replacement for `fanout`/`flow`: prose tasks that need decomposition
-  keep the planner surfaces. This mode refuses to plan by design.
-- Not a DAG: legs are independent by construction. Dependencies between legs
-  are the flow surface's job.
-- Not a scheduler: one manifest, one round, one run.
+| Leg records | Parent `outcome` |
+|---|---|
+| every leg `succeeded` and `harvested-N`/`dir-empty`/`dir-absent` | `completed` |
+| at least one leg succeeded; at least one `failed`/`timed_out`/`killed`/`harvest_failed` | `partial` |
+| no leg succeeded | `failed` |
+
+  `dir-empty` and `dir-absent` do not degrade the parent outcome by
+  themselves: a leg whose whole answer is its final message legitimately
+  writes no artifact. `harvest_failed` always degrades to at least `partial`
+  — artifacts were (or may have been) written and cannot be served, which is
+  a loss the outcome must not paper over.
+
+- **A timed-out leg** is recorded `timed_out`, receives cooperative
+  termination, and its harvest is still attempted during cooperative teardown.
+
+### D3 — The per-leg record, and what must be durable before the notice
+
+Each leg gets one durable record in the run directory,
+`{run_dir}/legs/{label}.json`:
+
+```json
+{
+  "label": "review-module-a",
+  "status": "succeeded",
+  "outcome": "success",
+  "started_at": "...", "finished_at": "...",
+  "cwd": "/abs/path/worktrees/module-a",
+  "model": "<resolved spec>",
+  "brief_hash": "<content hash recorded at submit>",
+  "harvest_state": "harvested-3",
+  "harvest_detail": {"files": 3, "bytes": 18211, "skipped": []},
+  "artifacts": ["module-a/verdict.md", "module-a/notes.md", "module-a/log.txt"]
+}
+```
+
+- **Ordering guarantee**: on every cooperative path (normal completion,
+  per-leg timeout, round-level cancellation, `job.kill` reaching the group
+  cooperatively), the leg's harvest runs and its record is persisted BEFORE
+  the parent terminalizes, and the parent's single terminal notice fires only
+  after the last record is durable. A notification consumer and a polling
+  consumer therefore read the same facts; there is no window where the notice
+  says "done" and a leg record is still being written.
+- **Hard-kill honesty**: a process cannot run cleanup after an uncatchable
+  kill. For a leg that died hard, the surviving parent (or, if the parent
+  itself died, the existing orphan-reaping path on the job surface) records
+  harvest state from what is on disk at reap time. A scratch directory that
+  cannot be read then records `harvest_failed` with a reason — never an empty
+  artifact list presented as if nothing was written. The guarantee is
+  explicitly bounded: harvest-before-notice holds on cooperative paths;
+  hard-kill paths guarantee only that the record says what could and could
+  not be established.
+- **Failure states are distinct and never collapse** (each is its own fact a
+  reader may act on differently): `dir-absent` (leg never created the scratch
+  dir — NOT evidence the leg had no artifacts to write), `dir-empty` (created,
+  nothing written — also not "clean", it is its own fact), `harvested-N`
+  (N regular files moved), `harvest_failed` (scratch existed or should have
+  and could not be fully served; partial harvests record what landed plus the
+  failure).
+
+### D4 — The leg artifact channel
+
+For each leg the runner creates a scratch directory inside that leg's own cwd
+tree — `{cwd}/.lionagi/leg-artifacts-{run_id}-{label}/` — and exports its
+absolute path to the leg process as `LIONAGI_LEG_ARTIFACTS`. A sandboxed leg
+can always write there: it is inside the tree the sandbox already permits.
+No sandbox configuration changes anywhere.
+
+- **Harvest is a bounded copy of regular files only.** Relative paths under
+  the scratch dir are preserved under `{run_dir}/artifacts/{label}/`.
+  Symlinks are never followed — each is recorded by name in
+  `harvest_detail.skipped`, because a leg-created symlink pointing outside
+  the leg's tree would otherwise turn the harvester (which is not sandboxed)
+  into a copy proxy and falsify the no-sandbox-widening claim. Special files
+  are skipped and recorded the same way. Per-leg caps: 1024 files, 256 MiB —
+  an order of magnitude above observed verdict artifacts (single-digit
+  markdown files); the cap exists so one runaway leg cannot fill the run
+  store, and hitting it records `harvest_failed` with the count at the cap,
+  never a silent truncation.
+- **Collisions are unrepresentable**, not handled: labels are unique and
+  path-safe by D1's pattern, and each label owns its directory.
+- **The scratch dir is removed after harvest** on cooperative paths. On
+  hard-kill paths it may survive; the reap-time harvest (D3) consumes it.
+- **The env var name is a decision with a check**: before implementation
+  merges, the name is swept against the variables a leg already inherits
+  (provider CLIs document theirs; the leg baseline environment is
+  enumerable), and a test asserts the runner refuses to overwrite a variable
+  that already exists in the leg's inherited environment — a collision is a
+  configuration error surfaced loudly, not a silent override.
+- **The read surface is `job.output`**: its existing `artifacts` +
+  `artifacts_state` fields list the harvested files with zero new read
+  surface. `job.status` stays artifact-free. Nothing in this ADR changes the
+  ADR-0106 result-contract shapes.
+- **This directory is a new named surface and inherits no protections.** It
+  gets its own adversarial pass before the implementation merges (leg writes
+  hostile names, symlink escapes, cap-overflow, mid-harvest kill), with the
+  victim-alive-and-feature-works outcome asserted, not just absence of the
+  attack's effect.
+
+### D5 — No-planner is a tested invariant, not a documentation claim
+
+The mode's run record carries `planner_invocations: 0` as an asserted field —
+the mode has no code path that constructs a planning turn, and the record
+says so per round rather than the docs saying so once.
+
+The named drift vector is not this mode's own code: it is a
+configuration-side default. Agent profiles carry model/effort/system-prompt
+defaults, and a profile (or a future orchestrator default) that would
+silently interpose a planning model on submissions that name it must FAIL a
+test. Concretely: the test suite includes a submission whose profile is
+configured the way the planner surfaces expect (an orchestrator-shaped
+profile), and the mode either refuses the configuration by name or executes
+the round with zero planning turns — a planned round is a test failure, not
+a fallback. No diff of this feature's own code would show that drift, which
+is exactly why it is pinned by a test rather than a review.
 
 ## Consequences
 
 - The N-briefs round becomes one submission, one wait, one notice, and one
-  `job.status` read for all verdict artifacts.
+  `job.output` read for all verdict artifacts.
 - The brief-as-contract property becomes structural: nothing between the
-  manifest and the leg can rewrite a brief, so a review round's inputs are
-  exactly what the caller wrote.
-- The manifest is a durable record of what was dispatched — the run snapshots
-  it, so "what did leg 3 actually receive" has a first-class answer.
-- The scratch-and-harvest channel adds a small teardown obligation (harvest
-  must run on every terminal path, including kill), and its failure mode must
-  be loud: a leg whose scratch cannot be harvested reports that fact in its
-  outcome rather than presenting an empty artifact list as if nothing was
-  written.
+  manifest and the leg can rewrite a brief, and the recorded content hashes
+  make "what did leg 3 actually receive" a first-class, verifiable answer.
+- Briefs stop carrying output-path contortion; sandboxed legs write to an
+  announced in-tree path and the runner does the serving.
+- What becomes harder: the runner takes on a harvest obligation on every
+  terminal path, and its failure modes must stay loud (D3's distinct states
+  exist precisely so a harvest problem cannot masquerade as an artifact-less
+  leg). A contributor touching leg teardown must now know the
+  harvest-before-notice ordering.
+- Reversal costs: D1 (manifest schema) is versioned and extendable; D4's env
+  var name is effectively frozen the day a consumer's briefs reference it —
+  which is why its collision check happens before first merge, not after.
 
-## Open questions
+## Alternatives considered
 
-1. Command and verb naming.
-2. Whether an inline manifest (object in the MCP call, no file) is accepted in
-   v1 or file-path-only.
-3. Whether per-leg environment passthrough (beyond `LIONAGI_LEG_ARTIFACTS`) is
-   in scope for v1.
+- **N independent agent submissions (status quo)** — fully deterministic and
+  available today; loses on N handles, N notices, hand harvest, and
+  per-brief output-path contortion. Remains the correct fallback until this
+  mode lands and is the interim recommendation.
+- **Planner fanout with a "do not rewrite the briefs" instruction** — would
+  reuse the whole existing surface; loses because a prompt prohibition is a
+  request, not a control, and the failure mode (silently rephrased contract)
+  is exactly the one the round cannot tolerate or even reliably detect.
+- **Caller-managed artifact paths in briefs** — no runner changes at all;
+  loses because it is the P3 status quo: sandbox-constrained path contortion
+  in every brief, no uniform read surface, artifacts invisible to
+  `job.output`.
+- **A separate collector process that sweeps leg cwds after the round** —
+  decouples harvest from the runner; loses because it is a second lifecycle
+  to operate (its own liveness, its own failure states) and it cannot give
+  the harvest-before-notice ordering guarantee without re-coupling to the
+  runner's terminalization anyway.
+- **Extending `job.status` with artifact fields** — one read instead of two
+  for pollers; loses because the artifact listing already exists on
+  `job.output`, `status()` is deliberately the cheap frequently-polled read,
+  and widening it duplicates a contract that ADR-0106-adjacent consumers
+  already bind to. Rejected in favor of naming `job.output` correctly.
+- **Inline manifest object in the MCP call** — DEFERRED, not rejected: it
+  would save a temp file for machine-generated rounds, but v1's consumers
+  produce brief files on disk anyway, the file path gives snapshot-and-hash
+  evidence for free, and adding a second input shape later is
+  backward-compatible while removing one is not.
+
+## Notes
+
+- Command and MCP verb naming is an open question for sign-off; the mode
+  ships beside `fanout.submit` whatever the name.
+- Per-leg environment passthrough beyond `LIONAGI_LEG_ARTIFACTS` is out of v1
+  unless the consuming workflow demonstrates a need; every added variable is
+  surface area the collision check and the adversarial pass must then cover.

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -187,10 +187,11 @@ concurrency caps compose the same way they do for the planner fanout.
 - **A timed-out leg** is recorded `timed_out`, receives cooperative
   termination escalating to hard kill, and its harvest runs only after its
   process's death is confirmed. The quiescence invariant (D3) is
-  path-independent: `round_state: complete` is never published while any
-  member of the run's recorded process-control domain survives, on
-  cooperative and reap paths alike. D3 states that domain exactly and names
-  the one residual it cannot close.
+  path-independent: `round_state: complete` is never published before a
+  quiescence sweep has run against every recorded control group — the
+  runner's own and each leg's, all captured at spawn — and observed each
+  empty, on cooperative and reap paths alike. D3 states that domain
+  exactly and names the residuals the sweep cannot close.
 
 ### D3 — Durable records, ordering, and the two-stage end
 
@@ -206,11 +207,22 @@ Each leg gets one durable record in the run directory,
   "model": "<resolved spec>",
   "env_keys": ["CARGO_TARGET_DIR"],
   "brief_hash": "<content hash recorded at submit>",
+  "pgid": 41230,
   "harvest_state": "harvested-3",
   "harvest_detail": {"files": 3, "bytes": 18211, "skipped": []},
   "artifacts": ["module-a/verdict.md", "module-a/notes.md", "module-a/log.txt"]
 }
 ```
+
+The dispatch facts — label, cwd, model, `env_keys`, `brief_hash`,
+`started_at`, and the leg's own process group (`pgid`, captured at spawn
+exactly as the provider subprocess layer already captures its child's) —
+are durably recorded in the leg record's first write, at spawn; status and
+harvest fields complete the record at finalization. The spawn-time write is
+what makes a reaper's quiescence sweep possible at all: the control domain
+is read from the run directory, never from a live runner's memory, so a
+reaper that shared nothing with the dead runner sweeps the same groups the
+runner would have.
 
 The round gets one summary record, `{run_dir}/round.json`:
 
@@ -267,8 +279,8 @@ OBSERVABLE, never silent.
   escalation parameter is possible future work, not claimed here. Claim
   recovery by the operator is deliberately narrower than group cleanup —
   the operator only needs to free the claim. The reaper that then acquires
-  it owns the rest: its pre-harvest group kill and absence check (above)
-  are what make a leader-only kill safe, because surviving group members
+  it owns the rest: its pre-harvest quiescence sweep (above) is what makes
+  a leader-only kill safe, because surviving domain members
   hold no claim and cannot outlive the reaper's first act.
   The reaper holders are server-side actors a job-group signal cannot
   reach; their work is bounded by construction — the same per-leg file and
@@ -277,13 +289,14 @@ OBSERVABLE, never silent.
   recovery for a server-side holder, and it is sufficient because the
   claim is kernel-held and leaves no persistent state behind.
 - **Cooperative ordering guarantee**: on normal completion and per-leg
-  timeout, the finalizer first proves the recorded process group holds no
-  member besides itself — a surviving descendant of a leg that already
-  ended, still inside the group, receives the same hard kill and its
-  absence is verified, so a straggler is ended at round close rather than
-  tolerated into the harvest window (the finalizer cannot use the group
-  kill here, being a member itself; it scans the recorded group and
-  signals the survivors individually, identity-checked the same way).
+  timeout, the finalizer first proves every recorded control group quiet.
+  For each leg's recorded group it hard-kills identity-verified survivors
+  and verifies absence — a leg that ended normally leaves its group empty
+  already, and the sweep confirms exactly that; a straggling descendant
+  still inside it is ended at round close rather than tolerated into the
+  harvest window. For the runner's own group — which it cannot group-kill,
+  being a member — it scans and signals survivors individually,
+  identity-checked the same way.
   Only then every leg's harvest runs and its record persists, then
   `round.json` is written with `round_state: complete`, and only then does
   the parent terminalize and its single notice fire. A notification consumer
@@ -303,20 +316,30 @@ OBSERVABLE, never silent.
   reaper first CHECKS the claim, not an unconditional handoff. Only on
   acquiring the lock — which a dead owner cannot still hold, the kernel
   released it with the process — does it proceed, and its FIRST act on the
-  claim is quiescence, not harvest: a hard kill of the run's recorded
-  process group (the raw `os.killpg` primitive, identity-verified against
-  the recorded pgid and the group marker every member inherits — not the
-  existing plain-kill helper, whose killed-marking record write belongs to
-  ordinary kills; the reaper's single terminal write comes later, after
-  harvest), then verification that no member of that group survives.
-  `round_state: complete` is never published while any member of the
-  recorded group is alive. The recorded group is the quiescence domain,
-  stated exactly: it is the strongest control the launch primitive
-  establishes portably — the initial child receives its own session, and
-  nothing prevents a descendant from leaving that session. A leg that
-  deliberately detaches into a new session while keeping the scratch path
-  can therefore still write after `complete`; that residual is accepted
-  and named rather than papered over. Such an escapee is the caller's own
+  claim is quiescence, not harvest: a hard kill of every recorded control
+  group — the runner's and each leg's, read from the run directory (the
+  raw `os.killpg` primitive, identity-verified against each recorded pgid
+  and the group marker every descendant inherits — environment survives a
+  new session, so the marker identifies leg-group members too — not the existing
+  plain-kill helper, whose killed-marking record write belongs to ordinary
+  kills; the reaper's single terminal write comes later, after harvest),
+  then verification that no member of any recorded group survives.
+  `round_state: complete` is never published before that sweep has
+  observed every recorded group empty. The recorded groups are the
+  quiescence domain, stated exactly, and it is plural by design: the
+  provider subprocess layer starts every leg in its own session, so one
+  shared group never existed to sweep — an ordinary leg sits inside the
+  domain because its group was recorded at spawn, not because it stayed
+  inside anyone else's. What the sweep cannot close, named rather than
+  papered over: a descendant that deliberately leaves its own leg's
+  recorded session while keeping the scratch path can still write after
+  `complete`; a member that forks during the sweep can leave a child the
+  verification pass never observed; and identification and signal are two
+  syscalls, so the sweep inherits the job surface's stated guarantee shape
+  — never a signal without positive identification, not never a missed or
+  misdirected one (the internals documentation states this window and why
+  process groups alone cannot close it). All three residuals fall under
+  the same consumer rule below. Such an escapee is the caller's own
   agent executing the caller's own brief, so it crosses no privilege
   boundary and sabotages only its author's round: D4's harvest copies
   defensively, so the published record describes the harvested copies and
@@ -325,8 +348,10 @@ OBSERVABLE, never silent.
   residual, stated as a rule: consume through the round record only —
   `job.output` serves the harvested copies under the run directory and
   never reads a scratch tree, so the read surface enforces this by
-  construction; a leg-artifacts directory that exists or reappears after
-  `round_state: complete` is the escapee's signature, sits outside the
+  construction; a leg-artifacts directory that reappears after
+  `round_state: complete` — or survives it without that leg's record
+  naming a failed removal (D4 removes every harvested scratch before
+  `complete` on all paths) — is an escapee's signature, sits outside the
   round's guarantees, and is disposable — deleting it changes nothing
   recorded; and a leg that detaches workers past its own round is a defect
   in that leg's brief, fixed in the brief, not a runner defect. A mechanically non-escapable process
@@ -344,8 +369,8 @@ OBSERVABLE, never silent.
   definition of the path, so the lock is free; acquisition still serializes
   it against a concurrent kill-reaper) and performs the same
   quiescence-then-harvest-then-record sequence before its terminal write —
-  a dead parent does not mean dead legs, so the pre-harvest group kill and
-  absence check apply identically — recording
+  a dead parent does not mean dead legs, so the pre-harvest quiescence
+  sweep applies identically — recording
   `"recorded_by": "orphan-reaper"`. Where the existing reaper (or any non-manifest-aware
   writer) has already published a terminal status, the manifest-aware pass
   still runs, writes the records late, and flips `round_state` from
@@ -389,8 +414,13 @@ No sandbox configuration changes anywhere.
   silent truncation.
 - **Collisions are unrepresentable**, not handled: labels are unique and
   path-safe by D1's pattern, and each label owns its directory.
-- **The scratch dir is removed after harvest** on cooperative paths. On
-  hard-kill paths it may survive; the reap-time harvest (D3) consumes it.
+- **The scratch dir is removed after harvest on every finalization path** —
+  cooperative, kill-reaper, and orphan-reaper alike — and the removal
+  precedes `round_state: complete`. That ordering is what entitles D3's
+  residual rule to read a surviving directory as an escapee's signature
+  rather than permitted reap residue. A removal that fails is recorded in
+  that leg's record, and a directory whose survival is recorded there is
+  not escapee evidence.
 - **The env var name is a decision with a check**: before implementation
   merges, the name is swept against the variables a leg already inherits
   (provider CLIs document theirs; the leg baseline environment is

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -277,7 +277,14 @@ OBSERVABLE, never silent.
   recovery for a server-side holder, and it is sufficient because the
   claim is kernel-held and leaves no persistent state behind.
 - **Cooperative ordering guarantee**: on normal completion and per-leg
-  timeout, every leg's harvest runs and its record persists, then
+  timeout, the finalizer first proves the recorded process group holds no
+  member besides itself — a surviving descendant of a leg that already
+  ended, still inside the group, receives the same hard kill and its
+  absence is verified, so a straggler is ended at round close rather than
+  tolerated into the harvest window (the finalizer cannot use the group
+  kill here, being a member itself; it scans the recorded group and
+  signals the survivors individually, identity-checked the same way).
+  Only then every leg's harvest runs and its record persists, then
   `round.json` is written with `round_state: complete`, and only then does
   the parent terminalize and its single notice fire. A notification consumer
   and a polling consumer read the same facts; there is no cooperative window
@@ -314,7 +321,15 @@ OBSERVABLE, never silent.
   boundary and sabotages only its author's round: D4's harvest copies
   defensively, so the published record describes the harvested copies and
   stays internally consistent — writes made after recorded-domain
-  quiescence simply miss the round. A mechanically non-escapable process
+  quiescence simply miss the round. What a consumer does about the
+  residual, stated as a rule: consume through the round record only —
+  `job.output` serves the harvested copies under the run directory and
+  never reads a scratch tree, so the read surface enforces this by
+  construction; a leg-artifacts directory that exists or reappears after
+  `round_state: complete` is the escapee's signature, sits outside the
+  round's guarantees, and is disposable — deleting it changes nothing
+  recorded; and a leg that detaches workers past its own round is a defect
+  in that leg's brief, fixed in the brief, not a runner defect. A mechanically non-escapable process
   domain would close the residual; that is platform-specific hardening
   this ADR names and does not adopt. Only then the manifest-aware reap:
   harvest each leg's scratch from disk as D4

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -4,8 +4,9 @@
 - **Kind**: Aspirational (records the target state)
 - **Area**: orchestration
 - **Date**: 2026-08-03
-- **Relations**: extends ADR-0106 (machine result contract); composes with the
-  MCP job surface (`job.output` is the artifact listing read)
+- **Relations**: extends ADR-0106 (machine result contract; D6 here names one
+  additive change to it); composes with the MCP job surface (`job.output` is
+  the artifact and round-summary read)
 
 ## Context
 
@@ -46,10 +47,11 @@ work that is common and currently unserved. The problems, concretely:
 | Concern | Decision |
 |---------|----------|
 | Input format and validation | D1: closed manifest schema v1, file-path-only, snapshotted at submit |
-| Execution and aggregation | D2: independent parallel legs; per-leg timeout from spawn; parent outcome table |
-| Durable per-leg record and ordering | D3: per-leg record persisted before parent terminalization and its one notice |
-| Leg artifact channel | D4: scratch dir inside leg cwd, env-announced, harvested as bounded regular-file copy |
+| Execution and aggregation | D2: independent parallel legs; per-leg timeout from spawn; no parent deadline in v1; total outcome rules |
+| Durable per-leg record and ordering | D3: per-leg records + round summary durable before cooperative terminalization; two-stage kill; the hard-kill window is observable, never silent |
+| Leg artifact channel | D4: scratch dir inside leg cwd, env-announced, harvested by descriptor-anchored bounded copy |
 | Planner absence | D5: no-planner is a tested invariant with the profile-default drift vector as a named failure case |
+| Observation contract | D6: closed job outcome preserved; round facts served by a versioned additive `round` field on `job.output`; the notice is the signal, not the carrier |
 
 **Out of scope**: dependencies between legs (the flow surface's job);
 scheduling recurring rounds (`li schedule` composes on top); any change to the
@@ -72,13 +74,15 @@ manifest_version: 1            # required, exactly 1
 defaults:                      # optional; every key below optional
   model: <model spec>          # XOR agent, at each level
   agent: <profile name>
-  timeout: 1200                # seconds, positive, <= 86400
+  timeout: 1200                # per-leg default, seconds, positive, <= 86400
 legs:                          # required, 1..64 entries
   - brief: /abs/path/briefs/module-a.md    # required
     cwd: /abs/path/worktrees/module-a      # required
     label: review-module-a                 # required
     model: <model spec>        # optional per-leg override
     timeout: 900               # optional per-leg override
+    env:                       # optional; closed map of named variables
+      CARGO_TARGET_DIR: /abs/path/targets/module-a
 ```
 
 Exact semantics, refuse-early at submit (nothing spawns, no job record is
@@ -101,9 +105,26 @@ would-be-refused submissions):
   ignores both defaults (no cross-level merging of the pair — merging `model`
   from one level with `agent` from another would construct a configuration
   nobody wrote).
-- **`timeout`**: positive integer seconds, at most 86400. The ceiling is a
-  sanity bound, not a derivation: a leg that needs more than a day is not a
-  round leg.
+- **`timeout`**: positive integer seconds, at most 86400, and it is a PER-LEG
+  value at both levels: `defaults.timeout` is nothing more than the default
+  each leg inherits. The ceiling is a sanity bound, not a derivation: a leg
+  that needs more than a day is not a round leg.
+- **`env`** (per-leg, optional): a closed map of named environment variables
+  set for that leg — keys matching `[A-Z][A-Z0-9_]{0,63}`, string values,
+  passed via the process environment array at spawn (never through a shell).
+  Deny-by-default: nothing travels from the submitting process's environment;
+  beyond its baseline, a leg receives exactly the variables named here, and
+  the manifest snapshot is their durable source. A declared key that also
+  exists in the leg's baseline is overridden by the manifest value — that is
+  the feature (the declared value is the reproducible one); the D4 refusal
+  rule protects only the runner's own reserved name, and
+  `LIONAGI_LEG_ARTIFACTS` is accordingly refused here at submit. Declared
+  keys are listed in the leg's durable record as `env_keys`; the record never
+  re-prints values. Manifests are durable evidence, so credentials do not
+  belong in them: a secret a leg needs stays in the runner's own environment
+  and reaches the leg through the baseline, named nowhere. The consuming
+  workflow demonstrated the concrete cases (actor identity resolving wrong on
+  workspace cwds, per-worktree build target directories).
 - **Leg count 1..64.** The floor is definitional. The ceiling is one order of
   magnitude above the largest observed round (13) — a bound that exists so a
   generated manifest with a bug cannot fan out unbounded, chosen loose enough
@@ -113,7 +134,7 @@ would-be-refused submissions):
   a natural durable-evidence story, and parity with `prompt_file`, and the
   consuming workflow already produces brief files on disk.
 
-### D2 — Round execution: independence, clocks, aggregation
+### D2 — Round execution: independence, clocks, total aggregation
 
 Legs execute in parallel under the existing worker concurrency machinery;
 concurrency caps compose the same way they do for the planner fanout.
@@ -125,29 +146,35 @@ concurrency caps compose the same way they do for the planner fanout.
 - **Per-leg timeout clock starts at leg process spawn**, not at submit and not
   at queue admission — queue wait under a concurrency cap is not the leg's
   time. What a timeout interrupts is the leg's own execution.
-- **An optional round timeout** (defaults key `timeout` does double duty: it
-  is the per-leg default; a future `round_timeout` is deliberately NOT in v1
-  — one knob until a consumer demonstrates the second is needed).
-- **Parent terminalization**: the parent run becomes terminal only when every
-  leg has a durable per-leg record including its harvest state (D3). Parent
-  `outcome` derives from the leg records:
+- **There is no parent deadline in v1.** `defaults.timeout` is only the
+  per-leg default (D1). A round ends when its last leg ends. External
+  cancellation (`job.kill`) is an EVENT, not a clock, and is specified in D3;
+  a leg stopped by it records `cancelled`. A `round_timeout` field is
+  deliberately absent until a consumer demonstrates the need — one knob, one
+  meaning.
+- **Leg terminal vocabulary**: `succeeded`, `failed`, `timed_out`,
+  `cancelled`, `killed` — plus the orthogonal harvest state (D3). Every leg
+  ends in exactly one.
+- **Parent aggregation is total by construction** — three rules cover every
+  combination of leg terminal states and harvest states, so no mixed round is
+  undecided:
 
-| Leg records | Parent `outcome` |
+| Rule (evaluated in order) | Round `result` |
 |---|---|
-| every leg `succeeded` and `harvested-N`/`dir-empty`/`dir-absent` | `completed` |
-| at least one leg succeeded; at least one `failed`/`timed_out`/`killed`/`harvest_failed` | `partial` |
-| no leg succeeded | `failed` |
+| every leg `succeeded` AND no leg `harvest_failed` | `completed` |
+| at least one leg `succeeded` (anything else true of the others) | `partial` |
+| no leg `succeeded` | `failed` |
 
-  `dir-empty` and `dir-absent` do not degrade the parent outcome by
-  themselves: a leg whose whole answer is its final message legitimately
-  writes no artifact. `harvest_failed` always degrades to at least `partial`
-  — artifacts were (or may have been) written and cannot be served, which is
-  a loss the outcome must not paper over.
+  `dir-empty` and `dir-absent` never degrade the result by themselves: a leg
+  whose whole answer is its final message legitimately writes no artifact.
+  `harvest_failed` always degrades below `completed` — artifacts were (or may
+  have been) written and cannot be served, a loss the result must not paper
+  over.
 
 - **A timed-out leg** is recorded `timed_out`, receives cooperative
   termination, and its harvest is still attempted during cooperative teardown.
 
-### D3 — The per-leg record, and what must be durable before the notice
+### D3 — Durable records, ordering, and the two-stage end
 
 Each leg gets one durable record in the run directory,
 `{run_dir}/legs/{label}.json`:
@@ -156,10 +183,10 @@ Each leg gets one durable record in the run directory,
 {
   "label": "review-module-a",
   "status": "succeeded",
-  "outcome": "success",
   "started_at": "...", "finished_at": "...",
   "cwd": "/abs/path/worktrees/module-a",
   "model": "<resolved spec>",
+  "env_keys": ["CARGO_TARGET_DIR"],
   "brief_hash": "<content hash recorded at submit>",
   "harvest_state": "harvested-3",
   "harvest_detail": {"files": 3, "bytes": 18211, "skipped": []},
@@ -167,29 +194,56 @@ Each leg gets one durable record in the run directory,
 }
 ```
 
-- **Ordering guarantee**: on every cooperative path (normal completion,
-  per-leg timeout, round-level cancellation, `job.kill` reaching the group
-  cooperatively), the leg's harvest runs and its record is persisted BEFORE
-  the parent terminalizes, and the parent's single terminal notice fires only
-  after the last record is durable. A notification consumer and a polling
-  consumer therefore read the same facts; there is no window where the notice
-  says "done" and a leg record is still being written.
-- **Hard-kill honesty**: a process cannot run cleanup after an uncatchable
-  kill. For a leg that died hard, the surviving parent (or, if the parent
-  itself died, the existing orphan-reaping path on the job surface) records
-  harvest state from what is on disk at reap time. A scratch directory that
-  cannot be read then records `harvest_failed` with a reason — never an empty
-  artifact list presented as if nothing was written. The guarantee is
-  explicitly bounded: harvest-before-notice holds on cooperative paths;
-  hard-kill paths guarantee only that the record says what could and could
-  not be established.
-- **Failure states are distinct and never collapse** (each is its own fact a
-  reader may act on differently): `dir-absent` (leg never created the scratch
-  dir — NOT evidence the leg had no artifacts to write), `dir-empty` (created,
-  nothing written — also not "clean", it is its own fact), `harvested-N`
-  (N regular files moved), `harvest_failed` (scratch existed or should have
-  and could not be fully served; partial harvests record what landed plus the
-  failure).
+The round gets one summary record, `{run_dir}/round.json`:
+
+```json
+{
+  "round_version": 1,
+  "round_state": "complete",
+  "result": "partial",
+  "legs_total": 4, "legs_succeeded": 3,
+  "legs": ["review-module-a", "review-module-b", "..."]
+}
+```
+
+`round_state` is the honesty field: `complete` means every leg record and
+harvest is durably written; `pending_harvest` means a terminal status became
+visible before cleanup finished (possible only on the non-cooperative paths
+below). A reader who finds a terminal job with `round_state: pending_harvest`
+is told, in the record itself, that leg facts are still landing — the window
+exists and is OBSERVABLE, never silent.
+
+- **Cooperative ordering guarantee**: on normal completion and per-leg
+  timeout, every leg's harvest runs and its record persists, then
+  `round.json` is written with `round_state: complete`, and only then does
+  the parent terminalize and its single notice fire. A notification consumer
+  and a polling consumer read the same facts; there is no cooperative window
+  where the notice says "done" and a record is missing.
+- **`job.kill` is two-stage for manifest runs.** The current kill path writes
+  `status: "killed"` and `finished_at` immediately when no end is recorded
+  (`lionagi/mcp/jobs.py`, `_mark_killed`), which would make the parent
+  observable as terminal while cleanup has not run. For a manifest run the
+  kill surface instead records `kill_requested_at` and signals the group
+  WITHOUT writing the terminal fields; the runner's cooperative teardown then
+  harvests, records, and terminalizes exactly as above. If the runner does
+  not terminalize within a bounded grace (default 30 s — long enough for N
+  bounded harvests, short enough that a kill still means something), the kill
+  surface performs a manifest-aware reap: harvest each leg's scratch from
+  disk as D4 specifies, write each leg record with what could be established
+  (`harvest_failed` with a reason where a scratch is unreadable — never an
+  empty artifact list), write `round.json`, then make its single terminal
+  write. Records written by a reaper say so (`"recorded_by": "reaper"`).
+- **An already-dead parent** (crash, OOM, machine restart) is found by the
+  existing orphan-reaping path on the job surface; for manifest runs that
+  reaper performs the same disk-side harvest-then-record sequence before its
+  terminal write. Where the existing reaper (or any non-manifest-aware
+  writer) has already published a terminal status, the manifest-aware pass
+  still runs, writes the records late, and flips `round_state` from
+  `pending_harvest` to `complete` — late facts beat lost facts.
+- **The bound, stated plainly**: harvest-before-notice holds on cooperative
+  paths. On kill and reap paths the guarantee is weaker and explicit —
+  `round_state` names whether the facts are all in, and every leg record
+  distinguishes what was established from what could not be.
 
 ### D4 — The leg artifact channel
 
@@ -199,17 +253,27 @@ absolute path to the leg process as `LIONAGI_LEG_ARTIFACTS`. A sandboxed leg
 can always write there: it is inside the tree the sandbox already permits.
 No sandbox configuration changes anywhere.
 
-- **Harvest is a bounded copy of regular files only.** Relative paths under
-  the scratch dir are preserved under `{run_dir}/artifacts/{label}/`.
-  Symlinks are never followed — each is recorded by name in
-  `harvest_detail.skipped`, because a leg-created symlink pointing outside
-  the leg's tree would otherwise turn the harvester (which is not sandboxed)
-  into a copy proxy and falsify the no-sandbox-widening claim. Special files
-  are skipped and recorded the same way. Per-leg caps: 1024 files, 256 MiB —
-  an order of magnitude above observed verdict artifacts (single-digit
-  markdown files); the cap exists so one runaway leg cannot fill the run
-  store, and hitting it records `harvest_failed` with the count at the cap,
-  never a silent truncation.
+- **Harvest is a descriptor-anchored bounded copy.** The leg author controls
+  the scratch tree's contents, so the harvester (which is NOT sandboxed)
+  treats it as hostile input. The scratch root is opened once as a directory
+  with no-follow semantics and all traversal proceeds from that descriptor
+  (`openat`-style), never by re-resolving paths — a path re-resolution
+  between check and open is exactly the race a hostile leg would use to swap
+  a checked regular file for a symlink. Each candidate is opened no-follow
+  and its opened identity is verified against the pre-open `lstat`
+  (device+inode); a mismatch records `skipped_swapped`. Symlinks are never
+  followed (`skipped_symlink`). **Hard links are refused**: a hard link is a
+  regular file and would pass a naive regular-files-only rule while making
+  the harvester copy an inode the leg never produced under the scratch root
+  — the copy-proxy escape by another door. Files with link count other than
+  one record `skipped_hardlink`. Special files are skipped and recorded.
+  Relative paths are preserved under `{run_dir}/artifacts/{label}/`.
+- **Caps are enforced during the copy, not before it**: 1024 files, 256 MiB
+  per leg — an order of magnitude above observed verdict artifacts
+  (single-digit markdown files); a pre-copy size check would race a growing
+  file, so bytes are counted as written and the cap aborts the copy at the
+  boundary, recording `harvest_failed` with the counts at the cap. Never a
+  silent truncation.
 - **Collisions are unrepresentable**, not handled: labels are unique and
   path-safe by D1's pattern, and each label owns its directory.
 - **The scratch dir is removed after harvest** on cooperative paths. On
@@ -220,15 +284,14 @@ No sandbox configuration changes anywhere.
   enumerable), and a test asserts the runner refuses to overwrite a variable
   that already exists in the leg's inherited environment — a collision is a
   configuration error surfaced loudly, not a silent override.
-- **The read surface is `job.output`**: its existing `artifacts` +
-  `artifacts_state` fields list the harvested files with zero new read
-  surface. `job.status` stays artifact-free. Nothing in this ADR changes the
-  ADR-0106 result-contract shapes.
+- **The read surface is `job.output`** (D6). `job.status` stays
+  artifact-free.
 - **This directory is a new named surface and inherits no protections.** It
-  gets its own adversarial pass before the implementation merges (leg writes
-  hostile names, symlink escapes, cap-overflow, mid-harvest kill), with the
-  victim-alive-and-feature-works outcome asserted, not just absence of the
-  attack's effect.
+  gets its own adversarial pass before the implementation merges, and the
+  required arms now include: hostile file names, symlink escapes, HARD-LINK
+  escapes, check-to-open swap races, cap overflow mid-copy, and kill during
+  harvest — with the victim-alive-and-feature-works outcome asserted, not
+  just absence of the attack's effect.
 
 ### D5 — No-planner is a tested invariant, not a documentation claim
 
@@ -247,23 +310,57 @@ the round with zero planning turns — a planned round is a test failure, not
 a fallback. No diff of this feature's own code would show that drift, which
 is exactly why it is pinned by a test rather than a review.
 
+### D6 — Observation contract: closed outcomes preserved, round facts on `job.output`
+
+The job surface's `outcome` is a closed vocabulary —
+`{succeeded, failed, cancelled, indeterminate}` (`lionagi/mcp/jobs.py`,
+`_OUTCOMES`) — and consumers legitimately bind to it. `partial` does NOT
+join that set; widening a closed vocabulary breaks every consumer that
+enumerated it, for the benefit of one producer.
+
+- **Mapping**: round `completed` → job outcome `succeeded`; round `partial`
+  or `failed` → job outcome `failed`; a round killed before any leg spawned
+  → `cancelled`. The coarse job outcome answers "did the round come out
+  clean"; anything finer is the round summary's job.
+- **The read**: for manifest runs, `job.output`'s response carries one
+  additive field, `round` — the full `round.json` content (round_version,
+  round_state, result, counts, and the per-leg records inlined). Additive
+  field on an existing read: consumers that do not know it ignore it;
+  nothing existing changes shape. This is a named, versioned amendment to
+  the ADR-0106-adjacent result surface, carried by this ADR rather than
+  smuggled in by implementation.
+- **The notice is the signal, not the carrier.** The terminal-notice payload
+  is unchanged. A notification consumer that needs leg facts performs the
+  `job.output` read on receipt; the cooperative ordering guarantee (D3) makes
+  that read complete by the time the notice fires, and `round_state` covers
+  the non-cooperative window honestly.
+
 ## Consequences
 
 - The N-briefs round becomes one submission, one wait, one notice, and one
-  `job.output` read for all verdict artifacts.
+  `job.output` read for round result, per-leg outcomes, and all verdict
+  artifacts.
 - The brief-as-contract property becomes structural: nothing between the
   manifest and the leg can rewrite a brief, and the recorded content hashes
   make "what did leg 3 actually receive" a first-class, verifiable answer.
 - Briefs stop carrying output-path contortion; sandboxed legs write to an
   announced in-tree path and the runner does the serving.
 - What becomes harder: the runner takes on a harvest obligation on every
-  terminal path, and its failure modes must stay loud (D3's distinct states
-  exist precisely so a harvest problem cannot masquerade as an artifact-less
-  leg). A contributor touching leg teardown must now know the
-  harvest-before-notice ordering.
+  terminal path, kill becomes two-stage for manifest runs (a contributor
+  touching `job.kill` or the reaper must now know the manifest-aware
+  branch), and the harvester must be written as a hostile-input consumer
+  (descriptor-anchored, no-follow, link-count checks) rather than a tree
+  copy.
+- The `pending_harvest` window is a deliberate admission: on non-cooperative
+  ends, facts can arrive after the terminal status. The alternative — holding
+  the terminal status until harvest completes on a path where the harvesting
+  process may itself be dead — would trade an observable window for an
+  unbounded wait.
 - Reversal costs: D1 (manifest schema) is versioned and extendable; D4's env
   var name is effectively frozen the day a consumer's briefs reference it —
   which is why its collision check happens before first merge, not after.
+  D6's additive field is cheap to add and expensive to remove, which is the
+  usual asymmetry of read surfaces.
 
 ## Alternatives considered
 
@@ -287,18 +384,41 @@ is exactly why it is pinned by a test rather than a review.
 - **Extending `job.status` with artifact fields** — one read instead of two
   for pollers; loses because the artifact listing already exists on
   `job.output`, `status()` is deliberately the cheap frequently-polled read,
-  and widening it duplicates a contract that ADR-0106-adjacent consumers
-  already bind to. Rejected in favor of naming `job.output` correctly.
+  and widening it duplicates a contract consumers already bind to.
+- **Adding `partial` to the closed `_OUTCOMES` vocabulary** — would let the
+  job outcome carry the round result directly; loses because the set is
+  closed precisely so consumers can enumerate it, and every existing
+  consumer's match over four values silently mishandles a fifth. The round
+  summary field is additive instead; ignorance of it is safe.
+- **Holding the terminal write until reap-time harvest completes** — would
+  make harvest-before-notice unconditional; loses because on the
+  already-dead-parent path there may be nobody to finish the harvest
+  promptly, and an unbounded non-terminal state is worse than an observable
+  `pending_harvest` window (a caller waiting on terminal would wait on a
+  corpse).
 - **Inline manifest object in the MCP call** — DEFERRED, not rejected: it
   would save a temp file for machine-generated rounds, but v1's consumers
   produce brief files on disk anyway, the file path gives snapshot-and-hash
   evidence for free, and adding a second input shape later is
-  backward-compatible while removing one is not.
+  backward-compatible while removing one is not. The consuming workflow has
+  since confirmed it will use the file path exclusively.
+- **Wildcard environment inheritance for legs** — one flag instead of named
+  keys; loses because it forwards whatever the submitting process happened to
+  carry (secrets included), makes a round unreproducible from its manifest,
+  and turns the collision check into an unenumerable surface. Named keys with
+  deny-by-default is what the consuming workflow itself asked for.
 
 ## Notes
 
 - Command and MCP verb naming is an open question for sign-off; the mode
   ships beside `fanout.submit` whatever the name.
-- Per-leg environment passthrough beyond `LIONAGI_LEG_ARTIFACTS` is out of v1
-  unless the consuming workflow demonstrates a need; every added variable is
-  surface area the collision check and the adversarial pass must then cover.
+- Per-leg environment is IN v1 as D1's `env` map: the consuming workflow
+  demonstrated the need with named cases and asked for deny-by-default with a
+  closed per-leg allowlist. What contains it: keys are recorded per leg
+  (`env_keys`), values reach the process only through the environment array
+  (D1), and the reserved-name refusal is a submit-time validation with its
+  own test. The D4 collision check still owns the runner's reserved name.
+- The 30 s kill grace in D3 is a default, not a derivation: it must cover N
+  bounded harvests (256 MiB cap each, local disk) while keeping `job.kill`
+  meaningful as an interruption; implementations may make it configurable
+  but the default ships as stated.

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -187,11 +187,19 @@ concurrency caps compose the same way they do for the planner fanout.
 - **A timed-out leg** is recorded `timed_out`, receives cooperative
   termination escalating to hard kill, and its harvest runs only after its
   process's death is confirmed. The quiescence invariant (D3) is
-  path-independent: `round_state: complete` is never published before a
-  quiescence sweep has run against every recorded control group — the
-  runner's own and each leg's, all captured at spawn — and observed each
-  empty, on cooperative and reap paths alike. D3 states that domain
-  exactly and names the residuals the sweep cannot close.
+  path-independent in what it protects, and its predicate names the one
+  process that must survive to publish: `round_state: complete` is never
+  published before a quiescence sweep has run against every recorded
+  control group — the runner's own and each leg's, all captured at spawn.
+  On reap paths the reaper belongs to no recorded group, so the predicate
+  is absolute: every recorded group observed empty. On the cooperative
+  path the publishing finalizer is a member of the runner's own group and
+  must outlive the sweep to write the summary, so the predicate there is
+  every leg group observed empty and the runner's group holding no member
+  but the identified finalizer itself — demanding the finalizer's own
+  absence would make cooperative publication impossible, not safer. D3
+  states the domain exactly and names the residuals the sweep cannot
+  close.
 
 ### D3 — Durable records, ordering, and the two-stage end
 
@@ -215,10 +223,16 @@ Each leg gets one durable record in the run directory,
 ```
 
 The dispatch facts — label, cwd, model, `env_keys`, `brief_hash`,
-`started_at`, and the leg's own process group (`pgid`, captured at spawn
-exactly as the provider subprocess layer already captures its child's) —
+`started_at`, and the leg's own process group (`pgid`) —
 are durably recorded in the leg record's first write, at spawn; status and
-harvest fields complete the record at finalization. The spawn-time write is
+harvest fields complete the record at finalization. The `pgid` capture is
+the manifest runner's own duty, named here as required work: it reads the
+group immediately after the spawn returns, the same spawn-time capture the
+job surface performs for its own child. The provider subprocess layer
+starts each leg's new session but today neither captures nor persists the
+resulting group, so the runner performs the read itself (or a provider API
+is added that returns it) — this ADR does not describe that capture as
+existing. The spawn-time write is
 what makes a reaper's quiescence sweep possible at all: the control domain
 is read from the run directory, never from a live runner's memory, so a
 reaper that shared nothing with the dead runner sweeps the same groups the
@@ -295,8 +309,10 @@ OBSERVABLE, never silent.
   already, and the sweep confirms exactly that; a straggling descendant
   still inside it is ended at round close rather than tolerated into the
   harvest window. For the runner's own group — which it cannot group-kill,
-  being a member — it scans and signals survivors individually,
-  identity-checked the same way.
+  being a member — it scans and signals survivors other than itself
+  individually, identity-checked the same way; the cooperative predicate
+  is "no member but the finalizer" (D2), because the finalizer must
+  survive its own sweep to publish.
   Only then every leg's harvest runs and its record persists, then
   `round.json` is written with `round_state: complete`, and only then does
   the parent terminalize and its single notice fire. A notification consumer
@@ -323,14 +339,22 @@ OBSERVABLE, never silent.
   new session, so the marker identifies leg-group members too — not the existing
   plain-kill helper, whose killed-marking record write belongs to ordinary
   kills; the reaper's single terminal write comes later, after harvest),
-  then verification that no member of any recorded group survives.
-  `round_state: complete` is never published before that sweep has
-  observed every recorded group empty. The recorded groups are the
+  then verification that no member of any recorded group survives — a
+  reaper belongs to no recorded group, so the reap-path predicate is
+  absolute emptiness, differing from the cooperative predicate (D2) by
+  exactly the publishing finalizer. `round_state: complete` is never
+  published before that sweep has observed every recorded group empty. The recorded groups are the
   quiescence domain, stated exactly, and it is plural by design: the
   provider subprocess layer starts every leg in its own session, so one
   shared group never existed to sweep — an ordinary leg sits inside the
   domain because its group was recorded at spawn, not because it stayed
-  inside anyone else's. What the sweep cannot close, named rather than
+  inside anyone else's. That correction earns a standing rule for any
+  future revision of this domain: a membership sweep names and cites the
+  mechanism that populates the set it sweeps, because a sweep over a
+  domain nobody joins is indistinguishable from a clean sweep and fails
+  toward reassuring. Here the populating mechanism is the runner's
+  spawn-time `pgid` capture written into each leg record's first write,
+  plus the job surface's recording of the runner's own group. What the sweep cannot close, named rather than
   papered over: a descendant that deliberately leaves its own leg's
   recorded session while keeping the scratch path can still write after
   `complete`; a member that forks during the sweep can leave a child the

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -354,7 +354,16 @@ OBSERVABLE, never silent.
   domain nobody joins is indistinguishable from a clean sweep and fails
   toward reassuring. Here the populating mechanism is the runner's
   spawn-time `pgid` capture written into each leg record's first write,
-  plus the job surface's recording of the runner's own group. What the sweep cannot close, named rather than
+  plus the job surface's recording of the runner's own group. Its
+  companion rule, earned by the successor defect: a membership or
+  quiescence predicate states where the observer sits relative to the set
+  it observes — the observer is inside the measured population unless
+  something puts it outside, and a predicate that forgets its own
+  observer fails toward unsatisfiable, while one that forgets who joins
+  fails toward reassuring. That is why the predicates above are stated
+  per path rather than once: the reap-path observer is outside every
+  recorded group and demands absolute emptiness; the cooperative observer
+  is a member of the runner's group and exempts exactly itself. What the sweep cannot close, named rather than
   papered over: a descendant that deliberately leaves its own leg's
   recorded session while keeping the scratch path can still write after
   `complete`; a member that forks during the sweep can leave a child the

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -248,6 +248,17 @@ OBSERVABLE, never silent.
   record already present leaves it — first write wins, `recorded_by` names
   the winner — so even a mis-sequenced writer cannot produce two competing
   records for one leg.
+- **A hung live holder has a named recovery, per holder — one signal path
+  does not cover all three.** The runner holder lives in the job's own
+  process group: `job.kill` delivers the stop signal (the MCP surface sends
+  a fixed SIGTERM and exposes no signal choice), and an operator's group
+  SIGKILL through the CLI kill surface releases the claim with the process.
+  The reaper holders are server-side actors a job-group signal cannot
+  reach; their work is bounded by construction — the same per-leg file and
+  byte caps that bound every harvest — and one that nonetheless hangs
+  holds the claim until the serving process restarts. Restart is the named
+  recovery for a server-side holder, and it is sufficient because the
+  claim is kernel-held and leaves no persistent state behind.
 - **Cooperative ordering guarantee**: on normal completion and per-leg
   timeout, every leg's harvest runs and its record persists, then
   `round.json` is written with `round_state: complete`, and only then does
@@ -266,11 +277,8 @@ OBSERVABLE, never silent.
   surface waits and re-checks — the stop signal has been delivered, and the
   terminal write belongs to the claim holder; grace expiry is when the
   reaper first CHECKS the claim, not an unconditional handoff. Only on
-  acquiring the lock — which a dead owner cannot still hold (the kernel
-  released it with the process), and which a hung-but-alive holder keeps
-  until it exits; escalation is the caller's act, `job.kill` accepts the
-  signal to send and SIGKILL is not survivable — does it perform a
-  manifest-aware reap: harvest each leg's scratch from disk as D4
+  acquiring the lock — which a dead owner cannot still hold, the kernel
+  released it with the process — does it perform a manifest-aware reap: harvest each leg's scratch from disk as D4
   specifies, write each leg record with what could be established
   (`harvest_failed` with a reason where a scratch is unreadable — never an
   empty artifact list), write `round.json`, then make its single terminal
@@ -369,14 +377,25 @@ terminal fix landed, and has shipped it ever since (`lionagi/mcp/jobs.py`,
 `_OUTCOMES`; `indeterminate`, reserved at freeze, gained its producer when
 ADR-0107's reaper landed) — an unversioned expansion that
 ADR-0107's Notes later recorded as a pending ADR-0106 amendment item.
-This ADR carries that amendment as an ERRATUM: the vocabulary is corrected
-to the four values the wire ships, the true timing is recorded in the
-correction, and `contract_version` still does not move. The document
-correction changes nothing on the wire; the D2-breaking event was the
-2026-07-25 unversioned code change, and a retroactive bump today would
-tell consumers — every one of whom faces the four-value wire either way —
-that behavior changed today when it did not. Recording the violation as an
-erratum keeps D2's rule intact instead of manufacturing an exception to
+This ADR carries that amendment as an ERRATUM with a stated migration
+policy, and `contract_version` does not move. Precision the record owes
+its readers: envelope stamping itself began at 20:11 that same day, so
+stamped `contract_version: 1` envelopes spoke a three-value wire for under
+three hours on 2026-07-25 and a four-value wire ever since. A bump today
+was considered and declined: D2's mismatch rule tells a conforming
+consumer to stop trusting the surface, which is the right medicine when
+decoding would otherwise go wrong — here the payload shape is unchanged,
+the only delta is one more value in a closed set, and a bump would cost
+every current consumer a coordinated update for a change none of them
+would observe in payload shape. The proportionate remedy is the policy
+now stated normatively in ADR-0106's correction: consumers built against
+the three-value text add the `cancelled` branch, and until they do they
+treat an out-of-vocabulary `outcome` the way `indeterminate` is treated —
+result not establishable, never success and never failure. The erratum is
+also a consumer notice, stated plainly there: any consumer exhaustively
+matching three values has been exposed to an unlisted `cancelled` since
+2026-07-25 22:54. Recording the violation as an erratum with a migration
+policy keeps D2's rule intact instead of manufacturing an exception to
 it. `partial` does NOT join the set either way: widening a closed
 vocabulary with a genuinely new value breaks every consumer that
 enumerated it, for the benefit of one producer.

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -185,7 +185,11 @@ concurrency caps compose the same way they do for the planner fanout.
   over.
 
 - **A timed-out leg** is recorded `timed_out`, receives cooperative
-  termination, and its harvest is still attempted during cooperative teardown.
+  termination escalating to hard kill, and its harvest runs only after its
+  process's death is confirmed. The quiescence invariant (D3) is
+  path-independent: `round_state: complete` is never published while any
+  process that can write a leg's scratch is alive, on cooperative and reap
+  paths alike.
 
 ### D3 — Durable records, ordering, and the two-stage end
 
@@ -260,8 +264,11 @@ OBSERVABLE, never silent.
   which releases the claim with the process. No existing CLI or MCP
   surface performs that escalation for this id class today; a first-class
   escalation parameter is possible future work, not claimed here. Claim
-  recovery is deliberately narrower than group cleanup: surviving group
-  members hold no claim and remain the existing kill machinery's concern.
+  recovery by the operator is deliberately narrower than group cleanup —
+  the operator only needs to free the claim. The reaper that then acquires
+  it owns the rest: its pre-harvest group kill and absence check (above)
+  are what make a leader-only kill safe, because surviving group members
+  hold no claim and cannot outlive the reaper's first act.
   The reaper holders are server-side actors a job-group signal cannot
   reach; their work is bounded by construction — the same per-leg file and
   byte caps that bound every harvest — and one that nonetheless hangs
@@ -287,7 +294,14 @@ OBSERVABLE, never silent.
   terminal write belongs to the claim holder; grace expiry is when the
   reaper first CHECKS the claim, not an unconditional handoff. Only on
   acquiring the lock — which a dead owner cannot still hold, the kernel
-  released it with the process — does it perform a manifest-aware reap: harvest each leg's scratch from disk as D4
+  released it with the process — does it proceed, and its FIRST act on the
+  claim is quiescence, not harvest: a hard kill of the run's recorded
+  process group (`os.killpg`, a primitive the server-side reaper already
+  holds; identity-verified against the recorded pgid and the group marker
+  every member inherits), then verification that no member survives.
+  `round_state: complete` is never published while any process that can
+  write a scratch directory is alive. Only then the manifest-aware reap:
+  harvest each leg's scratch from disk as D4
   specifies, write each leg record with what could be established
   (`harvest_failed` with a reason where a scratch is unreadable — never an
   empty artifact list), write `round.json`, then make its single terminal
@@ -297,8 +311,10 @@ OBSERVABLE, never silent.
   existing orphan-reaping path on the job surface; for manifest runs that
   reaper acquires the same finalization lock (its previous owner is dead by
   definition of the path, so the lock is free; acquisition still serializes
-  it against a concurrent kill-reaper) and performs the same disk-side
-  harvest-then-record sequence before its terminal write, recording
+  it against a concurrent kill-reaper) and performs the same
+  quiescence-then-harvest-then-record sequence before its terminal write —
+  a dead parent does not mean dead legs, so the pre-harvest group kill and
+  absence check apply identically — recording
   `"recorded_by": "orphan-reaper"`. Where the existing reaper (or any non-manifest-aware
   writer) has already published a terminal status, the manifest-aware pass
   still runs, writes the records late, and flips `round_state` from

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -249,10 +249,19 @@ OBSERVABLE, never silent.
   the winner — so even a mis-sequenced writer cannot produce two competing
   records for one leg.
 - **A hung live holder has a named recovery, per holder — one signal path
-  does not cover all three.** The runner holder lives in the job's own
-  process group: `job.kill` delivers the stop signal (the MCP surface sends
-  a fixed SIGTERM and exposes no signal choice), and an operator's group
-  SIGKILL through the CLI kill surface releases the claim with the process.
+  does not cover all three.** The runner holder is the runner process
+  itself, and the claim descriptor is close-on-exec, so no surviving child
+  holds the claim. `job.kill` delivers the stop request (the MCP surface
+  sends a fixed SIGTERM and exposes no signal choice). Where that is
+  ignored, the recovery is an operator kill of the recorded leader pid
+  with the identity checks the job record already supports — the recorded
+  pid, and the group-marker environment variable every group member
+  inherits, exist for exactly this verification — escalating to SIGKILL,
+  which releases the claim with the process. No existing CLI or MCP
+  surface performs that escalation for this id class today; a first-class
+  escalation parameter is possible future work, not claimed here. Claim
+  recovery is deliberately narrower than group cleanup: surviving group
+  members hold no claim and remain the existing kill machinery's concern.
   The reaper holders are server-side actors a job-group signal cannot
   reach; their work is bounded by construction — the same per-leg file and
   byte caps that bound every harvest — and one that nonetheless hangs

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -229,16 +229,21 @@ who finds a terminal job with `round_state: pending_harvest` is told, in the
 record itself, that leg facts are still landing — the window exists and is
 OBSERVABLE, never silent.
 
-- **Finalization has exactly one owner at a time.** The right to harvest,
-  write leg records, and flip `round_state` is taken by atomically creating
-  `{run_dir}/finalize.lock` (create-exclusive), which records the owner's
-  role (`runner`, `kill-reaper`, or `orphan-reaper`), its pid, and the run's
-  job marker. The cooperative runner claims it when teardown starts. A
-  reaper may claim only when no live owner holds it: either no claim exists,
-  or the recorded owner is dead — owner-death established from the recorded
-  identity (pid plus job marker), never from elapsed time. While a live
-  owner holds the claim, a reaper does not touch scratch directories or
-  records. Every leg record and `round.json` write lands by
+- **Finalization has exactly one owner at a time, and the claim cannot go
+  stale.** The claim is an OS advisory lock (`flock`-style, exclusive,
+  acquired non-blocking) held on `{run_dir}/finalize.lock` for the duration
+  of finalization; the cooperative runner acquires it when teardown starts.
+  The descriptor is opened close-on-exec — a lock a spawned leg could
+  inherit would keep a dead runner's claim alive from inside a living leg.
+  The kernel couples the lock's lifetime to its holder's: a dead owner's
+  claim vanishes with its process, so there is no stale-lock repair path
+  for two reapers to race on — takeover IS acquisition, the same primitive
+  every claimant uses. A failed non-blocking acquire means a live owner
+  exists; the failed claimant re-checks later and touches no scratch
+  directory or record meanwhile. The file's content (owner role `runner` /
+  `kill-reaper` / `orphan-reaper`, pid, the run's job marker, claimed_at)
+  is observability, written by the holder after acquiring — never the
+  mechanism itself. Every leg record and `round.json` write lands by
   temp-file-plus-atomic-rename, and a writer that finds a complete leg
   record already present leaves it — first write wins, `recorded_by` names
   the winner — so even a mis-sequenced writer cannot produce two competing
@@ -261,8 +266,11 @@ OBSERVABLE, never silent.
   surface waits and re-checks — the stop signal has been delivered, and the
   terminal write belongs to the claim holder; grace expiry is when the
   reaper first CHECKS the claim, not an unconditional handoff. Only on
-  taking the claim (no owner, or owner dead by recorded identity) does it
-  perform a manifest-aware reap: harvest each leg's scratch from disk as D4
+  acquiring the lock — which a dead owner cannot still hold (the kernel
+  released it with the process), and which a hung-but-alive holder keeps
+  until it exits; escalation is the caller's act, `job.kill` accepts the
+  signal to send and SIGKILL is not survivable — does it perform a
+  manifest-aware reap: harvest each leg's scratch from disk as D4
   specifies, write each leg record with what could be established
   (`harvest_failed` with a reason where a scratch is unreadable — never an
   empty artifact list), write `round.json`, then make its single terminal
@@ -270,9 +278,9 @@ OBSERVABLE, never silent.
   "kill-reaper"`).
 - **An already-dead parent** (crash, OOM, machine restart) is found by the
   existing orphan-reaping path on the job surface; for manifest runs that
-  reaper takes the finalization claim the same way (its owner is dead by
-  definition of the path, but the claim still serializes it against a
-  concurrent kill-reaper) and performs the same disk-side
+  reaper acquires the same finalization lock (its previous owner is dead by
+  definition of the path, so the lock is free; acquisition still serializes
+  it against a concurrent kill-reaper) and performs the same disk-side
   harvest-then-record sequence before its terminal write, recording
   `"recorded_by": "orphan-reaper"`. Where the existing reaper (or any non-manifest-aware
   writer) has already published a terminal status, the manifest-aware pass
@@ -354,17 +362,24 @@ is exactly why it is pinned by a test rather than a review.
 ### D6 — Observation contract: closed outcomes preserved, round facts on `job.output`
 
 The job surface's `outcome` is a closed vocabulary, and consumers
-legitimately bind to it. The contract text (ADR-0106) lists
-`succeeded | failed | indeterminate`; the implementation has additionally
-emitted `cancelled` since before that text froze (`lionagi/mcp/jobs.py`,
-`_OUTCOMES`) — a drift ADR-0107's Notes records as a pending ADR-0106
-amendment item. This ADR carries that amendment: ADR-0106's vocabulary is
-corrected to the four values the wire already ships. That is a record
-catching up to shipped behavior — nothing on the wire changes, so
-`contract_version` does not move; the increment exists to warn consumers of
-wire changes, and there is none. `partial` does NOT join the set either
-way: widening a closed vocabulary with a genuinely new value breaks every
-consumer that enumerated it, for the benefit of one producer.
+legitimately bind to it. The contract text (ADR-0106) froze at three
+values (`succeeded | failed | indeterminate`) on 2026-07-25; the wire
+began emitting `cancelled` hours later that same day, when the li-kill
+terminal fix landed, and has shipped it ever since (`lionagi/mcp/jobs.py`,
+`_OUTCOMES`; `indeterminate`, reserved at freeze, gained its producer when
+ADR-0107's reaper landed) — an unversioned expansion that
+ADR-0107's Notes later recorded as a pending ADR-0106 amendment item.
+This ADR carries that amendment as an ERRATUM: the vocabulary is corrected
+to the four values the wire ships, the true timing is recorded in the
+correction, and `contract_version` still does not move. The document
+correction changes nothing on the wire; the D2-breaking event was the
+2026-07-25 unversioned code change, and a retroactive bump today would
+tell consumers — every one of whom faces the four-value wire either way —
+that behavior changed today when it did not. Recording the violation as an
+erratum keeps D2's rule intact instead of manufacturing an exception to
+it. `partial` does NOT join the set either way: widening a closed
+vocabulary with a genuinely new value breaks every consumer that
+enumerated it, for the benefit of one producer.
 
 - **Mapping**: round `completed` → job outcome `succeeded`; round `partial`
   or `failed` → job outcome `failed`; a round killed before any leg spawned

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -112,19 +112,32 @@ would-be-refused submissions):
 - **`env`** (per-leg, optional): a closed map of named environment variables
   set for that leg — keys matching `[A-Z][A-Z0-9_]{0,63}`, string values,
   passed via the process environment array at spawn (never through a shell).
-  Deny-by-default: nothing travels from the submitting process's environment;
-  beyond its baseline, a leg receives exactly the variables named here, and
-  the manifest snapshot is their durable source. A declared key that also
-  exists in the leg's baseline is overridden by the manifest value — that is
-  the feature (the declared value is the reproducible one); the D4 refusal
-  rule protects only the runner's own reserved name, and
+  Deny-by-default at the manifest surface: no manifest mechanism forwards
+  any environment — not the submitting client's, not the serving process's;
+  the map is literal values only, and the manifest snapshot is their durable
+  source. The baseline a leg otherwise inherits is the runner process's own
+  environment — today the serving daemon's environment as constructed at
+  spawn (`lionagi/mcp/jobs.py`, the submit path's `env` dict handed to
+  `Popen`) — and this ADR neither defines, freezes, nor filters that
+  baseline: scoping it is engine-wide hardening for every job kind at once,
+  a separate decision this ADR names and does not carry. A declared key
+  that also exists in the baseline is overridden by the manifest value —
+  that is the feature (the declared value is the recorded one); the D4
+  refusal rule protects only the runner's own reserved name, and
   `LIONAGI_LEG_ARTIFACTS` is accordingly refused here at submit. Declared
-  keys are listed in the leg's durable record as `env_keys`; the record never
-  re-prints values. Manifests are durable evidence, so credentials do not
-  belong in them: a secret a leg needs stays in the runner's own environment
-  and reaches the leg through the baseline, named nowhere. The consuming
-  workflow demonstrated the concrete cases (actor identity resolving wrong on
-  workspace cwds, per-worktree build target directories).
+  keys are listed in the leg's durable record as `env_keys`; the record
+  never re-prints values. Manifest values are recorded verbatim in the
+  snapshot, which is exactly why a credential in one is a rule violation
+  rather than a supported path — the mechanism cannot stop an author from
+  writing one, and what it CAN guarantee is that nothing hides: whatever a
+  manifest carries, its snapshot shows. A leg that legitimately needs a
+  secret gets it from the serving environment, the channel the existing
+  agent surface already provides; this ADR adds no new one.
+  The reproducibility claim is scoped accordingly: declared keys are the
+  recorded, reproducible deltas over that baseline, and a round is
+  reproducible given the same serving environment, no stronger. The
+  consuming workflow demonstrated the concrete cases (actor identity
+  resolving wrong on workspace cwds, per-worktree build target directories).
 - **Leg count 1..64.** The floor is definitional. The ceiling is one order of
   magnitude above the largest observed round (13) — a bound that exists so a
   generated manifest with a bug cannot fan out unbounded, chosen loose enough
@@ -206,13 +219,30 @@ The round gets one summary record, `{run_dir}/round.json`:
 }
 ```
 
-`round_state` is the honesty field: `complete` means every leg record and
-harvest is durably written; `pending_harvest` means a terminal status became
-visible before cleanup finished (possible only on the non-cooperative paths
-below). A reader who finds a terminal job with `round_state: pending_harvest`
-is told, in the record itself, that leg facts are still landing — the window
-exists and is OBSERVABLE, never silent.
+`round.json` is first written at spawn with `round_state: "pending_harvest"`
+and flipped to `complete` as the last act of finalization — the summary
+exists before any leg runs, so a terminal status published by ANY writer at
+ANY point (including a legacy or non-manifest-aware one) is observably
+pending rather than silently incomplete. `round_state` is the honesty field:
+`complete` means every leg record and harvest is durably written; a reader
+who finds a terminal job with `round_state: pending_harvest` is told, in the
+record itself, that leg facts are still landing — the window exists and is
+OBSERVABLE, never silent.
 
+- **Finalization has exactly one owner at a time.** The right to harvest,
+  write leg records, and flip `round_state` is taken by atomically creating
+  `{run_dir}/finalize.lock` (create-exclusive), which records the owner's
+  role (`runner`, `kill-reaper`, or `orphan-reaper`), its pid, and the run's
+  job marker. The cooperative runner claims it when teardown starts. A
+  reaper may claim only when no live owner holds it: either no claim exists,
+  or the recorded owner is dead — owner-death established from the recorded
+  identity (pid plus job marker), never from elapsed time. While a live
+  owner holds the claim, a reaper does not touch scratch directories or
+  records. Every leg record and `round.json` write lands by
+  temp-file-plus-atomic-rename, and a writer that finds a complete leg
+  record already present leaves it — first write wins, `recorded_by` names
+  the winner — so even a mis-sequenced writer cannot produce two competing
+  records for one leg.
 - **Cooperative ordering guarantee**: on normal completion and per-leg
   timeout, every leg's harvest runs and its record persists, then
   `round.json` is written with `round_state: complete`, and only then does
@@ -226,24 +256,35 @@ exists and is OBSERVABLE, never silent.
   kill surface instead records `kill_requested_at` and signals the group
   WITHOUT writing the terminal fields; the runner's cooperative teardown then
   harvests, records, and terminalizes exactly as above. If the runner does
-  not terminalize within a bounded grace (default 30 s — long enough for N
-  bounded harvests, short enough that a kill still means something), the kill
-  surface performs a manifest-aware reap: harvest each leg's scratch from
-  disk as D4 specifies, write each leg record with what could be established
+  not terminalize within a bounded grace (default 30 s), the kill surface
+  checks the finalization claim: while a live owner holds it, the kill
+  surface waits and re-checks — the stop signal has been delivered, and the
+  terminal write belongs to the claim holder; grace expiry is when the
+  reaper first CHECKS the claim, not an unconditional handoff. Only on
+  taking the claim (no owner, or owner dead by recorded identity) does it
+  perform a manifest-aware reap: harvest each leg's scratch from disk as D4
+  specifies, write each leg record with what could be established
   (`harvest_failed` with a reason where a scratch is unreadable — never an
   empty artifact list), write `round.json`, then make its single terminal
-  write. Records written by a reaper say so (`"recorded_by": "reaper"`).
+  write. Records written by a reaper say so (`"recorded_by":
+  "kill-reaper"`).
 - **An already-dead parent** (crash, OOM, machine restart) is found by the
   existing orphan-reaping path on the job surface; for manifest runs that
-  reaper performs the same disk-side harvest-then-record sequence before its
-  terminal write. Where the existing reaper (or any non-manifest-aware
+  reaper takes the finalization claim the same way (its owner is dead by
+  definition of the path, but the claim still serializes it against a
+  concurrent kill-reaper) and performs the same disk-side
+  harvest-then-record sequence before its terminal write, recording
+  `"recorded_by": "orphan-reaper"`. Where the existing reaper (or any non-manifest-aware
   writer) has already published a terminal status, the manifest-aware pass
   still runs, writes the records late, and flips `round_state` from
   `pending_harvest` to `complete` — late facts beat lost facts.
 - **The bound, stated plainly**: harvest-before-notice holds on cooperative
   paths. On kill and reap paths the guarantee is weaker and explicit —
   `round_state` names whether the facts are all in, and every leg record
-  distinguishes what was established from what could not be.
+  distinguishes what was established from what could not be. At every point
+  there is at most one finalization owner and records are first-write-wins,
+  so the weaker guarantee is about WHEN facts land, never about competing
+  versions of them.
 
 ### D4 — The leg artifact channel
 
@@ -312,23 +353,39 @@ is exactly why it is pinned by a test rather than a review.
 
 ### D6 — Observation contract: closed outcomes preserved, round facts on `job.output`
 
-The job surface's `outcome` is a closed vocabulary —
-`{succeeded, failed, cancelled, indeterminate}` (`lionagi/mcp/jobs.py`,
-`_OUTCOMES`) — and consumers legitimately bind to it. `partial` does NOT
-join that set; widening a closed vocabulary breaks every consumer that
-enumerated it, for the benefit of one producer.
+The job surface's `outcome` is a closed vocabulary, and consumers
+legitimately bind to it. The contract text (ADR-0106) lists
+`succeeded | failed | indeterminate`; the implementation has additionally
+emitted `cancelled` since before that text froze (`lionagi/mcp/jobs.py`,
+`_OUTCOMES`) — a drift ADR-0107's Notes records as a pending ADR-0106
+amendment item. This ADR carries that amendment: ADR-0106's vocabulary is
+corrected to the four values the wire already ships. That is a record
+catching up to shipped behavior — nothing on the wire changes, so
+`contract_version` does not move; the increment exists to warn consumers of
+wire changes, and there is none. `partial` does NOT join the set either
+way: widening a closed vocabulary with a genuinely new value breaks every
+consumer that enumerated it, for the benefit of one producer.
 
 - **Mapping**: round `completed` → job outcome `succeeded`; round `partial`
   or `failed` → job outcome `failed`; a round killed before any leg spawned
   → `cancelled`. The coarse job outcome answers "did the round come out
   clean"; anything finer is the round summary's job.
 - **The read**: for manifest runs, `job.output`'s response carries one
-  additive field, `round` — the full `round.json` content (round_version,
-  round_state, result, counts, and the per-leg records inlined). Additive
-  field on an existing read: consumers that do not know it ignore it;
-  nothing existing changes shape. This is a named, versioned amendment to
-  the ADR-0106-adjacent result surface, carried by this ADR rather than
-  smuggled in by implementation.
+  additive field, `round`, and its shape is exact. `round` is an ADR-0106
+  D7 availability wrapper — `{available, value, reason_code, detail}` —
+  because it is read-derived and D7 applies to every read-derived field.
+  `available: false`, with `reason_code` distinguishing missing from
+  unreadable from malformed, is a read failure of `round.json`; it is NOT
+  how in-flight harvest is expressed — `round_state: "pending_harvest"` is
+  data inside a readable summary. `value` has two parts, matching the two
+  kinds of read behind it: `summary` is the `round.json` content verbatim
+  (its `legs` stay labels, as D3 shows), and `leg_records` is an array read
+  from `{run_dir}/legs/*.json`, each entry its own wrapper
+  `{label, available, value, reason_code, detail}` — one unreadable leg
+  record must not poison the others or masquerade as an absent leg.
+  Consumers that do not know `round` ignore it; nothing existing changes
+  shape. This is a named, versioned amendment to the ADR-0106 result
+  surface, carried by this ADR rather than smuggled in by implementation.
 - **The notice is the signal, not the carrier.** The terminal-notice payload
   is unchanged. A notification consumer that needs leg facts performs the
   `job.output` read on receipt; the cooperative ordering guarantee (D3) makes
@@ -348,9 +405,10 @@ enumerated it, for the benefit of one producer.
 - What becomes harder: the runner takes on a harvest obligation on every
   terminal path, kill becomes two-stage for manifest runs (a contributor
   touching `job.kill` or the reaper must now know the manifest-aware
-  branch), and the harvester must be written as a hostile-input consumer
-  (descriptor-anchored, no-follow, link-count checks) rather than a tree
-  copy.
+  branch), finalization becomes a claimed single-owner step
+  (`finalize.lock`) every terminal writer must respect, and the harvester
+  must be written as a hostile-input consumer (descriptor-anchored,
+  no-follow, link-count checks) rather than a tree copy.
 - The `pending_harvest` window is a deliberate admission: on non-cooperative
   ends, facts can arrive after the terminal status. The alternative — holding
   the terminal status until harvest completes on a path where the harvesting
@@ -406,7 +464,10 @@ enumerated it, for the benefit of one producer.
   keys; loses because it forwards whatever the submitting process happened to
   carry (secrets included), makes a round unreproducible from its manifest,
   and turns the collision check into an unenumerable surface. Named keys with
-  deny-by-default is what the consuming workflow itself asked for.
+  deny-by-default is what the consuming workflow itself asked for. This
+  rejection is about a manifest-level mechanism; the baseline the runner
+  already provides to every job kind is a distinct, pre-existing channel,
+  named in D1 and out of this ADR's scope.
 
 ## Notes
 

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -1,0 +1,123 @@
+# ADR-0110: Deterministic manifest fan-out — legs from briefs, no planner
+
+- **Status**: Proposed
+- **Kind**: Aspirational (records the target state)
+- **Area**: orchestration
+- **Date**: 2026-08-03
+- **Relations**: extends ADR-0106 (machine result contract); composes with the
+  MCP job surface (`job.status` artifact listing)
+
+## Context
+
+Every orchestrating surface this package ships puts a planner model between the
+caller's task statement and the legs that execute it. `li o fanout` runs a
+decomposition phase first — "orchestrator decomposing task into ≤N assignments"
+(`lionagi/cli/orchestrate/fanout.py:254`) — and the assignments the workers
+receive are the planner's text, not the caller's. `li o flow` has the
+orchestrator compose the DAG. Playbooks template the planner's prompt; they do
+not remove the planner.
+
+That is the right shape for a prose task. It is the wrong shape for a class of
+work that is common and currently unserved: the caller already holds N
+pre-written briefs — review instructions, audit scopes, per-module checklists —
+and each brief IS the contract for its leg. A planner that can rephrase,
+merge, or re-scope those briefs is not adding intelligence; it is corrupting
+the input. Multi-round document review is the sharpest instance: the brief
+states what the reviewer must check, so any surface that lets another model
+rewrite it disqualifies itself.
+
+Callers in this position today fall back to submitting N independent agent
+runs. That works — it is the only deterministic form — but the costs compound
+with round count:
+
+- N run handles to track and N terminal notices to receive, when the caller
+  wants one answer to "is the round done".
+- Artifact harvest by hand: each brief must name output paths, and sandboxed
+  CLI legs (workspace-write) cannot write outside their own cwd tree, so the
+  paths must be contorted to land inside it. Meanwhile every run already has
+  an artifacts directory that `job.status` lists (`lionagi/mcp/jobs.py:736-750`,
+  `:1740-1741`) — but a leg is never told where it is and could not write
+  there if it were.
+- Per-leg working directories are the norm, not the exception: one round may
+  span two repositories, and PR-review rounds are per-worktree by
+  construction. Any surface with a single run-level cwd excludes the most
+  common round shapes.
+
+## Decision
+
+Add a deterministic fan-out mode: legs are built one-per-brief from a caller
+manifest, verbatim, with no planner phase.
+
+**1. Manifest in, one run out.** A YAML/JSON manifest declares the legs:
+
+```yaml
+defaults:
+  model: gpt/large-effort-spec   # any model spec or agent profile name
+  timeout: 1200
+legs:
+  - brief: /abs/path/briefs/module-a.md
+    cwd: /abs/path/worktrees/module-a
+    label: review-module-a
+  - brief: /abs/path/briefs/module-b.md
+    cwd: /abs/path/worktrees/module-b
+    label: review-module-b
+    model: other/spec            # per-leg override wins over defaults
+```
+
+Each leg's prompt is the brief file's text, unmodified. `brief`, `cwd`, and
+`label` are per-leg; `model`/`agent`, `timeout`, and other run knobs may be
+set in `defaults` and overridden per leg. Brief files are read and snapshotted
+at submit time (same rule as `prompt_file` on the agent surface: editing the
+file afterwards cannot change what an already-submitted run executes).
+
+**2. One run id, one terminal notice.** The manifest run is a single job. Legs
+execute in parallel under the existing worker concurrency machinery; the
+terminal notice fires once, when the last leg ends, and carries per-leg
+outcomes. Per-leg status remains observable mid-run through the job surface.
+
+**3. A sanctioned leg artifact channel, without widening any sandbox.** For
+each leg the runner creates a scratch directory inside that leg's own cwd tree
+and exports its absolute path to the leg process as `LIONAGI_LEG_ARTIFACTS`.
+A sandboxed leg can always write there — it is inside the tree the sandbox
+already permits. When the leg reaches a terminal state, the runner harvests
+the scratch directory's contents into the run's artifacts directory under the
+leg's label and removes the scratch. `job.status` then lists every leg's
+artifacts with zero new read surface, and briefs stop carrying output-path
+contortions.
+
+**4. Same surface everywhere.** The mode ships as a CLI command and as an MCP
+verb beside `fanout.submit`, taking the manifest as a file path. Submission
+validation follows the existing refuse-early pattern (`lionagi/mcp/dispatch.py:600-617`):
+a manifest that would be refused on start — unreadable brief, relative path,
+empty legs — is refused at submit, before a job record exists.
+
+## What this is not
+
+- Not a replacement for `fanout`/`flow`: prose tasks that need decomposition
+  keep the planner surfaces. This mode refuses to plan by design.
+- Not a DAG: legs are independent by construction. Dependencies between legs
+  are the flow surface's job.
+- Not a scheduler: one manifest, one round, one run.
+
+## Consequences
+
+- The N-briefs round becomes one submission, one wait, one notice, and one
+  `job.status` read for all verdict artifacts.
+- The brief-as-contract property becomes structural: nothing between the
+  manifest and the leg can rewrite a brief, so a review round's inputs are
+  exactly what the caller wrote.
+- The manifest is a durable record of what was dispatched — the run snapshots
+  it, so "what did leg 3 actually receive" has a first-class answer.
+- The scratch-and-harvest channel adds a small teardown obligation (harvest
+  must run on every terminal path, including kill), and its failure mode must
+  be loud: a leg whose scratch cannot be harvested reports that fact in its
+  outcome rather than presenting an empty artifact list as if nothing was
+  written.
+
+## Open questions
+
+1. Command and verb naming.
+2. Whether an inline manifest (object in the MCP call, no file) is accepted in
+   v1 or file-path-only.
+3. Whether per-leg environment passthrough (beyond `LIONAGI_LEG_ARTIFACTS`) is
+   in scope for v1.

--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -352,7 +352,9 @@ group."
   looking alive but may still be running for all this can tell); a
   conclusive loss whose fenced reap could not be published (the transition
   is retried by the next observation); and a record predating the
-  spawn-phase field, which lands here by the same absence of evidence. Only
+  spawn-phase field that is not shown alive — phase absence alone is never
+  stopped evidence, and a live pre-field record is classified running and
+  stays in `pending`. Only
   an explicitly-`preparing` record is kept out (fresh → `pending`, aged →
   `unresolved_spawn`). Not
   `pending` (waiting longer can't resolve it), not a per-id `error`

--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -346,14 +346,21 @@ group."
 `all_terminal`, `timed_out`, `pending`, `stopped_without_end`, and
 `unresolved_spawn` — never a bare boolean, since mixed outcomes are the norm.
 
-- **`stopped_without_end`**: a run whose process is gone but whose loss
-  couldn't be conclusively established (e.g. an unaskable pid) — stopped
-  looking alive but may still be running for all this can tell. Not
+- **`stopped_without_end`**: a run that stopped — or can't be shown to be
+  progressing — and could not be resolved. Three ways in: a loss that
+  couldn't be conclusively established (e.g. an unaskable pid — stopped
+  looking alive but may still be running for all this can tell); a
+  conclusive loss whose fenced reap could not be published (the transition
+  is retried by the next observation); and a record predating the
+  spawn-phase field, which lands here by the same absence of evidence. Only
+  an explicitly-`preparing` record is kept out (fresh → `pending`, aged →
+  `unresolved_spawn`). Not
   `pending` (waiting longer can't resolve it), not a per-id `error`
   (observing it succeeded). Because such an id resolves nothing by waiting, a
   caller looping until `all_terminal` would otherwise re-poll as fast as
   possible — so a call that would return having waited zero time, while any id
-  is here, first sleeps one poll interval (bounded by the remaining window)
+  is here or in `unresolved_spawn`, first sleeps one poll interval (bounded by
+  the remaining window)
   before observing again. This floor is spent once at the boundary rather than
   relying on every client to back off on its own; `max_wait=0` is exempt by
   construction (no window to spend).

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -2307,11 +2307,13 @@ async def wait(
     docs/internals/mcp.md#wait-result-buckets for the full ``pending`` /
     ``stopped_without_end`` / ``unresolved_spawn`` / ``all_terminal`` /
     ``timed_out`` contract, including why ``unresolved_spawn`` exists and the
-    back-off floor for ``stopped_without_end`` ids.
+    back-off floor paid while any id sits in either special bucket.
 
-    Observing does not touch the run — this function only reads; a wait that
-    expires, or whose caller cancels or disconnects, leaves the durable record
-    untouched (cancelling an observation is not cancelling the work).
+    Observing leaves the run as it was, with one fenced exception: resolving
+    a status may durably reap a conclusively-gone started orphan (see
+    ``_reap_if_conclusively_gone``). A wait that expires, or whose caller
+    cancels or disconnects, leaves the durable record untouched (cancelling
+    an observation is not cancelling the work).
     """
     import anyio  # deferred: the CLI's terminal hook also imports this module and stays import-light
 


### PR DESCRIPTION
## What

ADR-0110, Status: Proposed. A deterministic fan-out mode: legs built one-per-brief from a caller manifest, verbatim, no planner phase.

- Manifest (YAML/JSON) declares legs: per-leg `brief` (absolute path, snapshotted at submit), `cwd`, `label`, optional per-leg `model`/`agent` overriding a `defaults` block.
- One run id, parallel legs under existing worker concurrency, one terminal notice carrying per-leg outcomes.
- Sanctioned leg artifact channel with no sandbox widening: runner creates a scratch dir inside each leg's own cwd tree, exports `LIONAGI_LEG_ARTIFACTS`, harvests into the run's artifacts dir (already listed by `job.status`) at leg terminal.
- Ships as CLI command + MCP verb beside `fanout.submit`; refuse-early validation at submit.

## Why

Every orchestrating surface today puts a planner model between the caller's task statement and the legs (`fanout` decomposes, `flow` plans the DAG, playbooks template the planner). For multi-round review work — N pre-written briefs, each the contract for its leg — a planner that can rewrite the briefs disqualifies the surface, and the deterministic fallback (N independent agent runs) costs N handles, N terminal notices, hand-harvested artifacts, and contorted output paths under sandboxed CLI legs.

## Notes

Spec only — no implementation in this PR. Open questions listed in the ADR: naming, inline-manifest vs file-only, per-leg env passthrough scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)