### PR TITLE
Let codex/<name> name a codex config profile

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -51,7 +51,6 @@ __all__ = (
     "build_imodel_from_spec",
     "parse_model_spec",
     "resolve_codex_config_profile",
-    "resolve_model_spec",
     "resolve_persisted_effort",
     "AgentProfile",
     "AgentProfileNotFoundError",
@@ -88,7 +87,12 @@ def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | Non
     Two deliberate limits, both narrowing rather than widening:
 
     * Only a bare name is looked up, so an ordinary vendor model id such as
-      ``deepseek/deepseek-v4-flash-0731`` is never treated as a path.
+      ``deepseek/deepseek-v4-flash-0731`` is never treated as a path. Bare
+      excludes dots as well as separators, so a profile must be named like
+      ``deepseek-flash`` and one named ``gpt-5.6-sol`` is not resolved at all.
+      That cuts the other way usefully: model ids carry dots and version
+      numbers, so a profile name cannot collide with a real one and quietly
+      stand in for it.
     * Table-valued keys (notably ``mcp_servers``) are not applied, and are
       logged. lionagi decides a leg's MCP server set explicitly, and quietly
       re-introducing servers from a config file would go around that.
@@ -104,6 +108,19 @@ def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | Non
     codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
     profile_path = codex_home / f"{model}.config.toml"
     if not profile_path.is_file():
+        # A symlink whose target is unreadable is not the same as no profile.
+        # `is_file()` follows the link and answers False for both, so falling
+        # through here would send the name to codex as a model id — the exact
+        # silent substitution this function exists to prevent, arriving through
+        # a file the operator can see sitting right there.
+        broken_target = _unreadable_symlink_target(profile_path)
+        if broken_target is not None:
+            raise ValueError(
+                f"codex config profile {str(profile_path)!r} is a symlink whose "
+                f"target {broken_target!r} is unreadable. Repair or remove the "
+                f"link; running without it would send {model!r} to codex as a "
+                f"model id and silently run something else."
+            )
         return None
 
     import toml
@@ -143,6 +160,14 @@ def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | Non
             "— lionagi applies a profile's model and scalar settings, and sets "
             "a leg's MCP servers itself"
         )
+
+    # Say which model is actually being run. A profile whose name collides with
+    # a real model id would otherwise substitute without a word, which is the
+    # quiet half of the same failure this function fixes: the caller asks for
+    # one thing, a different thing runs, and the leg looks healthy either way.
+    from ._logging import progress
+
+    progress(f"codex profile {model!r} resolves to model {resolved!r}")
     return resolved, overrides
 
 
