### PR TITLE
Record why a run failed, not just that it failed

### DIFF
--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -1171,6 +1171,13 @@ async def _run_agent(
     except (TimeoutError, LionTimeoutError) as exc:
         _terminal_status = "timed_out"
         _terminal_exc = exc
+        from lionagi.mcp._terminal_cause import write_terminal_cause
+
+        # Written on the timeout path too, even though a timeout is never one of
+        # the typed provider errors. A recorded `unknown` says the cause was
+        # looked at and was not a provider error; no record at all says nobody
+        # looked, and a reader cannot tell those apart after the fact.
+        write_terminal_cause(exc)
         from lionagi.cli._logging import warn
 
         warn(f"agent timed out after {timeout}s")
@@ -1179,6 +1186,12 @@ async def _run_agent(
     except BaseException as exc:
         _terminal_status = classify_exception(exc)
         _terminal_exc = exc
+        from lionagi.mcp._terminal_cause import write_terminal_cause
+
+        # Before the re-raise: this is the last point that still holds the
+        # exception object, and the hook that records the run's end runs in a
+        # different process where only its own class name would survive.
+        write_terminal_cause(exc)
         # Nothing after this try block runs, so the teardown below is this
         # run's last chance to notify. Every other path falls through to the
         # tail, where the status is still being decided.

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -31,6 +31,7 @@ from typing import Any
 # The CLI runs this file's module by absolute interpreter path; lionagi is on
 # the path because that interpreter is the one lionagi is installed in.
 from . import config, jobs
+from ._terminal_cause import read_terminal_cause
 
 _DELIVERY_TIMEOUT_S = 30
 
@@ -439,6 +440,14 @@ def main(argv: list[str] | None = None) -> int:
         # completion the record contradicts; run stays non-terminal.
         _note_persistence_failure(args.run_id, "terminal status")
         return 1
+
+    # Before the notice: the cause belongs to how the run ended, and a delivery
+    # that hangs or fails must not be what decides whether the reason was kept.
+    # Absent, unreadable and malformed all come back as None, and None leaves
+    # the field off rather than writing a placeholder that reads like an answer.
+    cause = read_terminal_cause(jobs.failure_cause_path(args.run_id))
+    if cause is not None:
+        jobs.record_failure_cause(args.run_id, cause)
 
     outcome = deliver_terminal_notice(
         args.run_id,

--- a/lionagi/mcp/_terminal_cause.py
+++ b/lionagi/mcp/_terminal_cause.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -34,10 +35,23 @@ from lionagi.mcp import config
 from lionagi.providers._provider_errors import ProviderError
 
 __all__ = [
+    "STATUS_SOURCES",
     "allowed_cause_classes",
+    "provider_status",
     "read_terminal_cause",
     "write_terminal_cause",
 ]
+
+# How the status question was answered. "absent" is a measurement -- the message
+# was read and named no status -- and "unreadable" is the admission that it was
+# not read at all. Collapsing the two would let a broken extractor report what a
+# working one reports for a connection that never completed.
+STATUS_SOURCES = frozenset({"received", "absent", "unreadable"})
+
+# A provider status code as adapters spell it in a message, e.g.
+# "UNAVAILABLE (code 503)". Only the digits are captured: the surrounding text
+# is the provider's own prose and is exactly what must not be stored.
+_STATUS_CODE_RE = re.compile(r"\(code\s+(?P<code>\d{3})\)")
 
 # Anything else is reported as this: a terminal exception that was not one of
 # our typed provider errors. Deliberately still recorded, because "the cause was
@@ -67,13 +81,49 @@ def allowed_cause_classes() -> frozenset[str]:
     return frozenset(walk(ProviderError) | {UNKNOWN_CAUSE})
 
 
+def provider_status(exc: BaseException) -> tuple[str, int | None]:
+    """Whether a provider status code reached us, and which one.
+
+    The class alone does not separate the two ways a provider call ends badly.
+    One adapter raises the same class with the same message prefix for a service
+    that answered ``UNAVAILABLE (code 503)`` and for a DNS lookup that never
+    resolved, and those are opposite facts: the first is the provider's own
+    answer, the second means no round trip happened and the fault is on this
+    side. A status code is what tells them apart, and unlike the message it
+    cannot carry a credential.
+
+    Returns the state first because it is the part that must not be inferred
+    from the number. ``"received"`` carries an int; ``"absent"`` means the
+    message was read and held no status, which is itself the signal that no
+    round trip completed; ``"unreadable"`` means this function could not look.
+    Absent and unreadable are separate for the same reason a missing status is
+    not a zero: an instrument that did not run must never report what a working
+    one reports when it finds nothing.
+    """
+    try:
+        text = str(exc)
+    except Exception:  # noqa: BLE001 — an exception whose str() raises is unreadable, not statusless
+        return ("unreadable", None)
+    match = _STATUS_CODE_RE.search(text)
+    if match is None:
+        return ("absent", None)
+    try:
+        return ("received", int(match.group("code")))
+    except (ValueError, IndexError):  # pragma: no cover — the pattern only matches digits
+        return ("unreadable", None)
+
+
 def write_terminal_cause(exc: BaseException) -> None:
-    """Record *exc*'s class and retry hint, if this run has a cause file.
+    """Record *exc*'s class, retry hint and provider status, if this run has a cause file.
 
     Called from the CLI's terminal exception path, where raising would replace
     the run's real failure with this one, so every failure here is silent by
     design: no cause file configured, an unwritable directory, and a serialisation
     failure all end the same way, with the record simply not gaining a cause.
+
+    ``provider_status`` is written only when one was received. A caller reads
+    ``status_source`` to know which question it is answering, and never has to
+    decide what a missing number means.
     """
     target = os.environ.get(config.CAUSE_FILE_ENV_VAR)
     if not target:
@@ -85,7 +135,17 @@ def write_terminal_cause(exc: BaseException) -> None:
         cls = type(exc)
         name = cls.__name__ if issubclass(cls, ProviderError) else UNKNOWN_CAUSE
         retryable = bool(getattr(cls, "retryable", False)) if name != UNKNOWN_CAUSE else False
-        Path(target).write_text(json.dumps({"class": name, "retryable": retryable}))
+        source, code = provider_status(exc)
+        record: dict[str, Any] = {
+            "class": name,
+            "retryable": retryable,
+            "status_source": source,
+        }
+        # Present only for "received", so an absent status cannot be read as a
+        # code and a code can never be confused with its own absence.
+        if code is not None:
+            record["provider_status"] = code
+        Path(target).write_text(json.dumps(record))
     except Exception:  # noqa: BLE001, S110 — see docstring: this must not raise
         pass
 
@@ -114,4 +174,23 @@ def read_terminal_cause(path: str | os.PathLike[str] | None) -> dict[str, Any] |
     name = loaded.get("class")
     if not isinstance(name, str) or name not in allowed_cause_classes():
         name = UNKNOWN_CAUSE
-    return {"class": name, "retryable": loaded.get("retryable") is True}
+    # A status_source this reader does not recognise is "unreadable" rather than
+    # "absent": an unrecognised value means the two processes disagree about the
+    # schema, and that is a failure to read, not a measurement that found none.
+    source = loaded.get("status_source")
+    if not isinstance(source, str) or source not in STATUS_SOURCES:
+        source = "unreadable"
+    cause: dict[str, Any] = {
+        "class": name,
+        "retryable": loaded.get("retryable") is True,
+        "status_source": source,
+    }
+    code = loaded.get("provider_status")
+    # A code is carried only alongside the state that claims one, and only as an
+    # int. `isinstance(True, int)` is True in Python, so bools are excluded
+    # explicitly or a `true` in that field would be read back as status 1.
+    if source == "received" and isinstance(code, int) and not isinstance(code, bool):
+        cause["provider_status"] = code
+    elif source == "received":
+        cause["status_source"] = "unreadable"
+    return cause

--- a/lionagi/mcp/_terminal_cause.py
+++ b/lionagi/mcp/_terminal_cause.py
@@ -1,0 +1,117 @@
+"""The typed cause of a run's terminal exception, handed from the CLI to the job record.
+
+A failed job record says a run failed and stops there, so the reason has to be
+read out of console prose by whoever asks next. The exception that ended the run
+is a typed object inside the CLI process, and it is thrown away at exactly the
+moment it becomes useful. This carries the two facts a caller can act on — which
+class it was, and whether that class is worth retrying — across the process
+boundary, so a caller can branch without parsing anything.
+
+Writer and reader live together deliberately. They are in different processes and
+neither imports the other, so the schema is the only thing holding them in
+agreement; split across two files it would be two schemas that happen to match
+today.
+
+**The exception's message is not carried, and that is a decision rather than an
+omission.** Provider messages quote whatever the provider said, which routinely
+includes an API key. The credential masker in ``lionagi.state.engine`` closes the
+``user:secret@`` shape and documents itself as a backstop, so it would not catch
+a bare token. The message is already in the run's console log, which is one
+channel with whatever exposure it already has. Copying it into the job record —
+a file that gets read, quoted, and passed on by the observer verbs — would open a
+second one onto the same secret for no classification value: the class and the
+retry hint are the parts a caller branches on.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from lionagi.mcp import config
+from lionagi.providers._provider_errors import ProviderError
+
+__all__ = [
+    "allowed_cause_classes",
+    "read_terminal_cause",
+    "write_terminal_cause",
+]
+
+# Anything else is reported as this: a terminal exception that was not one of
+# our typed provider errors. Deliberately still recorded, because "the cause was
+# not a provider error" tells a caller to stop looking for one.
+UNKNOWN_CAUSE = "unknown"
+
+# Bounds the read. The file this module writes is two short fields; a larger one
+# was written by something else, and parsing it would be answering about a
+# different file.
+_MAX_CAUSE_BYTES = 4096
+
+
+def allowed_cause_classes() -> frozenset[str]:
+    """Every class name that may be stored, derived from the hierarchy itself.
+
+    Derived rather than listed so a provider error added later is admissible
+    without a second edit here, and so a value that is not one of our classes
+    can never become one by being written into a list.
+    """
+
+    def walk(cls: type) -> set[str]:
+        names = {cls.__name__}
+        for sub in cls.__subclasses__():
+            names |= walk(sub)
+        return names
+
+    return frozenset(walk(ProviderError) | {UNKNOWN_CAUSE})
+
+
+def write_terminal_cause(exc: BaseException) -> None:
+    """Record *exc*'s class and retry hint, if this run has a cause file.
+
+    Called from the CLI's terminal exception path, where raising would replace
+    the run's real failure with this one, so every failure here is silent by
+    design: no cause file configured, an unwritable directory, and a serialisation
+    failure all end the same way, with the record simply not gaining a cause.
+    """
+    target = os.environ.get(config.CAUSE_FILE_ENV_VAR)
+    if not target:
+        return
+    try:
+        # Read off the class, never the instance: `retryable` is a ClassVar
+        # classification hint, and an instance attribute shadowing it would be
+        # some other subsystem's runtime state, not this classification.
+        cls = type(exc)
+        name = cls.__name__ if issubclass(cls, ProviderError) else UNKNOWN_CAUSE
+        retryable = bool(getattr(cls, "retryable", False)) if name != UNKNOWN_CAUSE else False
+        Path(target).write_text(json.dumps({"class": name, "retryable": retryable}))
+    except Exception:  # noqa: BLE001, S110 — see docstring: this must not raise
+        pass
+
+
+def read_terminal_cause(path: str | os.PathLike[str] | None) -> dict[str, Any] | None:
+    """Read a cause file back, or ``None`` if there is nothing trustworthy in it.
+
+    Fail-closed at every step, because the caller is the terminal hook and a
+    malformed file must not cost the run its record. The class name is forced
+    into :func:`allowed_cause_classes` here, at the boundary that stores it,
+    rather than trusted of the writer: the two run in different processes and
+    different versions, so an unrecognised value is exactly what this should
+    expect to see.
+    """
+    if not path:
+        return None
+    try:
+        p = Path(path)
+        if p.stat().st_size > _MAX_CAUSE_BYTES:
+            return None
+        loaded = json.loads(p.read_text())
+    except Exception:  # noqa: BLE001 — absent, unreadable and malformed are one outcome
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    name = loaded.get("class")
+    if not isinstance(name, str) or name not in allowed_cause_classes():
+        name = UNKNOWN_CAUSE
+    return {"class": name, "retryable": loaded.get("retryable") is True}

--- a/lionagi/mcp/config.py
+++ b/lionagi/mcp/config.py
@@ -34,6 +34,16 @@ RUN_ID_ENV_VAR = "LIONAGI_RUN_ID"
 # rest on a variable another subsystem owns and can reassign.
 JOB_MARKER_ENV_VAR = "LIONAGI_MCP_JOB_RUN_ID"
 
+# Where a run writes the typed class of the exception that ended it, for the
+# terminal hook to lift into the job record (lionagi/mcp/_terminal_cause.py).
+# Named per job rather than derived from the run id inside the child: the child
+# is free to reassign RUN_ID_ENV_VAR for a sub-run, and a cause file placed by
+# that name would land in a directory this server never reads.
+CAUSE_FILE_ENV_VAR = "LIONAGI_MCP_CAUSE_FILE"
+
+# Inside the job directory, so it is removed with the job and never outlives it.
+CAUSE_FILENAME = "terminal_cause.json"
+
 # Explicit override for the argv prefix that invokes the ``li`` CLI, split on
 # whitespace. Rarely needed: the server runs inside lionagi's own environment,
 # so the interpreter running it already resolves the CLI (see li_command).

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1177,6 +1177,10 @@ def submit(
         # Inherited by every process the child spawns, so a live group member
         # can later be asked what it belongs to instead of guessed from timing.
         env[config.JOB_MARKER_ENV_VAR] = run_id
+        # Where the run drops the typed class of whatever exception ended it, so
+        # the terminal hook can record a cause instead of leaving the reason to
+        # be read out of console prose.
+        env[config.CAUSE_FILE_ENV_VAR] = str(d / config.CAUSE_FILENAME)
 
         # Checked before anything is written: Popen raising this late would
         # leave a job recorded "running" for a run that never started.
@@ -2413,3 +2417,35 @@ def record_notify_delivery(run_id: str, outcome: dict[str, Any]) -> WriteResult:
             return WriteResult(None, guard.state)
         job["notify_delivery"] = outcome
         return WriteResult(job, guard.state)
+
+
+def record_failure_cause(run_id: str, cause: dict[str, Any]) -> WriteResult:
+    """Record the typed class of the exception that ended *run_id*.
+
+    Merged under the same per-run lock as every other mutation, and merged
+    alone: a cause describes how the run ended and must never carry a stale copy
+    of the lifecycle fields back over an end recorded while the hook was
+    starting, for the same reason ``record_notify_delivery`` does not.
+
+    Only called with a cause that was actually read. A run whose cause file is
+    absent leaves this field off the record entirely, so a caller can tell a run
+    that reported no typed cause from one that predates the field.
+    """
+    with _locked_job(run_id) as guard:
+        job = guard.record
+        if job is None:
+            return WriteResult(None, guard.state)
+        job["failure_cause"] = cause
+        return WriteResult(job, guard.state)
+
+
+def failure_cause_path(run_id: str) -> Path | None:
+    """Where *run_id*'s cause file would be, or None if it has no job directory.
+
+    Resolved through ``config.job_dir`` — the same function the submit that set
+    the child's environment used — so the two cannot drift onto different
+    layouts. Reading the path back off the record instead would be checking the
+    value against itself.
+    """
+    d = config.job_dir(run_id)
+    return d / config.CAUSE_FILENAME if d.is_dir() else None

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -605,9 +605,18 @@ async def ndjson_from_cli(
             except asyncio.CancelledError:
                 raise
             err = b"".join(stderr_chunks).decode(errors="replace").strip()
+            # Emptiness is decided on what was captured, before the drain note
+            # is appended. Deciding it on the concatenated string instead lets
+            # the note itself count as output, so a truncated drain that
+            # captured nothing would report neither the exit code nor the fact
+            # that there was nothing to quote. No probe I built reaches that
+            # arm; this orders the two steps so its reachability stops
+            # mattering.
+            if not err:
+                err = _no_stderr_reason(rc, stderr_unavailable, stderr_drain_error)
             if drain_truncated:
-                err = (err or "") + " [stderr drain timed out]"
-            raise RuntimeError(err or _no_stderr_reason(rc, stderr_unavailable, stderr_drain_error))
+                err += " [stderr drain timed out]"
+            raise RuntimeError(err)
 
     finally:
         await end_child_group(proc)

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -397,6 +397,33 @@ def observe_spawned(pid: int) -> SpawnedProcess:
     return SpawnedProcess(pid=pid, pgid=pgid, create_time=created)
 
 
+def _no_stderr_reason(
+    rc: int,
+    unavailable: str | None,
+    drain_error: str | None,
+) -> str:
+    """Why a nonzero exit came with no stderr to quote.
+
+    A child that failed silently and a capture that failed to read it are
+    different facts about different components, and the caller acts on them
+    differently: the first is the child's own report and there is nothing more
+    to find, the second means the report exists somewhere this process did not
+    look. Collapsing both into the exit code makes a broken instrument read
+    exactly like a quiet subprocess, which is the direction that hides the
+    instrument.
+
+    The drain error contributes its exception type and never its message: that
+    message can embed the bytes being read when it raised, and this string is
+    what a caller stores or forwards.
+    """
+    exited = f"CLI subprocess exited with code {rc}"
+    if drain_error is not None:
+        return f"{exited}; reading its stderr failed with {drain_error}, so no output was captured"
+    if unavailable is not None:
+        return f"{exited} and {unavailable}"
+    return f"{exited} and wrote nothing to stderr"
+
+
 async def ndjson_from_cli(
     cmd: list[str],
     *,
@@ -476,10 +503,17 @@ async def ndjson_from_cli(
     stderr_cap = 256 * 1024
     stderr_chunks: list[bytes] = []
     stderr_total = 0
+    # Why the drain records how it ended: an empty `stderr_chunks` is produced
+    # by a child that said nothing, by a child whose stderr was never opened,
+    # and by a drain that raised — and the caller below turns emptiness into
+    # the message a human reads. Without this the three arrive as one.
+    stderr_unavailable: str | None = None
+    stderr_drain_error: str | None = None
 
     async def _drain_stderr() -> None:
-        nonlocal stderr_total
+        nonlocal stderr_total, stderr_unavailable, stderr_drain_error
         if proc.stderr is None:
+            stderr_unavailable = "its stderr was never opened"
             return
         try:
             while True:
@@ -492,6 +526,10 @@ async def ndjson_from_cli(
                     stderr_chunks.append(take)
                     stderr_total += len(take)
         except Exception as exc:
+            # Type only. The exception's message can embed the bytes it was
+            # reading, and this string is going into an error a caller may
+            # store or send on.
+            stderr_drain_error = type(exc).__name__
             log.debug("stderr drain ended: %s", exc)
 
     stderr_task = asyncio.create_task(_drain_stderr())
@@ -569,7 +607,7 @@ async def ndjson_from_cli(
             err = b"".join(stderr_chunks).decode(errors="replace").strip()
             if drain_truncated:
                 err = (err or "") + " [stderr drain timed out]"
-            raise RuntimeError(err or f"CLI subprocess exited with code {rc}")
+            raise RuntimeError(err or _no_stderr_reason(rc, stderr_unavailable, stderr_drain_error))
 
     finally:
         await end_child_group(proc)

--- a/tests/cli/test_agent_sigterm_and_failed_logging.py
+++ b/tests/cli/test_agent_sigterm_and_failed_logging.py
@@ -304,6 +304,7 @@ class TestTheTerminalPathReachesTheCauseWriter:
         assert json.loads(cause.read_text()) == {
             "class": "ProviderQuotaError",
             "retryable": True,
+            "status_source": "absent",
         }
 
     @pytest.mark.asyncio
@@ -361,4 +362,8 @@ class TestTheTerminalPathReachesTheCauseWriter:
         assert cause.exists(), "the timeout path never reached the cause writer"
         # `unknown` rather than nothing: a reader must be able to tell a cause
         # that was looked at from a run where nobody looked.
-        assert json.loads(cause.read_text()) == {"class": "unknown", "retryable": False}
+        assert json.loads(cause.read_text()) == {
+            "class": "unknown",
+            "retryable": False,
+            "status_source": "absent",
+        }

--- a/tests/cli/test_agent_sigterm_and_failed_logging.py
+++ b/tests/cli/test_agent_sigterm_and_failed_logging.py
@@ -1,13 +1,19 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for li agent diagnostic logging on failure/SIGTERM.
+"""Tests for what li agent records about its own terminal exception.
 
 Covers the two `classify_exception(exc) == "failed"` log_error sites (the
 inner _run_agent except and the outer run_agent except) plus run_agent()'s
 SigtermInterrupt dispatch and _util.classify_exception()'s SigtermInterrupt
 mapping. Previously both "failed" sites re-raised silently, relying on
 Python's default traceback printer — unreliable under SIGTERM/process death.
+
+The last class here covers the same two handlers writing the typed cause file
+that the MCP terminal hook lifts into the job record. Its schema and failure
+paths are held in tests/mcp/test_terminal_cause.py; what these arms establish
+is that the real terminal path reaches the writer at all, which no test of the
+writer itself can answer.
 """
 
 from __future__ import annotations
@@ -260,3 +266,99 @@ def test_classify_exception_sigterm_interrupt_distinct_from_aborted():
     from lionagi.ln.concurrency import SigtermInterrupt
 
     assert classify_exception(SigtermInterrupt("received SIGTERM")) != "aborted"
+
+
+# ---------------------------------------------------------------------------
+# Both handlers write the typed cause the MCP job record reads
+# ---------------------------------------------------------------------------
+
+
+class TestTheTerminalPathReachesTheCauseWriter:
+    """Whether the real path reaches the writer, which the writer's own tests
+    cannot answer: they establish that it works when called, not that anything
+    calls it."""
+
+    @pytest.mark.asyncio
+    async def test_a_provider_failure_leaves_its_class_on_disk(self, monkeypatch, tmp_path):
+        import json
+
+        from lionagi.mcp import config
+        from lionagi.providers._provider_errors import ProviderQuotaError
+
+        Branch = _wire_agent_stubs(monkeypatch, tmp_path)
+        monkeypatch.setattr("lionagi.cli.agent.log_error", lambda msg: None)
+        cause = tmp_path / "terminal_cause.json"
+        monkeypatch.setenv(config.CAUSE_FILE_ENV_VAR, str(cause))
+
+        async def fake_operate(self, instruction=None, **kw):
+            raise ProviderQuotaError("quota exhausted until next window")
+
+        monkeypatch.setattr(Branch, "operate", fake_operate)
+
+        from lionagi.cli.agent import _run_agent
+
+        with pytest.raises(ProviderQuotaError):
+            await _run_agent("codex/model", "do the thing")
+
+        assert cause.exists(), "the failing terminal path never reached the cause writer"
+        assert json.loads(cause.read_text()) == {
+            "class": "ProviderQuotaError",
+            "retryable": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_run_outside_a_job_writes_nothing_and_still_fails_normally(
+        self, monkeypatch, tmp_path
+    ):
+        """`li agent` run by hand has no cause file configured. The absence must
+        cost the run nothing: the original exception still propagates, and this
+        arm fails if the writer ever starts raising on a missing variable."""
+        from lionagi.mcp import config
+
+        Branch = _wire_agent_stubs(monkeypatch, tmp_path)
+        monkeypatch.setattr("lionagi.cli.agent.log_error", lambda msg: None)
+        monkeypatch.delenv(config.CAUSE_FILE_ENV_VAR, raising=False)
+
+        async def fake_operate(self, instruction=None, **kw):
+            raise _BoomError("simulated inner failure")
+
+        monkeypatch.setattr(Branch, "operate", fake_operate)
+
+        from lionagi.cli.agent import _run_agent
+
+        with pytest.raises(_BoomError):
+            await _run_agent("codex/model", "do the thing")
+
+        assert not list(tmp_path.glob("**/terminal_cause.json"))
+
+    @pytest.mark.asyncio
+    async def test_a_timeout_records_that_the_cause_was_not_a_provider_error(
+        self, monkeypatch, tmp_path
+    ):
+        """The timeout handler is a second, separate site. Without its own arm a
+        change there is invisible, since the failure handler's arm above would
+        stay green."""
+        import json
+
+        from lionagi.mcp import config
+
+        Branch = _wire_agent_stubs(monkeypatch, tmp_path)
+        cause = tmp_path / "terminal_cause.json"
+        monkeypatch.setenv(config.CAUSE_FILE_ENV_VAR, str(cause))
+
+        async def fake_operate(self, instruction=None, **kw):
+            raise TimeoutError("agent ran past its deadline")
+
+        monkeypatch.setattr(Branch, "operate", fake_operate)
+
+        from lionagi.cli.agent import _run_agent
+
+        _res, _prov, _bid, terminal_status, _sid = await _run_agent(
+            "codex/model", "do the thing", timeout=1
+        )
+
+        assert terminal_status == "timed_out"
+        assert cause.exists(), "the timeout path never reached the cause writer"
+        # `unknown` rather than nothing: a reader must be able to tell a cause
+        # that was looked at from a run where nobody looked.
+        assert json.loads(cause.read_text()) == {"class": "unknown", "retryable": False}

--- a/tests/mcp/test_terminal_cause.py
+++ b/tests/mcp/test_terminal_cause.py
@@ -16,12 +16,15 @@ import pytest
 
 from lionagi.mcp import _notify_hook, config, jobs
 from lionagi.mcp._terminal_cause import (
+    STATUS_SOURCES,
     UNKNOWN_CAUSE,
     allowed_cause_classes,
+    provider_status,
     read_terminal_cause,
     write_terminal_cause,
 )
 from lionagi.providers._provider_errors import (
+    ProviderAdapterError,
     ProviderAuthError,
     ProviderError,
     ProviderQuotaError,
@@ -61,6 +64,7 @@ class TestWhatTheWriterRecords:
         assert read_terminal_cause(cause_file) == {
             "class": "ProviderQuotaError",
             "retryable": True,
+            "status_source": "absent",
         }
 
     def test_a_non_retryable_provider_error_says_so(self, cause_file):
@@ -68,6 +72,7 @@ class TestWhatTheWriterRecords:
         assert read_terminal_cause(cause_file) == {
             "class": "ProviderAuthError",
             "retryable": False,
+            "status_source": "absent",
         }
 
     def test_a_plain_exception_is_recorded_as_looked_at_and_not_a_provider_error(self, cause_file):
@@ -78,6 +83,7 @@ class TestWhatTheWriterRecords:
         assert read_terminal_cause(cause_file) == {
             "class": UNKNOWN_CAUSE,
             "retryable": False,
+            "status_source": "absent",
         }
 
     def test_the_retry_hint_comes_from_the_class_not_from_the_instance(self, cause_file):
@@ -147,12 +153,20 @@ class TestTheReaderFailsClosed:
         impossible. Pinned at the boundary that stores it."""
         p = tmp_path / "c.json"
         p.write_text(json.dumps({"class": "rm -rf /; DROP TABLE runs", "retryable": True}))
-        assert read_terminal_cause(p) == {"class": UNKNOWN_CAUSE, "retryable": True}
+        assert read_terminal_cause(p) == {
+            "class": UNKNOWN_CAUSE,
+            "retryable": True,
+            "status_source": "unreadable",
+        }
 
     def test_a_non_boolean_retry_hint_becomes_false_rather_than_truthy(self, tmp_path):
         p = tmp_path / "c.json"
         p.write_text(json.dumps({"class": "ProviderQuotaError", "retryable": "yes"}))
-        assert read_terminal_cause(p) == {"class": "ProviderQuotaError", "retryable": False}
+        assert read_terminal_cause(p) == {
+            "class": "ProviderQuotaError",
+            "retryable": False,
+            "status_source": "unreadable",
+        }
 
 
 def _job(monkeypatch, tmp_path) -> str:
@@ -181,14 +195,20 @@ class TestTheHookLiftsItIntoTheRecord:
     def test_a_failed_run_with_a_cause_gets_it_on_the_record(self, monkeypatch, tmp_path):
         rid = _job(monkeypatch, tmp_path)
         jobs.failure_cause_path(rid).write_text(
-            json.dumps({"class": "ProviderQuotaError", "retryable": True})
+            json.dumps(
+                {"class": "ProviderQuotaError", "retryable": True, "status_source": "absent"}
+            )
         )
 
         assert _notify_hook.main(["--run-id", rid, "--status", "failed"]) == 0
 
         record = jobs._read_job(rid)
         assert record["status"] == "failed"
-        assert record["failure_cause"] == {"class": "ProviderQuotaError", "retryable": True}
+        assert record["failure_cause"] == {
+            "class": "ProviderQuotaError",
+            "retryable": True,
+            "status_source": "absent",
+        }
 
     def test_a_run_with_no_cause_file_still_gets_its_record(self, monkeypatch, tmp_path):
         """The whole point of fail-closed here: the cause is an addition to the
@@ -230,3 +250,170 @@ class TestTheHookLiftsItIntoTheRecord:
     ):
         monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
         assert jobs.failure_cause_path("no-such-run") is None
+
+
+class TestTheProviderStatusDiscriminator:
+    """Two failures arrive as the same class with the same message prefix and
+    mean opposite things. Only a status code separates them, so these arms are
+    built from the two real messages that motivated the field.
+    """
+
+    # Both observed on one adapter, in one hour, in one directory. Identical up
+    # to the colon; the whole difference is whether a status code appears.
+    A_SERVICE_THAT_ANSWERED = (
+        "agy returned status=ERROR: Eligibility check failed: "
+        "UNAVAILABLE (code 503): The service is currently unavailable."
+    )
+    A_LOOKUP_THAT_NEVER_RESOLVED = (
+        "agy returned status=ERROR: Eligibility check failed: "
+        'Post "https://example.invalid/v1internal:loadCodeAssist": '
+        "dial tcp: lookup example.invalid: no such host"
+    )
+
+    def test_a_received_status_is_reported_with_its_code(self):
+        assert provider_status(ProviderAdapterError(self.A_SERVICE_THAT_ANSWERED)) == (
+            "received",
+            503,
+        )
+
+    def test_no_round_trip_reports_absent_and_carries_no_number(self):
+        source, code = provider_status(ProviderAdapterError(self.A_LOOKUP_THAT_NEVER_RESOLVED))
+        assert source == "absent"
+        assert code is None
+
+    def test_the_two_are_told_apart_despite_one_class_and_one_prefix(self):
+        """The point of the field. Asserting each arm alone would still pass if
+        both returned the same answer, which is the state that made the raw
+        message look necessary."""
+        answered = provider_status(ProviderAdapterError(self.A_SERVICE_THAT_ANSWERED))
+        never = provider_status(ProviderAdapterError(self.A_LOOKUP_THAT_NEVER_RESOLVED))
+        assert answered != never
+        assert type(ProviderAdapterError(self.A_SERVICE_THAT_ANSWERED)) is type(
+            ProviderAdapterError(self.A_LOOKUP_THAT_NEVER_RESOLVED)
+        )
+
+    def test_an_exception_that_cannot_be_read_is_not_reported_as_statusless(self):
+        class Unreadable(Exception):
+            def __str__(self) -> str:
+                raise ValueError("this exception's message cannot be rendered")
+
+        assert provider_status(Unreadable()) == ("unreadable", None)
+
+
+class TestTheRecordNeverCarriesTheMessage:
+    """The credential argument that justifies storing a code instead of the
+    message has to be enforced by the code. A reader of the commit message is
+    not a control.
+    """
+
+    def test_no_fragment_of_the_message_reaches_the_file(self, tmp_path, monkeypatch):
+        secret = "sk-liveTOKEN9f3a2b7c1d"
+        exc = ProviderAdapterError(
+            f"agy returned status=ERROR: UNAVAILABLE (code 503): rejected key {secret} at host vault.internal"
+        )
+        target = tmp_path / "cause.json"
+        monkeypatch.setenv(config.CAUSE_FILE_ENV_VAR, str(target))
+        write_terminal_cause(exc)
+
+        raw = target.read_text()
+        assert secret not in raw
+        # Every whitespace-separated run in the message long enough to be a
+        # value rather than a connective: none of them may appear.
+        for token in {t for t in str(exc).replace(":", " ").split() if len(t) > 5}:
+            assert token not in raw, f"the message fragment {token!r} reached the record"
+
+    def test_only_a_closed_set_of_strings_is_ever_stored(self, tmp_path, monkeypatch):
+        """Substring checks catch what a test author thought to look for. This
+        asserts the shape instead: every string in the record comes from a set
+        this module owns, so an added field carrying provider prose fails here
+        without anyone having predicted its wording.
+        """
+        exc = ProviderAdapterError(
+            "agy returned status=ERROR: UNAVAILABLE (code 503): db://user:hunter2@internal-host/prod"
+        )
+        target = tmp_path / "cause.json"
+        monkeypatch.setenv(config.CAUSE_FILE_ENV_VAR, str(target))
+        write_terminal_cause(exc)
+
+        stored = json.loads(target.read_text())
+        allowed = allowed_cause_classes() | STATUS_SOURCES
+        for key, value in stored.items():
+            if isinstance(value, str):
+                assert value in allowed, f"{key} carries free text: {value!r}"
+            else:
+                assert isinstance(value, (bool, int)), (
+                    f"{key} is neither a known string nor a number"
+                )
+
+    def test_the_status_code_does_survive(self, tmp_path, monkeypatch):
+        """The companion arm. Storing nothing at all would satisfy every
+        assertion above, so the field has to be shown present and correct."""
+        exc = ProviderAdapterError("agy returned status=ERROR: UNAVAILABLE (code 503): unavailable")
+        target = tmp_path / "cause.json"
+        monkeypatch.setenv(config.CAUSE_FILE_ENV_VAR, str(target))
+        write_terminal_cause(exc)
+
+        stored = json.loads(target.read_text())
+        assert stored["status_source"] == "received"
+        assert stored["provider_status"] == 503
+
+
+class TestAbsentStatusIsItsOwnState:
+    def test_absent_never_becomes_a_number(self, tmp_path, monkeypatch):
+        exc = ProviderAdapterError("agy returned status=ERROR: dial tcp: no such host")
+        target = tmp_path / "cause.json"
+        monkeypatch.setenv(config.CAUSE_FILE_ENV_VAR, str(target))
+        write_terminal_cause(exc)
+
+        stored = json.loads(target.read_text())
+        assert stored["status_source"] == "absent"
+        assert "provider_status" not in stored, (
+            "a missing status must be missing, not zero and not null-shaped"
+        )
+
+    def test_a_reader_cannot_turn_a_bool_into_status_one(self, tmp_path):
+        """isinstance(True, int) is True in Python, so a `true` in this field
+        would otherwise read back as status 1 — a valid-looking code invented
+        from a value that is not one."""
+        target = tmp_path / "cause.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "class": "ProviderAdapterError",
+                    "retryable": False,
+                    "status_source": "received",
+                    "provider_status": True,
+                }
+            )
+        )
+        cause = read_terminal_cause(target)
+        assert "provider_status" not in cause
+        assert cause["status_source"] == "unreadable"
+
+    def test_a_status_source_this_reader_does_not_know_is_unreadable_not_absent(self, tmp_path):
+        target = tmp_path / "cause.json"
+        target.write_text(
+            json.dumps(
+                {"class": "ProviderAdapterError", "retryable": False, "status_source": "invented"}
+            )
+        )
+        assert read_terminal_cause(target)["status_source"] == "unreadable"
+
+
+class TestARecordFromABeforeTheFieldExisted:
+    def test_a_cause_written_without_a_status_source_reads_as_unreadable(self, tmp_path):
+        """The writer runs in another process at another version, so a file
+        predating this field is a real shape to expect. It reads as unreadable
+        rather than absent, because a writer that never looked and a writer that
+        looked and found none are different facts, and only the second is a
+        measurement a caller may act on.
+        """
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps({"class": "ProviderQuotaError", "retryable": True}))
+        cause = read_terminal_cause(p)
+        assert cause["status_source"] == "unreadable"
+        assert "provider_status" not in cause
+        # The fields that did exist still survive: a new field must not cost a
+        # caller the ones it already had.
+        assert cause["class"] == "ProviderQuotaError"
+        assert cause["retryable"] is True

--- a/tests/mcp/test_terminal_cause.py
+++ b/tests/mcp/test_terminal_cause.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""The typed cause of a terminal exception, from the CLI process to the job record.
+
+The loss being closed: a failed job record said a run failed and nothing about
+why, so every caller re-derived the reason from console prose. These arms hold
+the two ends of that channel to the same schema, and hold the failure paths to
+fail-closed — a run whose cause cannot be read must still get its record.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.mcp import _notify_hook, config, jobs
+from lionagi.mcp._terminal_cause import (
+    UNKNOWN_CAUSE,
+    allowed_cause_classes,
+    read_terminal_cause,
+    write_terminal_cause,
+)
+from lionagi.providers._provider_errors import (
+    ProviderAuthError,
+    ProviderError,
+    ProviderQuotaError,
+)
+
+
+@pytest.fixture
+def cause_file(monkeypatch, tmp_path):
+    """A configured cause path, as a spawned run would see it."""
+    path = tmp_path / "terminal_cause.json"
+    monkeypatch.setenv(config.CAUSE_FILE_ENV_VAR, str(path))
+    return path
+
+
+class TestTheClosedSetIsDerivedFromTheHierarchy:
+    def test_it_holds_the_provider_errors_and_nothing_wider(self):
+        """A hand-maintained list would drift from the classes it names; this
+        asserts both directions, since a set that admitted everything would
+        satisfy a membership check on its own."""
+        allowed = allowed_cause_classes()
+        assert "ProviderQuotaError" in allowed
+        assert "ProviderError" in allowed
+        assert UNKNOWN_CAUSE in allowed
+        assert "RuntimeError" not in allowed
+        assert "Exception" not in allowed
+
+    def test_a_subclass_defined_later_is_admissible_without_a_second_edit(self):
+        class ProviderInventedForThisTest(ProviderError):
+            retryable = True
+
+        assert "ProviderInventedForThisTest" in allowed_cause_classes()
+
+
+class TestWhatTheWriterRecords:
+    def test_a_provider_error_round_trips_with_its_retry_hint(self, cause_file):
+        write_terminal_cause(ProviderQuotaError("out of quota"))
+        assert read_terminal_cause(cause_file) == {
+            "class": "ProviderQuotaError",
+            "retryable": True,
+        }
+
+    def test_a_non_retryable_provider_error_says_so(self, cause_file):
+        write_terminal_cause(ProviderAuthError("bad key"))
+        assert read_terminal_cause(cause_file) == {
+            "class": "ProviderAuthError",
+            "retryable": False,
+        }
+
+    def test_a_plain_exception_is_recorded_as_looked_at_and_not_a_provider_error(self, cause_file):
+        """`unknown` and absent are different answers: this one says the cause
+        was read and was not one of ours, which tells a caller to stop looking
+        for a provider reason rather than to go and look."""
+        write_terminal_cause(RuntimeError("something else entirely"))
+        assert read_terminal_cause(cause_file) == {
+            "class": UNKNOWN_CAUSE,
+            "retryable": False,
+        }
+
+    def test_the_retry_hint_comes_from_the_class_not_from_the_instance(self, cause_file):
+        """`retryable` is a class-level classification. An instance attribute of
+        the same name belongs to some other subsystem's runtime state, and
+        letting it through would make the stored hint mean two things."""
+        exc = ProviderQuotaError("out of quota")
+        exc.retryable = False  # shadows the ClassVar on this instance only
+        write_terminal_cause(exc)
+        assert read_terminal_cause(cause_file)["retryable"] is True
+
+    def test_the_exceptions_message_reaches_no_part_of_the_file(self, cause_file):
+        """The message is deliberately not carried, and a provider quoting a
+        credential back is exactly why. Asserted over the raw bytes, not the
+        parsed fields, so a message smuggled into a key or an unread field
+        still fails this."""
+        secret = "sk-ant-notarealkey-000111222333"
+        write_terminal_cause(ProviderAuthError(f"401 from provider using {secret}"))
+        raw = cause_file.read_text()
+        assert secret not in raw
+        assert "401" not in raw
+        assert "provider using" not in raw
+
+
+class TestTheWriterNeverRaisesIntoTheTerminalPath:
+    """It is called while a run's real failure is propagating. Anything it
+    raised would replace that failure with this one."""
+
+    def test_no_configured_cause_file_is_a_silent_no_op(self, monkeypatch):
+        monkeypatch.delenv(config.CAUSE_FILE_ENV_VAR, raising=False)
+        write_terminal_cause(ProviderQuotaError("out of quota"))  # must not raise
+
+    def test_an_unwritable_target_is_a_silent_no_op(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(
+            config.CAUSE_FILE_ENV_VAR, str(tmp_path / "no" / "such" / "dir" / "c.json")
+        )
+        write_terminal_cause(ProviderQuotaError("out of quota"))  # must not raise
+
+
+class TestTheReaderFailsClosed:
+    def test_an_absent_file_reads_as_nothing_rather_than_as_a_cause(self, tmp_path):
+        assert read_terminal_cause(tmp_path / "never-written.json") is None
+
+    def test_no_configured_path_reads_as_nothing(self):
+        assert read_terminal_cause(None) is None
+
+    def test_malformed_json_reads_as_nothing_rather_than_raising(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text("{not json at all")
+        assert read_terminal_cause(p) is None
+
+    def test_a_json_document_that_is_not_an_object_reads_as_nothing(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text('["ProviderQuotaError"]')
+        assert read_terminal_cause(p) is None
+
+    def test_an_oversized_file_is_refused_rather_than_parsed(self, tmp_path):
+        """Something other than this writer produced it, so parsing it would be
+        answering about a different file."""
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps({"class": "ProviderQuotaError", "pad": "x" * 8192}))
+        assert read_terminal_cause(p) is None
+
+    def test_a_class_name_outside_the_set_is_pinned_never_stored_verbatim(self, tmp_path):
+        """The writer runs in another process at another version, so an
+        unrecognised value is what this should expect rather than treat as
+        impossible. Pinned at the boundary that stores it."""
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps({"class": "rm -rf /; DROP TABLE runs", "retryable": True}))
+        assert read_terminal_cause(p) == {"class": UNKNOWN_CAUSE, "retryable": True}
+
+    def test_a_non_boolean_retry_hint_becomes_false_rather_than_truthy(self, tmp_path):
+        p = tmp_path / "c.json"
+        p.write_text(json.dumps({"class": "ProviderQuotaError", "retryable": "yes"}))
+        assert read_terminal_cause(p) == {"class": "ProviderQuotaError", "retryable": False}
+
+
+def _job(monkeypatch, tmp_path) -> str:
+    """A recorded job with a real directory, as submit() would have left it."""
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_COMMAND", raising=False)
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_SENDER", raising=False)
+    monkeypatch.delenv("LIONAGI_MCP_NOTIFY_TARGET", raising=False)
+    rid = jobs.new_run_id()
+    config.job_dir(rid).mkdir(parents=True)
+    jobs._write_job(
+        {
+            "run_id": rid,
+            "pid": 1,
+            "kind": "agent",
+            "label": "t",
+            "cwd": None,
+            "status": "running",
+            "log": None,
+        }
+    )
+    return rid
+
+
+class TestTheHookLiftsItIntoTheRecord:
+    def test_a_failed_run_with_a_cause_gets_it_on_the_record(self, monkeypatch, tmp_path):
+        rid = _job(monkeypatch, tmp_path)
+        jobs.failure_cause_path(rid).write_text(
+            json.dumps({"class": "ProviderQuotaError", "retryable": True})
+        )
+
+        assert _notify_hook.main(["--run-id", rid, "--status", "failed"]) == 0
+
+        record = jobs._read_job(rid)
+        assert record["status"] == "failed"
+        assert record["failure_cause"] == {"class": "ProviderQuotaError", "retryable": True}
+
+    def test_a_run_with_no_cause_file_still_gets_its_record(self, monkeypatch, tmp_path):
+        """The whole point of fail-closed here: the cause is an addition to the
+        record, never a precondition for having one."""
+        rid = _job(monkeypatch, tmp_path)
+        assert not jobs.failure_cause_path(rid).exists()
+
+        assert _notify_hook.main(["--run-id", rid, "--status", "failed"]) == 0
+
+        record = jobs._read_job(rid)
+        assert record["status"] == "failed"
+        assert record["finished_at"] is not None
+        # Absent, not a placeholder: nobody reported a cause, which a caller
+        # must be able to tell from a cause that was read and was `unknown`.
+        assert "failure_cause" not in record
+
+    def test_a_corrupt_cause_file_costs_the_run_neither_its_record_nor_the_hooks_exit(
+        self, monkeypatch, tmp_path
+    ):
+        rid = _job(monkeypatch, tmp_path)
+        jobs.failure_cause_path(rid).write_text("\x00\x00 not json \xff")
+
+        assert _notify_hook.main(["--run-id", rid, "--status", "failed"]) == 0
+
+        record = jobs._read_job(rid)
+        assert record["status"] == "failed"
+        assert "failure_cause" not in record
+
+    def test_the_path_resolves_through_the_same_function_the_spawn_used(
+        self, monkeypatch, tmp_path
+    ):
+        """Writer and reader agreeing by construction rather than by two paths
+        that match today."""
+        rid = _job(monkeypatch, tmp_path)
+        assert jobs.failure_cause_path(rid) == config.job_dir(rid) / config.CAUSE_FILENAME
+
+    def test_an_unknown_run_has_no_cause_path_rather_than_an_invented_one(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+        assert jobs.failure_cause_path("no-such-run") is None

--- a/tests/providers/test_cli_subprocess_silent_failure.py
+++ b/tests/providers/test_cli_subprocess_silent_failure.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A nonzero exit with nothing to quote has more than one cause, and the
+message a caller stores has to say which.
+
+`ndjson_from_cli` raises with the child's stderr when there is any, and with a
+constructed reason when there is not. Before this, every reason was the same
+sentence — the exit code — so a child that failed silently, a child whose
+stderr was never opened, and a drain that raised while reading all arrived as
+one fact. That direction hides the instrument: a broken capture reads exactly
+like a quiet subprocess, and a reader who takes it at face value goes looking
+at the child.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+from lionagi.providers._cli_subprocess import _no_stderr_reason, ndjson_from_cli
+
+
+def _cmd(script: str) -> list[str]:
+    return [sys.executable, "-c", script]
+
+
+# Exits nonzero having written nothing anywhere.
+_SILENT_FAILURE = "import sys; sys.exit(3)"
+# Exits nonzero with something on stderr, so the quoting path is exercised by
+# the same test file that covers its absence.
+_SPEAKS_THEN_FAILS = "import sys; sys.stderr.write('the child explained itself'); sys.exit(4)"
+
+
+class TestTheReasonsAreDistinguishable:
+    """The property under test is mutual distinctness, not any one wording.
+
+    Asserting the sentences individually would let a change that reverted two
+    of them to a shared string keep passing, which is the exact regression
+    this file exists to catch.
+    """
+
+    def test_every_no_stderr_reason_differs_from_every_other(self):
+        reasons = [
+            _no_stderr_reason(3, None, None),
+            _no_stderr_reason(3, "its stderr was never opened", None),
+            _no_stderr_reason(3, None, "OSError"),
+        ]
+        assert len(set(reasons)) == len(reasons), (
+            f"two of these carry the same text, so a caller cannot tell them apart: {reasons}"
+        )
+
+    def test_a_drain_failure_is_not_reported_as_a_quiet_child(self):
+        quiet = _no_stderr_reason(3, None, None)
+        broken = _no_stderr_reason(3, None, "OSError")
+        assert "wrote nothing" in quiet
+        assert "wrote nothing" not in broken
+        assert "OSError" in broken
+
+    def test_the_drain_exceptions_message_is_never_carried_only_its_type(self):
+        """The drain's exception can embed the bytes it was reading when it
+        raised, and this string is what a caller stores or forwards."""
+        reason = _no_stderr_reason(3, None, "OSError")
+        assert "OSError" in reason
+        # A type name is what the caller records; anything the exception said
+        # about its input is not available to be recorded in the first place,
+        # which is why the parameter is a type name and not an exception.
+        assert reason.count("OSError") == 1
+
+    def test_the_exit_code_survives_in_every_arm(self):
+        """It is the one fact present in all three, and dropping it while
+        adding detail would be a silent loss of the original message."""
+        for reason in (
+            _no_stderr_reason(7, None, None),
+            _no_stderr_reason(7, "its stderr was never opened", None),
+            _no_stderr_reason(7, None, "OSError"),
+        ):
+            assert "7" in reason
+
+
+class TestAgainstARealChild:
+    @pytest.mark.asyncio
+    async def test_a_silent_nonzero_exit_says_the_stderr_was_empty(self):
+        async def run():
+            async for _ in ndjson_from_cli(_cmd(_SILENT_FAILURE)):
+                pass  # pragma: no cover - the child writes no stdout
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await asyncio.wait_for(asyncio.create_task(run()), timeout=30)
+
+        message = str(exc_info.value)
+        assert "wrote nothing to stderr" in message, message
+        assert "3" in message, message
+
+    @pytest.mark.asyncio
+    async def test_a_child_that_does_speak_is_still_quoted_verbatim(self):
+        """The added arms must not displace the case that already worked: when
+        there is stderr, it is the message, and none of the constructed
+        reasons appear."""
+
+        async def run():
+            async for _ in ndjson_from_cli(_cmd(_SPEAKS_THEN_FAILS)):
+                pass  # pragma: no cover - the child writes no stdout
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await asyncio.wait_for(asyncio.create_task(run()), timeout=30)
+
+        message = str(exc_info.value)
+        assert "the child explained itself" in message, message
+        assert "wrote nothing to stderr" not in message, message


### PR DESCRIPTION
## What

A failed job record said `status: failed` and nothing else. The exception that ended the run is a typed object at the moment it becomes useful, and it was dropped before the record, so every consumer reading job status over MCP saw a failure with no reason and retried into whatever caused it.

Two separate losses were stacked here, and they are fixed separately because they are different components failing in different ways.

## 1. The child CLI's own report could collapse to an exit code

A nonzero exit raised with the child's stderr when there was any, and with the exit code when there was not. That made three different facts arrive as one sentence: a child that failed silently, a child whose stderr was never opened, and a drain that raised while reading it. The drain swallowed its own exception into a debug log, so a broken capture read exactly like a quiet subprocess.

That direction hides the instrument. A reader who takes the collapsed message at face value goes looking at the child, and there is nothing there to find, because the report exists somewhere the process never looked.

The drain now records how it ended and the message names it. The drain's exception contributes its type and never its message, because that message can embed the bytes being read when it raised, and this string is what a caller stores or forwards. A child that does speak is still quoted verbatim.

A follow-up commit orders two steps at the raise site: emptiness is now decided on what was captured, before the drain note is appended, so the note cannot count as captured output. Two probes built to induce that arm, one holding both pipes open through a detached grandchild, failed to reach it. It is not claimed as a demonstrated failure. Ordering the steps makes its reachability stop mattering, which is cheaper than establishing whether it is reachable at all.

## 2. The typed cause never reached the record

The run now drops the class of whatever exception ended it into a file in its own job directory, named by an environment variable set at submit, and the terminal hook lifts it into the record as `failure_cause`.

**The exception's message is deliberately not carried.** Provider messages quote whatever the provider said, which routinely includes an API key, and the existing credential masker closes the `user:secret@` shape rather than a bare token. The message is already in the run's console log, which is one channel with whatever exposure it already has. Copying it into the job record, a file the observer verbs read, quote and pass on, opens a second channel onto the same secret. What a caller branches on is the class and the retry hint.

Reader and writer live in one module on purpose: they are in different processes, neither imports the other, and split across two files the schema would be two schemas that happen to agree today. The reader forces the class name through a set derived from the exception hierarchy itself, at the boundary that stores it, rather than trusting the writer, because the two processes can be different versions.

A run whose cause file is absent leaves the field off the record entirely, so a caller can tell a run that reported no typed cause from one that predates the field.

## Tests

37 tests across three files. The reason-construction arms are asserted to differ from each other as a set rather than individually, because asserting them one by one would let a change that collapsed two back into a shared string keep passing, which is the regression the file exists to catch.

## Note on the suite

`tests/mcp/test_schedule_verbs.py`, `test_catalog_sufficiency.py` and `test_stdio_transport.py` fail locally on this branch. They fail identically on `main` under the same invocation (8 failed, 30 passed, 5 errors on both), so this branch neither adds nor fixes them. Reported separately rather than folded in here.
