### PR TITLE
Say which sqlite busy_timeout a process is actually using

### DIFF
--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -61,6 +61,67 @@ def _busy_timeout_from_env() -> int:
 # it at connection time — tests that need a different wait retune it here.
 SQLITE_BUSY_TIMEOUT_MS = _busy_timeout_from_env()
 
+_busy_timeout_announced = False
+
+
+def announce_busy_timeout() -> None:
+    """Say once per process what busy_timeout this process's connections use.
+
+    The value is a deployment property that lives in one config file's env
+    block, so it is set once per config and every new config that spawns a
+    lionagi process starts at the built-in default. Against a large contended
+    store that default is the difference between a write that waits and a write
+    that reports "database is locked", and until now nothing said which one was
+    in effect — it could only be inferred by reading the config that launched
+    the process, from outside the process.
+
+    The source is recomputed here rather than recorded when the module was
+    imported, so the line describes what is actually in effect at the moment a
+    connection is about to use it. That matters because the module attribute is
+    writable: tests retune it, and a provenance captured at import would keep
+    claiming the environment's answer after something else had replaced it.
+    """
+    global _busy_timeout_announced
+    if _busy_timeout_announced:
+        return
+    _busy_timeout_announced = True
+
+    effective = SQLITE_BUSY_TIMEOUT_MS
+    raw = os.environ.get("LIONAGI_SQLITE_BUSY_TIMEOUT_MS")
+    if raw is None:
+        _log.info(
+            "sqlite busy_timeout is %dms, the built-in default: "
+            "LIONAGI_SQLITE_BUSY_TIMEOUT_MS is not set for this process",
+            effective,
+        )
+        return
+    try:
+        asked = int(raw)
+    except ValueError:
+        asked = None
+    if asked is not None and asked > 0 and asked == effective:
+        _log.info(
+            "sqlite busy_timeout is %dms, from LIONAGI_SQLITE_BUSY_TIMEOUT_MS",
+            effective,
+        )
+    elif asked is None or asked <= 0:
+        # Also warned when the value was first read, which happens at import —
+        # possibly before this process configured logging at all. Repeating it
+        # here is the difference between a warning that was emitted and one that
+        # was seen.
+        _log.warning(
+            "sqlite busy_timeout is %dms: LIONAGI_SQLITE_BUSY_TIMEOUT_MS=%r is not usable",
+            effective,
+            raw,
+        )
+    else:
+        _log.info(
+            "sqlite busy_timeout is %dms, set in-process; "
+            "LIONAGI_SQLITE_BUSY_TIMEOUT_MS asks for %dms",
+            effective,
+            asked,
+        )
+
 
 def has_wal_reset_fix(version_info: tuple[int, ...]) -> bool:
     """Whether a linked SQLite carries the fix for the WAL-reset corruption race
@@ -267,6 +328,7 @@ def make_engine(url: str, **overrides):
 
     if dialect == "sqlite":
         _warn_if_wal_reset_unfixed()
+        announce_busy_timeout()
         kwargs: dict = {"echo": False, "json_serializer": _dumps_with_uuid}
         kwargs.update(overrides)
         engine = create_async_engine(url, **kwargs)

--- a/lionagi/studio/services/_db.py
+++ b/lionagi/studio/services/_db.py
@@ -123,6 +123,11 @@ async def open_db(path: str) -> AsyncIterator[aiosqlite.Connection]:
     lock wait that differs between them is a difference nobody chose.
     """
     global _ACTIVE_CONNECTIONS
+    # Announced here as well as in make_engine because this is a second,
+    # independent way into the store: a process that only ever opens
+    # connections this way would otherwise never say which timeout it uses.
+    # The announcement is once per process, so two call sites is one line.
+    _state_engine.announce_busy_timeout()
     async with aiosqlite.connect(path) as db:
         _ACTIVE_CONNECTIONS += 1
         try:

