### PR TITLE
fix(providers): say when a child spawns without its declared secrets

### DIFF
--- a/lionagi/providers/_secret_resolution.py
+++ b/lionagi/providers/_secret_resolution.py
@@ -272,10 +272,26 @@ async def fill_declared_secrets(
     A variable that already carries a value is never looked up and never
     overwritten, so exporting one is still the way to override the store for a
     single run.
+
+    A REFUSED lookup returns ``env`` unchanged, exactly as an absent one does,
+    and says so before it does. The two are one value apart at the return and
+    the child dies the same way in both cases -- on a missing variable, naming
+    the variable and not the lookup -- so without this the operator debugging
+    that child has nothing pointing at their own configuration.
     """
     resolution = resolve_secret_lookup_config(settings=settings)
     lookup = resolution.lookup
     if lookup is None:
+        if resolution.reason:
+            # The validator already warned that the config is bad. This is the
+            # separate statement: and therefore this child gets none of the
+            # variables it declared.
+            logger.warning(
+                "spawning without declared secrets: the configured lookup was "
+                "refused (%s), so any variable it would have filled is absent "
+                "from this child's environment",
+                resolution.reason,
+            )
         return env
 
     source: Mapping[str, str] = os.environ if env is None else env

--- a/tests/providers/test_secret_resolution.py
+++ b/tests/providers/test_secret_resolution.py
@@ -237,6 +237,60 @@ class TestFillingTheChildEnvironment:
 
 
 @pytest.mark.asyncio
+class TestARefusedLookupIsDistinguishableFromAnAbsentOne:
+    """Both return ``env`` untouched, so the return value cannot tell them
+    apart and the child dies identically either way -- on a missing variable,
+    naming the variable and never the lookup. The log is where they separate.
+
+    These arms are paired on purpose: asserting only that the refused case
+    warns would pass just as well with the warning emitted unconditionally,
+    which is the outcome that makes the signal worthless.
+    """
+
+    async def test_a_refused_lookup_says_the_child_is_spawning_without_them(self, caplog):
+        caplog.set_level(logging.WARNING)
+        base = {"PATH": "/usr/bin"}
+        # `argv` is not a list, so the config is refused rather than absent.
+        assert (
+            await fill_declared_secrets(
+                base, settings={"secrets": {"lookup": {"argv": "not-a-list", "names": [NAME]}}}
+            )
+            is base
+        )
+        assert "spawning without declared secrets" in caplog.text
+        assert "refused" in caplog.text
+
+    async def test_nothing_configured_stays_silent(self, caplog):
+        """The discriminating half. Chosen silence is not a problem to report,
+        and a machine that configured no lookup must not be warned at every
+        spawn -- an alarm that fires for everyone trains its reader to skip it.
+        """
+        caplog.set_level(logging.WARNING)
+        base = {"PATH": "/usr/bin"}
+        assert await fill_declared_secrets(base, settings={}) is base
+        assert "spawning without declared secrets" not in caplog.text
+
+    async def test_the_reason_reaches_the_operator_not_just_the_type(self, caplog):
+        """The reason identifier is what says WHICH refusal happened. Without
+        it the message narrows the problem to `your lookup config` and leaves
+        the operator to diff it against the schema by hand."""
+        caplog.set_level(logging.WARNING)
+        await fill_declared_secrets(
+            {}, settings={"secrets": {"lookup": {"argv": [], "names": [NAME]}}}
+        )
+        assert "lookup_argv" in caplog.text
+
+    async def test_a_working_lookup_does_not_claim_the_child_went_without(self, caplog):
+        """A lookup that resolves must not emit the refusal line. Sharing one
+        branch with the success path would make the warning fire on the runs it
+        has nothing to say about."""
+        caplog.set_level(logging.WARNING)
+        env = await fill_declared_secrets({}, settings=_block(_PRINTS_A_VALUE))
+        assert env[NAME] == f"resolved::{NAME}"
+        assert "spawning without declared secrets" not in caplog.text
+
+
+@pytest.mark.asyncio
 class TestTheValueDoesNotReachTheLogs:
     async def test_a_successful_lookup_logs_no_value(self, caplog):
         caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
## What

When a `secrets.lookup` is configured but refused, `fill_declared_secrets` returned the environment unchanged and said nothing about it. An absent lookup returns the same value, so the two are indistinguishable at the return, and the child then fails identically in both cases: on a missing environment variable, naming the variable and never the lookup.

The result is that someone who misconfigures a lookup sees only their child dying on a missing key, with nothing pointing back at their own configuration.

## Change

One branch in `fill_declared_secrets`. When the resolution carries a refusal reason, warn that this child is spawning without its declared secrets, naming the reason identifier.

The config validator already warns that a lookup block is malformed. This is the separate statement it never made, that the spawn is consequently going ahead without any of the declared variables. The reason identifier is included so the message narrows to which refusal occurred rather than to "your lookup config".

Deliberately silent when nothing is configured. That is a chosen silence rather than a problem to report, and warning on every spawn on a machine that configures no lookup would train its reader to skip the line.

## Tests

Four arms, each paired with its opposite, because asserting only that the refused case warns would pass equally well with the warning emitted unconditionally, and that outcome makes the signal worthless:

- a refused lookup warns, and names the reason
- nothing configured stays silent
- a working lookup does not claim the child went without

Both mutations were run against a predicted set of failing arms, stated before running:

- removing the guard so the warning fires unconditionally reddens the silent-case arm alone
- removing the warning entirely reddens the two refusal arms alone

Each reddened exactly the predicted arms and no others. Full providers suite: 517 passed, 3 xfailed.
