### PR TITLE
feat(orchestrate): manifest schema v1 loader

### DIFF
--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -269,7 +269,15 @@ OBSERVABLE, never silent.
   The kernel couples the lock's lifetime to its holder's: a dead owner's
   claim vanishes with its process, so there is no stale-lock repair path
   for two reapers to race on — takeover IS acquisition, the same primitive
-  every claimant uses. A failed non-blocking acquire means a live owner
+  every claimant uses. Acquisition carries an obligation: every decision
+  to claim is made on a PRE-acquisition observation, and the gap between
+  observing and acquiring is exactly where a live holder finishes,
+  publishes, and exits — releasing the very lock whose availability the
+  claimant then reads as confirmation of its premise. So a claim holder's
+  FIRST act, on every path, is to re-read the run's terminal status and
+  `round.json`'s `round_state` under the claim, and to proceed on what
+  that re-read shows — never on the observation that motivated the claim.
+  A failed non-blocking acquire means a live owner
   exists; the failed claimant re-checks later and touches no scratch
   directory or record meanwhile. The file's content (owner role `runner` /
   `kill-reaper` / `orphan-reaper`, pid, the run's job marker, claimed_at)
@@ -295,7 +303,7 @@ OBSERVABLE, never silent.
   the operator only needs to free the claim. The reaper that then acquires
   it owns the rest: its pre-harvest quiescence sweep (above) is what makes
   a leader-only kill safe, because surviving domain members
-  hold no claim and cannot outlive the reaper's first act.
+  hold no claim and cannot outlive the reaper's quiescence sweep.
   The reaper holders are server-side actors a job-group signal cannot
   reach; their work is bounded by construction — the same per-leg file and
   byte caps that bound every harvest — and one that nonetheless hangs
@@ -331,8 +339,16 @@ OBSERVABLE, never silent.
   terminal write belongs to the claim holder; grace expiry is when the
   reaper first CHECKS the claim, not an unconditional handoff. Only on
   acquiring the lock — which a dead owner cannot still hold, the kernel