--- a/tests/state/test_busy_timeout_announcement.py
+++ b/tests/state/test_busy_timeout_announcement.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""What a process says about the busy_timeout its connections will use.
+
+The value is a deployment property set once per config file, so a process
+started from a config that never mentions it silently runs the built-in
+default. These arms hold the announcement to naming the effective value AND
+where it came from: a bare number cannot tell "deliberately set to the default"
+from "nobody set anything", which is the whole distinction the line exists for.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lionagi.state import engine as eng
+
+ENV = "LIONAGI_SQLITE_BUSY_TIMEOUT_MS"
+
+
+@pytest.fixture
+def announce(monkeypatch, caplog):
+    """Re-arm the once-per-process guard so each arm gets a fresh announcement."""
+    monkeypatch.setattr(eng, "_busy_timeout_announced", False)
+
+    def run() -> list[logging.LogRecord]:
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=eng._log.name):
+            eng.announce_busy_timeout()
+        return list(caplog.records)
+
+    return run
+
+
+class TestItNamesTheValueAndItsSource:
+    def test_an_unset_variable_is_named_as_such_not_just_reported_as_a_number(
+        self, monkeypatch, announce
+    ):
+        """The case the line exists for. A process that prints only "5000"
+        leaves a reader unable to tell a chosen default from an unset one."""
+        monkeypatch.delenv(ENV, raising=False)
+        monkeypatch.setattr(eng, "SQLITE_BUSY_TIMEOUT_MS", 5000)
+
+        records = announce()
+
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "5000ms" in msg
+        assert ENV in msg
+        assert "not set" in msg
+        assert records[0].levelno == logging.INFO
+
+    def test_a_value_from_the_environment_says_where_it_came_from(self, monkeypatch, announce):
+        monkeypatch.setenv(ENV, "30000")
+        monkeypatch.setattr(eng, "SQLITE_BUSY_TIMEOUT_MS", 30000)
+
+        records = announce()
+
+        msg = records[0].getMessage()
+        assert "30000ms" in msg
+        assert f"from {ENV}" in msg
+        assert records[0].levelno == logging.INFO
+
+    def test_an_unusable_value_warns_and_names_what_was_asked_for(self, monkeypatch, announce):
+        """Repeated here deliberately. The same condition is warned about when
+        the variable is first read, which happens at import — possibly before
+        the process configured logging, in which case that warning was emitted
+        and never seen."""
+        monkeypatch.setenv(ENV, "not-a-number")
+        monkeypatch.setattr(eng, "SQLITE_BUSY_TIMEOUT_MS", 5000)
+
+        records = announce()
+
+        assert records[0].levelno == logging.WARNING
+        msg = records[0].getMessage()
+        assert "5000ms" in msg
+        assert "not-a-number" in msg
+        assert "not usable" in msg
+
+    def test_zero_is_treated_as_unusable_rather_than_as_a_request(self, monkeypatch, announce):
+        """busy_timeout=0 means never wait, which is never what a deployment
+        that bothered to set the variable is asking for."""
+        monkeypatch.setenv(ENV, "0")
+        monkeypatch.setattr(eng, "SQLITE_BUSY_TIMEOUT_MS", 5000)
+
+        records = announce()
+
+        assert records[0].levelno == logging.WARNING
+        assert "not usable" in records[0].getMessage()
+
+    def test_an_in_process_override_is_not_reported_as_the_environments_value(
+        self, monkeypatch, announce
+    ):
+        """The module attribute is writable and tests retune it. A provenance
+        captured when the module was imported would keep crediting the
+        environment for a value something else had replaced."""
+        monkeypatch.setenv(ENV, "30000")
+        monkeypatch.setattr(eng, "SQLITE_BUSY_TIMEOUT_MS", 250)
+
+        records = announce()
+
+        msg = records[0].getMessage()
+        assert "250ms" in msg
+        assert "in-process" in msg
+        assert "30000ms" in msg
+        assert f"from {ENV}" not in msg
+
+
+class TestItSaysThisOncePerProcess:
+    def test_a_second_call_adds_nothing(self, monkeypatch, caplog):
+        """Every connection would otherwise repeat it, and a line repeated per
+        connection is one a reader learns to skip."""
+        monkeypatch.setattr(eng, "_busy_timeout_announced", False)
+        monkeypatch.delenv(ENV, raising=False)
+        monkeypatch.setattr(eng, "SQLITE_BUSY_TIMEOUT_MS", 5000)
+
+        with caplog.at_level(logging.INFO, logger=eng._log.name):
+            caplog.clear()
+            eng.announce_busy_timeout()
+            first = len(caplog.records)
+            # The guard is deliberately NOT re-armed: this is the real second
+            # call, and the assertion is on records captured across it rather
+            # than on a container this test controls.
+            eng.announce_busy_timeout()
+            eng.announce_busy_timeout()
+            total = len(caplog.records)
+
+        assert first == 1, "the first call must actually say something"
+        assert total == 1, f"two further calls added {total - first} lines"
+
+
+class TestBothStoreEntryPointsAnnounce:
+    """The engine and the Studio connection helper are two independent ways
+    into one store file. A process that only used the second would never say
+    which timeout it had."""
+
+    def test_make_engine_announces_on_the_sqlite_path(self, monkeypatch, tmp_path, caplog):
+        monkeypatch.setattr(eng, "_busy_timeout_announced", False)
+        monkeypatch.delenv(ENV, raising=False)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=eng._log.name):
+            eng.make_engine(f"sqlite+aiosqlite:///{tmp_path / 'x.db'}")
+
+        assert any("busy_timeout" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_the_studio_connection_helper_announces(self, monkeypatch, tmp_path, caplog):
+        from lionagi.studio.services import _db
+
+        monkeypatch.setattr(eng, "_busy_timeout_announced", False)
+        monkeypatch.delenv(ENV, raising=False)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=eng._log.name):
+            async with _db.open_db(str(tmp_path / "studio.db")):
+                pass
+
+        assert any("busy_timeout" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Why

The SQLite `busy_timeout` is a deployment property. It lives in one config
file's env block, which means it is set once per config, and every new config
that spawns a lionagi process starts at the built-in default.

Against a large contended store that default is the difference between a write
that waits and a write that reports "database is locked" after already waiting
as long as it was allowed to. Nothing said which one was in effect. The only way
to find out was to read the config that launched the process, from outside the
process.

## What changed

Each process now says once, at the point a connection is about to use it, what
timeout it has and where that came from:

```
sqlite busy_timeout is 5000ms, the built-in default: LIONAGI_SQLITE_BUSY_TIMEOUT_MS is not set for this process
sqlite busy_timeout is 30000ms, from LIONAGI_SQLITE_BUSY_TIMEOUT_MS
sqlite busy_timeout is 5000ms: LIONAGI_SQLITE_BUSY_TIMEOUT_MS='' is not usable
sqlite busy_timeout is 250ms, set in-process; LIONAGI_SQLITE_BUSY_TIMEOUT_MS asks for 30000ms
```

A bare number would not have done. It cannot distinguish a deliberately chosen
default from a variable nobody set, and that distinction is the entire reason
for the line.

**The in-code default is unchanged.** This makes the current value visible; it
does not pick a different one.

## Two details worth the review time

**The source is recomputed at announcement time, not recorded at import.** The
module attribute is writable — tests retune it — and a provenance captured at
import would go on crediting the environment for a value something else had
replaced. There is an arm for exactly that case.

**Both entry points announce.** The engine factory and the Studio connection
helper are two independent ways into one store file, and a process that only
ever opened connections the second way would never have said which timeout it
had. The announcement is once per process, so the second call site costs one
line and no extra output. Each call site has its own arm, and removing either
one leaves the other's arm green.

An unusable value is warned about here as well as where it is first read. That
first read happens at import, possibly before the process has configured logging
at all, which is the difference between a warning that was emitted and one that
was seen.
