### PR TITLE
fix(providers): a denied tool permission is not an unclassified failure

### DIFF
--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -78,6 +78,23 @@ class ProviderTeardownError(ProviderError):
     retryable: ClassVar[bool] = True
 
 
+class ProviderPermissionError(ProviderError):
+    """The turn produced nothing because the CLI could not be granted a tool permission.
+
+    Separate from the adapter catch-all because the two demand opposite
+    responses. An adapter error carries no identified cause and tells a caller
+    nothing it can act on. This one names a configuration defect on THIS side
+    that a person can fix in one line, and it is not a provider fault at all:
+    the provider answered, and answered successfully. A headless CLI cannot
+    prompt for a permission, so a tool call it was not pre-granted is denied and
+    the turn returns empty.
+
+    Not retryable, and the distinction matters more here than elsewhere: an
+    unmodified retry reproduces this exactly, forever, while a consumer reading
+    it as a provider condition waits for an outage that is not happening.
+    """
+
+
 class ProviderAdapterError(ProviderError):
     """A CLI adapter reported a non-success status with no more specific cause
     identified from the message text (e.g. an `agy` turn ending status=ERROR)."""
@@ -173,6 +190,14 @@ _TEARDOWN_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"agy\s+teardown\s+failed:\s*event\s+loop\s+is\s+closed", re.IGNORECASE),
 ]
 
+# A turn that ended with nothing because a tool call could not be permitted.
+# Matched on what the adapter says about the cause rather than on the word
+# "permission" alone, which appears in plenty of unrelated provider text.
+_PERMISSION_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"auto[\s._-]?denied", re.IGNORECASE),
+    re.compile(r"cannot\s+prompt\s+for\s+a?\s*tool\s+permission", re.IGNORECASE),
+]
+
 # Catch-all for adapters (e.g. `agy`) that report a bare non-success status
 # with no parseable cause in the message. Checked last — a more specific
 # pattern above always wins when the adapter's own text names one.
