### PR TITLE
feat(providers): resolve declared secrets into a spawned CLI leg's environment

### DIFF
--- a/docs/internals/runtime.md
+++ b/docs/internals/runtime.md
@@ -1049,6 +1049,51 @@ the serialized config — this only decides which of the two receivers the endpo
 notifying. A test written with a plain nested function cannot see any of this: `deepcopy` of a
 function returns the same object, and only a bound method has a receiver to rebind.
 
+### `_secret_resolution.py`
+
+Every CLI provider authenticates from its child's own environment: a codex `model_providers`
+entry names an `env_key` and the CLI reads that variable itself. When the value is kept in a
+keychain or a vault rather than exported, the spawning process has nothing to pass and the child
+dies on a missing variable that says nothing about where the value was meant to come from.
+
+`secrets.lookup` in `~/.lionagi/settings.yaml` names a command that prints one secret to stdout,
+and the variables it may be asked for:
+
+```yaml
+secrets:
+  lookup:
+    argv: [security, find-generic-password, -s, "{name}", -a, lionagi, -w]
+    names: [OPENROUTER_API_KEY]
+```
+
+`fill_declared_secrets()` is awaited once inside `ndjson_from_cli`, which is the single spawn
+seam for all four CLI providers, so this is wired in one place rather than four. It is purely
+additive: with nothing configured it returns the caller's `env` unchanged — `None` included, so
+an inheriting child stays inheriting instead of being frozen to a snapshot — and a lookup that
+fails leaves the child to fail exactly as it already did.
+
+- **Global settings only** (`load_settings(include_project=False)`). The project-local file is
+  the content of whatever tree happens to be checked out, and a repository must not get to name
+  the program that reads this machine's secret store. Where a secret lives is a property of the
+  machine.
+- **A refusal is distinguishable from silence.** `SecretLookupResolution.reason` is set iff a
+  lookup was configured and rejected; nothing configured and `enabled: false` both carry no
+  reason. Otherwise a typo'd block and an unconfigured machine both arrive as "the environment
+  was not changed". Reasons are short stable identifiers and never interpolate configured values.
+- **Every refusal is total.** One malformed name rejects the whole block rather than being
+  dropped from it, because a silently skipped name leaves the block reading as configured while
+  resolving less than it says.
+- **argv is a list, never a command string**, so nothing is ever split and no shape reaches a
+  shell. At least one argument after the program must contain `{name}` (a lookup that cannot say
+  which secret it wants is refused), and `argv[0]` must not, since the program to run may not
+  vary with the variable being looked up.
+- **A variable that already has a value is never looked up and never overwritten**, so exporting
+  one is still how a single run overrides the store.
+- **The value reaches the child's environment and nothing else.** Never a file, never an argv,
+  never a log line: `_run_lookup` reports only the program name, the variable name and the exit
+  status, and discards stdout on every failure path — a store that prints its errors to stdout
+  uses the same channel the secret arrives on.
+
 ### `anthropic/claude_code.py`
 
 - **CLI flag metadata protocol.** Every CLI-mappable `ClaudeCodeRequest` field carries a

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -25,6 +25,8 @@ from lionagi.ln._proc import (
 )
 from lionagi.ln.concurrency.utils import maybe_await
 
+from ._secret_resolution import fill_declared_secrets
+
 log = logging.getLogger(__name__)
 
 # Sentinel that means "do not pass stdin to create_subprocess_exec at all"
