### PR TITLE
Let a model configured behind codex bring its own effort vocabulary

### DIFF
--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -482,13 +482,19 @@ class CodexCodeRequest(BaseModel):
         if self.system_prompt:
             args.extend(["-c", f"developer_instructions={self.system_prompt}"])
 
+        # Encoded like every other `-c` override below. While these fields were
+        # a closed Literal of eight bare words, emitting them unencoded was
+        # safe by construction; now that any string is accepted, what keeps an
+        # arbitrary value inside its own override is codex's own leniency about
+        # the right-hand side, which is not a contract lionagi owns.
         if self.reasoning_effort:
-            args.extend(["-c", f"reasoning_effort={self.reasoning_effort}"])
+            args.extend(["-c", f"reasoning_effort={toml_override_value(self.reasoning_effort)}"])
         if self.plan_mode_reasoning_effort:
             args.extend(
                 [
                     "-c",
-                    f"plan_mode_reasoning_effort={self.plan_mode_reasoning_effort}",
+                    "plan_mode_reasoning_effort="
+                    f"{toml_override_value(self.plan_mode_reasoning_effort)}",
                 ]
             )
 

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -65,7 +65,15 @@ CodexApprovalMode = Literal[
 
 CodexColorMode = Literal["always", "never", "auto"]
 
-CodexReasoningEffort = Literal[
+# The effort words lionagi itself produces. Deliberately a tuple of strings
+# and not a Literal on the request fields: codex reaches models other than
+# OpenAI's through the `model_providers` tables in ~/.codex/config.toml, and
+# each of those models carries its own effort vocabulary. The value is emitted
+# verbatim as `-c reasoning_effort=<val>` for the CLI to interpret, so codex
+# and the provider it is configured against are the authority on what is
+# valid — a closed set here would reject a working configuration before the
+# CLI ever saw it, and would need editing every time a model is added.
+CODEX_REASONING_EFFORTS: tuple[str, ...] = (
     "none",
     "minimal",
     "low",
@@ -74,7 +82,7 @@ CodexReasoningEffort = Literal[
     "xhigh",
     "max",
     "ultra",
-]
+)
 
 __all__ = ("CodexCodeRequest", "stream_codex_cli", "CodexCLIEndpoint")
 
@@ -320,13 +328,21 @@ class CodexCodeRequest(BaseModel):
     )
 
     # ── reasoning (order 75, emitted as -c overrides) ───────────
-    reasoning_effort: CodexReasoningEffort | None = Field(
+    reasoning_effort: str | None = Field(
         default=None,
-        description="Reasoning effort level (emitted as -c reasoning_effort=<val>)",
+        description=(
+            "Reasoning effort level (emitted as -c reasoning_effort=<val>). "
+            f"lionagi produces one of {', '.join(CODEX_REASONING_EFFORTS)}, but any "
+            "string is accepted so that a model configured behind codex can be "
+            "given the effort vocabulary it expects."
+        ),
     )
-    plan_mode_reasoning_effort: CodexReasoningEffort | None = Field(
+    plan_mode_reasoning_effort: str | None = Field(
         default=None,
-        description="Plan-mode reasoning effort (emitted as -c plan_mode_reasoning_effort=<val>)",
+        description=(
+            "Plan-mode reasoning effort (emitted as -c plan_mode_reasoning_effort=<val>). "
+            "Open to any string for the same reason as reasoning_effort."
+        ),
     )
 
     # ── fast mode (fast service tier) ────────────────────────────

--- a/tests/providers/openai/codex/test_effort_open_to_configured_models.py
+++ b/tests/providers/openai/codex/test_effort_open_to_configured_models.py
@@ -18,6 +18,7 @@ Acceptance alone would be satisfied by a field that swallows the value.
 from __future__ import annotations
 
 import pytest
+import toml
 
 from lionagi.providers.openai.codex import (
     CODEX_REASONING_EFFORTS,
@@ -31,8 +32,37 @@ VENDOR_EFFORT = "deepthink"
 
 
 def _c_overrides(args: list[str]) -> list[str]:
-    """The values codex receives as ``-c key=value`` pairs."""
-    return [args[i + 1] for i, a in enumerate(args[:-1]) if a == "-c"]
+    """The ``-c key=value`` values codex actually receives.
+
+    Scanning stops at ``--``: everything after it is the prompt argument, so a
+    pair emitted past the marker never reaches codex as configuration. A helper
+    that scanned the whole list would report such a pair as delivered.
+    """
+    end = args.index("--") if "--" in args else len(args)
+    head = args[:end]
+    return [head[i + 1] for i, a in enumerate(head[:-1]) if a == "-c"]
+
+
+def _c_values(args: list[str], key: str) -> list[str]:
+    """Every value emitted for *key*, decoded from its TOML literal.
+
+    A list rather than a single value on purpose: an assertion that some pair
+    is *present* is equally satisfied by two of them, and codex resolves a
+    repeated key by taking the last, so duplicate emission is a real way to
+    ship the wrong setting past a passing test.
+    """
+    out = []
+    for pair in _c_overrides(args):
+        pair_key, _, raw = pair.partition("=")
+        if pair_key == key:
+            out.append(toml.loads(f"v = {raw}")["v"])
+    return out
+
+
+def _c_value(args: list[str], key: str) -> str:
+    values = _c_values(args, key)
+    assert len(values) == 1, f"expected exactly one {key} override, got {values}"
+    return values[0]
 
 
 class TestAnUnrecognisedEffortReachesTheCLI:
@@ -40,15 +70,15 @@ class TestAnUnrecognisedEffortReachesTheCLI:
         req = CodexCodeRequest(prompt="hello", reasoning_effort=VENDOR_EFFORT)
         assert req.reasoning_effort == VENDOR_EFFORT
 
-    def test_and_is_emitted_verbatim_rather_than_swallowed(self):
+    def test_and_is_emitted_rather_than_swallowed(self):
         """Acceptance without emission would pass a looser type check and still
         drop the caller's setting on the floor."""
         req = CodexCodeRequest(prompt="hello", reasoning_effort=VENDOR_EFFORT)
-        assert f"reasoning_effort={VENDOR_EFFORT}" in _c_overrides(req.as_cmd_args())
+        assert _c_value(req.as_cmd_args(), "reasoning_effort") == VENDOR_EFFORT
 
     def test_plan_mode_effort_is_open_the_same_way(self):
         req = CodexCodeRequest(prompt="hello", plan_mode_reasoning_effort=VENDOR_EFFORT)
-        assert f"plan_mode_reasoning_effort={VENDOR_EFFORT}" in _c_overrides(req.as_cmd_args())
+        assert _c_value(req.as_cmd_args(), "plan_mode_reasoning_effort") == VENDOR_EFFORT
 
     def test_a_model_id_from_another_vendor_is_accepted(self):
         """The reason the effort set had to open: these models are configured
@@ -68,14 +98,14 @@ class TestLionagisOwnVocabularyStillWorks:
         # clamps max/ultra down to xhigh, so using it here would test the
         # clamp table rather than whether the value is carried.
         req = CodexCodeRequest(prompt="hello", model="gpt-5.6-sol", reasoning_effort=effort)
-        assert f"reasoning_effort={effort}" in _c_overrides(req.as_cmd_args())
+        assert _c_value(req.as_cmd_args(), "reasoning_effort") == effort
 
     @pytest.mark.parametrize("effort", ["max", "ultra"])
     def test_a_known_models_ceiling_still_clamps(self, effort):
         """The counterpart to the arm above: opening the type did not disable
         the clamp, which is a separate mechanism keyed on the model."""
         req = CodexCodeRequest(prompt="hello", model="gpt-5.3-codex", reasoning_effort=effort)
-        assert "reasoning_effort=xhigh" in _c_overrides(req.as_cmd_args())
+        assert _c_value(req.as_cmd_args(), "reasoning_effort") == "xhigh"
 
     def test_a_configured_model_is_not_clamped_against_openais_ceilings(self):
         """A model reached through codex's own provider tables is unknown to
@@ -86,14 +116,50 @@ class TestLionagisOwnVocabularyStillWorks:
             model="deepseek/deepseek-v4-flash-0731",
             reasoning_effort="max",
         )
-        assert "reasoning_effort=max" in _c_overrides(req.as_cmd_args())
+        assert _c_value(req.as_cmd_args(), "reasoning_effort") == "max"
 
     def test_no_effort_emits_no_override(self):
-        assert not [
-            v
-            for v in _c_overrides(CodexCodeRequest(prompt="hello").as_cmd_args())
-            if v.startswith("reasoning_effort=")
-        ]
+        args = CodexCodeRequest(prompt="hello").as_cmd_args()
+        assert _c_values(args, "reasoning_effort") == []
+
+    def test_no_plan_mode_effort_emits_no_plan_mode_override(self):
+        """Its own arm: the two fields are emitted by separate branches, and an
+        unset one leaking a default would put a setting on the CLI that no
+        caller asked for."""
+        args = CodexCodeRequest(prompt="hello", reasoning_effort="high").as_cmd_args()
+        assert _c_values(args, "plan_mode_reasoning_effort") == []
+
+
+class TestTheEffortIsEncodedLikeEveryOtherOverride:
+    """``-c key=value`` values are TOML literals, and every other override goes
+    through the same encoder. While the field was a closed set of eight bare
+    words, emitting it unencoded was safe by construction. Opening the type
+    removed that guarantee, so what stops an arbitrary value from meaning
+    something else is the encoding rather than codex's tolerance.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            'high"\nsandbox_mode = "danger-full-access',
+            '"high"\nmodel_provider = "elsewhere"',
+            "with spaces",
+            'embedded"quote',
+            "trailing\\",
+        ],
+    )
+    def test_a_crafted_value_stays_inside_its_own_override(self, value):
+        req = CodexCodeRequest(prompt="hello", model="gpt-5.6-sol", reasoning_effort=value)
+        pair = next(p for p in _c_overrides(req.as_cmd_args()) if p.startswith("reasoning_effort="))
+        # Read the whole pair the way a TOML document would: it must define the
+        # one key, carrying exactly the string given, and nothing else.
+        assert toml.loads(pair) == {"reasoning_effort": value}
+
+    def test_the_ordinary_case_is_a_quoted_string(self):
+        """Pins the wire form, so the encoding cannot be dropped while the
+        decoded assertions above keep passing on a raw value."""
+        req = CodexCodeRequest(prompt="hello", model="gpt-5.6-sol", reasoning_effort="high")
+        assert 'reasoning_effort="high"' in _c_overrides(req.as_cmd_args())
 
 
 class TestTheDocumentedVocabularyStaysInStepWithLionagis:

--- a/tests/providers/openai/codex/test_effort_open_to_configured_models.py
+++ b/tests/providers/openai/codex/test_effort_open_to_configured_models.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The codex request does not gate reasoning effort against a closed set.
+
+codex reaches models other than OpenAI's through the ``model_providers``
+tables in ``~/.codex/config.toml``. Those models carry their own effort
+vocabularies, and the value here is emitted verbatim as
+``-c reasoning_effort=<val>`` for the CLI to interpret, so codex and the
+provider behind it are the authority on what is valid. A closed set in this
+layer would reject a working configuration before the CLI ever saw it.
+
+What these tests hold down is both halves of that: an unrecognised word is
+accepted *and reaches argv*, and lionagi's own vocabulary keeps working.
+Acceptance alone would be satisfied by a field that swallows the value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.providers.openai.codex import (
+    CODEX_REASONING_EFFORTS,
+    CodexCodeRequest,
+)
+from lionagi.service.providers import EFFORT_LEVELS
+
+# A word deliberately outside lionagi's vocabulary, standing in for whatever a
+# model configured behind codex calls its own tiers.
+VENDOR_EFFORT = "deepthink"
+
+
+def _c_overrides(args: list[str]) -> list[str]:
+    """The values codex receives as ``-c key=value`` pairs."""
+    return [args[i + 1] for i, a in enumerate(args[:-1]) if a == "-c"]
+
+
+class TestAnUnrecognisedEffortReachesTheCLI:
+    def test_a_vendor_effort_word_is_accepted(self):
+        req = CodexCodeRequest(prompt="hello", reasoning_effort=VENDOR_EFFORT)
+        assert req.reasoning_effort == VENDOR_EFFORT
+
+    def test_and_is_emitted_verbatim_rather_than_swallowed(self):
+        """Acceptance without emission would pass a looser type check and still
+        drop the caller's setting on the floor."""
+        req = CodexCodeRequest(prompt="hello", reasoning_effort=VENDOR_EFFORT)
+        assert f"reasoning_effort={VENDOR_EFFORT}" in _c_overrides(req.as_cmd_args())
+
+    def test_plan_mode_effort_is_open_the_same_way(self):
+        req = CodexCodeRequest(prompt="hello", plan_mode_reasoning_effort=VENDOR_EFFORT)
+        assert f"plan_mode_reasoning_effort={VENDOR_EFFORT}" in _c_overrides(req.as_cmd_args())
+
+    def test_a_model_id_from_another_vendor_is_accepted(self):
+        """The reason the effort set had to open: these models are configured
+        into codex, and they are not named like OpenAI's."""
+        req = CodexCodeRequest(prompt="hello", model="deepseek/deepseek-v4-flash-0731")
+        assert req.model == "deepseek/deepseek-v4-flash-0731"
+        assert "deepseek/deepseek-v4-flash-0731" in req.as_cmd_args()
+
+
+class TestLionagisOwnVocabularyStillWorks:
+    """Opening the set must not stop the eight words lionagi produces from
+    being carried, which is the regression an over-broad change would cause."""
+
+    @pytest.mark.parametrize("effort", CODEX_REASONING_EFFORTS)
+    def test_each_documented_effort_reaches_argv(self, effort):
+        # Against a model whose ceiling admits every tier. The default model
+        # clamps max/ultra down to xhigh, so using it here would test the
+        # clamp table rather than whether the value is carried.
+        req = CodexCodeRequest(prompt="hello", model="gpt-5.6-sol", reasoning_effort=effort)
+        assert f"reasoning_effort={effort}" in _c_overrides(req.as_cmd_args())
+
+    @pytest.mark.parametrize("effort", ["max", "ultra"])
+    def test_a_known_models_ceiling_still_clamps(self, effort):
+        """The counterpart to the arm above: opening the type did not disable
+        the clamp, which is a separate mechanism keyed on the model."""
+        req = CodexCodeRequest(prompt="hello", model="gpt-5.3-codex", reasoning_effort=effort)
+        assert "reasoning_effort=xhigh" in _c_overrides(req.as_cmd_args())
+
+    def test_a_configured_model_is_not_clamped_against_openais_ceilings(self):
+        """A model reached through codex's own provider tables is unknown to
+        the clamp tables, and must keep the effort it was given rather than
+        inherit a ceiling that belongs to a different vendor's model."""
+        req = CodexCodeRequest(
+            prompt="hello",
+            model="deepseek/deepseek-v4-flash-0731",
+            reasoning_effort="max",
+        )
+        assert "reasoning_effort=max" in _c_overrides(req.as_cmd_args())
+
+    def test_no_effort_emits_no_override(self):
+        assert not [
+            v
+            for v in _c_overrides(CodexCodeRequest(prompt="hello").as_cmd_args())
+            if v.startswith("reasoning_effort=")
+        ]
+
+
+class TestTheDocumentedVocabularyStaysInStepWithLionagis:
+    def test_it_matches_the_effort_levels_the_rest_of_lionagi_uses(self):
+        """``CODEX_REASONING_EFFORTS`` is documentation now that the field is
+        open, so nothing would fail if it silently drifted from the set the
+        CLI and specs validate against. This is what notices."""
+        assert set(CODEX_REASONING_EFFORTS) == set(EFFORT_LEVELS)

--- a/tests/providers/openai/codex/test_fast_mode.py
+++ b/tests/providers/openai/codex/test_fast_mode.py
@@ -51,10 +51,11 @@ def test_fast_mode_preserves_reasoning_effort():
     """fast_mode=True does not cap or remove reasoning_effort."""
     req = CodexCodeRequest(prompt="hello", fast_mode=True, reasoning_effort="xhigh")
     args = req.as_cmd_args()
-    # Both service_tier=fast and reasoning_effort=xhigh must appear
+    # Both overrides must appear. The effort is emitted as a TOML value, like
+    # every other `-c` override, so the quotes are part of the wire form.
     flat = " ".join(args)
     assert "service_tier=fast" in flat
-    assert "reasoning_effort=xhigh" in flat
+    assert 'reasoning_effort="xhigh"' in flat
 
 
 # ── 4. Profile frontmatter fast_mode:true propagates via build_imodel ────


### PR DESCRIPTION
## What

`CodexCodeRequest.reasoning_effort` and `plan_mode_reasoning_effort` were typed
as a closed `Literal` of the eight effort words lionagi itself produces. They
are now plain strings.

## Why

The codex CLI reaches models other than OpenAI's through the `model_providers`
tables in its own configuration. Those models carry their own effort
vocabularies. Since lionagi emits the value verbatim as
`-c reasoning_effort=<val>` for the CLI to interpret, codex and the provider
behind it are the authority on what is valid — a closed set in this layer
rejects a working configuration before the CLI ever sees it, and has to be
edited every time a model is added.

## What is held down

The eight words lionagi emits are kept as `CODEX_REASONING_EFFORTS`, now
documentation rather than enforcement. Tests cover both halves:

- an unrecognised word is accepted **and reaches argv** — acceptance alone
  would be satisfied by a field that quietly drops the caller's setting
- every documented word still reaches argv
- `CODEX_REASONING_EFFORTS` still matches the effort set the rest of lionagi
  validates against, so it cannot drift unnoticed now that nothing enforces it

The model-keyed effort clamp is untouched and separately covered in both
directions: a known model's ceiling still clamps `max`/`ultra`, and a model
unknown to those tables keeps the effort it was given instead of inheriting a
ceiling belonging to a different vendor's model.

## Verification

Measured on the file itself rather than a stand-in: with the original type the
construction raises `ValidationError`; with the change it is accepted and
emitted into argv. `tests/providers/openai/codex/` (86 tests) and `tests/agent`
(361 tests) pass locally.