### PR TITLE
Report message-persistence events lost at teardown

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1018,10 +1018,18 @@ def _make_message_handler(
     return _on_message
 
 
-async def _flush_pending_message_events(ctx: dict) -> None:
-    """Retry queued messages before teardown reads completion evidence."""
+async def _flush_pending_message_events(ctx: dict) -> bool:
+    """Retry queued messages before teardown reads completion evidence.
+
+    Returns whether every queue emptied. What follows this reads the run's
+    completion evidence, so a queue that gave up here means that evidence is
+    being read against a transcript missing messages the run produced.
+    """
+    flushed = True
     for retry_queue in ctx.get("message_retry_queues", []):
-        await retry_queue.flush()
+        if not await retry_queue.flush_final():
+            flushed = False
+    return flushed
 
 
 async def _reopen_session_for_resume(

--- a/lionagi/hooks/_message_retry.py
+++ b/lionagi/hooks/_message_retry.py
@@ -59,6 +59,32 @@ class MessagePersistRetryQueue:
                 return True
             return await self._drain_locked(force=True)
 
+    async def flush_final(self) -> bool:
+        """Flush at teardown, and say so when events did not make it.
+
+        ``flush`` reports failure only by returning ``False``, and that is the
+        whole of what the failing path says. The state log is deliberately quiet
+        when nothing changed, and a queue that has been failing long enough to
+        reach teardown is already in the state it would be transitioning to, so
+        the last attempt these events will ever get is exactly the attempt that
+        emits nothing. A caller that drops the return value is then told nothing
+        at all, by a queue that just lost their messages.
+
+        Losing them is an outcome rather than a state change, so it is reported
+        here whichever state the queue was already in. The count is included
+        because it is the part nobody can reconstruct afterwards: the events are
+        gone, and no later sweep has anything left to find.
+        """
+        flushed = await self.flush()
+        if not flushed:
+            self._logger.error(
+                "live persist gave up for %s at teardown: %d event(s) were never "
+                "written and are lost",
+                self._owner,
+                self.pending_count,
+            )
+        return flushed
+
     async def _drain_locked(self, *, force: bool = False) -> bool:
         if self._retry_deferred and not force:
             return False

--- a/lionagi/hooks/_message_retry.py
+++ b/lionagi/hooks/_message_retry.py
@@ -39,6 +39,7 @@ class MessagePersistRetryQueue:
         self._consecutive_failures = 0
         self._retry_deferred = False
         self._state = "healthy"
+        self._reported_loss_count: int | None = None
 
     @property
     def pending_count(self) -> int:
@@ -74,16 +75,32 @@ class MessagePersistRetryQueue:
         here whichever state the queue was already in. The count is included
         because it is the part nobody can reconstruct afterwards: the events are
         gone, and no later sweep has anything left to find.
+
+        Teardown reaches this more than once. The hook bus flushes on
+        ``SESSION_END`` and the run teardown flushes before it reads completion
+        evidence, and both traverse the same queues without either being able to
+        see the other. The repeated *attempt* is wanted — the store may have come
+        back between them, and the second call is a real last chance — so what is
+        suppressed is the repeated *report*: the same loss, restated, reads as
+        two separate incidents. A count that has changed is a different fact and
+        is reported again, and a flush that finally succeeds clears the marker so
+        a later loss is not swallowed as a repeat.
         """
         flushed = await self.flush()
-        if not flushed:
+        if flushed:
+            self._reported_loss_count = None
+            return True
+
+        lost = self.pending_count
+        if lost != self._reported_loss_count:
+            self._reported_loss_count = lost
             self._logger.error(
                 "live persist gave up for %s at teardown: %d event(s) were never "
                 "written and are lost",
                 self._owner,
-                self.pending_count,
+                lost,
             )
-        return flushed
+        return False
 
     async def _drain_locked(self, *, force: bool = False) -> bool:
         if self._retry_deferred and not force:

--- a/lionagi/hooks/bus.py
+++ b/lionagi/hooks/bus.py
@@ -186,10 +186,18 @@ class HookBus:
         if point is not HookPoint.MESSAGE_ADD:
             await self._record(point, kwargs)
 
-    async def flush_message_retries(self) -> None:
-        """Flush default message-hook retries before terminal lifecycle work."""
+    async def flush_message_retries(self) -> bool:
+        """Flush default message-hook retries before terminal lifecycle work.
+
+        Returns whether every queue emptied. The queues report their own losses,
+        so this is for a caller that can do something about it rather than the
+        record that it happened.
+        """
+        flushed = True
         for retry_queue in getattr(self, "_message_retry_queues", {}).values():
-            await retry_queue.flush()
+            if not await retry_queue.flush_final():
+                flushed = False
+        return flushed
 
 
 # ── Decorator for user-defined handlers ───────────────────────────────────────

--- a/tests/hooks/test_message_retry.py
+++ b/tests/hooks/test_message_retry.py
@@ -213,3 +213,92 @@ async def test_the_run_teardown_reports_whether_its_queues_emptied():
     healthy = MessagePersistRetryQueue(_FakeDB(fail_ids=set()), logger=logger, owner="b2")
     await healthy.submit(_event("good-1"))
     assert await _flush_pending_message_events({"message_retry_queues": [healthy]}) is True
+
+
+async def test_both_teardown_paths_over_one_queue_report_the_loss_once(caplog):
+    """The two teardowns reach the same queue, and neither can see the other.
+
+    The hook bus flushes on ``SESSION_END`` and the run teardown flushes before
+    reading completion evidence. One queue traversed by both would report its
+    loss twice, and one loss restated reads as two incidents — the crying-wolf
+    the report exists to avoid.
+
+    Asserted through both real entry points rather than by calling
+    ``flush_final`` twice, because the duplication is a property of the two
+    paths meeting, not of the method.
+    """
+    from lionagi.cli._runs import _flush_pending_message_events
+    from lionagi.hooks.bus import HookBus
+
+    logger = logging.getLogger("test")
+    queue = await _deferred_queue(_RefusingDB(), logger)
+
+    bus = HookBus()
+    bus._message_retry_queues = {"b1": queue}
+
+    with caplog.at_level(logging.ERROR, logger="test"):
+        assert await bus.flush_message_retries() is False
+        assert await _flush_pending_message_events({"message_retry_queues": [queue]}) is False
+
+    losses = [rec for rec in caplog.records if rec.levelno >= logging.ERROR]
+    assert len(losses) == 1, (
+        f"one loss, reported once across both teardown paths; got {len(losses)}"
+    )
+    assert "4" in losses[0].message
+
+    # Both calls still returned False. Suppressing the repeated report must not
+    # suppress the answer a caller acts on.
+    assert queue.pending_count == 4
+
+
+async def test_a_loss_that_grows_between_teardowns_is_reported_again(caplog):
+    """The over-suppression arm. A second call is silenced because it restates
+    one fact, not because a queue may only ever report once: events lost since
+    the first report are a different fact and nobody else will name them."""
+    logger = logging.getLogger("test")
+    db = _RefusingDB()
+    queue = await _deferred_queue(db, logger)
+
+    with caplog.at_level(logging.ERROR, logger="test"):
+        assert await queue.flush_final() is False
+        await queue.submit(_event("m4"))
+        assert await queue.flush_final() is False
+
+    losses = [rec for rec in caplog.records if rec.levelno >= logging.ERROR]
+    assert len(losses) == 2, "a changed count is a new fact"
+    assert "4" in losses[0].message
+    assert "5" in losses[1].message
+
+
+async def test_a_recovery_between_teardowns_does_not_swallow_a_later_loss(caplog):
+    """The marker is cleared by a flush that succeeds, so a queue that recovers
+    and then loses new events reports that loss rather than reading it as a
+    repeat of the one already on the record."""
+
+    class _FlakyDB:
+        def __init__(self) -> None:
+            self.persisted: list[str] = []
+            self.refuse = True
+
+        async def _persist_live_message(self, message: dict[str, Any], **kwargs: Any) -> None:
+            if self.refuse:
+                raise RuntimeError("database is locked")
+            self.persisted.append(message["id"])
+
+    logger = logging.getLogger("test")
+    db = _FlakyDB()
+    queue = await _deferred_queue(db, logger)
+
+    with caplog.at_level(logging.ERROR, logger="test"):
+        assert await queue.flush_final() is False  # 4 lost, reported
+        db.refuse = False
+        assert await queue.flush_final() is True  # drains, marker cleared
+        db.refuse = True
+        for i in range(4):
+            await queue.submit(_event(f"later-{i}"))
+        assert await queue.flush_final() is False  # 4 again, but a new 4
+
+    losses = [rec for rec in caplog.records if rec.levelno >= logging.ERROR]
+    assert len(losses) == 2, (
+        "the second loss has the same count as the first and is still a different loss"
+    )

--- a/tests/hooks/test_message_retry.py
+++ b/tests/hooks/test_message_retry.py
@@ -95,3 +95,121 @@ async def test_transient_error_still_head_of_line_blocks_until_deferred():
 
     assert db.persisted == []
     assert queue.pending_count == 2
+
+
+class _RefusingDB:
+    """Refuses every write, the way a contended sqlite does."""
+
+    def __init__(self) -> None:
+        self.persisted: list[str] = []
+        self.attempts = 0
+
+    async def _persist_live_message(self, message: dict[str, Any], **kwargs: Any) -> None:
+        self.attempts += 1
+        raise RuntimeError("database is locked")
+
+
+async def _deferred_queue(db, logger):
+    """A queue driven past its consecutive-failure limit, as real traffic does."""
+    queue = MessagePersistRetryQueue(db, logger=logger, owner="b1")
+    for i in range(4):
+        await queue.submit(_event(f"m{i}"))
+    return queue
+
+
+async def test_a_teardown_that_loses_messages_says_so(caplog):
+    """The last attempt these events get is the one that used to say nothing.
+
+    By teardown the queue is already deferred, so the state log stays quiet
+    because nothing changed, and the only other signal is a return value.
+    """
+    db = _RefusingDB()
+    logger = logging.getLogger("test")
+    queue = await _deferred_queue(db, logger)
+    assert queue.pending_count == 4
+
+    with caplog.at_level(logging.ERROR, logger="test"):
+        flushed = await queue.flush_final()
+
+    assert flushed is False
+    losses = [rec for rec in caplog.records if rec.levelno >= logging.ERROR]
+    assert len(losses) == 1, "the loss is reported once, not per event and not never"
+    assert "lost" in losses[0].message
+    # The count is the part nobody can reconstruct once the events are gone.
+    assert "4" in losses[0].message
+
+
+async def test_a_healthy_teardown_stays_quiet(caplog):
+    """The other direction. A report that always fires is a report nobody reads,
+    and this one exists to be believed the once it appears."""
+    db = _FakeDB(fail_ids=set())
+    logger = logging.getLogger("test")
+    queue = MessagePersistRetryQueue(db, logger=logger, owner="b1")
+    await queue.submit(_event("good-1"))
+
+    with caplog.at_level(logging.DEBUG, logger="test"):
+        flushed = await queue.flush_final()
+
+    assert flushed is True
+    assert db.persisted == ["good-1"]
+    assert [rec for rec in caplog.records if rec.levelno >= logging.WARNING] == []
+
+
+async def test_a_teardown_that_recovers_stays_quiet(caplog):
+    """A queue that was failing and then drains is not a loss. Reporting one
+    here is exactly the crying-wolf this is meant to avoid."""
+
+    class _RecoveringDB:
+        def __init__(self) -> None:
+            self.persisted: list[str] = []
+            self.refuse = True
+
+        async def _persist_live_message(self, message: dict[str, Any], **kwargs: Any) -> None:
+            if self.refuse:
+                raise RuntimeError("database is locked")
+            self.persisted.append(message["id"])
+
+    db = _RecoveringDB()
+    logger = logging.getLogger("test")
+    queue = await _deferred_queue(db, logger)
+    db.refuse = False
+
+    with caplog.at_level(logging.WARNING, logger="test"):
+        flushed = await queue.flush_final()
+
+    assert flushed is True
+    assert queue.pending_count == 0
+    assert db.persisted == ["m0", "m1", "m2", "m3"], "order is preserved across the recovery"
+    assert [rec for rec in caplog.records if rec.levelno >= logging.ERROR] == []
+
+
+async def test_the_bus_reports_whether_its_queues_emptied(caplog):
+    """The bus teardown discarded this, so nothing downstream could tell."""
+    from lionagi.hooks.bus import HookBus
+
+    logger = logging.getLogger("test")
+    bus = HookBus()
+    bus._message_retry_queues = {"b1": await _deferred_queue(_RefusingDB(), logger)}
+
+    with caplog.at_level(logging.ERROR, logger="test"):
+        assert await bus.flush_message_retries() is False
+
+    healthy = MessagePersistRetryQueue(_FakeDB(fail_ids=set()), logger=logger, owner="b2")
+    await healthy.submit(_event("good-1"))
+    bus._message_retry_queues = {"b2": healthy}
+
+    assert await bus.flush_message_retries() is True
+
+
+async def test_the_run_teardown_reports_whether_its_queues_emptied():
+    """The second teardown that discarded it. What runs after this reads the
+    run's completion evidence."""
+    from lionagi.cli._runs import _flush_pending_message_events
+
+    logger = logging.getLogger("test")
+    lost = await _deferred_queue(_RefusingDB(), logger)
+    assert await _flush_pending_message_events({"message_retry_queues": [lost]}) is False
+
+    healthy = MessagePersistRetryQueue(_FakeDB(fail_ids=set()), logger=logger, owner="b2")
+    await healthy.submit(_event("good-1"))
+    assert await _flush_pending_message_events({"message_retry_queues": [healthy]}) is True


### PR DESCRIPTION
A branch persists each live message as it is produced. When those writes fail
the events are queued and retried in order, and after three consecutive
failures the queue defers: it stops retrying inline and waits for one last
attempt at teardown. That last attempt is the one nobody could observe.

The state log reports transitions and deliberately stays quiet when the state
has not changed. By teardown a queue that has been failing is already deferred,
so the final flush transitions to the state it is already in and emits nothing.
Its only other signal is a return value, and both teardown call sites discarded
it: the hook bus at session end, and the run teardown in the CLI.

Driving the queue with a store that refuses every write, which is what a
contended sqlite does, produces four messages dropped, zero log lines from the
flush, and a `False` that nobody reads. Nothing downstream can tell the
difference between that and a clean shutdown.

Absence of evidence is not evidence here either, and in a way worth naming:
recovery logs at debug while failure logs at warning. So "no recovery line in
the log" is equally consistent with a queue that recovered and a queue that
lost everything, and the only place the two differ is the path that said
nothing.

**What changed.** The queue reports the loss at the point it becomes final,
naming the owner and the number of events. The count is included because it is
the part nobody can reconstruct afterwards: the events are gone, and no later
sweep has anything left to find. Both teardown paths now return whether their
queues emptied, including the run teardown, where what runs next reads the
run's completion evidence — against a transcript missing messages the run
produced.

The state-change dedup is unchanged on purpose. It exists to stop repeated
warnings during retry churn and it is right for that. Losing messages is an
outcome rather than a state change, so it is reported whichever state the queue
was already in, rather than by weakening the thing that keeps ordinary retries
from flooding the log.

## Tests

Five tests, and they run in both directions, because a report that fires on
healthy teardowns is one nobody believes by the time it matters.

- A deferred queue whose store keeps refusing reports the loss exactly once,
  names the count, and returns `False`.
- A healthy teardown stays quiet and returns `True`.
- A queue that was failing and then drains stays quiet, empties, and preserves
  the original order across the recovery. This is the arm that separates a real
  loss from a queue that had a bad minute.
- Both teardown call sites report whether their queues emptied.

The queue under test is the real one, driven by a store that refuses writes,
rather than a stand-in that reproduces the shape: a stand-in would prove
something about the stand-in.

Each behaviour is mutation-verified against an unmutated green baseline. The
loss report is removed and the loss test is confirmed to go red; the report is
then made unconditional and the two quiet-teardown tests go red; each call site
is reverted to discarding its result and the test naming it goes red. The
runner scores from a report file that only a real test run emits, so an
interpreter that failed to start cannot be counted as a detection, and it
asserts every file came back byte-identical.

Suites green: `tests/hooks/`, `tests/cli/`, `tests/studio/` — 3927 tests, 0
failures, 0 errors.