@@ -429,9 +431,14 @@ async def ndjson_from_cli(
     exception propagates through the teardown below, which ends the group it
     was called for.
     """
+    # Every CLI provider spawns through here, so a secret the child must read
+    # from its own environment is filled in one place rather than four. Purely
+    # additive: with nothing configured this returns ``env`` unchanged, and a
+    # lookup that fails leaves the child to fail the way it already failed.
+    child_env = await fill_declared_secrets(env)
     kwargs: dict[str, Any] = dict(
         cwd=str(cwd) if cwd else None,
-        env=env,
+        env=dict(child_env) if child_env is not None else None,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         start_new_session=True,

--- a/lionagi/providers/_secret_resolution.py
+++ b/lionagi/providers/_secret_resolution.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Fill declared secrets into a spawned CLI child's environment.
+
+A CLI provider authenticates from its own process environment: a codex model
+provider names an ``env_key`` and the CLI reads that variable itself. When the
+secret is kept somewhere other than the environment -- a keychain, a password
+manager, a vault agent -- the spawning process has no value to pass on, and
+the child dies with a missing-variable error that says nothing about where the
+value was meant to come from.
+
+``secrets.lookup`` in ``~/.lionagi/settings.yaml`` names a command that prints
+one secret to stdout, and the variables it may be asked for::
+
+    secrets:
+      lookup:
+        argv: [security, find-generic-password, -s, "{name}", -a, lionagi, -w]
+        names: [OPENROUTER_API_KEY]
+
+Read from the **global** settings file only, never the project-local one. The
+merged project file is content of whatever tree happens to be checked out, and
+a repository has no business naming the program that reads this machine's
+secrets. Where the value lives is a property of the machine, so it is
+configured once, where the machine is configured.
+
+The resolved value reaches the child through its environment and nowhere else:
+never a file, never an argv, never a log line. Failures are best-effort and
+additive -- a lookup that does not work leaves the environment exactly as it
+would have been, and the child fails the way it already failed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from lionagi.ln._proc import aterminate_process_group
+from lionagi.ln.concurrency import CancelScope, get_cancelled_exc_class
+
+__all__ = (
+    "ResolvedSecretLookup",
+    "SecretLookupResolution",
+    "fill_declared_secrets",
+    "resolve_secret_lookup_config",
+)
+
+logger = logging.getLogger(__name__)
+
+# POSIX-portable environment variable name. The names are the one part of the
+# configuration interpolated into an argument, so a name that is not one is
+# refused rather than passed to the command.
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# The token in each argument replaced with the variable being looked up.
+_NAME_PLACEHOLDER = "{name}"
+
+# A lookup runs on the spawn path, so its budget is what a caller will accept
+# waiting before the CLI child starts. A keychain that wants to prompt will
+# exceed this, which is deliberate: the prompt is answered once, out of band,
+# and the variable exported, rather than blocking every leg.
+_LOOKUP_TIMEOUT_SECONDS = 15.0
+
+_ALLOWED_KEYS = frozenset({"argv", "names", "enabled"})
+
+
+@dataclass(frozen=True)
+class ResolvedSecretLookup:
+    """A validated lookup: a fixed program, and the names it may be asked for."""
+
+    argv: tuple[str, ...]
+    names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SecretLookupResolution:
+    """The outcome of resolving ``secrets.lookup``: a lookup, or why not.
+
+    ``reason`` is set iff a lookup was asked for and refused. Chosen silence
+    (nothing configured, or ``enabled: false``) carries no reason, so a
+    misconfigured lookup stays distinguishable from an absent one instead of
+    both arriving as "no secrets were filled". Reasons are short stable
+    identifiers and never interpolate configured values; the offending value
+    goes in the matching warning.
+    """
+
+    lookup: ResolvedSecretLookup | None = None
+    reason: str | None = None
+
+
+# Nothing was configured, so nothing was refused.
+_NOT_CONFIGURED = SecretLookupResolution()
+
+
+def _rejected(reason: str) -> SecretLookupResolution:
+    return SecretLookupResolution(reason=reason)
+
+
+def resolve_secret_lookup_config(
+    *, settings: dict[str, Any] | None = None
+) -> SecretLookupResolution:
+    """Resolve ``secrets.lookup`` to a validated lookup, or to why there is none.
+
+    Every refusal is total: one bad name rejects the whole block rather than
+    being dropped from it. A silently skipped name reads as configured while
+    resolving nothing, which is the failure this is meant to make visible.
+    """
+    if settings is None:
+        # Imported here rather than at module scope: this module is reached
+        # from the provider spawn path, and the settings loader pulls in the
+        # agent package.
+        from lionagi.agent.settings import load_settings
+
+        try:
+            settings = load_settings(include_project=False)
+        except Exception as exc:  # noqa: BLE001 -- malformed settings must never block a spawn
+            logger.warning("secrets.lookup settings resolution failed: %s", exc)
+            return _rejected("settings_load_failed")
+
+    secrets_cfg = settings.get("secrets") if isinstance(settings, dict) else None
+    source = secrets_cfg.get("lookup") if isinstance(secrets_cfg, Mapping) else None
+    if source is None:
+        return _NOT_CONFIGURED
+
+    if not isinstance(source, Mapping):
+        logger.warning(
+            "secrets.lookup must be a mapping with 'argv' and 'names', got %s: %r",
+            type(source).__name__,
+            source,
+        )
+        return _rejected("lookup_not_a_mapping")
+
+    if source.get("enabled") is False:
+        return _NOT_CONFIGURED
+
+    unknown_keys = tuple(key for key in source if key not in _ALLOWED_KEYS)
+    if unknown_keys:
+        logger.warning(
+            "secrets.lookup keys must be 'argv', 'names' and/or 'enabled', got "
+            "unknown keys %r; resolving to disabled.",
+            unknown_keys,
+        )
+        return _rejected("lookup_has_unknown_keys")
+
+    argv = source.get("argv")
+    if (
+        not isinstance(argv, Sequence)
+        or isinstance(argv, str)
+        or not all(isinstance(arg, str) for arg in argv)
+    ):
+        logger.warning(
+            "secrets.lookup argv must be a list of strings, got %r; resolving to disabled.",
+            argv,
+        )
+        return _rejected("lookup_argv_not_a_list_of_strings")
+    if not argv:
+        logger.warning("secrets.lookup argv is empty; resolving to disabled.")
+        return _rejected("lookup_argv_is_empty")
+    if not any(_NAME_PLACEHOLDER in arg for arg in argv[1:]):
+        logger.warning(
+            "secrets.lookup argv contains no %s placeholder, so it cannot say "
+            "which secret it is being asked for; resolving to disabled.",
+            _NAME_PLACEHOLDER,
+        )
+        return _rejected("lookup_argv_has_no_name_placeholder")
+    if _NAME_PLACEHOLDER in argv[0]:
+        logger.warning(
+            "secrets.lookup argv[0] is the program to run and must not vary "
+            "with the variable being looked up; resolving to disabled."
+        )
+        return _rejected("lookup_argv_program_is_not_fixed")
+
+    names = source.get("names")
+    if (
+        not isinstance(names, Sequence)
+        or isinstance(names, str)
+        or not all(isinstance(name, str) for name in names)
+    ):
+        logger.warning(
+            "secrets.lookup names must be a list of strings, got %r; resolving to disabled.",
+            names,
+        )
+        return _rejected("lookup_names_not_a_list_of_strings")
+    if not names:
+        logger.warning("secrets.lookup names is empty; resolving to disabled.")
+        return _rejected("lookup_names_is_empty")
+    invalid = tuple(name for name in names if not _ENV_NAME_RE.match(name))
+    if invalid:
+        logger.warning(
+            "secrets.lookup names must be environment variable names, got %r; "
+            "resolving to disabled.",
+            invalid,
+        )
+        return _rejected("lookup_names_has_an_invalid_environment_variable_name")
+
+    return SecretLookupResolution(lookup=ResolvedSecretLookup(argv=tuple(argv), names=tuple(names)))
+
+
+async def _run_lookup(lookup: ResolvedSecretLookup, name: str) -> str | None:
+    """Run the lookup for one variable, returning its value or None.
+
+    Nothing derived from the command's output reaches a log: stdout carries
+    the secret on success, and a command that prints its errors there would
+    otherwise have them recorded through the same channel. Only the program
+    name, the variable name and the exit status are ever reported.
+    """
+    argv = tuple(arg.replace(_NAME_PLACEHOLDER, name) for arg in lookup.argv)
+    program = os.path.basename(argv[0])
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        stdout_bytes, _ = await asyncio.wait_for(
+            proc.communicate(), timeout=_LOOKUP_TIMEOUT_SECONDS
+        )
+    except asyncio.TimeoutError:
+        if proc is not None:
+            await aterminate_process_group(proc, grace=None)
+            await proc.wait()
+        logger.warning("secret lookup %s for %s timed out", program, name)
+        return None
+    except get_cancelled_exc_class():
+        # The child must still be reaped, and the scope is already cancelled.
+        if proc is not None:
+            with CancelScope(shield=True):
+                await aterminate_process_group(proc, grace=None)
+                await proc.wait()
+        raise
+    except Exception as exc:  # noqa: BLE001 -- a lookup failure must never block a spawn
+        # Only the exception type: a message can carry the argv, and the argv
+        # carries the variable's location in whatever store is being read.
+        logger.warning(
+            "secret lookup %s for %s failed to run (%s)", program, name, type(exc).__name__
+        )
+        return None
+
+    if proc.returncode != 0:
+        logger.warning("secret lookup %s for %s exited %s", program, name, proc.returncode)
+        return None
+    value = stdout_bytes.decode(errors="replace").strip()
+    if not value:
+        # Told apart from a failed run on purpose: the command worked and the
+        # store holds nothing under that name, which is a configuration answer
+        # rather than a broken lookup.
+        logger.warning("secret lookup %s for %s returned nothing", program, name)
+        return None
+    return value
+
+
+async def fill_declared_secrets(
+    env: Mapping[str, str] | None,
+    *,
+    settings: dict[str, Any] | None = None,
+) -> Mapping[str, str] | None:
+    """Return the environment a CLI child should get, with declared secrets filled.
+
+    ``env`` follows the CLI request-model convention: ``None`` means the child
+    inherits this process's environment. That is returned unchanged when there
+    is nothing to add, so a machine that configures no lookup spawns exactly
+    the environment it did before, and an inheriting child stays an inheriting
+    child rather than being handed a snapshot.
+
+    A variable that already carries a value is never looked up and never
+    overwritten, so exporting one is still the way to override the store for a
+    single run.
+    """
+    resolution = resolve_secret_lookup_config(settings=settings)
+    lookup = resolution.lookup
+    if lookup is None:
+        return env
+
+    source: Mapping[str, str] = os.environ if env is None else env
+    missing = [name for name in lookup.names if not source.get(name)]
+    if not missing:
+        return env
+
+    resolved: dict[str, str] = {}
+    for name in missing:
+        value = await _run_lookup(lookup, name)
+        if value is not None:
+            resolved[name] = value
+    if not resolved:
+        return env
+
+    logger.debug("filled %s from the configured secret lookup", sorted(resolved))
+    return {**source, **resolved}

--- a/tests/providers/test_secret_resolution.py
+++ b/tests/providers/test_secret_resolution.py
@@ -1,0 +1,309 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""``secrets.lookup`` fills a declared variable into a CLI child's environment.
+
+A CLI provider reads its credential from its own environment. When the value
+lives in a keychain instead, the spawning process has nothing to pass and the
+child dies on a missing variable. These cover the two halves: what counts as a
+configured lookup, and what the child actually receives.
+
+The failure mode worth guarding is quiet. A lookup that resolves nothing and a
+machine that configured none both end with the child's environment untouched,
+so the resolution keeps them apart explicitly rather than reporting one number
+for both.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lionagi.providers._cli_subprocess import ndjson_from_cli
+from lionagi.providers._secret_resolution import (
+    fill_declared_secrets,
+    resolve_secret_lookup_config,
+)
+
+NAME = "LIONAGI_TEST_SECRET"
+OTHER = "LIONAGI_TEST_SECRET_TWO"
+
+# Prints a value derived from the name it was asked for, so an arm can tell
+# "the lookup ran for the right variable" from "something produced a string".
+_PRINTS_A_VALUE = [sys.executable, "-c", "import sys; print('resolved::' + sys.argv[1])", "{name}"]
+# Prints a value AND fails. A lookup that only exited nonzero would be refused
+# twice over -- by the exit status and by the empty result -- and an arm that
+# two mechanisms reject stays green when the one it is named for is removed.
+_EXITS_NONZERO = [
+    sys.executable,
+    "-c",
+    "import sys; print('resolved::' + sys.argv[1]); sys.exit(3)",
+    "{name}",
+]
+_PRINTS_NOTHING = [sys.executable, "-c", "pass", "{name}"]
+_NO_SUCH_PROGRAM = ["/nonexistent/lionagi-secret-lookup", "{name}"]
+
+
+def _block(argv, names=(NAME,), **extra):
+    return {"secrets": {"lookup": {"argv": list(argv), "names": list(names), **extra}}}
+
+
+@pytest.fixture
+def lionagi_home(tmp_path, monkeypatch):
+    """A throwaway ``~/.lionagi`` so the real one is never read or written."""
+    home = tmp_path / "home"
+    (home / ".lionagi").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    return home
+
+
+def _write_global(home, block):
+    (home / ".lionagi" / "settings.yaml").write_text(yaml.safe_dump(block))
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_secret(monkeypatch):
+    """The declared names must start absent, or an arm that asserts a fill
+    would pass on a value the environment already carried."""
+    monkeypatch.delenv(NAME, raising=False)
+    monkeypatch.delenv(OTHER, raising=False)
+
+
+class TestWhatCountsAsAConfiguredLookup:
+    def test_a_valid_block_resolves_to_its_argv_and_names(self):
+        resolved = resolve_secret_lookup_config(settings=_block(_PRINTS_A_VALUE))
+        assert resolved.reason is None
+        assert resolved.lookup.argv == tuple(_PRINTS_A_VALUE)
+        assert resolved.lookup.names == (NAME,)
+
+    def test_argv_must_be_a_list_not_a_command_string(self):
+        """A string would have to be split, and splitting is where a value
+        with a space in it stops meaning what it says."""
+        resolved = resolve_secret_lookup_config(
+            settings={
+                "secrets": {"lookup": {"argv": "security find-generic-password", "names": [NAME]}}
+            }
+        )
+        assert resolved.reason == "lookup_argv_not_a_list_of_strings"
+
+    def test_argv_without_the_placeholder_cannot_say_what_it_is_asked_for(self):
+        resolved = resolve_secret_lookup_config(settings=_block([sys.executable, "-c", "pass"]))
+        assert resolved.reason == "lookup_argv_has_no_name_placeholder"
+
+    def test_the_program_may_not_vary_with_the_variable(self):
+        resolved = resolve_secret_lookup_config(settings=_block(["/bin/{name}", "-w", "{name}"]))
+        assert resolved.reason == "lookup_argv_program_is_not_fixed"
+
+    def test_one_bad_name_rejects_the_whole_block(self):
+        """Dropping just the bad name would leave the block reading as
+        configured while quietly resolving less than it says."""
+        resolved = resolve_secret_lookup_config(
+            settings=_block(_PRINTS_A_VALUE, names=[NAME, "not a var name"])
+        )
+        assert resolved.reason == "lookup_names_has_an_invalid_environment_variable_name"
+        assert resolved.lookup is None
+
+    def test_unknown_keys_are_refused_rather_than_ignored(self):
+        resolved = resolve_secret_lookup_config(
+            settings=_block(_PRINTS_A_VALUE, argvv=["typo"]),
+        )
+        assert resolved.reason == "lookup_has_unknown_keys"
+
+    @pytest.mark.parametrize(
+        ("settings", "reason"),
+        [
+            ({"secrets": {"lookup": ["not", "a", "mapping"]}}, "lookup_not_a_mapping"),
+            ({"secrets": {"lookup": {"argv": [], "names": [NAME]}}}, "lookup_argv_is_empty"),
+            (
+                {"secrets": {"lookup": {"argv": ["p", "{name}"], "names": []}}},
+                "lookup_names_is_empty",
+            ),
+            (
+                {"secrets": {"lookup": {"argv": ["p", "{name}"], "names": "NOT_A_LIST"}}},
+                "lookup_names_not_a_list_of_strings",
+            ),
+        ],
+    )
+    def test_each_malformed_shape_names_why(self, settings, reason):
+        assert resolve_secret_lookup_config(settings=settings).reason == reason
+
+
+class TestSilenceIsToldApartFromRefusal:
+    """Both end with an untouched environment. Only the reason separates a
+    machine that configured nothing from one whose config does not work."""
+
+    @pytest.mark.parametrize(
+        "settings",
+        [
+            {},
+            {"secrets": {}},
+            {"secrets": {"lookup": None}},
+            _block(_PRINTS_A_VALUE, enabled=False),
+        ],
+        ids=["nothing", "no-lookup-key", "lookup-null", "disabled"],
+    )
+    def test_chosen_silence_carries_no_reason(self, settings):
+        resolved = resolve_secret_lookup_config(settings=settings)
+        assert resolved.lookup is None
+        assert resolved.reason is None
+
+    def test_a_broken_config_carries_one(self):
+        resolved = resolve_secret_lookup_config(settings=_block(["p"], names=[NAME]))
+        assert resolved.lookup is None
+        assert resolved.reason is not None
+
+
+class TestACheckedOutRepoCannotNameTheProgram:
+    """The lookup command reads this machine's secret store. Project settings
+    are the content of whatever tree is checked out, so they are not read."""
+
+    def test_a_project_settings_file_is_not_honoured(self, lionagi_home, tmp_path, monkeypatch):
+        project = tmp_path / "some-checkout"
+        (project / ".lionagi").mkdir(parents=True)
+        (project / ".lionagi" / "settings.yaml").write_text(yaml.safe_dump(_block(_PRINTS_A_VALUE)))
+        monkeypatch.chdir(project)
+
+        # The plant is real: the same file IS picked up by a project-merging
+        # load. Without this arm, an unreadable or misplaced fixture would make
+        # the assertion below pass for the wrong reason.
+        from lionagi.agent.settings import load_settings
+
+        assert load_settings()["secrets"]["lookup"]["names"] == [NAME]
+
+        assert resolve_secret_lookup_config().lookup is None
+
+    def test_the_global_file_is_honoured(self, lionagi_home, tmp_path, monkeypatch):
+        """The other half: the mechanism does read a file, so the arm above is
+        about which file and not about the loader being inert."""
+        monkeypatch.chdir(tmp_path)
+        _write_global(lionagi_home, _block(_PRINTS_A_VALUE))
+        assert resolve_secret_lookup_config().lookup.names == (NAME,)
+
+
+@pytest.mark.asyncio
+class TestFillingTheChildEnvironment:
+    async def test_a_missing_declared_name_is_filled(self):
+        env = await fill_declared_secrets({"PATH": "/usr/bin"}, settings=_block(_PRINTS_A_VALUE))
+        assert env[NAME] == f"resolved::{NAME}"
+        assert env["PATH"] == "/usr/bin"
+
+    async def test_a_name_already_set_is_never_looked_up(self):
+        """The lookup is live and would return something different, so an
+        unchanged value can only mean it was not consulted."""
+        env = await fill_declared_secrets(
+            {NAME: "already-exported", OTHER: ""},
+            settings=_block(_PRINTS_A_VALUE, names=[NAME, OTHER]),
+        )
+        assert env[NAME] == "already-exported"
+        # Same call, same lookup: the empty one WAS filled, which is what
+        # proves the lookup was working while the set one went untouched.
+        assert env[OTHER] == f"resolved::{OTHER}"
+
+    async def test_an_undeclared_missing_variable_is_not_filled(self):
+        env = await fill_declared_secrets({}, settings=_block(_PRINTS_A_VALUE, names=[NAME]))
+        assert OTHER not in env
+
+    async def test_nothing_configured_returns_the_env_unchanged(self):
+        base = {"PATH": "/usr/bin"}
+        assert await fill_declared_secrets(base, settings={}) is base
+
+    async def test_an_inheriting_child_stays_inheriting(self):
+        """``None`` means inherit. Handing back a snapshot instead would freeze
+        the environment at spawn-decision time for every child."""
+        assert await fill_declared_secrets(None, settings={}) is None
+
+    async def test_inheriting_plus_a_fill_yields_a_whole_environment(self, monkeypatch):
+        monkeypatch.setenv("LIONAGI_TEST_MARKER", "inherited")
+        env = await fill_declared_secrets(None, settings=_block(_PRINTS_A_VALUE))
+        assert env[NAME] == f"resolved::{NAME}"
+        # Replacing rather than extending would strip everything the child
+        # needs, PATH included.
+        assert env["LIONAGI_TEST_MARKER"] == "inherited"
+        assert "PATH" in env
+
+    @pytest.mark.parametrize(
+        "argv",
+        [_EXITS_NONZERO, _PRINTS_NOTHING, _NO_SUCH_PROGRAM],
+        ids=["exits-3", "empty", "no-program"],
+    )
+    async def test_a_lookup_that_does_not_work_leaves_the_env_alone(self, argv):
+        base = {"PATH": "/usr/bin"}
+        assert await fill_declared_secrets(base, settings=_block(argv)) is base
+
+
+@pytest.mark.asyncio
+class TestTheValueDoesNotReachTheLogs:
+    async def test_a_successful_lookup_logs_no_value(self, caplog):
+        caplog.set_level(logging.DEBUG)
+        env = await fill_declared_secrets({}, settings=_block(_PRINTS_A_VALUE))
+        assert env[NAME] == f"resolved::{NAME}"  # the value exists to be leaked
+        assert "resolved::" not in caplog.text
+
+    async def test_a_failing_lookup_does_not_log_what_it_printed(self, caplog):
+        """The leak-prone path: a store that prints the secret and then exits
+        nonzero. stdout is the same channel the value arrives on."""
+        caplog.set_level(logging.DEBUG)
+        leaky = [
+            sys.executable,
+            "-c",
+            "import sys; print('resolved::' + sys.argv[1]); sys.exit(4)",
+            "{name}",
+        ]
+        base = {}
+        assert await fill_declared_secrets(base, settings=_block(leaky)) is base
+        assert "exited 4" in caplog.text  # the failure IS reported
+        assert "resolved::" not in caplog.text
+
+
+@pytest.mark.asyncio
+class TestTheSpawnSeamActuallyUsesIt:
+    """Every CLI provider spawns through ``ndjson_from_cli``. Resolution that
+    never reaches the child is the whole defect this exists to prevent, and
+    only reading it back out of a real child proves it did."""
+
+    async def test_the_child_process_receives_the_resolved_value(
+        self, lionagi_home, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        _write_global(lionagi_home, _block(_PRINTS_A_VALUE))
+        cmd = [
+            sys.executable,
+            "-c",
+            f"import os, json; print(json.dumps({{'seen': os.environ.get({NAME!r})}}))",
+        ]
+        seen = [obj async for obj in ndjson_from_cli(cmd, env={**os.environ})]
+        assert seen == [{"seen": f"resolved::{NAME}"}]
+
+    async def test_a_child_spawned_with_no_env_still_receives_it(
+        self, lionagi_home, tmp_path, monkeypatch
+    ):
+        """gemini passes no ``env`` at all, so the inherit path is a real one
+        and not a theoretical branch."""
+        monkeypatch.chdir(tmp_path)
+        _write_global(lionagi_home, _block(_PRINTS_A_VALUE))
+        cmd = [
+            sys.executable,
+            "-c",
+            f"import os, json; print(json.dumps({{'seen': os.environ.get({NAME!r})}}))",
+        ]
+        seen = [obj async for obj in ndjson_from_cli(cmd)]
+        assert seen == [{"seen": f"resolved::{NAME}"}]
+
+    async def test_with_nothing_configured_the_child_environment_is_untouched(
+        self, lionagi_home, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("LIONAGI_TEST_MARKER", "inherited")
+        cmd = [
+            sys.executable,
+            "-c",
+            "import os, json; print(json.dumps({'marker': os.environ.get('LIONAGI_TEST_MARKER'),"
+            f" 'seen': os.environ.get({NAME!r})}}))",
+        ]
+        seen = [obj async for obj in ndjson_from_cli(cmd)]
+        assert seen == [{"marker": "inherited", "seen": None}]


### PR DESCRIPTION
A CLI provider authenticates from its child's own environment: a codex
`model_providers` entry names an `env_key` and the CLI reads that variable
itself. When the value is kept in a keychain or a vault rather than exported,
the spawning process has nothing to pass on, and the leg dies on a missing
variable that says nothing about where the value was meant to come from.

`secrets.lookup` in `~/.lionagi/settings.yaml` names a command that prints one
secret to stdout, and the variables it may be asked for:

```yaml
secrets:
  lookup:
    argv: [security, find-generic-password, -s, "{name}", -a, lionagi, -w]
    names: [OPENROUTER_API_KEY]
```

It is awaited once inside `ndjson_from_cli`, the single spawn seam shared by
all four CLI providers (codex, claude_code, gemini_code, pi), so this is wired
in one place rather than four.

## Properties

- **Global settings only.** The project-local file is the content of whatever
  tree happens to be checked out, and a repository must not get to name the
  program that reads this machine's secret store.
- **Purely additive.** With nothing configured the caller's `env` comes back
  unchanged, `None` included, so an inheriting child stays inheriting rather
  than being frozen to a snapshot. A lookup that fails leaves the child to fail
  exactly as it already did.
- **An exported value always wins.** A variable that already carries a value is
  never looked up and never overwritten, so exporting one still overrides the
  store for a single run.
- **The value reaches the child's environment and nowhere else** — never a
  file, never an argv, never a log line. Failures report the program name, the
  variable name and the exit status, and discard stdout on every path, since a
  store that prints its errors to stdout uses the same channel the secret
  arrives on.
- **A refused lookup stays distinguishable from an unconfigured one.** Both
  leave the environment untouched, so the resolution carries a stable reason
  identifier iff a lookup was asked for and rejected. Every refusal is total:
  one malformed name rejects the whole block rather than being dropped from it,
  which would leave the block reading as configured while resolving less than
  it says.
- **argv is a list, never a command string**, so nothing is split and no shape
  reaches a shell. At least one argument after the program must carry `{name}`,
  and `argv[0]` must not, since the program to run may not vary with the
  variable being looked up.

## Testing

31 new tests; `tests/providers` 489 passed / 3 xfailed, and `tests/cli
tests/agent tests/service` 4619 passed / 2 skipped.

The spawn-seam arms read the value back out of a **real child process** rather
than asserting on the computed environment, since resolution that never reaches
the child is the defect this exists to prevent.

Every negative arm plants the positive first: a lookup that fails is a lookup
that runs and fails, not an absent one, so refusal is what produces the result
rather than absence producing the same value. The exit-status arm feeds a
command that prints *and* fails, because a command that merely exited nonzero
would be refused twice over and would stay green if the check it names were
removed.

Ten mutants, each with its reddened arms declared before the run and
reconciled arm by arm afterwards: seam not consulted, project settings
honoured, already-set variable overwritten, empty result accepted, nonzero exit
accepted, placeholder rule removed, program-fixed rule removed, bad name
dropped instead of rejecting, `enabled: false` ignored, unknown keys ignored.
All ten reddened exactly their declared arms and nothing else.