@@ -220,6 +245,16 @@ def classify_provider_error(
     for pat in _TEARDOWN_PATTERNS:
         if pat.search(combined):
             return ProviderTeardownError(content, stderr_tail=stderr_tail, raw=content)
+
+    # Ahead of the adapter catch-all deliberately, and the order is the whole
+    # change rather than a tidiness preference. A permission failure is reported
+    # BY an adapter, so its text can satisfy both patterns; whichever branch runs
+    # first wins, and the catch-all would swallow the specific cause while every
+    # pattern-level test still passed. The arm that pins this feeds a string
+    # matching both.
+    for pat in _PERMISSION_PATTERNS:
+        if pat.search(combined):
+            return ProviderPermissionError(content, stderr_tail=stderr_tail, raw=content)
 
     for pat in _ADAPTER_PATTERNS:
         if pat.search(combined):

--- a/tests/providers/test_provider_permission_error.py
+++ b/tests/providers/test_provider_permission_error.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A denied tool permission is a local configuration defect and gets its own type.
+
+Before this, a turn that produced nothing because a headless CLI could not be
+granted a tool permission arrived as a bare ``ProviderError``, which is the same
+thing an unclassified provider failure arrives as. The two demand opposite
+responses: one is fixed here in one line, the other tells a caller nothing. A
+consumer branching on type could not tell them apart.
+
+No LLM and no network: these call the classifier and read the record.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lionagi.mcp._terminal_cause import allowed_cause_classes, read_terminal_cause
+from lionagi.providers._provider_errors import (
+    ProviderAdapterError,
+    ProviderError,
+    ProviderPermissionError,
+    classify_provider_error,
+)
+
+# Verbatim from lionagi/providers/google/gemini_code.py, where it is raised.
+AUTO_DENY = (
+    "agy reported status=SUCCESS with no response content. "
+    "A tool call was most likely auto-denied, because headless "
+    "print mode cannot prompt for a tool permission. Re-run with "
+    "yolo to auto-approve tools, or add an allow-rule under "
+    "permissions.allow in the agy settings."
+)
+
+
+class TestTheDeniedPermissionGetsItsOwnType:
+    def test_the_auto_deny_message_classifies_as_a_permission_error(self):
+        assert type(classify_provider_error(AUTO_DENY)) is ProviderPermissionError
+
+    def test_it_is_not_retryable(self):
+        """An unmodified retry reproduces this exactly and forever. Marking it
+        retryable would be an instruction to keep paying for the same failure."""
+        assert ProviderPermissionError.retryable is False
+
+    def test_an_adapter_status_with_no_named_cause_still_lands_on_the_adapter_class(self):
+        """The must-NOT-match arm. A pattern loose enough to take this would be
+        relabelling every adapter failure as a permission problem."""
+        got = classify_provider_error("agy returned status=ERROR")
+        assert type(got) is ProviderAdapterError
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "the user denied the request",
+            "permissions are insufficient for this resource",
+            "access to the file was denied by the operating system",
+        ],
+    )
+    def test_unrelated_denial_prose_is_not_taken(self, text):
+        """`denied` and `permission` occur throughout ordinary provider text.
+        Matching either word alone would make this class the catch-all it exists
+        to be distinguished from."""
+        assert type(classify_provider_error(text)) is ProviderError
+
+
+class TestTheBranchOrderIsWhatMakesItReachable:
+    def test_a_message_matching_both_patterns_yields_the_specific_class(self):
+        """The arm the pattern tests cannot reach. A permission failure is
+        reported BY an adapter, so one string can satisfy both catalogues, and
+        then only the ORDER of the branches decides. Every pattern-level
+        assertion above still passes with the catch-all moved in front of the
+        specific check, so without this arm the ordering is untested and the
+        change is inert at the exact site it exists for.
+        """
+        both = "agy returned status=SUCCESS — a tool call was auto-denied"
+
+        from lionagi.providers import _provider_errors as mod
+
+        assert any(p.search(both) for p in mod._PERMISSION_PATTERNS)
+        assert any(p.search(both) for p in mod._ADAPTER_PATTERNS)
+
+        assert type(classify_provider_error(both)) is ProviderPermissionError
+
+
+class TestNothingThatCaughtItBeforeStopsCatching:
+    def test_an_existing_handler_catching_providererror_still_catches_this(self):
+        """Inheritance, asserted rather than assumed, because it is the property
+        this change could break for every caller at once."""
+        with pytest.raises(ProviderError):
+            raise classify_provider_error(AUTO_DENY)
+
+    def test_the_record_admits_the_new_class_name(self):
+        assert "ProviderPermissionError" in allowed_cause_classes()
+
+
+class TestTheRecordsWrittenBeforeThisChangeStillRead:
+    def test_a_historical_record_saying_providererror_is_still_accepted(self, tmp_path):
+        """Every auto-deny already on disk says ProviderError. A reader that only
+        admitted the new name would report nothing across the entire historical
+        population, silently, and any aggregate spanning the change would be
+        computed from one side of it.
+        """
+        target = tmp_path / "cause.json"
+        target.write_text(
+            json.dumps({"class": "ProviderError", "retryable": False, "status_source": "absent"})
+        )
+
+        got = read_terminal_cause(target)
+
+        assert got is not None
+        assert got["class"] == "ProviderError"
+
+    def test_a_record_written_after_this_change_reads_back_as_the_new_class(self, tmp_path):
+        target = tmp_path / "cause.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "class": "ProviderPermissionError",
+                    "retryable": False,
+                    "status_source": "absent",
+                }
+            )
+        )
+
+        got = read_terminal_cause(target)
+
+        assert got is not None
+        assert got["class"] == "ProviderPermissionError"
+
+
+class TestTheHierarchyStaysWhereTheRecordCanSeeIt:
+    def test_every_provider_error_subclass_lives_in_the_module_the_record_imports(self):
+        """``allowed_cause_classes`` walks ``__subclasses__()``, which only sees
+        classes already imported into the running interpreter. That is safe here
+        for one reason and one only: every subclass is defined in the single
+        module the record imports, so importing ``ProviderError`` defines all of
+        them. A subclass added in some other module would be admissible in the
+        writer's process and unknown in the reader's, depending on import order,
+        and nothing would say so.
+
+        Asserting the invariant rather than replacing the derivation: an explicit
+        list is what the derivation was written to avoid, since a class added
+        without a second edit there would silently read back as 'unknown'.
+        """
+        import lionagi.providers._provider_errors as owner
+
+        def walk(cls: type) -> set[type]:
+            found = {cls}
+            for sub in cls.__subclasses__():
+                found |= walk(sub)
+            return found
+
+        strays = {
+            f"{c.__module__}.{c.__name__}"
+            for c in walk(ProviderError) - {ProviderError}
+            if c.__module__ != owner.__name__
+        }
+        assert not strays, f"ProviderError subclasses outside {owner.__name__}: {sorted(strays)}"


### PR DESCRIPTION
## What was conflated

A headless CLI cannot prompt for a tool permission. When a tool call it was not pre-granted comes up, the call is denied and the turn returns empty — and that arrived as a bare `ProviderError`, which is exactly what an unclassified provider failure arrives as.

