### PR TITLE
fix(engines): let an engine grant its CLI legs the tools they were given

### DIFF
--- a/lionagi/engines/engine.py
+++ b/lionagi/engines/engine.py
@@ -428,6 +428,12 @@ class EngineRun:
             cwd=cwd,
             system_prompt=extra_prompt,
             khive_injection=injection,
+            # Read off the engine rather than defaulted here: create_agent is
+            # the single grant site, and a grant this path could not express
+            # was the whole defect -- a headless CLI cannot prompt for a tool
+            # permission, so a leg spawned without this is denied every tool
+            # call and reports success with nothing in it.
+            yolo=self.engine.yolo,
         )
         if mcp_servers is not None:
             spec.mcp_servers = mcp_servers
@@ -743,12 +749,21 @@ class Engine:
         agent_cwd: str | None = None,
         agent_extra_prompt: str | None = None,
         khive_injection: Any = None,
+        yolo: bool = False,
     ) -> None:
         # Run-wide agent defaults: pin every agent to a working directory (e.g. a
         # provisioned worktree) and/or a shared standards prompt; per-call
         # make_agent(cwd=..., extra_prompt=...) still wins.
         self.agent_cwd = agent_cwd
         self.agent_extra_prompt = agent_extra_prompt
+        # Auto-approve tool permission requests for every agent this engine
+        # spawns, applied per provider from the same table the CLI and profile
+        # paths use. Default False: auto-approving tool execution is not
+        # something a caller should receive without asking for it. What this
+        # switch buys is that asking is now POSSIBLE from here -- without it the
+        # table is unreachable on this path, and a CLI that cannot prompt for a
+        # permission has no way to be granted one.
+        self.yolo = yolo
         # Run-wide khive context-injection default for every stage agent
         # (True/mapping/policy enable, False disables even a profile opt-in,
         # None defers to each stage role's agent profile).

--- a/tests/engines/test_engine_leg_permission_grant.py
+++ b/tests/engines/test_engine_leg_permission_grant.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""An engine-spawned CLI leg can be granted its provider's tool permissions.
+
+The loss being closed: the per-provider permission table was applied only under
+``spec.yolo``, and the engine composed every spec without it, so the table was
+unreachable from this path by any route. A headless CLI cannot prompt for a tool
+permission, so a leg spawned that way was denied every tool call and reported
+success carrying nothing.
+
+No LLM: these read the kwargs the engine put on the built branch's model.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.engines.engine import Engine
+
+
+def _model_kwargs(branch) -> dict:
+    """The provider kwargs the factory resolved for this branch's CLI model."""
+    return dict(branch.chat_model.endpoint.config.kwargs)
+
+
+class TestNothingIsGrantedWithoutAsking:
+    def test_an_engine_defaults_to_no_auto_approval(self):
+        """Auto-approving tool execution is not something a caller receives by
+        default. The defect was that asking was impossible, not that the answer
+        was no."""
+        assert Engine().yolo is False
+
+    @pytest.mark.asyncio
+    async def test_a_default_engines_leg_carries_no_permission_grant(self):
+        """The companion arm. Every assertion about the grant arriving would
+        also pass with the grant hardcoded on, and that would be a worse defect
+        than the one being fixed."""
+        run = Engine(model="gemini_code/gemini-3.6-flash").new_run()
+        branch = await run.make_agent("researcher", name="r")
+        assert _model_kwargs(branch).get("yolo") is not True
+
+
+class TestTheGrantReachesTheLeg:
+    @pytest.mark.asyncio
+    async def test_an_opted_in_engine_grants_its_gemini_leg_its_tools(self):
+        """The defect arm. Before the engine could pass yolo, this kwarg could
+        not be produced on this path however the caller asked."""
+        run = Engine(model="gemini_code/gemini-3.6-flash", yolo=True).new_run()
+        branch = await run.make_agent("researcher", name="r")
+        assert _model_kwargs(branch).get("yolo") is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model", "kwarg", "expected"),
+        [
+            ("gemini_code/gemini-3.6-flash", "yolo", True),
+            ("claude_code/claude-sonnet-5", "permission_mode", "bypassPermissions"),
+            ("codex/gpt-5.6", "full_auto", True),
+        ],
+    )
+    async def test_every_cli_provider_gets_its_own_grant_not_geminis(self, model, kwarg, expected):
+        """The failure was noticed through gemini because gemini is the provider
+        whose default fails loudly. The gate it was stuck behind is the same one
+        that delivers bypassPermissions and full_auto, so a gemini-shaped fix
+        would have left the other two silently ungranted. Parametrised so a
+        provider added to the table without a route here is visible.
+        """
+        run = Engine(model=model, yolo=True).new_run()
+        branch = await run.make_agent("researcher", name="r")
+        assert _model_kwargs(branch).get(kwarg) == expected
+
+
+class TestTheEngineIsWhatDecides:
+    @pytest.mark.asyncio
+    async def test_the_grant_follows_the_engine_and_not_a_module_default(self):
+        """Two runs of two engines, differing only in this switch, must differ
+        in the built leg. Asserting the True case alone cannot tell a threaded
+        value from a constant.
+        """
+        granted = (
+            await Engine(model="gemini_code/gemini-3.6-flash", yolo=True)
+            .new_run()
+            .make_agent("researcher", name="a")
+        )
+        withheld = (
+            await Engine(model="gemini_code/gemini-3.6-flash", yolo=False)
+            .new_run()
+            .make_agent("researcher", name="b")
+        )
+
+        assert _model_kwargs(granted).get("yolo") is True
+        assert _model_kwargs(withheld).get("yolo") is not True


