### PR TITLE
fix(cli,studio): answer from the store that holds it, and report only when the status is final

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -620,6 +620,18 @@ leg is about to fire on this same session, so this leg's teardown must not stamp
 status the resumed leg would then be blocked from overwriting by the ADR-0035 terminal guard
 (see `_runs.py` `_teardown_common` defer_terminal, below).
 
+The same ownership governs the direct no-persistence notice, and for the same reason: an
+interim leg has no answer to report. It is delivered from the tail rather than from the
+teardown, past every line that can still move the status — the empty-resumed-stream conversion
+to `failed`, and the auto-resume recursion that makes this leg interim. Delivering from the
+teardown reported `timed_out` for a run that went on to complete, and `completed` for one whose
+own return value said `failed`. Only the propagating-exception path still delivers from the
+teardown, because there the status is settled and nothing after the `try` block runs; the
+delivery is idempotent so those two reaches cannot both fire. The condition is the recursion's
+own branch and not the `will_auto_resume` computed earlier in teardown: that one is read before
+the effective status is applied, so suppressing on it could silence a leg that then does not
+recurse.
+
 ## `_agent_depth.py` — inherited agent-depth env marker
 
 `LIONAGI_AGENT_DEPTH` (integer string; unset/`0` = top-level, `>=1` = spawned worker) lets an

--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -38,6 +38,19 @@ the SPA fallback: a catch-all `/{full_path:path}` route would intercept
 `/api/shows` before FastAPI's trailing-slash redirect fires, whereas an
 exception handler runs only after every route has been tried and missed.
 
+**Startup and the 501 store guard** — `StoreNotAddressableError` becomes a 501
+at the route, which only helps if startup gets far enough for routes to be
+reachable at all. A subsystem that can read only a local SQLite file must
+therefore skip itself during `lifespan` rather than raise: `operator_startup`
+checks `require_file_store()` and returns empty against a server-backed or
+in-memory store, because raising there aborts the whole lifespan and the
+daemon serves nothing, including the routes whose whole job is to say this
+condition cannot be served. `OperatorStore.path()` raises the same
+`StoreNotAddressableError` as the rest of the SQLite-direct layer rather than
+an `OperatorStoreError`, so its routes answer 501 (permanent) instead of 503
+(retryable), and the definition of which stores this layer can open stays in
+one place.
+
 ## lionagi/studio/cli.py
 
 **`_validate_chain_action_node`** — Validates one `chain_action` node, recursing

--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -47,9 +47,13 @@ in-memory store, because raising there aborts the whole lifespan and the
 daemon serves nothing, including the routes whose whole job is to say this
 condition cannot be served. `OperatorStore.path()` raises the same
 `StoreNotAddressableError` as the rest of the SQLite-direct layer rather than
-an `OperatorStoreError`, so its routes answer 501 (permanent) instead of 503
-(retryable), and the definition of which stores this layer can open stays in
-one place.
+an `OperatorStoreError`, so the routes that open the store answer 501
+(permanent) instead of 503 (retryable), and the definition of which stores this
+layer can open stays in one place. The qualifier is doing work: a route that
+never opens the store is unaffected and answers normally in every mode.
+`GET /operator/models` returns its catalog from `operator/catalog.py` and so
+returns 200 against a server-backed store like any other, which is worth
+knowing before reading a 200 there as evidence that the store is reachable.
 
 ## lionagi/studio/cli.py
 
@@ -247,17 +251,33 @@ message ids) must not fall through to `0 or fallback`.
 - **`_find_definition_file`** — Candidates are literal-path joins, not glob
   patterns. Symlinks outside `base` are intentionally left unresolved and
   unrestricted — restricting them would break symlinked agent definitions.
-- **`_ensure_db` and the mixed-source reads** — `list_definitions` and
-  `get_definition` answer from two stores at once: current content from disk,
-  version history from SQLite. `save_definition` writes through `StateDB`, so
-  on a server-backed store the history lands in the server while the read side
-  falls back to the default local path — an old local database still present
-  from a previous deployment, reported as this definition's versions over
-  content read live from disk. `_ensure_db` answers False for a store with no
-  file for that reason, so the disk half is still served and the history is
-  simply left out. Routes whose whole answer *is* history (`get_version`)
-  refuse with `require_file_store` instead; the difference is whether dropping
-  the DB half leaves a usable answer.
+- **The mixed-source reads** — `list_definitions` and `get_definition` answer
+  from two places at once: current content from disk, version history from the
+  store. Both halves now resolve the same way, because history is read through
+  `StateDB` exactly as `save_definition` writes it. Reading SQLite directly was
+  the failure this replaces: writes went through `StateDB` and landed in the
+  configured server while reads fell back to the default local path, so an old
+  local database left over from a previous deployment was reported as this
+  definition's versions, laid over content read live from disk. Nothing in that
+  payload looks wrong; the two halves simply came from different stores.
+
+  When the store cannot be read at all, the disk half is still answered and the
+  history half is null rather than empty. The distinction is the point: an
+  empty history is a claim about the definition, and a caller told there are no
+  versions concludes nothing was ever saved. The true statement is about the
+  store, so `get_definition` returns `versions: null` with
+  `history_available: false`, and `list_definitions` reports `has_versions:
+  null` for the same reason. A client that does not handle it fails on a null
+  instead of quietly believing the definition was never versioned.
+
+  Routes whose whole answer *is* history have no disk half to fall back on, so
+  they refuse: `get_version` and `rollback_definition` raise
+  `HistoryUnavailableError` and the routes map it to 503. 503 rather than the 501
+  the Operator routes use, and the two are not interchangeable — every store
+  this deployment can be configured for is one `StateDB` reads, so failing to
+  read it is an operational condition a retry can outlive, where the Operator's
+  SQLite-only store makes the refusal permanent for that deployment. The
+  refusal body is a fixed string and carries nothing the driver said.
 
 ## lionagi/studio/services/playbooks.py
 

--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -247,6 +247,17 @@ message ids) must not fall through to `0 or fallback`.
 - **`_find_definition_file`** — Candidates are literal-path joins, not glob
   patterns. Symlinks outside `base` are intentionally left unresolved and
   unrestricted — restricting them would break symlinked agent definitions.
+- **`_ensure_db` and the mixed-source reads** — `list_definitions` and
+  `get_definition` answer from two stores at once: current content from disk,
+  version history from SQLite. `save_definition` writes through `StateDB`, so
+  on a server-backed store the history lands in the server while the read side
+  falls back to the default local path — an old local database still present
+  from a previous deployment, reported as this definition's versions over
+  content read live from disk. `_ensure_db` answers False for a store with no
+  file for that reason, so the disk half is still served and the history is
+  simply left out. Routes whose whole answer *is* history (`get_version`)
+  refuse with `require_file_store` instead; the difference is whether dropping
+  the DB half leaves a usable answer.
 
 ## lionagi/studio/services/playbooks.py
 

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -342,8 +342,29 @@ def load_last_branch() -> tuple[str | None, str]:
 
 
 def save_last_branch_pointer(run_id: str, branch_id: str) -> None:
