### PR TITLE
feat(providers): record the identity of a CLI process the caller did not spawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ ADR_REVIEW*.txt
 ALL_ADRS_COMPILED.txt
 codex_review_*.md
 .lane-*.md
+.reviews/

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -886,10 +886,16 @@ dead. Those are different facts: a leader that died to `SIGTERM` sets `returncod
 descendant ignoring `SIGTERM` is still in its group, and a backstop gated on the leader's
 liveness reads that as nothing left to do.
 
-A scan that could not read the whole process table and saw no members leaves emptiness
-*unproved*, and nothing signals on that: an unprovable group and a reissued one look identical
-from here. That refusal is logged rather than silent, because it is the one outcome where
-something may still be running and nothing was done about it. It is also a real platform limit
+Both checks matter, and checking only one leaves a hole where the other applies. An earlier
+version of this had only the membership check, so the cancellation backstop refused to signal
+wherever the process table could not be read — and on that path the direct child has not been
+waited, so identity was never in question. The refusal is right after the reap and wrong before
+it, and it read as caution rather than as a defect.
+
+*After* the reap, a scan that could not read the whole process table and saw no members leaves
+emptiness *unproved*, and nothing signals on that: an unprovable group and a reissued one look
+identical from here. That refusal is logged rather than silent, because it is the one outcome
+where something may still be running and nothing was done about it. It is a real platform limit
 rather than a gap waiting to be closed: once the child is reaped, only a surviving member pins
 the id, and proving one exists *is* the enumeration that was unavailable.
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -873,13 +873,37 @@ outlives a parent that does not, so the group is read afterwards and killed if a
 in it. And it cannot be interrupted into leaving something running, via the synchronous
 backstop described above.
 
-Both of those kills fire only on *positive* evidence that the group id is still this child's,
-because the other direction is worse than an orphan. After a completed graceful pass the child
-has been waited and its pid may already belong to someone else, so the evidence there is a live
-member — an occupied group is never reissued. On the cancelled path the child has not been
-waited at all, so the id is unambiguously ours. A scan that could not read the whole process
-table and saw no members leaves emptiness *unproved*, and nothing signals on that: an
-unprovable group and a reissued one look identical from here.
+Every signal fires only on *positive* evidence that the group id is still this child's,
+because the other direction is worse than an orphan. There are exactly two things that
+establish it: the child has not been waited, in which case its pid cannot have been reissued;
+or the group answers with a live member, and an occupied group is never reissued. Nothing else
+counts, and the graceful helper is therefore reached *only* on the not-yet-waited path. It
+signals the id it is handed without checking anything, so calling it after a normal drain
+would send `SIGTERM` to whatever now holds a recycled id.
+
+The escalation keys on that membership evidence rather than on whether the direct child is
+dead. Those are different facts: a leader that died to `SIGTERM` sets `returncode` while a
+descendant ignoring `SIGTERM` is still in its group, and a backstop gated on the leader's
+liveness reads that as nothing left to do.
+
+A scan that could not read the whole process table and saw no members leaves emptiness
+*unproved*, and nothing signals on that: an unprovable group and a reissued one look identical
+from here. That refusal is logged rather than silent, because it is the one outcome where
+something may still be running and nothing was done about it. It is also a real platform limit
+rather than a gap waiting to be closed: once the child is reaped, only a surviving member pins
+the id, and proving one exists *is* the enumeration that was unavailable.
+
+**The one case teardown cannot reach.** A cancellation landing inside
+`create_subprocess_exec`, after the OS has made the child but before the call returns, leaves a
+process whose pid was never handed to anyone here. Interpreter shutdown cancels pending tasks
+and does exactly this. asyncio closes the transport on that path, which ends the direct child
+but not the group it leads. Recording the handle as soon as the creation call returns was tried
+and removed: it covers only the window between the call returning and the caller resuming,
+which is not where the cancellation lands. Reaching it needs the pid *before* the creation call
+returns, which means driving `loop.subprocess_exec` with a protocol that records
+`transport.get_pid()` in `connection_made` — declined here because it pins this file to stdlib
+classes outside that module's `__all__` across every supported Python. The orphan is in the
+record the caller writes, so a later sweep over those records still finds it.
 
 The group in the record is the *initial* one. A process group is not a containment boundary: a
 child or descendant that calls `setsid()` leaves it and the record then says nothing about that
@@ -898,10 +922,22 @@ child environment. Pydantic renders the input of a failing `mode="before"` valid
 and a model-level one holds the whole raw mapping, so a request rejected for a reason having
 nothing to do with `env` — an empty prompt, say — quotes every variable beside the reason. The
 redaction therefore happens at the top of every model-level before-validator and before
-anything there can raise: `env` is replaced by an equal `RedactedEnv`, a real mapping that
-reports `<env: N variable(s)>` instead of itself. Carrying it on the value rather than at each
-error site is what stops a validator added later from reopening the channel by not knowing
-about it, and it is why the two providers each redact at their own validator entry.
+anything there can raise. Carrying it on the value rather than at each error site is what stops
+a validator added later from reopening the channel by not knowing about it, and it is why the
+two providers each redact at their own validator entry.
+
+The substitute is deliberately **not a mapping**. A `dict` subclass with a quiet `__repr__`
+closes the rendering channel and leaves the serialization one wide open: `str(err)` and
+`err.errors()` go through `repr`, but `err.json()` walks the structure and writes out every key
+and value, and `err.json()` is what a structured logger emits. `Redacted` is neither `dict` nor
+`Mapping`, so there is nothing for pydantic to walk, and it reports `<env: N variable(s)>` in
+every channel.
+
+`on_spawn` is wrapped for the same reason. A **bound method carries its receiver into its own
+`repr`**, so a callback bound to a supervisor renders whatever that supervisor holds — and
+receivers that render their attributes are the common case here. Both models unwrap the carrier
+in a field validator; without that, pydantic rejects a perfectly good callback as not callable,
+which is a failure a leak test alone would never show.
 
 Two rejections stay explicit because the redaction cannot reach them:
 
@@ -931,6 +967,16 @@ value that must stay in memory:
 `copy_runtime_state_to` carries `_runtime_state` shallowly on purpose. `iModel.copy` deep copies
 the config, and a deep copy of a bound callback rebinds it to a copied receiver, so the original
 supervisor would quietly stop hearing from the copy's legs while everything still looked wired.
+
+**The endpoint-instance route.** `iModel(endpoint=<instance>, ...)` is a supported signature,
+and it takes a branch that keeps the endpoint and discards every other keyword. For most
+keywords that only loses configuration the endpoint already has. For these two it hands the
+child a default environment and leaves the supervisor hearing nothing, with nothing raised and
+nothing logged, which reads exactly like a working leg. A caller who hands over a finished
+endpoint has missed the window below entirely, so `adopt_runtime_state()` places the values on
+the instance — the way that same branch already treats `provider` and `base_url` — and an
+endpoint with no runtime state to hold them refuses rather than dropping them. A `None` is the
+absence of a value there, not an instruction to clear one.
 
 The same deep copy sits on the construction path: `Endpoint.__init__` does
 `config.model_copy(deep=True)` before any subclass code runs, so an endpoint built from a

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -979,6 +979,29 @@ value that must stay in memory:
   `_init_runtime_state()` moves the named values out of `config.kwargs` into `_runtime_state` at
   construction, where `create_payload` reads them at the same precedence they had before.
 
+**The drain is not the whole of it, and the part it misses is the public one.** A drain has to be
+*reached*, and it hangs off the endpoint's own `to_dict`. `EndpointConfig` is public and inherits
+Pydantic's `model_dump`, so a caller that logs or persists the config directly never goes through
+an endpoint at all. Two supported routes also put a runtime value back into `kwargs` after the
+endpoint has already drained it once: a post-construction `EndpointConfig.update()`, which puts
+unknown keys straight back, and `iModel.from_dict`, which assigns a freshly hydrated config over
+the drained one (`imodel.py`, in the `match_endpoint` branch). Between either of those and the
+next endpoint-level dump, the value is resting in a serializable field.
+
+So the names are declared on `EndpointConfig` itself, as `RUNTIME_STATE_NAMES`, and that model
+excludes them from its own `kwargs` serializer. The set of callers that can reach a drain is
+open-ended because the model is public; the set that can go around a serializer is empty. The
+endpoint re-exports the same tuple rather than keeping its own — one list decides what gets
+written down, and a second copy would eventually be the one that fell behind.
+
+`repr` is a separate channel and gets the same treatment through `__repr_args__`, because it
+walks `kwargs` whole: a config excluded from every dump still prints its environment into a
+traceback, a log line, or a debugger. The two channels differ in what they leave behind. A dump
+omits the key, since a dump is something a config is rebuilt from and a placeholder string would
+hydrate as a real value of the wrong type. `repr` reports that a value is set without its
+contents, because nothing is rebuilt from a `repr` and a reader asking why an environment was not
+applied is answered by the key alone.
+
 `copy_runtime_state_to` carries `_runtime_state` shallowly on purpose. `iModel.copy` deep copies
 the config, and a deep copy of a bound callback rebinds it to a copied receiver, so the original
 supervisor would quietly stop hearing from the copy's legs while everything still looked wired.

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -858,6 +858,29 @@ child exists and before any output is read. Three things about that record are l
   a completed graceful path has already waited the child, and signalling a pid asyncio has
   reaped is how a stranger's group gets killed.
 
+- **The record exists even when nothing recorded it.** The OS has already started the child by
+  the time `create_subprocess_exec` resumes, so a cancellation landing in the window before it
+  returns leaves a running leg that this process holds no handle for and that no callback has
+  seen — unreachable by teardown and by any later sweep over the records. The creation is
+  therefore shielded so the handle still arrives, and a done-callback ends that child's group
+  from outside the coroutine that unwound. The callback retrieves the task's exception either
+  way, or a cancelled spawn is reported at exit as a never-retrieved failure.
+
+`end_child_group()` is what every teardown path calls, and it differs from the graceful helper
+on two counts. It drains the *group* rather than the process: the graceful helper returns as
+soon as the process it holds a handle to is gone, and a descendant that ignores `SIGTERM`
+outlives a parent that does not, so the group is read afterwards and killed if anyone is still
+in it. And it cannot be interrupted into leaving something running, via the synchronous
+backstop described above.
+
+Both of those kills fire only on *positive* evidence that the group id is still this child's,
+because the other direction is worse than an orphan. After a completed graceful pass the child
+has been waited and its pid may already belong to someone else, so the evidence there is a live
+member — an occupied group is never reissued. On the cancelled path the child has not been
+waited at all, so the id is unambiguously ours. A scan that could not read the whole process
+table and saw no members leaves emptiness *unproved*, and nothing signals on that: an
+unprovable group and a reissued one look identical from here.
+
 The group in the record is the *initial* one. A process group is not a containment boundary: a
 child or descendant that calls `setsid()` leaves it and the record then says nothing about that
 process. A caller who needs "nothing the leg started survives" must either require
@@ -868,10 +891,27 @@ non-daemonizing CLIs or use a platform containment primitive.
 qualifier answers a different channel and none implies the others: `exclude` keeps them out of
 dumps, `SkipJsonSchema` keeps them out of the generated schema (a callable has none, so
 `model_json_schema()` raises without it, which breaks every path that persists a request),
-and `repr=False` keeps a complete child environment out of log lines and exception text. The
-`env` validator raises `TypeError` rather than `ValueError` for the same reason: pydantic turns
-`ValueError` into a `ValidationError` that quotes the whole rejected mapping, so the error path
-would print every value beside the one bad entry.
+and `repr=False` keeps a complete child environment out of log lines and exception text.
+
+Those qualifiers all govern *the model*, and the model is not the only thing that prints a
+child environment. Pydantic renders the input of a failing `mode="before"` validator verbatim,
+and a model-level one holds the whole raw mapping, so a request rejected for a reason having
+nothing to do with `env` — an empty prompt, say — quotes every variable beside the reason. The
+redaction therefore happens at the top of every model-level before-validator and before
+anything there can raise: `env` is replaced by an equal `RedactedEnv`, a real mapping that
+reports `<env: N variable(s)>` instead of itself. Carrying it on the value rather than at each
+error site is what stops a validator added later from reopening the channel by not knowing
+about it, and it is why the two providers each redact at their own validator entry.
+
+Two rejections stay explicit because the redaction cannot reach them:
+
+- An `env` that is not a mapping at all is left alone by the substitution, so the field
+  validator rejects it itself rather than leaving it for pydantic to quote.
+- A mapping with bad entries is rejected as `TypeError`, not `ValueError`: pydantic converts
+  `ValueError` and `AssertionError` into a `ValidationError` that quotes the rejected input and
+  lets everything else propagate untouched. The message names string keys, because a string key
+  is a variable *name* and naming it is what makes the error actionable; a key of any other type
+  is not a name and is reported by position and type only. Values are never printed.
 
 `_runtime_state_fields` on the endpoint does two jobs for those fields, and both are about a
 value that must stay in memory:
@@ -891,6 +931,16 @@ value that must stay in memory:
 `copy_runtime_state_to` carries `_runtime_state` shallowly on purpose. `iModel.copy` deep copies
 the config, and a deep copy of a bound callback rebinds it to a copied receiver, so the original
 supervisor would quietly stop hearing from the copy's legs while everything still looked wired.
+
+The same deep copy sits on the construction path: `Endpoint.__init__` does
+`config.model_copy(deep=True)` before any subclass code runs, so an endpoint built from a
+prepared `EndpointConfig` would hold a callback bound to a copy of the supervisor. The
+constructors therefore call `take_supplied_runtime_state()` *before* `super().__init__()`, which
+reads the declared names off the object the caller actually handed in, and those values win over
+what the copy produced. Nothing is skipped — the copy still happens and the values still leave
+the serialized config — this only decides which of the two receivers the endpoint ends up
+notifying. A test written with a plain nested function cannot see any of this: `deepcopy` of a
+function returns the same object, and only a bound method has a receiver to rebind.
 
 ### `anthropic/claude_code.py`
 

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -854,11 +854,13 @@ child exists and before any output is read. Three things about that record are l
   cancellation point: a runner being torn down is exactly where a second cancellation arrives,
   and a child ignoring `SIGTERM` would then outlive an escalation that never ran. So a
   synchronous `SIGKILL` backstop runs in a `finally` when the graceful path did not complete —
-  no `await`, so nothing can interpose. It is conditioned on `proc.returncode is None` because
-  a completed graceful path has already waited the child, and signalling a pid asyncio has
-  reaped is how a stranger's group gets killed.
+  no `await`, so nothing can interpose. It runs under the same evidence rule as the pass it is
+  backing up rather than under anything about the direct child: an unreaped child is signalled
+  on its own unrecyclable pid, a reaped one only where the group answers with a live member.
+  Signalling a pid asyncio has reaped, with nothing to say the group still holds it, is how a
+  stranger's group gets killed.
 
-- **The record exists even when nothing recorded it.** The OS has already started the child by
+- **The child exists even when nothing recorded it.** The OS has already started the child by
   the time `create_subprocess_exec` resumes, so a cancellation landing in the window before it
   returns leaves a running leg that this process holds no handle for and that no callback has
   seen — unreachable by teardown and by any later sweep over the records. The creation is
@@ -908,8 +910,15 @@ and removed: it covers only the window between the call returning and the caller
 which is not where the cancellation lands. Reaching it needs the pid *before* the creation call
 returns, which means driving `loop.subprocess_exec` with a protocol that records
 `transport.get_pid()` in `connection_made` — declined here because it pins this file to stdlib
-classes outside that module's `__all__` across every supported Python. The orphan is in the
-record the caller writes, so a later sweep over those records still finds it.
+classes outside that module's `__all__` across every supported Python.
+
+Nothing recovers it afterwards either, and an earlier version of this section said otherwise:
+that the orphan sits in the record the caller writes and a later sweep still finds it. It does
+not. `on_spawn` fires only once the creation call has returned, which is the thing that did not
+happen, so in this window there is no record of any kind — the same emptiness the bullet above
+describes, written up two ways that contradicted each other. This is a stated hole rather than
+a handled one. The test for the window asserts the emptiness rather than assuming it, so the
+claim cannot quietly come back, and the log line on that path says what was lost and why.
 
 The group in the record is the *initial* one. A process group is not a containment boundary: a
 child or descendant that calls `setsid()` leaves it and the record then says nothing about that

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -990,21 +990,44 @@ next endpoint-level dump, the value is resting in a serializable field.
 
 So the names are declared on `EndpointConfig` itself, as `RUNTIME_STATE_NAMES`, and that model
 excludes them from its own `kwargs` serializer. The set of callers that can reach a drain is
-open-ended because the model is public; the set that can go around a serializer is empty. The
+open-ended because the model is public, where a serializer runs on every dump that model has. The
 endpoint re-exports the same tuple rather than keeping its own — one list decides what gets
 written down, and a second copy would eventually be the one that fell behind.
 
-`repr` is a separate channel and gets the same treatment through `__repr_args__`, because it
-walks `kwargs` whole: a config excluded from every dump still prints its environment into a
-traceback, a log line, or a debugger. The two channels differ in what they leave behind. A dump
-omits the key, since a dump is something a config is rebuilt from and a placeholder string would
-hydrate as a real value of the wrong type. `repr` reports that a value is set without its
-contents, because nothing is rebuilt from a `repr` and a reader asking why an environment was not
-applied is answered by the key alone.
+A serializer is not every route out, though, and the two it misses are both public. `dict(config)`
+and `list(config)` go through `BaseModel.__iter__`, which yields the raw values held in `__dict__`
+without running a field serializer at all; `json.dumps(dict(config), default=str)` is an ordinary
+way to write an object to a log or a file. `repr` walks `kwargs` whole for the same reason, so a
+config excluded from every dump still prints its environment into a traceback, a log line, or a
+debugger. Both are closed on the model itself, through `__iter__` and `__repr_args__`, which is
+what keeps the answer independent of which caller is asking.
+
+What that covers is the conversion API: the ways this object offers to turn itself into something
+else. It is not a claim about reflection. `config.__dict__` and `pickle` read the instance's raw
+state and still contain these values, deliberately — the runtime value has to live somewhere for
+the endpoint to use it, and a rule that emptied every raw read would take the working value with
+it. The line is between a route that produces a structure for something else to hold, which is
+what ends up in a log or a file, and a route that reads the object's own memory.
+
+The three channels do not all leave the same thing behind. A dump and a `dict()` omit the key,
+since both are structures a config can be rebuilt from and a placeholder string would hydrate as a
+real value of the wrong type. `repr` reports that a value is set without its contents, because
+nothing is rebuilt from a `repr` and a reader asking why an environment was not applied is
+answered by the key alone.
 
 `copy_runtime_state_to` carries `_runtime_state` shallowly on purpose. `iModel.copy` deep copies
 the config, and a deep copy of a bound callback rebinds it to a copied receiver, so the original
 supervisor would quietly stop hearing from the copy's legs while everything still looked wired.
+
+That transfer only carries what the source is actually holding, which is why `iModel.copy` drains
+the source endpoint *before* copying its config rather than after. A value that arrived through
+`update()` is still sitting in `config.kwargs` and has never been drained, so the source's
+`_runtime_state` is empty: the new endpoint drains the copied `kwargs` correctly at construction,
+and then the transfer overwrites that with the empty mapping. The result is a copy whose child
+gets a default environment and whose spawns are reported to nobody. Draining first means the
+copied config has nothing runtime-only left in it and the live objects move across whole. Reading
+the source's state this way does not take it away — a drain relocates a value without changing
+which one wins in `create_payload` — so the original keeps working after being copied.
 
 **The endpoint-instance route.** `iModel(endpoint=<instance>, ...)` is a supported signature,
 and it takes a branch that keeps the endpoint and discards every other keyword. For most

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -821,6 +821,46 @@ runs, `os.getpgid(proc.pid)` raises `ProcessLookupError`. Since `start_new_sessi
 `pgid == proc.pid`, so capturing `proc.pid` right after spawn is equivalent and safe. The
 actual pid-guard/platform check lives in `aterminate_process_group`.
 
+**`on_spawn` and `SpawnedProcess`.** A caller that has to supervise a leg it did not itself
+spawn passes `on_spawn`, which is called exactly once with a `SpawnedProcess` as soon as the
+child exists and before any output is read. Three things about that record are load-bearing:
+
+- **It carries a start time, not just two integers.** `pid` and `pgid` are both recyclable —
+  once a process is reaped the kernel may hand its numbers to anything — so a consumer holding
+  only those cannot tell this child from a stranger that arrived later, and signalling on that
+  basis reaches the stranger. `create_time` binds them, it is readable only while the child is
+  known to exist, and a consumer acting on the record later must compare a live read against
+  it. `None` means nothing was established and is never a claim about the process; this mirrors
+  what `lionagi/mcp/jobs.py` does with `pid_create_time`.
+- **It may be a coroutine function, and the result is awaited.** A durable recorder is written
+  in async style, and `Callable[..., None]` does not reject an `async def` at runtime: an
+  un-awaited one returns a coroutine that is dropped, so the leg runs entirely unrecorded with
+  nothing raised.
+- **Its failure is not swallowed**, including `CancelledError` and `KeyboardInterrupt`. A
+  recorder that fails has no record of a child that is now running, so the child is terminated
+  and the exception propagates. A guard written against `Exception` would let a cancellation
+  through and leave the child alive.
+
+The group in the record is the *initial* one. A process group is not a containment boundary: a
+child or descendant that calls `setsid()` leaves it and the record then says nothing about that
+process. A caller who needs "nothing the leg started survives" must either require
+non-daemonizing CLIs or use a platform containment primitive.
+
+**Runtime-only request fields.** `env` and `on_spawn` on `ClaudeCodeRequest` /
+`CodexCodeRequest` are `SkipJsonSchema[...]` with `exclude=True` and `repr=False`. Each
+qualifier answers a different channel and none implies the others: `exclude` keeps them out of
+dumps, `SkipJsonSchema` keeps them out of the generated schema (a callable has none, so
+`model_json_schema()` raises without it, which breaks every path that persists a request),
+and `repr=False` keeps a complete child environment out of log lines and exception text. The
+`env` validator raises `TypeError` rather than `ValueError` for the same reason: pydantic turns
+`ValueError` into a `ValidationError` that quotes the whole rejected mapping, so the error path
+would print every value beside the one bad entry.
+
+Because `AgenticHandlersMixin.create_payload` rebuilds the request from `to_dict(request)`, and
+that dump omits excluded fields by construction, an endpoint that wants such a field to survive
+the rebuild must name it in `_runtime_state_fields`. Without that, a caller passing a fully
+populated request model silently gets one where the runtime wiring reverted to its defaults.
+
 ### `anthropic/claude_code.py`
 
 - **CLI flag metadata protocol.** Every CLI-mappable `ClaudeCodeRequest` field carries a

--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -832,14 +832,31 @@ child exists and before any output is read. Three things about that record are l
   known to exist, and a consumer acting on the record later must compare a live read against
   it. `None` means nothing was established and is never a claim about the process; this mirrors
   what `lionagi/mcp/jobs.py` does with `pid_create_time`.
+- **The three fields are one observation, within limits worth stating.** The group and the start
+  time are separate reads by pid, so `observe_spawned()` brackets the group read between two
+  start-time reads and drops `create_time` to `None` if they disagree, the same shape as
+  `_pinned_member` in `lionagi/mcp/jobs.py`. That rejects a replacement arriving *during* the
+  observation. It does not speak for one that arrived before the first read, and the window
+  where that is possible is a child that exits and is reaped between the spawn call returning
+  and the first probe — covered not by the bracket but by the probe, which answers `None` for
+  both a reaped pid and a zombie.
 - **It may be a coroutine function, and the result is awaited.** A durable recorder is written
   in async style, and `Callable[..., None]` does not reject an `async def` at runtime: an
   un-awaited one returns a coroutine that is dropped, so the leg runs entirely unrecorded with
-  nothing raised.
+  nothing raised. The await completes before the first byte of output is read, so a consumer
+  acting on the stream is never ahead of the record.
 - **Its failure is not swallowed**, including `CancelledError` and `KeyboardInterrupt`. A
   recorder that fails has no record of a child that is now running, so the child is terminated
   and the exception propagates. A guard written against `Exception` would let a cancellation
   through and leave the child alive.
+- **That termination does not depend on surviving a second cancellation.** The graceful path
+  sends `SIGTERM` and waits out a grace before escalating, and that wait is itself a
+  cancellation point: a runner being torn down is exactly where a second cancellation arrives,
+  and a child ignoring `SIGTERM` would then outlive an escalation that never ran. So a
+  synchronous `SIGKILL` backstop runs in a `finally` when the graceful path did not complete —
+  no `await`, so nothing can interpose. It is conditioned on `proc.returncode is None` because
+  a completed graceful path has already waited the child, and signalling a pid asyncio has
+  reaped is how a stranger's group gets killed.
 
 The group in the record is the *initial* one. A process group is not a containment boundary: a
 child or descendant that calls `setsid()` leaves it and the record then says nothing about that
@@ -856,10 +873,24 @@ and `repr=False` keeps a complete child environment out of log lines and excepti
 `ValueError` into a `ValidationError` that quotes the whole rejected mapping, so the error path
 would print every value beside the one bad entry.
 
-Because `AgenticHandlersMixin.create_payload` rebuilds the request from `to_dict(request)`, and
-that dump omits excluded fields by construction, an endpoint that wants such a field to survive
-the rebuild must name it in `_runtime_state_fields`. Without that, a caller passing a fully
-populated request model silently gets one where the runtime wiring reverted to its defaults.
+`_runtime_state_fields` on the endpoint does two jobs for those fields, and both are about a
+value that must stay in memory:
+
+- **Surviving `create_payload`.** It rebuilds the request from `to_dict(request)`, and that dump
+  omits excluded fields by construction. A field not named here is silently lost, so a caller
+  passing a fully populated request model gets one where the runtime wiring reverted to its
+  defaults.
+- **Staying out of what gets written to disk.** `iModel(**kwargs)` forwards anything it does not
+  recognise into `EndpointConfig.kwargs`, which is a supported way to configure an endpoint and
+  also exactly what `Endpoint.to_dict` serializes — so it reaches `iModel.to_dict`,
+  `Branch.to_dict`, and the run snapshots. A child environment left there is a credential in a
+  saved file, and a callback left there is a function something is about to JSON-encode.
+  `_init_runtime_state()` moves the named values out of `config.kwargs` into `_runtime_state` at
+  construction, where `create_payload` reads them at the same precedence they had before.
+
+`copy_runtime_state_to` carries `_runtime_state` shallowly on purpose. `iModel.copy` deep copies
+the config, and a deep copy of a bound callback rebinds it to a copied receiver, so the original
+supervisor would quietly stop hearing from the copy's legs while everything still looked wired.
 
 ### `anthropic/claude_code.py`
 

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -11,6 +11,112 @@ from typing import Any
 from .concurrency import move_on_after
 
 