-  released it with the process — does it proceed, and its FIRST act on the
-  claim is quiescence, not harvest: a hard kill of every recorded control
+  released it with the process — does it proceed, and per the claim
+  obligation above its first act is the re-read of terminal status and
+  `round_state`. A round found `complete` means a finalizer proved every
+  recorded group quiet before publishing; the reaper releases the claim
+  and the kill path is never entered — the grace-expiry observation is
+  stale, and firing the one destructive primitive in this sequence on it
+  would act on a premise the claim's own availability had already
+  falsified. Only when the re-read shows the round unfinalized does the
+  destructive work begin, and it begins with
+  quiescence, not harvest: a hard kill of every recorded control
   group — the runner's and each leg's, read from the run directory (the
   raw `os.killpg` primitive, identity-verified against each recorded pgid
   and the group marker every descendant inherits — environment survives a

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -277,6 +277,15 @@ OBSERVABLE, never silent.
   FIRST act, on every path, is to re-read the run's terminal status and
   `round.json`'s `round_state` under the claim, and to proceed on what
   that re-read shows — never on the observation that motivated the claim.
+  The re-read admits exactly four dispositions, shared by every claimant:
+  terminal and `complete` — release, nothing is owed; nonterminal but
+  `complete` — the dead holder finished everything except the parent's
+  terminal write, so the claimant makes that single write from the
+  recorded facts and touches nothing else (no kill, no harvest:
+  `complete` is published only after a proved-quiet sweep); terminal but
+  `pending_harvest` — the late-facts pass (below): records land late and
+  `round_state` flips; neither terminal nor `complete` — the claimant's
+  full path runs, quiescence first wherever the path is destructive.
   A failed non-blocking acquire means a live owner
   exists; the failed claimant re-checks later and touches no scratch
   directory or record meanwhile. The file's content (owner role `runner` /
@@ -342,11 +351,16 @@ OBSERVABLE, never silent.
   released it with the process — does it proceed, and per the claim
   obligation above its first act is the re-read of terminal status and
   `round_state`. A round found `complete` means a finalizer proved every
-  recorded group quiet before publishing; the reaper releases the claim
-  and the kill path is never entered — the grace-expiry observation is
-  stale, and firing the one destructive primitive in this sequence on it
-  would act on a premise the claim's own availability had already
-  falsified. Only when the re-read shows the round unfinalized does the
+  recorded group quiet before publishing, and the kill path is never
+  entered — the grace-expiry observation is stale, and firing the one
+  destructive primitive in this sequence on it would act on a premise the
+  claim's own availability had already falsified. What remains owed is
+  only what the dead finalizer had not yet written: a parent still
+  nonterminal gets its single terminal write from the recorded facts (the
+  finalizer died between publishing `complete` and terminalizing —
+  releasing without that write would strand the run nonterminal forever);
+  a parent already terminal means release with nothing to do. Only when
+  the re-read shows the round unfinalized does the
   destructive work begin, and it begins with
   quiescence, not harvest: a hard kill of every recorded control
   group — the runner's and each leg's, read from the run directory (the
@@ -416,7 +430,10 @@ OBSERVABLE, never silent.
   existing orphan-reaping path on the job surface; for manifest runs that
   reaper acquires the same finalization lock (its previous owner is dead by
   definition of the path, so the lock is free; acquisition still serializes
-  it against a concurrent kill-reaper) and performs the same
+  it against a concurrent kill-reaper), takes the same post-acquisition
+  re-read and dispositions as every claimant — a round already `complete`
+  is terminalized or released, never re-harvested and never swept — and
+  where the re-read shows the round unfinalized performs the same
   quiescence-then-harvest-then-record sequence before its terminal write —
   a dead parent does not mean dead legs, so the pre-harvest quiescence
   sweep applies identically — recording

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -283,8 +283,13 @@ OBSERVABLE, never silent.
   terminal write, so the claimant makes that single write from the
   recorded facts and touches nothing else (no kill, no harvest:
   `complete` is published only after a proved-quiet sweep); terminal but
-  `pending_harvest` — the late-facts pass (below): records land late and
-  `round_state` flips; neither terminal nor `complete` — the claimant's
+  `pending_harvest` — the late-facts pass (below), whose sequence is
+  exactly the unfinalized path minus its last step: quiescence sweep of
+  every recorded group first (`complete` is never published before one),
+  then harvest, then records, then the `round_state` flip — and no second
+  terminal write and no second notice, because the run already has its
+  terminal facts and the latch (ADR-0107) keeps them; neither terminal
+  nor `complete` — the claimant's
   full path runs, quiescence first wherever the path is destructive.
   A failed non-blocking acquire means a live owner
   exists; the failed claimant re-checks later and touches no scratch
@@ -554,8 +559,19 @@ enumerated it, for the benefit of one producer.
 
 - **Mapping**: round `completed` → job outcome `succeeded`; round `partial`
   or `failed` → job outcome `failed`; a round killed before any leg spawned
-  → `cancelled`. The coarse job outcome answers "did the round come out
-  clean"; anything finer is the round summary's job.
+  → `cancelled`. The mapping governs the terminal write a manifest-aware
+  finalizer makes, and only that write: where a terminal outcome already
+  exists when the late-facts pass runs, ADR-0107's terminal latch keeps the
+  first recorded end — including an orphan reap's `indeterminate` — and the
+  late pass never rewrites it. A reader can therefore observe round
+  `completed` beside job outcome `indeterminate`; that is ADR-0107's named
+  succeeded-but-indeterminate window surfacing through the round field,
+  stated here so it reads as a known edge rather than a contract violation.
+  The job outcome answers "what did the first recorded end conclude"; the
+  round summary is authoritative for the round's own facts, and anything
+  finer than the outcome is its job. The required tests include this
+  interleaving: a terminal-latched run whose late pass computes round
+  `completed` must surface both values unchanged.
 - **The read**: for manifest runs, `job.output`'s response carries one
   additive field, `round`, and its shape is exact. `round` is an ADR-0106
   D7 availability wrapper — `{available, value, reason_code, detail}` —

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -537,8 +537,10 @@ enumerated it, for the benefit of one producer.
   `{label, available, value, reason_code, detail}` — one unreadable leg
   record must not poison the others or masquerade as an absent leg.
   Consumers that do not know `round` ignore it; nothing existing changes
-  shape. This is a named, versioned amendment to the ADR-0106 result
-  surface, carried by this ADR rather than smuggled in by implementation.
+  shape. This is an additive field of the kind ADR-0106 D2 already permits,
+  introduced and specified here rather than smuggled in by implementation —
+  ADR-0106 itself is unchanged by it and contains no `round` text to look
+  for.
 - **The notice is the signal, not the carrier.** The terminal-notice payload
   is unchanged. A notification consumer that needs leg facts performs the
   `job.output` read on receipt; the cooperative ordering guarantee (D3) makes

--- a/lionagi/cli/orchestrate/_manifest.py
+++ b/lionagi/cli/orchestrate/_manifest.py
@@ -30,6 +30,8 @@ __all__ = (
     "MAX_LEGS",
     "MAX_TIMEOUT_SECONDS",
     "LABEL_PATTERN",
+    "ENV_KEY_PATTERN",
+    "RESERVED_ENV_KEYS",
     "ManifestError",
     "Leg",
     "Manifest",
@@ -42,10 +44,15 @@ MAX_LEGS = 64
 MAX_TIMEOUT_SECONDS = 86400
 
 LABEL_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+ENV_KEY_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+
+# The runner's own reserved name (the leg artifact channel); a manifest that
+# sets it would silently redirect harvest, so it is refused at load.
+RESERVED_ENV_KEYS = frozenset({"LIONAGI_LEG_ARTIFACTS"})
 
 _TOP_LEVEL_KEYS = frozenset({"manifest_version", "defaults", "legs"})
 _DEFAULTS_KEYS = frozenset({"model", "agent", "timeout"})
-_LEG_KEYS = frozenset({"brief", "cwd", "label", "model", "agent", "timeout"})
+_LEG_KEYS = frozenset({"brief", "cwd", "label", "model", "agent", "timeout", "env"})
 
 
 class ManifestError(LionError):
@@ -68,6 +75,14 @@ class Leg:
     timeout: int | None
     brief_bytes: bytes
     brief_hash: str
+    # Sorted (key, value) pairs, not a dict: the manifest is a snapshot and a
+    # mutable mapping on a frozen dataclass would let a caller edit the record.
+    env: tuple[tuple[str, str], ...]
+
+    @property
+    def env_keys(self) -> tuple[str, ...]:
+        """Declared env key names, the form the durable leg record lists."""
+        return tuple(k for k, _ in self.env)
 
 
 @dataclass(frozen=True, slots=True)
@@ -201,6 +216,25 @@ def _validate_brief(value: Any, where: str) -> tuple[Path, bytes, str]:
     return resolved, data, digest
 
 
+def _validate_env(value: Any, where: str) -> tuple[tuple[str, str], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, dict):
+        raise ManifestError(f"{where}.env must be a mapping, got {type(value).__name__}")
+    pairs: list[tuple[str, str]] = []
+    for key, val in value.items():
+        if not isinstance(key, str) or not ENV_KEY_PATTERN.fullmatch(key):
+            raise ManifestError(f"{where}.env key {key!r} must match {ENV_KEY_PATTERN.pattern!r}")
+        if key in RESERVED_ENV_KEYS:
+            raise ManifestError(f"{where}.env must not set reserved key {key!r}")
+        if isinstance(val, bool) or not isinstance(val, str):
+            raise ManifestError(
+                f"{where}.env[{key!r}] must be a string value, got {type(val).__name__}"
+            )
+        pairs.append((key, val))
+    return tuple(sorted(pairs))
+
+
 def _validate_cwd(value: Any, where: str) -> Path:
     if not isinstance(value, str):
         raise ManifestError(f"{where}.cwd must be a string path, got {type(value).__name__}")
@@ -248,6 +282,8 @@ def _load_leg(
     leg_timeout = _validate_timeout(leg_raw.get("timeout"), where)
     timeout = leg_timeout if leg_timeout is not None else default_timeout
 
+    env = _validate_env(leg_raw.get("env"), where)
+
     return Leg(
         label=label,
         brief=brief_path,
@@ -257,4 +293,5 @@ def _load_leg(
         timeout=timeout,
         brief_bytes=brief_bytes,
         brief_hash=brief_hash,
+        env=env,
     )

--- a/lionagi/cli/orchestrate/_manifest.py
+++ b/lionagi/cli/orchestrate/_manifest.py
@@ -110,7 +110,7 @@ def load_manifest(path: str | Path) -> Manifest:
     _refuse_unknown_keys(raw, _TOP_LEVEL_KEYS, "manifest")
 
     version = raw.get("manifest_version")
-    if version != MANIFEST_VERSION:
+    if isinstance(version, bool) or version != MANIFEST_VERSION:
         raise ManifestError(f"manifest_version must be exactly {MANIFEST_VERSION}, got {version!r}")
 
     defaults_raw = raw.get("defaults", {})

--- a/lionagi/cli/orchestrate/_manifest.py
+++ b/lionagi/cli/orchestrate/_manifest.py
@@ -14,8 +14,10 @@ already loaded.
 from __future__ import annotations
 
 import json
+import os
 import re
-from dataclasses import dataclass
+import stat as stat_module
+from dataclasses import dataclass, field
 from hashlib import blake2b
 from pathlib import Path
 from typing import Any
@@ -102,6 +104,24 @@ class _StrictYamlLoader(yaml.SafeLoader):
                 )
             seen.add(key)
         return super().construct_mapping(node, deep=deep)
+
+
+@dataclass(slots=True)
+class _BriefCache:
+    """Per-load snapshot cache with two keys, closing two alias routes.
+
+    `by_literal` is keyed by the submitted pathname string: a repeated
+    literal never resolves or reads a second time, so a path whose target
+    is swapped between two legs cannot hand them different content —
+    resolution itself is time-dependent and must happen at most once per
+    spelling. `by_identity` is keyed by (st_dev, st_ino) captured by fstat
+    on the descriptor actually read: distinct spellings of one physical
+    file (hard links, symlink and target) coalesce onto the first accepted
+    snapshot even if the file changes between their reads.
+    """
+
+    by_literal: dict[str, tuple[Path, bytes, str]] = field(default_factory=dict)
+    by_identity: dict[tuple[int, int], tuple[bytes, str]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -202,10 +222,7 @@ def load_manifest(path: str | Path) -> Manifest:
 
     legs: list[Leg] = []
     seen_labels: dict[str, int] = {}
-    # Keyed by resolved brief path: two legs naming the same file must share
-    # one read and one snapshot, or a write landing between the reads hands a
-    # single manifest two contradictory versions of the same brief.
-    brief_cache: dict[Path, tuple[bytes, str]] = {}
+    brief_cache = _BriefCache()
     for index, leg_raw in enumerate(legs_raw):
         legs.append(
             _load_leg(
@@ -275,27 +292,49 @@ def _validate_label(value: Any, where: str) -> str:
     return lowered
 
 
-def _validate_brief(
-    value: Any, where: str, cache: dict[Path, tuple[bytes, str]]
-) -> tuple[Path, bytes, str]:
+def _read_brief_file(resolved: Path) -> tuple[bytes, tuple[int, int]]:
+    """Read a brief through one descriptor, returning bytes and file identity.
+
+    fstat on the open descriptor binds the (device, inode) identity to the
+    bytes actually read; a stat beside a separate read could straddle a
+    concurrent swap of the path's target.
+    """
+    with open(resolved, "rb") as fh:
+        st = os.fstat(fh.fileno())
+        if not stat_module.S_ISREG(st.st_mode):
+            raise OSError(f"not a regular file: {resolved}")
+        return fh.read(), (st.st_dev, st.st_ino)
+
+
+def _validate_brief(value: Any, where: str, cache: _BriefCache) -> tuple[Path, bytes, str]:
     if not isinstance(value, str):
         raise ManifestError(f"{where}.brief must be a string path, got {type(value).__name__}")
+    hit = cache.by_literal.get(value)
+    if hit is not None:
+        return hit
     path = Path(value)
     if not path.is_absolute():
         raise ManifestError(f"{where}.brief must be an absolute path, got {value!r}")
     resolved = path.resolve()
-    cached = cache.get(resolved)
-    if cached is not None:
-        data, digest = cached
-        return resolved, data, digest
     if not resolved.is_file():
         raise ManifestError(f"{where}.brief does not exist or is not a regular file: {resolved}")
-    data = resolved.read_bytes()
-    if not data.decode("utf-8", "replace").strip():
-        raise ManifestError(f"{where}.brief is empty: {resolved}")
-    digest = blake2b(data).hexdigest()
-    cache[resolved] = (data, digest)
-    return resolved, data, digest
+    try:
+        data, identity = _read_brief_file(resolved)
+    except OSError as exc:
+        raise ManifestError(f"{where}.brief could not be read: {resolved} ({exc})") from exc
+    known = cache.by_identity.get(identity)
+    if known is not None:
+        # A second spelling of one physical file: the first accepted snapshot
+        # wins, and the fresh read is discarded.
+        data, digest = known
+    else:
+        if not data.decode("utf-8", "replace").strip():
+            raise ManifestError(f"{where}.brief is empty: {resolved}")
+        digest = blake2b(data).hexdigest()
+        cache.by_identity[identity] = (data, digest)
+    result = (resolved, data, digest)
+    cache.by_literal[value] = result
+    return result
 
 
 def _validate_env(value: Any, where: str) -> tuple[tuple[str, str], ...]:
@@ -336,7 +375,7 @@ def _load_leg(
     default_model: str | None,
     default_agent: str | None,
     default_timeout: int | None,
-    brief_cache: dict[Path, tuple[bytes, str]],
+    brief_cache: _BriefCache,
 ) -> Leg:
     where = f"legs[{index}]"
     if not isinstance(leg_raw, dict):

--- a/lionagi/cli/orchestrate/_manifest.py
+++ b/lionagi/cli/orchestrate/_manifest.py
@@ -63,6 +63,47 @@ class ManifestError(LionError):
     """
 
 
+class _StrictYamlLoader(yaml.SafeLoader):
+    """SafeLoader that refuses YAML merge keys and duplicate mapping keys.
+
+    `yaml.safe_load` expands a merge key (`<<`) into its target mapping and
+    collapses duplicate keys last-write-wins BEFORE any schema check can see
+    the raw document, so either one would smuggle values past the
+    closed-schema validation. Refusing them at construction keeps what the
+    validator sees identical to what the file says.
+    """
+
+    def construct_mapping(self, node, deep=False):
+        seen = set()
+        for key_node, _ in node.value:
+            if key_node.tag == "tag:yaml.org,2002:merge":
+                raise yaml.constructor.ConstructorError(
+                    None,
+                    None,
+                    "merge keys ('<<') are not allowed in a manifest",
+                    key_node.start_mark,
+                )
+            key = self.construct_object(key_node, deep=True)
+            try:
+                duplicate = key in seen
+            except TypeError:
+                raise yaml.constructor.ConstructorError(
+                    None,
+                    None,
+                    f"unhashable mapping key {key!r}",
+                    key_node.start_mark,
+                ) from None
+            if duplicate:
+                raise yaml.constructor.ConstructorError(
+                    None,
+                    None,
+                    f"duplicate mapping key {key!r}",
+                    key_node.start_mark,
+                )
+            seen.add(key)
+        return super().construct_mapping(node, deep=deep)
+
+
 @dataclass(frozen=True, slots=True)
 class Leg:
     """One validated, snapshotted leg of a manifest."""
@@ -112,8 +153,22 @@ def load_manifest(path: str | Path) -> Manifest:
 
     text = resolved.read_text()
     is_json = resolved.suffix.lower() == ".json"
+
+    def _refuse_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict:
+        obj: dict = {}
+        for key, val in pairs:
+            if key in obj:
+                raise ManifestError(f"manifest {resolved} has duplicate key {key!r}")
+            obj[key] = val
+        return obj
+
     try:
-        raw = json.loads(text) if is_json else yaml.safe_load(text)
+        if is_json:
+            raw = json.loads(text, object_pairs_hook=_refuse_duplicate_json_keys)
+        else:
+            # _StrictYamlLoader subclasses SafeLoader; S506 only recognizes
+            # the literal safe_load spelling.
+            raw = yaml.load(text, Loader=_StrictYamlLoader)  # noqa: S506
     except (json.JSONDecodeError, yaml.YAMLError) as exc:
         kind = "JSON" if is_json else "YAML"
         raise ManifestError(f"manifest {resolved} is not valid {kind}: {exc}") from exc
@@ -125,7 +180,9 @@ def load_manifest(path: str | Path) -> Manifest:
     _refuse_unknown_keys(raw, _TOP_LEVEL_KEYS, "manifest")
 
     version = raw.get("manifest_version")
-    if isinstance(version, bool) or version != MANIFEST_VERSION:
+    # type() rather than isinstance: bool is an int subclass, and a float 1.0
+    # compares equal to 1 — both must be refused, only the exact integer passes.
+    if type(version) is not int or version != MANIFEST_VERSION:
         raise ManifestError(f"manifest_version must be exactly {MANIFEST_VERSION}, got {version!r}")
 
     defaults_raw = raw.get("defaults", {})
@@ -145,9 +202,21 @@ def load_manifest(path: str | Path) -> Manifest:
 
     legs: list[Leg] = []
     seen_labels: dict[str, int] = {}
+    # Keyed by resolved brief path: two legs naming the same file must share
+    # one read and one snapshot, or a write landing between the reads hands a
+    # single manifest two contradictory versions of the same brief.
+    brief_cache: dict[Path, tuple[bytes, str]] = {}
     for index, leg_raw in enumerate(legs_raw):
         legs.append(
-            _load_leg(leg_raw, index, seen_labels, default_model, default_agent, default_timeout)
+            _load_leg(
+                leg_raw,
+                index,
+                seen_labels,
+                default_model,
+                default_agent,
+                default_timeout,
+                brief_cache,
+            )
         )
 
     return Manifest(
@@ -160,6 +229,12 @@ def load_manifest(path: str | Path) -> Manifest:
 
 
 def _refuse_unknown_keys(obj: dict, allowed: frozenset[str], where: str) -> None:
+    # YAML happily yields int or bool mapping keys ("1:", "on:"); refuse them
+    # by name before the set arithmetic, which assumes strings.
+    non_string = [key for key in obj if not isinstance(key, str)]
+    if non_string:
+        rendered = ", ".join(repr(key) for key in sorted(non_string, key=repr))
+        raise ManifestError(f"{where} has non-string key(s): {rendered}")
     unknown = sorted(set(obj) - allowed)
     if unknown:
         raise ManifestError(f"{where} has unknown key(s): {', '.join(unknown)}")
@@ -200,19 +275,26 @@ def _validate_label(value: Any, where: str) -> str:
     return lowered
 
 
-def _validate_brief(value: Any, where: str) -> tuple[Path, bytes, str]:
+def _validate_brief(
+    value: Any, where: str, cache: dict[Path, tuple[bytes, str]]
+) -> tuple[Path, bytes, str]:
     if not isinstance(value, str):
         raise ManifestError(f"{where}.brief must be a string path, got {type(value).__name__}")
     path = Path(value)
     if not path.is_absolute():
         raise ManifestError(f"{where}.brief must be an absolute path, got {value!r}")
     resolved = path.resolve()
+    cached = cache.get(resolved)
+    if cached is not None:
+        data, digest = cached
+        return resolved, data, digest
     if not resolved.is_file():
         raise ManifestError(f"{where}.brief does not exist or is not a regular file: {resolved}")
     data = resolved.read_bytes()
     if not data.decode("utf-8", "replace").strip():
         raise ManifestError(f"{where}.brief is empty: {resolved}")
     digest = blake2b(data).hexdigest()
+    cache[resolved] = (data, digest)
     return resolved, data, digest
 
 
@@ -254,6 +336,7 @@ def _load_leg(
     default_model: str | None,
     default_agent: str | None,
     default_timeout: int | None,
+    brief_cache: dict[Path, tuple[bytes, str]],
 ) -> Leg:
     where = f"legs[{index}]"
     if not isinstance(leg_raw, dict):
@@ -270,7 +353,7 @@ def _load_leg(
         raise ManifestError(f"{where} collides with legs[{seen_labels[label]}] after lowercasing")
     seen_labels[label] = index
 
-    brief_path, brief_bytes, brief_hash = _validate_brief(leg_raw["brief"], where)
+    brief_path, brief_bytes, brief_hash = _validate_brief(leg_raw["brief"], where, brief_cache)
     cwd_path = _validate_cwd(leg_raw["cwd"], where)
 
     leg_model, leg_agent = _resolve_model_agent(leg_raw, where)

--- a/lionagi/cli/orchestrate/_manifest.py
+++ b/lionagi/cli/orchestrate/_manifest.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Manifest schema v1: closed-schema validation and snapshot loading for a
+declaratively fanned-out round.
+
+A manifest names its legs by file path; this module is the refuse-early
+layer that turns a path into a validated, immutable `Manifest` before
+anything spawns. Every brief file named by a leg is read exactly once, here,
+so the returned object owns its own snapshot bytes and a content hash — the
+caller's later edits to the manifest or any brief cannot change what was
+already loaded.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from hashlib import blake2b
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from lionagi._errors import LionError
+
+__all__ = (
+    "MANIFEST_VERSION",
+    "MIN_LEGS",
+    "MAX_LEGS",
+    "MAX_TIMEOUT_SECONDS",
+    "LABEL_PATTERN",
+    "ManifestError",
+    "Leg",
+    "Manifest",
+    "load_manifest",
+)
+
+MANIFEST_VERSION = 1
+MIN_LEGS = 1
+MAX_LEGS = 64
+MAX_TIMEOUT_SECONDS = 86400
+
+LABEL_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
+_TOP_LEVEL_KEYS = frozenset({"manifest_version", "defaults", "legs"})
+_DEFAULTS_KEYS = frozenset({"model", "agent", "timeout"})
+_LEG_KEYS = frozenset({"brief", "cwd", "label", "model", "agent", "timeout"})
+
+
+class ManifestError(LionError):
+    """A manifest file failed schema, path, or uniqueness validation.
+
+    The message names the offending top-level key, `defaults` key, or leg
+    (by label once its label is known to be valid, otherwise by index).
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class Leg:
+    """One validated, snapshotted leg of a manifest."""
+
+    label: str
+    brief: Path
+    cwd: Path
+    model: str | None
+    agent: str | None
+    timeout: int | None
+    brief_bytes: bytes
+    brief_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class Manifest:
+    """A validated manifest: every leg snapshotted, every default resolved."""
+
+    manifest_version: int
+    legs: tuple[Leg, ...]
+    default_model: str | None
+    default_agent: str | None
+    default_timeout: int | None
+
+
+def load_manifest(path: str | Path) -> Manifest:
+    """Read, parse, and validate a manifest file, snapshotting every brief.
+
+    `path` is read once here (YAML by default, JSON when the suffix is
+    `.json`); every leg's brief file is likewise read exactly once. Nothing
+    in the returned `Manifest` is re-read from disk afterward.
+    """
+    manifest_path = Path(path)
+    if not manifest_path.is_absolute():
+        raise ManifestError(f"manifest path must be absolute, got {path!r}")
+    resolved = manifest_path.resolve()
+    if not resolved.is_file():
+        raise ManifestError(f"manifest file does not exist: {resolved}")
+
+    text = resolved.read_text()
+    is_json = resolved.suffix.lower() == ".json"
+    try:
+        raw = json.loads(text) if is_json else yaml.safe_load(text)
+    except (json.JSONDecodeError, yaml.YAMLError) as exc:
+        kind = "JSON" if is_json else "YAML"
+        raise ManifestError(f"manifest {resolved} is not valid {kind}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ManifestError(
+            f"manifest {resolved} must be a mapping at the top level, got {type(raw).__name__}"
+        )
+    _refuse_unknown_keys(raw, _TOP_LEVEL_KEYS, "manifest")
+
+    version = raw.get("manifest_version")
+    if version != MANIFEST_VERSION:
+        raise ManifestError(f"manifest_version must be exactly {MANIFEST_VERSION}, got {version!r}")
+
+    defaults_raw = raw.get("defaults", {})
+    if not isinstance(defaults_raw, dict):
+        raise ManifestError(f"defaults must be a mapping, got {type(defaults_raw).__name__}")
+    _refuse_unknown_keys(defaults_raw, _DEFAULTS_KEYS, "defaults")
+    default_model, default_agent = _resolve_model_agent(defaults_raw, "defaults")
+    default_timeout = _validate_timeout(defaults_raw.get("timeout"), "defaults")
+
+    legs_raw = raw.get("legs")
+    if not isinstance(legs_raw, list):
+        raise ManifestError(f"legs must be a list, got {type(legs_raw).__name__}")
+    if not (MIN_LEGS <= len(legs_raw) <= MAX_LEGS):
+        raise ManifestError(
+            f"legs must contain {MIN_LEGS}..{MAX_LEGS} entries, got {len(legs_raw)}"
+        )
+
+    legs: list[Leg] = []
+    seen_labels: dict[str, int] = {}
+    for index, leg_raw in enumerate(legs_raw):
+        legs.append(
+            _load_leg(leg_raw, index, seen_labels, default_model, default_agent, default_timeout)
+        )
+
+    return Manifest(
+        manifest_version=version,
+        legs=tuple(legs),
+        default_model=default_model,
+        default_agent=default_agent,
+        default_timeout=default_timeout,
+    )
+
+
+def _refuse_unknown_keys(obj: dict, allowed: frozenset[str], where: str) -> None:
+    unknown = sorted(set(obj) - allowed)
+    if unknown:
+        raise ManifestError(f"{where} has unknown key(s): {', '.join(unknown)}")
+
+
+def _resolve_model_agent(obj: dict, where: str) -> tuple[str | None, str | None]:
+    model = obj.get("model")
+    agent = obj.get("agent")
+    if model is not None and agent is not None:
+        raise ManifestError(f"{where} names both model and agent; a level may set only one")
+    if model is not None and not isinstance(model, str):
+        raise ManifestError(f"{where}.model must be a string, got {type(model).__name__}")
+    if agent is not None and not isinstance(agent, str):
+        raise ManifestError(f"{where}.agent must be a string, got {type(agent).__name__}")
+    return model, agent
+
+
+def _validate_timeout(value: Any, where: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ManifestError(f"{where}.timeout must be a positive integer, got {value!r}")
+    if not (1 <= value <= MAX_TIMEOUT_SECONDS):
+        raise ManifestError(
+            f"{where}.timeout must be between 1 and {MAX_TIMEOUT_SECONDS} seconds, got {value}"
+        )
+    return value
+
+
+def _validate_label(value: Any, where: str) -> str:
+    if not isinstance(value, str):
+        raise ManifestError(f"{where}.label must be a string, got {type(value).__name__}")
+    lowered = value.lower()
+    if not LABEL_PATTERN.fullmatch(lowered):
+        raise ManifestError(
+            f"{where}.label {value!r} must match {LABEL_PATTERN.pattern!r} after lowercasing"
+        )
+    return lowered
+
+
+def _validate_brief(value: Any, where: str) -> tuple[Path, bytes, str]:
+    if not isinstance(value, str):
+        raise ManifestError(f"{where}.brief must be a string path, got {type(value).__name__}")
+    path = Path(value)
+    if not path.is_absolute():
+        raise ManifestError(f"{where}.brief must be an absolute path, got {value!r}")
+    resolved = path.resolve()
+    if not resolved.is_file():
+        raise ManifestError(f"{where}.brief does not exist or is not a regular file: {resolved}")
+    data = resolved.read_bytes()
+    if not data.decode("utf-8", "replace").strip():
+        raise ManifestError(f"{where}.brief is empty: {resolved}")
+    digest = blake2b(data).hexdigest()
+    return resolved, data, digest
+
+
+def _validate_cwd(value: Any, where: str) -> Path:
+    if not isinstance(value, str):
+        raise ManifestError(f"{where}.cwd must be a string path, got {type(value).__name__}")
+    path = Path(value)
+    if not path.is_absolute():
+        raise ManifestError(f"{where}.cwd must be an absolute path, got {value!r}")
+    resolved = path.resolve()
+    if not resolved.is_dir():
+        raise ManifestError(f"{where}.cwd does not exist or is not a directory: {resolved}")
+    return resolved
+
+
+def _load_leg(
+    leg_raw: Any,
+    index: int,
+    seen_labels: dict[str, int],
+    default_model: str | None,
+    default_agent: str | None,
+    default_timeout: int | None,
+) -> Leg:
+    where = f"legs[{index}]"
+    if not isinstance(leg_raw, dict):
+        raise ManifestError(f"{where} must be a mapping, got {type(leg_raw).__name__}")
+    _refuse_unknown_keys(leg_raw, _LEG_KEYS, where)
+
+    for required in ("brief", "cwd", "label"):
+        if required not in leg_raw:
+            raise ManifestError(f"{where} is missing required key {required!r}")
+
+    label = _validate_label(leg_raw["label"], where)
+    where = f"leg {label!r}"
+    if label in seen_labels:
+        raise ManifestError(f"{where} collides with legs[{seen_labels[label]}] after lowercasing")
+    seen_labels[label] = index
+
+    brief_path, brief_bytes, brief_hash = _validate_brief(leg_raw["brief"], where)
+    cwd_path = _validate_cwd(leg_raw["cwd"], where)
+
+    leg_model, leg_agent = _resolve_model_agent(leg_raw, where)
+    if leg_model is not None or leg_agent is not None:
+        model, agent = leg_model, leg_agent
+    else:
+        model, agent = default_model, default_agent
+
+    leg_timeout = _validate_timeout(leg_raw.get("timeout"), where)
+    timeout = leg_timeout if leg_timeout is not None else default_timeout
+
+    return Leg(
+        label=label,
+        brief=brief_path,
+        cwd=cwd_path,
+        model=model,
+        agent=agent,
+        timeout=timeout,
+        brief_bytes=brief_bytes,
+        brief_hash=brief_hash,
+    )

--- a/tests/cli/orchestrate/test_manifest.py
+++ b/tests/cli/orchestrate/test_manifest.py
@@ -1,0 +1,484 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Manifest schema v1: closed-schema validation and snapshot semantics."""
+
+from __future__ import annotations
+
+import json
+from hashlib import blake2b
+
+import pytest
+import yaml
+
+from lionagi.cli.orchestrate._manifest import (
+    MAX_LEGS,
+    MAX_TIMEOUT_SECONDS,
+    ManifestError,
+    load_manifest,
+)
+
+
+def _write(path, content: str):
+    path.write_text(content)
+    return path
+
+
+def _brief(tmp_path, name="brief.md", content="Review module A.\n"):
+    return _write(tmp_path / name, content)
+
+
+def _minimal_manifest_dict(tmp_path, *, brief=None, cwd=None, label="leg-a"):
+    brief = brief or _brief(tmp_path)
+    cwd = cwd or (tmp_path / "work")
+    cwd.mkdir(exist_ok=True)
+    return {
+        "manifest_version": 1,
+        "legs": [
+            {"brief": str(brief), "cwd": str(cwd), "label": label},
+        ],
+    }
+
+
+def _dump_yaml(tmp_path, data, name="manifest.yaml"):
+    return _write(tmp_path / name, yaml.safe_dump(data))
+
+
+def _dump_json(tmp_path, data, name="manifest.json"):
+    return _write(tmp_path / name, json.dumps(data))
+
+
+# ── success cases ───────────────────────────────────────────────────────
+
+
+def test_minimal_manifest_loads(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    manifest = load_manifest(manifest_path)
+
+    assert manifest.manifest_version == 1
+    assert len(manifest.legs) == 1
+    leg = manifest.legs[0]
+    assert leg.label == "leg-a"
+    assert leg.model is None
+    assert leg.agent is None
+    assert leg.timeout is None
+    assert leg.brief_bytes == (tmp_path / "brief.md").read_bytes()
+    assert leg.brief_hash == blake2b(leg.brief_bytes).hexdigest()
+
+
+def test_full_manifest_with_per_leg_overrides(tmp_path):
+    (tmp_path / "work-a").mkdir()
+    (tmp_path / "work-b").mkdir()
+    brief_a = _brief(tmp_path, "a.md", "Brief A.\n")
+    brief_b = _brief(tmp_path, "b.md", "Brief B.\n")
+    data = {
+        "manifest_version": 1,
+        "defaults": {"agent": "reviewer", "timeout": 1200},
+        "legs": [
+            {
+                "brief": str(brief_a),
+                "cwd": str(tmp_path / "work-a"),
+                "label": "leg-a",
+            },
+            {
+                "brief": str(brief_b),
+                "cwd": str(tmp_path / "work-b"),
+                "label": "leg-b",
+                "model": "codex/gpt-5",
+                "timeout": 300,
+            },
+        ],
+    }
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    manifest = load_manifest(manifest_path)
+
+    assert manifest.default_agent == "reviewer"
+    assert manifest.default_timeout == 1200
+    leg_a, leg_b = manifest.legs
+    assert leg_a.agent == "reviewer" and leg_a.model is None
+    assert leg_a.timeout == 1200
+    assert leg_b.model == "codex/gpt-5" and leg_b.agent is None
+    assert leg_b.timeout == 300
+
+
+def test_yaml_and_json_parity(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    yaml_path = _dump_yaml(tmp_path, data, "manifest.yaml")
+    json_path = _dump_json(tmp_path, data, "manifest.json")
+
+    from_yaml = load_manifest(yaml_path)
+    from_json = load_manifest(json_path)
+
+    assert from_yaml == from_json
+
+
+# ── snapshot semantics ──────────────────────────────────────────────────
+
+
+def test_brief_edit_after_load_has_no_effect(tmp_path):
+    brief = _brief(tmp_path, content="original content\n")
+    data = _minimal_manifest_dict(tmp_path, brief=brief)
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    manifest = load_manifest(manifest_path)
+    original_bytes = manifest.legs[0].brief_bytes
+    original_hash = manifest.legs[0].brief_hash
+
+    brief.write_text("mutated after load\n")
+
+    assert manifest.legs[0].brief_bytes == original_bytes
+    assert manifest.legs[0].brief_hash == original_hash
+    assert manifest.legs[0].brief_bytes != brief.read_bytes()
+
+
+def test_manifest_edit_after_load_has_no_effect(tmp_path):
+    data = _minimal_manifest_dict(tmp_path, label="leg-a")
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    manifest = load_manifest(manifest_path)
+
+    other_brief = _brief(tmp_path, "other.md", "other\n")
+    (tmp_path / "work2").mkdir()
+    mutated = _minimal_manifest_dict(
+        tmp_path, brief=other_brief, cwd=tmp_path / "work2", label="leg-b"
+    )
+    _dump_yaml(tmp_path, mutated, manifest_path.name)
+
+    assert manifest.legs[0].label == "leg-a"
+
+
+# ── top-level schema ────────────────────────────────────────────────────
+
+
+def test_manifest_path_must_be_absolute(tmp_path):
+    with pytest.raises(ManifestError, match="must be absolute"):
+        load_manifest("relative/manifest.yaml")
+
+
+def test_manifest_file_must_exist(tmp_path):
+    with pytest.raises(ManifestError, match="does not exist"):
+        load_manifest(tmp_path / "missing.yaml")
+
+
+def test_manifest_must_be_a_mapping(tmp_path):
+    manifest_path = _write(tmp_path / "manifest.yaml", "- just\n- a\n- list\n")
+    with pytest.raises(ManifestError, match="must be a mapping"):
+        load_manifest(manifest_path)
+
+
+def test_manifest_rejects_invalid_yaml(tmp_path):
+    manifest_path = _write(tmp_path / "manifest.yaml", "legs: [unclosed\n")
+    with pytest.raises(ManifestError, match="not valid YAML"):
+        load_manifest(manifest_path)
+
+
+def test_manifest_rejects_invalid_json(tmp_path):
+    manifest_path = _write(tmp_path / "manifest.json", "{not json")
+    with pytest.raises(ManifestError, match="not valid JSON"):
+        load_manifest(manifest_path)
+
+
+def test_manifest_rejects_unknown_top_level_key(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["extra_knob"] = True
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="unknown key.*extra_knob"):
+        load_manifest(manifest_path)
+
+
+def test_manifest_version_must_be_exactly_one(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["manifest_version"] = 2
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="manifest_version must be exactly 1"):
+        load_manifest(manifest_path)
+
+
+def test_manifest_version_missing(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    del data["manifest_version"]
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="manifest_version must be exactly 1"):
+        load_manifest(manifest_path)
+
+
+def test_legs_must_be_a_list(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"] = "not-a-list"
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="legs must be a list"):
+        load_manifest(manifest_path)
+
+
+def test_legs_below_floor_refused(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"] = []
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match=r"legs must contain 1\.\.64 entries, got 0"):
+        load_manifest(manifest_path)
+
+
+def test_legs_above_ceiling_refused(tmp_path):
+    brief = _brief(tmp_path)
+    (tmp_path / "work").mkdir()
+    leg_template = {
+        "brief": str(brief),
+        "cwd": str(tmp_path / "work"),
+    }
+    legs = [{**leg_template, "label": f"leg-{i}"} for i in range(MAX_LEGS + 1)]
+    data = {"manifest_version": 1, "legs": legs}
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match=rf"got {MAX_LEGS + 1}"):
+        load_manifest(manifest_path)
+
+
+def test_legs_at_ceiling_accepted(tmp_path):
+    brief = _brief(tmp_path)
+    (tmp_path / "work").mkdir()
+    legs = [
+        {"brief": str(brief), "cwd": str(tmp_path / "work"), "label": f"leg-{i}"}
+        for i in range(MAX_LEGS)
+    ]
+    data = {"manifest_version": 1, "legs": legs}
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    assert len(manifest.legs) == MAX_LEGS
+
+
+# ── defaults ─────────────────────────────────────────────────────────────
+
+
+def test_defaults_rejects_unknown_key(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["defaults"] = {"nonsense": 1}
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="defaults has unknown key.*nonsense"):
+        load_manifest(manifest_path)
+
+
+def test_defaults_rejects_model_and_agent_together(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["defaults"] = {"model": "openai/gpt-5", "agent": "reviewer"}
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="defaults names both model and agent"):
+        load_manifest(manifest_path)
+
+
+# ── leg schema ──────────────────────────────────────────────────────────
+
+
+def test_leg_rejects_unknown_key(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["nonsense"] = 1
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match=r"legs\[0\] has unknown key.*nonsense"):
+        load_manifest(manifest_path)
+
+
+@pytest.mark.parametrize("missing", ["brief", "cwd", "label"])
+def test_leg_missing_required_key(tmp_path, missing):
+    data = _minimal_manifest_dict(tmp_path)
+    del data["legs"][0][missing]
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match=f"missing required key {missing!r}"):
+        load_manifest(manifest_path)
+
+
+def test_leg_rejects_model_and_agent_together(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["model"] = "openai/gpt-5"
+    data["legs"][0]["agent"] = "reviewer"
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="names both model and agent"):
+        load_manifest(manifest_path)
+
+
+def test_leg_model_ignores_default_agent_entirely(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["defaults"] = {"agent": "reviewer"}
+    data["legs"][0]["model"] = "openai/gpt-5"
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    leg = manifest.legs[0]
+    assert leg.model == "openai/gpt-5"
+    assert leg.agent is None
+
+
+def test_leg_agent_ignores_default_model_entirely(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["defaults"] = {"model": "openai/gpt-5"}
+    data["legs"][0]["agent"] = "reviewer"
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    leg = manifest.legs[0]
+    assert leg.agent == "reviewer"
+    assert leg.model is None
+
+
+def test_leg_with_neither_inherits_full_default_pair(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["defaults"] = {"model": "openai/gpt-5"}
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    leg = manifest.legs[0]
+    assert leg.model == "openai/gpt-5"
+    assert leg.agent is None
+
+
+def test_leg_timeout_overrides_default_timeout(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["defaults"] = {"timeout": 1200}
+    data["legs"][0]["timeout"] = 60
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    assert manifest.legs[0].timeout == 60
+
+
+@pytest.mark.parametrize("bad_timeout", [0, -1, 86401, 900.5, "900", True])
+def test_timeout_rejects_out_of_range_or_wrong_type(tmp_path, bad_timeout):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["timeout"] = bad_timeout
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="timeout"):
+        load_manifest(manifest_path)
+
+
+def test_timeout_at_ceiling_accepted(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["timeout"] = MAX_TIMEOUT_SECONDS
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    assert manifest.legs[0].timeout == MAX_TIMEOUT_SECONDS
+
+
+# ── label ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "../escape",
+        "a/b",
+        "/abs/path",
+        "..",
+        ".",
+        "",
+        "-leading-dash",
+        "a" * 65,
+    ],
+)
+def test_hostile_labels_refused(tmp_path, label):
+    data = _minimal_manifest_dict(tmp_path, label=label)
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="label"):
+        load_manifest(manifest_path)
+
+
+def test_label_at_max_length_accepted(tmp_path):
+    label = "a" * 64
+    data = _minimal_manifest_dict(tmp_path, label=label)
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    assert manifest.legs[0].label == label
+
+
+def test_label_is_lowercased(tmp_path):
+    data = _minimal_manifest_dict(tmp_path, label="LEG-A")
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    assert manifest.legs[0].label == "leg-a"
+
+
+def test_label_collision_after_lowercasing_refused(tmp_path):
+    brief = _brief(tmp_path)
+    (tmp_path / "work-a").mkdir()
+    (tmp_path / "work-b").mkdir()
+    data = {
+        "manifest_version": 1,
+        "legs": [
+            {"brief": str(brief), "cwd": str(tmp_path / "work-a"), "label": "A-x"},
+            {"brief": str(brief), "cwd": str(tmp_path / "work-b"), "label": "a-x"},
+        ],
+    }
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="collides with legs\\[0\\]"):
+        load_manifest(manifest_path)
+
+
+# ── brief ───────────────────────────────────────────────────────────────
+
+
+def test_brief_must_be_absolute(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["brief"] = "relative/brief.md"
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="brief must be an absolute path"):
+        load_manifest(manifest_path)
+
+
+def test_brief_must_exist(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["brief"] = str(tmp_path / "does-not-exist.md")
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="does not exist or is not a regular file"):
+        load_manifest(manifest_path)
+
+
+def test_brief_must_be_a_regular_file_not_a_directory(tmp_path):
+    brief_dir = tmp_path / "brief-as-dir"
+    brief_dir.mkdir()
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["brief"] = str(brief_dir)
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="does not exist or is not a regular file"):
+        load_manifest(manifest_path)
+
+
+def test_brief_empty_after_strip_refused(tmp_path):
+    brief = _brief(tmp_path, content="   \n\t\n")
+    data = _minimal_manifest_dict(tmp_path, brief=brief)
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="brief is empty"):
+        load_manifest(manifest_path)
+
+
+def test_brief_symlink_is_resolved(tmp_path):
+    real = _brief(tmp_path, "real.md", "real content\n")
+    link = tmp_path / "link.md"
+    link.symlink_to(real)
+    data = _minimal_manifest_dict(tmp_path, brief=link)
+    manifest_path = _dump_yaml(tmp_path, data)
+    manifest = load_manifest(manifest_path)
+    assert manifest.legs[0].brief == real.resolve()
+    assert manifest.legs[0].brief_bytes == b"real content\n"
+
+
+# ── cwd ─────────────────────────────────────────────────────────────────
+
+
+def test_cwd_must_be_absolute(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["cwd"] = "relative/dir"
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="cwd must be an absolute path"):
+        load_manifest(manifest_path)
+
+
+def test_cwd_must_exist(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["cwd"] = str(tmp_path / "no-such-dir")
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="does not exist or is not a directory"):
+        load_manifest(manifest_path)
+
+
+def test_cwd_must_be_a_directory_not_a_file(tmp_path):
+    cwd_file = tmp_path / "cwd-as-file"
+    cwd_file.write_text("not a directory\n")
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["cwd"] = str(cwd_file)
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="does not exist or is not a directory"):
+        load_manifest(manifest_path)

--- a/tests/cli/orchestrate/test_manifest.py
+++ b/tests/cli/orchestrate/test_manifest.py
@@ -490,3 +490,87 @@ def test_cwd_must_be_a_directory_not_a_file(tmp_path):
     manifest_path = _dump_yaml(tmp_path, data)
     with pytest.raises(ManifestError, match="does not exist or is not a directory"):
         load_manifest(manifest_path)
+
+
+# ── env ─────────────────────────────────────────────────────────────────
+
+
+def test_env_map_loads_as_sorted_pairs_with_verbatim_values(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["env"] = {
+        "ZED_VAR": "z value",
+        "CARGO_TARGET_DIR": "/abs/targets/module-a",
+    }
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    leg = load_manifest(manifest_path).legs[0]
+
+    assert leg.env == (
+        ("CARGO_TARGET_DIR", "/abs/targets/module-a"),
+        ("ZED_VAR", "z value"),
+    )
+    assert leg.env_keys == ("CARGO_TARGET_DIR", "ZED_VAR")
+
+
+def test_env_omitted_is_empty_tuple(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    leg = load_manifest(manifest_path).legs[0]
+
+    assert leg.env == ()
+    assert leg.env_keys == ()
+
+
+def test_env_must_be_a_mapping(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["env"] = ["CARGO_TARGET_DIR=/abs"]
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="env must be a mapping"):
+        load_manifest(manifest_path)
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    ["lower_case", "1LEADING_DIGIT", "_LEADING_UNDERSCORE", "HAS-DASH", "X" * 65, ""],
+)
+def test_env_key_pattern_refused_by_name(tmp_path, bad_key):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["env"] = {bad_key: "value"}
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="env key"):
+        load_manifest(manifest_path)
+
+
+def test_env_key_at_max_length_is_accepted(tmp_path):
+    key = "K" + "X" * 63
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["env"] = {key: "value"}
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    assert load_manifest(manifest_path).legs[0].env == ((key, "value"),)
+
+
+def test_env_reserved_leg_artifacts_key_is_refused(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["env"] = {"LIONAGI_LEG_ARTIFACTS": "/abs/elsewhere"}
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="reserved key 'LIONAGI_LEG_ARTIFACTS'"):
+        load_manifest(manifest_path)
+
+
+@pytest.mark.parametrize("bad_value", [8080, True, None, ["a"], {"nested": "no"}])
+def test_env_values_must_be_strings(tmp_path, bad_value):
+    data = _minimal_manifest_dict(tmp_path)
+    data["legs"][0]["env"] = {"PORT_HINT": bad_value}
+    manifest_path = _dump_json(tmp_path, data)
+    with pytest.raises(ManifestError, match="must be a string value"):
+        load_manifest(manifest_path)
+
+
+def test_env_in_defaults_is_refused_as_unknown_key(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["defaults"] = {"env": {"CARGO_TARGET_DIR": "/abs"}}
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="defaults has unknown key"):
+        load_manifest(manifest_path)

--- a/tests/cli/orchestrate/test_manifest.py
+++ b/tests/cli/orchestrate/test_manifest.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 from hashlib import blake2b
+from pathlib import Path
 
 import pytest
 import yaml
@@ -574,3 +575,179 @@ def test_env_in_defaults_is_refused_as_unknown_key(tmp_path):
     manifest_path = _dump_yaml(tmp_path, data)
     with pytest.raises(ManifestError, match="defaults has unknown key"):
         load_manifest(manifest_path)
+
+
+# ── raw-document strictness and snapshot identity ───────────────────────
+
+
+def test_shared_brief_is_read_once_with_one_snapshot(tmp_path, monkeypatch):
+    brief = _brief(tmp_path, "shared.md", "first\n")
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    data = {
+        "manifest_version": 1,
+        "legs": [
+            {"brief": str(brief), "cwd": str(cwd), "label": "leg-a"},
+            {"brief": str(brief), "cwd": str(cwd), "label": "leg-b"},
+        ],
+    }
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    reads: list[Path] = []
+    real_read_bytes = Path.read_bytes
+
+    def mutating_read_bytes(self):
+        content = real_read_bytes(self)
+        reads.append(self)
+        # A write landing right after the first read: any second read of the
+        # same brief would observe it and split the snapshot.
+        self.write_text("second\n")
+        return content
+
+    monkeypatch.setattr(Path, "read_bytes", mutating_read_bytes)
+    manifest = load_manifest(manifest_path)
+
+    assert len(reads) == 1
+    assert manifest.legs[0].brief_bytes == manifest.legs[1].brief_bytes == b"first\n"
+    assert manifest.legs[0].brief_hash == manifest.legs[1].brief_hash
+
+
+@pytest.mark.parametrize("dump", [_dump_yaml, _dump_json])
+def test_manifest_version_float_refused(tmp_path, dump):
+    data = _minimal_manifest_dict(tmp_path)
+    data["manifest_version"] = 1.0
+    with pytest.raises(ManifestError, match="manifest_version must be exactly 1"):
+        load_manifest(dump(tmp_path, data))
+
+
+def test_manifest_version_string_refused(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["manifest_version"] = "1"
+    with pytest.raises(ManifestError, match="manifest_version must be exactly 1"):
+        load_manifest(_dump_yaml(tmp_path, data))
+
+
+def test_yaml_merge_key_refused(tmp_path):
+    brief = _brief(tmp_path)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    text = (
+        "manifest_version: 1\n"
+        "defaults:\n"
+        "  <<: {timeout: 86400}\n"
+        "legs:\n"
+        f"  - {{brief: '{brief}', cwd: '{cwd}', label: leg-a}}\n"
+    )
+    with pytest.raises(ManifestError, match="merge keys"):
+        load_manifest(_write(tmp_path / "manifest.yaml", text))
+
+
+def test_yaml_duplicate_top_level_key_refused(tmp_path):
+    brief = _brief(tmp_path)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    text = (
+        "manifest_version: 2\n"
+        "manifest_version: 1\n"
+        "legs:\n"
+        f"  - {{brief: '{brief}', cwd: '{cwd}', label: leg-a}}\n"
+    )
+    with pytest.raises(ManifestError, match="duplicate mapping key"):
+        load_manifest(_write(tmp_path / "manifest.yaml", text))
+
+
+def test_yaml_duplicate_env_key_refused(tmp_path):
+    brief = _brief(tmp_path)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    text = (
+        "manifest_version: 1\n"
+        "legs:\n"
+        f"  - brief: '{brief}'\n"
+        f"    cwd: '{cwd}'\n"
+        "    label: leg-a\n"
+        "    env:\n"
+        "      PORT_HINT: '8001'\n"
+        "      PORT_HINT: '8002'\n"
+    )
+    with pytest.raises(ManifestError, match="duplicate mapping key"):
+        load_manifest(_write(tmp_path / "manifest.yaml", text))
+
+
+def test_json_duplicate_key_refused(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    text = (
+        '{"manifest_version": 2, "manifest_version": 1, "legs": ' + json.dumps(data["legs"]) + "}"
+    )
+    with pytest.raises(ManifestError, match="duplicate key"):
+        load_manifest(_write(tmp_path / "manifest.json", text))
+
+
+def test_non_string_top_level_key_refused(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    text = yaml.safe_dump(data) + "1: stray\n"
+    with pytest.raises(ManifestError, match="manifest has non-string key"):
+        load_manifest(_write(tmp_path / "manifest.yaml", text))
+
+
+def test_yaml_bool_key_under_defaults_refused(tmp_path):
+    brief = _brief(tmp_path)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    text = (
+        "manifest_version: 1\n"
+        "defaults:\n"
+        "  on: reviewer\n"
+        "legs:\n"
+        f"  - {{brief: '{brief}', cwd: '{cwd}', label: leg-a}}\n"
+    )
+    with pytest.raises(ManifestError, match="defaults has non-string key"):
+        load_manifest(_write(tmp_path / "manifest.yaml", text))
+
+
+def test_non_string_leg_key_refused(tmp_path):
+    brief = _brief(tmp_path)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    text = (
+        "manifest_version: 1\n"
+        "legs:\n"
+        f"  - brief: '{brief}'\n"
+        f"    cwd: '{cwd}'\n"
+        "    label: leg-a\n"
+        "    2: stray\n"
+    )
+    with pytest.raises(ManifestError, match=r"legs\[0\] has non-string key"):
+        load_manifest(_write(tmp_path / "manifest.yaml", text))
+
+
+def test_non_string_env_key_refused_by_name(tmp_path):
+    brief = _brief(tmp_path)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    text = (
+        "manifest_version: 1\n"
+        "legs:\n"
+        f"  - brief: '{brief}'\n"
+        f"    cwd: '{cwd}'\n"
+        "    label: leg-a\n"
+        "    env:\n"
+        "      1: '8001'\n"
+    )
+    with pytest.raises(ManifestError, match="env key 1 must match"):
+        load_manifest(_write(tmp_path / "manifest.yaml", text))
+
+
+def test_yaml_unhashable_key_refused(tmp_path):
+    brief = _brief(tmp_path)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    text = (
+        "manifest_version: 1\n"
+        "? [a, b]\n"
+        ": stray\n"
+        "legs:\n"
+        f"  - {{brief: '{brief}', cwd: '{cwd}', label: leg-a}}\n"
+    )
+    with pytest.raises(ManifestError, match="unhashable mapping key"):
+        load_manifest(_write(tmp_path / "manifest.yaml", text))

--- a/tests/cli/orchestrate/test_manifest.py
+++ b/tests/cli/orchestrate/test_manifest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from lionagi.cli.orchestrate import _manifest
 from lionagi.cli.orchestrate._manifest import (
     MAX_LEGS,
     MAX_TIMEOUT_SECONDS,
@@ -580,7 +581,7 @@ def test_env_in_defaults_is_refused_as_unknown_key(tmp_path):
 # ── raw-document strictness and snapshot identity ───────────────────────
 
 
-def test_shared_brief_is_read_once_with_one_snapshot(tmp_path, monkeypatch):
+def test_shared_brief_literal_is_read_once_with_one_snapshot(tmp_path, monkeypatch):
     brief = _brief(tmp_path, "shared.md", "first\n")
     cwd = tmp_path / "work"
     cwd.mkdir()
@@ -594,21 +595,95 @@ def test_shared_brief_is_read_once_with_one_snapshot(tmp_path, monkeypatch):
     manifest_path = _dump_yaml(tmp_path, data)
 
     reads: list[Path] = []
-    real_read_bytes = Path.read_bytes
+    real_read = _manifest._read_brief_file
 
-    def mutating_read_bytes(self):
-        content = real_read_bytes(self)
-        reads.append(self)
+    def mutating_read(resolved):
+        result = real_read(resolved)
+        reads.append(resolved)
         # A write landing right after the first read: any second read of the
-        # same brief would observe it and split the snapshot.
-        self.write_text("second\n")
-        return content
+        # same brief would observe it and split the snapshot. A repeated
+        # literal must not even re-resolve, so no second call happens at all.
+        brief.write_text("second\n")
+        return result
 
-    monkeypatch.setattr(Path, "read_bytes", mutating_read_bytes)
+    monkeypatch.setattr(_manifest, "_read_brief_file", mutating_read)
     manifest = load_manifest(manifest_path)
 
     assert len(reads) == 1
     assert manifest.legs[0].brief_bytes == manifest.legs[1].brief_bytes == b"first\n"
+    assert manifest.legs[0].brief_hash == manifest.legs[1].brief_hash
+
+
+def test_physical_alias_briefs_coalesce_onto_first_snapshot(tmp_path, monkeypatch):
+    # Two distinct spellings of one physical file, with the file rewritten
+    # between their reads: both legs must carry the first accepted snapshot.
+    brief_a = _brief(tmp_path, "a.md", "first\n")
+    brief_b = _brief(tmp_path, "b.md", "unused\n")
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    data = {
+        "manifest_version": 1,
+        "legs": [
+            {"brief": str(brief_a), "cwd": str(cwd), "label": "leg-a"},
+            {"brief": str(brief_b), "cwd": str(cwd), "label": "leg-b"},
+        ],
+    }
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    shared_identity = (1, 42)
+    contents = iter([b"first\n", b"second\n"])
+
+    def aliased_read(resolved):
+        return next(contents), shared_identity
+
+    monkeypatch.setattr(_manifest, "_read_brief_file", aliased_read)
+    manifest = load_manifest(manifest_path)
+
+    assert manifest.legs[0].brief_bytes == manifest.legs[1].brief_bytes == b"first\n"
+    assert manifest.legs[0].brief_hash == manifest.legs[1].brief_hash
+
+
+def test_symlink_and_target_share_one_snapshot(tmp_path):
+    target = _brief(tmp_path, "real.md", "the one brief\n")
+    link = tmp_path / "link.md"
+    link.symlink_to(target)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    data = {
+        "manifest_version": 1,
+        "legs": [
+            {"brief": str(link), "cwd": str(cwd), "label": "leg-a"},
+            {"brief": str(target), "cwd": str(cwd), "label": "leg-b"},
+        ],
+    }
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    manifest = load_manifest(manifest_path)
+
+    assert manifest.legs[0].brief_bytes == manifest.legs[1].brief_bytes
+    assert manifest.legs[0].brief_hash == manifest.legs[1].brief_hash
+
+
+def test_hard_link_briefs_share_one_snapshot(tmp_path):
+    import os as _os
+
+    original = _brief(tmp_path, "orig.md", "hard-linked brief\n")
+    alias = tmp_path / "alias.md"
+    _os.link(original, alias)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    data = {
+        "manifest_version": 1,
+        "legs": [
+            {"brief": str(original), "cwd": str(cwd), "label": "leg-a"},
+            {"brief": str(alias), "cwd": str(cwd), "label": "leg-b"},
+        ],
+    }
+    manifest_path = _dump_yaml(tmp_path, data)
+
+    manifest = load_manifest(manifest_path)
+
+    assert manifest.legs[0].brief_bytes == manifest.legs[1].brief_bytes
     assert manifest.legs[0].brief_hash == manifest.legs[1].brief_hash
 
 

--- a/tests/cli/orchestrate/test_manifest.py
+++ b/tests/cli/orchestrate/test_manifest.py
@@ -196,6 +196,14 @@ def test_manifest_version_must_be_exactly_one(tmp_path):
         load_manifest(manifest_path)
 
 
+def test_manifest_version_true_is_not_one(tmp_path):
+    data = _minimal_manifest_dict(tmp_path)
+    data["manifest_version"] = True
+    manifest_path = _dump_yaml(tmp_path, data)
+    with pytest.raises(ManifestError, match="manifest_version must be exactly 1"):
+        load_manifest(manifest_path)
+
+
 def test_manifest_version_missing(tmp_path):
     data = _minimal_manifest_dict(tmp_path)
     del data["manifest_version"]


### PR DESCRIPTION
## Summary

Implements the manifest schema v1 loader specified in ADR-0110: the refuse-early layer that turns a manifest file path into a validated, immutable `Manifest` before anything spawns.

- **Closed schema, refuse-unknown-keys at every level.** Top level (`manifest_version`, `defaults`, `legs`), `defaults` (`model`/`agent`/`timeout`), and each leg (`brief`, `cwd`, `label`, `model`, `agent`, `timeout`, `env`). `manifest_version` must equal 1 exactly (booleans refused).
- **Snapshot semantics.** Every brief file is read exactly once at load; the returned `Manifest` owns its own bytes and a BLAKE2b content hash. Later edits to the manifest or any brief cannot change what was loaded. `Leg` and `Manifest` are frozen slotted dataclasses.
- **Labels** lowercase, pattern-validated, collision-checked after lowercasing; error messages name the leg by label once the label is known valid, otherwise by index.
- **Per-leg `env` map.** Keys match `^[A-Z][A-Z0-9_]{0,63}$`, values are literal strings recorded verbatim; the runner's reserved artifact-channel name is refused at load. Stored as sorted immutable pairs so the snapshot stays a snapshot; `env_keys` exposes the declared names the way the durable leg record lists them. No manifest mechanism forwards inherited environment — the map is the recorded, reproducible delta.
- **Model/agent exclusivity** per level (a level sets one, never both), leg-level settings overriding defaults as a pair; timeout bounds 1..86400.
- **ADR wording fix:** the round field is named as an additive field of the kind the result-contract ADR already permits, not an amendment to it.

## Testing

72 tests in `tests/cli/orchestrate/test_manifest.py` covering schema refusals by name, snapshot immutability, hash stability, label collision, default resolution, timeout bounds, and the env map (sorted pairs, verbatim values, reserved-key refusal, key-pattern edges at 64/65 chars, non-string values, env-in-defaults refused). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)