-    ensure_lionagi_dir(LIONAGI_HOME)
-    _LAST_BRANCH_POINTER.write_text(json.dumps({"run_id": run_id, "branch_id": branch_id}))
+    """Record which branch `--continue` should pick up next. Best effort.
+
+    This is a convenience pointer, and it is written late — after a run has
+    produced its answer and, in the agent path, before that answer's terminal
+    notice goes out. Letting a filesystem error escape from here would cost the
+    caller the notice and the return value both, to protect a file whose only
+    job is to save someone typing a branch id.
+
+    So the failure is reported and not raised. It is reported rather than
+    swallowed because the next `--continue` will silently pick up an older run,
+    and that is confusing precisely when nobody remembers this warning.
+    """
+    from lionagi.cli._logging import warn
+
+    try:
+        ensure_lionagi_dir(LIONAGI_HOME)
+        _LAST_BRANCH_POINTER.write_text(json.dumps({"run_id": run_id, "branch_id": branch_id}))
+    except Exception as exc:  # noqa: BLE001 — a convenience pointer never fails a run
+        _log.warning("could not write the last-branch pointer: %r", exc, exc_info=exc)
+        warn(
+            f"could not record this run as the last branch ({exc}); "
+            f"`li agent -c` will resume an earlier run instead of this one"
+        )
 
 
 # ── Introspection ───────────────────────────────────────────────────────

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -1306,6 +1306,10 @@ async def _run_agent(
         if _write_run_manifest is not None:
             _write_run_manifest(run_manifest)
 
+    # Bookkeeping, and the terminal notice below has not gone out yet. This call
+    # reports its own failures rather than raising for exactly that reason: a
+    # run that finished still owes its answer to whoever asked to be told, and
+    # an unwritable convenience pointer is not a reason to withhold it.
     save_last_branch_pointer(run.run_id, branch_id)
 
     session_id = live.get("session_id") if live else None

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -1051,6 +1051,58 @@ async def _run_agent(
 
     _terminal_status = "completed"
     _terminal_exc: BaseException | None = None
+    _propagating = False
+    _direct_notice_sent = False
+
+    async def _deliver_direct_notice() -> None:
+        """Send this run's one terminal notice on the no-persistence route.
+
+        No session entity ever existed for this run, so the registered path
+        was never reached and nothing else will ever deliver for it. Which
+        makes *when* this is called the whole question: it reads
+        ``_terminal_status`` at call time, and a status is not this run's
+        answer until every later line that can still change it has run.
+
+        Shielded, because the guarantee it exists to provide is that a
+        terminal notice arrives, and the caller is a teardown path where a
+        cancellation is exactly what is expected to arrive.
+
+        Idempotent by flag rather than by the caller being careful: it is
+        reached from a ``finally`` and from the ordinary tail, and those two
+        overlap on nothing today, which is the sort of thing that stays true
+        only until someone adds a branch.
+        """
+        nonlocal _direct_notice_sent
+
+        if not notify or _notify_session_id is not None or _direct_notice_sent:
+            return
+        _direct_notice_sent = True
+        import anyio as _anyio
+
+        with _anyio.CancelScope(shield=True):
+            try:
+                from lionagi.cli.orchestrate._notify import deliver_flow_notify_now
+
+                _reason_code, _, _ = resolve_run_reason(
+                    status=_terminal_status, exception=_terminal_exc
+                )
+                await deliver_flow_notify_now(
+                    override=notify,
+                    run=run,
+                    entity_kind="session",
+                    entity_id=branch_id,
+                    invocation_id=invocation_id,
+                    flow_kind="agent",
+                    playbook=None,
+                    save_dir=str(run.artifact_root),
+                    cwd=cwd or os.getcwd(),
+                    started_at=run_manifest["started_at"],
+                    terminal_status=_terminal_status,
+                    reason_code=_reason_code,
+                    occurred_at=time.time(),
+                )
+            except Exception as _notify_exc:  # noqa: BLE001 — a notifier failure must never affect the run
+                log_error(f"direct-path notify.on_terminal delivery failed: {_notify_exc!r}")
 
     # Armed unconditionally, not only when --timeout is set: the steer receipt
     # ack below is the operator's only signal that a queued message was
@@ -1127,6 +1179,10 @@ async def _run_agent(
     except BaseException as exc:
         _terminal_status = classify_exception(exc)
         _terminal_exc = exc
+        # Nothing after this try block runs, so the teardown below is this
+        # run's last chance to notify. Every other path falls through to the
+        # tail, where the status is still being decided.
+        _propagating = True
         if _terminal_status == "failed":
             # Default traceback printing is unreliable under SIGTERM/process
             # death — leave a one-line diagnostic before it propagates.
@@ -1218,37 +1274,15 @@ async def _run_agent(
                 run_manifest["ended_at"] = time.time()
             if _write_run_manifest is not None:
                 _write_run_manifest(run_manifest)
-            # No session entity ever existed for this run (persistence setup
-            # failed), so register_flow_notify_scope above was never reached —
-            # this run's terminal status is now known, and delivering it here
-            # is the only chance this run gets. Same resolution, same payload
-            # shape as the registered path; see deliver_flow_notify_now.
-            if notify and _notify_session_id is None:
-                try:
-                    from lionagi.cli.orchestrate._notify import (
-                        deliver_flow_notify_now,
-                    )
-
-                    _reason_code, _, _ = resolve_run_reason(
-                        status=_terminal_status, exception=_terminal_exc
-                    )
-                    await deliver_flow_notify_now(
-                        override=notify,
-                        run=run,
-                        entity_kind="session",
-                        entity_id=branch_id,
-                        invocation_id=invocation_id,
-                        flow_kind="agent",
-                        playbook=None,
-                        save_dir=str(run.artifact_root),
-                        cwd=cwd or os.getcwd(),
-                        started_at=run_manifest["started_at"],
-                        terminal_status=_terminal_status,
-                        reason_code=_reason_code,
-                        occurred_at=time.time(),
-                    )
-                except Exception as _notify_exc:  # noqa: BLE001 — a notifier failure must never affect the run
-                    log_error(f"direct-path notify.on_terminal delivery failed: {_notify_exc!r}")
+            # Only when an exception is on its way out, because then this is
+            # the last code this run executes. On every other path the status
+            # is not settled yet: an empty resumed stream becomes `failed`
+            # below, and a leg about to auto-resume has no terminal answer of
+            # its own at all — the resumed leg carries the notice. Sending
+            # from here regardless is how a notifier was told `timed_out`
+            # about a run that went on to complete.
+            if _propagating:
+                await _deliver_direct_notice()
             # Unregister after teardown fires the terminal transition.
             if _notify_scope_name is not None:
                 unregister_flow_notify_scope(_notify_scope_name)
@@ -1279,6 +1313,12 @@ async def _run_agent(
     if _terminal_status == "timed_out" and resume_on_timeout and not _auto_resumed:
         from lionagi.cli._logging import warn
 
+        # Deliberately keyed on this branch rather than on the `will_auto_resume`
+        # the teardown computed: that one is read before the effective status is
+        # applied, so the two can disagree, and a notice suppressed on a
+        # recursion that then does not happen is a leg that never reports at all.
+        # The recursive call owns the notice, which is what makes it the final
+        # status rather than an interim one.
         warn(
             f"[auto-resume] session {session_id or branch_id} timed out after "
             f"{timeout}s — resuming once with 'continue and conclude the task'"
@@ -1309,6 +1349,10 @@ async def _run_agent(
             _auto_resumed=True,
             _injection_totals=_injection_totals,
         )
+
+    # Past every line that can still move the status, and past the recursion
+    # that would have made this leg an interim one, so this is the run's answer.
+    await _deliver_direct_notice()
 
     return res or "", provider, branch_id, _terminal_status, session_id
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -5178,6 +5178,30 @@ class StateDB:
             )
         return [dict(r) for r in rows]
 
+    async def list_latest_definition_versions(self) -> list[dict[str, Any]]:
+        """Latest version and timestamp for every definition, in one read.
+
+        For enriching a listing. The alternative is a query per definition,
+        which is the shape that turns a directory scan into a request storm;
+        the table holds one row per saved version, so grouping it whole is
+        cheaper than asking about each name in turn.
+        """
+        async with self._read() as conn:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT kind, name, MAX(version) AS version,"
+                            " MAX(created_at) AS created_at FROM definitions"
+                            " GROUP BY kind, name"
+                        )
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        return [dict(r) for r in rows]
+
     # ── Session signals (Phase C Move 1) ─────────────────────────────
 
     async def insert_session_signal(

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -29,7 +29,7 @@ from typing import Any
 
 from lionagi.state import db as state_db_mod
 
-from ..services._db import open_db
+from ..services._db import open_db, require_file_store
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS studio_operator_conversations (
@@ -173,10 +173,23 @@ class OperatorStore:
         self._schema_lock = asyncio.Lock()
 
     def path(self) -> Path:
+        """The StateDB file these tables live in.
+
+        A store with no file at all is refused as
+        :class:`StoreNotAddressableError` rather than as an
+        ``OperatorStoreError``, because those two say different things to a
+        caller. An Operator error is about this subsystem and the routes map it
+        to 503, which invites a retry; a server-backed or in-memory store is
+        not a condition that resolves by waiting, and the app answers 501 for
+        it everywhere else. Reusing the existing refusal also keeps one
+        definition of which stores this SQLite-direct layer can open, instead of
+        a second one here that could drift from it.
+        """
         if self._db_path is not None:
             return self._db_path
+        require_file_store()
         path = state_db_mod.state_db_file()
-        if path is None:
+        if path is None:  # pragma: no cover — require_file_store already refused
             raise OperatorStoreError(
                 "Studio Operator currently requires a local StateDB file; "
                 "no ephemeral fallback is available"

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -57,6 +57,29 @@ def _relative_path(full_path: Path) -> str:
 
 
 async def _ensure_db() -> bool:
+    """Whether version history is readable from here, at all.
+
+    Two ways it is not, and they are different conditions with the same
+    answer. A store file that has not been created yet holds no history. A
+    store with no file at all — a server, or an in-memory database — holds
+    history this SQLite-direct layer cannot reach, and ``store_path()`` falls
+    back to the default path for it. Enriching from that path is worse than
+    not enriching: a deployment that once ran on the local file still has it,
+    so the routes report version numbers and audit messages out of a database
+    nobody serves, over content read live from disk, in one payload that looks
+    entirely consistent. Writes are unaffected — ``save_definition`` goes
+    through ``StateDB`` and lands in the configured store — which is exactly
+    what makes the stale read plausible rather than obviously empty.
+
+    Routes whose whole answer is history refuse instead, with
+    ``require_file_store``. The two callers here are mixed-source: their disk
+    content is current and correct whatever the store is, so they answer that
+    and leave the history they cannot see out of it.
+    """
+    from lionagi.state import db as db_mod
+
+    if db_mod.state_db_file() is None:
+        return False
     return store_exists()
 
 

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from functools import partial
 from pathlib import Path
@@ -12,11 +13,15 @@ from pydantic import BaseModel
 
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
 
+# Imported eagerly: the state package resolves attributes lazily, so this
+# reaches the small URL-handling module without pulling the database layer in.
+from lionagi.state.engine import mask_credentials
+
 from ..registry import studio_route
-from ._db import open_db as _open_db
-from ._db import require_file_store, store_exists, store_path
 from ._path_safety import validate_name_component
 from .agents import _is_protected_system
+
+_log = logging.getLogger("lionagi.studio")
 
 # Per-(kind, name) concurrency lock, shared across all requests in this process.
 # Spans both the DB write and the disk write so a crash between them cannot leave disk ahead of history.
@@ -56,31 +61,62 @@ def _relative_path(full_path: Path) -> str:
         return str(full_path)
 
 
-async def _ensure_db() -> bool:
-    """Whether version history is readable from here, at all.
+class HistoryUnavailableError(Exception):
+    """The configured store could not be read. Distinct from holding nothing."""
 
-    Two ways it is not, and they are different conditions with the same
-    answer. A store file that has not been created yet holds no history. A
-    store with no file at all — a server, or an in-memory database — holds
-    history this SQLite-direct layer cannot reach, and ``store_path()`` falls
-    back to the default path for it. Enriching from that path is worse than
-    not enriching: a deployment that once ran on the local file still has it,
-    so the routes report version numbers and audit messages out of a database
-    nobody serves, over content read live from disk, in one payload that looks
-    entirely consistent. Writes are unaffected — ``save_definition`` goes
-    through ``StateDB`` and lands in the configured store — which is exactly
-    what makes the stale read plausible rather than obviously empty.
 
-    Routes whose whole answer is history refuse instead, with
-    ``require_file_store``. The two callers here are mixed-source: their disk
-    content is current and correct whatever the store is, so they answer that
-    and leave the history they cannot see out of it.
+# What the caller is told. The reason is logged rather than returned: a caller
+# can do nothing with a driver's connection error, and a driver that quotes the
+# connection string it failed on quotes the store password with it.
+#
+# The masking below is a backstop, not a repair of a demonstrated leak. Five
+# store failures were measured here — refused connection, unresolvable host,
+# unknown driver, unparseable URL, unknown scheme — and every one names a
+# socket or a plugin without quoting the URL. The set of drivers is open, and
+# masking a message that has nothing to mask costs nothing.
+_HISTORY_UNAVAILABLE_DETAIL = "Definition history is not readable right now"
+
+
+async def _read_history(kind: str, name: str) -> list[dict[str, Any]]:
+    """Version history for one definition, from the store that actually holds it.
+
+    History is read through ``StateDB``, the same way ``save_definition``
+    writes it, so a file, an in-memory database and a server all answer from
+    the store the deployment is configured for. Reading SQLite directly instead
+    could only ever see a local file, which for a server-backed deployment is a
+    database nobody serves: version numbers and audit messages out of an old
+    local file, laid over content read live from disk, in one payload that
+    looks entirely consistent.
+
+    Raising when the store cannot be read is the point. Returning an empty list
+    would say this definition has no versions, which is a claim about the
+    definition; the true statement is that this deployment cannot answer, which
+    is a claim about the store. A caller told "no versions" reasonably concludes
+    nothing was ever saved.
     """
-    from lionagi.state import db as db_mod
+    from lionagi.state.db import StateDB
 
-    if db_mod.state_db_file() is None:
-        return False
-    return store_exists()
+    try:
+        async with StateDB() as db:
+            rows = await db.list_definition_versions(kind, name)
+    except Exception as exc:  # noqa: BLE001 — any unreadable store is the same answer
+        _log.warning(
+            "definition history is unreadable for %s/%s: %s",
+            kind,
+            name,
+            mask_credentials(repr(exc)),
+        )
+        raise HistoryUnavailableError(mask_credentials(str(exc))) from exc
+
+    return [
+        {
+            "id": r["id"],
+            "version": r["version"],
+            "created_at": r["created_at"],
+            "message": r["message"],
+        }
+        for r in rows
+    ]
 
 
 async def list_definitions(kind: str | None = None) -> list[dict[str, Any]]:
@@ -129,23 +165,33 @@ async def list_definitions(kind: str | None = None) -> list[dict[str, Any]]:
 
     result = await anyio.to_thread.run_sync(partial(_scan_disk, kind))
 
-    if result and await _ensure_db():
-        conditions = " OR ".join("(kind = ? AND name = ?)" for _ in result)
-        params = [value for item in result for value in (item["kind"], item["name"])]
-        async with _open_db(store_path()) as db:
-            cur = await db.execute(
-                f"SELECT kind, name, MAX(version) AS v, MAX(created_at) AS ts"  # noqa: S608
-                f" FROM definitions WHERE {conditions} GROUP BY kind, name",
-                params,
+    if result:
+        from lionagi.state.db import StateDB
+
+        try:
+            async with StateDB() as db:
+                rows = await db.list_latest_definition_versions()
+        except Exception as exc:  # noqa: BLE001 — any unreadable store is the same answer
+            # Same distinction the single-definition route makes: unknown is
+            # null, not False. Reporting has_versions=False here would say
+            # these definitions have never been saved.
+            _log.warning(
+                "definition history is unreadable for the listing: %s",
+                mask_credentials(repr(exc)),
             )
-            rows = await cur.fetchall()
+            for entry in result:
+                entry["has_versions"] = None
+                entry["history_available"] = False
+            return result
+
         versions = {(row["kind"], row["name"]): row for row in rows}
         for entry in result:
+            entry["history_available"] = True
             row = versions.get((entry["kind"], entry["name"]))
-            if row and row["v"] is not None:
+            if row and row["version"] is not None:
                 entry["has_versions"] = True
-                entry["version"] = row["v"]
-                entry["updated_at"] = row["ts"] or entry["updated_at"]
+                entry["version"] = row["version"]
+                entry["updated_at"] = row["created_at"] or entry["updated_at"]
 
     return result
 
@@ -166,65 +212,72 @@ async def get_definition(kind: str, name: str) -> dict[str, Any] | None:
 
     content = await anyio.to_thread.run_sync(disk_file.read_text)
 
-    versions: list[dict[str, Any]] = []
-    if await _ensure_db():
-        async with _open_db(store_path()) as db:
-            cur = await db.execute(
-                "SELECT id, version, created_at, message FROM definitions WHERE kind = ? AND name = ? ORDER BY version DESC",
-                (kind, name),
-            )
-            rows = await cur.fetchall()
-            versions = [
-                {
-                    "id": r["id"],
-                    "version": r["version"],
-                    "created_at": r["created_at"],
-                    "message": r["message"],
-                }
-                for r in rows
-            ]
-
-    current_version = versions[0]["version"] if versions else 0
+    # The disk half is current and correct whatever the store is, so it is
+    # answered either way. The history half is null rather than empty when the
+    # store cannot be read: a client that does not handle it fails on a null
+    # instead of quietly believing this definition was never versioned.
+    try:
+        versions = await _read_history(kind, name)
+    except HistoryUnavailableError:
+        return {
+            "kind": kind,
+            "name": name,
+            "path": _relative_path(disk_file),
+            "content": content,
+            "version": None,
+            "versions": None,
+            "history_available": False,
+        }
 
     return {
         "kind": kind,
         "name": name,
         "path": _relative_path(disk_file),
         "content": content,
-        "version": current_version,
+        "version": versions[0]["version"] if versions else 0,
         "versions": versions,
+        "history_available": True,
     }
 
 
 async def get_version(kind: str, name: str, version: int) -> dict[str, Any] | None:
-    """Get a specific historical version's content."""
+    """Get a specific historical version's content.
+
+    This route's whole answer is history, so it has nothing to fall back on:
+    it either reads the store or it refuses. Raising ``HistoryUnavailableError``
+    keeps that refusal distinct from ``None``, which means the store answered
+    and does not have this version.
+    """
     # Validate at service boundary — kind/name are used in SQL WHERE clauses
     # and, indirectly, in any path lookups that build on this function.
     validate_name_component(kind, label="kind")
     validate_name_component(name, label="name")
 
-    require_file_store()
-    if not await _ensure_db():
+    from lionagi.state.db import StateDB
+
+    try:
+        async with StateDB() as db:
+            row = await db.get_definition(kind, name, version=version)
+    except Exception as exc:  # noqa: BLE001 — any unreadable store is the same answer
+        _log.warning(
+            "definition version is unreadable for %s/%s: %s",
+            kind,
+            name,
+            mask_credentials(repr(exc)),
+        )
+        raise HistoryUnavailableError(mask_credentials(str(exc))) from exc
+
+    if not row:
         return None
 
-    async with _open_db(store_path()) as db:
-        cur = await db.execute(
-            "SELECT id, content, version, created_at, message FROM definitions"
-            " WHERE kind = ? AND name = ? AND version = ?",
-            (kind, name, version),
-        )
-        row = await cur.fetchone()
-        if not row:
-            return None
-
-        return {
-            "kind": kind,
-            "name": name,
-            "version": row["version"],
-            "content": row["content"],
-            "created_at": row["created_at"],
-            "message": row["message"],
-        }
+    return {
+        "kind": kind,
+        "name": name,
+        "version": row["version"],
+        "content": row["content"],
+        "created_at": row["created_at"],
+        "message": row["message"],
+    }
 
 
 async def save_definition(
@@ -300,16 +353,24 @@ async def rollback_definition(kind: str, name: str, target_version: int) -> dict
     if not old:
         return None
 
-    current_version = 0
-    if await _ensure_db():
-        async with _open_db(store_path()) as db:
-            cur = await db.execute(
-                "SELECT MAX(version) AS v FROM definitions WHERE kind = ? AND name = ?",
-                (kind, name),
-            )
-            row = await cur.fetchone()
-            if row and row["v"] is not None:
-                current_version = row["v"]
+    from lionagi.state.db import StateDB
+
+    # The read above already refused if the store was unreadable, so reaching
+    # here means it answered once. It can still go away between the two reads,
+    # and that is the same condition under the same route, so it gets the same
+    # refusal rather than an uncaught error.
+    try:
+        async with StateDB() as db:
+            latest = await db.get_definition(kind, name)
+    except Exception as exc:  # noqa: BLE001 — any unreadable store is the same answer
+        _log.warning(
+            "definition history became unreadable mid-rollback for %s/%s: %s",
+            kind,
+            name,
+            mask_credentials(repr(exc)),
+        )
+        raise HistoryUnavailableError(mask_credentials(str(exc))) from exc
+    current_version = latest["version"] if latest else 0
 
     save_result = await save_definition(
         kind,
@@ -424,7 +485,18 @@ async def get_definition_route(kind: str, name: str) -> dict[str, Any]:
     name="get_version",
 )
 async def get_version_route(kind: str, name: str, version: int) -> dict[str, Any]:
-    v = await get_version(kind, name, version)
+    # 503, not 501: every store this deployment can be configured for is one
+    # StateDB can read, so failing to read it is an operational condition a
+    # retry can outlive. 501 would tell the caller to stop asking.
+    #
+    # The driver's own message is not repeated back over HTTP. It routinely
+    # quotes the connection string it failed on, which carries the store
+    # password, and a caller can do nothing with it either way. The diagnosis
+    # goes to the log, where it is masked.
+    try:
+        v = await get_version(kind, name, version)
+    except HistoryUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=_HISTORY_UNAVAILABLE_DETAIL) from exc
     if v is None:
         raise HTTPException(
             status_code=404, detail=f"Version {version} not found for {kind}/{name}"
@@ -459,7 +531,10 @@ async def rollback_definition_route(
     name: str,
     version: int = Query(..., description="Target version to restore"),
 ) -> dict[str, Any]:
-    result = await rollback_definition(kind, name, version)
+    try:
+        result = await rollback_definition(kind, name, version)
+    except HistoryUnavailableError as exc:
+        raise HTTPException(status_code=503, detail=_HISTORY_UNAVAILABLE_DETAIL) from exc
     if result is None:
         raise HTTPException(
             status_code=404, detail=f"Version {version} not found for {kind}/{name}"

--- a/lionagi/studio/services/operator.py
+++ b/lionagi/studio/services/operator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from typing import Any, Literal
 
 from fastapi import HTTPException, Query, Request
@@ -28,6 +29,8 @@ from ..operator.types import (
 )
 from ..registry import studio_route
 from ._sse import sse_response
+
+_log = logging.getLogger(__name__)
 
 
 def _http_error(exc: OperatorStoreError) -> HTTPException:
@@ -53,6 +56,26 @@ def _http_error(exc: OperatorStoreError) -> HTTPException:
 
 
 async def operator_startup() -> list[str]:
+    """Recover Operator turns interrupted by a previous daemon exit.
+
+    Skipped where the configured store has no file. The Operator's tables live
+    in the local StateDB file and nowhere else, so a server-backed or in-memory
+    store holds nothing for this to recover — and raising here aborts the whole
+    lifespan, so the daemon never starts serving and the 501 the routes would
+    have answered is never reached. A subsystem that cannot run must not take
+    the ones that can down with it.
+    """
+    from ._db import StoreNotAddressableError, require_file_store
+
+    try:
+        require_file_store()
+    except StoreNotAddressableError as exc:
+        _log.warning(
+            "Studio Operator disabled: %s. Its routes answer 501; the rest of "
+            "the daemon is unaffected.",
+            exc,
+        )
+        return []
     return await get_operator_coordinator().startup()
 
 

--- a/tests/apps_studio_server/test_definitions_batch2.py
+++ b/tests/apps_studio_server/test_definitions_batch2.py
@@ -55,66 +55,6 @@ class TestListDefinitionsNPlusOne:
             (agents_dir / f"agent{i}.md").write_text(f"# Agent {i}\ncontent")
 
         fake_db = tmp_path / "state.db"
-        fake_db.touch()  # exists → _ensure_db() returns True
-
-        monkeypatch.setattr(defs_mod, "LIONAGI_HOME", fake_home)
-        monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
-        monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", fake_home / "playbooks")
-        monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir})
-        # Patch DEFAULT_DB_PATH on BOTH the source module and definitions'
-        # local import — _ensure_db() uses the latter (from-import binding).
-        monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-
-        return defs_mod
-
-    def test_single_db_connect_for_multiple_definitions(self, tmp_path, monkeypatch):
-        """list_definitions() must open exactly one DB connection regardless of file count."""
-        defs_mod = self._setup(tmp_path, monkeypatch, n_agents=3)
-
-        connect_count = 0
-
-        def fake_connect(path):
-            nonlocal connect_count
-            connect_count += 1
-            return _FakeDB()
-
-        monkeypatch.setattr("aiosqlite.connect", fake_connect)
-
-        result = _run(defs_mod.list_definitions("agent"))
-
-        assert len(result) == 3, f"Expected 3 definitions, got {len(result)}"
-        assert connect_count == 1, (
-            f"Expected exactly 1 DB connection for {len(result)} definitions, got {connect_count}"
-        )
-
-    def test_no_db_connect_when_no_definitions(self, tmp_path, monkeypatch):
-        """list_definitions() must not open any DB connection when no files exist."""
-        defs_mod = self._setup(tmp_path, monkeypatch, n_agents=0)
-
-        connect_count = 0
-
-        def fake_connect(path):
-            nonlocal connect_count
-            connect_count += 1
-            return _FakeDB()
-
-        monkeypatch.setattr("aiosqlite.connect", fake_connect)
-
-        result = _run(defs_mod.list_definitions("agent"))
-        assert result == []
-        assert connect_count == 0, "No DB connect expected when no definitions found"
-
-    def test_version_info_populated_from_batch_query(self, tmp_path, monkeypatch):
-        """Batch query results must be mapped back to the correct entry."""
-        import lionagi.state.db as state_db_mod
-        import lionagi.studio.services.definitions as defs_mod
-
-        fake_home = tmp_path / "lionagi_home"
-        agents_dir = fake_home / "agents"
-        agents_dir.mkdir(parents=True)
-        (agents_dir / "myagent.md").write_text("# Agent\ncontent")
-
-        fake_db = tmp_path / "state.db"
         fake_db.touch()
 
         monkeypatch.setattr(defs_mod, "LIONAGI_HOME", fake_home)
@@ -123,33 +63,64 @@ class TestListDefinitionsNPlusOne:
         monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir})
         monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
 
-        class _RowLike:
-            def __init__(self, data):
-                self._data = data
+        return defs_mod
 
-            def __getitem__(self, key):
-                return self._data[key]
+    @staticmethod
+    def _count_history_reads(monkeypatch, rows=()):
+        """Count the history reads a listing makes, whatever the store is.
 
-        class _CursorWithRow:
-            async def fetchall(self):
-                return [_RowLike({"kind": "agent", "name": "myagent", "v": 7, "ts": 9999.0})]
+        Anchored to the portable reader rather than to a SQLite connection:
+        history moved to StateDB so that a server-backed deployment answers
+        from the store it is configured for, and a test that counts
+        `aiosqlite.connect` calls stops measuring anything at that point while
+        continuing to pass.
+        """
+        from lionagi.state.db import StateDB
 
-        class _DBWithRow:
-            row_factory = None
+        calls = []
 
-            async def execute(self, sql, params=None):
-                return _CursorWithRow()
+        async def _fake(self):
+            calls.append(1)
+            return list(rows)
 
-            async def __aenter__(self):
-                return self
+        monkeypatch.setattr(StateDB, "list_latest_definition_versions", _fake)
+        return calls
 
-            async def __aexit__(self, *args):
-                pass
+    def test_single_history_read_for_multiple_definitions(self, tmp_path, monkeypatch):
+        """One history read regardless of how many definitions are on disk."""
+        defs_mod = self._setup(tmp_path, monkeypatch, n_agents=3)
+        calls = self._count_history_reads(monkeypatch)
 
-        monkeypatch.setattr("aiosqlite.connect", lambda path: _DBWithRow())
+        result = _run(defs_mod.list_definitions("agent"))
+
+        assert len(result) == 3, f"Expected 3 definitions, got {len(result)}"
+        assert len(calls) == 1, (
+            f"Expected exactly 1 history read for {len(result)} definitions, got {len(calls)}"
+        )
+
+    def test_no_history_read_when_no_definitions(self, tmp_path, monkeypatch):
+        """Nothing on disk means nothing to enrich, so the store is not touched."""
+        defs_mod = self._setup(tmp_path, monkeypatch, n_agents=0)
+        calls = self._count_history_reads(monkeypatch)
+
+        result = _run(defs_mod.list_definitions("agent"))
+        assert result == []
+        assert len(calls) == 0, "No history read expected when no definitions were found"
+
+    def test_version_info_populated_from_batch_query(self, tmp_path, monkeypatch):
+        """Batch query results must be mapped back to the correct entry."""
+        defs_mod = self._setup(tmp_path, monkeypatch, n_agents=0)
+        agents_dir = defs_mod.KIND_DIRS["agent"]
+        (agents_dir / "myagent.md").write_text("# Agent\ncontent")
+
+        self._count_history_reads(
+            monkeypatch,
+            rows=[{"kind": "agent", "name": "myagent", "version": 7, "created_at": 9999.0}],
+        )
 
         result = _run(defs_mod.list_definitions("agent"))
         assert len(result) == 1
         assert result[0]["has_versions"] is True
         assert result[0]["version"] == 7
         assert result[0]["updated_at"] == 9999.0
+        assert result[0]["history_available"] is True

--- a/tests/apps_studio_server/test_not_answerable.py
+++ b/tests/apps_studio_server/test_not_answerable.py
@@ -157,3 +157,66 @@ def test_readiness_route_stays_200_when_store_is_server_backed(tmp_path, monkeyp
     assert r.status_code == 200
     body = r.json()
     assert body["status"] in {"unavailable", "healthy", "slow"}
+
+
+# ── Startup must reach the routes that do the refusing ──────────────────────
+
+
+def test_the_daemon_starts_against_a_server_backed_store(tmp_path, monkeypatch):
+    """Every test above builds the client without entering the lifespan, so
+    none of them exercises startup — and startup is where a subsystem that can
+    only read a local file gets to abort the whole daemon before a single
+    route is reachable. The Operator did exactly that: its store resolves the
+    StateDB file eagerly during recovery, so a server-backed deployment never
+    served anything, and the 501 those routes are supposed to answer was
+    unreachable by construction.
+
+    The port here is one nothing listens on, so the connection is refused
+    rather than hanging. That is the point: the rest of startup tolerates a
+    store it cannot reach, and the assertion is that the Operator does too.
+    """
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@127.0.0.1:1/db")
+
+    from lionagi.studio.app import app
+
+    with TestClient(app, base_url="http://127.0.0.1:8765", raise_server_exceptions=False) as client:
+        r = client.get("/api/operator/conversations")
+
+    assert r.status_code == 501, (
+        "the daemon started, so the route got to answer — and its answer is the "
+        "permanent one, not a 503 inviting a retry that cannot help"
+    )
+    body = r.json()
+    assert body["backend"] == "postgresql"
+    assert "secret" not in str(body), "the refusal must not echo the store URL"
+
+
+def test_operator_startup_recovers_nothing_rather_than_refusing(tmp_path, monkeypatch):
+    """The startup half on its own, without a client: a store with no file
+    holds no interrupted turns, so there is nothing to recover and no reason
+    to raise. Asserted separately because the test above would also pass if
+    the Operator were removed from the lifespan altogether."""
+    default = tmp_path / "state.db"
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@127.0.0.1:1/db")
+
+    from lionagi.studio.services.operator import operator_startup
+
+    assert _run(operator_startup()) == []
+
+
+def test_operator_startup_still_recovers_against_a_file_store(tmp_path, monkeypatch):
+    """The arm that stops the gate above from being a blanket disable: a real
+    file-backed store still runs Operator recovery, which is what a guard
+    keyed on the wrong condition would have silently switched off."""
+    default = tmp_path / "state.db"
+    _run(StateDB(default).open())
+    _configure(monkeypatch, default=default, url=None)
+
+    from lionagi.studio.operator.coordinator import get_operator_coordinator
+    from lionagi.studio.services.operator import operator_startup
+
+    assert _run(operator_startup()) == []
+    assert get_operator_coordinator()._started, (
+        "the coordinator never started, so recovery was skipped on a store that has a file"
+    )

--- a/tests/apps_studio_server/test_not_answerable.py
+++ b/tests/apps_studio_server/test_not_answerable.py
@@ -162,7 +162,24 @@ def test_readiness_route_stays_200_when_store_is_server_backed(tmp_path, monkeyp
 # ── Startup must reach the routes that do the refusing ──────────────────────
 
 
-def test_the_daemon_starts_against_a_server_backed_store(tmp_path, monkeypatch):
+@pytest.fixture
+def fresh_operator():
+    """A coordinator built from this test's configured store, not an earlier one.
+
+    The coordinator is a process-global singleton holding a store instance, and
+    a test that leaves it started leaves the next one reading whatever file it
+    was constructed with. Found the hard way: the 501 test below passed on its
+    own and answered 200 inside the full suite, from a store no assertion in it
+    had ever named.
+    """
+    from lionagi.studio.operator.coordinator import reset_operator_coordinator_for_testing
+
+    _run(reset_operator_coordinator_for_testing())
+    yield
+    _run(reset_operator_coordinator_for_testing())
+
+
+def test_the_daemon_starts_against_a_server_backed_store(tmp_path, monkeypatch, fresh_operator):
     """Every test above builds the client without entering the lifespan, so
     none of them exercises startup — and startup is where a subsystem that can
     only read a local file gets to abort the whole daemon before a single
@@ -205,10 +222,17 @@ def test_operator_startup_recovers_nothing_rather_than_refusing(tmp_path, monkey
     assert _run(operator_startup()) == []
 
 
-def test_operator_startup_still_recovers_against_a_file_store(tmp_path, monkeypatch):
+def test_operator_startup_still_recovers_against_a_file_store(
+    tmp_path, monkeypatch, fresh_operator
+):
     """The arm that stops the gate above from being a blanket disable: a real
     file-backed store still runs Operator recovery, which is what a guard
-    keyed on the wrong condition would have silently switched off."""
+    keyed on the wrong condition would have silently switched off.
+
+    The fixture matters here for a second reason: `_started` is what this
+    asserts, and inheriting a coordinator some earlier test already started
+    would satisfy it without this call doing anything.
+    """
     default = tmp_path / "state.db"
     _run(StateDB(default).open())
     _configure(monkeypatch, default=default, url=None)
@@ -216,6 +240,7 @@ def test_operator_startup_still_recovers_against_a_file_store(tmp_path, monkeypa
     from lionagi.studio.operator.coordinator import get_operator_coordinator
     from lionagi.studio.services.operator import operator_startup
 
+    assert not get_operator_coordinator()._started, "the premise: nothing has started it yet"
     assert _run(operator_startup()) == []
     assert get_operator_coordinator()._started, (
         "the coordinator never started, so recovery was skipped on a store that has a file"

--- a/tests/apps_studio_server/test_services_store_resolution.py
+++ b/tests/apps_studio_server/test_services_store_resolution.py
@@ -181,10 +181,86 @@ def test_history_enrichment_is_dropped_rather_than_read_from_a_stale_file(tmp_pa
     assert got["content"] == "what is on disk now", (
         "the disk half is correct whatever the store is, and must still be answered"
     )
-    assert got["versions"] == [], "history came from a database this deployment does not serve"
-    assert got["version"] == 0
-    assert listed[0]["has_versions"] is False
-    assert listed[0]["version"] == 0
+    # The stale local file must not be the source, and "unreadable" must not be
+    # dressed up as "empty": an empty history is a claim about the definition,
+    # and the true statement here is about the store. A caller told there are no
+    # versions concludes nothing was ever saved, which is the opposite of true.
+    assert "what the old local database holds" not in str(got)
+    assert got["history_available"] is False
+    assert got["versions"] is None, "an unreadable history is null, never an empty list"
+    assert got["version"] is None
+    assert listed[0]["history_available"] is False
+    assert listed[0]["has_versions"] is None, "unknown, not False"
+
+
+def test_the_routes_that_are_only_history_refuse_rather_than_report_absence(tmp_path, monkeypatch):
+    """A version read and a rollback have no disk half to fall back on, so an
+    unreadable store leaves them nothing true to say. Answering 404 would say
+    the store was read and does not have this version.
+
+    503 rather than 501: every store this deployment can be configured for is
+    one StateDB reads, so an unreadable one is an operational condition a retry
+    can outlive. The Operator routes answer 501 for the opposite reason, their
+    store being SQLite-only, and the two must not be conflated.
+
+    The port is one nothing listens on, so the connection is refused rather
+    than hanging.
+    """
+    from fastapi.testclient import TestClient
+
+    default = tmp_path / "state.db"
+    disk = tmp_path / "agents"
+    disk.mkdir()
+    (disk / "demo.md").write_text("what is on disk now")
+    _configure(monkeypatch, default=default, url="postgresql://user:secret@127.0.0.1:1/db")
+
+    import lionagi.studio.services.definitions as definitions_mod
+
+    monkeypatch.setitem(definitions_mod.KIND_DIRS, "agent", disk)
+
+    from lionagi.studio.app import app
+
+    with TestClient(app, base_url="http://127.0.0.1:8765", raise_server_exceptions=False) as client:
+        version_read = client.get("/api/definitions/agent/demo/versions/1")
+        rollback = client.post("/api/definitions/agent/demo/rollback?version=1")
+
+    for label, response in (("version read", version_read), ("rollback", rollback)):
+        assert response.status_code == 503, f"{label}: {response.text}"
+        # The body is the fixed refusal and carries nothing the driver said.
+        # Asserting that directly, rather than searching the body for the
+        # password: the five store failures reachable from here name a socket
+        # or a plugin and never quote the URL, so a search for the credential
+        # passes whether or not anything guards it. What is worth pinning is
+        # that the driver's message does not reach the caller at all, which is
+        # the property that keeps this true for a driver that does quote it.
+        assert response.json()["detail"] == definitions_mod._HISTORY_UNAVAILABLE_DETAIL, (
+            f"{label} passed the driver's own message through"
+        )
+
+
+def test_a_readable_store_still_answers_those_routes(tmp_path, monkeypatch):
+    """The over-refusal arm for the pair above. Without it, a version route
+    that refused unconditionally would pass that test."""
+    from fastapi.testclient import TestClient
+
+    store = tmp_path / "state.db"
+    _seed_definition(store, content="what the database holds", message="recorded")
+    disk = tmp_path / "agents"
+    disk.mkdir()
+    (disk / "demo.md").write_text("what is on disk now")
+    _configure(monkeypatch, default=store, url=None)
+
+    import lionagi.studio.services.definitions as definitions_mod
+
+    monkeypatch.setitem(definitions_mod.KIND_DIRS, "agent", disk)
+
+    from lionagi.studio.app import app
+
+    with TestClient(app, base_url="http://127.0.0.1:8765", raise_server_exceptions=False) as client:
+        response = client.get("/api/definitions/agent/demo/versions/1")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["content"] == "what the database holds"
 
 
 def test_history_enrichment_still_happens_against_the_configured_file(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_services_store_resolution.py
+++ b/tests/apps_studio_server/test_services_store_resolution.py
@@ -131,3 +131,78 @@ def test_a_configured_store_is_never_created_by_reading_it(tmp_path, monkeypatch
 
     assert store_exists() is False
     assert not configured.exists()
+
+
+# ── A store with no file is not a store that is merely empty ────────────────
+
+
+def _seed_definition(db_path: Path, *, content: str, message: str) -> None:
+    async def _go():
+        async with StateDB(db_path) as db:
+            await db.save_definition(
+                kind="agent",
+                name="demo",
+                path="agents/demo.md",
+                content=content,
+                message=message,
+            )
+
+    _run(_go())
+
+
+def test_history_enrichment_is_dropped_rather_than_read_from_a_stale_file(tmp_path, monkeypatch):
+    """The definition routes read current content from disk and enrich it with
+    version history from the store. Against a server-backed store there is no
+    file for that history, and resolution falls back to the default path — so a
+    deployment that once ran locally still has that database, and the route
+    reported its versions and audit messages over content read live from disk.
+    Nothing about the payload looks wrong; the two halves simply came from
+    different stores, and only one of them is the store in use.
+
+    Writes are not affected, which is what makes it plausible rather than
+    obviously broken: `save_definition` goes through StateDB and lands in the
+    configured store, so the local file only ever looks out of date, never
+    empty.
+    """
+    import lionagi.studio.services.definitions as definitions_mod
+
+    fallback = tmp_path / "state.db"
+    _seed_definition(fallback, content="what the old local database holds", message="old")
+    disk = tmp_path / "agents"
+    disk.mkdir()
+    (disk / "demo.md").write_text("what is on disk now")
+
+    _configure(monkeypatch, default=fallback, url="postgresql://user:secret@host/prod")
+    monkeypatch.setitem(definitions_mod.KIND_DIRS, "agent", disk)
+
+    got = _run(definitions_mod.get_definition("agent", "demo"))
+    listed = _run(definitions_mod.list_definitions("agent"))
+
+    assert got["content"] == "what is on disk now", (
+        "the disk half is correct whatever the store is, and must still be answered"
+    )
+    assert got["versions"] == [], "history came from a database this deployment does not serve"
+    assert got["version"] == 0
+    assert listed[0]["has_versions"] is False
+    assert listed[0]["version"] == 0
+
+
+def test_history_enrichment_still_happens_against_the_configured_file(tmp_path, monkeypatch):
+    """The over-refusal arm, on the same seeded database: configure it as the
+    store and the identical call must enrich. Without this, dropping enrichment
+    unconditionally would pass the test above."""
+    import lionagi.studio.services.definitions as definitions_mod
+
+    store = tmp_path / "state.db"
+    _seed_definition(store, content="what the database holds", message="recorded")
+    disk = tmp_path / "agents"
+    disk.mkdir()
+    (disk / "demo.md").write_text("what is on disk now")
+
+    _configure(monkeypatch, default=store, url=None)
+    monkeypatch.setitem(definitions_mod.KIND_DIRS, "agent", disk)
+
+    got = _run(definitions_mod.get_definition("agent", "demo"))
+
+    assert got["version"] == 1
+    assert [v["message"] for v in got["versions"]] == ["recorded"]

--- a/tests/cli/test_agent_notify_without_persistence.py
+++ b/tests/cli/test_agent_notify_without_persistence.py
@@ -28,6 +28,7 @@ usable is configured — never merely because persistence broke.
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -341,3 +342,42 @@ async def test_a_run_that_raises_still_reports_before_the_exception_leaves(monke
     assert notices == ["failed"], (
         f"a run that raised must still report, exactly once; got {notices}"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_pointer_write_does_not_cost_the_run_its_notice(
+    monkeypatch, tmp_path, caplog
+):
+    """The last-branch pointer is written after teardown and before the tail
+    that delivers, so anything raising there takes the notice with it.
+
+    The fault injected here is the filesystem's rather than a stand-in raiser:
+    the pointer is aimed at a directory and the real helper is put back, because
+    what has to survive is a write that fails, not a function someone replaced.
+    """
+    _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
+
+    import lionagi.cli._runs as runs_mod
+    import lionagi.cli.agent as agent_mod
+
+    marker = tmp_path / "delivered.txt"
+    script = _write_fake_notifier(tmp_path)
+    notify_cmd = f"{sys.executable} {script} {marker} {{status}}"
+
+    # The shared harness stubs the pointer write out; this test is about it.
+    monkeypatch.setattr(agent_mod, "save_last_branch_pointer", runs_mod.save_last_branch_pointer)
+    blocked = tmp_path / "pointer-is-a-directory"
+    blocked.mkdir()
+    monkeypatch.setattr(runs_mod, "_LAST_BRANCH_POINTER", blocked)
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli"):
+        _res, _provider, _branch_id, status, _session = await agent_mod._run_agent(
+            "codex/model", "do the thing", notify=notify_cmd
+        )
+
+    assert status == "completed"
+    assert marker.exists(), "the pointer write took the terminal notice with it"
+    assert marker.read_text() == "completed"
+    # Reported, not swallowed: the next `-c` will resume something else, and a
+    # silent version of this is worse than the failure it is hiding.
+    assert any("last-branch pointer" in rec.message for rec in caplog.records)

--- a/tests/cli/test_agent_notify_without_persistence.py
+++ b/tests/cli/test_agent_notify_without_persistence.py
@@ -197,3 +197,110 @@ async def test_control_disabling_the_direct_path_delivers_nothing(monkeypatch, t
         "the old path recorded nothing either — this is what made the run look "
         "exactly like one that never asked for a notifier at all"
     )
+
+
+def _write_appending_notifier(tmp_path: Path) -> Path:
+    """Like the fake notifier above, but appends.
+
+    The question in the two tests below is how MANY notices one logical run
+    sends, so a notifier that overwrites would report a two-notice run and a
+    one-notice run identically — and the wrong count is the defect.
+    """
+    script = tmp_path / "appending_notifier.py"
+    script.write_text("import sys\nopen(sys.argv[1], 'a').write(sys.argv[2] + '\\n')\n")
+    return script
+
+
+@pytest.mark.asyncio
+async def test_a_leg_that_will_auto_resume_leaves_the_notice_to_the_resumed_leg(
+    monkeypatch, tmp_path
+):
+    """A timed-out leg that is about to auto-resume has no answer yet.
+
+    Its status is `timed_out` and the run is not over: the recursion below it
+    carries on and can finish the work. Delivering from the interim leg told
+    the notifier the run timed out while the run went on to complete, and the
+    notifier's whole job is to report how the run ended.
+
+    Both legs are real here, including the recursion and the per-leg run
+    allocation. Pinning them to one run directory would hide the count behind
+    the once-per-run delivery guard, which is a different mechanism from the
+    one under test.
+    """
+    _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+    from lionagi._errors import TimeoutError as LionTimeoutError
+    from lionagi.cli._runs import allocate_run as real_allocate_run
+
+    monkeypatch.setattr(agent_mod, "allocate_run", real_allocate_run)
+
+    marker = tmp_path / "notices.txt"
+    script = _write_appending_notifier(tmp_path)
+
+    turns = {"n": 0}
+
+    async def operate(self, instruction=None, **kw):
+        turns["n"] += 1
+        if turns["n"] == 1:
+            raise LionTimeoutError("synthetic")
+        return "the resumed leg concluded the task"
+
+    monkeypatch.setattr(Branch, "operate", operate)
+    branch_file = tmp_path / "branch.json"
+    branch_file.write_text("{}")
+    monkeypatch.setattr(agent_mod, "find_branch", lambda rid: (None, branch_file))
+    monkeypatch.setattr(Branch, "from_dict", classmethod(lambda cls, data: Branch()))
+
+    result = await agent_mod._run_agent(
+        "codex/model",
+        "do the thing",
+        timeout=1,
+        resume_on_timeout=True,
+        notify=f"{sys.executable} {script} {marker} {{status}}",
+    )
+
+    assert turns["n"] == 2, "the resume never happened, so this asserts nothing about it"
+    notices = marker.read_text().split() if marker.exists() else []
+    assert notices == ["completed"], (
+        f"one notice, carrying the status the run actually reached; got {notices}"
+    )
+    assert result[3] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_resumed_stream_notifies_the_status_it_is_converted_to(
+    monkeypatch, tmp_path
+):
+    """A resume that produces nothing is converted from `completed` to
+    `failed`, and that conversion happens after the teardown that used to
+    deliver. So the notifier was told `completed` about a run whose own
+    return value, manifest and log line all said `failed`."""
+    _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+
+    marker = tmp_path / "notices.txt"
+    script = _write_appending_notifier(tmp_path)
+
+    async def operate(self, instruction=None, **kw):
+        return ""
+
+    monkeypatch.setattr(Branch, "operate", operate)
+    branch_file = tmp_path / "branch.json"
+    branch_file.write_text("{}")
+    monkeypatch.setattr(agent_mod, "find_branch", lambda rid: (None, branch_file))
+    monkeypatch.setattr(Branch, "from_dict", classmethod(lambda cls, data: Branch()))
+
+    result = await agent_mod._run_agent(
+        "codex/model",
+        "do the thing",
+        resume="resumed-branch",
+        notify=f"{sys.executable} {script} {marker} {{status}}",
+    )
+
+    assert result[3] == "failed", "the conversion this test is about did not happen"
+    notices = marker.read_text().split() if marker.exists() else []
+    assert notices == ["failed"], f"the notice must agree with the returned status; got {notices}"

--- a/tests/cli/test_agent_notify_without_persistence.py
+++ b/tests/cli/test_agent_notify_without_persistence.py
@@ -304,3 +304,40 @@ async def test_an_empty_resumed_stream_notifies_the_status_it_is_converted_to(
     assert result[3] == "failed", "the conversion this test is about did not happen"
     notices = marker.read_text().split() if marker.exists() else []
     assert notices == ["failed"], f"the notice must agree with the returned status; got {notices}"
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_raises_still_reports_before_the_exception_leaves(monkeypatch, tmp_path):
+    """The path where teardown really is the last chance.
+
+    Delivery happens in the tail for every ordinary outcome, because that is
+    where the status stops changing. An exception propagating out of the leg
+    never reaches the tail, so teardown delivers for it — and a failed run is
+    the case the direct path exists for. Without a notice the MCP server that
+    wired `--notify` eventually observes a vanished process and publishes an
+    indeterminate outcome, which is the opposite of what happened here.
+    """
+    _wire_agent_stubs(monkeypatch, tmp_path, persist=None)
+
+    import lionagi.cli.agent as agent_mod
+    from lionagi import Branch
+
+    marker = tmp_path / "notices.txt"
+    script = _write_appending_notifier(tmp_path)
+
+    async def operate(self, instruction=None, **kw):
+        raise RuntimeError("the work itself blew up")
+
+    monkeypatch.setattr(Branch, "operate", operate)
+
+    with pytest.raises(RuntimeError, match="blew up"):
+        await agent_mod._run_agent(
+            "codex/model",
+            "do the thing",
+            notify=f"{sys.executable} {script} {marker} {{status}}",
+        )
+
+    notices = marker.read_text().split() if marker.exists() else []
+    assert notices == ["failed"], (
+        f"a run that raised must still report, exactly once; got {notices}"
+    )


### PR DESCRIPTION
Three defects that share one shape: a subsystem that can only read a local
SQLite file, or a status that is not final yet, answering as though it were.

**A leg with no answer yet must not send the run's terminal notice.** When
persistence setup fails there is no session entity to fire the registered
`--notify` callback, so the run delivers its own notice directly. That delivery
sat in the teardown `finally`, which runs before two later lines that can still
change the status:

- a timed-out leg about to auto-resume sent `timed_out`, and the resumed leg
  then finished the work;
- a resume producing an empty stream sent `completed` and was converted to
  `failed` on the next line.

Measured with the real recursion and the real per-leg run allocation: two
notices for one logical run, `timed_out` then `completed`, while the run
returned `completed`. Now one, `completed`.

Delivery moves to the tail, past the conversion and past the recursion, so the
leg that reports is the leg that has an answer. The teardown still delivers when
an exception is propagating, because nothing after the `try` block runs there
and the status is settled; the delivery is idempotent by flag, so the two
reaches cannot double up rather than relying on them staying disjoint. The
suppression keys on the recursion's own branch and not on the `will_auto_resume`
computed earlier in teardown: that value is read before the effective status is
applied, so the two can disagree, and a notice suppressed for a recursion that
then does not happen is a leg that never reports at all.

This is the ADR-0035 resumed-leg ownership rule the persistence-backed teardown
already follows, applied to the notification path.

**A subsystem that cannot run must not stop the daemon from starting.** The
Studio Operator's tables live in the local StateDB file and nowhere else, and
its recovery resolves that file eagerly during `lifespan`. Against a
PostgreSQL-configured or in-memory store it raised there, so the daemon never
started serving — including the routes whose entire job is to answer that this
store cannot be read. The 501 was unreachable by construction.

Startup now skips against a store with no file: there is nothing there to
recover, and the routes say so per request. The Operator's store also raises the
same `StoreNotAddressableError` as the rest of the SQLite-direct layer rather
than a subsystem-specific error, so those routes answer 501 (permanent) instead
of 503 (retryable, by a retry that cannot help), and which stores this layer can
open stays defined in one place.

**A definition's history must come from the store that holds it.** The
definition routes answer from two stores at once: current content from disk,
version history through the SQLite-direct layer. `save_definition` writes
through `StateDB` and lands in the configured store, but the read side falls
back to the default local path when there is no file to name — so a deployment
that once ran locally still has that database, and the route reported its
version numbers and audit messages over content read live from disk. Nothing
about the payload looks wrong; the two halves simply came from different stores
and only one of them is in use. The write path being correct is what makes the
stale read plausible rather than obviously empty.

`_ensure_db` now answers False for a store with no file, which covers both mixed
readers at the one place they consult. The disk half is still served, because it
is correct whatever the store is; only the history this layer cannot see is left
out. Routes whose whole answer *is* history keep refusing outright — the
difference is whether dropping the DB half leaves a usable answer.

## Tests

Each defect was reproduced before it was fixed, and each fix is mutation-verified
in **both** directions, because a guard that always refuses passes every
must-refuse test and is still wrong. The over-refusal arms are real tests, not
notes: enrichment must still happen against a configured file store, and Operator
recovery must still run against one.

The notify tests use an appending notifier rather than an overwriting one,
because the defect there is the *count* of notices for a single logical run, and
an overwriting notifier reports one and two identically.

The Studio startup tests enter the lifespan. None of the existing 501 tests did,
which is exactly why a subsystem aborting startup was invisible to a suite that
already covered the 501 itself.

One mutation arm survived and turned out to be a genuine gap rather than a
broken mutant: moving the notice out of teardown left one reach behind it, the
propagating-exception path, and nothing exercised it — so the flag deciding it
could have been wrong in either direction with every test green. A test was
added for it.

`tests/cli/` and `tests/apps_studio_server/` — 4072 tests, 0 failures, 0 errors.