Those two demand opposite responses:

- an unclassified failure carries no identified cause and tells a caller nothing it can act on
- this one names a configuration defect on *our* side that a person fixes in one line, and it is not a provider fault at all. The provider answered, and answered successfully.

A consumer branching on type could not separate them, so the reasonable reading of the first was applied to the second: wait for the provider. That wait does not terminate, because nothing is down.

## Change

`ProviderPermissionError`, `retryable = False`. An unmodified retry reproduces it exactly and forever.

Matched on what the adapter says about the cause (`auto-denied`, `cannot prompt for a tool permission`) rather than on the word `permission` or `denied` alone, which occur throughout ordinary provider text.

## The branch order is the change

The permission check runs *before* the adapter catch-all, and that ordering is load-bearing rather than tidy. A permission failure is reported **by** an adapter, so a single string can satisfy both catalogues, and then only the order of the branches decides which class comes back. The catch-all in front would swallow the specific cause while every pattern-level assertion still passed.

One arm therefore feeds a string matching both catalogues, and asserts both memberships before asserting the outcome.

## Nothing keyed on retryable moves

The auto-deny text says `agy reported status=` while the adapter catalogue matches `agy returned status=`. Different verb, so it never reached the adapter class and fell through to base `ProviderError` — also `retryable = False`. `RunReasons` splits `FAILED_PROVIDER_RETRYABLE` from `FAILED_PROVIDER_NONRETRYABLE` on that attribute, and the split is unchanged for this message.

## An invariant the record quietly depends on

`allowed_cause_classes()` derives admissible names by walking `__subclasses__()`, which only sees classes already imported into the running interpreter. That is safe here for exactly one reason: every subclass lives in the single module the record imports, so importing `ProviderError` defines all of them.

A subclass added in some other module would be admissible in the writer's process and unknown in the reader's, depending on import order, and nothing would say so. A test now asserts the invariant, rather than replacing the derivation with the explicit list the derivation was written to avoid — a class added without a second edit to that list would silently read back as `unknown`, which is the failure the derivation prevents.

## Records written before this change

Every auto-deny already on disk says `ProviderError`. The reader accepts both names, and an arm pins it: a consumer keyed only on the new name would read zero across the entire historical population, silently, and any aggregate spanning the change would be computed from one side of it.

## Necessary, and not sufficient, for a consumer that walks the MRO

Stated because the section above could otherwise be read as a claim that typing the error fixes the consumers downstream of it. It does not, for at least one real consumer, and the mechanism is worth knowing.

A classifier that builds its search text from the exception's ancestry —

```python
names = " ".join(t.__name__ for t in type(exc).__mro__)
text = f"{names} {exc!r}"
if any(m in text for m in ("ProviderError", "RateLimit", "ServiceUnavailable")):
    return "provider-outage"
```

— matches `ProviderError` for *every* subclass of it, because that name is in the MRO by construction. Measured on this branch:

```
classified as: ProviderPermissionError
MRO names: ProviderPermissionError ProviderError RuntimeError Exception BaseException object
'ProviderError' in text -> True
```

So a more specific class cannot escape a substring test over its own ancestry. That is not a weakness of the class; it is what a subclass is. Such a consumer needs its own check placed *ahead* of the broad one — the same branch-order property this PR fixes here, holding identically there.

Two things follow for anyone writing that check. Key it on the message text, which works against a deployment that does not yet carry this change; and note that every record already on disk names `ProviderError`, so a check keyed only on the new name reads zero across the entire historical population, silently. The type is the durable second matcher, because it survives rewording where prose does not. It is not the first one.

What this PR does is make the cause nameable and stable. Making it *reachable* is a change at each consumer that currently answers the question with a substring test.

## Verification

Four mutations, each with the reddened arm set stated before the run and reconciled after. Every one matched exactly.

1. permission loop moved after the adapter loop → **1 red**, the ordering arm alone
2. permission patterns emptied → **2 red**
3. pattern loosened to bare `denied` → **2 red**
4. a `ProviderError` subclass defined outside the owning module → **1 red**

Prediction 1 is the one worth stating the fixture reasoning for. The real auto-deny text cannot match the adapter pattern (`reported` vs `returned`), so it cannot test branch order however it is classified — it stays green under that mutation, and only the purpose-built both-matching string reddens. Without that arm the ordering would be untested and the change inert at the exact site it exists for.

`tests/providers` and `tests/mcp`: 1418 passed, 3 xfailed (pre-existing, unrelated — the `pi` adapter conformance divergence).