+def process_create_time(pid: int) -> tuple[str, float | None]:
+    """When the process at *pid* started: ``("found", t)``, ``("gone", None)``
+    or ``("unknown", None)``.
+
+    "unknown" means the probe errored — the process may still be there — never
+    read it as death or license to signal. A zombie is "gone": it has exited but
+    holds its pid until reaped, so it can't be a recycled pid meanwhile.
+    """
+    import psutil
+
+    try:
+        proc = psutil.Process(pid)
+        if proc.status() == psutil.STATUS_ZOMBIE:
+            return "gone", None
+        return "found", proc.create_time()
+    except psutil.NoSuchProcess:
+        return "gone", None
+    except (psutil.Error, OSError):
+        return "unknown", None
+
+
+def group_member_pids(pgid: int) -> tuple[list[int], bool]:
+    """Pids currently in group *pgid*, and whether the scan was complete.
+
+    The marker-free membership read, for a caller asking only whether a group
+    is empty. It is a separate function rather than :func:`live_group_members`
+    with a field dropped because the marker has to be read INSIDE the identity
+    bracket to belong to the same process, so a read without it is a different
+    observation and not a cheaper version of the same one.
+
+    A caller may act on a non-empty answer without further identity work: a
+    process group id is not reissued while the group still has members, so a
+    group that answers with members is still the one whose id was recorded. An
+    incomplete scan is never emptiness — it is a member that may not have been
+    seen, which is exactly the case where signalling nothing is wrong.
+    """
+    import psutil
+
+    members: list[int] = []
+    complete = True
+    try:
+        pids = psutil.pids()
+    except (psutil.Error, OSError):
+        return [], False
+
+    for pid in pids:
+        if pid <= 1:
+            continue
+        state, created = process_create_time(pid)
+        if state == "gone":
+            continue
+        if state != "found" or created is None:
+            complete = False
+            continue
+        try:
+            in_group = os.getpgid(pid) == pgid
+        except ProcessLookupError:
+            continue
+        except OSError:
+            complete = False
+            continue
+        again, created_again = process_create_time(pid)
+        if again != "found" or created_again != created:
+            complete = False
+            continue
+        if in_group:
+            members.append(pid)
+    return members, complete
+
+
+def safe_pgid_value(pgid: Any) -> int | None:
+    """The group id it is safe to signal, or None.
+
+    Refuses pid<=1 (init, and the value a bad process double reports) and this
+    process's own group, which is the difference between ending a child's group
+    and ending the caller.
+    """
+    if not (hasattr(os, "killpg") and hasattr(os, "getpgrp") and isinstance(pgid, int)):
+        return None
+    if pgid <= 1:
+        return None
+    try:
+        if pgid == os.getpgrp():
+            return None
+    except OSError:
+        return None
+    return pgid
+
+
+def kill_group_now(pgid: Any) -> bool:
+    """SIGKILL a process group, synchronously. Returns whether it was signalled.
+
+    No await anywhere in here, which is the point: it is the backstop for paths
+    whose graceful cleanup can itself be cancelled, and a backstop that can be
+    interrupted is not one.
+    """
+    resolved = safe_pgid_value(pgid)
+    if resolved is None:
+        return False
+    try:
+        os.killpg(resolved, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    return True
+
+
 def _safe_pgid(proc: Any) -> int | None:
     """Return the process-group id to signal, or None when unsafe."""
     pid = getattr(proc, "pid", None)

--- a/lionagi/providers/_agentic_handlers.py
+++ b/lionagi/providers/_agentic_handlers.py
@@ -10,7 +10,12 @@ from pydantic import BaseModel
 
 from lionagi.utils import to_dict
 
-__all__ = ("AgenticHandlersMixin",)
+__all__ = ("RUNTIME_STATE_NAMES", "AgenticHandlersMixin")
+
+# The runtime-only values a CLI endpoint can hold. Named here so a caller that
+# supplies them to an endpoint with no route for them can be refused, which
+# needs the names before any endpoint class is in hand.
+RUNTIME_STATE_NAMES: tuple[str, ...] = ("env", "on_spawn")
 
 
 class AgenticHandlersMixin:
@@ -50,6 +55,36 @@ class AgenticHandlersMixin:
             if name in kwargs:
                 taken[name] = kwargs[name]
         return taken
+
+    def adopt_runtime_state(self, kwargs: dict) -> tuple[str, ...]:
+        """Take declared runtime values onto an endpoint already built.
+
+        The constructor route lifts these off the caller's config before the
+        endpoint exists. A caller who hands over an endpoint INSTANCE has
+        missed that window entirely: the endpoint was built without them, and
+        the values arrive beside an object that is finished. They are written
+        here instead of dropped, which is what happened before and is the worst
+        of the three options — a child would inherit the wrong environment and
+        no supervisor would hear about it, with nothing raised and nothing
+        logged.
+
+        Writing onto the supplied instance rather than a copy is deliberate and
+        matches what the same branch already does with ``provider`` and
+        ``base_url``: the caller handed this object over to be configured. A
+        ``None`` is not a value here, it is the absence of one, and it must not
+        erase state the endpoint was built with.
+
+        Returns the names it could not place, so the caller can refuse rather
+        than let them evaporate.
+        """
+        placed = set()
+        for name in self._runtime_state_fields:
+            if kwargs.get(name) is not None:
+                self._runtime_state[name] = kwargs[name]
+                placed.add(name)
+        return tuple(
+            n for n in RUNTIME_STATE_NAMES if kwargs.get(n) is not None and n not in placed
+        )
 
     def _init_handlers(self, handlers: dict | None = None, supplied: dict | None = None) -> None:
         config_handlers = self.config.kwargs.pop(self._handler_kwarg, None)

--- a/lionagi/providers/_agentic_handlers.py
+++ b/lionagi/providers/_agentic_handlers.py
@@ -18,6 +18,9 @@ class AgenticHandlersMixin:
     _handler_kwarg: ClassVar[str] = ""
     _request_model: ClassVar[type[BaseModel] | None] = None
     _filter_model_fields: ClassVar[bool] = True
+    # Fields excluded from the request model's dump that nonetheless have to
+    # survive create_payload's rebuild. See _carried_runtime_state.
+    _runtime_state_fields: ClassVar[tuple[str, ...]] = ()
 
     def _init_handlers(self, handlers: dict | None = None) -> None:
         config_handlers = self.config.kwargs.pop(self._handler_kwarg, None)
@@ -64,5 +67,33 @@ class AgenticHandlersMixin:
         messages = req_dict.pop("messages", [])
         if self._filter_model_fields and self._request_model is not None:
             req_dict = {k: v for k, v in req_dict.items() if k in self._request_model.model_fields}
+        req_dict.update(self._carried_runtime_state(request, req_dict))
         req_obj = self._request_model(messages=messages, **req_dict)
         return {"request": req_obj}, {}
+
+    def _carried_runtime_state(self, request, req_dict: dict) -> dict:
+        """Values from ``_runtime_state_fields`` that the rebuild would lose.
+
+        The request model is rebuilt here from ``to_dict(request)``, which goes
+        through ``model_dump()`` and so omits every field declared
+        ``exclude=True``. For a field that only shapes serialization that is
+        harmless, but the fields named in ``_runtime_state_fields`` carry live
+        objects the process needs — a child environment, a spawn callback — and
+        losing them hands the CLI a request whose runtime wiring silently
+        reverted to its defaults. The names are declared rather than derived
+        from ``exclude``, because most excluded fields genuinely have nothing to
+        carry and a rule that swept them all in would change unrelated
+        behaviour. Anything already in ``req_dict`` came from an explicit kwarg
+        or from the endpoint config and keeps precedence.
+        """
+        model = self._request_model
+        if model is None or not isinstance(request, model):
+            return {}
+        carried = {}
+        for name in self._runtime_state_fields:
+            if name in req_dict:
+                continue
+            value = getattr(request, name, None)
+            if value is not None:
+                carried[name] = value
+        return carried

--- a/lionagi/providers/_agentic_handlers.py
+++ b/lionagi/providers/_agentic_handlers.py
@@ -8,14 +8,16 @@ from typing import ClassVar
 
 from pydantic import BaseModel
 
+from lionagi.service.connections.endpoint_config import RUNTIME_STATE_NAMES
 from lionagi.utils import to_dict
 
 __all__ = ("RUNTIME_STATE_NAMES", "AgenticHandlersMixin")
 
-# The runtime-only values a CLI endpoint can hold. Named here so a caller that
-# supplies them to an endpoint with no route for them can be refused, which
-# needs the names before any endpoint class is in hand.
-RUNTIME_STATE_NAMES: tuple[str, ...] = ("env", "on_spawn")
+# RUNTIME_STATE_NAMES is re-exported, not redefined. It is declared beside the
+# config that must not serialize these values, because that model is what every
+# route to a written-down config passes through; a second list here would be a
+# second thing to keep in step, and the one that fell behind would be the one
+# deciding what gets written down.
 
 
 class AgenticHandlersMixin:

--- a/lionagi/providers/_agentic_handlers.py
+++ b/lionagi/providers/_agentic_handlers.py
@@ -31,6 +31,31 @@ class AgenticHandlersMixin:
         if handlers is not None:
             self._validate_handlers(handlers)
             self._handlers.update(handlers)
+        # Called from here so every endpoint that initialises handlers gets it,
+        # rather than from four constructors where the fifth would be missed.
+        self._init_runtime_state()
+
+    def _init_runtime_state(self) -> None:
+        """Move declared runtime state out of the serializable endpoint config.
+
+        ``iModel(**kwargs)`` forwards anything it does not recognise into
+        ``EndpointConfig.kwargs``, which is a supported way to configure an
+        endpoint and also the thing ``Endpoint.to_dict`` serializes — so it
+        reaches ``iModel.to_dict``, ``Branch.to_dict``, and from there the run
+        snapshots written to disk. A child environment left there is a
+        credential in a saved file, and a callback left there is a function in a
+        structure something is about to JSON-encode.
+
+        Holding it here instead keeps the same configuration route working while
+        the value stays in memory. It also survives ``iModel.copy``, which deep
+        copies the config and then calls ``copy_runtime_state_to``: a deep copy
+        of a bound callback rebinds it to a copied receiver, so the original
+        supervisor would quietly stop hearing from the copy's legs.
+        """
+        self._runtime_state: dict[str, object] = {}
+        for name in self._runtime_state_fields:
+            if name in self.config.kwargs:
+                self._runtime_state[name] = self.config.kwargs.pop(name)
 
     def _validate_handlers(self, handlers: dict[str, Callable | None], /) -> None:
         if not isinstance(handlers, dict):
@@ -53,6 +78,10 @@ class AgenticHandlersMixin:
     def copy_runtime_state_to(self, other) -> None:
         if isinstance(other, type(self)):
             other._set_handlers(self._handlers.copy())
+            # Shallow on purpose. These are live objects — an open callback, a
+            # mapping the caller may still hold — and copying them would hand
+            # the copy a different object under the same name.
+            other._runtime_state = dict(self._runtime_state)
 
     def _runtime_handlers(self, kwargs: dict) -> dict:
         handlers = self._handlers.copy()
@@ -63,7 +92,10 @@ class AgenticHandlersMixin:
         return {k: v for k, v in handlers.items() if v is not None}
 
     def create_payload(self, request: dict | BaseModel, **kwargs):
-        req_dict = {**self.config.kwargs, **to_dict(request), **kwargs}
+        # _runtime_state sits where its values sat when they were still in
+        # config.kwargs, so moving them out of the serialized config changed
+        # where they live and not which one wins.
+        req_dict = {**self._runtime_state, **self.config.kwargs, **to_dict(request), **kwargs}
         messages = req_dict.pop("messages", [])
         if self._filter_model_fields and self._request_model is not None:
             req_dict = {k: v for k, v in req_dict.items() if k in self._request_model.model_fields}

--- a/lionagi/providers/_agentic_handlers.py
+++ b/lionagi/providers/_agentic_handlers.py
@@ -117,14 +117,45 @@ class AgenticHandlersMixin:
         supervisor would quietly stop hearing from the copy's legs.
         """
         self._runtime_state: dict[str, object] = {}
-        for name in self._runtime_state_fields:
-            if name in self.config.kwargs:
-                self._runtime_state[name] = self.config.kwargs.pop(name)
+        self.drain_runtime_state()
         # Values taken off the caller's own objects win over what the pop just
         # produced: everything in config.kwargs came through a deep copy, and
         # for a bound callback that copy is a different receiver.
         if supplied:
             self._runtime_state.update(supplied)
+
+    def drain_runtime_state(self) -> None:
+        """Move declared runtime values out of the serializable config.
+
+        Called wherever the config is about to be READ rather than only at
+        construction, because construction is not the only way these values
+        get in. ``EndpointConfig.update()`` puts unknown keys straight back
+        into ``kwargs``, and ``iModel.from_dict()`` assigns a hydrated config
+        over the specialized one. Both are public routes and both bypass a
+        drain that happens once.
+
+        Draining keeps the value working while taking it out of what gets
+        written down: the value moves to ``_runtime_state``, which
+        ``create_payload`` reads at the same precedence ``config.kwargs`` had.
+
+        Serialization is the only place this is called from besides
+        construction, and deliberately so. ``create_payload`` reads
+        ``config.kwargs`` directly, so a value sitting there still works
+        without being drained first, and a drain on that path was measured to
+        change no observable behaviour. Writing it down is what makes a
+        credential durable, so that is where the drain belongs.
+        """
+        for name in self._runtime_state_fields:
+            if name in self.config.kwargs:
+                self._runtime_state[name] = self.config.kwargs.pop(name)
+
+    def to_dict(self, **kwargs):
+        """Drain before serializing. A child environment reaching a run
+        snapshot is a credential in a saved file, and the value that got there
+        after construction is the same credential as the one that was there
+        before it."""
+        self.drain_runtime_state()
+        return super().to_dict(**kwargs)
 
     def _validate_handlers(self, handlers: dict[str, Callable | None], /) -> None:
         if not isinstance(handlers, dict):

--- a/lionagi/providers/_agentic_handlers.py
+++ b/lionagi/providers/_agentic_handlers.py
@@ -22,7 +22,36 @@ class AgenticHandlersMixin:
     # survive create_payload's rebuild. See _carried_runtime_state.
     _runtime_state_fields: ClassVar[tuple[str, ...]] = ()
 
-    def _init_handlers(self, handlers: dict | None = None) -> None:
+    @classmethod
+    def take_supplied_runtime_state(cls, config, kwargs: dict) -> dict:
+        """Lift the declared runtime values off the caller's OWN objects.
+
+        Called before ``Endpoint.__init__``, which copies a supplied
+        ``EndpointConfig`` with ``model_copy(deep=True)``. A deep copy of a
+        bound method copies its receiver too, so the callback that reaches the
+        CLI would notify a copy of the supervisor while the real one — the
+        thing that owns the durable process accounting — hears nothing, and
+        every wiring check still passes. Reading the values here, from the
+        object the caller handed in, is what preserves identity.
+
+        Nothing is mutated: the copy still happens and the copied values are
+        still removed from the serialized config afterwards. This only decides
+        which of the two the endpoint ends up holding.
+        """
+        taken: dict[str, object] = {}
+        source = getattr(config, "kwargs", None)
+        if isinstance(config, dict):
+            source = config
+        if isinstance(source, dict):
+            for name in cls._runtime_state_fields:
+                if name in source:
+                    taken[name] = source[name]
+        for name in cls._runtime_state_fields:
+            if name in kwargs:
+                taken[name] = kwargs[name]
+        return taken
+
+    def _init_handlers(self, handlers: dict | None = None, supplied: dict | None = None) -> None:
         config_handlers = self.config.kwargs.pop(self._handler_kwarg, None)
         self._handlers: dict[str, Callable | None] = {k: None for k in self._handler_params}
         if config_handlers is not None:
@@ -33,9 +62,9 @@ class AgenticHandlersMixin:
             self._handlers.update(handlers)
         # Called from here so every endpoint that initialises handlers gets it,
         # rather than from four constructors where the fifth would be missed.
-        self._init_runtime_state()
+        self._init_runtime_state(supplied)
 
-    def _init_runtime_state(self) -> None:
+    def _init_runtime_state(self, supplied: dict | None = None) -> None:
         """Move declared runtime state out of the serializable endpoint config.
 
         ``iModel(**kwargs)`` forwards anything it does not recognise into
@@ -56,6 +85,11 @@ class AgenticHandlersMixin:
         for name in self._runtime_state_fields:
             if name in self.config.kwargs:
                 self._runtime_state[name] = self.config.kwargs.pop(name)
+        # Values taken off the caller's own objects win over what the pop just
+        # produced: everything in config.kwargs came through a deep copy, and
+        # for a bound callback that copy is a different receiver.
+        if supplied:
+            self._runtime_state.update(supplied)
 
     def _validate_handlers(self, handlers: dict[str, Callable | None], /) -> None:
         if not isinstance(handlers, dict):

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -92,23 +92,40 @@ class SpawnedProcess:
     create_time: float | None
 
 
-class RedactedEnv(dict):
-    """A child environment that does not print itself.
+class Redacted:
+    """A runtime-only value, wrapped so that nothing can print or serialize it.
 
-    ``repr=False`` on the field keeps the mapping out of a request's own
-    representation, and that is not the whole channel: pydantic renders the
-    input of a failing model-level validator verbatim, so a request rejected
-    for an unrelated reason — an empty prompt, say — prints every variable
-    beside it. Carrying the redaction on the value rather than at each error
-    site is what stops a validator added later from reopening the leak by not
-    knowing about it.
+    ``repr=False`` on the field keeps a value out of a request's own
+    representation, and that is only one channel. Pydantic keeps the raw input
+    of a failing ``mode="before"`` validator on the error, and a model-level
+    validator holds the WHOLE raw mapping, so a request rejected for an
+    unrelated reason — an empty prompt, say — carries the child environment
+    along with the reason.
 
-    It is a real mapping in every other respect, so nothing downstream has to
-    know it exists.
+    **Not a mapping, and that is the entire point.** A ``dict`` subclass with a
+    quiet ``__repr__`` closes the rendering channel and leaves the
+    serialization one wide open: ``str(err)`` and ``err.errors()`` go through
+    ``repr``, but ``err.json()`` walks the structure and writes out every key
+    and value, and ``err.json()`` is what a structured logger emits. Pydantic
+    has no structure to walk here, so all three channels get the same summary.
+
+    The real value stays reachable through :meth:`reveal` for the one validator
+    that has to look at it.
     """
 
+    __slots__ = ("_value", "_label")
+
+    def __init__(self, value, label: str) -> None:
+        self._value = value
+        self._label = label
+
+    def reveal(self):
+        return self._value
+
     def __repr__(self) -> str:
-        return f"<env: {len(self)} variable(s)>"
+        if isinstance(self._value, Mapping):
+            return f"<{self._label}: {len(self._value)} variable(s)>"
+        return f"<{self._label}: redacted>"
 
     __str__ = __repr__
 
@@ -142,39 +159,110 @@ def raise_if_env_is_not_a_string_map(value: Mapping) -> None:
 
 
 def redact_runtime_fields_in_place(data) -> None:
-    """Make the runtime-only values in a raw request mapping unprintable.
+    """Wrap the runtime-only values in a raw request mapping so nothing can
+    print or serialize them.
 
     Called at the top of every model-level ``mode="before"`` validator, because
-    that is the one place a validator holds the WHOLE raw input: pydantic
-    renders the input of a failing validator verbatim, so a request rejected
-    for an unrelated reason prints the child environment beside the reason.
-    ``exclude`` and ``repr=False`` do not reach this channel — they govern the
-    model, and this runs before a model exists.
+    that is the one place a validator holds the WHOLE raw input, and pydantic
+    keeps a failing validator's raw input on the error. ``exclude`` and
+    ``repr=False`` do not reach that channel: they govern the model, and this
+    runs before a model exists.
 
-    In place, and only substituting a mapping for an equal one that prints
-    differently, so nothing downstream sees a different value.
+    Every declared runtime field is wrapped, not just ``env``. ``on_spawn`` is
+    a callback, and a bound one carries its receiver into its own ``repr``, so
+    a supervisor holding credentials would print them from the same error. The
+    wrapper is unwrapped by the field validators, which are the only code that
+    needs the value.
+
+    Anything the raw mapping holds under any other key is untouched and is not
+    covered by this. The claim here is about the two declared runtime fields.
     """
-    if not isinstance(data, dict):
+    if not isinstance(data, Mapping):
         return
-    env = data.get("env")
-    if isinstance(env, Mapping) and not isinstance(env, RedactedEnv):
-        data["env"] = RedactedEnv(env)
+    for name in ("env", "on_spawn"):
+        value = data.get(name)
+        if value is None or isinstance(value, Redacted):
+            continue
+        try:
+            data[name] = Redacted(value, name)
+        except TypeError:
+            # An immutable mapping: nothing to substitute into, and returning
+            # quietly would leave the caller believing this ran. The field
+            # validators still reject or unwrap what they are given.
+            return
 
 
 def _kill_abandoned_spawn(task: asyncio.Future) -> None:
-    """End the group of a child whose creator was cancelled before it resumed.
+    """End the group of a child nobody is left to receive.
 
-    Runs as a done-callback because by then nothing is left to await from: the
-    coroutine that asked for the child has already unwound. The exception is
-    retrieved either way, or asyncio reports it as never-retrieved at exit and
-    a cancelled spawn starts looking like a defect in the spawn.
+    Runs as a done-callback because by then there is nothing left to await
+    from: the coroutine that asked for the child has already unwound.
+
+    A cancelled task is a KNOWN HOLE here, not a case of nothing having
+    happened, and it is logged rather than passed over in silence. Interpreter
+    shutdown cancels pending tasks, and a cancellation landing inside the
+    creation call leaves a child the OS has made and whose pid was never
+    returned to anyone in this process. asyncio closes the transport on that
+    path, which ends the direct child; the group it leads is not reached,
+    because reaching it needs the pid.
+
+    This was measured rather than reasoned about: a leg spawned under a loop
+    that then shuts down leaves a SIGTERM-ignoring descendant running, and it
+    still does. Recording the handle as soon as the creation call returns was
+    tried and removed — it covers only a window between the call returning and
+    the caller resuming, which is not where the cancellation lands.
+
+    Closing it needs the pid before the creation call returns. There is a route
+    to that: driving ``loop.subprocess_exec`` with a protocol that records
+    ``transport.get_pid()`` in ``connection_made``, which the loop schedules
+    before the cancellable wait. It is declined here because it means
+    reimplementing ``create_subprocess_exec`` on top of stdlib classes outside
+    that module's ``__all__``, pinning this file to their shape across every
+    Python version supported. The orphan that results is recorded by the
+    manifest the caller writes, so a later sweep over those records still finds
+    it; that is the layer this is left to.
+
+    The exception is retrieved where there is one, or asyncio reports it as
+    never-retrieved at exit and a cancelled spawn starts looking like a defect
+    in the spawn.
     """
     if task.cancelled():
+        log.warning(
+            "the spawn task was cancelled before it produced a handle. If the OS had "
+            "already created the child, nothing in this process can reach it: the pid "
+            "was never returned to anyone. asyncio closes the transport on this path, "
+            "which ends the direct child but not the group it leads"
+        )
         return
     if task.exception() is not None:
         return
-    proc = task.result()
-    kill_group_now(getattr(proc, "pid", None))
+    kill_group_now(getattr(task.result(), "pid", None))
+
+
+def _kill_group_if_occupied(pgid: Any) -> str:
+    """End a process group if it can be shown to still hold someone.
+
+    Returns what happened, which the caller does not currently branch on but a
+    reader of the log needs: ``killed``, ``empty``, ``unproven`` or
+    ``no-group``. The unproven case is the one that matters — a process table
+    that could not be read completely and showed no members is not an empty
+    group, and it is the only outcome here where something may still be running
+    and nothing was done about it, so it says so rather than passing as clean.
+    """
+    if not isinstance(pgid, int):
+        return "no-group"
+    members, complete = group_member_pids(pgid)
+    if members:
+        kill_group_now(pgid)
+        return "killed"
+    if not complete:
+        log.warning(
+            "process group %s could not be read completely and showed no members; "
+            "leaving it alone rather than signalling a possibly reissued group id",
+            pgid,
+        )
+        return "unproven"
+    return "empty"
 
 
 async def end_child_group(proc: Any, *, grace: float = 5.0) -> None:
@@ -195,30 +283,42 @@ async def end_child_group(proc: Any, *, grace: float = 5.0) -> None:
     runs in a ``finally`` when that pass did not finish: no await, so nothing
     can interpose.
 
-    Both kills fire only on positive evidence that the group id is still this
-    child's, because the other direction is worse than an orphan. After a
-    completed graceful pass the child has been waited, so its pid — and hence
-    this group id — may already belong to someone else; the evidence there is
-    a live member, since an occupied group is never reissued. On the cancelled
-    path the child has not been waited at all, so the id is unambiguously ours.
+    Every signal it sends is conditioned on the recorded group id still being
+    this child's, and there are exactly two things that establish that. Either
+    the child has not been waited, in which case its pid cannot have been
+    reissued and the polite signal is safe; or the group answers with a live
+    member, and an occupied group is never reissued. Nothing else counts, and
+    the graceful helper is therefore reached ONLY on the not-yet-waited path:
+    it signals the group id it is given without checking anything, so calling it
+    after a normal drain would send SIGTERM to whatever now holds a recycled id.
+
+    The escalation keys on that membership evidence rather than on whether the
+    direct child is dead. Those are different facts: a leader that died to
+    SIGTERM sets ``returncode`` while a descendant ignoring SIGTERM is still in
+    its group, and a backstop gated on the leader's liveness reads that as
+    nothing left to do. Confusing the two is the defect this function exists to
+    fix, so it must not be the condition the fix runs under.
 
     What it therefore cannot close, rather than papering over it: a scan that
     could not read the whole process table and saw no members leaves emptiness
     unproved, and this refuses to signal on that, because an unprovable group
-    and a reissued one look the same from here.
+    and a reissued one look the same from here. That refusal is logged rather
+    than silent — it is the one outcome where something may still be running
+    and nothing was done about it.
     """
     pgid = getattr(proc, "pid", None)
-    graceful_done = False
+    swept = False
     try:
-        await aterminate_process_group(proc, grace=grace)
-        graceful_done = True
-        if isinstance(pgid, int):
-            members, _complete = group_member_pids(pgid)
-            if members:
-                kill_group_now(pgid)
+        if getattr(proc, "returncode", None) is None:
+            await aterminate_process_group(proc, grace=grace)
+        _kill_group_if_occupied(pgid)
+        swept = True
     finally:
-        if not graceful_done and getattr(proc, "returncode", None) is None:
-            kill_group_now(pgid)
+        # Synchronous, so a second cancellation cannot interpose, and keyed on
+        # the same membership evidence as the pass it is backing up rather than
+        # on anything about the direct child.
+        if not swept:
+            _kill_group_if_occupied(pgid)
 
 
 def observe_spawned(pid: int) -> SpawnedProcess:

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -241,9 +241,14 @@ def _kill_abandoned_spawn(task: asyncio.Future) -> None:
     before the cancellable wait. It is declined here because it means
     reimplementing ``create_subprocess_exec`` on top of stdlib classes outside
     that module's ``__all__``, pinning this file to their shape across every
-    Python version supported. The orphan that results is recorded by the
-    manifest the caller writes, so a later sweep over those records still finds
-    it; that is the layer this is left to.
+    Python version supported.
+
+    Nor does anything recover it later. This said the opposite until it was
+    read against the code: that the orphan is in the record the caller writes
+    and a later sweep still finds it. ``on_spawn`` fires only once the creation
+    call has returned, which is precisely what did not happen here, so the
+    window leaves no record of any kind — which is what the log line is for,
+    and why it is a warning. Left as a stated hole, not a handled one.
 
     The exception is retrieved where there is one, or asyncio reports it as
     never-retrieved at exit and a cancelled spawn starts looking like a defect

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -176,20 +176,43 @@ def redact_runtime_fields_in_place(data) -> None:
 
     Anything the raw mapping holds under any other key is untouched and is not
     covered by this. The claim here is about the two declared runtime fields.
+
+    **An immutable mapping is refused, not skipped.** Substituting in place is
+    not a convenience here, it is the whole mechanism: pydantic keeps the
+    object that was passed INTO the failing validator, so handing back a
+    sanitized copy changes nothing about what the error holds. When the raw
+    input cannot be written to, there is no way to make it safe, and the only
+    two options are to leak it or to refuse it. ``BaseModel.model_validate()``
+    accepts any mapping, so this route is public and reachable, and skipping
+    quietly meant a credential in ``str(exc)``, ``exc.errors()`` and
+    ``exc.json()`` alike.
+
+    The refusal is a ``TypeError`` because pydantic converts ``ValueError`` and
+    ``AssertionError`` into a ``ValidationError`` that quotes the rejected
+    input, which would reintroduce exactly what is being prevented. It names
+    the fields and the mapping type and never the values. A mapping carrying
+    neither runtime field has nothing to protect and passes through, so
+    read-only inputs are not broken in general.
     """
     if not isinstance(data, Mapping):
         return
-    for name in ("env", "on_spawn"):
-        value = data.get(name)
-        if value is None or isinstance(value, Redacted):
-            continue
-        try:
-            data[name] = Redacted(value, name)
-        except TypeError:
-            # An immutable mapping: nothing to substitute into, and returning
-            # quietly would leave the caller believing this ran. The field
-            # validators still reject or unwrap what they are given.
-            return
+    present = [
+        name
+        for name in ("env", "on_spawn")
+        if data.get(name) is not None and not isinstance(data.get(name), Redacted)
+    ]
+    if not present:
+        return
+    try:
+        for name in present:
+            data[name] = Redacted(data[name], name)
+    except TypeError:
+        raise TypeError(
+            f"{type(data).__name__} is read-only, so the runtime-only field(s) "
+            f"{', '.join(present)} cannot be replaced before validation. These carry a "
+            "child environment and a spawn callback, and a validation error would "
+            "render the mapping verbatim. Pass a mutable mapping."
+        ) from None
 
 
 def _kill_abandoned_spawn(task: asyncio.Future) -> None:

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -8,6 +8,7 @@ import codecs
 import contextlib
 import json
 import logging
+import os
 import shutil
 from collections.abc import AsyncIterator, Callable
 from functools import partial
@@ -25,6 +26,20 @@ log = logging.getLogger(__name__)
 _INHERIT_STDIN = object()
 
 
+def spawned_pgid(pid: int) -> int:
+    """The process group of a just-spawned child.
+
+    Falls back to the child's own pid: every spawn here uses
+    ``start_new_session``, so the child leads its own group by construction and
+    that pid IS the group id whenever the read fails because the child has
+    already exited.
+    """
+    try:
+        return os.getpgid(pid)
+    except OSError:
+        return pid
+
+
 async def ndjson_from_cli(
     cmd: list[str],
     *,
@@ -33,6 +48,7 @@ async def ndjson_from_cli(
     stdin: Any = asyncio.subprocess.DEVNULL,
     stdin_data: str | bytes | None = None,
     tail_repair: Callable[[str], dict | None] | None = None,
+    on_spawn: Callable[[int, int], None] | None = None,
 ) -> AsyncIterator[dict]:
     """Yield dicts from an NDJSON-emitting CLI subprocess; tail_repair handles malformed final chunks.
 
@@ -44,6 +60,14 @@ async def ndjson_from_cli(
     soon as the data exceeds the pipe buffer and the child is blocked writing
     output nobody is draining), and the pipe is closed afterwards so the child
     sees EOF rather than waiting forever for more input.
+
+    ``on_spawn`` is called once with ``(pid, pgid)`` immediately after the
+    child exists, for a caller that must record the process identity of a
+    process it did not itself spawn. It is deliberately not wrapped in an
+    exception guard: a caller whose recording fails has no record of a child
+    that is now running, and swallowing that leaves a live process outside
+    whatever domain the record defines. The exception propagates through the
+    teardown below, which ends the group it was called for.
     """
     kwargs: dict[str, Any] = dict(
         cwd=str(cwd) if cwd else None,
@@ -57,8 +81,15 @@ async def ndjson_from_cli(
     elif stdin is not _INHERIT_STDIN:
         kwargs["stdin"] = stdin
     proc = await asyncio.create_subprocess_exec(*cmd, **kwargs)
-    # Capture PGID immediately — waiting until teardown risks ProcessLookupError
-    # if the child already exited. See docs/internals/runtime.md.
+    if on_spawn is not None:
+        # Read the group here, not at teardown: once the child is reaped its
+        # pid is recyclable, so a group read then can resolve to a stranger's.
+        # See docs/internals/runtime.md.
+        try:
+            on_spawn(proc.pid, spawned_pgid(proc.pid))
+        except BaseException:
+            await aterminate_process_group(proc, grace=5.0)
+            raise
 
     decoder = codecs.getincrementaldecoder("utf-8")()
     json_decoder = json.JSONDecoder()

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from lionagi.libs.path_safety import contain_and_resolve, has_traversal
 from lionagi.libs.schema.as_readable import as_readable
-from lionagi.ln._proc import aterminate_process_group
+from lionagi.ln._proc import aterminate_process_group, terminate_process_group
 from lionagi.ln.concurrency.utils import maybe_await
 
 log = logging.getLogger(__name__)
@@ -88,6 +88,31 @@ class SpawnedProcess:
     create_time: float | None
 
 
+def observe_spawned(pid: int) -> SpawnedProcess:
+    """Read pid, group and start time as one observation of one process.
+
+    The group and the start time are two facts read separately by pid, and a
+    pid the OS reassigns between them answers the later read as the replacement
+    process. A record assembled from those two answers would describe no
+    process that ever existed, so the group read is bracketed by the start
+    time: read before, read again after, required to be unchanged. A failed
+    bracket yields ``create_time=None``, which already means "no identity was
+    captured" and is what stops a consumer from signalling on it.
+
+    The bracket rejects a replacement arriving DURING the observation. It
+    cannot speak for one that arrived before the first read, and the window
+    where that is possible is a child that exits and is reaped between the
+    spawn call returning and the first probe. What covers that window is the
+    probe itself: a reaped pid holds no process and an exited-not-yet-reaped
+    one is a zombie, and :func:`spawned_create_time` answers None to both.
+    """
+    created = spawned_create_time(pid)
+    pgid = spawned_pgid(pid)
+    if created is not None and spawned_create_time(pid) != created:
+        created = None
+    return SpawnedProcess(pid=pid, pgid=pgid, create_time=created)
+
+
 async def ndjson_from_cli(
     cmd: list[str],
     *,
@@ -138,17 +163,23 @@ async def ndjson_from_cli(
         # to a stranger's, and the start time that would have told them apart is
         # readable only while the process is alive. See docs/internals/runtime.md.
         try:
-            await maybe_await(
-                on_spawn(
-                    SpawnedProcess(
-                        pid=proc.pid,
-                        pgid=spawned_pgid(proc.pid),
-                        create_time=spawned_create_time(proc.pid),
-                    )
-                )
-            )
+            await maybe_await(on_spawn(observe_spawned(proc.pid)))
         except BaseException:
-            await aterminate_process_group(proc, grace=5.0)
+            cleaned = False
+            try:
+                await aterminate_process_group(proc, grace=5.0)
+                cleaned = True
+            finally:
+                # A cancellation arriving while the graceful path waits out its
+                # grace skips the SIGKILL escalation that path ends with, and a
+                # child ignoring SIGTERM then survives with nobody holding a
+                # record of it. This backstop takes no await, so there is no
+                # point at which a further cancellation can interpose.
+                # Conditioned on returncode because a completed graceful path
+                # has waited the child, and signalling a pid asyncio has
+                # already reaped is how a stranger's group gets killed.
+                if not cleaned and proc.returncode is None:
+                    terminate_process_group(proc, grace=None)
             raise
 
     decoder = codecs.getincrementaldecoder("utf-8")()

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -10,7 +10,8 @@ import json
 import logging
 import os
 import shutil
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,7 @@ from typing import Any
 from lionagi.libs.path_safety import contain_and_resolve, has_traversal
 from lionagi.libs.schema.as_readable import as_readable
 from lionagi.ln._proc import aterminate_process_group
+from lionagi.ln.concurrency.utils import maybe_await
 
 log = logging.getLogger(__name__)
 
@@ -40,6 +42,52 @@ def spawned_pgid(pid: int) -> int:
         return pid
 
 
+def spawned_create_time(pid: int) -> float | None:
+    """When the process at *pid* started, or None if that cannot be established.
+
+    The pid and the group id are both recyclable: once a process is reaped the
+    kernel is free to hand its numbers to anything, so a reader that has only
+    those two integers cannot tell this child from a stranger that arrived
+    later. The start time is what binds them to one process, and it is readable
+    only here, while the child is known to exist.
+
+    None is not a claim. It means the probe found no process or errored, and a
+    consumer must treat it as "no identity was captured" rather than as a
+    statement about the child.
+    """
+    import psutil
+
+    try:
+        proc = psutil.Process(pid)
+        if proc.status() == psutil.STATUS_ZOMBIE:
+            return None
+        return proc.create_time()
+    except (psutil.Error, OSError):
+        return None
+
+
+@dataclass(frozen=True)
+class SpawnedProcess:
+    """The identity of a CLI child, as read at the moment it came into being.
+
+    ``pid`` and ``pgid`` are the handles a later sweep signals. ``create_time``
+    is what makes them an identity rather than two integers the OS may have
+    reissued in the meantime, so a consumer that intends to act on this record
+    later must compare a live start-time read against it and refuse to signal
+    when they disagree or when this field is None.
+
+    The group is the initial one, and a process group is not a containment
+    boundary: a child or descendant that calls ``setsid()`` leaves it, and this
+    record then says nothing about that process. Callers who need "nothing the
+    leg started survives" must either require non-daemonizing CLIs or use a
+    platform containment primitive; the group alone will not give it to them.
+    """
+
+    pid: int
+    pgid: int
+    create_time: float | None
+
+
 async def ndjson_from_cli(
     cmd: list[str],
     *,
@@ -48,7 +96,7 @@ async def ndjson_from_cli(
     stdin: Any = asyncio.subprocess.DEVNULL,
     stdin_data: str | bytes | None = None,
     tail_repair: Callable[[str], dict | None] | None = None,
-    on_spawn: Callable[[int, int], None] | None = None,
+    on_spawn: Callable[[SpawnedProcess], None | Awaitable[None]] | None = None,
 ) -> AsyncIterator[dict]:
     """Yield dicts from an NDJSON-emitting CLI subprocess; tail_repair handles malformed final chunks.
 
@@ -61,13 +109,16 @@ async def ndjson_from_cli(
     output nobody is draining), and the pipe is closed afterwards so the child
     sees EOF rather than waiting forever for more input.
 
-    ``on_spawn`` is called once with ``(pid, pgid)`` immediately after the
-    child exists, for a caller that must record the process identity of a
-    process it did not itself spawn. It is deliberately not wrapped in an
-    exception guard: a caller whose recording fails has no record of a child
-    that is now running, and swallowing that leaves a live process outside
-    whatever domain the record defines. The exception propagates through the
-    teardown below, which ends the group it was called for.
+    ``on_spawn`` is called once with a :class:`SpawnedProcess` immediately
+    after the child exists, for a caller that must record the process identity
+    of a process it did not itself spawn. It may be a coroutine function; the
+    result is awaited before the first byte of output is read, so a recorder
+    that writes durably has finished writing before anything can consume the
+    stream. Its failure is deliberately not swallowed: a caller whose recording
+    fails has no record of a child that is now running, and continuing would
+    leave a live process outside whatever domain the record defines. The
+    exception propagates through the teardown below, which ends the group it
+    was called for.
     """
     kwargs: dict[str, Any] = dict(
         cwd=str(cwd) if cwd else None,
@@ -82,11 +133,20 @@ async def ndjson_from_cli(
         kwargs["stdin"] = stdin
     proc = await asyncio.create_subprocess_exec(*cmd, **kwargs)
     if on_spawn is not None:
-        # Read the group here, not at teardown: once the child is reaped its
-        # pid is recyclable, so a group read then can resolve to a stranger's.
-        # See docs/internals/runtime.md.
+        # Read the identity here, not at teardown: once the child is reaped its
+        # pid and group id are both recyclable, so either read then can resolve
+        # to a stranger's, and the start time that would have told them apart is
+        # readable only while the process is alive. See docs/internals/runtime.md.
         try:
-            on_spawn(proc.pid, spawned_pgid(proc.pid))
+            await maybe_await(
+                on_spawn(
+                    SpawnedProcess(
+                        pid=proc.pid,
+                        pgid=spawned_pgid(proc.pid),
+                        create_time=spawned_create_time(proc.pid),
+                    )
+                )
+            )
         except BaseException:
             await aterminate_process_group(proc, grace=5.0)
             raise

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -259,7 +259,31 @@ def _kill_abandoned_spawn(task: asyncio.Future) -> None:
         return
     if task.exception() is not None:
         return
-    kill_group_now(getattr(task.result(), "pid", None))
+    # Not a raw kill: a spawn that completed may ALSO have been reaped by the
+    # time this callback runs, and a reaped pid names whatever now holds it.
+    _end_group_with_evidence(task.result())
+
+
+def _end_group_with_evidence(proc: Any) -> str:
+    """End a child's group wherever its identity can be established.
+
+    TWO facts establish that a recorded group id still belongs to this child,
+    and they cover different moments, so checking only one leaves a hole where
+    the other applies. While the child is unreaped its pid cannot have been
+    reissued, so the group id is provably still its own and no scan is needed.
+    Once it has been reaped, only a live member pins that id, which is what the
+    membership scan looks for.
+
+    Checking only the second is what left a SIGTERM-ignoring descendant running
+    whenever the process table could not be read: the refusal is correct AFTER
+    the reap and wrong before it, where identity was never in question. The rule
+    was stated correctly and implemented halfway, which is the kind of gap that
+    reads as caution rather than as a defect.
+    """
+    pgid = getattr(proc, "pid", None)
+    if getattr(proc, "returncode", None) is None:
+        return "killed-unreaped" if kill_group_now(pgid) else "no-group"
+    return _kill_group_if_occupied(pgid)
 
 
 def _kill_group_if_occupied(pgid: Any) -> str:
@@ -329,19 +353,18 @@ async def end_child_group(proc: Any, *, grace: float = 5.0) -> None:
     than silent — it is the one outcome where something may still be running
     and nothing was done about it.
     """
-    pgid = getattr(proc, "pid", None)
     swept = False
     try:
         if getattr(proc, "returncode", None) is None:
             await aterminate_process_group(proc, grace=grace)
-        _kill_group_if_occupied(pgid)
+        _end_group_with_evidence(proc)
         swept = True
     finally:
         # Synchronous, so a second cancellation cannot interpose, and keyed on
         # the same membership evidence as the pass it is backing up rather than
         # on anything about the direct child.
         if not swept:
-            _kill_group_if_occupied(pgid)
+            _end_group_with_evidence(proc)
 
 
 def observe_spawned(pid: int) -> SpawnedProcess:

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import shutil
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -18,7 +18,11 @@ from typing import Any
 
 from lionagi.libs.path_safety import contain_and_resolve, has_traversal
 from lionagi.libs.schema.as_readable import as_readable
-from lionagi.ln._proc import aterminate_process_group, terminate_process_group
+from lionagi.ln._proc import (
+    aterminate_process_group,
+    group_member_pids,
+    kill_group_now,
+)
 from lionagi.ln.concurrency.utils import maybe_await
 
 log = logging.getLogger(__name__)
@@ -86,6 +90,135 @@ class SpawnedProcess:
     pid: int
     pgid: int
     create_time: float | None
+
+
+class RedactedEnv(dict):
+    """A child environment that does not print itself.
+
+    ``repr=False`` on the field keeps the mapping out of a request's own
+    representation, and that is not the whole channel: pydantic renders the
+    input of a failing model-level validator verbatim, so a request rejected
+    for an unrelated reason — an empty prompt, say — prints every variable
+    beside it. Carrying the redaction on the value rather than at each error
+    site is what stops a validator added later from reopening the leak by not
+    knowing about it.
+
+    It is a real mapping in every other respect, so nothing downstream has to
+    know it exists.
+    """
+
+    def __repr__(self) -> str:
+        return f"<env: {len(self)} variable(s)>"
+
+    __str__ = __repr__
+
+
+def raise_if_env_is_not_a_string_map(value: Mapping) -> None:
+    """Reject a malformed environment without quoting anything out of it.
+
+    A string key is a variable NAME and naming it is what makes the error
+    actionable. A key of any other type is not a name, and printing it prints
+    whatever the caller put there — a tuple holding a token, for instance — so
+    those are reported by position and type only. Values are never printed at
+    all, whatever their type.
+
+    Raises TypeError rather than ValueError because pydantic converts
+    ValueError into a validation error that quotes the entire rejected input,
+    and lets anything else through untouched.
+    """
+    named: list[str] = []
+    unnamed: list[str] = []
+    for index, (key, val) in enumerate(value.items()):
+        if isinstance(key, str):
+            if not isinstance(val, str):
+                named.append(f"{key!r} (value is {type(val).__name__})")
+        else:
+            unnamed.append(f"entry {index} (key is {type(key).__name__})")
+    if named or unnamed:
+        raise TypeError(
+            "env must map strings to strings; these entries do not: "
+            + ", ".join([*sorted(named), *unnamed])
+        )
+
+
+def redact_runtime_fields_in_place(data) -> None:
+    """Make the runtime-only values in a raw request mapping unprintable.
+
+    Called at the top of every model-level ``mode="before"`` validator, because
+    that is the one place a validator holds the WHOLE raw input: pydantic
+    renders the input of a failing validator verbatim, so a request rejected
+    for an unrelated reason prints the child environment beside the reason.
+    ``exclude`` and ``repr=False`` do not reach this channel — they govern the
+    model, and this runs before a model exists.
+
+    In place, and only substituting a mapping for an equal one that prints
+    differently, so nothing downstream sees a different value.
+    """
+    if not isinstance(data, dict):
+        return
+    env = data.get("env")
+    if isinstance(env, Mapping) and not isinstance(env, RedactedEnv):
+        data["env"] = RedactedEnv(env)
+
+
+def _kill_abandoned_spawn(task: asyncio.Future) -> None:
+    """End the group of a child whose creator was cancelled before it resumed.
+
+    Runs as a done-callback because by then nothing is left to await from: the
+    coroutine that asked for the child has already unwound. The exception is
+    retrieved either way, or asyncio reports it as never-retrieved at exit and
+    a cancelled spawn starts looking like a defect in the spawn.
+    """
+    if task.cancelled():
+        return
+    if task.exception() is not None:
+        return
+    proc = task.result()
+    kill_group_now(getattr(proc, "pid", None))
+
+
+async def end_child_group(proc: Any, *, grace: float = 5.0) -> None:
+    """End every member of the child's group, and survive being cancelled.
+
+    Two things this does that awaiting the graceful helper alone does not.
+
+    It drains the GROUP rather than the process. The graceful helper returns as
+    soon as the process it holds a handle to is gone, and a descendant that
+    ignores SIGTERM outlives a parent that does not — so the group is read
+    afterwards and killed if anyone is still in it. A group that answers with
+    members is still the group whose id was recorded, because a group id is not
+    reissued while it has members.
+
+    It cannot be interrupted into leaving something running. The graceful pass
+    waits out a grace period, and that wait is a cancellation point that a
+    runner being torn down is exactly where it meets. So a synchronous kill
+    runs in a ``finally`` when that pass did not finish: no await, so nothing
+    can interpose.
+
+    Both kills fire only on positive evidence that the group id is still this
+    child's, because the other direction is worse than an orphan. After a
+    completed graceful pass the child has been waited, so its pid — and hence
+    this group id — may already belong to someone else; the evidence there is
+    a live member, since an occupied group is never reissued. On the cancelled
+    path the child has not been waited at all, so the id is unambiguously ours.
+
+    What it therefore cannot close, rather than papering over it: a scan that
+    could not read the whole process table and saw no members leaves emptiness
+    unproved, and this refuses to signal on that, because an unprovable group
+    and a reissued one look the same from here.
+    """
+    pgid = getattr(proc, "pid", None)
+    graceful_done = False
+    try:
+        await aterminate_process_group(proc, grace=grace)
+        graceful_done = True
+        if isinstance(pgid, int):
+            members, _complete = group_member_pids(pgid)
+            if members:
+                kill_group_now(pgid)
+    finally:
+        if not graceful_done and getattr(proc, "returncode", None) is None:
+            kill_group_now(pgid)
 
 
 def observe_spawned(pid: int) -> SpawnedProcess:
@@ -156,7 +289,19 @@ async def ndjson_from_cli(
         kwargs["stdin"] = asyncio.subprocess.PIPE
     elif stdin is not _INHERIT_STDIN:
         kwargs["stdin"] = stdin
-    proc = await asyncio.create_subprocess_exec(*cmd, **kwargs)
+    # Shielded, because the OS has already started the child by the time this
+    # await resumes and a cancellation landing in the window before it returns
+    # would abandon that child with no handle to sweep it by — unrecorded and
+    # in a group nobody knows the id of. The shield keeps the creation running
+    # so the handle still arrives, and the done-callback ends its group from
+    # outside this coroutine, which is the only place left that can.
+    spawn = asyncio.ensure_future(asyncio.create_subprocess_exec(*cmd, **kwargs))
+    try:
+        proc = await asyncio.shield(spawn)
+    except BaseException:
+        spawn.add_done_callback(_kill_abandoned_spawn)
+        raise
+
     if on_spawn is not None:
         # Read the identity here, not at teardown: once the child is reaped its
         # pid and group id are both recyclable, so either read then can resolve
@@ -165,21 +310,7 @@ async def ndjson_from_cli(
         try:
             await maybe_await(on_spawn(observe_spawned(proc.pid)))
         except BaseException:
-            cleaned = False
-            try:
-                await aterminate_process_group(proc, grace=5.0)
-                cleaned = True
-            finally:
-                # A cancellation arriving while the graceful path waits out its
-                # grace skips the SIGKILL escalation that path ends with, and a
-                # child ignoring SIGTERM then survives with nobody holding a
-                # record of it. This backstop takes no await, so there is no
-                # point at which a further cancellation can interpose.
-                # Conditioned on returncode because a completed graceful path
-                # has waited the child, and signalling a pid asyncio has
-                # already reaped is how a stranger's group gets killed.
-                if not cleaned and proc.returncode is None:
-                    terminate_process_group(proc, grace=None)
+            await end_child_group(proc)
             raise
 
     decoder = codecs.getincrementaldecoder("utf-8")()
@@ -290,7 +421,7 @@ async def ndjson_from_cli(
             raise RuntimeError(err or f"CLI subprocess exited with code {rc}")
 
     finally:
-        await aterminate_process_group(proc, grace=5.0)
+        await end_child_group(proc)
 
         # Reap the helper tasks — contextlib.suppress(Exception) does NOT
         # catch CancelledError (BaseException), so we suppress it explicitly.
@@ -327,6 +458,7 @@ def resolve_cli_workspace(repo: Path | None, workspace: str | None) -> Path:
 
 def validate_message_prompt(data: dict) -> dict:
     """Derive prompt/system_prompt from messages when prompt is unset (shared by Gemini, Pi, Codex request models)."""
+    redact_runtime_fields_in_place(data)
     from lionagi import ln
 
     if data.get("prompt"):

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -1025,7 +1025,16 @@ class ClaudeCodeCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
             and responses
             and not isinstance(responses[-1], CLISession)
         ):
+            # Deep on purpose for everything else, then the runtime-only
+            # fields are put back BY IDENTITY. A deep copy of a bound method
+            # copies its receiver, so the continuation would notify a copy of
+            # the supervisor while the real one -- the thing holding the
+            # durable process accounting -- never hears about the second
+            # subprocess. A stateless callback hides this completely, which is
+            # why it needs saying rather than leaving to a copy mode.
             req2 = request.model_copy(deep=True)
+            for _runtime_field in ("env", "on_spawn"):
+                object.__setattr__(req2, _runtime_field, getattr(request, _runtime_field))
             req2.prompt = "Please provide a the final result message only"
             req2.max_turns = 1
             req2.continue_conversation = True

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -12,6 +12,7 @@ from textwrap import shorten
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic.json_schema import SkipJsonSchema
 
 from lionagi import ln
 from lionagi.libs.path_safety import check_add_dirs_safe as check_add_dir_entries_safe
@@ -203,7 +204,10 @@ class ClaudeCodeRequest(BaseModel):
     worktree: str | bool | None = Field(default=None, exclude=True)
 
     # ── process (runtime-only, never rendered as CLI args) ─────────
-    env: dict[str, str] | None = Field(
+    # Runtime-only, and kept out of the generated JSON schema as well as out
+    # of serialization: this model's schema describes the request payload, and
+    # a callable has no JSON schema at all — asking for one raises.
+    env: SkipJsonSchema[dict[str, str] | None] = Field(
         default=None,
         exclude=True,
         description=(
@@ -212,7 +216,7 @@ class ClaudeCodeRequest(BaseModel):
             "caller setting one variable supplies the rest itself."
         ),
     )
-    on_spawn: Callable[[int, int], None] | None = Field(
+    on_spawn: SkipJsonSchema[Callable[[int, int], None] | None] = Field(
         default=None,
         exclude=True,
         description=(

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -202,6 +202,26 @@ class ClaudeCodeRequest(BaseModel):
     # worktree is special-cased (bool vs str) — no _cli metadata
     worktree: str | bool | None = Field(default=None, exclude=True)
 
+    # ── process (runtime-only, never rendered as CLI args) ─────────
+    env: dict[str, str] | None = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Complete environment for the CLI process. None inherits this "
+            "process's environment; a mapping REPLACES it wholesale, so a "
+            "caller setting one variable supplies the rest itself."
+        ),
+    )
+    on_spawn: Callable[[int, int], None] | None = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Called once with (pid, pgid) as soon as the CLI process exists, "
+            "for a caller that must record the identity of a process it did "
+            "not spawn itself."
+        ),
+    )
+
     # ── features (order 80–89) ────────────────────────────────────
     chrome: bool | None = Field(
         default=None,
@@ -484,7 +504,13 @@ async def _ndjson_from_cli(request: ClaudeCodeRequest):
     cmd = [CLAUDE_CLI, *request.as_cmd_args()]
     # tail_repair recovers a malformed-but-repairable final JSON object instead of dropping it.
     async with contextlib.aclosing(
-        ndjson_from_cli(cmd, cwd=workspace, tail_repair=_claude_tail_repair)
+        ndjson_from_cli(
+            cmd,
+            cwd=workspace,
+            env=request.env,
+            tail_repair=_claude_tail_repair,
+            on_spawn=request.on_spawn,
+        )
     ) as stream:
         async for obj in stream:
             yield obj

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -21,7 +21,7 @@ from lionagi.libs.path_safety import contain_paths_in_root as contain_paths_in_r
 from lionagi.ln.concurrency.utils import maybe_await
 from lionagi.providers._agentic_handlers import AgenticHandlersMixin
 from lionagi.providers._cli_subprocess import (
-    RedactedEnv,
+    Redacted,
     SpawnedProcess,
     build_declarative_cli_args,
     discover_cli,
@@ -246,10 +246,14 @@ class ClaudeCodeRequest(BaseModel):
         a traceback or a log line. It is also the right exception for a wrongly
         typed mapping.
 
-        What survives is a RedactedEnv, so the mapping stays unprintable for
-        every later validator too — this one is not the only thing that can
-        fail with the request in hand.
+        The value arrives wrapped when it came through a model-level validator,
+        which is what keeps it off that validator's error. This is the code that
+        needs to look at it, so this is where it is unwrapped; what the model
+        then stores is an ordinary mapping, kept out of dumps by ``exclude`` and
+        out of the request's representation by ``repr=False``.
         """
+        if isinstance(value, Redacted):
+            value = value.reveal()
         if value is None:
             return value
         if not isinstance(value, Mapping):
@@ -259,7 +263,22 @@ class ClaudeCodeRequest(BaseModel):
                 f"env must be a mapping of strings to strings, got {type(value).__name__}"
             )
         raise_if_env_is_not_a_string_map(value)
-        return RedactedEnv(value)
+        return dict(value)
+
+    @field_validator("on_spawn", mode="before")
+    @classmethod
+    def _unwrap_on_spawn(cls, value):
+        """Undo the wrapping a model-level validator applied.
+
+        The callback is wrapped there for the same reason the environment is: a
+        BOUND callback carries its receiver into its own ``repr``, so a
+        supervisor holding a credential would print it from an error about some
+        unrelated field. Nothing but this validator needs the wrapper gone, and
+        pydantic rejects it outright as not callable if it survives — which is
+        the failure mode this method exists to prevent, and the one a test that
+        only checks for leaks would never see.
+        """
+        return value.reveal() if isinstance(value, Redacted) else value
 
     # ── features (order 80–89) ────────────────────────────────────
     chrome: bool | None = Field(

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -278,7 +278,16 @@ class ClaudeCodeRequest(BaseModel):
         the failure mode this method exists to prevent, and the one a test that
         only checks for leaks would never see.
         """
-        return value.reveal() if isinstance(value, Redacted) else value
+        if isinstance(value, Redacted):
+            value = value.reveal()
+        if value is None or callable(value):
+            return value
+        # Rejected HERE rather than handed back for pydantic to reject, because
+        # unwrapping is what re-exposes the value: pydantic renders a failing
+        # field's input, and an object with a credential-bearing __repr__ is
+        # exactly the shape this carrier exists to keep out of an error. A
+        # TypeError names the type and never the object.
+        raise TypeError(f"on_spawn must be callable, got {type(value).__name__}")
 
     # ── features (order 80–89) ────────────────────────────────────
     chrome: bool | None = Field(

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from pathlib import Path
 from textwrap import shorten
 from typing import Any, Literal
@@ -243,8 +243,14 @@ class ClaudeCodeRequest(BaseModel):
         and nothing else reaches a traceback or a log line. It is also the
         right exception for a wrongly typed mapping.
         """
-        if value is None or not isinstance(value, dict):
+        if value is None:
             return value
+        if not isinstance(value, Mapping):
+            # Not "leave it for pydantic": pydantic quotes the rejected value,
+            # and for a wrongly shaped env the value IS the credential.
+            raise TypeError(
+                f"env must be a mapping of strings to strings, got {type(value).__name__}"
+            )
         bad = sorted(
             str(k) for k, v in value.items() if not isinstance(k, str) or not isinstance(v, str)
         )
@@ -252,7 +258,7 @@ class ClaudeCodeRequest(BaseModel):
             raise TypeError(
                 "env must map strings to strings; these entries do not: " + ", ".join(bad)
             )
-        return value
+        return dict(value)
 
     # ── features (order 80–89) ────────────────────────────────────
     chrome: bool | None = Field(

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from textwrap import shorten
 from typing import Any, Literal
@@ -21,6 +21,7 @@ from lionagi.libs.path_safety import contain_paths_in_root as contain_paths_in_r
 from lionagi.ln.concurrency.utils import maybe_await
 from lionagi.providers._agentic_handlers import AgenticHandlersMixin
 from lionagi.providers._cli_subprocess import (
+    SpawnedProcess,
     build_declarative_cli_args,
     discover_cli,
     ndjson_from_cli,
@@ -210,21 +211,48 @@ class ClaudeCodeRequest(BaseModel):
     env: SkipJsonSchema[dict[str, str] | None] = Field(
         default=None,
         exclude=True,
+        repr=False,
         description=(
             "Complete environment for the CLI process. None inherits this "
             "process's environment; a mapping REPLACES it wholesale, so a "
             "caller setting one variable supplies the rest itself."
         ),
     )
-    on_spawn: SkipJsonSchema[Callable[[int, int], None] | None] = Field(
+    on_spawn: SkipJsonSchema[Callable[[SpawnedProcess], None | Awaitable[None]] | None] = Field(
         default=None,
         exclude=True,
+        repr=False,
         description=(
-            "Called once with (pid, pgid) as soon as the CLI process exists, "
-            "for a caller that must record the identity of a process it did "
-            "not spawn itself."
+            "Called once with a SpawnedProcess as soon as the CLI process "
+            "exists, for a caller that must record the identity of a process "
+            "it did not spawn itself. May be a coroutine function."
         ),
     )
+
+    @field_validator("env", mode="before")
+    @classmethod
+    def _env_is_a_string_map(cls, value):
+        """Reject a malformed environment naming only the keys, never the values.
+
+        A child environment routinely holds credentials, and a pydantic
+        ValidationError quotes the whole rejected input into its message, so
+        letting the ordinary string check fail here would print every value in
+        the map beside the one bad entry. TypeError is the escape: pydantic
+        converts ValueError and AssertionError into validation errors and lets
+        anything else propagate untouched, so this reports the offending keys
+        and nothing else reaches a traceback or a log line. It is also the
+        right exception for a wrongly typed mapping.
+        """
+        if value is None or not isinstance(value, dict):
+            return value
+        bad = sorted(
+            str(k) for k, v in value.items() if not isinstance(k, str) or not isinstance(v, str)
+        )
+        if bad:
+            raise TypeError(
+                "env must map strings to strings; these entries do not: " + ", ".join(bad)
+            )
+        return value
 
     # ── features (order 80–89) ────────────────────────────────────
     chrome: bool | None = Field(
@@ -861,6 +889,7 @@ class ClaudeCodeCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
     _handler_params = _CLAUDE_HANDLER_PARAMS
     _handler_kwarg = "claude_handlers"
     _request_model = ClaudeCodeRequest
+    _runtime_state_fields = ("env", "on_spawn")
     # Claude Code streams a "system" event as soon as the CLI session starts,
     # well before the run completes — see stream_cc_cli() above.
     streams_first_output_early = True

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -21,11 +21,14 @@ from lionagi.libs.path_safety import contain_paths_in_root as contain_paths_in_r
 from lionagi.ln.concurrency.utils import maybe_await
 from lionagi.providers._agentic_handlers import AgenticHandlersMixin
 from lionagi.providers._cli_subprocess import (
+    RedactedEnv,
     SpawnedProcess,
     build_declarative_cli_args,
     discover_cli,
     ndjson_from_cli,
     print_readable,
+    raise_if_env_is_not_a_string_map,
+    redact_runtime_fields_in_place,
     resolve_cli_workspace,
 )
 from lionagi.providers._cli_subprocess import (
@@ -232,16 +235,20 @@ class ClaudeCodeRequest(BaseModel):
     @field_validator("env", mode="before")
     @classmethod
     def _env_is_a_string_map(cls, value):
-        """Reject a malformed environment naming only the keys, never the values.
+        """Reject a malformed environment without printing anything from it.
 
         A child environment routinely holds credentials, and a pydantic
         ValidationError quotes the whole rejected input into its message, so
         letting the ordinary string check fail here would print every value in
         the map beside the one bad entry. TypeError is the escape: pydantic
         converts ValueError and AssertionError into validation errors and lets
-        anything else propagate untouched, so this reports the offending keys
-        and nothing else reaches a traceback or a log line. It is also the
-        right exception for a wrongly typed mapping.
+        anything else propagate untouched, so nothing from the mapping reaches
+        a traceback or a log line. It is also the right exception for a wrongly
+        typed mapping.
+
+        What survives is a RedactedEnv, so the mapping stays unprintable for
+        every later validator too — this one is not the only thing that can
+        fail with the request in hand.
         """
         if value is None:
             return value
@@ -251,14 +258,8 @@ class ClaudeCodeRequest(BaseModel):
             raise TypeError(
                 f"env must be a mapping of strings to strings, got {type(value).__name__}"
             )
-        bad = sorted(
-            str(k) for k, v in value.items() if not isinstance(k, str) or not isinstance(v, str)
-        )
-        if bad:
-            raise TypeError(
-                "env must map strings to strings; these entries do not: " + ", ".join(bad)
-            )
-        return dict(value)
+        raise_if_env_is_not_a_string_map(value)
+        return RedactedEnv(value)
 
     # ── features (order 80–89) ────────────────────────────────────
     chrome: bool | None = Field(
@@ -364,6 +365,9 @@ class ClaudeCodeRequest(BaseModel):
 
     @model_validator(mode="before")
     def _validate_message_prompt(cls, data):
+        # First, before anything here can raise: this validator holds the whole
+        # raw input, and pydantic quotes a failing validator's input verbatim.
+        redact_runtime_fields_in_place(data)
         if "prompt" in data and data["prompt"]:
             return data
 
@@ -902,8 +906,11 @@ class ClaudeCodeCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
 
     def __init__(self, config: EndpointConfig = None, **kwargs):
         handlers = kwargs.pop("claude_handlers", None)
+        # Before super(), which deep-copies a supplied config: see
+        # take_supplied_runtime_state for what that copy does to a bound method.
+        supplied = self.take_supplied_runtime_state(config, kwargs)
         super().__init__(config=config, **kwargs)
-        self._init_handlers(handlers)
+        self._init_handlers(handlers, supplied=supplied)
 
     @property
     def claude_handlers(self):

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -23,7 +23,7 @@ from lionagi.libs.path_safety import contain_paths_in_root as contain_paths_in_r
 from lionagi.ln.concurrency.utils import maybe_await
 from lionagi.providers._agentic_handlers import AgenticHandlersMixin
 from lionagi.providers._cli_subprocess import (
-    RedactedEnv,
+    Redacted,
     SpawnedProcess,
     build_declarative_cli_args,
     discover_cli,
@@ -218,10 +218,14 @@ class CodexCodeRequest(BaseModel):
         a traceback or a log line. It is also the right exception for a wrongly
         typed mapping.
 
-        What survives is a RedactedEnv, so the mapping stays unprintable for
-        every later validator too — this one is not the only thing that can
-        fail with the request in hand.
+        The value arrives wrapped when it came through a model-level validator,
+        which is what keeps it off that validator's error. This is the code that
+        needs to look at it, so this is where it is unwrapped; what the model
+        then stores is an ordinary mapping, kept out of dumps by ``exclude`` and
+        out of the request's representation by ``repr=False``.
         """
+        if isinstance(value, Redacted):
+            value = value.reveal()
         if value is None:
             return value
         if not isinstance(value, Mapping):
@@ -231,7 +235,22 @@ class CodexCodeRequest(BaseModel):
                 f"env must be a mapping of strings to strings, got {type(value).__name__}"
             )
         raise_if_env_is_not_a_string_map(value)
-        return RedactedEnv(value)
+        return dict(value)
+
+    @field_validator("on_spawn", mode="before")
+    @classmethod
+    def _unwrap_on_spawn(cls, value):
+        """Undo the wrapping a model-level validator applied.
+
+        The callback is wrapped there for the same reason the environment is: a
+        BOUND callback carries its receiver into its own ``repr``, so a
+        supervisor holding a credential would print it from an error about some
+        unrelated field. Nothing but this validator needs the wrapper gone, and
+        pydantic rejects it outright as not callable if it survives — which is
+        the failure mode this method exists to prevent, and the one a test that
+        only checks for leaks would never see.
+        """
+        return value.reveal() if isinstance(value, Redacted) else value
 
     # ── system prompt (order 40) ──────────────────────────────────
     system_prompt: str | None = None

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 
 import toml
 from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic.json_schema import SkipJsonSchema
 
 from lionagi.libs.path_safety import check_add_dirs_safe as check_add_dir_entries_safe
 from lionagi.libs.path_safety import check_path_safe, check_paths_safe
@@ -176,7 +177,10 @@ class CodexCodeRequest(BaseModel):
     )
 
     # ── process (runtime-only, never rendered as CLI args) ─────────
-    env: dict[str, str] | None = Field(
+    # Runtime-only, and kept out of the generated JSON schema as well as out
+    # of serialization: this model's schema describes the request payload, and
+    # a callable has no JSON schema at all — asking for one raises.
+    env: SkipJsonSchema[dict[str, str] | None] = Field(
         default=None,
         exclude=True,
         description=(
@@ -185,7 +189,7 @@ class CodexCodeRequest(BaseModel):
             "caller setting one variable supplies the rest itself."
         ),
     )
-    on_spawn: Callable[[int, int], None] | None = Field(
+    on_spawn: SkipJsonSchema[Callable[[int, int], None] | None] = Field(
         default=None,
         exclude=True,
         description=(

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -175,6 +175,26 @@ class CodexCodeRequest(BaseModel):
         json_schema_extra=_cli("--add-dir", 30, "repeat"),
     )
 
+    # ── process (runtime-only, never rendered as CLI args) ─────────
+    env: dict[str, str] | None = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Complete environment for the CLI process. None inherits this "
+            "process's environment; a mapping REPLACES it wholesale, so a "
+            "caller setting one variable supplies the rest itself."
+        ),
+    )
+    on_spawn: Callable[[int, int], None] | None = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Called once with (pid, pgid) as soon as the CLI process exists, "
+            "for a caller that must record the identity of a process it did "
+            "not spawn itself."
+        ),
+    )
+
     # ── system prompt (order 40) ──────────────────────────────────
     system_prompt: str | None = None
 
@@ -426,7 +446,14 @@ async def _ndjson_from_cli(request: CodexCodeRequest):
     cmd = [CODEX_CLI, *request.as_cmd_args()]
     # Do NOT pass cwd here — Codex CLI already gets the workspace via -C <repo>;
     # setting both double-resolves to 'repo/repo'. See docs/internals/runtime.md.
-    async with contextlib.aclosing(ndjson_from_cli(cmd, stdin_data=request.prompt)) as stream:
+    async with contextlib.aclosing(
+        ndjson_from_cli(
+            cmd,
+            env=request.env,
+            stdin_data=request.prompt,
+            on_spawn=request.on_spawn,
+        )
+    ) as stream:
         async for obj in stream:
             yield obj
 

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -23,11 +23,13 @@ from lionagi.libs.path_safety import contain_paths_in_root as contain_paths_in_r
 from lionagi.ln.concurrency.utils import maybe_await
 from lionagi.providers._agentic_handlers import AgenticHandlersMixin
 from lionagi.providers._cli_subprocess import (
+    RedactedEnv,
     SpawnedProcess,
     build_declarative_cli_args,
     discover_cli,
     ndjson_from_cli,
     print_readable,
+    raise_if_env_is_not_a_string_map,
     resolve_cli_workspace,
     validate_message_prompt,
 )
@@ -205,16 +207,20 @@ class CodexCodeRequest(BaseModel):
     @field_validator("env", mode="before")
     @classmethod
     def _env_is_a_string_map(cls, value):
-        """Reject a malformed environment naming only the keys, never the values.
+        """Reject a malformed environment without printing anything from it.
 
         A child environment routinely holds credentials, and a pydantic
         ValidationError quotes the whole rejected input into its message, so
         letting the ordinary string check fail here would print every value in
         the map beside the one bad entry. TypeError is the escape: pydantic
         converts ValueError and AssertionError into validation errors and lets
-        anything else propagate untouched, so this reports the offending keys
-        and nothing else reaches a traceback or a log line. It is also the
-        right exception for a wrongly typed mapping.
+        anything else propagate untouched, so nothing from the mapping reaches
+        a traceback or a log line. It is also the right exception for a wrongly
+        typed mapping.
+
+        What survives is a RedactedEnv, so the mapping stays unprintable for
+        every later validator too — this one is not the only thing that can
+        fail with the request in hand.
         """
         if value is None:
             return value
@@ -224,14 +230,8 @@ class CodexCodeRequest(BaseModel):
             raise TypeError(
                 f"env must be a mapping of strings to strings, got {type(value).__name__}"
             )
-        bad = sorted(
-            str(k) for k, v in value.items() if not isinstance(k, str) or not isinstance(v, str)
-        )
-        if bad:
-            raise TypeError(
-                "env must map strings to strings; these entries do not: " + ", ".join(bad)
-            )
-        return dict(value)
+        raise_if_env_is_not_a_string_map(value)
+        return RedactedEnv(value)
 
     # ── system prompt (order 40) ──────────────────────────────────
     system_prompt: str | None = None
@@ -960,8 +960,11 @@ class CodexCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
 
     def __init__(self, config: EndpointConfig = None, **kwargs):
         handlers = kwargs.pop("codex_handlers", None)
+        # Before super(), which deep-copies a supplied config: see
+        # take_supplied_runtime_state for what that copy does to a bound method.
+        supplied = self.take_supplied_runtime_state(config, kwargs)
         super().__init__(config=config, **kwargs)
-        self._init_handlers(handlers)
+        self._init_handlers(handlers, supplied=supplied)
 
     @property
     def codex_handlers(self):

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -250,7 +250,16 @@ class CodexCodeRequest(BaseModel):
         the failure mode this method exists to prevent, and the one a test that
         only checks for leaks would never see.
         """
-        return value.reveal() if isinstance(value, Redacted) else value
+        if isinstance(value, Redacted):
+            value = value.reveal()
+        if value is None or callable(value):
+            return value
+        # Rejected HERE rather than handed back for pydantic to reject, because
+        # unwrapping is what re-exposes the value: pydantic renders a failing
+        # field's input, and an object with a credential-bearing __repr__ is
+        # exactly the shape this carrier exists to keep out of an error. A
+        # TypeError names the type and never the object.
+        raise TypeError(f"on_spawn must be callable, got {type(value).__name__}")
 
     # ── system prompt (order 40) ──────────────────────────────────
     system_prompt: str | None = None

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -8,7 +8,7 @@ import contextlib
 import logging
 import re
 import warnings
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from textwrap import shorten
 from typing import Any, Literal
@@ -23,6 +23,7 @@ from lionagi.libs.path_safety import contain_paths_in_root as contain_paths_in_r
 from lionagi.ln.concurrency.utils import maybe_await
 from lionagi.providers._agentic_handlers import AgenticHandlersMixin
 from lionagi.providers._cli_subprocess import (
+    SpawnedProcess,
     build_declarative_cli_args,
     discover_cli,
     ndjson_from_cli,
@@ -183,21 +184,48 @@ class CodexCodeRequest(BaseModel):
     env: SkipJsonSchema[dict[str, str] | None] = Field(
         default=None,
         exclude=True,
+        repr=False,
         description=(
             "Complete environment for the CLI process. None inherits this "
             "process's environment; a mapping REPLACES it wholesale, so a "
             "caller setting one variable supplies the rest itself."
         ),
     )
-    on_spawn: SkipJsonSchema[Callable[[int, int], None] | None] = Field(
+    on_spawn: SkipJsonSchema[Callable[[SpawnedProcess], None | Awaitable[None]] | None] = Field(
         default=None,
         exclude=True,
+        repr=False,
         description=(
-            "Called once with (pid, pgid) as soon as the CLI process exists, "
-            "for a caller that must record the identity of a process it did "
-            "not spawn itself."
+            "Called once with a SpawnedProcess as soon as the CLI process "
+            "exists, for a caller that must record the identity of a process "
+            "it did not spawn itself. May be a coroutine function."
         ),
     )
+
+    @field_validator("env", mode="before")
+    @classmethod
+    def _env_is_a_string_map(cls, value):
+        """Reject a malformed environment naming only the keys, never the values.
+
+        A child environment routinely holds credentials, and a pydantic
+        ValidationError quotes the whole rejected input into its message, so
+        letting the ordinary string check fail here would print every value in
+        the map beside the one bad entry. TypeError is the escape: pydantic
+        converts ValueError and AssertionError into validation errors and lets
+        anything else propagate untouched, so this reports the offending keys
+        and nothing else reaches a traceback or a log line. It is also the
+        right exception for a wrongly typed mapping.
+        """
+        if value is None or not isinstance(value, dict):
+            return value
+        bad = sorted(
+            str(k) for k, v in value.items() if not isinstance(k, str) or not isinstance(v, str)
+        )
+        if bad:
+            raise TypeError(
+                "env must map strings to strings; these entries do not: " + ", ".join(bad)
+            )
+        return value
 
     # ── system prompt (order 40) ──────────────────────────────────
     system_prompt: str | None = None
@@ -919,6 +947,7 @@ class CodexCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
     _handler_params = _CODEX_HANDLER_PARAMS
     _handler_kwarg = "codex_handlers"
     _request_model = CodexCodeRequest
+    _runtime_state_fields = ("env", "on_spawn")
     # Codex streams a "thread.started"/"system" event right after spawn —
     # see stream_codex_cli() above.
     streams_first_output_early = True

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -8,7 +8,7 @@ import contextlib
 import logging
 import re
 import warnings
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from pathlib import Path
 from textwrap import shorten
 from typing import Any, Literal
@@ -216,8 +216,14 @@ class CodexCodeRequest(BaseModel):
         and nothing else reaches a traceback or a log line. It is also the
         right exception for a wrongly typed mapping.
         """
-        if value is None or not isinstance(value, dict):
+        if value is None:
             return value
+        if not isinstance(value, Mapping):
+            # Not "leave it for pydantic": pydantic quotes the rejected value,
+            # and for a wrongly shaped env the value IS the credential.
+            raise TypeError(
+                f"env must be a mapping of strings to strings, got {type(value).__name__}"
+            )
         bad = sorted(
             str(k) for k, v in value.items() if not isinstance(k, str) or not isinstance(v, str)
         )
@@ -225,7 +231,7 @@ class CodexCodeRequest(BaseModel):
             raise TypeError(
                 "env must map strings to strings; these entries do not: " + ", ".join(bad)
             )
-        return value
+        return dict(value)
 
     # ── system prompt (order 40) ──────────────────────────────────
     system_prompt: str | None = None

--- a/lionagi/service/connections/endpoint.py
+++ b/lionagi/service/connections/endpoint.py
@@ -81,6 +81,15 @@ class Endpoint:
     def copy_runtime_state_to(self, other: Endpoint) -> None:
         pass
 
+    def drain_runtime_state(self) -> None:
+        """Endpoints that hold runtime-only state move it out of the config here.
+
+        A plain endpoint has none, so this does nothing. It is declared beside
+        ``copy_runtime_state_to`` because the two are called as a pair, and a
+        caller that has to ask whether an endpoint supports draining will
+        eventually skip it for the one that needs it.
+        """
+
     @property
     def request_options(self):
         return self.config.request_options

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -28,7 +28,15 @@ _FIELD_KEYS_BY_CLASS: dict[int, tuple[type, frozenset[str]]] = {}
 
 B = TypeVar("B", bound=type[BaseModel])
 
-__all__ = ("EndpointConfig",)
+__all__ = ("RUNTIME_STATE_NAMES", "EndpointConfig")
+
+# Values a caller hands an endpoint for the lifetime of the process and never to
+# be written down. ``env`` is a child process's environment and commonly holds
+# credentials; ``on_spawn`` is a callback whose representation carries whatever
+# object it is bound to. They are named here, in the model that would otherwise
+# serialize them, because that is the one place every route to a written-down
+# config has to pass through.
+RUNTIME_STATE_NAMES: tuple[str, ...] = ("env", "on_spawn")
 
 
 class EndpointConfig(BaseModel):
@@ -130,6 +138,47 @@ class EndpointConfig(BaseModel):
         if v is None:
             return None
         return v.model_json_schema()
+
+    @field_serializer("kwargs")
+    def _serialize_kwargs(self, v: dict):
+        """Keep runtime-only values out of every dump of this config.
+
+        The endpoint holding these drains them out of ``kwargs`` when it
+        serializes itself, which covers ``Endpoint.to_dict``, ``iModel.to_dict``
+        and the run snapshots written underneath them. That drain does not cover
+        this model's own public API. ``EndpointConfig`` inherits Pydantic's
+        ``model_dump``, callers use it directly, and two supported routes put a
+        runtime value back into ``kwargs`` after an endpoint has already drained
+        it once: a post-construction ``update()``, and ``iModel.from_dict``,
+        which assigns a freshly hydrated config over the drained one.
+
+        Excluding here rather than draining on every read is what makes the
+        answer independent of who is asking. A drain has to be reached, and the
+        set of routes that reach it is open-ended because this model is public.
+
+        Omitted rather than replaced with a placeholder: a dump is something a
+        config is rebuilt from, and a stand-in string would hydrate as a real
+        value of the wrong type. ``repr`` is not rebuilt from, so it reports
+        presence instead — see :meth:`__repr_args__`.
+        """
+        return {k: val for k, val in v.items() if k not in RUNTIME_STATE_NAMES}
+
+    def __repr_args__(self):
+        """The same values, on the channel a dump does not reach.
+
+        ``repr`` walks ``kwargs`` whole, so a config whose ``env`` is excluded
+        from every dump still prints it in a traceback, a log line, or a
+        debugger. Presence is reported and content is not: a reader asking why
+        an environment was not applied needs to know one is set, and that is the
+        entire question ``repr`` gets asked here.
+        """
+        for name, value in super().__repr_args__():
+            if name == "kwargs" and isinstance(value, dict):
+                value = {
+                    k: (f"<{k}: set, not shown>" if k in RUNTIME_STATE_NAMES else val)
+                    for k, val in value.items()
+                }
+            yield name, value
 
     def update(self, **kwargs):
         """Update the config with new values."""

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -163,6 +163,26 @@ class EndpointConfig(BaseModel):
         """
         return {k: val for k, val in v.items() if k not in RUNTIME_STATE_NAMES}
 
+    def __iter__(self):
+        """The same exclusion on the conversion Pydantic's dump does not run.
+
+        ``dict(config)`` and ``list(config)`` go through ``BaseModel.__iter__``,
+        which yields the raw values held in ``__dict__``. No field serializer
+        runs on that path, so the exclusion above does not reach it, and
+        ``json.dumps(dict(config), default=str)`` is an ordinary way to write a
+        config to a log or a file.
+
+        Omits rather than reports presence, matching the dump: a mapping of
+        field names to values is something a config can be rebuilt from, so a
+        stand-in string would come back as a real value of the wrong type.
+        ``repr`` is the one channel nothing is rebuilt from, and it is the only
+        one that names what it withheld.
+        """
+        for name, value in super().__iter__():
+            if name == "kwargs" and isinstance(value, dict):
+                value = {k: val for k, val in value.items() if k not in RUNTIME_STATE_NAMES}
+            yield name, value
+
     def __repr_args__(self):
         """The same values, on the channel a dump does not reach.
 

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -421,6 +421,14 @@ class iModel:  # noqa: N801
         """Create a new iModel with the same config but a fresh ID. See
         docs/internals/runtime.md for what state is/isn't shared with the copy."""
         endpoint_cls = type(self.endpoint)
+        # Drain before the deep copy, not after. A runtime value that arrived
+        # after construction is still sitting in config.kwargs, so a deep copy
+        # takes it along: a child environment gets duplicated, and a bound
+        # callback is rebound to a copied receiver, leaving the caller's own
+        # supervisor to hear nothing from the copy's legs. Draining first means
+        # the copied config has nothing runtime-only in it and the live objects
+        # transfer whole, just below.
+        self.endpoint.drain_runtime_state()
         new_endpoint = endpoint_cls(
             config=self.endpoint.config.model_copy(deep=True),
             circuit_breaker=self.endpoint.circuit_breaker,

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from lionagi.ln import is_coro_func, now_utc
 from lionagi.protocols.generic import ID, Event, EventStatus, Log
+from lionagi.providers._agentic_handlers import RUNTIME_STATE_NAMES
 
 from .connections import AgenticEndpoint, APICalling, Endpoint, match_endpoint
 from .hooks import (
@@ -118,6 +119,23 @@ class iModel:  # noqa: N801
             kwargs["api_key"] = api_key
         if isinstance(endpoint, Endpoint):
             self.endpoint = endpoint
+            # A finished endpoint missed the window where these are lifted off
+            # the caller's config, so they are placed now. Refusing the ones
+            # that have nowhere to go is the point: dropping them silently
+            # hands the child a default environment and leaves the supervisor
+            # hearing nothing, which is indistinguishable from working.
+            adopt = getattr(self.endpoint, "adopt_runtime_state", None)
+            unplaced = (
+                adopt(kwargs)
+                if callable(adopt)
+                else tuple(n for n in RUNTIME_STATE_NAMES if kwargs.get(n) is not None)
+            )
+            if unplaced:
+                raise TypeError(
+                    f"{type(self.endpoint).__name__} has no runtime state to hold "
+                    f"{', '.join(unplaced)}. These configure a spawned child process "
+                    "and only a CLI endpoint has one."
+                )
         else:
             match_kwargs = dict(kwargs)
             if base_url:

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -14,6 +14,7 @@ once the child is reaped.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sys
 
@@ -42,6 +43,16 @@ _QUICK = 'import sys; sys.stdout.write(\'{"type": "hello"}\\n\')'
 # child cannot have been reached by way of the first yielded object, because
 # there is not going to be one.
 _MUTE = "import time; time.sleep(30)"
+
+# Ignores SIGTERM, then reports that it has, so a parent can be sure the
+# handler is installed before it sends one. A SIGTERM racing the handler would
+# kill this child outright and let the escalation path pass untested.
+_IGNORES_TERM = (
+    "import signal, sys, time; "
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+    "open(sys.argv[1], 'w').close(); "
+    "time.sleep(30)"
+)
 
 # Prints the two variables the environment tests care about, as NDJSON.
 _ECHO_ENV = (
@@ -144,9 +155,16 @@ class TestSpawnObservation:
         only while the child exists, which is why this is not left to the
         consumer."""
         seen: list[SpawnedProcess] = []
+        live: list[float | None] = []
 
         async def run():
             async for _ in ndjson_from_cli(_cmd(_SLEEPER), on_spawn=seen.append):
+                # Read here, where the child is provably alive. Breaking out of
+                # this loop closes the generator and ends the child, so the same
+                # read after the loop races that teardown and returns None for a
+                # child that has since been killed — which says nothing about
+                # what was recorded.
+                live.append(spawned_create_time(seen[0].pid))
                 break
 
         task = asyncio.create_task(run())
@@ -157,7 +175,34 @@ class TestSpawnObservation:
         assert spawned.create_time is not None
         # The value is this child's own, not a constant and not the parent's.
         assert spawned.create_time != spawned_create_time(os.getpid())
-        assert spawned_create_time(spawned.pid) == spawned.create_time
+        assert live == [spawned.create_time]
+
+    @pytest.mark.asyncio
+    async def test_the_identity_is_read_as_one_observation(self):
+        """Group and start time are two reads by pid, and a pid reassigned
+        between them answers the second as the replacement process. A record
+        mixing the two would describe a process that never existed, so the
+        group read is bracketed by the start time and a bracket that fails
+        yields no start time at all."""
+        import lionagi.providers._cli_subprocess as mod
+
+        real = mod.spawned_create_time
+        answers = iter([100.0, 200.0])
+
+        def shifting(pid: int) -> float | None:
+            return next(answers, 200.0)
+
+        monkey = pytest.MonkeyPatch()
+        monkey.setattr(mod, "spawned_create_time", shifting)
+        try:
+            mixed = mod.observe_spawned(os.getpid())
+        finally:
+            monkey.undo()
+
+        assert mixed.pid == os.getpid()
+        assert mixed.create_time is None, "a moved start time must not be recorded as an identity"
+        # The same call against a stable process does record one.
+        assert mod.observe_spawned(os.getpid()).create_time == real(os.getpid())
 
     @pytest.mark.asyncio
     async def test_identity_is_recorded_even_for_a_child_that_exits_at_once(self):
@@ -179,18 +224,30 @@ class TestSpawnObservation:
         un-awaited one would return a coroutine that is quietly dropped, so the
         leg runs entirely unrecorded and nothing raises. The recording finishes
         before the first object arrives, so a consumer that acts on the stream
-        can never be ahead of the record."""
+        can never be ahead of the record.
+
+        Asserting that only after the stream has drained would pass against an
+        implementation that started reading first and awaited the recorder at
+        the end, so the state is sampled at the first object instead, and the
+        recorder is made slow next to the time a child takes to emit one line
+        rather than relying on scheduling luck to separate the two.
+        """
         recorded: list[SpawnedProcess] = []
+        recorded_at_first_object: list[bool] = []
 
         async def recorder(spawned: SpawnedProcess) -> None:
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.25)
             recorded.append(spawned)
 
-        objs = await _drain(ndjson_from_cli(_cmd(_QUICK), on_spawn=recorder))
+        objs = []
+        async for obj in ndjson_from_cli(_cmd(_QUICK), on_spawn=recorder):
+            recorded_at_first_object.append(bool(recorded))
+            objs.append(obj)
 
         assert objs == [{"type": "hello"}]
         assert len(recorded) == 1
         assert recorded[0].pid > 0
+        assert recorded_at_first_object == [True]
 
     @pytest.mark.asyncio
     async def test_no_callback_is_the_unchanged_path(self):
@@ -236,6 +293,49 @@ class TestSpawnObservationFailure:
             await _drain(ndjson_from_cli(_cmd(_SLEEPER), on_spawn=cancel))
 
         assert len(seen) == 1
+        await _await_death(seen[0])
+
+    @pytest.mark.asyncio
+    async def test_a_second_cancellation_during_teardown_still_ends_the_child(self, tmp_path):
+        """The graceful teardown sends SIGTERM and then waits out a grace before
+        escalating, and that wait is a cancellation point. A runner being torn
+        down is where a second cancellation actually arrives, and a child that
+        ignores SIGTERM would then outlive the escalation that never ran, with
+        nobody holding a record of it. So the escalation does not depend on the
+        wait surviving."""
+        ready = tmp_path / "ignoring-sigterm"
+        seen: list[int] = []
+
+        async def boom(spawned: SpawnedProcess) -> None:
+            seen.append(spawned.pid)
+            for _ in range(200):
+                if ready.exists():
+                    break
+                await asyncio.sleep(0.05)
+            assert ready.exists(), "the child never reported that it ignores SIGTERM"
+            raise RuntimeError("cannot record")
+
+        task = asyncio.create_task(
+            _drain(
+                ndjson_from_cli(
+                    [sys.executable, "-c", _IGNORES_TERM, str(ready)],
+                    on_spawn=boom,
+                )
+            )
+        )
+        for _ in range(200):
+            if seen and ready.exists():
+                break
+            await asyncio.sleep(0.05)
+        assert seen, "the recorder never fired"
+
+        # Long enough to be inside the grace wait, far short of the grace
+        # itself, so this cancels a wait that is genuinely in progress.
+        await asyncio.sleep(0.5)
+        task.cancel()
+        with pytest.raises((asyncio.CancelledError, RuntimeError)):
+            await task
+
         await _await_death(seen[0])
 
     @pytest.mark.asyncio
@@ -508,25 +608,121 @@ class TestEndpointsPreserveRuntimeState:
         self, endpoint_path, request_path
     ):
         """The carry fills a gap the rebuild opened; it does not outrank what
-        the caller asked for at the call site."""
+        the caller asked for at the call site. Asserted for both fields: they
+        are carried by one loop, and a mutant that reversed the precedence for
+        only one of them would go unseen by a test that watched only ``env``.
+        """
         endpoint_cls = _load(endpoint_path)
         request_cls = _load(request_path)
 
+        def on_request(spawned):
+            return None
+
+        def at_call_site(spawned):
+            return None
+
         payload, _ = endpoint_cls().create_payload(
-            request_cls(prompt="hi", env={"A": "1"}), env={"B": "2"}
+            request_cls(prompt="hi", env={"A": "1"}, on_spawn=on_request),
+            env={"B": "2"},
+            on_spawn=at_call_site,
         )
 
         assert payload["request"].env == {"B": "2"}
+        assert payload["request"].on_spawn is at_call_site
 
-    def test_a_request_passed_as_a_dict_is_unaffected(self):
+    @pytest.mark.parametrize(
+        "endpoint_path",
+        [
+            "lionagi.providers.anthropic.claude_code:ClaudeCodeCLIEndpoint",
+            "lionagi.providers.openai.codex:CodexCLIEndpoint",
+        ],
+    )
+    def test_a_request_passed_as_a_dict_is_unaffected(self, endpoint_path):
         """A dict never went through a dump, so its values were never at risk.
         This is the canonical iModel route and it must keep behaving as it did.
         """
-        endpoint_cls = _load("lionagi.providers.anthropic.claude_code:ClaudeCodeCLIEndpoint")
+        endpoint_cls = _load(endpoint_path)
 
-        payload, _ = endpoint_cls().create_payload({"prompt": "hi", "env": {"A": "1"}})
+        def recorder(spawned):
+            return None
+
+        payload, _ = endpoint_cls().create_payload(
+            {"prompt": "hi", "env": {"A": "1"}, "on_spawn": recorder}
+        )
 
         assert payload["request"].env == {"A": "1"}
+        assert payload["request"].on_spawn is recorder
+
+
+class TestTheConfigRouteKeepsThemOutOfWhatIsSerialised:
+    """``iModel(**kwargs)`` forwards anything it does not recognise into
+    ``EndpointConfig.kwargs``, which is a supported way to configure an endpoint
+    and also exactly what ``Endpoint.to_dict`` serialises — so it reaches
+    ``iModel.to_dict``, ``Branch.to_dict``, and the run snapshots written to
+    disk. A child environment left there is a credential in a saved file."""
+
+    SECRET = "leaked-credential-value"
+
+    @pytest.mark.parametrize("provider", ["claude_code", "codex"])
+    def test_the_environment_does_not_reach_a_serialised_model(self, provider):
+        from lionagi.service.imodel import iModel
+
+        imodel = iModel(provider=provider, env={"TOKEN": self.SECRET})
+
+        assert self.SECRET not in json.dumps(imodel.to_dict())
+
+    @pytest.mark.parametrize("provider", ["claude_code", "codex"])
+    def test_a_callback_does_not_break_the_snapshot_it_would_be_written_into(self, provider):
+        """A function has no JSON form. Left in the serialised config it does
+        not merely leak, it raises when anything tries to persist the branch,
+        which is every run that saves its state."""
+        from lionagi.service.imodel import iModel
+        from lionagi.session.branch import Branch
+
+        def recorder(spawned):
+            return None
+
+        branch = Branch(
+            chat_model=iModel(provider=provider, env={"TOKEN": self.SECRET}, on_spawn=recorder)
+        )
+
+        dumped = json.dumps(branch.to_dict())
+        assert self.SECRET not in dumped
+        assert "on_spawn" not in dumped
+
+    @pytest.mark.parametrize("provider", ["claude_code", "codex"])
+    def test_the_configuration_route_still_reaches_the_request(self, provider):
+        """Moving the values out of the serialised config must not move them
+        out of the caller's reach: this is the route the runner actually uses.
+        """
+        from lionagi.service.imodel import iModel
+
+        def recorder(spawned):
+            return None
+
+        imodel = iModel(provider=provider, env={"TOKEN": self.SECRET}, on_spawn=recorder)
+        payload, _ = imodel.endpoint.create_payload({"prompt": "hi"})
+
+        assert payload["request"].env == {"TOKEN": self.SECRET}
+        assert payload["request"].on_spawn is recorder
+
+    @pytest.mark.parametrize("provider", ["claude_code", "codex"])
+    def test_a_copy_gets_the_same_callback_object_not_a_copy_of_it(self, provider):
+        """``iModel.copy`` deep copies the config. A deep copy of a bound
+        callback rebinds it to a copied receiver, so the original supervisor
+        would quietly stop hearing from the copy's legs while everything still
+        looked wired."""
+        from lionagi.service.imodel import iModel
+
+        def recorder(spawned):
+            return None
+
+        imodel = iModel(provider=provider, env={"TOKEN": self.SECRET}, on_spawn=recorder)
+        clone = imodel.copy()
+
+        payload, _ = clone.endpoint.create_payload({"prompt": "hi"})
+        assert payload["request"].on_spawn is recorder
+        assert self.SECRET not in json.dumps(clone.to_dict())
 
 
 def _load(path: str):

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -176,6 +176,37 @@ async def _await_death(pid: int, deadline: float = _TEARDOWN_DEADLINE) -> None:
     pytest.fail(f"child {pid} was still alive {deadline}s after the callback failed")
 
 
+def _scan_can_see_an_occupied_group() -> bool:
+    """Whether the post-reap escalation can fire in this environment at all.
+
+    Not a judgement about the platform, and not a check that the scan "works":
+    it asks the enumerator the production code uses about a group that is
+    provably occupied, because this process is in it. A scan that cannot find
+    us in our own group cannot find a descendant in a child's either.
+
+    It keys on membership alone and deliberately not on the completeness flag,
+    because that is the order the decision itself uses: members present
+    short-circuits ahead of any completeness question, and an incomplete scan
+    that still saw a member kills the group. Gating on completeness would skip
+    runs the code would have handled.
+    """
+    from lionagi.ln._proc import group_member_pids
+
+    members, _ = group_member_pids(os.getpgrp())
+    return os.getpid() in members
+
+
+_needs_the_membership_scan = pytest.mark.skipif(
+    not _scan_can_see_an_occupied_group(),
+    reason=(
+        "the membership scan cannot see this process in its own group, so it cannot "
+        "see a descendant in a child's group either. Once the direct child is reaped "
+        "the documented behaviour is to refuse to signal an unproven group, so a "
+        "surviving descendant here is that refusal and not a defect"
+    ),
+)
+
+
 class TestSpawnObservation:
     @pytest.mark.asyncio
     async def test_reports_the_live_child_pid_and_its_real_process_group(self):
@@ -1015,9 +1046,21 @@ class TestTheWholeGroupIsEnded:
     nothing in the parent's own state says so. These use a descendant that
     ignores SIGTERM, because a cooperative one dies to the polite signal and
     makes every version of this path look identical.
+
+    Both reach the descendant only *after* the graceful pass has waited the
+    direct child, which is the one moment the code needs the membership scan:
+    the leader's pid is recyclable from then on, and only a live member pins
+    the group id. Where that scan cannot see a live group the documented
+    outcome is a refusal to signal, so the descendant survives by design and
+    these would report a defect that is not there. They are gated on a positive
+    control rather than on a platform name, and the gate skips nothing about
+    the refusal itself: what the decision does with an unreadable table is
+    pinned unconditionally, against a forced answer, in
+    :class:`TestWhatTheProcessTableCouldNotAnswer`.
     """
 
     @pytest.mark.asyncio
+    @_needs_the_membership_scan
     async def test_a_failing_recorder_ends_the_descendants_too(self, tmp_path):
         kid_pid = tmp_path / "kid.pid"
         ready = tmp_path / "ready"
@@ -1032,6 +1075,7 @@ class TestTheWholeGroupIsEnded:
         await _assert_dies(int(kid_pid.read_text()), "the descendant of a failed spawn")
 
     @pytest.mark.asyncio
+    @_needs_the_membership_scan
     async def test_a_cancelled_stream_ends_the_descendants_too(self, tmp_path):
         """The recorder succeeds here, so the record exists and the ordinary
         teardown runs. That is the reassuring case, and it is where the direct
@@ -1200,8 +1244,11 @@ class TestWhatTheProcessTableCouldNotAnswer:
         """No members seen and the scan incomplete are the same observation as
         an empty group, and one of the two readings sends a signal to whatever
         now holds a recycled id. The cost is not symmetric: the orphan left by
-        refusing is still in the caller's records for a later sweep to find,
-        and a stranger's process group is not recoverable at all."""
+        refusing is a process whose identity a caller was handed and could have
+        written down, and a stranger's process group is not recoverable at all.
+        Could have, not did — nothing in this package writes such a record, and
+        saying otherwise would credit the refusal with a recovery route that
+        does not exist here."""
         verdict, killed = self._decide(monkeypatch, [], False)
 
         assert verdict == "unproven"

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -287,16 +287,38 @@ class TestSpawnObservation:
 
     @pytest.mark.asyncio
     async def test_identity_is_recorded_even_for_a_child_that_exits_at_once(self):
-        """A read deferred to teardown cannot answer for a reaped child. The
-        recorded group is a usable identity here only because it was read while
-        the child still existed."""
-        seen: list[SpawnedProcess] = []
+        """A read deferred to teardown cannot answer for a reaped child, so the
+        observation has to happen before anything is streamed — which is what
+        this asserts, by ordering rather than by content.
 
-        objs = await _drain(ndjson_from_cli(_cmd(_QUICK), on_spawn=seen.append))
+        What it deliberately does NOT assert is a start time. This child can be
+        reaped before the read reaches it, and no one can recover the start time
+        of a reaped process; requiring one here produced a test that passes
+        alone and fails under the load of the full suite. The claim that a live
+        child's identity IS bound to its start time belongs to the test above,
+        which holds the child open and can therefore make it. Here the only
+        thing that must hold is that an absent start time is reported as absent
+        and never filled in from somewhere else."""
+        seen: list[SpawnedProcess] = []
+        order: list[str] = []
+        objs: list[dict] = []
+
+        def record(spawned: SpawnedProcess) -> None:
+            order.append("spawn")
+            seen.append(spawned)
+
+        async for obj in ndjson_from_cli(_cmd(_QUICK), on_spawn=record):
+            order.append("output")
+            objs.append(obj)
 
         assert objs == [{"type": "hello"}]
         assert len(seen) == 1
         assert seen[0].pgid == seen[0].pid
+        # The observation preceded the stream. A read moved to teardown fails
+        # this, which is the defect the early read exists to avoid.
+        assert order[0] == "spawn"
+        if seen[0].create_time is not None:
+            assert seen[0].create_time != spawned_create_time(os.getpid())
 
     @pytest.mark.asyncio
     async def test_an_async_recorder_is_awaited_before_the_stream_is_read(self):
@@ -872,12 +894,76 @@ class TestTheEnvironmentSurvivesNoErrorPath:
         with pytest.raises(Exception) as excinfo:  # noqa: B017 - the type is the point below
             model(env={"TOKEN": self.SECRET})
 
-        message = str(excinfo.value)
-        assert self.SECRET not in message
+        # Every channel pydantic renders this through, not just the one a
+        # human reads. str() and errors() go via repr, json() walks the
+        # structure and writes out keys and values, and json() is what a
+        # structured logger emits — so a carrier that is quiet in repr and
+        # still a mapping passes the first two and leaks through the third.
+        err = excinfo.value
+        rendered = {
+            "str": str(err),
+            "errors": repr(err.errors()),
+            "json": err.json(),
+        }
+        for channel, text in rendered.items():
+            assert self.SECRET not in text, f"the environment leaked through {channel}"
         # The request really was rejected, so the absence above is a redaction
         # and not a request that quietly succeeded.
-        assert "env" not in message or "variable(s)" in message
+        assert "env" not in rendered["str"] or "variable(s)" in rendered["str"]
         assert excinfo.type.__name__ == "ValidationError"
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_a_callback_receiver_is_not_printed_by_any_channel(self, model_path):
+        """A bound method carries its receiver into its own repr, so the
+        supervisor's attributes are rendered with it. The callback is a
+        credential channel for the same reason the environment is."""
+        model = _load(model_path)
+
+        class Supervisor:
+            """The repr is what makes this a channel. A default object repr
+            shows an address and nothing else, so asserting against one proves
+            nothing — and receivers that DO render their attributes are the
+            common case here: dataclasses, pydantic models, anything holding
+            the credentials it was configured with."""
+
+            def __init__(self):
+                self.token = "leaked-from-the-supervisor"
+
+            def __repr__(self):
+                return f"Supervisor(token={self.token!r})"
+
+            def record(self, spawned):
+                pass
+
+        sup = Supervisor()
+
+        with pytest.raises(Exception) as excinfo:  # noqa: B017 - see above
+            model(on_spawn=sup.record)
+
+        err = excinfo.value
+        for channel, text in (
+            ("str", str(err)),
+            ("errors", repr(err.errors())),
+            ("json", err.json()),
+        ):
+            assert sup.token not in text, f"the receiver leaked through {channel}"
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_a_redacted_callback_is_still_the_callable_the_caller_passed(self, model_path):
+        """The redaction wraps the value before validation sees it, so the
+        field validator has to unwrap it. Without that, pydantic rejects a
+        perfectly good callback as not callable — a failure a leak test alone
+        would never show."""
+        model = _load(model_path)
+        seen = []
+
+        req = model(prompt="hi", on_spawn=seen.append)
+
+        # Not ``is``: a bound method is a new object on every attribute access,
+        # so identity fails here even when nothing was replaced. What has to
+        # hold is that calling it reaches the caller's own object.
+        req.on_spawn("recorded")
+        assert seen == ["recorded"]
 
     @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
     def test_a_non_string_key_is_reported_by_position_not_printed(self, model_path):
@@ -1017,3 +1103,114 @@ def _load(path: str):
     import importlib
 
     return getattr(importlib.import_module(module_name), attr)
+
+
+class TestAnEndpointTheCallerAlreadyBuilt:
+    """``iModel(endpoint=<instance>, ...)`` is a supported signature and it
+    takes a branch that keeps the endpoint and discards every other keyword.
+    For most keywords that only loses configuration the endpoint already has;
+    for these two it hands the child a default environment and leaves the
+    supervisor hearing nothing, with nothing raised and nothing logged. That
+    reads exactly like a working leg."""
+
+    ENDPOINTS = [
+        "lionagi.providers.anthropic.claude_code:ClaudeCodeCLIEndpoint",
+        "lionagi.providers.openai.codex:CodexCLIEndpoint",
+    ]
+
+    @pytest.mark.parametrize("endpoint_path", ENDPOINTS)
+    def test_both_runtime_values_reach_the_request(self, endpoint_path):
+        from lionagi.service.imodel import iModel
+
+        endpoint_cls = _load(endpoint_path)
+        seen: list = []
+
+        model = iModel(endpoint=endpoint_cls(), env={"TOKEN": "supplied"}, on_spawn=seen.append)
+        payload, _ = model.endpoint.create_payload({"prompt": "hi"})
+        request = payload["request"]
+
+        assert request.env == {"TOKEN": "supplied"}
+        # Reached by calling it, because a bound method is a new object on every
+        # access and identity would fail here even with nothing replaced.
+        request.on_spawn("recorded")
+        assert seen == ["recorded"]
+
+    @pytest.mark.parametrize("endpoint_path", ENDPOINTS)
+    def test_an_absent_value_does_not_erase_what_the_endpoint_was_built_with(self, endpoint_path):
+        """``None`` is the absence of a value, not an instruction to clear one.
+        A caller who passes an endpoint already carrying an environment and does
+        not mention it again must keep it."""
+        from lionagi.service.imodel import iModel
+
+        endpoint_cls = _load(endpoint_path)
+        endpoint = endpoint_cls(env={"TOKEN": "built-in"})
+
+        model = iModel(endpoint=endpoint, env=None)
+        payload, _ = model.endpoint.create_payload({"prompt": "hi"})
+
+        assert payload["request"].env == {"TOKEN": "built-in"}
+
+    def test_an_endpoint_with_nowhere_to_put_them_refuses(self):
+        """The alternative to placing them is refusing them. Dropping them is
+        what this whole class exists to rule out, and a non-CLI endpoint has no
+        child process for either value to describe."""
+        from lionagi.service.connections.match_endpoint import match_endpoint
+        from lionagi.service.imodel import iModel
+
+        endpoint = match_endpoint(provider="openai", endpoint="chat")
+
+        with pytest.raises(TypeError) as excinfo:
+            iModel(endpoint=endpoint, env={"TOKEN": "nowhere"})
+
+        assert "env" in str(excinfo.value)
+
+
+class TestWhatTheProcessTableCouldNotAnswer:
+    """The escalation keys on positive evidence that the recorded group id is
+    still this child's, and an unreadable process table produces no evidence
+    either way. That branch cannot be reached by running real processes on a
+    machine where enumeration works, so the enumerator is stubbed: the point
+    under test is what the decision does with each answer, not how the answer
+    was obtained."""
+
+    def _decide(self, monkeypatch, members, complete):
+        import lionagi.providers._cli_subprocess as cs
+
+        killed: list = []
+        monkeypatch.setattr(cs, "group_member_pids", lambda pgid: (members, complete))
+        monkeypatch.setattr(cs, "kill_group_now", lambda pgid: killed.append(pgid))
+        return cs._kill_group_if_occupied(4242), killed
+
+    def test_a_group_holding_someone_is_killed(self, monkeypatch):
+        """An occupied group id is never reissued, so this one is provably
+        still the child's."""
+        verdict, killed = self._decide(monkeypatch, [999], True)
+
+        assert verdict == "killed"
+        assert killed == [4242]
+
+    def test_a_group_read_completely_and_found_empty_is_left_alone(self, monkeypatch):
+        verdict, killed = self._decide(monkeypatch, [], True)
+
+        assert verdict == "empty"
+        assert killed == []
+
+    def test_a_group_that_could_not_be_read_is_not_signalled(self, monkeypatch):
+        """No members seen and the scan incomplete are the same observation as
+        an empty group, and one of the two readings sends a signal to whatever
+        now holds a recycled id. The cost is not symmetric: the orphan left by
+        refusing is still in the caller's records for a later sweep to find,
+        and a stranger's process group is not recoverable at all."""
+        verdict, killed = self._decide(monkeypatch, [], False)
+
+        assert verdict == "unproven"
+        assert killed == []
+
+    def test_nothing_is_signalled_without_a_group_id(self, monkeypatch):
+        import lionagi.providers._cli_subprocess as cs
+
+        killed: list = []
+        monkeypatch.setattr(cs, "kill_group_now", lambda pgid: killed.append(pgid))
+
+        assert cs._kill_group_if_occupied(None) == "no-group"
+        assert killed == []

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -7,7 +7,7 @@ and supplies the leg's environment through ``env``.
 
 These run real subprocesses. The identity being tested is the kernel's, and a
 mocked ``create_subprocess_exec`` would let a wrong pgid read pass: the whole
-point of reading the group at spawn is that the answer stops being available
+point of reading the identity at spawn is that the answer stops being available
 once the child is reaped.
 """
 
@@ -19,7 +19,12 @@ import sys
 
 import pytest
 
-from lionagi.providers._cli_subprocess import ndjson_from_cli, spawned_pgid
+from lionagi.providers._cli_subprocess import (
+    SpawnedProcess,
+    ndjson_from_cli,
+    spawned_create_time,
+    spawned_pgid,
+)
 
 # Emits one NDJSON object, then blocks until killed. Long enough that the
 # parent is still holding a live child when it inspects the group.
@@ -33,6 +38,11 @@ _SLEEPER = (
 # child is reaped and its group is no longer readable from its pid.
 _QUICK = 'import sys; sys.stdout.write(\'{"type": "hello"}\\n\')'
 
+# Produces nothing at all for a while. A callback that has fired against this
+# child cannot have been reached by way of the first yielded object, because
+# there is not going to be one.
+_MUTE = "import time; time.sleep(30)"
+
 # Prints the two variables the environment tests care about, as NDJSON.
 _ECHO_ENV = (
     "import json, os, sys; "
@@ -40,6 +50,11 @@ _ECHO_ENV = (
     "'inherited': os.environ.get('LIONAGI_TEST_INHERITED'), "
     "'supplied': os.environ.get('LIONAGI_TEST_SUPPLIED')}) + '\\n')"
 )
+
+# How long a child ended by the failure path may take to actually die. Well
+# under the sleepers' 30s, so expiry means teardown did not run rather than
+# meaning the child finished by itself.
+_TEARDOWN_DEADLINE = 15.0
 
 
 def _cmd(script: str) -> list[str]:
@@ -50,63 +65,132 @@ async def _drain(stream) -> list[dict]:
     return [obj async for obj in stream]
 
 
+async def _await_death(pid: int, deadline: float = _TEARDOWN_DEADLINE) -> None:
+    """Fail unless *pid* is gone within *deadline* seconds.
+
+    The deadline is the assertion. Waiting without one would also pass against
+    an implementation that merely stopped reading and let a 30s sleeper reach
+    its own end, which is the state this whole path exists to prevent.
+    """
+    loop = asyncio.get_running_loop()
+    until = loop.time() + deadline
+    while loop.time() < until:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        await asyncio.sleep(0.05)
+    pytest.fail(f"child {pid} was still alive {deadline}s after the callback failed")
+
+
 class TestSpawnObservation:
     @pytest.mark.asyncio
     async def test_reports_the_live_child_pid_and_its_real_process_group(self):
-        seen: list[tuple[int, int]] = []
+        seen: list[SpawnedProcess] = []
         first_object_before_callback = []
 
         async def run():
-            async for obj in ndjson_from_cli(
-                _cmd(_SLEEPER), on_spawn=lambda pid, pgid: seen.append((pid, pgid))
-            ):
+            async for obj in ndjson_from_cli(_cmd(_SLEEPER), on_spawn=seen.append):
                 first_object_before_callback.append(obj)
                 # The child is still alive here, so the kernel can still be
                 # asked what the callback claimed.
-                pid, pgid = seen[0]
-                assert os.getpgid(pid) == pgid
+                assert os.getpgid(seen[0].pid) == seen[0].pgid
                 break
 
         task = asyncio.create_task(run())
         await asyncio.wait_for(task, timeout=30)
 
         assert len(seen) == 1
-        pid, pgid = seen[0]
+        spawned = seen[0]
         # start_new_session=True: the child leads its own group, so the group
         # is the child's own pid and never this test process's.
-        assert pgid == pid
-        assert pgid != os.getpgid(0)
+        assert spawned.pgid == spawned.pid
+        assert spawned.pgid != os.getpgid(0)
         assert first_object_before_callback == [{"type": "hello"}]
 
     @pytest.mark.asyncio
-    async def test_callback_fires_before_any_object_is_yielded(self):
-        """The ordering IS the contract: a caller arming a per-leg timeout or
-        recording a quiescence-domain member must have the identity before the
-        leg can produce anything the caller might act on."""
-        order: list[str] = []
+    async def test_the_callback_fires_on_a_child_that_has_produced_nothing(self):
+        """The ordering IS the contract, and "before the first object" is too
+        weak to state it: an implementation that recorded just before yielding
+        would satisfy that and still leave a leg unrecorded for as long as it
+        stayed quiet. This child never speaks, so a recording made here was
+        made against the spawn and nothing else."""
+        seen: list[SpawnedProcess] = []
+        objects: list[dict] = []
 
-        async for _ in ndjson_from_cli(
-            _cmd(_QUICK), on_spawn=lambda pid, pgid: order.append("spawn")
-        ):
-            order.append("object")
+        async def run():
+            async for obj in ndjson_from_cli(_cmd(_MUTE), on_spawn=seen.append):
+                objects.append(obj)  # pragma: no cover - the child is mute
 
-        assert order == ["spawn", "object"]
+        task = asyncio.create_task(run())
+        try:
+            # Generous next to a spawn, tiny next to the child's 30s silence.
+            for _ in range(100):
+                if seen:
+                    break
+                await asyncio.sleep(0.05)
+            assert seen, "the callback had not fired while the child sat silent"
+            assert objects == []
+        finally:
+            task.cancel()
+            with pytest.raises((asyncio.CancelledError, ProcessLookupError)):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_the_recorded_identity_is_bound_to_a_start_time(self):
+        """pid and pgid are both recyclable, so on their own they name whatever
+        the kernel has handed those numbers to by the time anyone looks. The
+        start time is what makes them refer to this child, and it is readable
+        only while the child exists, which is why this is not left to the
+        consumer."""
+        seen: list[SpawnedProcess] = []
+
+        async def run():
+            async for _ in ndjson_from_cli(_cmd(_SLEEPER), on_spawn=seen.append):
+                break
+
+        task = asyncio.create_task(run())
+        await asyncio.wait_for(task, timeout=30)
+
+        assert len(seen) == 1
+        spawned = seen[0]
+        assert spawned.create_time is not None
+        # The value is this child's own, not a constant and not the parent's.
+        assert spawned.create_time != spawned_create_time(os.getpid())
+        assert spawned_create_time(spawned.pid) == spawned.create_time
 
     @pytest.mark.asyncio
     async def test_identity_is_recorded_even_for_a_child_that_exits_at_once(self):
-        """A group read deferred to teardown cannot answer for a reaped child.
-        The recorded group is a usable identity here only because it was read
-        while the child still existed."""
-        seen: list[tuple[int, int]] = []
+        """A read deferred to teardown cannot answer for a reaped child. The
+        recorded group is a usable identity here only because it was read while
+        the child still existed."""
+        seen: list[SpawnedProcess] = []
 
-        objs = await _drain(
-            ndjson_from_cli(_cmd(_QUICK), on_spawn=lambda pid, pgid: seen.append((pid, pgid)))
-        )
+        objs = await _drain(ndjson_from_cli(_cmd(_QUICK), on_spawn=seen.append))
 
         assert objs == [{"type": "hello"}]
         assert len(seen) == 1
-        pid, pgid = seen[0]
-        assert pgid == pid
+        assert seen[0].pgid == seen[0].pid
+
+    @pytest.mark.asyncio
+    async def test_an_async_recorder_is_awaited_before_the_stream_is_read(self):
+        """A durable recorder is written in the runner's own async style, and
+        ``Callable[..., None]`` does not reject an ``async def`` at runtime: an
+        un-awaited one would return a coroutine that is quietly dropped, so the
+        leg runs entirely unrecorded and nothing raises. The recording finishes
+        before the first object arrives, so a consumer that acts on the stream
+        can never be ahead of the record."""
+        recorded: list[SpawnedProcess] = []
+
+        async def recorder(spawned: SpawnedProcess) -> None:
+            await asyncio.sleep(0)
+            recorded.append(spawned)
+
+        objs = await _drain(ndjson_from_cli(_cmd(_QUICK), on_spawn=recorder))
+
+        assert objs == [{"type": "hello"}]
+        assert len(recorded) == 1
+        assert recorded[0].pid > 0
 
     @pytest.mark.asyncio
     async def test_no_callback_is_the_unchanged_path(self):
@@ -125,25 +209,51 @@ class TestSpawnObservationFailure:
         class RecorderFailed(RuntimeError):
             pass
 
-        def boom(pid: int, pgid: int) -> None:
-            seen.append(pid)
+        def boom(spawned: SpawnedProcess) -> None:
+            seen.append(spawned.pid)
             raise RecorderFailed("cannot record")
 
         with pytest.raises(RecorderFailed):
             await _drain(ndjson_from_cli(_cmd(_SLEEPER), on_spawn=boom))
 
         assert len(seen) == 1
-        pid = seen[0]
-        # The child was a 30s sleeper: still being here means it was ended
-        # rather than having finished on its own.
-        for _ in range(100):
-            try:
-                os.kill(pid, 0)
-            except ProcessLookupError:
-                break
-            await asyncio.sleep(0.05)
-        else:  # pragma: no cover - only reached if teardown did not run
-            pytest.fail(f"child {pid} still alive after the recorder failed")
+        await _await_death(seen[0])
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_recorder_also_leaves_no_running_child(self):
+        """``CancelledError`` and ``KeyboardInterrupt`` do not derive from
+        ``Exception``, so a guard written against that base would let both pass
+        while the child it had just created kept running. Cancellation is the
+        realistic one: a runner shutting down mid-spawn is exactly when an
+        unrecorded survivor is least likely to be noticed."""
+        seen: list[int] = []
+
+        def cancel(spawned: SpawnedProcess) -> None:
+            seen.append(spawned.pid)
+            raise asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            await _drain(ndjson_from_cli(_cmd(_SLEEPER), on_spawn=cancel))
+
+        assert len(seen) == 1
+        await _await_death(seen[0])
+
+    @pytest.mark.asyncio
+    async def test_a_failing_async_recorder_is_treated_the_same(self):
+        seen: list[int] = []
+
+        class RecorderFailed(RuntimeError):
+            pass
+
+        async def boom(spawned: SpawnedProcess) -> None:
+            seen.append(spawned.pid)
+            raise RecorderFailed("cannot record")
+
+        with pytest.raises(RecorderFailed):
+            await _drain(ndjson_from_cli(_cmd(_SLEEPER), on_spawn=boom))
+
+        assert len(seen) == 1
+        await _await_death(seen[0])
 
 
 class TestSpawnedPgid:
@@ -158,6 +268,17 @@ class TestSpawnedPgid:
 
     def test_reads_the_real_group_of_a_live_process(self):
         assert spawned_pgid(os.getpid()) == os.getpgid(os.getpid())
+
+
+class TestSpawnedCreateTime:
+    def test_reads_a_live_process_start_time(self):
+        assert spawned_create_time(os.getpid()) is not None
+
+    def test_a_reaped_pid_yields_no_start_time_rather_than_a_wrong_one(self):
+        """None here has to mean "nothing was established". Returning any
+        number for a pid whose process is gone would hand a consumer a binding
+        that matches whatever the OS next puts at that pid."""
+        assert spawned_create_time(_a_reaped_pid()) is None
 
 
 def _a_reaped_pid() -> int:
@@ -203,26 +324,68 @@ class TestRequestModelsCarryThem:
     def test_claude_code_request_keeps_them_off_the_wire(self):
         from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
 
-        req = ClaudeCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=lambda pid, pgid: None)
+        req = ClaudeCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=lambda spawned: None)
 
         assert req.env == {"A": "1"}
         assert callable(req.on_spawn)
         dumped = req.model_dump()
         assert "env" not in dumped and "on_spawn" not in dumped
-        args = req.as_cmd_args()
-        assert not [a for a in args if "env" in a.lower() or "spawn" in a.lower()]
+        assert req.as_cmd_args() == ClaudeCodeRequest(prompt="hi").as_cmd_args()
 
     def test_codex_request_keeps_them_off_the_wire(self):
         from lionagi.providers.openai.codex import CodexCodeRequest
 
-        req = CodexCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=lambda pid, pgid: None)
+        req = CodexCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=lambda spawned: None)
 
         assert req.env == {"A": "1"}
         assert callable(req.on_spawn)
         dumped = req.model_dump()
         assert "env" not in dumped and "on_spawn" not in dumped
-        args = req.as_cmd_args()
-        assert not [a for a in args if "env" in a.lower() or "spawn" in a.lower()]
+        assert req.as_cmd_args() == CodexCodeRequest(prompt="hi").as_cmd_args()
+
+    def test_the_argv_baseline_is_a_real_comparison(self):
+        """The two tests above assert an EXACT argv match against a request
+        without the runtime fields, rather than scanning for suspicious-looking
+        tokens. A scan passes for anything whose spelling the scan did not
+        anticipate, including the environment's own values. This asserts the
+        baseline is not vacuously equal to everything."""
+        from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+
+        baseline = ClaudeCodeRequest(prompt="hi").as_cmd_args()
+        assert baseline != ClaudeCodeRequest(prompt="hi", model="opus").as_cmd_args()
+
+    def test_neither_field_is_rendered_by_repr(self):
+        """``exclude=True`` governs serialisation only. A complete child
+        environment normally carries credentials, and pydantic's default repr
+        would print the whole mapping into any log line, f-string, or exception
+        that happens to include the request."""
+        from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+        from lionagi.providers.openai.codex import CodexCodeRequest
+
+        secret = "leaked-credential-value"
+        for model in (ClaudeCodeRequest, CodexCodeRequest):
+            req = model(prompt="hi", env={"TOKEN": secret}, on_spawn=lambda spawned: None)
+            assert secret not in repr(req)
+            assert secret not in str(req)
+            assert "on_spawn" not in repr(req)
+            # The value is still there to be used; it is only unprinted.
+            assert req.env == {"TOKEN": secret}
+
+    def test_a_malformed_environment_is_rejected_without_printing_any_value(self):
+        """The error a bad environment raises is itself a disclosure channel:
+        pydantic quotes the entire rejected input into a ValidationError, so a
+        single wrongly typed entry would print every credential beside it."""
+        from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+        from lionagi.providers.openai.codex import CodexCodeRequest
+
+        secret = "leaked-credential-value"
+        for model in (ClaudeCodeRequest, CodexCodeRequest):
+            with pytest.raises(TypeError) as excinfo:
+                model(prompt="hi", env={"TOKEN": secret, "BROKEN": 1})
+            message = str(excinfo.value)
+            assert "BROKEN" in message
+            assert secret not in message
+            assert "TOKEN" not in message
 
     def test_both_default_to_absent(self):
         from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
@@ -263,7 +426,7 @@ class TestRequestModelsCarryThem:
         monkeypatch.setattr(cc, "ndjson_from_cli", fake_ndjson)
         monkeypatch.setattr(cc, "CLAUDE_CLI", "claude")
 
-        recorder = lambda pid, pgid: None  # noqa: E731 - identity is what is asserted
+        recorder = lambda spawned: None  # noqa: E731 - identity is what is asserted
         req = cc.ClaudeCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=recorder)
         await _drain(cc.stream_cc_cli_events(req))
 
@@ -285,9 +448,89 @@ class TestRequestModelsCarryThem:
         monkeypatch.setattr(cx, "ndjson_from_cli", fake_ndjson)
         monkeypatch.setattr(cx, "CODEX_CLI", "codex")
 
-        recorder = lambda pid, pgid: None  # noqa: E731 - identity is what is asserted
+        recorder = lambda spawned: None  # noqa: E731 - identity is what is asserted
         req = cx.CodexCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=recorder)
         await _drain(cx.stream_codex_cli_events(req))
 
         assert captured["env"] == {"A": "1"}
         assert captured["on_spawn"] is recorder
+
+
+class TestEndpointsPreserveRuntimeState:
+    """``create_payload`` rebuilds the request from its dump, and the dump omits
+    both fields by construction. Without an explicit carry, a caller who passes
+    the advertised request model to an endpoint gets a leg with the inherited
+    environment and no spawn record, silently and with nothing raised."""
+
+    @pytest.mark.parametrize(
+        "endpoint_path,request_path",
+        [
+            (
+                "lionagi.providers.anthropic.claude_code:ClaudeCodeCLIEndpoint",
+                "lionagi.providers.anthropic.claude_code:ClaudeCodeRequest",
+            ),
+            (
+                "lionagi.providers.openai.codex:CodexCLIEndpoint",
+                "lionagi.providers.openai.codex:CodexCodeRequest",
+            ),
+        ],
+    )
+    def test_a_populated_request_survives_create_payload(self, endpoint_path, request_path):
+        endpoint_cls = _load(endpoint_path)
+        request_cls = _load(request_path)
+
+        def recorder(spawned):
+            return None
+
+        payload, _ = endpoint_cls().create_payload(
+            request_cls(prompt="hi", env={"A": "1"}, on_spawn=recorder)
+        )
+
+        rebuilt = payload["request"]
+        assert rebuilt is not None
+        assert rebuilt.env == {"A": "1"}
+        assert rebuilt.on_spawn is recorder
+
+    @pytest.mark.parametrize(
+        "endpoint_path,request_path",
+        [
+            (
+                "lionagi.providers.anthropic.claude_code:ClaudeCodeCLIEndpoint",
+                "lionagi.providers.anthropic.claude_code:ClaudeCodeRequest",
+            ),
+            (
+                "lionagi.providers.openai.codex:CodexCLIEndpoint",
+                "lionagi.providers.openai.codex:CodexCodeRequest",
+            ),
+        ],
+    )
+    def test_an_explicit_keyword_still_overrides_the_carried_value(
+        self, endpoint_path, request_path
+    ):
+        """The carry fills a gap the rebuild opened; it does not outrank what
+        the caller asked for at the call site."""
+        endpoint_cls = _load(endpoint_path)
+        request_cls = _load(request_path)
+
+        payload, _ = endpoint_cls().create_payload(
+            request_cls(prompt="hi", env={"A": "1"}), env={"B": "2"}
+        )
+
+        assert payload["request"].env == {"B": "2"}
+
+    def test_a_request_passed_as_a_dict_is_unaffected(self):
+        """A dict never went through a dump, so its values were never at risk.
+        This is the canonical iModel route and it must keep behaving as it did.
+        """
+        endpoint_cls = _load("lionagi.providers.anthropic.claude_code:ClaudeCodeCLIEndpoint")
+
+        payload, _ = endpoint_cls().create_payload({"prompt": "hi", "env": {"A": "1"}})
+
+        assert payload["request"].env == {"A": "1"}
+
+
+def _load(path: str):
+    module_name, _, attr = path.partition(":")
+    import importlib
+
+    return getattr(importlib.import_module(module_name), attr)

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -1372,6 +1372,108 @@ class TestRuntimeValuesArriveAfterConstructionToo:
         assert payload["request"].env == {"TOKEN": self.SECRET}
 
 
+class TestTheConfigsOwnSerialiserIsAlsoAPublicRoute:
+    """The two tests above serialize the whole model, and the drain that keeps
+    them clean hangs off the endpoint's ``to_dict``. ``EndpointConfig`` is
+    public and inherits Pydantic's ``model_dump``, so a caller that logs or
+    persists the config directly never reaches that drain.
+
+    Every test here serializes BEFORE any ``Endpoint.to_dict`` or
+    ``iModel.to_dict``. That ordering is the whole point: a drain runs on the
+    first higher-level dump, so a test that snapshots the model first would
+    find the config already clean and pass against the defect.
+    """
+
+    SECRET = "config-serialiser-canary"
+    PROVIDERS = ["claude_code", "codex"]
+
+    @staticmethod
+    def _fresh(provider):
+        from lionagi.service.imodel import iModel
+
+        return iModel(provider=provider)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_an_update_does_not_reach_the_configs_own_dump(self, provider):
+        config = self._fresh(provider).endpoint.config
+        config.update(env={"TOKEN": self.SECRET})
+
+        assert self.SECRET not in config.model_dump_json()
+        assert self.SECRET not in json.dumps(config.model_dump(), default=str)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_hydrated_config_does_not_reach_its_own_dump(self, provider):
+        from lionagi.service.imodel import iModel
+
+        snapshot = self._fresh(provider).to_dict()
+        snapshot["endpoint"]["config"]["kwargs"]["env"] = {"TOKEN": self.SECRET}
+
+        config = iModel.from_dict(snapshot).endpoint.config
+
+        assert self.SECRET not in config.model_dump_json()
+        assert self.SECRET not in json.dumps(config.model_dump(), default=str)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_callbacks_receiver_does_not_reach_the_configs_own_dump(self, provider):
+        """A callback is not a credential, but it is bound to something that
+        holds one, and a serializer reaching an unknown type falls back to its
+        ``repr``."""
+        secret = self.SECRET
+
+        class Supervisor:
+            def __init__(self):
+                self.token = secret
+
+            def on_spawn(self, spawned):
+                return None
+
+        supervisor = Supervisor()
+        config = self._fresh(provider).endpoint.config
+        config.update(on_spawn=supervisor.on_spawn)
+
+        assert self.SECRET not in json.dumps(config.model_dump(), default=str)
+        # Without the exclusion this raises instead of leaking, because a bound
+        # method has no JSON form. Raising in a logger is its own failure, so
+        # the assertion is that it now serializes and says nothing.
+        assert self.SECRET not in config.model_dump_json()
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_runtime_value_is_not_printed_by_the_config_either(self, provider):
+        """``repr`` walks ``kwargs`` whole. A config excluded from every dump
+        still reaches a traceback, a log line, and a debugger through this."""
+        config = self._fresh(provider).endpoint.config
+        config.update(env={"TOKEN": self.SECRET})
+
+        assert self.SECRET not in repr(config)
+        assert self.SECRET not in str(config)
+        # Presence is still reported: a reader asking why an environment was
+        # not applied is answered by the key, never by the value.
+        assert "env" in repr(config)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_an_ordinary_keyword_still_serialises_and_still_prints(self, provider):
+        """The over-refusal arm. An exclusion that drops everything passes every
+        test above and is still wrong, and ``kwargs`` is how a caller configures
+        an endpoint."""
+        config = self._fresh(provider).endpoint.config
+        config.update(some_ordinary_option="keep-me")
+
+        assert "keep-me" in config.model_dump_json()
+        assert config.model_dump()["kwargs"]["some_ordinary_option"] == "keep-me"
+        assert "keep-me" in repr(config)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_the_value_still_works_after_being_kept_out_of_the_dump(self, provider):
+        """Excluding a value from what gets written down must not stop it
+        reaching the child. Protect-by-dropping also passes a leak test."""
+        model = self._fresh(provider)
+        model.endpoint.config.update(env={"TOKEN": self.SECRET})
+
+        assert self.SECRET not in model.endpoint.config.model_dump_json()
+        payload, _ = model.endpoint.create_payload({"prompt": "ok"})
+        assert payload["request"].env == {"TOKEN": self.SECRET}
+
+
 class TestTheContinuationKeepsTheCallersOwnRecorder:
     """The continuation request is deep-copied, and a deep copy of a bound
     method copies its receiver. The copy would notify a duplicate supervisor

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -19,6 +19,7 @@ import json
 import os
 import signal
 import sys
+from types import MappingProxyType
 
 import pytest
 
@@ -1214,3 +1215,71 @@ class TestWhatTheProcessTableCouldNotAnswer:
 
         assert cs._kill_group_if_occupied(None) == "no-group"
         assert killed == []
+
+
+class TestTheRawInputShapesTheFixWasNotWrittenAgainst:
+    """The redaction was built against ``Model(**mutable_dict)`` and held there.
+    Two other shapes reach the same validators and neither was covered: an
+    immutable mapping through ``model_validate``, and a callback that is not
+    callable at all. Both put the value back into the error the carrier exists
+    to keep it out of."""
+
+    SECRET = "raw-input-canary"
+
+    @staticmethod
+    def _channels(exc) -> dict[str, str]:
+        """Every channel pydantic renders through, or the message for a plain
+        exception. Asserting on one of these is how the first version of this
+        protection passed while leaking."""
+        errors = getattr(exc, "errors", None)
+        if errors is None:
+            return {"str": str(exc)}
+        return {"str": str(exc), "errors": repr(exc.errors()), "json": exc.json()}
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_an_immutable_mapping_is_refused_rather_than_left_unredacted(self, model_path):
+        """Substituting in place is the mechanism, not a convenience: pydantic
+        keeps the object passed INTO the failing validator, so a sanitized copy
+        would change nothing. A mapping that cannot be written to can only be
+        leaked or refused."""
+        model = _load(model_path)
+
+        with pytest.raises(TypeError) as excinfo:
+            model.model_validate(MappingProxyType({"prompt": "", "env": {"TOKEN": self.SECRET}}))
+
+        for channel, text in self._channels(excinfo.value).items():
+            assert self.SECRET not in text, f"the environment leaked through {channel}"
+        # Refused for the right reason, and named so a caller can act on it.
+        assert "env" in str(excinfo.value)
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_a_read_only_mapping_without_runtime_fields_still_validates(self, model_path):
+        """The refusal is scoped to inputs that actually carry something to
+        protect. Without this, the fix for the leak breaks every read-only
+        mapping in general, which no leak test would have caught."""
+        model = _load(model_path)
+
+        request = model.model_validate(MappingProxyType({"prompt": "hi"}))
+
+        assert request.prompt == "hi"
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_a_callback_that_is_not_callable_is_rejected_without_being_printed(self, model_path):
+        """Unwrapping the carrier is what re-exposes the value. Handing a
+        non-callable back for pydantic to reject renders its ``repr`` in the
+        field error, so the rejection has to happen where the unwrapping does."""
+        model = _load(model_path)
+        secret = self.SECRET
+
+        class NotACallback:
+            def __repr__(self):
+                return f"NotACallback(token={secret!r})"
+
+        with pytest.raises(TypeError) as excinfo:
+            model(prompt="hi", on_spawn=NotACallback())
+
+        for channel, text in self._channels(excinfo.value).items():
+            assert self.SECRET not in text, f"the callback leaked through {channel}"
+        # The type is named, because a type name is not a credential and a
+        # caller cannot fix this without it.
+        assert "NotACallback" in str(excinfo.value)

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -1283,3 +1283,85 @@ class TestTheRawInputShapesTheFixWasNotWrittenAgainst:
         # The type is named, because a type name is not a credential and a
         # caller cannot fix this without it.
         assert "NotACallback" in str(excinfo.value)
+
+
+class TestRuntimeValuesArriveAfterConstructionToo:
+    """The drain ran once, at construction, and construction is not the only
+    way these values get in. ``EndpointConfig.update()`` puts unknown keys
+    straight back into the serializable ``kwargs`` and ``iModel.from_dict()``
+    assigns a hydrated config over the specialized one. Both are public, and a
+    value that arrives by either is the same credential as one passed to the
+    constructor."""
+
+    SECRET = "post-construction-canary"
+    PROVIDERS = ["claude_code", "codex"]
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_an_update_does_not_reach_a_serialised_model(self, provider):
+        from lionagi.service.imodel import iModel
+
+        model = iModel(provider=provider)
+        model.endpoint.config.update(env={"TOKEN": self.SECRET})
+
+        # Serialized BEFORE any payload is built, because that ordering is what
+        # would leave a drain hung off create_payload unreached.
+        assert self.SECRET not in json.dumps(model.to_dict())
+        payload, _ = model.endpoint.create_payload({"prompt": "ok"})
+        assert payload["request"].env == {"TOKEN": self.SECRET}
+        assert self.SECRET not in json.dumps(model.to_dict())
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_hydrated_config_does_not_reach_a_serialised_model(self, provider):
+        from lionagi.service.imodel import iModel
+
+        model = iModel(provider=provider)
+        payload_dict = model.to_dict()
+        payload_dict["endpoint"]["config"]["kwargs"]["env"] = {"TOKEN": self.SECRET}
+
+        rebuilt = iModel.from_dict(payload_dict)
+
+        assert self.SECRET not in json.dumps(rebuilt.to_dict())
+        payload, _ = rebuilt.endpoint.create_payload({"prompt": "ok"})
+        assert payload["request"].env == {"TOKEN": self.SECRET}
+
+
+class TestTheContinuationKeepsTheCallersOwnRecorder:
+    """The continuation request is deep-copied, and a deep copy of a bound
+    method copies its receiver. The copy would notify a duplicate supervisor
+    while the real one, which holds the durable process accounting, never hears
+    about the second subprocess. A stateless callback hides this entirely."""
+
+    @pytest.mark.asyncio
+    async def test_auto_finish_notifies_the_supervisor_the_caller_passed(self, monkeypatch):
+        import lionagi.providers.anthropic.claude_code as cc
+
+        class Supervisor:
+            def __init__(self):
+                self.seen: list = []
+
+            def observe(self, spawned):
+                self.seen.append(spawned)
+
+        supervisor = Supervisor()
+        seen_requests: list = []
+
+        async def fake_stream(request, session, **handlers):
+            # Record the request each leg was given, then hand the recorder the
+            # identity it would get from a real spawn.
+            seen_requests.append(request)
+            on_spawn = getattr(request, "on_spawn", None)
+            if on_spawn is not None:
+                on_spawn(f"leg-{len(seen_requests)}")
+            yield cc.StreamChunk(type="system", metadata={})
+
+        monkeypatch.setattr(cc, "stream_claude_code_cli", fake_stream)
+
+        endpoint = cc.ClaudeCodeCLIEndpoint()
+        request = cc.ClaudeCodeRequest(prompt="ok", auto_finish=True, on_spawn=supervisor.observe)
+        await endpoint._call({"request": request}, {})
+
+        # Both legs ran, and both reported to the object the caller handed in.
+        assert len(seen_requests) == 2, "auto_finish did not produce a continuation leg"
+        assert supervisor.seen == ["leg-1", "leg-2"]
+        assert seen_requests[1] is not seen_requests[0]
+        assert seen_requests[1].on_spawn.__self__ is supervisor

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -14,8 +14,10 @@ once the child is reaped.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
+import signal
 import sys
 
 import pytest
@@ -66,6 +68,85 @@ _ECHO_ENV = (
 # under the sleepers' 30s, so expiry means teardown did not run rather than
 # meaning the child finished by itself.
 _TEARDOWN_DEADLINE = 15.0
+
+_REQUEST_MODELS = [
+    "lionagi.providers.anthropic.claude_code:ClaudeCodeRequest",
+    "lionagi.providers.openai.codex:CodexCodeRequest",
+]
+
+# The descendant these tests are actually about. It ignores SIGTERM, writes its
+# own pid where the test can read it, and then outlives anything polite.
+_STUBBORN_DESCENDANT = (
+    "import os, signal, sys, time\n"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+    "open(sys.argv[1], 'w').write(str(os.getpid()))\n"
+    "time.sleep(60)\n"
+)
+
+# A CLI parent that starts that descendant inside its own group and then reports
+# ready. The parent itself dies promptly on SIGTERM, which is the shape that
+# matters: waiting the process a handle points at is not draining the group it
+# leads, so a teardown that equates the two leaves the descendant running.
+_PARENT_WITH_STUBBORN_CHILD = (
+    "import os, subprocess, sys, time\n"
+    "subprocess.Popen([sys.executable, '-c', sys.argv[1], sys.argv[2]])\n"
+    "while not os.path.exists(sys.argv[2]):\n"
+    "    time.sleep(0.02)\n"
+    "open(sys.argv[3], 'w').close()\n"
+    "time.sleep(60)\n"
+)
+
+
+def _stubborn_cmd(kid_pid_file, ready_file) -> list[str]:
+    return [
+        sys.executable,
+        "-c",
+        _PARENT_WITH_STUBBORN_CHILD,
+        _STUBBORN_DESCENDANT,
+        str(kid_pid_file),
+        str(ready_file),
+    ]
+
+
+async def _wait_for_file(path, limit: float = 15.0) -> bool:
+    loop = asyncio.get_running_loop()
+    until = loop.time() + limit
+    while loop.time() < until:
+        if path.exists():
+            return True
+        await asyncio.sleep(0.05)
+    return False
+
+
+def _is_alive(pid: int) -> bool:
+    """Alive and not a corpse. A zombie answers signal 0 and is not running."""
+    import psutil
+
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except psutil.Error:
+        return False
+
+
+async def _assert_dies(pid: int, what: str, deadline: float = _TEARDOWN_DEADLINE) -> None:
+    """Fail unless *pid* is gone within the deadline, and never leave it running.
+
+    Separate from :func:`_await_death` on two counts, both about a pid this
+    process did not spawn. It is not our child, so nothing here reaps it and it
+    can sit as a zombie that ``os.kill(pid, 0)`` answers for; status is what
+    distinguishes a corpse from a runner. And it ignores SIGTERM and sleeps for
+    a minute, so a failing assertion that merely reported would leave it behind
+    for every later test in the session to trip over.
+    """
+    loop = asyncio.get_running_loop()
+    until = loop.time() + deadline
+    while loop.time() < until:
+        if not _is_alive(pid):
+            return
+        await asyncio.sleep(0.05)
+    with contextlib.suppress(OSError):
+        os.kill(pid, signal.SIGKILL)
+    pytest.fail(f"{what} ({pid}) outlived the teardown by {deadline}s")
 
 
 def _cmd(script: str) -> list[str]:
@@ -707,22 +788,228 @@ class TestTheConfigRouteKeepsThemOutOfWhatIsSerialised:
         assert payload["request"].on_spawn is recorder
 
     @pytest.mark.parametrize("provider", ["claude_code", "codex"])
-    def test_a_copy_gets_the_same_callback_object_not_a_copy_of_it(self, provider):
-        """``iModel.copy`` deep copies the config. A deep copy of a bound
-        callback rebinds it to a copied receiver, so the original supervisor
-        would quietly stop hearing from the copy's legs while everything still
-        looked wired."""
+    def test_a_copy_still_notifies_the_original_supervisor(self, provider):
+        """``iModel.copy`` deep copies the config, and a deep copy of a bound
+        callback copies its receiver too — so the copy's legs would report to a
+        copied supervisor while the real one, which owns the durable process
+        accounting, hears nothing and every wiring check still passes.
+
+        It has to be a BOUND method. ``deepcopy`` of a plain function returns
+        the same object, so a test written with a nested function stays green
+        against an implementation that deep copies everything, which is the one
+        thing it exists to catch.
+        """
         from lionagi.service.imodel import iModel
 
-        def recorder(spawned):
-            return None
-
-        imodel = iModel(provider=provider, env={"TOKEN": self.SECRET}, on_spawn=recorder)
+        supervisor = _Supervisor()
+        imodel = iModel(provider=provider, env={"TOKEN": self.SECRET}, on_spawn=supervisor.observe)
         clone = imodel.copy()
 
         payload, _ = clone.endpoint.create_payload({"prompt": "hi"})
-        assert payload["request"].on_spawn is recorder
+        payload["request"].on_spawn("spawned")
+
+        assert supervisor.seen == ["spawned"], "the copy reported to a different supervisor"
+        assert payload["request"].env == {"TOKEN": self.SECRET}, "the copy lost the environment"
         assert self.SECRET not in json.dumps(clone.to_dict())
+
+    @pytest.mark.parametrize(
+        "endpoint_path",
+        [
+            "lionagi.providers.anthropic.claude_code:ClaudeCodeCLIEndpoint",
+            "lionagi.providers.openai.codex:CodexCLIEndpoint",
+        ],
+    )
+    def test_a_supplied_config_still_notifies_the_original_supervisor(self, endpoint_path):
+        """The other construction route. ``Endpoint.__init__`` copies a supplied
+        ``EndpointConfig`` with ``model_copy(deep=True)`` before anything of
+        ours runs, so the runtime values have to be lifted off the caller's own
+        object first or the endpoint holds the copy's rebound callback."""
+        import copy as copy_module
+
+        endpoint_cls = _load(endpoint_path)
+        supervisor = _Supervisor()
+
+        config = copy_module.deepcopy(endpoint_cls().config)
+        config.kwargs["on_spawn"] = supervisor.observe
+        config.kwargs["env"] = {"TOKEN": self.SECRET}
+
+        endpoint = endpoint_cls(config=config)
+        payload, _ = endpoint.create_payload({"prompt": "hi"})
+        payload["request"].on_spawn("spawned")
+
+        assert supervisor.seen == ["spawned"]
+        assert payload["request"].env == {"TOKEN": self.SECRET}
+        assert self.SECRET not in json.dumps(endpoint.to_dict())
+
+
+class _Supervisor:
+    """Stands in for the thing that owns durable process accounting.
+
+    Its ``observe`` is a bound method precisely because that is what a deep
+    copy rebinds; a module-level function would be copied to itself and prove
+    nothing.
+    """
+
+    def __init__(self):
+        self.seen: list[object] = []
+
+    def observe(self, spawned):
+        self.seen.append(spawned)
+
+
+class TestTheEnvironmentSurvivesNoErrorPath:
+    """``repr=False`` governs the model's own representation. It says nothing
+    about the channel pydantic opens when a DIFFERENT validator fails: the
+    input of a failing model-level validator is rendered verbatim, and at that
+    point the input is the caller's whole raw mapping."""
+
+    SECRET = "leaked-credential-value"
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_an_unrelated_validation_failure_prints_no_variable(self, model_path):
+        model = _load(model_path)
+
+        with pytest.raises(Exception) as excinfo:  # noqa: B017 - the type is the point below
+            model(env={"TOKEN": self.SECRET})
+
+        message = str(excinfo.value)
+        assert self.SECRET not in message
+        # The request really was rejected, so the absence above is a redaction
+        # and not a request that quietly succeeded.
+        assert "env" not in message or "variable(s)" in message
+        assert excinfo.type.__name__ == "ValidationError"
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_a_non_string_key_is_reported_by_position_not_printed(self, model_path):
+        """A string key is a variable NAME and naming it is what makes the
+        error actionable. A key of any other type is not a name, and printing
+        it prints whatever the caller put in it."""
+        model = _load(model_path)
+        secret_key = (self.SECRET,)
+
+        with pytest.raises(TypeError) as excinfo:
+            model(prompt="hi", env={secret_key: "ok"})
+
+        message = str(excinfo.value)
+        assert self.SECRET not in message
+        assert "entry 0" in message and "tuple" in message
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_a_string_key_is_still_named_because_a_name_is_not_a_secret(self, model_path):
+        model = _load(model_path)
+
+        with pytest.raises(TypeError) as excinfo:
+            model(prompt="hi", env={"CARGO_TARGET_DIR": 3})
+
+        assert "CARGO_TARGET_DIR" in str(excinfo.value)
+
+    @pytest.mark.parametrize("model_path", _REQUEST_MODELS)
+    def test_an_environment_that_is_not_a_mapping_is_not_printed(self, model_path):
+        """The redaction substitutes one mapping for another. A caller who
+        passes a sequence of pairs — a plausible way to build an environment —
+        goes past it untouched, so this rejection is the only thing standing
+        between that value and an error that would quote the whole of it."""
+        model = _load(model_path)
+
+        with pytest.raises(TypeError) as excinfo:
+            model(prompt="hi", env=[("TOKEN", self.SECRET)])
+
+        message = str(excinfo.value)
+        assert self.SECRET not in message
+        assert "list" in message
+
+
+class TestTheWholeGroupIsEnded:
+    """A CLI leg is a group, not a process.
+
+    Every spawn here uses ``start_new_session``, so the child leads a group that
+    holds whatever it starts. Teardown that waits the handle it holds is waiting
+    one member of that group; the rest are reparented and keep running, and
+    nothing in the parent's own state says so. These use a descendant that
+    ignores SIGTERM, because a cooperative one dies to the polite signal and
+    makes every version of this path look identical.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_failing_recorder_ends_the_descendants_too(self, tmp_path):
+        kid_pid = tmp_path / "kid.pid"
+        ready = tmp_path / "ready"
+
+        async def boom(spawned: SpawnedProcess) -> None:
+            assert await _wait_for_file(ready), "the leg never reported ready"
+            raise RuntimeError("cannot record")
+
+        with pytest.raises(RuntimeError):
+            await _drain(ndjson_from_cli(_stubborn_cmd(kid_pid, ready), on_spawn=boom))
+
+        await _assert_dies(int(kid_pid.read_text()), "the descendant of a failed spawn")
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_stream_ends_the_descendants_too(self, tmp_path):
+        """The recorder succeeds here, so the record exists and the ordinary
+        teardown runs. That is the reassuring case, and it is where the direct
+        child dies promptly to SIGTERM, the wait it is being watched by returns,
+        and the escalation that would have reached the rest of the group never
+        fires."""
+        kid_pid = tmp_path / "kid.pid"
+        ready = tmp_path / "ready"
+        recorded: list[SpawnedProcess] = []
+
+        task = asyncio.create_task(
+            _drain(ndjson_from_cli(_stubborn_cmd(kid_pid, ready), on_spawn=recorded.append))
+        )
+        assert await _wait_for_file(ready), "the leg never reported ready"
+        assert recorded, "the recorder never fired"
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        await _assert_dies(int(kid_pid.read_text()), "the descendant of a cancelled stream")
+        await _await_death(recorded[0].pid)
+
+
+class TestACancellationBeforeTheHandleArrives:
+    @pytest.mark.asyncio
+    async def test_a_child_started_but_never_returned_is_still_ended(self, tmp_path, monkeypatch):
+        """The OS has already started the child by the time
+        ``create_subprocess_exec`` resumes. A cancellation landing in the window
+        before it returns leaves a running leg that this process holds no handle
+        for and that no callback has recorded, so neither the teardown below nor
+        any later sweep over the records can reach it.
+
+        The window is widened deliberately. It is real and short, and a test
+        that raced it would pass on timing rather than on the shield.
+        """
+        kid_pid = tmp_path / "kid.pid"
+        ready = tmp_path / "ready"
+        started: list[int] = []
+        recorded: list[SpawnedProcess] = []
+        real = asyncio.create_subprocess_exec
+
+        async def slow(*args, **kwargs):
+            proc = await real(*args, **kwargs)
+            started.append(proc.pid)
+            await asyncio.sleep(2.0)
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", slow)
+
+        task = asyncio.create_task(
+            _drain(ndjson_from_cli(_stubborn_cmd(kid_pid, ready), on_spawn=recorded.append))
+        )
+        assert await _wait_for_file(ready), "the leg never reported ready"
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        # The premise, asserted rather than assumed: the OS made the child and
+        # nothing recorded it. Without both, this passes for the wrong reason.
+        assert started, "the spawn never reached the OS"
+        assert not recorded, "the cancellation did not land inside the spawn window"
+
+        await _assert_dies(int(kid_pid.read_text()), "the descendant of an abandoned spawn")
+        await _assert_dies(started[0], "the abandoned leg")
 
 
 def _load(path: str):

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -19,7 +19,7 @@ import json
 import os
 import signal
 import sys
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 
 import pytest
 
@@ -1365,3 +1365,95 @@ class TestTheContinuationKeepsTheCallersOwnRecorder:
         assert supervisor.seen == ["leg-1", "leg-2"]
         assert seen_requests[1] is not seen_requests[0]
         assert seen_requests[1].on_spawn.__self__ is supervisor
+
+
+class TestIdentityIsEstablishedTwoWaysNotOne:
+    """A recorded group id is provably still this child's under either of two
+    facts, and they cover different moments. While the child is unreaped its
+    pid cannot have been reissued. Once it is reaped, only a live member pins
+    the id. Checking only the second refuses where identity was never in
+    question; checking only the first signals a number that may name a
+    stranger."""
+
+    def test_an_unreaped_child_is_ended_without_consulting_the_scan(self, monkeypatch):
+        """This is the half that was missing. On the cancellation backstop the
+        direct child has not been waited, so its pid cannot have been reissued
+        and the group is provably its own. Refusing here because the process
+        table could not be read left a SIGTERM-ignoring descendant alive on
+        every platform that cannot enumerate."""
+        import lionagi.providers._cli_subprocess as cs
+
+        signalled: list = []
+        scanned: list = []
+        monkeypatch.setattr(cs, "kill_group_now", lambda pgid: signalled.append(pgid) or True)
+        monkeypatch.setattr(
+            cs, "group_member_pids", lambda pgid: (scanned.append(pgid), ([], False))[1]
+        )
+
+        verdict = cs._end_group_with_evidence(SimpleNamespace(pid=4242, returncode=None))
+
+        assert verdict == "killed-unreaped"
+        assert signalled == [4242]
+        # The scan is not merely ignored, it is not reached: an unreadable
+        # process table must not be able to change this answer.
+        assert scanned == []
+
+    def test_a_reaped_child_still_defers_to_the_scan(self, monkeypatch):
+        """The other side of the same rule, so the fix cannot be satisfied by
+        always killing. Once reaped, the pid is just a number."""
+        import lionagi.providers._cli_subprocess as cs
+
+        signalled: list = []
+        monkeypatch.setattr(cs, "kill_group_now", lambda pgid: signalled.append(pgid) or True)
+        monkeypatch.setattr(cs, "group_member_pids", lambda pgid: ([], False))
+
+        verdict = cs._end_group_with_evidence(SimpleNamespace(pid=4242, returncode=0))
+
+        assert verdict == "unproven"
+        assert signalled == []
+
+    def test_a_completed_but_reaped_spawn_is_not_signalled(self, monkeypatch):
+        """A spawn task can complete AND its child be reaped before the
+        done-callback runs. The pid is then just a number, and the group scan
+        is the only thing that can say whether it still names this child."""
+        import lionagi.providers._cli_subprocess as cs
+
+        signalled: list = []
+        monkeypatch.setattr(cs, "kill_group_now", lambda pgid: signalled.append(pgid) or True)
+        monkeypatch.setattr(cs, "group_member_pids", lambda pgid: ([], True))
+
+        class CompletedSpawn:
+            def cancelled(self):
+                return False
+
+            def exception(self):
+                return None
+
+            def result(self):
+                return SimpleNamespace(pid=4242, returncode=0)
+
+        cs._kill_abandoned_spawn(CompletedSpawn())
+
+        assert signalled == []
+
+    def test_a_completed_and_still_running_spawn_is_signalled(self, monkeypatch):
+        """The other half, so the fix above cannot be satisfied by never
+        signalling at all. Unreaped means the id is still this child's."""
+        import lionagi.providers._cli_subprocess as cs
+
+        signalled: list = []
+        monkeypatch.setattr(cs, "kill_group_now", lambda pgid: signalled.append(pgid) or True)
+
+        class RunningSpawn:
+            def cancelled(self):
+                return False
+
+            def exception(self):
+                return None
+
+            def result(self):
+                return SimpleNamespace(pid=4242, returncode=None)
+
+        cs._kill_abandoned_spawn(RunningSpawn())
+
+        assert signalled == [4242]

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -232,6 +232,22 @@ class TestRequestModelsCarryThem:
             assert req.env is None
             assert req.on_spawn is None
 
+    def test_the_request_models_still_generate_a_json_schema(self):
+        """`exclude=True` keeps a field out of a serialised INSTANCE; it does
+        nothing about the model's schema, which is generated from the class and
+        walks every field. Endpoint config asks for exactly this schema when it
+        serialises `request_options`, and a callable has no JSON schema at all
+        — so a plain Callable field here fails every code path that persists a
+        CLI request, none of which is in this module."""
+        from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+        from lionagi.providers.openai.codex import CodexCodeRequest
+
+        for model in (ClaudeCodeRequest, CodexCodeRequest):
+            schema = model.model_json_schema()
+            properties = schema.get("properties", {})
+            assert "on_spawn" not in properties
+            assert "env" not in properties
+
     @pytest.mark.asyncio
     async def test_claude_code_stream_hands_both_to_the_spawn_helper(self, monkeypatch):
         import lionagi.providers.anthropic.claude_code as cc

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -1,0 +1,277 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A caller that must record the process identity of a CLI leg it did not spawn
+itself reads that identity through ``ndjson_from_cli``'s ``on_spawn`` callback,
+and supplies the leg's environment through ``env``.
+
+These run real subprocesses. The identity being tested is the kernel's, and a
+mocked ``create_subprocess_exec`` would let a wrong pgid read pass: the whole
+point of reading the group at spawn is that the answer stops being available
+once the child is reaped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+from lionagi.providers._cli_subprocess import ndjson_from_cli, spawned_pgid
+
+# Emits one NDJSON object, then blocks until killed. Long enough that the
+# parent is still holding a live child when it inspects the group.
+_SLEEPER = (
+    "import sys, time; "
+    'sys.stdout.write(\'{"type": "hello"}\\n\'); sys.stdout.flush(); '
+    "time.sleep(30)"
+)
+
+# Emits one object and exits immediately, so by the time the stream drains the
+# child is reaped and its group is no longer readable from its pid.
+_QUICK = 'import sys; sys.stdout.write(\'{"type": "hello"}\\n\')'
+
+# Prints the two variables the environment tests care about, as NDJSON.
+_ECHO_ENV = (
+    "import json, os, sys; "
+    "sys.stdout.write(json.dumps({'type': 'env', "
+    "'inherited': os.environ.get('LIONAGI_TEST_INHERITED'), "
+    "'supplied': os.environ.get('LIONAGI_TEST_SUPPLIED')}) + '\\n')"
+)
+
+
+def _cmd(script: str) -> list[str]:
+    return [sys.executable, "-c", script]
+
+
+async def _drain(stream) -> list[dict]:
+    return [obj async for obj in stream]
+
+
+class TestSpawnObservation:
+    @pytest.mark.asyncio
+    async def test_reports_the_live_child_pid_and_its_real_process_group(self):
+        seen: list[tuple[int, int]] = []
+        first_object_before_callback = []
+
+        async def run():
+            async for obj in ndjson_from_cli(
+                _cmd(_SLEEPER), on_spawn=lambda pid, pgid: seen.append((pid, pgid))
+            ):
+                first_object_before_callback.append(obj)
+                # The child is still alive here, so the kernel can still be
+                # asked what the callback claimed.
+                pid, pgid = seen[0]
+                assert os.getpgid(pid) == pgid
+                break
+
+        task = asyncio.create_task(run())
+        await asyncio.wait_for(task, timeout=30)
+
+        assert len(seen) == 1
+        pid, pgid = seen[0]
+        # start_new_session=True: the child leads its own group, so the group
+        # is the child's own pid and never this test process's.
+        assert pgid == pid
+        assert pgid != os.getpgid(0)
+        assert first_object_before_callback == [{"type": "hello"}]
+
+    @pytest.mark.asyncio
+    async def test_callback_fires_before_any_object_is_yielded(self):
+        """The ordering IS the contract: a caller arming a per-leg timeout or
+        recording a quiescence-domain member must have the identity before the
+        leg can produce anything the caller might act on."""
+        order: list[str] = []
+
+        async for _ in ndjson_from_cli(
+            _cmd(_QUICK), on_spawn=lambda pid, pgid: order.append("spawn")
+        ):
+            order.append("object")
+
+        assert order == ["spawn", "object"]
+
+    @pytest.mark.asyncio
+    async def test_identity_is_recorded_even_for_a_child_that_exits_at_once(self):
+        """A group read deferred to teardown cannot answer for a reaped child.
+        The recorded group is a usable identity here only because it was read
+        while the child still existed."""
+        seen: list[tuple[int, int]] = []
+
+        objs = await _drain(
+            ndjson_from_cli(_cmd(_QUICK), on_spawn=lambda pid, pgid: seen.append((pid, pgid)))
+        )
+
+        assert objs == [{"type": "hello"}]
+        assert len(seen) == 1
+        pid, pgid = seen[0]
+        assert pgid == pid
+
+    @pytest.mark.asyncio
+    async def test_no_callback_is_the_unchanged_path(self):
+        assert await _drain(ndjson_from_cli(_cmd(_QUICK))) == [{"type": "hello"}]
+
+
+class TestSpawnObservationFailure:
+    @pytest.mark.asyncio
+    async def test_a_failing_recorder_propagates_and_leaves_no_running_child(self):
+        """Swallowing the recorder's failure would leave a live leg outside
+        whatever domain the record defines — precisely the process nobody can
+        later sweep. So it propagates, and the child it was called for is
+        ended on the way out."""
+        seen: list[int] = []
+
+        class RecorderFailed(RuntimeError):
+            pass
+
+        def boom(pid: int, pgid: int) -> None:
+            seen.append(pid)
+            raise RecorderFailed("cannot record")
+
+        with pytest.raises(RecorderFailed):
+            await _drain(ndjson_from_cli(_cmd(_SLEEPER), on_spawn=boom))
+
+        assert len(seen) == 1
+        pid = seen[0]
+        # The child was a 30s sleeper: still being here means it was ended
+        # rather than having finished on its own.
+        for _ in range(100):
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                break
+            await asyncio.sleep(0.05)
+        else:  # pragma: no cover - only reached if teardown did not run
+            pytest.fail(f"child {pid} still alive after the recorder failed")
+
+
+class TestSpawnedPgid:
+    def test_falls_back_to_the_pid_when_the_group_cannot_be_read(self):
+        """Every spawn here uses start_new_session, so a child leads its own
+        group and its pid IS the group id. The fallback is exact rather than a
+        guess, which is why an unreadable group is not an error."""
+        # A pid that cannot be resolved: 0 is this process's group by
+        # definition, so use a pid this process may not query.
+        dead = _a_reaped_pid()
+        assert spawned_pgid(dead) == dead
+
+    def test_reads_the_real_group_of_a_live_process(self):
+        assert spawned_pgid(os.getpid()) == os.getpgid(os.getpid())
+
+
+def _a_reaped_pid() -> int:
+    """Spawn a trivial child, wait for it, and return its now-reaped pid."""
+    import subprocess
+
+    proc = subprocess.Popen([sys.executable, "-c", ""])  # noqa: S603 - fixed argv
+    proc.wait()
+    return proc.pid
+
+
+class TestLegEnvironment:
+    @pytest.mark.asyncio
+    async def test_none_inherits_this_process_environment(self, monkeypatch):
+        monkeypatch.setenv("LIONAGI_TEST_INHERITED", "from-parent")
+
+        objs = await _drain(ndjson_from_cli(_cmd(_ECHO_ENV)))
+
+        assert objs[0]["inherited"] == "from-parent"
+
+    @pytest.mark.asyncio
+    async def test_a_supplied_mapping_replaces_rather_than_merges(self, monkeypatch):
+        """The replace-wholesale contract is stated on the field because the
+        alternative reading (merge) is the one a caller assumes, and a caller
+        who assumes it ships a leg missing PATH."""
+        monkeypatch.setenv("LIONAGI_TEST_INHERITED", "from-parent")
+
+        objs = await _drain(
+            ndjson_from_cli(
+                _cmd(_ECHO_ENV),
+                env={"LIONAGI_TEST_SUPPLIED": "from-caller", "PATH": os.environ.get("PATH", "")},
+            )
+        )
+
+        assert objs[0]["supplied"] == "from-caller"
+        assert objs[0]["inherited"] is None
+
+
+class TestRequestModelsCarryThem:
+    """The runner sets these on a request object; nothing renders them as CLI
+    arguments and nothing serialises them into a persisted request."""
+
+    def test_claude_code_request_keeps_them_off_the_wire(self):
+        from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+
+        req = ClaudeCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=lambda pid, pgid: None)
+
+        assert req.env == {"A": "1"}
+        assert callable(req.on_spawn)
+        dumped = req.model_dump()
+        assert "env" not in dumped and "on_spawn" not in dumped
+        args = req.as_cmd_args()
+        assert not [a for a in args if "env" in a.lower() or "spawn" in a.lower()]
+
+    def test_codex_request_keeps_them_off_the_wire(self):
+        from lionagi.providers.openai.codex import CodexCodeRequest
+
+        req = CodexCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=lambda pid, pgid: None)
+
+        assert req.env == {"A": "1"}
+        assert callable(req.on_spawn)
+        dumped = req.model_dump()
+        assert "env" not in dumped and "on_spawn" not in dumped
+        args = req.as_cmd_args()
+        assert not [a for a in args if "env" in a.lower() or "spawn" in a.lower()]
+
+    def test_both_default_to_absent(self):
+        from lionagi.providers.anthropic.claude_code import ClaudeCodeRequest
+        from lionagi.providers.openai.codex import CodexCodeRequest
+
+        for req in (ClaudeCodeRequest(prompt="hi"), CodexCodeRequest(prompt="hi")):
+            assert req.env is None
+            assert req.on_spawn is None
+
+    @pytest.mark.asyncio
+    async def test_claude_code_stream_hands_both_to_the_spawn_helper(self, monkeypatch):
+        import lionagi.providers.anthropic.claude_code as cc
+
+        captured: dict = {}
+
+        async def fake_ndjson(cmd, **kwargs):
+            captured.update(kwargs)
+            captured["cmd"] = cmd
+            return
+            yield  # pragma: no cover - generator shape only
+
+        monkeypatch.setattr(cc, "ndjson_from_cli", fake_ndjson)
+        monkeypatch.setattr(cc, "CLAUDE_CLI", "claude")
+
+        recorder = lambda pid, pgid: None  # noqa: E731 - identity is what is asserted
+        req = cc.ClaudeCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=recorder)
+        await _drain(cc.stream_cc_cli_events(req))
+
+        assert captured["env"] == {"A": "1"}
+        assert captured["on_spawn"] is recorder
+
+    @pytest.mark.asyncio
+    async def test_codex_stream_hands_both_to_the_spawn_helper(self, monkeypatch):
+        import lionagi.providers.openai.codex as cx
+
+        captured: dict = {}
+
+        async def fake_ndjson(cmd, **kwargs):
+            captured.update(kwargs)
+            captured["cmd"] = cmd
+            return
+            yield  # pragma: no cover - generator shape only
+
+        monkeypatch.setattr(cx, "ndjson_from_cli", fake_ndjson)
+        monkeypatch.setattr(cx, "CODEX_CLI", "codex")
+
+        recorder = lambda pid, pgid: None  # noqa: E731 - identity is what is asserted
+        req = cx.CodexCodeRequest(prompt="hi", env={"A": "1"}, on_spawn=recorder)
+        await _drain(cx.stream_codex_cli_events(req))
+
+        assert captured["env"] == {"A": "1"}
+        assert captured["on_spawn"] is recorder

--- a/tests/providers/test_cli_subprocess_spawn_observation.py
+++ b/tests/providers/test_cli_subprocess_spawn_observation.py
@@ -1474,6 +1474,175 @@ class TestTheConfigsOwnSerialiserIsAlsoAPublicRoute:
         assert payload["request"].env == {"TOKEN": self.SECRET}
 
 
+class TestBuiltInConversionIsAlsoAPublicRoute:
+    """A field serializer runs on Pydantic's dumps. It does not run on Python's
+    own conversions: ``dict(config)`` and ``list(config)`` go through
+    ``BaseModel.__iter__``, which yields the raw values held in ``__dict__``.
+
+    ``json.dumps(dict(config), default=str)`` is an ordinary way to write an
+    object to a log or a file, and it reaches neither the endpoint's drain nor
+    the config's serializer, so it is a third route to the same disk.
+    """
+
+    SECRET = "builtin-conversion-canary"
+    PROVIDERS = ["claude_code", "codex"]
+
+    @staticmethod
+    def _fresh(provider):
+        from lionagi.service.imodel import iModel
+
+        return iModel(provider=provider)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_an_update_does_not_reach_a_dict_conversion(self, provider):
+        config = self._fresh(provider).endpoint.config
+        config.update(env={"TOKEN": self.SECRET})
+
+        assert self.SECRET not in json.dumps(dict(config), default=str)
+        assert self.SECRET not in json.dumps(list(config), default=str)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_hydrated_config_does_not_reach_a_dict_conversion(self, provider):
+        from lionagi.service.imodel import iModel
+
+        snapshot = self._fresh(provider).to_dict()
+        snapshot["endpoint"]["config"]["kwargs"]["env"] = {"TOKEN": self.SECRET}
+
+        config = iModel.from_dict(snapshot).endpoint.config
+
+        assert self.SECRET not in json.dumps(dict(config), default=str)
+        assert self.SECRET not in json.dumps(list(config), default=str)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_callbacks_receiver_does_not_reach_a_dict_conversion(self, provider):
+        """``default=str`` renders a bound method as its repr, which names the
+        object it is bound to, which is the object holding the credential."""
+        secret = self.SECRET
+
+        class Supervisor:
+            def __init__(self):
+                self.token = secret
+
+            def __repr__(self):
+                return f"<Supervisor token={self.token}>"
+
+            def on_spawn(self, spawned):
+                return None
+
+        supervisor = Supervisor()
+        config = self._fresh(provider).endpoint.config
+        config.update(on_spawn=supervisor.on_spawn)
+
+        assert self.SECRET not in json.dumps(dict(config), default=str)
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_an_ordinary_keyword_survives_a_dict_conversion(self, provider):
+        """The over-refusal arm. A conversion that yields nothing satisfies
+        every assertion above, and ``dict(config)`` is a supported way to read
+        a model's fields."""
+        config = self._fresh(provider).endpoint.config
+        config.update(some_ordinary_option="keep-me")
+
+        converted = dict(config)
+        assert converted["kwargs"]["some_ordinary_option"] == "keep-me"
+        assert converted["provider"] == config.provider
+
+
+class TestACopyKeepsTheRuntimeStateItWasGiven:
+    """``iModel.copy`` deep-copies the config and then transfers runtime state.
+
+    A value that arrived after construction is still in ``config.kwargs``, so
+    the deep copy takes a duplicate of it and the transfer that follows can
+    overwrite the result with whatever the source happens to be holding. What
+    the caller passed has to survive both steps, and so does the caller's own
+    object identity: a deep copy of a bound callback is bound to a copied
+    receiver, and the supervisor the caller still holds would never hear from
+    the copy's legs.
+    """
+
+    SECRET = "copied-runtime-canary"
+    PROVIDERS = ["claude_code", "codex"]
+
+    @staticmethod
+    def _request(model):
+        payload, _ = model.endpoint.create_payload({"prompt": "ok"})
+        return payload["request"]
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_copy_keeps_an_environment_added_after_construction(self, provider):
+        from lionagi.service.imodel import iModel
+
+        model = iModel(provider=provider)
+        model.endpoint.config.update(env={"TOKEN": self.SECRET})
+
+        # The control: it has to work before a copy, or losing it after one
+        # says nothing about copying.
+        assert self._request(model).env == {"TOKEN": self.SECRET}
+        assert self._request(model.copy()).env == {"TOKEN": self.SECRET}
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_copy_calls_back_the_callers_own_object(self, provider):
+        from lionagi.service.imodel import iModel
+
+        class Supervisor:
+            def __init__(self):
+                self.seen = []
+
+            def on_spawn(self, spawned):
+                self.seen.append(spawned)
+
+        supervisor = Supervisor()
+        model = iModel(provider=provider)
+        model.endpoint.config.update(on_spawn=supervisor.on_spawn)
+
+        assert self._request(model).on_spawn is not None
+        carried = self._request(model.copy()).on_spawn
+        assert carried is not None
+        # Identity, not presence. A rebound duplicate is also "not None" and
+        # reports to an object nobody is holding.
+        assert carried.__self__ is supervisor
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_the_original_still_works_after_being_copied(self, provider):
+        """Copying reads the source's runtime state. Reading it must not be
+        what takes it away."""
+        from lionagi.service.imodel import iModel
+
+        model = iModel(provider=provider)
+        model.endpoint.config.update(env={"TOKEN": self.SECRET})
+
+        model.copy()
+
+        assert self._request(model).env == {"TOKEN": self.SECRET}
+
+    @pytest.mark.parametrize("provider", PROVIDERS)
+    def test_a_copy_is_a_second_object_that_can_be_written_down(self, provider):
+        """A copy has the same public surface as what it was copied from, so
+        every exclusion has to hold on it too.
+
+        The value is put back after the copy on purpose. Asserting against a
+        fresh clone would assert nothing: copying moves the runtime value into
+        state the config does not serialize, so a clone read straight after
+        being made is clean whatever the serializer does.
+
+        The config's own channels are read before ``to_dict``, for the same
+        reason the class above reads them first: ``to_dict`` drains, so a test
+        that calls it first finds the config already clean and passes against
+        the defect it was written for.
+        """
+        from lionagi.service.imodel import iModel
+
+        clone = iModel(provider=provider).copy()
+        clone.endpoint.config.update(env={"TOKEN": self.SECRET})
+
+        assert self.SECRET not in json.dumps(dict(clone.endpoint.config), default=str)
+        assert self.SECRET not in clone.endpoint.config.model_dump_json()
+        assert self.SECRET not in repr(clone.endpoint.config)
+        assert self.SECRET not in json.dumps(clone.to_dict())
+        # And it still reaches the child it was set for.
+        assert self._request(clone).env == {"TOKEN": self.SECRET}
+
+
 class TestTheContinuationKeepsTheCallersOwnRecorder:
     """The continuation request is deep-copied, and a deep copy of a bound
     method copies its receiver. The copy would notify a duplicate supervisor

--- a/tests/service/connections/providers/test_cli_cancellation.py
+++ b/tests/service/connections/providers/test_cli_cancellation.py
@@ -304,6 +304,9 @@ class TestNdjsonCleanupPropagation:
                 # Simulate cancellation during second read
                 raise asyncio.CancelledError()
 
+            # Not waited, so still None: this child is cancelled mid-stream,
+            # and an unset MagicMock here would report it as already reaped.
+            mock_proc.returncode = None
             mock_proc.stdout = MagicMock()
             mock_proc.stdout.read = slow_read
             mock_proc.stderr = MagicMock()
@@ -456,7 +459,17 @@ def _make_mock_proc(pid=12345):
     mock_proc.stdout.read = AsyncMock(return_value=b"")
     mock_proc.stderr = MagicMock()
     mock_proc.stderr.read = AsyncMock(return_value=b"")
-    mock_proc.wait = AsyncMock(return_value=0)
+    # A real process reports None until it has been waited and an int after.
+    # Left unset this is a MagicMock, which is not None, so anything asking
+    # whether the child has been reaped is told yes about one still running --
+    # and teardown decisions turn on exactly that question.
+    mock_proc.returncode = None
+
+    async def _wait():
+        mock_proc.returncode = 0
+        return 0
+
+    mock_proc.wait = AsyncMock(side_effect=_wait)
     mock_proc.terminate = MagicMock()
     mock_proc.kill = MagicMock()
     return mock_proc
@@ -488,6 +501,14 @@ class TestProcessGroupCleanup:
                 "lionagi.ln._proc.os.killpg",
                 side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
             ),
+            # A mock pid names no real group, so without this the enumeration
+            # correctly reports nobody there and a conditioned kill correctly
+            # declines. The surviving descendant this test is about is the
+            # thing being stated here.
+            patch(
+                "lionagi.providers._cli_subprocess.group_member_pids",
+                return_value=([mock_proc.pid + 1], True),
+            ),
         ):
             mock_exec.return_value = mock_proc
 
@@ -515,6 +536,14 @@ class TestProcessGroupCleanup:
             patch(
                 "lionagi.ln._proc.os.killpg",
                 side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
+            ),
+            # A mock pid names no real group, so without this the enumeration
+            # correctly reports nobody there and a conditioned kill correctly
+            # declines. The surviving descendant this test is about is the
+            # thing being stated here.
+            patch(
+                "lionagi.providers._cli_subprocess.group_member_pids",
+                return_value=([mock_proc.pid + 1], True),
             ),
         ):
             mock_exec.return_value = mock_proc
@@ -587,8 +616,10 @@ class TestProcessGroupCleanup:
                 async for _ in stream:
                     pass
 
-        # Group-kill skipped; direct terminate still ran.
-        mock_proc.terminate.assert_called()
+        # Reaching here is the assertion: cleanup ran to completion with no
+        # AttributeError from the absent killpg. Asserting terminate() was
+        # called instead pins a call that does nothing on a child which has
+        # already exited, and would pass whether or not the group was dealt with.
 
     @pytest.mark.asyncio
     async def test_pi_cleanup_no_killpg_platform(self, monkeypatch):
@@ -611,7 +642,10 @@ class TestProcessGroupCleanup:
                 async for _ in stream:
                     pass
 
-        mock_proc.terminate.assert_called()
+        # Reaching here is the assertion: cleanup ran to completion with no
+        # AttributeError from the absent killpg. Asserting terminate() was
+        # called instead pins a call that does nothing on a child which has
+        # already exited, and would pass whether or not the group was dealt with.
 
 
 class TestKillpgUnavailablePlatform:
@@ -635,7 +669,10 @@ class TestKillpgUnavailablePlatform:
                 async for _ in stream:
                     pass
 
-        mock_proc.terminate.assert_called()
+        # Reaching here is the assertion: cleanup ran to completion with no
+        # AttributeError from the absent killpg. Asserting terminate() was
+        # called instead pins a call that does nothing on a child which has
+        # already exited, and would pass whether or not the group was dealt with.
 
     @pytest.mark.asyncio
     async def test_codex_cleanup_no_killpg_platform(self, monkeypatch):
@@ -655,7 +692,10 @@ class TestKillpgUnavailablePlatform:
                 async for _ in stream:
                     pass
 
-        mock_proc.terminate.assert_called()
+        # Reaching here is the assertion: cleanup ran to completion with no
+        # AttributeError from the absent killpg. Asserting terminate() was
+        # called instead pins a call that does nothing on a child which has
+        # already exited, and would pass whether or not the group was dealt with.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`ndjson_from_cli` gains `on_spawn`, called once with a `SpawnedProcess`
(`pid`, `pgid`, `create_time`) as soon as the child process exists, and may be
a coroutine function — the result is awaited before the first byte of output is
read, so a recorder that writes durably has finished before anything can
consume the stream. The two CLI request models
(`ClaudeCodeRequest`, `CodexCodeRequest`) gain `env` and `on_spawn` carriers.
Both are runtime-only: excluded from serialization, kept out of the generated
schema, never rendered as CLI arguments, and never printed.

This is the first slice of the deterministic manifest fan-out described in
ADR-0110. A runner that dispatches N legs through the provider layer has to
record each leg's process identity in a durable record, and it does not spawn
those processes itself. Nothing captured the group before this change.

**Why the identity is read at spawn, and what that read cannot establish.**
Once a child is reaped its pid and group id are both recyclable, so either read
at teardown can resolve to a stranger's. The start time is what binds them, and
it is readable only while the child is known to exist. The group read is
bracketed between two start-time reads and the record drops its start time if
they disagree, which rejects a replacement arriving during the observation. It
does not speak for one that arrived before the first read. That limit is
written where the claim is made rather than left implied.

**Why the whole group is ended, not the process.** Every spawn here uses
`start_new_session`, so the child leads a group holding whatever it starts.
Waiting the process a handle points at is not draining that group: a descendant
that ignores `SIGTERM` outlives a parent that does not, and nothing in the
parent's own state says so. Teardown reads the group afterwards and ends it.

**A deliberate direction call in that teardown.** Every signal fires only on
positive evidence that the group id still belongs to this child, and there are
exactly two things that establish it: the child has not been waited, so its pid
cannot have been reissued, or the group answers with a live member, and an
occupied group is never reissued. Nothing else counts. The graceful helper
signals the id it is handed without checking anything, so it is reached only on
the not-yet-waited path; after a normal drain it would have sent SIGTERM to
whatever now holds a recycled id.

The escalation keys on that membership evidence rather than on whether the
direct child is dead, because those are different facts. A leader that died to
SIGTERM sets its return code while a descendant ignoring SIGTERM is still in
its group, so a backstop gated on the leader's liveness reads that as nothing
left to do.

Where the process table cannot be read completely and no members were seen,
emptiness is unproved and nothing is signalled. The cost of guessing is not
symmetric: guessing wrong in one direction leaves an orphan whose identity a
caller was handed and could have written down, and guessing wrong in the other
sends a signal to an unrelated process group, which is not recoverable at all.
That refusal is logged rather than silent. It is a platform limit rather than a
gap left open, because once the child is reaped only a surviving member pins
the id, and proving one exists is the enumeration that was unavailable.

**Why the child is still ended when the caller is cancelled before it is
handed over, and the one case that stays open.** The creation is shielded so
the handle still arrives when the caller is cancelled, and a done-callback ends
that group from outside the coroutine that unwound.

That does not cover a cancellation landing inside `create_subprocess_exec`
itself, after the OS has made the child but before the call returns, which is
what interpreter shutdown does. The pid was never handed to anyone in this
process, so nothing here can reach the group; asyncio closes the transport on
that path, which ends the direct child but not the group it leads. This is
measured, not inferred: a leg spawned under a loop that then shuts down leaves
a SIGTERM-ignoring descendant running. Recording the handle as soon as the
creation call returns was tried and removed, because it covers only the window
between the call returning and the caller resuming, which is not where the
cancellation lands. Reaching it needs the pid before the creation call returns,
which means driving `loop.subprocess_exec` with a protocol that records the pid
in `connection_made`. That is declined here: it pins this module to stdlib
classes outside that module's `__all__` across every supported Python version.

Nothing recovers that child afterwards either. `on_spawn` fires only once the
creation call has returned, which is exactly what did not happen, so the window
leaves no record for any later sweep to find — the test for it asserts that
emptiness rather than assuming it. This is a stated hole rather than a handled
one, said in the code and in the notes, and the log line on that path says what
was lost and why.

**Why a failing recorder is not swallowed.** A caller whose recording failed
has no record of a process that is now running, which is exactly the process
nobody can later sweep. The exception propagates and the child's group is ended
on the way out.

**Why `env` replaces rather than merges.** Merge is the reading a caller
assumes, and a caller who assumes it ships a leg missing `PATH`. The contract
is stated on the field and asserted by a test that a merging implementation
fails.

**Why `exclude` and `repr=False` are not the whole of keeping a child
environment private.** Those govern the model, and pydantic renders the input
of a failing `mode="before"` validator verbatim. A model-level validator holds
the whole raw mapping, so a request rejected for an unrelated reason, an empty
prompt for instance, quoted every variable beside the reason. Both values are
replaced at the top of each model-level validator, before anything there can
raise.

The substitute is deliberately not a mapping. A dict subclass with a quiet
`__repr__` closes the rendering channel and leaves the serialization one open:
`str(err)` and `err.errors()` go through `repr`, but `err.json()` walks the
structure and writes out every key and value, and `err.json()` is what a
structured logger emits. The carrier is neither a `dict` nor a `Mapping`, so
there is nothing to walk, and it reports its size in every channel.

`on_spawn` is wrapped for the same reason: a bound method carries its receiver
into its own `repr`, so a callback bound to a supervisor renders whatever that
supervisor holds, and receivers that render their attributes are the common
case. Both models unwrap the carrier in a field validator. Without that step
pydantic rejects a perfectly good callback as not callable, which is a failure
a leak test alone would never show.

Two rejections stay explicit because the substitution cannot reach them: an
`env` that is not a mapping at all, and a mapping with bad entries, which
raises `TypeError` because pydantic converts `ValueError` into an error that
quotes its input. A key that is not a string is reported by position and type,
since a non-string key is not a variable name and may hold anything.

**Why the drain is not the whole of it, and the part it missed is the public
one.** Holding these values out of what gets written down was done by draining
them out of `EndpointConfig.kwargs` when the endpoint serializes itself, which
covers `Endpoint.to_dict`, `iModel.to_dict` and the run snapshots underneath.
A drain has to be reached. `EndpointConfig` is public and inherits Pydantic's
`model_dump`, so a caller that logs or persists the config directly never goes
through an endpoint at all, and two supported routes put a runtime value back
into `kwargs` after the endpoint has already drained it once: a
post-construction `update()`, and `iModel.from_dict`, which assigns a freshly
hydrated config over the drained one. Between either of those and the next
endpoint-level dump the value is resting in a serializable field, and `env`
commonly holds a credential.

The names are therefore declared on `EndpointConfig` itself and that model
excludes them from its own `kwargs` serializer. The endpoint re-exports the
same tuple rather than keeping a second copy, because one list decides what
gets written down and a second would eventually be the one that fell behind.

A serializer is not every route out, and the two it misses are both public.
`dict(config)` and `list(config)` go through `BaseModel.__iter__`, which yields
the raw values held in `__dict__` and runs no field serializer at all, so
`json.dumps(dict(config), default=str)`, an ordinary way to write an object to
a log, carried the environment straight through. `repr` walks `kwargs` whole
for the same reason, so a config excluded from every dump still printed the
environment into a traceback or a log line. Both are closed on the model
itself, through `__iter__` and `__repr_args__`, which is what keeps the answer
independent of which caller is asking.

What the three channels leave behind differs on purpose. A dump and a `dict()`
omit the key, because both are structures a config is rebuilt from and a
placeholder would hydrate as a real value of the wrong type. `repr` reports
that a value is set without its contents, because nothing is rebuilt from a
`repr` and a reader asking why an environment was not applied is answered by
the key alone.

That covers the conversion API rather than reflection. `config.__dict__` and
`pickle` still hold these values, deliberately: the endpoint needs them
somewhere to work, and a rule that emptied every raw read would take the
working value with it. The line is between a route that produces a structure
for something else to hold, which is what reaches a log or a file, and a route
that reads the object's own memory.

**Why the endpoint reads these values off the caller's own object.**
`Endpoint.__init__` deep-copies a supplied `EndpointConfig` before any subclass
code runs, and a deep copy of a bound method copies its receiver. An endpoint
built from a prepared config would notify a copy of the supervisor while every
wiring check still passed. The declared runtime values are taken from the
object the caller handed in, before that copy.

**Why a copy drains its source before copying it.** `iModel.copy()` deep-copies
the config and then transfers runtime state from the original. A value passed
through `update()` after construction is still sitting in `config.kwargs` and
has never been drained, so the original's runtime state is empty: the new
endpoint drained the copied `kwargs` correctly at construction, and the
transfer then overwrote that with the empty mapping. The copy's legs ran with a
default environment and reported their spawns to nobody, with nothing raised
and nothing logged. Draining the source first leaves nothing runtime-only in
the copied config and moves the live objects across whole, which also stops a
bound callback being deep-copied and rebound to a receiver the caller is not
holding. Reading the source this way does not take the value away from it: a
drain relocates a value without changing which one wins when the payload is
built, so the original keeps working after being copied.

**Why an endpoint the caller already built is a separate route.**
`iModel(endpoint=<instance>, ...)` is a supported signature, and it takes a
branch that keeps the endpoint and discards every other keyword. For most
keywords that only loses configuration the endpoint already has. For these two
it hands the child a default environment and leaves the supervisor hearing
nothing, with nothing raised and nothing logged, which reads exactly like a
working leg. The values are placed on the instance, the way that same branch
already treats `provider` and `base_url`, and an endpoint with no runtime state
to hold them refuses instead of dropping them. A `None` there is the absence of
a value, not an instruction to clear one.

## Tests

`tests/providers/test_cli_subprocess_spawn_observation.py` — 109 tests, real
subprocesses rather than a mocked `create_subprocess_exec`, because the
identity under test is the kernel's and the property being tested is that the
answer is read while it is still available. The process tests use a descendant
that ignores `SIGTERM`, because a cooperative one dies to the polite signal and
makes every version of the teardown look identical.

Two of those tests are gated, not unconditional. They reach the descendant only
after the direct child has been waited, which is the one moment the escalation
needs the membership scan, and where that scan cannot see a live group the
documented behaviour is to refuse to signal — so a surviving descendant there is
the rule working. The gate is a positive control rather than a platform name: it
asks the same enumerator about a group that is provably occupied, because this
process is in it. What the decision does with an unreadable process table is
pinned unconditionally against a forced answer, so the gate removes a
real-process arm and no coverage of the refusal itself.

The tests for the public config surface are ordered deliberately: each one
reads the config immediately after the route that put a value into it and
before any `Endpoint.to_dict` or `iModel.to_dict`. A higher-level dump drains
first, so a test that snapshots the model before checking the config would find
it already clean and pass against the defect. The dump, the built-in `dict()`
conversion and the `repr` channels are each asserted, and an over-refusal arm
keeps an ordinary keyword serializing, converting and printing, because an
exclusion that drops everything passes every leak test and is still wrong.

The copy tests assert identity rather than presence: a deep-copied callback is
also not `None` and reports to an object nobody is holding, so the assertion is
that the caller's own supervisor is the receiver. Each carries the control that
the value works before a copy, since losing it afterwards says nothing if it
never arrived.

Each behaviour is mutation-verified against an unmutated green baseline: the
defect is restored, the naming test is confirmed to go red, and the mutation is
reverted by inverse edit. Where a guard has two directions, both are mutated —
a guard that always refuses passes every must-refuse test and is still wrong.
The runner decides detected or survived from a report file that only a real test
run emits, and refuses a run that collected nothing, so a failure to start the
interpreter cannot be scored as a detection.

The shared teardown covers all four CLI providers, so
`tests/service/connections/providers/test_cli_cancellation.py` moves with it.
Its process double never set `returncode`, leaving a `MagicMock` that reports a
running child as already reaped, which is the one question every teardown
decision turns on; it now models the real lifecycle. Where a test asserted a
`terminate()` call on a child that has already exited, it asserts instead that
cleanup completed, since the old assertion passed whether or not the group was
dealt with.

Full suite: 17335 tests, 0 errors. The only two failures are in
`tests/tools/test_coding_toolkit.py` and belong to the optional `reader` extra:
a scipy binary wheel does not load on the machine this was run on, which breaks
the `docling` import chain those two tests require. Neither traceback enters
this package, and both pass in CI.
