### PR TITLE
fix(providers): resolve a codex config profile on the library path too

### DIFF
--- a/lionagi/cli/_providers.py
+++ b/lionagi/cli/_providers.py
@@ -14,6 +14,9 @@ from lionagi import iModel
 from lionagi._paths import find_lionagi_dirs as _find_lionagi_dirs
 from lionagi.libs.frontmatter import parse_frontmatter as _parse_frontmatter
 from lionagi.libs.path_safety import validate_bare_name
+from lionagi.providers.openai._codex_profile import (
+    resolve_codex_config_profile,
+)
 from lionagi.service.providers import (
     _CLAUDE_PROVIDER_NAMES,
     BACKENDS,
@@ -68,107 +71,11 @@ __all__ = (
 # ── iModel construction ───────────────────────────────────────────────────
 
 
-def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | None:
-    """Resolve a codex model part that names a codex config profile.
-
-    codex reaches models from other providers through a config profile:
-    ``-p <name>`` layers ``$CODEX_HOME/<name>.config.toml`` over the base
-    config, and such a file names a ``model`` and the ``model_provider`` that
-    serves it. So ``codex/<name>`` should mean "run that profile", not "run a
-    model literally called ``<name>``".
-
-    lionagi cannot forward this by passing ``-p``. codex accepts exactly one
-    profile per invocation and lionagi already spends that slot on a generated
-    profile carrying MCP server secrets, which is why supplying both is
-    refused outright. The file is therefore read here and its settings applied
-    directly: the profile's ``model`` becomes the model, and its remaining
-    scalars become ``-c`` overrides, which outrank config either way.
-
-    Two deliberate limits, both narrowing rather than widening:
-
-    * Only a bare name is looked up, so an ordinary vendor model id such as
-      ``deepseek/deepseek-v4-flash-0731`` is never treated as a path. Bare
-      excludes dots as well as separators, so a profile must be named like
-      ``deepseek-flash`` and one named ``gpt-5.6-sol`` is not resolved at all.
-      That cuts the other way usefully: model ids carry dots and version
-      numbers, so a profile name cannot collide with a real one and quietly
-      stand in for it.
-    * Table-valued keys (notably ``mcp_servers``) are not applied, and are
-      logged. lionagi decides a leg's MCP server set explicitly, and quietly
-      re-introducing servers from a config file would go around that.
-
-    Returns ``None`` when no such profile file exists, leaving the name to be
-    treated as a model id exactly as before.
-    """
-    try:
-        validate_bare_name(model, label="codex config profile name")
-    except ValueError:
-        return None
-
-    codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
-    profile_path = codex_home / f"{model}.config.toml"
-    if not profile_path.is_file():
-        # A symlink whose target is unreadable is not the same as no profile.
-        # `is_file()` follows the link and answers False for both, so falling
-        # through here would send the name to codex as a model id — the exact
-        # silent substitution this function exists to prevent, arriving through
-        # a file the operator can see sitting right there.
-        broken_target = _unreadable_symlink_target(profile_path)
-        if broken_target is not None:
-            raise ValueError(
-                f"codex config profile {str(profile_path)!r} is a symlink whose "
-                f"target {broken_target!r} is unreadable. Repair or remove the "
-                f"link; running without it would send {model!r} to codex as a "
-                f"model id and silently run something else."
-            )
-        return None
-
-    import toml
-
-    try:
-        data = toml.loads(profile_path.read_text())
-    except (OSError, toml.TomlDecodeError) as exc:
-        raise ValueError(
-            f"codex config profile {str(profile_path)!r} could not be read "
-            f"({type(exc).__name__}: {exc}). Fix or remove the file; running "
-            f"without it would send {model!r} as a model id instead."
-        ) from exc
-
-    resolved = data.get("model")
-    if not isinstance(resolved, str) or not resolved:
-        raise ValueError(
-            f"codex config profile {str(profile_path)!r} declares no 'model'. "
-            f"Add one, or use a model id instead of the profile name — "
-            f"without it {model!r} would be sent to codex as a model id and "
-            f"silently run something other than the profile."
-        )
-
-    overrides: dict[str, Any] = {}
-    skipped: list[str] = []
-    for key, value in data.items():
-        if key == "model":
-            continue
-        if isinstance(value, (str, int, float, bool)):
-            overrides[key] = value
-        else:
-            skipped.append(key)
-    if skipped:
-        from ._logging import warn
-
-        warn(
-            f"codex config profile {model!r}: ignoring {', '.join(sorted(skipped))} "
-            "— lionagi applies a profile's model and scalar settings, and sets "
-            "a leg's MCP servers itself"
-        )
-
-    # Say which model is actually being run. A profile whose name collides with
-    # a real model id would otherwise substitute without a word, which is the
-    # quiet half of the same failure this function fixes: the caller asks for
-    # one thing, a different thing runs, and the leg looks healthy either way.
-    from ._logging import progress
-
-    progress(f"codex profile {model!r} resolves to model {resolved!r}")
-    return resolved, overrides
+# Re-exported from the provider layer, where it now lives so the LIBRARY entry
+# point reaches it too. It sat here, under cli/, and a codex request built with
+# Branch(chat_model="codex/<profile>") therefore never resolved: the profile
+# NAME went to codex as a model id and codex rejected a model nobody asked for.
+# Kept in this module's namespace and __all__ because callers import it here.
 
 
 def build_imodel_from_spec(
@@ -195,9 +102,13 @@ def build_imodel_from_spec(
     # profile names a different model than the spec did.
     codex_profile_overrides: dict[str, Any] = {}
     if provider_raw == "codex" and "/" in ms.model:
-        resolved_profile = resolve_codex_config_profile(ms.model.split("/", 1)[1])
+        from ._logging import progress
+
+        profile_name = ms.model.split("/", 1)[1]
+        resolved_profile = resolve_codex_config_profile(profile_name)
         if resolved_profile is not None:
             profile_model, codex_profile_overrides = resolved_profile
+            progress(f"codex profile {profile_name!r} resolves to model {profile_model!r}")
             resolved_model = f"codex/{profile_model}"
             ms = ModelSpec(model=resolved_model, effort=ms.effort)
 
@@ -259,9 +170,13 @@ def build_chat_model(
     # different one than the spec did.
     codex_profile_overrides: dict[str, Any] = {}
     if provider == "codex":
+        from ._logging import progress
+
         resolved_profile = resolve_codex_config_profile(model)
         if resolved_profile is not None:
+            profile_name = model
             model, codex_profile_overrides = resolved_profile
+            progress(f"codex profile {profile_name!r} resolves to model {model!r}")
     if mcp_servers is not None:
         from lionagi.agent.factory import apply_forwarded_mcp_servers
 

--- a/lionagi/providers/openai/_codex_profile.py
+++ b/lionagi/providers/openai/_codex_profile.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Resolution of a codex config profile named as a model.
+
+Lives at the provider layer rather than under ``cli/`` because both entry
+points need it. A codex request built through the library --
+``Branch(chat_model="codex/deepseek-flash")`` -- reaches the same spawn as one
+built through ``li agent``, and while this resolution sat in the CLI package
+only the CLI path got it: the library path sent the profile NAME to codex as a
+model id, and codex answered with an unsupported-model error naming a model
+nobody had asked for.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from lionagi.libs.path_safety import validate_bare_name
+
+__all__ = ("resolve_codex_config_profile",)
+
+logger = logging.getLogger(__name__)
+
+
+def _unreadable_symlink_target(path: Path) -> str | None:
+    """Return a broken/non-file symlink's declared target, if applicable."""
+    if not path.is_symlink() or path.is_file():
+        return None
+    try:
+        return str(path.readlink())
+    except OSError:
+        return "<unreadable>"
+
+
+def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | None:
+    """Resolve a codex model part that names a codex config profile.
+
+    codex reaches models from other providers through a config profile:
+    ``-p <name>`` layers ``$CODEX_HOME/<name>.config.toml`` over the base
+    config, and such a file names a ``model`` and the ``model_provider`` that
+    serves it. So ``codex/<name>`` should mean "run that profile", not "run a
+    model literally called ``<name>``".
+
+    lionagi cannot forward this by passing ``-p``. codex accepts exactly one
+    profile per invocation and lionagi already spends that slot on a generated
+    profile carrying MCP server secrets, which is why supplying both is
+    refused outright. The file is therefore read here and its settings applied
+    directly: the profile's ``model`` becomes the model, and its remaining
+    scalars become ``-c`` overrides, which outrank config either way.
+
+    Two deliberate limits, both narrowing rather than widening:
+
+    * Only a bare name is looked up, so an ordinary vendor model id such as
+      ``deepseek/deepseek-v4-flash-0731`` is never treated as a path. Bare
+      excludes dots as well as separators, so a profile must be named like
+      ``deepseek-flash`` and one named ``gpt-5.6-sol`` is not resolved at all.
+      That cuts the other way usefully: model ids carry dots and version
+      numbers, so a profile name cannot collide with a real one and quietly
+      stand in for it.
+    * Table-valued keys (notably ``mcp_servers``) are not applied, and are
+      logged. lionagi decides a leg's MCP server set explicitly, and quietly
+      re-introducing servers from a config file would go around that.
+
+    Returns ``None`` when no such profile file exists, leaving the name to be
+    treated as a model id exactly as before.
+    """
+    try:
+        validate_bare_name(model, label="codex config profile name")
+    except ValueError:
+        return None
+
+    codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+    profile_path = codex_home / f"{model}.config.toml"
+    if not profile_path.is_file():
+        # A symlink whose target is unreadable is not the same as no profile.
+        # `is_file()` follows the link and answers False for both, so falling
+        # through here would send the name to codex as a model id — the exact
+        # silent substitution this function exists to prevent, arriving through
+        # a file the operator can see sitting right there.
+        broken_target = _unreadable_symlink_target(profile_path)
+        if broken_target is not None:
+            raise ValueError(
+                f"codex config profile {str(profile_path)!r} is a symlink whose "
+                f"target {broken_target!r} is unreadable. Repair or remove the "
+                f"link; running without it would send {model!r} to codex as a "
+                f"model id and silently run something else."
+            )
+        return None
+
+    import toml
+
+    try:
+        data = toml.loads(profile_path.read_text())
+    except (OSError, toml.TomlDecodeError) as exc:
+        raise ValueError(
+            f"codex config profile {str(profile_path)!r} could not be read "
+            f"({type(exc).__name__}: {exc}). Fix or remove the file; running "
+            f"without it would send {model!r} as a model id instead."
+        ) from exc
+
+    resolved = data.get("model")
+    if not isinstance(resolved, str) or not resolved:
+        raise ValueError(
+            f"codex config profile {str(profile_path)!r} declares no 'model'. "
+            f"Add one, or use a model id instead of the profile name — "
+            f"without it {model!r} would be sent to codex as a model id and "
+            f"silently run something other than the profile."
+        )
+
+    overrides: dict[str, Any] = {}
+    skipped: list[str] = []
+    for key, value in data.items():
+        if key == "model":
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            overrides[key] = value
+        else:
+            skipped.append(key)
+    if skipped:
+        logger.warning(
+            "codex config profile %r: ignoring %s — lionagi applies a profile's "
+            "model and scalar settings, and sets a leg's MCP servers itself",
+            model,
+            ", ".join(sorted(skipped)),
+        )
+
+    # Say which model is actually being run. A profile whose name collides with
+    # a real model id would otherwise substitute without a word, which is the
+    # quiet half of the same failure this function fixes: the caller asks for
+    # one thing, a different thing runs, and the leg looks healthy either way.
+    logger.info("codex profile %r resolves to model %r", model, resolved)
+    return resolved, overrides

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -357,10 +357,61 @@ class CodexCodeRequest(BaseModel):
         ),
     )
 
+    @classmethod
+    def _resolve_config_profile(cls, values):
+        """Turn a model that names a codex config profile into the profile.
+
+        Runs at the REQUEST level so both entry points reach it. The CLI
+        resolves this too, and did so alone for a while: a request built
+        through the library -- ``Branch(chat_model="codex/deepseek-flash")`` --
+        carried the profile NAME all the way to the spawn, codex read it as a
+        model id, and every leg died with an unsupported-model error naming a
+        model nobody had asked for.
+
+        Idempotent by construction, so the CLI path is unaffected: it has
+        already replaced the name with the profile's model id, and a real model
+        id carries dots or a slash, which the bare-name check rejects.
+
+        NOT a validator of its own, and that is deliberate. It has to run
+        before the effort clamp, whose ceilings are keyed on the model -- a
+        profile names a different model than the caller did, so clamping first
+        applies one model's ceiling to another's effort. Two ``mode="before"``
+        validators looked like the way to order that, and it is the wrong way:
+        pydantic runs them in REVERSE definition order, so the one written
+        first runs last. Written that way the clamp saw the profile NAME, and
+        the test that caught it is the one asserting a clamped OUTCOME rather
+        than that the effort survived. Called explicitly from the single
+        validator below, the order is stated rather than inherited.
+
+        Caller-supplied ``config_overrides`` WIN over the profile's. An
+        override passed at the call site is an explicit instruction; the
+        profile is a default sitting in a file.
+        """
+        from ._codex_profile import resolve_codex_config_profile
+
+        model = values.get("model")
+        if not isinstance(model, str) or not model:
+            return values
+        resolved = resolve_codex_config_profile(model)
+        if resolved is None:
+            return values
+        profile_model, profile_overrides = resolved
+        values["model"] = profile_model
+        if profile_overrides:
+            merged = dict(profile_overrides)
+            merged.update(values.get("config_overrides") or {})
+            values["config_overrides"] = merged
+        return values
+
     @model_validator(mode="before")
     @classmethod
-    def _clamp_effort(cls, values):
-        """Clamp max/ultra down to the target model's supported ceiling (model-dependent).
+    def _resolve_profile_then_clamp_effort(cls, values):
+        """Resolve a config-profile model, THEN clamp effort against it.
+
+        One validator running two steps in a written order, rather than two
+        validators relying on pydantic's. The clamp's ceilings are keyed on the
+        model id and a profile names a different model than the caller did, so
+        the sequence is load-bearing rather than cosmetic.
 
         `values` is the raw constructor input, which omits `model` when the
         caller relies on the field default (Pydantic v2 applies defaults
@@ -368,6 +419,8 @@ class CodexCodeRequest(BaseModel):
         default so the clamp is consistent either way.
         """
         from lionagi.service.providers import _clamp_codex_effort
+
+        values = cls._resolve_config_profile(values)
 
         model = values.get("model", cls.model_fields["model"].default)
         for key in ("reasoning_effort", "plan_mode_reasoning_effort"):

--- a/tests/providers/test_codex_profile_library_path.py
+++ b/tests/providers/test_codex_profile_library_path.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A codex config profile must resolve on the LIBRARY path, not only the CLI.
+
+``codex/<name>`` may name a codex config profile rather than a model, and
+resolving it used to live under ``lionagi/cli/``. Every caller that reached
+codex through the CLI got the resolution; every caller that built a request in
+process -- ``Branch(chat_model="codex/deepseek-flash")`` -- did not. Those legs
+carried the profile NAME all the way to the spawn, codex read it as a model id,
+and the run died with an unsupported-model error naming a model nobody had
+asked for.
+
+The tests here enter through the same door a library consumer does. The CLI's
+own behaviour is covered by ``tests/cli/test_codex_config_profile_spec.py``,
+and those tests keep passing against the re-export, which is what says the move
+did not change the CLI path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.providers.openai._codex_profile import resolve_codex_config_profile
+from lionagi.providers.openai.codex import CodexCodeRequest
+
+
+@pytest.fixture
+def codex_home(tmp_path, monkeypatch):
+    home = tmp_path / "codex_home"
+    home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    return home
+
+
+def _write(home, name: str, body: str) -> None:
+    (home / f"{name}.config.toml").write_text(body)
+
+
+class TestTheLibraryEntryPoint:
+    def test_a_request_built_in_process_resolves_the_profile(self, codex_home):
+        """THE regression. Without it the bare name reaches codex as a model id."""
+        _write(
+            codex_home,
+            "deepseek-flash",
+            'model_provider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash-0731"\n',
+        )
+        req = CodexCodeRequest(model="deepseek-flash", prompt="x")
+        assert req.model == "deepseek/deepseek-v4-flash-0731"
+        assert req.config_overrides == {"model_provider": "openrouter"}
+
+    def test_branch_reaches_the_same_resolution(self, codex_home):
+        """The consumer-facing entry, not just the request object underneath.
+
+        An application that constructs a Branch on a profile name reaches the
+        provider through this path and never touches the CLI, so it is the one
+        that has to work for the fix to mean anything."""
+        from lionagi import Branch
+
+        _write(
+            codex_home,
+            "deepseek-flash",
+            'model_provider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash-0731"\n',
+        )
+        branch = Branch(chat_model="codex/deepseek-flash")
+        payload, _ = branch.chat_model.endpoint.create_payload({"prompt": "x"})
+        assert payload["request"].model == "deepseek/deepseek-v4-flash-0731"
+
+    def test_a_plain_model_id_is_left_alone(self, codex_home):
+        """The narrowing that keeps this from becoming a substitution engine: a
+        vendor id carries a slash and dots, so it is never looked up as a file."""
+        req = CodexCodeRequest(model="deepseek/deepseek-v4-flash-0731", prompt="x")
+        assert req.model == "deepseek/deepseek-v4-flash-0731"
+        assert req.config_overrides == {}
+
+    def test_a_bare_name_with_no_profile_file_is_left_alone(self, codex_home):
+        req = CodexCodeRequest(model="no-such-profile", prompt="x")
+        assert req.model == "no-such-profile"
+
+    def test_resolution_is_idempotent_so_the_cli_path_is_unaffected(self, codex_home):
+        """The CLI resolves before constructing the request, so the request sees
+        an already-resolved id. Resolving twice must be a no-op, or the CLI path
+        would break the moment this hook landed."""
+        _write(
+            codex_home,
+            "deepseek-flash",
+            'model_provider = "openrouter"\nmodel = "deepseek/deepseek-v4-flash-0731"\n',
+        )
+        once = resolve_codex_config_profile("deepseek-flash")
+        assert once is not None
+        assert resolve_codex_config_profile(once[0]) is None
+        req = CodexCodeRequest(model=once[0], prompt="x", config_overrides=dict(once[1]))
+        assert req.model == "deepseek/deepseek-v4-flash-0731"
+        assert req.config_overrides == {"model_provider": "openrouter"}
+
+
+class TestOrderingAndPrecedence:
+    def test_the_effort_clamp_sees_the_PROFILES_model_not_the_profile_name(self, codex_home):
+        """Ordering, asserted through an OUTCOME that differs between the two.
+
+        The clamp's ceilings are keyed on the model id, and only some models
+        have one. ``gpt-5.6-luna`` clamps ``ultra`` down to ``max``; the bare
+        string ``luna-profile`` has no ceiling and would pass ``ultra``
+        through. So the clamped value is a direct readout of which string the
+        clamp saw, and it can only be ``max`` if resolution ran first.
+
+        A test that merely asserted the effort survived would pass under either
+        order.
+        """
+        _write(codex_home, "luna-profile", 'model = "gpt-5.6-luna"\n')
+        req = CodexCodeRequest(model="luna-profile", prompt="x", reasoning_effort="ultra")
+        assert req.model == "gpt-5.6-luna"
+        assert req.reasoning_effort == "max"
+
+        # The control that makes the above mean something: with no profile to
+        # resolve, the same effort on the same raw name is NOT clamped.
+        untouched = CodexCodeRequest(
+            model="luna-profile-absent", prompt="x", reasoning_effort="ultra"
+        )
+        assert untouched.reasoning_effort == "ultra"
+
+    def test_caller_supplied_overrides_beat_the_profiles(self, codex_home):
+        """An override at the call site is an instruction; the profile is a
+        default sitting in a file."""
+        _write(
+            codex_home,
+            "deepseek-flash",
+            'model_provider = "openrouter"\nsandbox = "read-only"\n'
+            'model = "deepseek/deepseek-v4-flash-0731"\n',
+        )
+        req = CodexCodeRequest(
+            model="deepseek-flash",
+            prompt="x",
+            config_overrides={"model_provider": "caller-wins"},
+        )
+        assert req.config_overrides == {
+            "model_provider": "caller-wins",
+            "sandbox": "read-only",
+        }
+
+    def test_a_broken_profile_refuses_rather_than_running_something_else(self, codex_home):
+        """The whole point of the mechanism is that a silent substitution is
+        worse than a loud refusal, and that has to hold on this path too."""
+        _write(codex_home, "no-model", 'model_provider = "openrouter"\n')
+        with pytest.raises(ValueError, match="declares no 'model'"):
+            CodexCodeRequest(model="no-model", prompt="x")


### PR DESCRIPTION
## The defect

`codex/<name>` may name a codex config profile (`$CODEX_HOME/<name>.config.toml`)
rather than a model. The code that resolved it lived under `lionagi/cli/`, so:

- **CLI callers** (`li agent -a <profile>`) got the resolution.
- **Library callers** (`Branch(chat_model="codex/<profile>")`) did not.

A library-built request carried the profile **name** all the way to the spawn.
codex read it as a model id and the run failed with an unsupported-model error
naming a model nobody had asked for.

## The fix

Resolver moves to `lionagi/providers/openai/_codex_profile.py`, where both entry
points reach it, and is re-exported from `lionagi.cli._providers` so existing
imports keep working. Resolution now happens on the request model.

Idempotent by construction, so the CLI path is unchanged: it has already
substituted the profile's model id, and a real model id carries dots or a slash,
which the bare-name lookup rejects. The CLI still prints which model actually
runs; the provider module logs the same fact through `logging`, since a library
consumer has no terminal to print to.

## Ordering, which is where this nearly went wrong

The effort clamp's ceilings are keyed on the model id, and a profile names a
different model than the caller did — so resolution must run first.

Two `mode="before"` validators looked like the way to order that. **pydantic
runs them in reverse definition order**, so the clamp ran first and saw the
profile name. One validator calling the two steps in sequence removes the
dependence on declaration order entirely.

The test that caught it asserts a clamped **outcome** that differs between the
two strings:

| model string | `ultra` clamps to |
|---|---|
| `gpt-5.6-luna` (what the profile declares) | `max` |
| `luna-profile` (the profile's name) | `ultra` — no ceiling |

So the clamped value is a direct readout of which string the clamp saw. A test
asserting only that the effort *survived* would have passed under either order.
A mutation swapping the two steps back reddens that test alone.

## Verification

- New `tests/providers/test_codex_profile_library_path.py` enters through the
  same door a library consumer does, including `Branch` end to end.
- Existing `tests/cli/test_codex_config_profile_spec.py` passes unchanged
  against the re-export — that is what says the move did not alter the CLI path.
- Precedence covered: caller-supplied `config_overrides` beat the profile's.
- Refusal covered: a profile declaring no `model` still raises rather than
  silently running something else, on this path too.
- 4791 pass across `tests/providers`, `tests/cli`, `tests/service`. The 5
  failures in that selection are present on the base commit with these changes
  stashed, and are unrelated (subprocess session isolation, stdin inheritance).