### PR TITLE
feat(state): report what a retention window can actually reach

### DIFF
--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -29,9 +29,11 @@ __all__ = [
     "_format_bytes",
     "_list_sessions",
     "_print_stats",
+    "_collect_message_breakdown",
     "_checkpoint",
     "_vacuum",
     "_prune",
+    "_prune_candidates",
     "_doctor",
     # CLI entrypoints
     "add_state_subparser",
@@ -430,6 +432,11 @@ _STATS_PRAGMAS = (
     "foreign_keys",
 )
 
+# Age thresholds the message breakdown reports, in days. Every one is printed
+# whether or not a row falls in it, because a bucket reading zero is itself the
+# answer: it says a prune keeping that many days can free nothing.
+_MESSAGE_AGE_DAYS = (7, 14, 30, 90)
+
 
 def _db_sizes() -> dict[str, Any]:
     """Bytes on disk for the configured store, when the configured store is a file.
@@ -469,8 +476,99 @@ def _db_sizes() -> dict[str, Any]:
     }
 
 
-async def _collect_stats(db: Any) -> dict[str, Any]:
-    """Row counts, the session status distribution, and the SQLite pragmas."""
+async def _collect_message_breakdown(db: Any, *, content_bytes: bool = False) -> dict[str, Any]:
+    """Messages by role and by age — the two axes a retention decision is made on.
+
+    A total row count cannot say whether a retention setting is able to reclaim
+    anything. A store whose oldest message is newer than the prune's keep-window
+    frees nothing at any ``--keep-days`` the prune accepts, and reports success
+    while doing it. The age histogram is what makes that readable before the
+    prune runs rather than after it has run and changed nothing.
+
+    ``content_bytes`` adds each role's summed content length, and is off by
+    default because it is the one query here that no index can serve. Measured
+    on a 1.68M-row store: role counts 0.9s, age counts 0.5s, byte sum 57s.
+    Bytes are what say which role is worth reclaiming, so the option exists;
+    charging every ``li state stats`` for it does not follow.
+    """
+    import time as _time
+
+    from sqlalchemy import text
+
+    now = _time.time()
+
+    async with db._read() as conn:
+        role_rows = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT role AS r, COUNT(*) AS n FROM messages GROUP BY role ORDER BY n DESC"
+                    )
+                )
+            )
+            .mappings()
+            .all()
+        )
+
+    by_role: list[dict[str, Any]] = [{"role": r["r"], "count": r["n"]} for r in role_rows]
+
+    if content_bytes:
+        async with db._read() as conn:
+            byte_rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT role AS r, SUM(LENGTH(content)) AS b "
+                            "FROM messages GROUP BY role"
+                        )
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        # LENGTH() over a JSON column measures the stored text, which is what
+        # occupies the file. It is not the same as the page count the row costs
+        # and is not presented as one.
+        sized = {r["r"]: r["b"] or 0 for r in byte_rows}
+        for entry in by_role:
+            entry["content_bytes"] = sized.get(entry["role"], 0)
+
+    by_age: list[dict[str, Any]] = []
+    for days in _MESSAGE_AGE_DAYS:
+        async with db._read() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text("SELECT COUNT(*) AS n FROM messages WHERE created_at < :cutoff"),
+                        {"cutoff": now - days * 86400},
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        by_age.append({"older_than_days": days, "count": row["n"]})
+
+    async with db._read() as conn:
+        row = (
+            (await conn.execute(text("SELECT MIN(created_at) AS oldest FROM messages")))
+            .mappings()
+            .first()
+        )
+    oldest = row["oldest"] if row else None
+    # None on an empty table, and reported as None rather than as an age of
+    # zero: no messages and messages all written this instant are different
+    # states, and only one of them says a prune has nothing to reach.
+    oldest_age_days = None if oldest is None else (now - oldest) / 86400.0
+
+    return {
+        "messages_by_role": by_role,
+        "messages_by_age": by_age,
+        "oldest_message_age_days": oldest_age_days,
+    }
+
+
+async def _collect_stats(db: Any, *, content_bytes: bool = False) -> dict[str, Any]:
+    """Row counts, the message breakdown, the session status distribution, and the pragmas."""
     from sqlalchemy import text
 
     counts: dict[str, int] = {}
@@ -507,6 +605,8 @@ async def _collect_stats(db: Any) -> dict[str, Any]:
             row = (await conn.execute(text(f"PRAGMA {pragma}"))).first()
         pragmas[pragma] = row[0] if row else None
 
+    breakdown = await _collect_message_breakdown(db, content_bytes=content_bytes)
+
     return {
         "row_counts": counts,
         # A list of pairs, not an object: a session whose status was never
@@ -514,10 +614,11 @@ async def _collect_stats(db: Any) -> dict[str, Any]:
         # would be indistinguishable from a status literally spelled that way.
         "sessions_by_status": [{"status": r["s"], "count": r["n"]} for r in status_rows],
         "pragmas": pragmas,
+        **breakdown,
     }
 
 
-async def _print_stats() -> None:
+async def _print_stats(*, content_bytes: bool = False) -> None:
     from lionagi.state.db import StateDB
 
     sizes = _db_sizes()
@@ -535,11 +636,38 @@ async def _print_stats() -> None:
         return
 
     async with StateDB() as db:
-        collected = await _collect_stats(db)
+        collected = await _collect_stats(db, content_bytes=content_bytes)
 
     print("Row counts:")
     for table, n in collected["row_counts"].items():
         print(f"  {table:<14} {n:>10}")
+    print()
+
+    print("Messages by role:")
+    for entry in collected["messages_by_role"]:
+        label = "(null)" if entry["role"] is None else entry["role"]
+        line = f"  {label:<14} {entry['count']:>10}"
+        if "content_bytes" in entry:
+            line += f"  {_format_bytes(entry['content_bytes']):>10} of content"
+        print(line)
+    if not collected["messages_by_role"]:
+        print("  (none)")
+    if not content_bytes:
+        print("  (pass --content-bytes for per-role size; it is a full scan)")
+    print()
+
+    print("Messages by age:")
+    for entry in collected["messages_by_age"]:
+        print(f"  older than {entry['older_than_days']:>3}d {entry['count']:>10}")
+    oldest = collected["oldest_message_age_days"]
+    if oldest is None:
+        print("  oldest          (no messages)")
+    else:
+        print(f"  oldest       {oldest:>10.1f}d")
+        # The comparison a reader would otherwise have to make by hand, and the
+        # one that decides whether `li state prune` can free anything: its
+        # keep-window is in the same unit as this number.
+        print("  a prune keeping more days than that reclaims nothing")
     print()
 
     print("Sessions by status:")
@@ -568,6 +696,68 @@ async def _vacuum() -> None:
 
     async with StateDB() as db:
         await db.vacuum()
+
+
+# Which sessions the prune deletes, written once. The prune selects ids with it
+# and the check below counts what it still selects afterwards; two copies of this
+# predicate drifting apart would make the pair agree while describing different
+# populations, which is worse than having no check.
+_PRUNE_VICTIMS = (
+    "FROM sessions "
+    "WHERE id NOT IN ("
+    "  SELECT id FROM sessions ORDER BY updated_at DESC LIMIT :keep_n"
+    ") AND (updated_at < :cutoff OR updated_at IS NULL)"
+)
+
+
+async def _prune_candidates(*, keep_days: int, keep_n: int) -> dict[str, Any]:
+    """Recount what the prune's own predicate selects, and how old the oldest session is.
+
+    Printed beside the prune's result so the command cannot report an outcome
+    nothing contradicts. A single number is undetectable when it is wrong; a
+    pair is not. After a real run this must read zero, and after a preview it
+    must equal the count the preview reported, so either disagreement is visible
+    without anyone querying anything.
+
+    The age is here because of the failure this was built for: a keep-window
+    wider than the whole store selects nothing, so the prune deletes nothing and
+    says so in the words of a success. Beside the oldest session's age that
+    sentence stops being ambiguous.
+    """
+    import time as _time
+
+    from sqlalchemy import text
+
+    from lionagi.state.db import StateDB
+
+    cutoff = _time.time() - (keep_days * 86400)
+    now = _time.time()
+
+    async with StateDB() as db:
+        async with db._read() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text(f"SELECT COUNT(*) AS n {_PRUNE_VICTIMS}"),  # noqa: S608
+                        {"keep_n": keep_n, "cutoff": cutoff},
+                    )
+                )
+                .mappings()
+                .first()
+            )
+            remaining = row["n"]
+            row = (
+                (await conn.execute(text("SELECT MIN(updated_at) AS oldest FROM sessions")))
+                .mappings()
+                .first()
+            )
+    oldest = row["oldest"] if row else None
+    return {
+        "candidates": remaining,
+        # None rather than an age of zero on an empty store: no sessions and
+        # sessions all touched this instant are different states.
+        "oldest_session_age_days": None if oldest is None else (now - oldest) / 86400.0,
+    }
 
 
 class _PreviewOnlyError(Exception):
@@ -611,12 +801,7 @@ async def _prune(
                 rows = (
                     (
                         await conn.execute(
-                            text(
-                                "SELECT id FROM sessions "
-                                "WHERE id NOT IN ("
-                                "  SELECT id FROM sessions ORDER BY updated_at DESC LIMIT :keep_n"
-                                ") AND (updated_at < :cutoff OR updated_at IS NULL)"
-                            ),
+                            text(f"SELECT id {_PRUNE_VICTIMS}"),  # noqa: S608
                             {"keep_n": keep_n, "cutoff": cutoff},
                         )
                     )
@@ -1096,14 +1281,25 @@ def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     # li state stats
-    state_sub.add_parser(
+    stats = state_sub.add_parser(
         "stats",
-        help="Print DB/WAL size, row counts, and lifecycle health.",
+        help="Print DB/WAL size, row counts, message role/age breakdown, and lifecycle health.",
         description=(
             "Report state.db + state.db-wal sizes, per-table row counts, "
-            "session status distribution, and SQLite PRAGMAs (journal_mode, "
+            "messages broken down by role and by age, session status "
+            "distribution, and SQLite PRAGMAs (journal_mode, "
             "wal_autocheckpoint, busy_timeout). Use to spot growth and "
-            "lock contention."
+            "lock contention, and to check before pruning whether the "
+            "keep-window can reach anything at all."
+        ),
+    )
+    stats.add_argument(
+        "--content-bytes",
+        action="store_true",
+        help=(
+            "Also sum each role's stored content size. No index can serve this, so it "
+            "scans every message row: measured at 57s on a 1.7M-row store against under "
+            "2s for the rest of this command."
         ),
     )
 
@@ -1234,7 +1430,7 @@ def run_state(args: argparse.Namespace) -> int:
         return 0
 
     if args.state_command == "stats":
-        run_async(_print_stats())
+        run_async(_print_stats(content_bytes=args.content_bytes))
         return 0
 
     if args.state_command == "checkpoint":
@@ -1261,6 +1457,25 @@ def run_state(args: argparse.Namespace) -> int:
             f"{result['branches']} branch(es), "
             f"{result['messages']} orphan message(s)"
         )
+        # Recomputed after the fact, never carried out of the prune's own
+        # transaction: a count the prune produced cannot contradict the prune.
+        check = run_async(_prune_candidates(keep_days=args.keep_days, keep_n=args.keep_n))
+        expected = result["sessions"] if args.dry_run else 0
+        print(
+            f"  still selected by --keep-days {args.keep_days} --keep-n {args.keep_n}: "
+            f"{check['candidates']} (expected {expected})"
+        )
+        age = check["oldest_session_age_days"]
+        if age is None:
+            print("  oldest session: (none)")
+        else:
+            print(f"  oldest session: {age:.1f}d")
+            if age < args.keep_days:
+                print(
+                    f"  NOTHING IS OLDER THAN --keep-days {args.keep_days}, so this "
+                    "reclaimed nothing and no smaller change to the data would have "
+                    "helped. Lower the window or prune on a different axis."
+                )
         return 0
 
     if args.state_command == "doctor":
@@ -1309,11 +1524,20 @@ async def _machine_stats_data() -> dict[str, Any]:
             absent = why
             result["row_counts"] = absent
             result["sessions_by_status"] = absent
+            result["messages_by_role"] = absent
+            result["messages_by_age"] = absent
             result["journal_mode"] = absent
             return result
         collected = await _collect_stats(db)
     result["row_counts"] = available(collected["row_counts"])
     result["sessions_by_status"] = available(collected["sessions_by_status"])
+    # Carried here for the same reason _STATS_TABLES is named once: a machine
+    # caller and the printout must not come to describe different databases.
+    # content_bytes is never requested on this path — a full scan behind an
+    # MCP call is a cost the caller cannot see coming.
+    result["messages_by_role"] = available(collected["messages_by_role"])
+    result["messages_by_age"] = available(collected["messages_by_age"])
+    result["oldest_message_age_days"] = available(collected["oldest_message_age_days"])
     # Only the one pragma that describes the database rather than the connection
     # that asked. busy_timeout, synchronous and the rest are settings of whichever
     # connection reads them, so reporting them here would hand a caller this

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -476,7 +476,7 @@ def _db_sizes() -> dict[str, Any]:
     }
 
 
-async def _collect_message_breakdown(db: Any, *, content_bytes: bool = False) -> dict[str, Any]:
+async def _collect_message_breakdown(db: Any) -> dict[str, Any]:
     """Messages by role and by age — the two axes a retention decision is made on.
 
     A total row count cannot say whether a retention setting is able to reclaim
@@ -485,11 +485,11 @@ async def _collect_message_breakdown(db: Any, *, content_bytes: bool = False) ->
     while doing it. The age histogram is what makes that readable before the
     prune runs rather than after it has run and changed nothing.
 
-    ``content_bytes`` adds each role's summed content length, and is off by
-    default because it is the one query here that no index can serve. Measured
-    on a 1.68M-row store: role counts 0.9s, age counts 0.5s, byte sum 57s.
-    Bytes are what say which role is worth reclaiming, so the option exists;
-    charging every ``li state stats`` for it does not follow.
+    Counts only. Summing content size is the one query here no index can serve
+    (57s against 1.68M rows, versus under 2s for everything else), and the
+    command that reclaims that content reports the size of the exact population
+    it is about to touch — which is the same number, measured where the decision
+    is actually taken.
     """
     import time as _time
 
@@ -511,27 +511,6 @@ async def _collect_message_breakdown(db: Any, *, content_bytes: bool = False) ->
         )
 
     by_role: list[dict[str, Any]] = [{"role": r["r"], "count": r["n"]} for r in role_rows]
-
-    if content_bytes:
-        async with db._read() as conn:
-            byte_rows = (
-                (
-                    await conn.execute(
-                        text(
-                            "SELECT role AS r, SUM(LENGTH(content)) AS b "
-                            "FROM messages GROUP BY role"
-                        )
-                    )
-                )
-                .mappings()
-                .all()
-            )
-        # LENGTH() over a JSON column measures the stored text, which is what
-        # occupies the file. It is not the same as the page count the row costs
-        # and is not presented as one.
-        sized = {r["r"]: r["b"] or 0 for r in byte_rows}
-        for entry in by_role:
-            entry["content_bytes"] = sized.get(entry["role"], 0)
 
     by_age: list[dict[str, Any]] = []
     for days in _MESSAGE_AGE_DAYS:
@@ -567,7 +546,7 @@ async def _collect_message_breakdown(db: Any, *, content_bytes: bool = False) ->
     }
 
 
-async def _collect_stats(db: Any, *, content_bytes: bool = False) -> dict[str, Any]:
+async def _collect_stats(db: Any) -> dict[str, Any]:
     """Row counts, the message breakdown, the session status distribution, and the pragmas."""
     from sqlalchemy import text
 
@@ -605,7 +584,7 @@ async def _collect_stats(db: Any, *, content_bytes: bool = False) -> dict[str, A
             row = (await conn.execute(text(f"PRAGMA {pragma}"))).first()
         pragmas[pragma] = row[0] if row else None
 
-    breakdown = await _collect_message_breakdown(db, content_bytes=content_bytes)
+    breakdown = await _collect_message_breakdown(db)
 
     return {
         "row_counts": counts,
@@ -618,7 +597,7 @@ async def _collect_stats(db: Any, *, content_bytes: bool = False) -> dict[str, A
     }
 
 
-async def _print_stats(*, content_bytes: bool = False) -> None:
+async def _print_stats() -> None:
     from lionagi.state.db import StateDB
 
     sizes = _db_sizes()
@@ -636,7 +615,7 @@ async def _print_stats(*, content_bytes: bool = False) -> None:
         return
 
     async with StateDB() as db:
-        collected = await _collect_stats(db, content_bytes=content_bytes)
+        collected = await _collect_stats(db)
 
     print("Row counts:")
     for table, n in collected["row_counts"].items():
@@ -646,14 +625,9 @@ async def _print_stats(*, content_bytes: bool = False) -> None:
     print("Messages by role:")
     for entry in collected["messages_by_role"]:
         label = "(null)" if entry["role"] is None else entry["role"]
-        line = f"  {label:<14} {entry['count']:>10}"
-        if "content_bytes" in entry:
-            line += f"  {_format_bytes(entry['content_bytes']):>10} of content"
-        print(line)
+        print(f"  {label:<14} {entry['count']:>10}")
     if not collected["messages_by_role"]:
         print("  (none)")
-    if not content_bytes:
-        print("  (pass --content-bytes for per-role size; it is a full scan)")
     print()
 
     print("Messages by age:")
@@ -1283,8 +1257,10 @@ def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
 
-    # li state stats
-    stats = state_sub.add_parser(
+    # li state stats — no flags, and the machine surface takes none either, so
+    # its projected schema stays empty and the two cannot describe different
+    # commands.
+    state_sub.add_parser(
         "stats",
         help="Print DB/WAL size, row counts, message role/age breakdown, and lifecycle health.",
         description=(
@@ -1294,15 +1270,6 @@ def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
             "wal_autocheckpoint, busy_timeout). Use to spot growth and "
             "lock contention, and to check before pruning whether the "
             "keep-window can reach anything at all."
-        ),
-    )
-    stats.add_argument(
-        "--content-bytes",
-        action="store_true",
-        help=(
-            "Also sum each role's stored content size. No index can serve this, so it "
-            "scans every message row: measured at 57s on a 1.7M-row store against under "
-            "2s for the rest of this command."
         ),
     )
 
@@ -1442,7 +1409,7 @@ def run_state(args: argparse.Namespace) -> int:
         return 0
 
     if args.state_command == "stats":
-        run_async(_print_stats(content_bytes=args.content_bytes))
+        run_async(_print_stats())
         return 0
 
     if args.state_command == "checkpoint":
@@ -1545,8 +1512,6 @@ async def _machine_stats_data() -> dict[str, Any]:
     result["sessions_by_status"] = available(collected["sessions_by_status"])
     # Carried here for the same reason _STATS_TABLES is named once: a machine
     # caller and the printout must not come to describe different databases.
-    # content_bytes is never requested on this path — a full scan behind an
-    # MCP call is a cost the caller cannot see coming.
     result["messages_by_role"] = available(collected["messages_by_role"])
     result["messages_by_age"] = available(collected["messages_by_age"])
     result["oldest_message_age_days"] = available(collected["oldest_message_age_days"])

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -664,10 +664,13 @@ async def _print_stats(*, content_bytes: bool = False) -> None:
         print("  oldest          (no messages)")
     else:
         print(f"  oldest       {oldest:>10.1f}d")
-        # The comparison a reader would otherwise have to make by hand, and the
-        # one that decides whether `li state prune` can free anything: its
-        # keep-window is in the same unit as this number.
-        print("  a prune keeping more days than that reclaims nothing")
+        # Said about MESSAGES, deliberately, and not about the prune as a whole.
+        # Message lifetime and session lifetime are independent here: `li state
+        # prune` selects by session age and then frees only messages nothing
+        # surviving still references, so it can delete thousands of old sessions
+        # and free no message rows at all. Since messages hold nearly all the
+        # bytes, "sessions deleted" is not a claim about space.
+        print("  (messages only — prune selects by SESSION age, see prune's own output)")
     print()
 
     print("Sessions by status:")
@@ -1343,7 +1346,16 @@ def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
             "Delete sessions older than --keep-days (default 30), keeping "
             "the most recent --keep-n (default 100). Foreign key cascades "
             "drop branches; messages are dropped if no other session "
-            "references them via progression. Use --dry-run to preview."
+            "references them via progression. Use --dry-run to preview.\n\n"
+            "SESSIONS ARE THE AXIS, AND MESSAGES HOLD THE BYTES. A message a "
+            "surviving progression still names is kept whatever its age, so a "
+            "run can delete thousands of sessions and free no message rows. "
+            "Read the message counts, not the session count, to judge whether "
+            "this reclaimed space; `li state stats` shows both distributions.\n\n"
+            "--dry-run is not a read. It runs the real deletes and rolls the "
+            "transaction back, which is what makes its counts exact rather "
+            "than estimated, and which means it takes the same write lock for "
+            "the same duration as the real thing."
         ),
     )
     prune.add_argument(

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -1449,10 +1449,18 @@ def run_state(args: argparse.Namespace) -> int:
             print("  oldest session: (none)")
         else:
             print(f"  oldest session: {age:.1f}d")
-            if age < args.keep_days:
+            # Gated on the operation's own count, not on the age alone. The same
+            # comparison means two opposite things depending on when it is read:
+            # before the prune it says the window reaches nothing, after a
+            # successful one it says the prune WORKED and every survivor is
+            # inside the window. Ungated it prints "this reclaimed nothing"
+            # directly beneath "deleted 2000 session(s)", and tells an operator
+            # to lower the window -- advice that deletes more, on the one path
+            # where nothing was wrong.
+            if result["sessions"] == 0 and age < args.keep_days:
                 print(
                     f"  NOTHING IS OLDER THAN --keep-days {args.keep_days}, so this "
-                    "reclaimed nothing and no smaller change to the data would have "
+                    "selected nothing and no smaller change to the data would have "
                     "helped. Lower the window or prune on a different axis."
                 )
         return 0

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -1513,6 +1513,7 @@ async def _machine_stats_data() -> dict[str, Any]:
             result["sessions_by_status"] = absent
             result["messages_by_role"] = absent
             result["messages_by_age"] = absent
+            result["oldest_message_age_days"] = absent
             result["journal_mode"] = absent
             return result
         collected = await _collect_stats(db)

--- a/tests/cli/test_state_retention_readouts.py
+++ b/tests/cli/test_state_retention_readouts.py
@@ -79,18 +79,18 @@ class TestTheBreakdownSeparatesRoles:
         counts = {e["role"]: e["count"] for e in got["messages_by_role"]}
         assert counts == {"action": 4, "user": 1}
 
-    async def test_the_byte_sum_is_withheld_unless_asked_for(self, temp_db_path: Path):
-        """The companion arm. Every assertion that bytes ARRIVE would pass just as
-        well with the scan running unconditionally, and that is the cost this
-        option exists to avoid paying on every invocation."""
+    async def test_the_breakdown_never_sums_content(self, temp_db_path: Path):
+        """Counts only, and this arm is what keeps it that way. Summing content
+        size is the one query here no index can serve — 57s against 1.68M rows
+        versus under 2s for everything else — so a scan added later would make
+        every `li state stats` pay for it, silently and permanently."""
         async with StateDB() as db:
             await _seed_message(db, role="action", age_days=0, text="some content")
 
-            without = await _collect_message_breakdown(db)
-            with_bytes = await _collect_message_breakdown(db, content_bytes=True)
+            got = await _collect_message_breakdown(db)
 
-        assert "content_bytes" not in without["messages_by_role"][0]
-        assert with_bytes["messages_by_role"][0]["content_bytes"] > 0
+        assert "content_bytes" not in got["messages_by_role"][0]
+        assert set(got["messages_by_role"][0]) == {"role", "count"}
 
 
 class TestTheAgeHistogramIsWhatMakesAKeepWindowCheckable:

--- a/tests/cli/test_state_retention_readouts.py
+++ b/tests/cli/test_state_retention_readouts.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The two readouts a retention decision is made from, and the pair that contradicts a prune.
+
+The failure these close: a store whose oldest row is newer than the prune's
+keep-window frees nothing at any window the prune accepts, deletes zero, and
+says so in the words of a success. Nothing in the old output could tell that
+apart from a store that had already been pruned clean.
+
+No LLM and no network: every arm seeds a temp SQLite file and reads it back.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli.state import (
+    _collect_message_breakdown,
+    _print_stats,
+    _prune,
+    _prune_candidates,
+)
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+async def _seed_message(db: StateDB, *, role: str, age_days: float, text: str = "x") -> str:
+    """One message of a given role, aged by writing created_at directly."""
+    mid = str(uuid.uuid4())
+    await db.insert_message(
+        {
+            "id": mid,
+            "created_at": time.time() - age_days * 86400,
+            "node_metadata": {},
+            "content": {"text": text},
+            "role": role,
+            "sender": "u",
+            "recipient": "x",
+            "channel": "test",
+        }
+    )
+    return mid
+
+
+async def _seed_session_aged(db: StateDB, *, age_days: float) -> str:
+    sid = str(uuid.uuid4())
+    pid = str(uuid.uuid4())
+    await db.create_progression(pid)
+    await db.create_session(
+        {"id": sid, "progression_id": pid, "status": "completed", "started_at": time.time()}
+    )
+    await db.execute(
+        "UPDATE sessions SET updated_at = ? WHERE id = ?",
+        (time.time() - age_days * 86400, sid),
+    )
+    return sid
+
+
+class TestTheBreakdownSeparatesRoles:
+    async def test_each_role_is_counted_on_its_own(self, temp_db_path: Path):
+        async with StateDB() as db:
+            for _ in range(4):
+                await _seed_message(db, role="action", age_days=0)
+            await _seed_message(db, role="user", age_days=0)
+
+            got = await _collect_message_breakdown(db)
+
+        counts = {e["role"]: e["count"] for e in got["messages_by_role"]}
+        assert counts == {"action": 4, "user": 1}
+
+    async def test_the_byte_sum_is_withheld_unless_asked_for(self, temp_db_path: Path):
+        """The companion arm. Every assertion that bytes ARRIVE would pass just as
+        well with the scan running unconditionally, and that is the cost this
+        option exists to avoid paying on every invocation."""
+        async with StateDB() as db:
+            await _seed_message(db, role="action", age_days=0, text="some content")
+
+            without = await _collect_message_breakdown(db)
+            with_bytes = await _collect_message_breakdown(db, content_bytes=True)
+
+        assert "content_bytes" not in without["messages_by_role"][0]
+        assert with_bytes["messages_by_role"][0]["content_bytes"] > 0
+
+
+class TestTheAgeHistogramIsWhatMakesAKeepWindowCheckable:
+    async def test_a_store_entirely_inside_the_window_reports_zero_in_every_bucket(
+        self, temp_db_path: Path
+    ):
+        """The exact shape that made the wrong-axis default invisible: rows exist,
+        the store is large, and no keep-window the prune accepts reaches any of
+        them."""
+        async with StateDB() as db:
+            for _ in range(5):
+                await _seed_message(db, role="action", age_days=1)
+
+            got = await _collect_message_breakdown(db)
+
+        assert all(e["count"] == 0 for e in got["messages_by_age"])
+        assert got["oldest_message_age_days"] == pytest.approx(1.0, abs=0.1)
+
+    async def test_an_older_store_populates_the_buckets_it_passes(self, temp_db_path: Path):
+        """Must-match beside the must-not-match above: the same instrument has to
+        report a non-zero somewhere, or the zeros prove nothing."""
+        async with StateDB() as db:
+            await _seed_message(db, role="action", age_days=40)
+
+            got = await _collect_message_breakdown(db)
+
+        buckets = {e["older_than_days"]: e["count"] for e in got["messages_by_age"]}
+        assert buckets[7] == 1
+        assert buckets[30] == 1
+        assert buckets[90] == 0
+
+    async def test_no_messages_is_not_an_age_of_zero(self, temp_db_path: Path):
+        """An empty store and a store written this instant are different states, and
+        only one of them means a prune has nothing to reach. Collapsing them is
+        the missing-subject-reads-as-empty-subject failure."""
+        async with StateDB() as db:
+            got = await _collect_message_breakdown(db)
+
+        assert got["oldest_message_age_days"] is None
+        assert got["messages_by_role"] == []
+
+    async def test_the_printout_says_so_rather_than_printing_a_number(
+        self, temp_db_path: Path, capsys: pytest.CaptureFixture
+    ):
+        async with StateDB() as db:
+            await _seed_session_aged(db, age_days=0)
+
+        await _print_stats()
+        out = capsys.readouterr().out
+        assert "(no messages)" in out
+        assert "Messages by age:" in out
+
+
+class TestThePruneCannotReportAnOutcomeNothingContradicts:
+    async def test_after_a_real_prune_nothing_its_predicate_selects_remains(
+        self, temp_db_path: Path
+    ):
+        async with StateDB() as db:
+            await _seed_session_aged(db, age_days=60)
+            await _seed_session_aged(db, age_days=60)
+
+        result = await _prune(keep_days=30, keep_n=0, dry_run=False)
+        check = await _prune_candidates(keep_days=30, keep_n=0)
+
+        assert result["sessions"] == 2
+        assert check["candidates"] == 0
+
+    async def test_a_preview_leaves_exactly_what_it_said_it_would_delete(self, temp_db_path: Path):
+        """The pair's other reading, and the one that proves the two SQL uses have
+        not drifted: a preview rolls back, so the recount must return the same
+        number the preview reported, computed by a separate query outside the
+        preview's transaction."""
+        async with StateDB() as db:
+            for _ in range(3):
+                await _seed_session_aged(db, age_days=60)
+
+        preview = await _prune(keep_days=30, keep_n=0, dry_run=True)
+        check = await _prune_candidates(keep_days=30, keep_n=0)
+
+        assert preview["sessions"] == 3
+        assert check["candidates"] == 3
+
+    async def test_the_recount_honours_keep_n_and_not_only_the_age(self, temp_db_path: Path):
+        """keep_n is half the predicate. A recount that read age alone would agree
+        with the prune on every age-only fixture and disagree here."""
+        async with StateDB() as db:
+            for _ in range(4):
+                await _seed_session_aged(db, age_days=60)
+
+        check = await _prune_candidates(keep_days=30, keep_n=3)
+
+        assert check["candidates"] == 1
+
+    async def test_preview_and_recount_agree_on_a_fixture_where_keep_n_binds(
+        self, temp_db_path: Path
+    ):
+        """The drift check has to exercise BOTH halves of the predicate. Every
+        other arm here passes keep_n=0, where the clause cannot change an answer,
+        so a copy that dropped keep_n would agree with the prune throughout and
+        the pair would read as confirming what it never tested."""
+        async with StateDB() as db:
+            for _ in range(5):
+                await _seed_session_aged(db, age_days=60)
+
+        preview = await _prune(keep_days=30, keep_n=2, dry_run=True)
+        check = await _prune_candidates(keep_days=30, keep_n=2)
+
+        assert preview["sessions"] == 3
+        assert check["candidates"] == 3
+
+    async def test_the_oldest_session_age_is_reported_beside_the_count(self, temp_db_path: Path):
+        async with StateDB() as db:
+            await _seed_session_aged(db, age_days=12)
+
+        check = await _prune_candidates(keep_days=30, keep_n=0)
+
+        assert check["candidates"] == 0
+        assert check["oldest_session_age_days"] == pytest.approx(12.0, abs=0.1)
+
+    async def test_no_sessions_reports_no_age_rather_than_zero(self, temp_db_path: Path):
+        async with StateDB() as db:
+            await db.execute("SELECT 1")
+
+        check = await _prune_candidates(keep_days=30, keep_n=0)
+
+        assert check["candidates"] == 0
+        assert check["oldest_session_age_days"] is None

--- a/tests/cli/test_state_retention_readouts.py
+++ b/tests/cli/test_state_retention_readouts.py
@@ -17,6 +17,7 @@ import time
 import uuid
 from pathlib import Path
 
+import anyio
 import pytest
 
 from lionagi.cli.state import (
@@ -24,6 +25,7 @@ from lionagi.cli.state import (
     _print_stats,
     _prune,
     _prune_candidates,
+    run_state,
 )
 from lionagi.state.db import StateDB
 
@@ -218,3 +220,96 @@ class TestThePruneCannotReportAnOutcomeNothingContradicts:
 
         assert check["candidates"] == 0
         assert check["oldest_session_age_days"] is None
+
+
+class TestTheBannerFiresOnTheStateItNames:
+    """The advisory reads the age, and the age means two OPPOSITE things.
+
+    ``oldest_session_age_days`` is taken over every surviving session, not over
+    the candidates, so ``age < keep_days`` says the window reaches nothing when
+    it is read BEFORE the prune, and says the prune WORKED when it is read after
+    a successful one. Both arms are here because a banner tested only where it
+    should print passes just as well when it always prints, and the harmful
+    direction is the one where it always prints: its advice is to lower the
+    window, which deletes more, delivered on the path where nothing was wrong.
+    """
+
+    def _prune_args(self, **overrides):
+        """Args from the real parser, so the fixture cannot drift from the CLI."""
+        import argparse
+
+        from lionagi.cli.state import add_state_subparser
+
+        parser = argparse.ArgumentParser()
+        add_state_subparser(parser.add_subparsers(dest="command"))
+        argv = ["state", "prune"]
+        for flag, value in overrides.items():
+            argv += [f"--{flag.replace('_', '-')}", str(value)]
+        return parser.parse_args(argv)
+
+    def test_it_prints_when_the_window_genuinely_reaches_nothing(
+        self, temp_db_path: Path, capsys: pytest.CaptureFixture
+    ):
+        async def seed():
+            async with StateDB() as db:
+                await _seed_session_aged(db, age_days=12)
+
+        anyio.run(seed)
+
+        assert run_state(self._prune_args(keep_days=30, keep_n=0)) == 0
+        out = capsys.readouterr().out
+
+        assert "deleted 0 session(s)" in out
+        assert "NOTHING IS OLDER THAN --keep-days 30" in out
+
+    def test_it_is_absent_after_a_prune_that_deleted_something(
+        self, temp_db_path: Path, capsys: pytest.CaptureFixture
+    ):
+        """The arm that would have caught this shipping.
+
+        Every survivor of a successful prune is inside the window by
+        construction, so the ungated condition holds on exactly the path where
+        the banner's sentence is false.
+        """
+
+        async def seed():
+            async with StateDB() as db:
+                for _ in range(2):
+                    await _seed_session_aged(db, age_days=60)
+                await _seed_session_aged(db, age_days=1)
+
+        anyio.run(seed)
+
+        assert run_state(self._prune_args(keep_days=30, keep_n=0)) == 0
+        out = capsys.readouterr().out
+
+        assert "deleted 2 session(s)" in out
+        # The survivor is 1 day old, so age < keep_days holds here -- which is
+        # precisely why the age alone cannot decide this.
+        assert "oldest session: " in out
+        assert "NOTHING IS OLDER" not in out
+
+    def test_it_is_absent_when_keep_n_held_the_old_rows_back(
+        self, temp_db_path: Path, capsys: pytest.CaptureFixture
+    ):
+        """The other half of the condition, which the two arms above cannot reach.
+
+        Both of them leave the store younger than the window, so a banner gated
+        on the count alone would satisfy them. Here nothing is deleted and the
+        store IS older than the window -- ``keep_n`` is holding the rows, not the
+        window failing to reach them -- so the advice to lower the window would
+        be wrong for a second, independent reason.
+        """
+
+        async def seed():
+            async with StateDB() as db:
+                for _ in range(2):
+                    await _seed_session_aged(db, age_days=60)
+
+        anyio.run(seed)
+
+        assert run_state(self._prune_args(keep_days=30, keep_n=2)) == 0
+        out = capsys.readouterr().out
+
+        assert "deleted 0 session(s)" in out
+        assert "NOTHING IS OLDER" not in out

--- a/tests/cli/test_state_retention_readouts.py
+++ b/tests/cli/test_state_retention_readouts.py
@@ -222,6 +222,44 @@ class TestThePruneCannotReportAnOutcomeNothingContradicts:
         assert check["oldest_session_age_days"] is None
 
 
+class TestTheMachineResultDescribesTheSameStoreOnBothPaths:
+    """A field that vanishes when the store is absent is worse than one reporting
+    absence, because the caller cannot tell it apart from a field that was never
+    part of the schema.
+
+    The arm asserts the two branches carry the SAME KEY SET rather than checking
+    for particular names. Listing names is what let this through in the first
+    place: three fields were added to the present branch and two to the absent
+    one, and no assertion in the file was about the relationship between them.
+    Written this way the next field added to either branch has to be added to
+    both, and nobody has to remember that it does.
+    """
+
+    async def test_both_branches_carry_the_same_keys(self, temp_db_path: Path):
+        from lionagi.cli.state import _machine_stats_data
+
+        async with StateDB() as db:
+            await _seed_message(db, role="action", age_days=1)
+        present = await _machine_stats_data()
+
+        # Point the reader at a path with no store. The absent branch is reached
+        # by the store being gone, not by an argument, so this is the only way in.
+        missing = temp_db_path.parent / "no-such-store.db"
+        import lionagi.state.db as dbm
+
+        original = dbm.DEFAULT_DB_PATH
+        dbm.DEFAULT_DB_PATH = missing
+        try:
+            absent = await _machine_stats_data()
+        finally:
+            dbm.DEFAULT_DB_PATH = original
+
+        # Positive control: the two calls really did take different branches,
+        # otherwise identical key sets would prove nothing at all.
+        assert present["row_counts"] != absent["row_counts"]
+        assert set(present) == set(absent)
+
+
 class TestTheBannerFiresOnTheStateItNames:
     """The advisory reads the age, and the age means two OPPOSITE things.
 

--- a/tests/mcp/golden_projections/state__stats.json
+++ b/tests/mcp/golden_projections/state__stats.json
@@ -2,7 +2,7 @@
   "path": "state stats",
   "schema": {
     "additionalProperties": false,
-    "description": "Report state.db + state.db-wal sizes, per-table row counts, session status distribution, and SQLite PRAGMAs (journal_mode, wal_autocheckpoint, busy_timeout). Use to spot growth and lock contention.",
+    "description": "Report state.db + state.db-wal sizes, per-table row counts, messages broken down by role and by age, session status distribution, and SQLite PRAGMAs (journal_mode, wal_autocheckpoint, busy_timeout). Use to spot growth and lock contention, and to check before pruning whether the keep-window can reach anything at all.",
     "properties": {},
     "title": "state stats",
     "type": "object"


### PR DESCRIPTION
## What was wrong

`li state stats` reported total row counts. `li state prune` reported success. Neither could say whether the prune's keep-window intersected the data at all, and nothing in either output could contradict the other.

Measured on a live 6.8 GiB store, 1.68M messages:

- 91% of content bytes are on `action` rows
- no message is older than 25 days, so the prune's default `--keep-days 30` reaches none of them
- sessions, meanwhile, reach back 111 days, and a dry run selects 4218 of them

Those last two together are the finding. A dry run reports *"would delete 4218 session(s), 7529 branch(es), 0 orphan message(s)"* — every number correct, and the one that matters is the last. Sessions are the axis the prune selects on; messages hold the bytes; and a message some surviving progression still names is kept whatever its age. So the command can delete thousands of sessions, free nothing, and read as a large success.

## stats

Messages broken down by role and by age, plus the oldest message's age.

Every age bucket prints whether or not a row falls in it. A bucket reading zero is the answer rather than an empty section — it is the thing that says a keep-window of that size can free nothing.

```
Messages by role:
  action            1422593
  assistant          218106
  user                36986
  system               6897

Messages by age:
  older than   7d    1132628
  older than  14d     691785
  older than  30d          0
  older than  90d          0
  oldest             25.0d
```

An empty store reports "(no messages)", not an age of zero. No messages and messages written this instant are different states and only one of them means a prune has nothing to reach.

## prune

Prints a recomputed candidate count beside its result, from a query outside its own transaction:

```
(dry-run) would delete 4218 session(s), 7529 branch(es), 0 orphan message(s)
  still selected by --keep-days 30 --keep-n 100: 4218 (expected 4218)
  oldest session: 111.2d
```

After a real run that count must read zero; after a preview it must equal what the preview reported. A single wrong number is undetectable where a pair is not, and until now nothing contradicted the success line.

The selection predicate moved into one constant both readings use. Two copies of it drifting would make the pair agree while describing different populations, which is worse than having no check at all.

The advisory beneath that pair is gated on the prune's own count, not on the age alone. `oldest_session_age_days` is taken over every surviving session rather than over the candidates, so `age < keep_days` says two opposite things depending on when it is read: before the prune it means the window reaches nothing; after a successful one it means the prune worked and every survivor is now inside the window. Ungated it printed "this reclaimed nothing", plus advice to lower the window, directly beneath "deleted 2000 session(s)" — a false claim and an instruction to delete more, on the one path where nothing was wrong.

## Cost

Counts only, and that is now enforced by an arm rather than by a default.

Per-role byte size was briefly behind a `--content-bytes` flag and has been removed. It reached the MCP surface's projected schema, because the projector reads the argparse parser and there is no way to mark a flag CLI-only, while the machine handler for `state stats` rejects every argument — so the schema would have promised a parameter the handler refuses. The golden projection test caught it, which is exactly the containment that file says it is.

Removed rather than worked around, because the flag's job was saying which role holds the bytes, and the command that reclaims those bytes reports the size of the exact population it is about to touch. Same number, measured where the decision is actually taken, without a 57s scan bolted onto a command that otherwise runs in under two seconds. Measured on the 1.68M-row store: role counts 0.9s, age counts 0.5s, byte sum 57s.

`li state stats` now has no flags and its projected schema has no properties, so the CLI and the machine surface cannot come to describe different commands.

The machine result carries the new fields on **both** branches. It gained three of them where the store is readable and, at first, only two where it is not, so `oldest_message_age_days` did not report absence when the store was gone, it vanished. A missing key is worse than one reporting absence: a caller cannot tell it from a field that was never part of the schema, while its siblings say plainly that the store could not be read.

The arm for that asserts the two branches carry the **same key set**, not that particular names are present. Listing names is what let the asymmetry through, since no assertion was about the relationship *between* the branches and both could be individually correct while disagreeing. Written this way, a field added to either branch has to be added to both. It carries a positive control that the two calls really did take different branches, because identical key sets would otherwise prove nothing.

## Verification

Seven mutations, each with the reddened arm set written down before the run and reconciled arm by arm afterwards. Every one reddened exactly its predicted set, and each run confirmed the mutant was present in the file before reading any result.

1. the recount drops `keep_n` → **2 red**, both keep_n-binding arms
2. an empty store reports age 0.0 instead of None → **2 red**
3. the breakdown sums content unconditionally → **1 red**
4. the age comparison inverted → **2 red**, both histogram arms
5. the advisory's count guard dropped → **1 red**, the many-victim arm
6. the advisory's age comparison dropped → **1 red**, the keep_n-bound arm
7. the absent branch's `oldest_message_age_days` removed → **1 red**, the key-set arm

These were re-run from scratch after the `--content-bytes` removal, with `--maxfail` overridden high. That override is not incidental: the repo's `addopts` carry `--maxfail=5`, so a mutation reddening more arms than that returns a truncated list which is indistinguishable in shape from a complete one — and if the cap happens to land on the predicted number, indistinguishable from a successful reconciliation too.

The advisory has three arms because both halves of its condition need one that discriminates. A zero-victim real run asserts it prints; a many-victim real run asserts it is absent, and that one is the whole point, since every survivor of a successful prune is inside the window by construction; a run where `keep_n` holds old rows back covers the age half, which the first two are blind to because both leave the store younger than the window. Args come from the real parser rather than a hand-built namespace, so the fixture cannot drift from the CLI.

The fixture-to-arm mapping is what made prediction 1 checkable and is worth stating: every other prune arm passes `keep_n=0`, where that clause cannot change an answer, so those arms are blind to half the predicate by construction. Two arms exist specifically to bind it, and without them a copy that dropped `keep_n` would have agreed with the prune throughout.

`tests/cli`, `tests/state` and `tests/mcp`: **4602 passed, 2 skipped, 1 failed**. The failure is `tests/cli/test_agent_depth_wiring.py::test_ndjson_from_cli_inherits_stamped_depth`, which asserts `env is None` while the shell running the suite exports `AI_AGENT`. Unrelated, confirmed failing identically at `origin/main` in a detached worktree, and filed separately.