### PR DESCRIPTION
## What

An engine-spawned CLI leg could not be granted its provider's tool permissions.

The per-provider permission table is applied in `create_agent` only under `spec.yolo`. `AgentSpec` defaults that to `False`, and the engine composed every spec without passing it, so the table was unreachable from this path by any route a caller could take. A headless CLI cannot prompt for a tool permission, so a leg spawned this way was denied every tool call and returned success carrying nothing.

The table itself was already correct, and the CLI and profile paths already reach it. Only the engine path could not express the grant.

## Scope is every CLI provider, not one

The same gate delivers `permission_mode: bypassPermissions` for claude-code and `full_auto` for codex. Those have workable defaults, so instead of failing outright they were silently more restricted than their caller asked for. The gemini case is the one that fails loudly, which makes it the detector rather than the bug — and a gemini-shaped fix would have left the other two ungranted.

## Change

`Engine` gains `yolo: bool = False`, and the compose call reads it.

The default stays `False`. Auto-approving tool execution is not something a caller should receive without asking for it. What was broken is that asking was impossible from here, not that the answer was no.

The value is read off the engine at the compose call rather than set on the spec afterwards. `create_agent` is documented as the single grant site, so the grant belongs in the spec's construction, even though assigning it post-compose would have worked the same way `mcp_servers` does.

## The other call sites were checked, not assumed

- The coding toolkit passes `yolo=False` explicitly, which is a deliberate choice for a sub-agent.
- The orchestrate worker path hands `create_agent` a prebuilt `chat_model`, which takes the earlier branch and skips the provider-kwargs block entirely, so it owns its own kwargs.

Neither is this defect, so this is a one-site fix rather than a partial sweep.

## Tests

Seven arms. The fixture-to-arm mapping matters, because the reddened set depends on it: the two arms driving an engine with no grant stay green under the defect, and the five driving an opted-in engine go red. Removing the threaded value reproduces the original defect and reddens exactly those five and no others.

The companion arm carries the weight. Every assertion that the grant *arrives* would pass equally well with the grant hardcoded on, and that would be a worse defect than the one being fixed. The provider arms are parametrised so a provider added to the table without a route here is visible.

`tests/engines` and `tests/agent`: 653 passed.