@@ -306,14 +331,6 @@ def resolve_persisted_effort(
     if provider in PROVIDERS_NO_EFFORT:
         effort = None
     return effort
-
-
-def resolve_model_spec(spec: str) -> tuple[str, str]:
-    """Legacy compat — returns (provider, model) by splitting on /."""
-    ms = parse_model_spec(spec)
-    if "/" in ms.model:
-        return ms.model.split("/", 1)
-    return ms.model, ms.model
 
 
 # ── CLI common args ───────────────────────────────────────────────────────

--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -50,6 +50,7 @@ __all__ = (
     "build_chat_model",
     "build_imodel_from_spec",
     "parse_model_spec",
+    "resolve_codex_config_profile",
     "resolve_model_spec",
     "resolve_persisted_effort",
     "AgentProfile",
@@ -66,6 +67,83 @@ __all__ = (
 )
 
 # ── iModel construction ───────────────────────────────────────────────────
+
+
+def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | None:
+    """Resolve a codex model part that names a codex config profile.
+
+    codex reaches models from other providers through a config profile:
+    ``-p <name>`` layers ``$CODEX_HOME/<name>.config.toml`` over the base
+    config, and such a file names a ``model`` and the ``model_provider`` that
+    serves it. So ``codex/<name>`` should mean "run that profile", not "run a
+    model literally called ``<name>``".
+
+    lionagi cannot forward this by passing ``-p``. codex accepts exactly one
+    profile per invocation and lionagi already spends that slot on a generated
+    profile carrying MCP server secrets, which is why supplying both is
+    refused outright. The file is therefore read here and its settings applied
+    directly: the profile's ``model`` becomes the model, and its remaining
+    scalars become ``-c`` overrides, which outrank config either way.
+
+    Two deliberate limits, both narrowing rather than widening:
+
+    * Only a bare name is looked up, so an ordinary vendor model id such as
+      ``deepseek/deepseek-v4-flash-0731`` is never treated as a path.
+    * Table-valued keys (notably ``mcp_servers``) are not applied, and are
+      logged. lionagi decides a leg's MCP server set explicitly, and quietly
+      re-introducing servers from a config file would go around that.
+
+    Returns ``None`` when no such profile file exists, leaving the name to be
+    treated as a model id exactly as before.
+    """
+    try:
+        validate_bare_name(model, label="codex config profile name")
+    except ValueError:
+        return None
+
+    codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+    profile_path = codex_home / f"{model}.config.toml"
+    if not profile_path.is_file():
+        return None
+
+    import toml
+
+    try:
+        data = toml.loads(profile_path.read_text())
+    except (OSError, toml.TomlDecodeError) as exc:
+        raise ValueError(
+            f"codex config profile {str(profile_path)!r} could not be read "
+            f"({type(exc).__name__}: {exc}). Fix or remove the file; running "
+            f"without it would send {model!r} as a model id instead."
+        ) from exc
+
+    resolved = data.get("model")
+    if not isinstance(resolved, str) or not resolved:
+        raise ValueError(
+            f"codex config profile {str(profile_path)!r} declares no 'model'. "
+            f"Add one, or use a model id instead of the profile name — "
+            f"without it {model!r} would be sent to codex as a model id and "
+            f"silently run something other than the profile."
+        )
+
+    overrides: dict[str, Any] = {}
+    skipped: list[str] = []
+    for key, value in data.items():
+        if key == "model":
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            overrides[key] = value
+        else:
+            skipped.append(key)
+    if skipped:
+        from ._logging import warn
+
+        warn(
+            f"codex config profile {model!r}: ignoring {', '.join(sorted(skipped))} "
+            "— lionagi applies a profile's model and scalar settings, and sets "
+            "a leg's MCP servers itself"
+        )
+    return resolved, overrides
 
 
 def build_imodel_from_spec(
@@ -87,6 +165,16 @@ def build_imodel_from_spec(
     # Resolve provider for yolo/effort kwarg lookup
     provider_raw = ms.model.split("/")[0] if "/" in ms.model else ms.model
     resolved_model = ms.model
+
+    # Before the effort clamp below, whose ceilings are keyed on the model: a
+    # profile names a different model than the spec did.
+    codex_profile_overrides: dict[str, Any] = {}
+    if provider_raw == "codex" and "/" in ms.model:
+        resolved_profile = resolve_codex_config_profile(ms.model.split("/", 1)[1])
+        if resolved_profile is not None:
+            profile_model, codex_profile_overrides = resolved_profile
+            resolved_model = f"codex/{profile_model}"
+            ms = ModelSpec(model=resolved_model, effort=ms.effort)
 
     if bypass:
         extra.update(PROVIDER_BYPASS_KWARGS.get(provider_raw, {}))
@@ -114,6 +202,11 @@ def build_imodel_from_spec(
             bare_model = ms.model.split("/", 1)[1] if "/" in ms.model else ms.model
             resolved_model = f"{provider_raw}/{resolve_agy_model(bare_model, effort=effort)}"
 
+    if codex_profile_overrides:
+        merged = dict(codex_profile_overrides)
+        merged.update(extra.get("config_overrides") or {})
+        extra["config_overrides"] = merged
+
     return iModel(
         model=resolved_model,
         endpoint="query_cli",
@@ -136,6 +229,14 @@ def build_chat_model(
     """Legacy: for agent.py compat. Returns bare spec string when no flags."""
     effort = normalize_effort(effort)
     extra: dict = {}
+    # Before anything keyed on the model — the effort clamp below included,
+    # since its ceilings belong to specific models and a profile names a
+    # different one than the spec did.
+    codex_profile_overrides: dict[str, Any] = {}
+    if provider == "codex":
+        resolved_profile = resolve_codex_config_profile(model)
+        if resolved_profile is not None:
+            model, codex_profile_overrides = resolved_profile
     if mcp_servers is not None:
         from lionagi.agent.factory import apply_forwarded_mcp_servers
 
@@ -170,6 +271,14 @@ def build_chat_model(
             from lionagi.providers.google.gemini_code import resolve_agy_model
 
             model = resolve_agy_model(model, effort=effort)
+
+    if codex_profile_overrides:
+        # Merged, never assigned: MCP server forwarding may already have put
+        # its own overrides here, and replacing the dict would drop a leg's
+        # server set on the floor.
+        merged = dict(codex_profile_overrides)
+        merged.update(extra.get("config_overrides") or {})
+        extra["config_overrides"] = merged
 
     if extra:
         return iModel(

--- a/tests/cli/test_codex_config_profile_spec.py
+++ b/tests/cli/test_codex_config_profile_spec.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""``codex/<name>`` may name a codex config profile rather than a model.
+
+A codex config profile (``$CODEX_HOME/<name>.config.toml``) names a model and
+the provider that serves it, and is how codex reaches models from other
+vendors. lionagi cannot forward it as ``-p``: codex accepts one profile per
+invocation and lionagi spends that slot on MCP server secrets. So it reads the
+file and applies the settings directly.
+
+The failure this guards against is silent rather than loud. Before, the
+profile name went to codex as a model id and codex ran *something else*, which
+looks like a working leg producing worse answers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.cli._providers import (
+    build_chat_model,
+    build_imodel_from_spec,
+    resolve_codex_config_profile,
+)
+
+
+@pytest.fixture
+def codex_home(tmp_path, monkeypatch):
+    home = tmp_path / "codex_home"
+    home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    return home
+
+
+def _write(home, name: str, body: str) -> None:
+    (home / f"{name}.config.toml").write_text(body)
+
+
+class TestWhatCountsAsAProfileName:
+    def test_a_profile_file_resolves_to_its_model_and_scalars(self, codex_home):
+        _write(
+            codex_home,
+            "deepseek-flash",
+            'model_provider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash-0731"\n',
+        )
+        assert resolve_codex_config_profile("deepseek-flash") == (
+            "deepseek/deepseek-v4-flash-0731",
+            {"model_provider": "openrouter"},
+        )
+
+    def test_an_ordinary_model_id_is_never_looked_up_as_a_path(self, codex_home):
+        """A vendor model id contains slashes. It must stay a model id.
+
+        The nested file is planted deliberately: without it, this passes
+        merely because nothing is there, which is true of any name at all and
+        so tests nothing about how the name is treated.
+        """
+        nested = codex_home / "deepseek"
+        nested.mkdir()
+        (nested / "deepseek-v4-flash-0731.config.toml").write_text('model = "planted"\n')
+        assert resolve_codex_config_profile("deepseek/deepseek-v4-flash-0731") is None
+
+    def test_a_name_that_escapes_codex_home_is_refused(self, codex_home, tmp_path):
+        """Planted at the traversal target, so refusing is the only thing that
+        can produce None. Pointed at a path that does not exist, this arm
+        passes with the guard deleted."""
+        (tmp_path / "escaped.config.toml").write_text('model = "escaped"\n')
+        assert (tmp_path / "escaped.config.toml").is_file()  # the arm is armed
+        assert resolve_codex_config_profile("../escaped") is None
+        assert resolve_codex_config_profile("..") is None
+
+    def test_an_absent_profile_leaves_the_name_alone(self, codex_home):
+        assert resolve_codex_config_profile("no-such-profile") is None
+
+
+class TestAProfileThatCannotBeHonouredFailsLoudly:
+    """Each of these would otherwise send the profile NAME to codex as a model
+    id, which runs a different model and reports success."""
+
+    def test_a_profile_declaring_no_model_raises(self, codex_home):
+        _write(codex_home, "half-written", 'model_provider = "openrouter"\n')
+        with pytest.raises(ValueError, match="declares no 'model'"):
+            resolve_codex_config_profile("half-written")
+
+    def test_an_unparseable_profile_raises(self, codex_home):
+        _write(codex_home, "broken", "model = = =\n")
+        with pytest.raises(ValueError, match="could not be read"):
+            resolve_codex_config_profile("broken")
+
+    def test_an_empty_model_value_is_not_accepted(self, codex_home):
+        _write(codex_home, "blank", 'model = ""\n')
+        with pytest.raises(ValueError, match="declares no 'model'"):
+            resolve_codex_config_profile("blank")
+
+
+class TestServersAreNotAdoptedFromAConfigFile:
+    def test_table_values_are_skipped(self, codex_home):
+        """lionagi decides a leg's MCP server set explicitly. Adopting servers
+        out of a config file would go around that decision silently."""
+        _write(
+            codex_home,
+            "with-servers",
+            'model = "vendor/m"\nmodel_provider = "openrouter"\n'
+            '[mcp_servers.snuck_in]\ncommand = "/bin/sh"\n',
+        )
+        resolved, overrides = resolve_codex_config_profile("with-servers")
+        assert resolved == "vendor/m"
+        assert overrides == {"model_provider": "openrouter"}
+        assert "mcp_servers" not in overrides
+
+
+class TestBothSpecEntryPointsHonourIt:
+    def test_the_li_agent_path_resolves(self, codex_home):
+        _write(
+            codex_home,
+            "flash",
+            'model_provider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash-0731"\n',
+        )
+        m = build_chat_model(provider="codex", model="flash", yolo=True, verbose=False, theme=None)
+        kwargs = m.endpoint.config.kwargs
+        assert kwargs["model"] == "deepseek/deepseek-v4-flash-0731"
+        assert kwargs["config_overrides"]["model_provider"] == "openrouter"
+
+    def test_the_orchestrate_path_resolves(self, codex_home):
+        _write(
+            codex_home,
+            "flash",
+            'model_provider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash-0731"\n',
+        )
+        m = build_imodel_from_spec("codex/flash", yolo=True)
+        config = m.endpoint.config
+        # The provider stays codex and the model becomes the vendor id the
+        # profile names — iModel splits the prefix off into its own field.
+        assert config.provider == "codex"
+        assert config.kwargs["model"] == "deepseek/deepseek-v4-flash-0731"
+        assert config.kwargs["config_overrides"]["model_provider"] == "openrouter"
+        # And it is still a CLI endpoint, which is what lets `li agent` accept
+        # it at all — an openrouter/* spec is refused there.
+        assert m.is_cli is True
+
+
+class TestTheEffortClampSeesTheResolvedModel:
+    """The clamp's ceilings are keyed on the model, so it has to run after
+    resolution. Pointing a profile at a model that IS in the ceiling table is
+    what makes the ordering observable at all."""
+
+    def test_a_profile_pointing_at_a_capped_model_is_clamped(self, codex_home):
+        _write(codex_home, "capped", 'model = "gpt-5.3-codex"\n')
+        m = build_chat_model(
+            provider="codex",
+            model="capped",
+            yolo=True,
+            verbose=False,
+            theme=None,
+            effort="ultra",
+        )
+        assert m.endpoint.config.kwargs["reasoning_effort"] == "xhigh"
+
+    def test_a_profile_pointing_at_an_uncapped_model_keeps_its_effort(self, codex_home):
+        _write(codex_home, "open", 'model = "vendor/some-model"\n')
+        m = build_chat_model(
+            provider="codex",
+            model="open",
+            yolo=True,
+            verbose=False,
+            theme=None,
+            effort="ultra",
+        )
+        assert m.endpoint.config.kwargs["reasoning_effort"] == "ultra"
+
+
+class TestForwardedMcpServersSurviveTheMerge:
+    def test_profile_overrides_do_not_replace_forwarded_server_config(self, codex_home):
+        """Both write ``config_overrides``. Assigning instead of merging would
+        drop whichever landed first, and a leg would run with no tools."""
+        _write(codex_home, "flash", 'model = "vendor/m"\nmodel_provider = "openrouter"\n')
+        m = build_chat_model(
+            provider="codex",
+            model="flash",
+            yolo=True,
+            verbose=False,
+            theme=None,
+            mcp_servers={"khive": {"command": "/bin/true"}},
+        )
+        overrides = m.endpoint.config.kwargs["config_overrides"]
+        assert overrides["model_provider"] == "openrouter"
+        # The forwarded server set is still present alongside it.
+        assert any("mcp_servers" in str(k) for k in overrides), overrides

--- a/tests/cli/test_codex_config_profile_spec.py
+++ b/tests/cli/test_codex_config_profile_spec.py
@@ -16,6 +16,8 @@ looks like a working leg producing worse answers.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from lionagi.cli._providers import (
@@ -72,6 +74,75 @@ class TestWhatCountsAsAProfileName:
 
     def test_an_absent_profile_leaves_the_name_alone(self, codex_home):
         assert resolve_codex_config_profile("no-such-profile") is None
+
+    def test_a_symlink_whose_target_is_unreadable_is_not_an_absent_profile(
+        self, codex_home, tmp_path
+    ):
+        """``is_file()`` follows the link and answers False for a broken one
+        exactly as it does for nothing at all, so the two would otherwise
+        collapse into the same silent fall-through to a model id — with a file
+        sitting in CODEX_HOME that the operator can see.
+
+        The link is planted pointing at a real path that is then removed, so it
+        is genuinely a dangling symlink rather than merely a missing name.
+        """
+        target = tmp_path / "gone.config.toml"
+        target.write_text('model = "vendor/m"\n')
+        link = codex_home / "dangling.config.toml"
+        link.symlink_to(target)
+        assert link.is_file()  # the plant landed and resolves while the target exists
+        target.unlink()
+        assert link.is_symlink() and not link.is_file()  # now genuinely dangling
+
+        with pytest.raises(ValueError, match="is a symlink whose target"):
+            resolve_codex_config_profile("dangling")
+
+    def test_a_symlink_that_resolves_is_read_normally(self, codex_home, tmp_path):
+        """The other half: linking is not itself suspicious, so a working link
+        must still resolve. Without this the arm above would be satisfied by
+        refusing every symlink."""
+        target = tmp_path / "real.config.toml"
+        target.write_text('model = "vendor/m"\nmodel_provider = "openrouter"\n')
+        (codex_home / "linked.config.toml").symlink_to(target)
+        assert resolve_codex_config_profile("linked") == (
+            "vendor/m",
+            {"model_provider": "openrouter"},
+        )
+
+
+class TestASuccessfulResolutionSaysWhatItRan:
+    def test_the_substituted_model_is_reported(self, codex_home, caplog):
+        """One name goes in and a different model runs. Doing that without a
+        word is the quiet half of the failure this resolver exists to fix."""
+        _write(codex_home, "deepseek-flash", 'model = "deepseek/deepseek-v4-flash-0731"\n')
+        # The CLI progress channel sets propagate=False, so caplog's root
+        # handler never sees it. Attaching to that logger directly is what
+        # makes an empty capture mean "nothing was logged" rather than "the
+        # instrument cannot reach this channel" — the two read identically.
+        logger = logging.getLogger("lionagi.cli.progress")
+        logger.addHandler(caplog.handler)
+        try:
+            with caplog.at_level(logging.INFO, logger="lionagi.cli.progress"):
+                resolved = resolve_codex_config_profile("deepseek-flash")
+        finally:
+            logger.removeHandler(caplog.handler)
+        # The line only runs on a successful resolution, so an arm that never
+        # resolved would assert on a log that was never reached and read as a
+        # missing log rather than a missing call.
+        assert resolved is not None
+        assert "deepseek-flash" in caplog.text
+        assert "deepseek/deepseek-v4-flash-0731" in caplog.text
+
+    def test_a_name_carrying_a_dot_is_not_resolved_at_all(self, codex_home):
+        """Bare excludes dots, so this file is never read. Planted so the
+        assertion is about the name rule rather than about an absent file, and
+        stated because the same name resolves once the dot is gone."""
+        _write(codex_home, "gpt-5.6-sol", 'model = "deepseek/deepseek-v4-flash-0731"\n')
+        assert (codex_home / "gpt-5.6-sol.config.toml").is_file()
+        assert resolve_codex_config_profile("gpt-5.6-sol") is None
+
+        _write(codex_home, "gpt-56-sol", 'model = "deepseek/deepseek-v4-flash-0731"\n')
+        assert resolve_codex_config_profile("gpt-56-sol") is not None
 
 
 class TestAProfileThatCannotBeHonouredFailsLoudly:


### PR DESCRIPTION
## The defect

A codex config profile (`$CODEX_HOME/<name>.config.toml`) names a model and the
provider that serves it, and it is how the codex CLI reaches models from other
vendors. So `codex/<name>` should mean "run that profile".

It did not. `<name>` went to codex as a **model id**, the profile file was never
consulted, and codex ran something else. That failure is silent: the leg
succeeds and answers from a model nobody chose.

There is a second, independent half. lionagi always emits `-m`, including its
own default, and `-m` outranks a layered profile — so even when a profile *was*
named explicitly, its model was overridden.

## Why it is not just forwarded as `-p`

codex accepts one profile per invocation, and lionagi already spends that slot
on a generated profile carrying MCP server secrets — supplying both is refused
outright today. So the file is read here and its settings applied directly: the
profile's `model` becomes the model, its remaining scalars become `-c`
overrides, which outrank config either way.

Resolution runs **ahead of the effort clamp**, whose ceilings are keyed on the
model. Running it after would apply one model's ceiling to another model's
name.

## Deliberately narrow

- Only a **bare name** is looked up. An ordinary vendor model id contains
  slashes and is never treated as a path, and a name cannot escape
  `$CODEX_HOME`.
- **Table-valued keys are not adopted**, and are logged. lionagi decides a
  leg's MCP server set explicitly; taking servers out of a config file would go
  around that decision silently.
- A profile that exists but declares no usable model **raises** rather than
  falling back to the name — that fallback is exactly the silent wrong-model
  failure this fixes.
- Forwarded MCP config survives: the two sources of `config_overrides` are
  merged, not assigned.

## Verification

13 new tests; `tests/cli` + `tests/agent` (3140 tests) pass locally.

Every test was mutation-checked with its expected failures declared in advance.
One mutation initially survived: deleting the bare-name guard changed nothing,
because the traversal fixture pointed at a path that did not exist, so the
guard was never what produced the refusal. The fixtures now plant a real file
at the traversal target and at the nested model-id path, so refusing is the
only thing that can produce the expected result. All six mutations then
reddened exactly the declared arms and nothing else.