### PR TITLE
feat(state): reclaim the message bodies the session prune cannot reach

### DIFF
--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -194,7 +194,7 @@ against rather than a copy of it.
 
 ## Operations the surface does not offer
 
-Twenty-nine further names are catalogued as **unavailable**, each with its
+Thirty further names are catalogued as **unavailable**, each with its
 reason. They are not omissions: a caller that asks what exists gets the name and
 why it cannot be called, which is a different answer from the name never having
 been considered. The right-hand column below abbreviates the reason; `help=true`
@@ -216,6 +216,7 @@ returns each one in full.
 | `state.import-teams` | Writes against the lifecycle store. | invalidating write |
 | `state.prune` | Writes against the lifecycle store. | invalidating write |
 | `state.vacuum` | Writes against the lifecycle store. | invalidating write |
+| `state.null-content` | Reclaiming the space held by old message bodies. | irreversible loss |
 | `hooks.import` | Importing hook commands from another tool's config. | grants privilege |
 | `plugin.disable` | Plugin bundle enablement. | grants privilege |
 | `plugin.enable` | Plugin bundle enablement. | grants privilege |

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -10,7 +10,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from lionagi.state.content_pruned import CONTENT_PRUNED_KEY
+from lionagi.state.content_pruned import CONTENT_PRUNED_KEY, pruned_content_sql
 
 from ._runs import RUNS_ROOT
 from ._util import EXIT_CODE_BY_STATUS
@@ -773,6 +773,7 @@ async def _prune(
 _NULL_CONTENT_TARGETS = (
     "FROM messages "
     "WHERE created_at < :cutoff "
+    "  AND content IS NOT NULL "
     f"  AND json_extract(content, '$.{CONTENT_PRUNED_KEY}') IS NULL"
 )
 
@@ -872,10 +873,8 @@ async def _null_content(
     """
     import time as _time
 
-    from sqlalchemy import bindparam, text
-    from sqlalchemy.types import JSON
+    from sqlalchemy import text
 
-    from lionagi.state.content_pruned import pruned_content
     from lionagi.state.db import StateDB
 
     now = _time.time()
@@ -919,26 +918,26 @@ async def _null_content(
                 target_count = int(measured["n"])
                 bytes_before = int(measured["b"])
 
-                # Every reclaimed row gets the same marker, so the original size
-                # it records is the batch's average rather than its own. The
-                # alternative is a statement per row, which on a million-row
-                # store is a different operation entirely; the per-row number is
-                # not worth that, and calling it what it is costs nothing.
-                marker = pruned_content(
-                    at=now,
-                    original_bytes=(bytes_before // target_count) if target_count else 0,
-                )
+                # The marker is built in SQL rather than in Python so that
+                # LENGTH(content) is evaluated against each row as it is
+                # overwritten. That makes original_bytes the row's OWN size in a
+                # single statement -- the alternative, one marker computed here
+                # and written everywhere, records a batch average under a
+                # per-row name.
                 await conn.execute(
                     text(
-                        "UPDATE messages SET content = :marker "
+                        # noqa on the interpolation: pruned_content_sql() takes
+                        # no argument here, so the expression is a constant of
+                        # this module's making and the only value crossing the
+                        # boundary is :at, which is bound.
+                        f"UPDATE messages SET content = {pruned_content_sql()} "  # noqa: S608
                         "WHERE id IN (SELECT id FROM null_content_batch)"
-                    ).bindparams(bindparam("marker", type_=JSON)),
-                    {"marker": marker},
+                    ),
+                    {"at": now},
                 )
 
                 # Read back inside the same transaction: what the markers
-                # actually occupy, rather than the length of the one Python
-                # rendered. SQLite stores this column and is the only authority
+                # actually occupy. SQLite wrote them and is the only authority
                 # on how much of it is there.
                 bytes_after = int(
                     (

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -10,6 +10,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from lionagi.state.content_pruned import CONTENT_PRUNED_KEY
+
 from ._runs import RUNS_ROOT
 from ._util import EXIT_CODE_BY_STATUS
 
@@ -32,6 +34,9 @@ __all__ = [
     "_checkpoint",
     "_vacuum",
     "_prune",
+    "_null_content",
+    "_null_content_candidates",
+    "_null_content_targets",
     "_doctor",
     # CLI entrypoints
     "add_state_subparser",
@@ -758,6 +763,213 @@ async def _prune(
     return counts
 
 
+# Which message bodies the reclaim replaces, written once so the operation and
+# the recount below cannot describe different populations. Two copies of this
+# drifting apart would make the pair agree while counting different rows, which
+# is worse than printing no check at all.
+#
+# The already-reclaimed exclusion is what makes a second run of the same command
+# a no-op instead of a marker rewrite that reports work it did not do.
+_NULL_CONTENT_TARGETS = (
+    "FROM messages "
+    "WHERE created_at < :cutoff "
+    f"  AND json_extract(content, '$.{CONTENT_PRUNED_KEY}') IS NULL"
+)
+
+
+def _null_content_targets(roles: tuple[str, ...]) -> str:
+    """The predicate, with the role filter appended when one was asked for."""
+    if not roles:
+        return _NULL_CONTENT_TARGETS
+    placeholders = ",".join(f":role{i}" for i in range(len(roles)))
+    return f"{_NULL_CONTENT_TARGETS} AND role IN ({placeholders})"
+
+
+def _null_content_params(*, cutoff: float, roles: tuple[str, ...]) -> dict[str, Any]:
+    params: dict[str, Any] = {"cutoff": cutoff}
+    for i, role in enumerate(roles):
+        params[f"role{i}"] = role
+    return params
+
+
+async def _null_content_candidates(
+    *,
+    older_than_days: int,
+    roles: tuple[str, ...],
+) -> dict[str, Any]:
+    """Recount what the reclaim's own predicate still selects, and their size.
+
+    Printed beside the result so the command cannot report an outcome nothing
+    contradicts. After a real run this has to read zero; after a preview it has
+    to equal what the preview reported. A single number is undetectable when it
+    is wrong, and a pair is not.
+
+    Runs outside the operation's transaction deliberately: inside it, it would
+    be reading the same uncommitted rows the operation just wrote and would
+    agree with it by construction.
+    """
+    import time as _time
+
+    from sqlalchemy import text
+
+    from lionagi.state.db import StateDB
+
+    cutoff = _time.time() - (older_than_days * 86400)
+    params = _null_content_params(cutoff=cutoff, roles=roles)
+    where = _null_content_targets(roles)
+
+    async with StateDB() as db:
+        async with db._read() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text(  # noqa: S608
+                            f"SELECT COUNT(*) AS n, "
+                            f"COALESCE(SUM(LENGTH(content)), 0) AS b, "
+                            f"MIN(created_at) AS oldest {where}"
+                        ),
+                        params,
+                    )
+                )
+                .mappings()
+                .first()
+            )
+
+    oldest = row["oldest"] if row else None
+    return {
+        "candidates": int(row["n"]) if row else 0,
+        "bytes": int(row["b"]) if row else 0,
+        # None rather than 0.0 when nothing is selected: no rows and rows
+        # written this instant are different states, and only one of them means
+        # the window has nothing to reach.
+        "oldest_age_days": None if oldest is None else (_time.time() - oldest) / 86400.0,
+    }
+
+
+async def _null_content(
+    *,
+    older_than_days: int,
+    roles: tuple[str, ...],
+    dry_run: bool,
+) -> dict[str, int]:
+    """Replace old message bodies with a marker, keeping every row and reference.
+
+    This exists because the prune cannot reach these bytes. The prune selects
+    SESSIONS; the bytes live on MESSAGES; and a message some surviving
+    progression still names is kept whatever its age. So a store can be almost
+    entirely message content, have every message inside a keep-window, and give
+    a prune nothing to delete.
+
+    The row, its id, its role, its timestamp and its place in every progression
+    all survive. What is dropped is the body, and in its place goes a value that
+    says a body was there and how large it was, so the removal stays legible
+    instead of reading as a turn that produced nothing.
+
+    ``dry_run`` performs the update and rolls it back, so the reported numbers
+    are measurements of the operation rather than an estimate of it. That makes
+    a preview a WRITE that takes the same lock for the same duration -- it is
+    not a read, and on a large store it is not a quick one.
+    """
+    import time as _time
+
+    from sqlalchemy import bindparam, text
+    from sqlalchemy.types import JSON
+
+    from lionagi.state.content_pruned import pruned_content
+    from lionagi.state.db import StateDB
+
+    now = _time.time()
+    cutoff = now - (older_than_days * 86400)
+    params = _null_content_params(cutoff=cutoff, roles=roles)
+    where = _null_content_targets(roles)
+
+    counts = {"messages": 0, "bytes_before": 0, "bytes_after": 0}
+
+    async with StateDB() as db:
+        try:
+            async with db._tx() as conn:
+                # The batch is pinned to a scratch table before anything is
+                # written, because both measurements have to be about the same
+                # rows and the predicate stops selecting them the moment the
+                # update lands. It also keeps the after-size away from markers
+                # an earlier run left behind, which the predicate excludes but a
+                # sum over "rows carrying a marker" would quietly re-include.
+                await conn.execute(text("DROP TABLE IF EXISTS null_content_batch"))
+                await conn.execute(
+                    text("CREATE TEMPORARY TABLE null_content_batch (id TEXT PRIMARY KEY)")
+                )
+                await conn.execute(
+                    text(f"INSERT INTO null_content_batch (id) SELECT id {where}"),  # noqa: S608
+                    params,
+                )
+
+                measured = (
+                    (
+                        await conn.execute(
+                            text(
+                                "SELECT COUNT(*) AS n, "
+                                "COALESCE(SUM(LENGTH(content)), 0) AS b "
+                                "FROM messages WHERE id IN (SELECT id FROM null_content_batch)"
+                            )
+                        )
+                    )
+                    .mappings()
+                    .first()
+                )
+                target_count = int(measured["n"])
+                bytes_before = int(measured["b"])
+
+                # Every reclaimed row gets the same marker, so the original size
+                # it records is the batch's average rather than its own. The
+                # alternative is a statement per row, which on a million-row
+                # store is a different operation entirely; the per-row number is
+                # not worth that, and calling it what it is costs nothing.
+                marker = pruned_content(
+                    at=now,
+                    original_bytes=(bytes_before // target_count) if target_count else 0,
+                )
+                await conn.execute(
+                    text(
+                        "UPDATE messages SET content = :marker "
+                        "WHERE id IN (SELECT id FROM null_content_batch)"
+                    ).bindparams(bindparam("marker", type_=JSON)),
+                    {"marker": marker},
+                )
+
+                # Read back inside the same transaction: what the markers
+                # actually occupy, rather than the length of the one Python
+                # rendered. SQLite stores this column and is the only authority
+                # on how much of it is there.
+                bytes_after = int(
+                    (
+                        (
+                            await conn.execute(
+                                text(
+                                    "SELECT COALESCE(SUM(LENGTH(content)), 0) AS b "
+                                    "FROM messages "
+                                    "WHERE id IN (SELECT id FROM null_content_batch)"
+                                )
+                            )
+                        )
+                        .mappings()
+                        .first()
+                    )["b"]
+                )
+                await conn.execute(text("DROP TABLE IF EXISTS null_content_batch"))
+
+                counts = {
+                    "messages": target_count,
+                    "bytes_before": bytes_before,
+                    "bytes_after": bytes_after,
+                }
+                if dry_run:
+                    raise _PreviewOnlyError(counts)
+        except _PreviewOnlyError as preview:
+            return preview.counts
+
+    return counts
+
+
 async def _doctor(
     *,
     stale_hours: int,
@@ -1168,6 +1380,59 @@ def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="Print what WOULD be deleted, but don't actually delete.",
     )
 
+    # li state null-content — reclaim message bodies the prune cannot reach
+    nullc = state_sub.add_parser(
+        "null-content",
+        help="Replace old message bodies with a marker, keeping the rows.",
+        description=(
+            "Reclaim the space held by message bodies older than --older-than "
+            "days, keeping every row, id, role, timestamp and progression "
+            "reference. THIS IS WHERE THE BYTES ARE, and prune cannot reach "
+            "them: prune selects SESSIONS, and a message any surviving "
+            "progression still names is kept whatever its age. A store can "
+            "therefore be almost entirely message content, have every message "
+            "inside a keep-window, and give a prune nothing to delete.\n\n"
+            "A reclaimed body is not emptied. It is replaced with a marker "
+            "recording that a body was there and how large it was, so it stays "
+            "distinguishable from a turn that genuinely produced nothing. "
+            "Reclaiming is not reversible: the text is gone.\n\n"
+            "The file does not shrink. Freed pages return to the database's own "
+            "free list and the bytes on disk stay where they are until "
+            "`li state vacuum` rebuilds the file.\n\n"
+            "--dry-run is not a read. It performs the update and rolls it back, "
+            "so its numbers measure the operation instead of estimating it, and "
+            "it takes the same write lock for the same duration."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    nullc.add_argument(
+        "--older-than",
+        type=int,
+        required=True,
+        metavar="DAYS",
+        help=(
+            "Reclaim bodies older than N days. Required and deliberately has no "
+            "default: there is no age that is safe to assume for an "
+            "irreversible operation."
+        ),
+    )
+    nullc.add_argument(
+        "--role",
+        action="append",
+        default=None,
+        metavar="ROLE",
+        help=(
+            "Limit to messages with this role; repeatable. Omitted means every "
+            "role. Check `li state stats` first — the roles are not evenly "
+            "sized, and one of them usually holds most of the bytes."
+        ),
+    )
+    nullc.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Perform the reclaim and roll it back, reporting what it measured.",
+    )
+
     # li state doctor — sweep stale 'running' sessions
     doctor = state_sub.add_parser(
         "doctor",
@@ -1261,6 +1526,42 @@ def run_state(args: argparse.Namespace) -> int:
             f"{result['branches']} branch(es), "
             f"{result['messages']} orphan message(s)"
         )
+        return 0
+
+    if args.state_command == "null-content":
+        roles = tuple(args.role or ())
+        result = run_async(
+            _null_content(
+                older_than_days=args.older_than,
+                roles=roles,
+                dry_run=args.dry_run,
+            )
+        )
+        prefix = "(dry-run) would reclaim" if args.dry_run else "reclaimed"
+        scope = f"role(s) {', '.join(roles)}" if roles else "every role"
+        freed = result["bytes_before"] - result["bytes_after"]
+        print(
+            f"{prefix} {result['messages']} message body(ies) older than "
+            f"{args.older_than}d, {scope}"
+        )
+        print(
+            f"  content size: {_format_bytes(result['bytes_before'])} → "
+            f"{_format_bytes(result['bytes_after'])} "
+            f"(freed {_format_bytes(freed)} inside the DB)"
+        )
+        # Recomputed from the same predicate, outside the operation's
+        # transaction. A real run has to leave nothing selected; a preview has
+        # to leave exactly what it reported. Until this line existed the success
+        # line was a number with nothing to contradict it.
+        check = run_async(_null_content_candidates(older_than_days=args.older_than, roles=roles))
+        expected = result["messages"] if args.dry_run else 0
+        print(
+            f"  still selected by --older-than {args.older_than}: "
+            f"{check['candidates']} (expected {expected})"
+        )
+        if check["oldest_age_days"] is not None:
+            print(f"  oldest still selected: {check['oldest_age_days']:.1f}d")
+        print("  the file does not shrink until `li state vacuum`")
         return 0
 
     if args.state_command == "doctor":
@@ -1364,6 +1665,7 @@ def machine_result(argv: list[str]) -> dict[str, Any]:
             "checkpoint": "it checkpoints the write-ahead log",
             "vacuum": "it rebuilds the database file",
             "prune": "it deletes rows",
+            "null-content": "it destroys message bodies, which is an irreversible write",
             "doctor": "it sweeps stale rows to a new status, which is a write",
         },
     )

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -765,6 +765,16 @@ _LONG_RUNNING = (
     "it is a process to start, not a call to make"
 )
 
+# Separate from _STORE_MUTATION, whose objection is that a write invalidates
+# answers the caller already holds. That one is about consistency and would be
+# answerable by a better result shape. This one is not: the content is gone, and
+# no reply a machine seam could return would undo the call that asked for it.
+_IRREVERSIBLE_LOSS = (
+    "it destroys message content permanently — the rows and their references "
+    "survive but the bodies do not, and nothing a machine result could say would "
+    "give a caller back what its own call removed"
+)
+
 
 ABSENT: tuple[AbsentVerb, ...] = (
     AbsentVerb(
@@ -814,6 +824,12 @@ ABSENT: tuple[AbsentVerb, ...] = (
         ("checkpoint", "prune", "vacuum", "import", "import-teams"),
         "Writes against the lifecycle store.",
         _STORE_MUTATION,
+    ),
+    *_absent(
+        "state",
+        ("null-content",),
+        "Reclaiming the space held by old message bodies.",
+        _IRREVERSIBLE_LOSS,
     ),
     *_absent(
         "studio",

--- a/lionagi/state/content_pruned.py
+++ b/lionagi/state/content_pruned.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The marker a reclaimed message body leaves in its place.
+
+Freeing space by emptying a message's content has one failure mode that
+matters, and it is not losing the text. It is losing the fact that text was
+ever there. A body written as an empty string, or as ``{}``, is exactly what a
+turn that genuinely produced nothing writes, so a reader handed one cannot say
+which it is looking at, and neither can anything above it: nothing downstream
+has a second source for that distinction, so the two collapse into one state
+permanently and silently.
+
+A reclaimed body is therefore not emptied. It is replaced by a value that says
+what it is and what used to be there, and this module is the vocabulary both
+sides use. The writer is ``li state null-content``; the readers are whatever
+displays or counts message bodies. Kept out of ``db.py`` so asking the question
+costs a reader nothing but this import.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = [
+    "CONTENT_PRUNED_KEY",
+    "pruned_content",
+    "content_was_pruned",
+]
+
+# The single key a reclaimed body carries. Prefixed rather than named something
+# like "pruned" because it shares a namespace with every content shape lionagi
+# writes -- instruction, assistant_response, function/arguments, and whatever a
+# future message type introduces -- and a collision would make a real body read
+# as reclaimed.
+CONTENT_PRUNED_KEY = "lion_content_pruned"
+
+
+def pruned_content(*, at: float, original_bytes: int) -> dict[str, Any]:
+    """The value a reclaimed message body is replaced with.
+
+    Carries when the reclaim happened and how large the body was, because a
+    marker that only says "gone" cannot answer the question the reclaim was
+    performed to answer: how much the operation actually recovered, after the
+    fact, from the store itself rather than from a number a command printed
+    once.
+    """
+    return {CONTENT_PRUNED_KEY: {"at": at, "original_bytes": original_bytes}}
+
+
+def content_was_pruned(content: Any) -> bool:
+    """True when this body was reclaimed, as opposed to having been empty.
+
+    Takes the column either raw (the JSON text SQLite stores) or hydrated (the
+    dict a reader has already parsed), because those reach consumers by
+    different routes and a predicate that only served one of them would answer
+    "no" for the other -- which is the same wrong answer as having no marker at
+    all, arrived at more expensively.
+
+    Anything unparseable is not reclaimed. This says nothing about the body
+    being well-formed; it answers one question only.
+    """
+    if isinstance(content, str):
+        # A marker is a few dozen bytes and a body can be megabytes. The
+        # substring test is what keeps this from parsing every row it is handed
+        # -- and it only ever short-circuits to False, so a body that merely
+        # mentions the key still goes through the parse below and is judged on
+        # its structure rather than on its text.
+        if CONTENT_PRUNED_KEY not in content:
+            return False
+        try:
+            content = json.loads(content)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return False
+    return isinstance(content, dict) and CONTENT_PRUNED_KEY in content

--- a/lionagi/state/content_pruned.py
+++ b/lionagi/state/content_pruned.py
@@ -16,6 +16,13 @@ what it is and what used to be there, and this module is the vocabulary both
 sides use. The writer is ``li state null-content``; the readers are whatever
 displays or counts message bodies. Kept out of ``db.py`` so asking the question
 costs a reader nothing but this import.
+
+A marker records ``at`` and ``original_bytes``, and ``original_bytes`` is the
+size of the body THAT ROW held rather than an average over whatever batch it was
+reclaimed in. That is a property of how the marker is written -- see
+``pruned_content_sql`` -- and it is stated here because this is the docstring a
+reader of the marker reaches for, and a per-row name over a batch number would
+fabricate exactly the kind of fact the marker exists to preserve.
 """
 
 from __future__ import annotations
@@ -25,7 +32,7 @@ from typing import Any
 
 __all__ = [
     "CONTENT_PRUNED_KEY",
-    "pruned_content",
+    "pruned_content_sql",
     "content_was_pruned",
 ]
 
@@ -37,16 +44,27 @@ __all__ = [
 CONTENT_PRUNED_KEY = "lion_content_pruned"
 
 
-def pruned_content(*, at: float, original_bytes: int) -> dict[str, Any]:
-    """The value a reclaimed message body is replaced with.
+def pruned_content_sql(*, at_param: str = "at", size_expr: str = "LENGTH(content)") -> str:
+    """The marker as a SQL expression, evaluated per row against the row it replaces.
 
-    Carries when the reclaim happened and how large the body was, because a
-    marker that only says "gone" cannot answer the question the reclaim was
-    performed to answer: how much the operation actually recovered, after the
-    fact, from the store itself rather than from a number a command printed
-    once.
+    A marker records ``at`` and ``original_bytes``. The size is built from an
+    expression over the row being replaced rather than passed in, and that is the
+    whole reason this is SQL rather than a dict: the database can read each old
+    body's length while overwriting it, in one statement, so ``original_bytes``
+    is the row's OWN size.
+
+    The alternative -- computing one size in Python and writing the same marker
+    everywhere -- makes the field a batch average wearing a per-row name. That
+    number is not wrong so much as answering a different question than its label,
+    which is the failure the marker exists to prevent rather than commit.
+
+    ``size_expr`` is a caller-supplied SQL fragment and is not a place to put
+    anything a caller did not write; the default is the only production use.
     """
-    return {CONTENT_PRUNED_KEY: {"at": at, "original_bytes": original_bytes}}
+    return (
+        f"json_object('{CONTENT_PRUNED_KEY}', "
+        f"json_object('at', :{at_param}, 'original_bytes', {size_expr}))"
+    )
 
 
 def content_was_pruned(content: Any) -> bool:

--- a/tests/cli/test_state_null_content.py
+++ b/tests/cli/test_state_null_content.py
@@ -35,7 +35,6 @@ from lionagi.cli.state import (
 from lionagi.state.content_pruned import (
     CONTENT_PRUNED_KEY,
     content_was_pruned,
-    pruned_content,
 )
 from lionagi.state.db import StateDB
 
@@ -175,11 +174,71 @@ class TestAReclaimedBodyIsDistinguishableFromAnEmptyOne:
 
         assert content_was_pruned(forged) is False
 
-    def test_the_marker_records_that_a_body_was_there_and_how_large(self):
-        marker = pruned_content(at=1.0, original_bytes=4096)
+    async def test_the_marker_records_the_size_of_the_body_that_row_held(self, temp_db_path):
+        """original_bytes is per-row, and this is the arm that keeps it honest.
 
-        assert marker[CONTENT_PRUNED_KEY]["original_bytes"] == 4096
-        assert marker[CONTENT_PRUNED_KEY]["at"] == 1.0
+        The marker is written by a SQL expression so LENGTH(content) is
+        evaluated against each row as it is overwritten. Computing one size in
+        Python and writing the same marker everywhere would record a batch
+        average under a per-row name -- a number that is not wrong so much as
+        answering a different question than its label, which is the failure the
+        marker exists to prevent rather than commit.
+
+        The fixture is two bodies of deliberately different sizes, because a
+        batch average and a per-row size are the SAME NUMBER for any fixture
+        whose rows are equal, and such a fixture cannot tell the two apart.
+        """
+        async with StateDB() as db:
+            await _seed_message(
+                db, mid="small", age_days=40, content={"assistant_response": "x" * 10}
+            )
+            await _seed_message(
+                db, mid="big", age_days=40, content={"assistant_response": "x" * 5000}
+            )
+            small_before = len(await _raw_content(db, "small"))
+            big_before = len(await _raw_content(db, "big"))
+
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            small = (await db.get_message("small"))["content"][CONTENT_PRUNED_KEY]
+            big = (await db.get_message("big"))["content"][CONTENT_PRUNED_KEY]
+
+        assert small["original_bytes"] == small_before
+        assert big["original_bytes"] == big_before
+        # The average of the two would be identical for both rows.
+        assert small["original_bytes"] != big["original_bytes"]
+
+    async def test_the_marker_carries_when_it_happened(self, temp_db_path):
+        before = time.time()
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40)
+
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            marker = (await db.get_message("old"))["content"][CONTENT_PRUNED_KEY]
+
+        assert before <= marker["at"] <= time.time()
+
+    async def test_the_stored_marker_has_exactly_the_documented_shape(self, temp_db_path):
+        """The marker is built in SQL, so nothing in Python states its shape.
+
+        This arm is that statement, written out independently: a field added or
+        renamed on the SQL side without the readers being told turns this red
+        instead of silently changing a format that is permanent once rows carry
+        it.
+        """
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40)
+
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            content = (await db.get_message("old"))["content"]
+
+        assert set(content) == {CONTENT_PRUNED_KEY}
+        assert set(content[CONTENT_PRUNED_KEY]) == {"at", "original_bytes"}
 
 
 class TestTheReclaimSelectsOnTheAxisTheBytesLiveOn:
@@ -296,6 +355,38 @@ class TestTheReclaimCannotReportAnOutcomeNothingContradicts:
         async with StateDB() as db:
             got = await db.get_message("old")
         assert got["content"][CONTENT_PRUNED_KEY]["original_bytes"] > 0
+
+    async def test_a_row_with_no_body_at_all_could_not_be_marked_as_having_had_one(
+        self, temp_db_path
+    ):
+        """A NULL body satisfies ``json_extract(...) IS NULL`` the same way an
+        unreclaimed body does, so without a clause of its own it would be handed
+        a marker asserting a body was there -- fabricating the one fact the
+        marker exists to preserve.
+
+        Two things stand between the store and that state, and this arm is here
+        because they are different kinds of thing. The predicate carries
+        ``content IS NOT NULL``, which is cheap and correct whatever the schema
+        does. The schema carries ``NOT NULL`` on the column, which is what makes
+        the state unreachable TODAY -- so the arm asserts the constraint rather
+        than pretending to construct a row it cannot construct. If that
+        constraint is ever relaxed this turns red at the same moment the
+        predicate's clause becomes the only thing left.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40)
+            # Positive control: the write path reaches the row at all, so a
+            # rejection below is the constraint and not a statement that missed.
+            await db.execute("UPDATE messages SET role = 'action' WHERE id = 'old'")
+            assert (await db.get_message("old"))["role"] == "action"
+
+            with pytest.raises(IntegrityError, match="NOT NULL"):
+                await db.execute("UPDATE messages SET content = NULL WHERE id = 'old'")
+
+        assert "content IS NOT NULL" in _null_content_targets(())
+        assert "content IS NOT NULL" in _null_content_targets(("action",))
 
     def test_both_readings_are_built_from_one_predicate(self):
         """The operation and the recount call the same builder. Two copies of

--- a/tests/cli/test_state_null_content.py
+++ b/tests/cli/test_state_null_content.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reclaiming a message body has to stay distinguishable from never having one.
+
+The prune selects sessions. The bytes live on messages, and a message any
+surviving progression still names is kept whatever its age, so a store can be
+almost entirely message content, have every message inside the keep-window, and
+give a prune nothing to delete. This command selects on the axis the bytes are
+actually on.
+
+The condition that shapes it: an emptied body is indistinguishable from a turn
+that genuinely produced nothing, and nothing downstream has a second source for
+that distinction, so the two would collapse into one state permanently. A
+reclaimed body therefore carries a marker, and the arms that matter most here
+assert the difference is visible AT THE CONSUMER rather than at the writer --
+the writer knowing what it wrote is not the property anyone depends on.
+
+No LLM and no network: these run against a temp SQLite file.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli.state import (
+    _null_content,
+    _null_content_candidates,
+    _null_content_targets,
+)
+from lionagi.state.content_pruned import (
+    CONTENT_PRUNED_KEY,
+    content_was_pruned,
+    pruned_content,
+)
+from lionagi.state.db import StateDB
+
+DAY = 86400.0
+
+
+@pytest.fixture
+def temp_db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Per-test temp file DB: patches DEFAULT_DB_PATH so StateDB() opens it."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+    return db_path
+
+
+async def _seed_message(
+    db: StateDB,
+    *,
+    mid: str,
+    age_days: float,
+    role: str = "assistant",
+    content: dict | None = None,
+) -> str:
+    await db.insert_message(
+        {
+            "id": mid,
+            "created_at": time.time() - age_days * DAY,
+            "node_metadata": {"lion_class": "AssistantResponse"},
+            "content": {"assistant_response": "x" * 500} if content is None else content,
+            "embedding": None,
+            "sender": "s",
+            "recipient": "r",
+            "channel": None,
+            "role": role,
+        }
+    )
+    return mid
+
+
+async def _raw_content(db: StateDB, mid: str) -> str | None:
+    """The column as SQLite holds it, before any reader hydrates it."""
+    from sqlalchemy import text
+
+    async with db._read() as conn:
+        row = (
+            (await conn.execute(text("SELECT content FROM messages WHERE id = :id"), {"id": mid}))
+            .mappings()
+            .first()
+        )
+    return None if row is None else row["content"]
+
+
+class TestAReclaimedBodyIsDistinguishableFromAnEmptyOne:
+    """The condition the whole design turns on, asserted where it has to hold."""
+
+    async def test_a_reclaimed_body_reads_as_reclaimed_through_get_message(self, temp_db_path):
+        """The consumer is StateDB.get_message, not the command that wrote it.
+
+        A writer can always tell what it just wrote. The property anyone
+        downstream depends on is that a reader arriving later, with no memory of
+        the operation, can still tell.
+        """
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40)
+
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            got = await db.get_message("old")
+
+        assert got is not None
+        assert content_was_pruned(got["content"]) is True
+
+    async def test_a_body_that_was_genuinely_empty_does_not_read_as_reclaimed(self, temp_db_path):
+        """The must-NOT-match half. Without this, a predicate that answered True
+        for everything would satisfy the arm above and destroy the distinction
+        it exists to make."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="empty", age_days=40, content={})
+            got = await db.get_message("empty")
+
+        assert got is not None
+        assert content_was_pruned(got["content"]) is False
+
+    async def test_a_body_holding_an_empty_string_does_not_read_as_reclaimed(self, temp_db_path):
+        """The shape a turn that produced nothing actually writes -- a real
+        content key with nothing in it, which is the case the marker exists to
+        stay separable from."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="blank", age_days=40, content={"assistant_response": ""})
+            got = await db.get_message("blank")
+
+        assert got is not None
+        assert content_was_pruned(got["content"]) is False
+
+    async def test_the_marker_is_never_null_and_never_an_empty_string(self, temp_db_path):
+        """Named separately from the predicate because a marker could satisfy
+        content_was_pruned and still be written as something a different reader
+        -- one that never imports this module -- reads as absence."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40)
+
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            raw = await _raw_content(db, "old")
+            got = await db.get_message("old")
+
+        assert raw is not None
+        assert raw != ""
+        assert got["content"] is not None
+        assert got["content"] != {}
+        assert got["content"] != ""
+
+    async def test_the_predicate_answers_the_same_raw_and_hydrated(self, temp_db_path):
+        """Consumers reach this column by two routes -- the raw JSON text and an
+        already-parsed dict -- and a predicate serving only one of them returns
+        the wrong answer for the other, which is the same failure as having no
+        marker at all."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40)
+
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            raw = await _raw_content(db, "old")
+            hydrated = (await db.get_message("old"))["content"]
+
+        assert isinstance(raw, str)
+        assert isinstance(hydrated, dict)
+        assert content_was_pruned(raw) == content_was_pruned(hydrated) is True
+
+    def test_a_body_merely_mentioning_the_key_is_not_reclaimed(self):
+        """The raw path short-circuits on a substring before parsing, so a body
+        whose TEXT contains the key has to be judged on its structure anyway --
+        otherwise quoting the marker's name in a message would forge one."""
+        forged = json.dumps({"assistant_response": f"we set {CONTENT_PRUNED_KEY} here"})
+
+        assert content_was_pruned(forged) is False
+
+    def test_the_marker_records_that_a_body_was_there_and_how_large(self):
+        marker = pruned_content(at=1.0, original_bytes=4096)
+
+        assert marker[CONTENT_PRUNED_KEY]["original_bytes"] == 4096
+        assert marker[CONTENT_PRUNED_KEY]["at"] == 1.0
+
+
+class TestTheReclaimSelectsOnTheAxisTheBytesLiveOn:
+    async def test_a_body_inside_the_window_is_untouched(self, temp_db_path):
+        async with StateDB() as db:
+            await _seed_message(db, mid="recent", age_days=5)
+
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            got = await db.get_message("recent")
+
+        assert content_was_pruned(got["content"]) is False
+        assert got["content"]["assistant_response"] == "x" * 500
+
+    async def test_the_row_and_everything_but_the_body_survives(self, temp_db_path):
+        """The point of reclaiming rather than deleting: the prune removes the
+        row and every reference to it, this keeps them. A message still named by
+        a progression stays nameable."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40, role="assistant")
+            before = await db.get_message("old")
+
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            after = await db.get_message("old")
+
+        assert after is not None
+        assert after["id"] == before["id"]
+        assert after["role"] == before["role"]
+        assert after["created_at"] == before["created_at"]
+        assert after["sender"] == before["sender"]
+
+    async def test_a_role_filter_reclaims_only_that_role(self, temp_db_path):
+        async with StateDB() as db:
+            await _seed_message(db, mid="act", age_days=40, role="action")
+            await _seed_message(db, mid="asst", age_days=40, role="assistant")
+
+        result = await _null_content(older_than_days=30, roles=("action",), dry_run=False)
+
+        async with StateDB() as db:
+            act = await db.get_message("act")
+            asst = await db.get_message("asst")
+
+        assert result["messages"] == 1
+        assert content_was_pruned(act["content"]) is True
+        assert content_was_pruned(asst["content"]) is False
+
+
+class TestTheReclaimCannotReportAnOutcomeNothingContradicts:
+    async def test_a_real_run_leaves_nothing_selected(self, temp_db_path):
+        async with StateDB() as db:
+            for i in range(3):
+                await _seed_message(db, mid=f"old{i}", age_days=40)
+
+        result = await _null_content(older_than_days=30, roles=(), dry_run=False)
+        check = await _null_content_candidates(older_than_days=30, roles=())
+
+        assert result["messages"] == 3
+        assert check["candidates"] == 0
+
+    async def test_a_preview_leaves_exactly_what_it_reported(self, temp_db_path):
+        """A preview performs the update and rolls it back, so the rows have to
+        still be there and still be selected afterwards. A preview that silently
+        committed would pass every other arm in this file."""
+        async with StateDB() as db:
+            for i in range(3):
+                await _seed_message(db, mid=f"old{i}", age_days=40)
+
+        preview = await _null_content(older_than_days=30, roles=(), dry_run=True)
+        check = await _null_content_candidates(older_than_days=30, roles=())
+
+        assert preview["messages"] == 3
+        assert check["candidates"] == 3
+
+        async with StateDB() as db:
+            got = await db.get_message("old0")
+        assert content_was_pruned(got["content"]) is False
+
+    async def test_preview_and_recount_agree_where_the_role_filter_binds(self, temp_db_path):
+        """The drift arm has to exercise the half of the predicate the others
+        cannot. Every arm above passes roles=(), where the role clause is absent
+        from the SQL entirely -- so a recount that dropped the role filter would
+        agree with the operation throughout and the pair would certify nothing.
+
+        This fixture is built so the two answers differ if the clause is lost:
+        four rows past the window, only one of them the requested role.
+        """
+        async with StateDB() as db:
+            await _seed_message(db, mid="act", age_days=40, role="action")
+            for i in range(3):
+                await _seed_message(db, mid=f"asst{i}", age_days=40, role="assistant")
+
+        preview = await _null_content(older_than_days=30, roles=("action",), dry_run=True)
+        check = await _null_content_candidates(older_than_days=30, roles=("action",))
+
+        assert preview["messages"] == 1
+        assert check["candidates"] == 1
+
+    async def test_a_second_run_reclaims_nothing(self, temp_db_path):
+        """Already-reclaimed rows are excluded by the predicate, so a re-run is a
+        no-op rather than a marker rewrite reporting work it did not do -- which
+        would also reset every recorded original size to the marker's own."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40)
+
+        first = await _null_content(older_than_days=30, roles=(), dry_run=False)
+        second = await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        assert first["messages"] == 1
+        assert second["messages"] == 0
+
+        async with StateDB() as db:
+            got = await db.get_message("old")
+        assert got["content"][CONTENT_PRUNED_KEY]["original_bytes"] > 0
+
+    def test_both_readings_are_built_from_one_predicate(self):
+        """The operation and the recount call the same builder. Two copies of
+        this drifting apart would make the pair agree while counting different
+        populations, which is worse than printing no check."""
+        assert "role IN" in _null_content_targets(("action",))
+        assert "role IN" not in _null_content_targets(())
+        assert _null_content_targets(("a", "b")).count(":role") == 2
+
+
+class TestTheSizesReported:
+    async def test_the_before_size_is_the_bodies_it_reached(self, temp_db_path):
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=40)
+            raw = await _raw_content(db, "old")
+        original = len(raw)
+
+        result = await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        assert result["bytes_before"] == original
+        assert result["bytes_after"] < result["bytes_before"]
+
+    async def test_the_after_size_excludes_markers_an_earlier_run_left(self, temp_db_path):
+        """Sizes are measured over the batch's own rows. Summing 'rows carrying a
+        marker' instead would fold in every previous run's markers and inflate
+        the after-size of every reclaim after the first."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="first", age_days=40)
+        await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        async with StateDB() as db:
+            await _seed_message(db, mid="second", age_days=40)
+        second = await _null_content(older_than_days=30, roles=(), dry_run=False)
+
+        assert second["messages"] == 1
+        # One row's marker, not two. A sum over all marked rows would roughly
+        # double this and the arm would be the only thing that noticed.
+        async with StateDB() as db:
+            one_marker = len(await _raw_content(db, "second"))
+        assert second["bytes_after"] == one_marker
+
+    async def test_an_empty_selection_reports_no_oldest_age_rather_than_zero(self, temp_db_path):
+        """No rows and rows written this instant are different states, and only
+        one of them means the window has nothing to reach. Reporting 0.0 for the
+        first makes it read as the second."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="recent", age_days=1)
+
+        check = await _null_content_candidates(older_than_days=30, roles=())
+
+        assert check["candidates"] == 0
+        assert check["oldest_age_days"] is None
+
+    async def test_a_non_empty_selection_reports_the_age_of_its_oldest(self, temp_db_path):
+        """The companion. Without it, a function hardcoded to return None would
+        satisfy the arm above."""
+        async with StateDB() as db:
+            await _seed_message(db, mid="old", age_days=45)
+
+        check = await _null_content_candidates(older_than_days=30, roles=())
+
+        assert check["candidates"] == 1
+        assert check["oldest_age_days"] == pytest.approx(45.0, abs=0.1)


### PR DESCRIPTION
## The gap

`li state prune` selects SESSIONS. The bytes live on MESSAGES, and a message any surviving progression still names is kept whatever its age. So a store can be almost entirely message content, have every message inside the keep-window, and give the prune nothing to delete.

Measured read-only on the live 6.8 GiB store, 1,685,541 messages:

| window | bodies | content |
|---|---|---|
| older than 7d | 1,132,988 | 3.06 GiB |
| older than 14d | 693,041 | 1.98 GiB |
| older than 30d | 0 | 0 |

The last row is the one that matters. The prune's default is `--keep-days 30`, so at its default settings it reaches zero bytes of message content, and there is no setting of it that reaches these bytes at all — the axis is wrong, not the threshold.

## What this adds

`li state null-content --older-than DAYS [--role ROLE] [--dry-run]`

Selects on the axis the bytes are on. The row, its id, role, timestamp, sender and every progression reference survive. Only the body goes, and reclaiming is not reversible.

## The marker is the design

A reclaimed body is not emptied.

An empty body — `{}`, or a real content key holding `""` — is exactly what a turn that genuinely produced nothing writes. Nothing downstream has a second source for that distinction, so a reader handed an emptied body cannot say which it is looking at, and neither can anything above it. The two states would collapse into one, permanently and silently.

So the body is replaced by a value that says what it is:

```json
{"lion_content_pruned": {"at": 1754345678.9, "original_bytes": 2831}}
```

`lionagi/state/content_pruned.py` is the vocabulary both sides use. It is deliberately not in `db.py`: asking the question should cost a reader one stdlib import, not an engine.

`original_bytes` is the size of the body **that row** held. The marker is built as a SQL expression rather than as a dict, so `LENGTH(content)` is evaluated against each row as it is overwritten and the number is true per row in a single statement. The alternative, one size computed in Python and written to every row in the batch, records a batch average under a per-row name — a number that is not wrong so much as answering a different question than its label, which is the failure the marker exists to prevent rather than commit.

The predicate also skips rows whose content is `NULL`. A `NULL` body satisfies `json_extract(...) IS NULL` exactly as an unreclaimed one does, so without a clause of its own it would be handed a marker asserting a body existed — fabricating the one fact the marker is for. That state is unreachable today because the column is `NOT NULL` (`schema.sql:47`, and `insert_message` raises before it), so the arm asserts the constraint rather than pretending to construct a row it cannot construct.

The predicate takes the column raw or hydrated, because consumers reach it by both routes and one that served only one of them would return the wrong answer for the other — which is the same failure as having no marker at all, arrived at more expensively.

**The key does not collide.** Zero of 1,685,541 rows in the live store already carry it, and the population is stated because the count means nothing without it.

## Reach

Nothing reconstructs a live conversation from `messages.content`. `get_branch_messages` has no production caller (tests only), and `run_resume` resolves a branch explicitly "without hydrating its messages". The consumers are Studio's session-detail view, the scheduler's file-overlap analysis (which already tolerates a missing path), and `get_message`. That is what bounds this; it is a caller grep, not an assumption.

## The command cannot report an outcome nothing contradicts

```
reclaimed 1132988 message body(ies) older than 7d, every role
  content size: 3.06 GiB → 68.4 MiB (freed 3.00 GiB inside the DB)
  still selected by --older-than 7: 0 (expected 0)
  the file does not shrink until `li state vacuum`
```

The recount comes from the same predicate, run outside the operation's transaction. Zero after a real run; the preview's own number after a preview. The predicate is written once and both readings build from it — two copies drifting apart would make the pair agree while counting different populations, which is worse than printing no check.

Two things the output says that a success line would otherwise let a reader assume:

- **the file does not shrink.** Freed pages go to the database's free list. The bytes on disk stay until `vacuum` rebuilds the file. Reporting 3 GiB freed without this would be a claim about the disk that is not true of it.
- **`--dry-run` is not a read.** It performs the update and rolls it back, so its numbers measure the operation rather than estimating it, and it takes the same write lock for the same duration.

`--older-than` is required and has no default: there is no age that is safe to assume for an irreversible operation. The subcommand is excluded from the MCP surface as an irreversible write.

## Not offered to the machine surface

`state.null-content` is catalogued as **unavailable**, with a reason of its own rather than the one the other state writes share. Theirs objects that a write invalidates answers the caller already holds — a consistency problem a better result shape could answer. This one cannot be answered: the content is gone, and no reply a machine seam could return would undo the call that asked for it.

The reference doc carries that table and its stated count, both checked against the registry, so both move with it.

## Verification

22 arms. Eight mutations, each with its reddened arm set stated in writing before the run and reconciled arm by arm afterwards.

| mutation | predicted | actual |
|---|---|---|
| M1 recount drops the role filter | 1 | 1 ✓ |
| M2 marker written as `{}` | 5 | **7** ✗ |
| M3 after-size summed over all marked rows | 1 | 1 ✓ |
| M4 empty selection reports age 0.0 | 1 | 1 ✓ |
| M5 already-reclaimed exclusion dropped | 3 | 3 ✓ |
| M6 predicate matches the raw substring | 1 | 1 ✓ |
| M7 size written as a constant instead of `LENGTH(content)` | 2 | 1, explained ✓ |
| M8 `content IS NOT NULL` clause dropped | 1 | 1 ✓ |

**M2 is the one worth reading.** Two things went wrong with it and only one was the code's.

Its first run reddened *nothing*. The mutation was `marker = {} or pruned_content(...)`, and `{}` is falsy, so it evaluated to the original — a mutation that never applied, wearing the appearance of arms that do not discriminate. Rewritten to actually apply, it reddened 7.

Then the 7 arrived as 5, because `--maxfail=5` is in `addopts` and the failure list was truncated at exactly the count I had predicted. A matching number is the most reassuring thing a truncated list can produce. Re-run uncapped, the true set is 7: the two I missed are `test_a_role_filter_reclaims_only_that_role` and `test_a_real_run_leaves_nothing_selected`, both explained by the mutation's own mechanism — a marker that no longer satisfies the predicate is re-selected forever, and no longer reads as reclaimed. No arm reddened for a reason the mutation cannot account for. M5 was re-run uncapped as well and confirmed at 3.

The fixture-to-arm mapping, since M1 is otherwise unfalsifiable: every arm except `test_preview_and_recount_agree_where_the_role_filter_binds` passes `roles=()`, where the role clause is absent from the SQL entirely. Those arms are blind to a dropped role filter by construction. One fixture exists specifically to bind it — four rows past the window, one of them the requested role — so the two answers differ if the clause is lost.

M7's miss is worth stating rather than rounding off. Predicted 2, reddened 1: the size arm caught it, and `test_a_second_run_reclaims_nothing` stayed green because its assertion is `original_bytes > 0` and the mutant's constant was 4096. Re-run with a constant of `0`, it reddens both. The prediction was wrong about the mutant, not about the arms.

Its first form was also a mutation that did not apply — the replacement put double quotes inside a double-quoted f-string, and the run came back as a collection error rather than as a result. A syntax break reads as everything failing, which is as uninformative as a mutation that silently evaluates to the original, so the mutant now has to import before its result counts.

Both source files were restored by copy, never by `git checkout`, and asserted byte-identical with `cmp` after every arm.

`tests/cli`, `tests/state` and `tests/mcp`: **4610 passed, 2 skipped, 1 failed**. `tests/mcp` is in that list because it was not in the first one, and it held the catalog-coverage gate this change had to satisfy — the suites a diff's own file paths suggest are not the suites that gate it. The failure is `test_agent_depth_wiring.py::test_ndjson_from_cli_inherits_stamped_depth`, which asserts `env is None` while the shell running the suite exports `AI_AGENT`. Unrelated to this change, confirmed failing identically at `origin/main` in a detached worktree, and filed separately.

No destructive operation was run against the live store. Every number above comes from `SELECT`s.

