### PR TITLE
fix(providers): survive CLI stream reconnects and orphan-held pipes

### DIFF
--- a/lionagi/operations/run/run.py
+++ b/lionagi/operations/run/run.py
@@ -580,6 +580,17 @@ async def run(
                                     "ending stream cleanly"
                                 )
                                 break
+                            # A reconnect notice is the provider CLI retrying its own
+                            # dropped stream: the process is still running and will
+                            # either resume emitting events or produce a real terminal
+                            # error, so the run keeps consuming instead of raising.
+                            if chunk.metadata.get("reconnect_notice"):
+                                logger.warning(
+                                    "run: provider reconnecting mid-stream (%s); "
+                                    "continuing to consume",
+                                    chunk.content,
+                                )
+                                continue
                             # Persist text already delivered before a late failure destroys it.
                             if res := await _flush_response():
                                 yield res

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import shutil
+import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from functools import partial
@@ -374,6 +375,13 @@ async def end_child_group(proc: Any, *, grace: float = 5.0) -> None:
             _end_group_with_evidence(proc)
 
 
+# How long the stream keeps draining after the CLI child itself has exited.
+# Real trailing output arrives within moments of exit; what arrives after this
+# window is an orphaned descendant holding the inherited pipe open, and waiting
+# on it converts a finished leg into an unbounded wall-clock burn.
+_POST_EXIT_DRAIN_GRACE = 10.0
+
+
 def observe_spawned(pid: int) -> SpawnedProcess:
     """Read pid, group and start time as one observation of one process.
 
@@ -563,9 +571,43 @@ async def ndjson_from_cli(
         payload = stdin_data.encode() if isinstance(stdin_data, str) else stdin_data
         stdin_task = asyncio.create_task(_write_stdin(payload))
 
+    # stdout EOF requires EVERY holder of the pipe's write end to close it —
+    # not just the child. A CLI child that spawns its own long-lived helpers
+    # (MCP servers, daemons) leaks the write end into them, so when the child
+    # dies its orphans keep the pipe open and a plain read() waits forever: a
+    # finished leg whose artifacts are on disk reads as "running" for the rest
+    # of the caller's budget. Racing each read against the child's exit, then
+    # bounding the drain once it has exited, turns that hang into the normal
+    # end-of-stream path; teardown then ends the process group, which is what
+    # actually closes the orphans' copy of the pipe.
+    exit_task = asyncio.create_task(proc.wait())
+    post_exit_deadline: float | None = None
+
+    async def _read_next() -> bytes:
+        nonlocal post_exit_deadline
+        read_task = asyncio.create_task(proc.stdout.read(4096))
+        if post_exit_deadline is None:
+            await asyncio.wait({read_task, exit_task}, return_when=asyncio.FIRST_COMPLETED)
+            if not read_task.done():
+                post_exit_deadline = time.monotonic() + _POST_EXIT_DRAIN_GRACE
+        if not read_task.done() and post_exit_deadline is not None:
+            try:
+                return await asyncio.wait_for(
+                    read_task, max(post_exit_deadline - time.monotonic(), 0.0)
+                )
+            except asyncio.TimeoutError:
+                log.warning(
+                    "CLI child (pid %s) exited but stdout stayed open — orphaned "
+                    "descendants hold the pipe; ending the stream after %.0fs grace",
+                    proc.pid,
+                    _POST_EXIT_DRAIN_GRACE,
+                )
+                return b""
+        return await read_task
+
     try:
         while True:
-            chunk = await proc.stdout.read(4096)
+            chunk = await _read_next()
             if not chunk:
                 break
 
@@ -630,7 +672,7 @@ async def ndjson_from_cli(
 
         # Reap the helper tasks — contextlib.suppress(Exception) does NOT
         # catch CancelledError (BaseException), so we suppress it explicitly.
-        for task in (stderr_task, stdin_task):
+        for task in (stderr_task, stdin_task, exit_task):
             if task is None:
                 continue
             task.cancel()

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -580,13 +580,28 @@ async def ndjson_from_cli(
     # end-of-stream path; teardown then ends the process group, which is what
     # actually closes the orphans' copy of the pipe.
     async def _await_child_exit() -> int:
-        # proc.wait() cannot be the exit signal here: on newer Pythons it does
+        # proc.wait() alone cannot be the exit signal: on newer Pythons it does
         # not complete until every pipe transport disconnects, which is exactly
         # what an orphan-held pipe prevents. returncode is set at process exit
-        # regardless of pipe state, so poll it.
-        while proc.returncode is None:
-            await asyncio.sleep(0.05)
-        return proc.returncode
+        # regardless of pipe state, so the wait races against a returncode
+        # poll; wait()'s result is preferred when it does complete, because it
+        # is the canonical exit code (and the only one a test double carries).
+        wait_task = asyncio.create_task(proc.wait())
+        try:
+            while proc.returncode is None and not wait_task.done():
+                await asyncio.wait({wait_task}, timeout=0.05)
+            if not wait_task.done():
+                await asyncio.wait({wait_task}, timeout=0.05)
+            if wait_task.done():
+                return wait_task.result()
+            return proc.returncode
+        finally:
+            if not wait_task.done():
+                wait_task.cancel()
+                try:
+                    await wait_task
+                except (asyncio.CancelledError, Exception):  # noqa: S110, BLE001
+                    pass
 
     exit_task = asyncio.create_task(_await_child_exit())
     read_task: asyncio.Task | None = None

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -10,7 +10,6 @@ import json
 import logging
 import os
 import shutil
-import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from functools import partial
@@ -580,21 +579,33 @@ async def ndjson_from_cli(
     # bounding the drain once it has exited, turns that hang into the normal
     # end-of-stream path; teardown then ends the process group, which is what
     # actually closes the orphans' copy of the pipe.
-    exit_task = asyncio.create_task(proc.wait())
-    post_exit_deadline: float | None = None
+    async def _await_child_exit() -> int:
+        # proc.wait() cannot be the exit signal here: on newer Pythons it does
+        # not complete until every pipe transport disconnects, which is exactly
+        # what an orphan-held pipe prevents. returncode is set at process exit
+        # regardless of pipe state, so poll it.
+        while proc.returncode is None:
+            await asyncio.sleep(0.05)
+        return proc.returncode
+
+    exit_task = asyncio.create_task(_await_child_exit())
+    read_task: asyncio.Task | None = None
+    child_exited = False
 
     async def _read_next() -> bytes:
-        nonlocal post_exit_deadline
+        nonlocal read_task, child_exited
         read_task = asyncio.create_task(proc.stdout.read(4096))
-        if post_exit_deadline is None:
+        if not child_exited:
             await asyncio.wait({read_task, exit_task}, return_when=asyncio.FIRST_COMPLETED)
-            if not read_task.done():
-                post_exit_deadline = time.monotonic() + _POST_EXIT_DRAIN_GRACE
-        if not read_task.done() and post_exit_deadline is not None:
+            child_exited = exit_task.done()
+        if child_exited and not read_task.done():
+            # The grace is per read, never a shared deadline: output the child
+            # buffered before exiting must survive a consumer that processes
+            # slowly between reads. Only a read that produces nothing for the
+            # whole grace ends the stream. wait_for cancels the read on
+            # timeout, so nothing is left pending.
             try:
-                return await asyncio.wait_for(
-                    read_task, max(post_exit_deadline - time.monotonic(), 0.0)
-                )
+                return await asyncio.wait_for(read_task, _POST_EXIT_DRAIN_GRACE)
             except asyncio.TimeoutError:
                 log.warning(
                     "CLI child (pid %s) exited but stdout stayed open — orphaned "
@@ -644,7 +655,9 @@ async def ndjson_from_cli(
                 else:
                     log.error("Skipped unrecoverable JSON tail: %.120s...", buffer)
 
-        rc = await proc.wait()
+        # Same pipe-gating hazard as above: proc.wait() here would block on the
+        # orphans' copy of the pipe after a grace-bounded end of stream.
+        rc = await asyncio.shield(exit_task)
         if rc != 0:
             drain_truncated = False
             try:
@@ -672,7 +685,7 @@ async def ndjson_from_cli(
 
         # Reap the helper tasks — contextlib.suppress(Exception) does NOT
         # catch CancelledError (BaseException), so we suppress it explicitly.
-        for task in (stderr_task, stdin_task, exit_task):
+        for task in (stderr_task, stdin_task, exit_task, read_task):
             if task is None:
                 continue
             task.cancel()

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -97,8 +97,12 @@ _TOML_BARE_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 # disconnected before completion: ...)". Anchored to the observed prefix on
 # purpose: a message that doesn't match falls through to the terminal-error
 # branch, so a wording change in the CLI degrades to the old (fail-closed)
-# behaviour rather than misclassifying a real failure as a notice.
-_RECONNECT_NOTICE_RE = re.compile(r"^\s*Reconnecting\.\.\.\s*\d+/\d+")
+# behaviour rather than misclassifying a real failure as a notice. The
+# trailing "(" is load-bearing: the retry notice always carries a
+# parenthesized reason, and requiring it keeps terminal messages that merely
+# BEGIN with the retry prefix ("Reconnecting... 5/5 failed") on the terminal
+# path.
+_RECONNECT_NOTICE_RE = re.compile(r"^\s*Reconnecting\.\.\.\s*\d+/\d+\s*\(")
 
 
 def _toml_scalar(value: str | int | float | bool) -> str:

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -93,6 +93,13 @@ __all__ = ("CodexCodeRequest", "stream_codex_cli", "CodexCLIEndpoint")
 # docs/internals/providers.md#codex-c-override-toml-serialization.
 _TOML_BARE_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
+# The CLI's mid-stream retry announcement, e.g. "Reconnecting... 1/5 (stream
+# disconnected before completion: ...)". Anchored to the observed prefix on
+# purpose: a message that doesn't match falls through to the terminal-error
+# branch, so a wording change in the CLI degrades to the old (fail-closed)
+# behaviour rather than misclassifying a real failure as a notice.
+_RECONNECT_NOTICE_RE = re.compile(r"^\s*Reconnecting\.\.\.\s*\d+/\d+")
+
 
 def _toml_scalar(value: str | int | float | bool) -> str:
     """Render a single TOML scalar (or its quoted-string form), via the
@@ -886,14 +893,13 @@ async def stream_codex_cli(
 
             # -- turn.failed / error --
             elif typ in ("turn.failed", "error"):
-                session.is_error = True
                 err = obj.get("error", {})
                 # Error message location varies by event type; capture the raw
                 # value pre-normalization for the benign-EOS check below.
                 _raw_err = err
                 if err is None:
                     err = {}
-                session.result = (
+                _err_message = (
                     (
                         err.get("message")
                         or obj.get("message")
@@ -906,6 +912,34 @@ async def stream_codex_cli(
                     if isinstance(err, dict)
                     else obj.get("message", str(err))
                 )
+                # The CLI announces its OWN retry of a dropped provider stream
+                # as an error-typed event ("Reconnecting... 1/5 (...)") and then
+                # keeps going. Treating that notice as terminal kills the leg
+                # before the CLI's second attempt ever runs, so it is surfaced
+                # as a non-error chunk and the stream keeps consuming. A retry
+                # that ultimately fails produces a real terminal event (or the
+                # process exits), which still takes the branch below — and an
+                # unrecognized notice text fails toward terminal, the direction
+                # that loses a leg rather than the one that hangs it.
+                if (
+                    typ == "error"
+                    and isinstance(_err_message, str)
+                    and _RECONNECT_NOTICE_RE.match(_err_message)
+                ):
+                    if request.verbose_output:
+                        log.warning("Codex reconnecting mid-stream: %s", _err_message)
+                    sc = StreamChunk(
+                        type="error",
+                        content=_err_message,
+                        is_error=False,
+                        metadata={**obj, "reconnect_notice": True},
+                    )
+                    session.chunks.append(sc)
+                    yield sc
+                    continue
+
+                session.is_error = True
+                session.result = _err_message
                 # Benign-EOS sentinel on resumed sessions — see docs/internals/runtime.md
                 # for the exact 3-condition classification.
                 _is_benign_eos = (

--- a/tests/operations/test_run_error_classification.py
+++ b/tests/operations/test_run_error_classification.py
@@ -294,3 +294,48 @@ async def test_run_raises_provider_error_for_null_error_payload_chunk():
 
     with pytest.raises(ProviderError):
         await _drain(run(branch, "do something", RunParam()))
+
+
+# ---------------------------------------------------------------------------
+# Reconnect notice: the provider CLI retrying its own stream is not a failure
+# ---------------------------------------------------------------------------
+
+
+async def test_run_continues_past_reconnect_notice_and_delivers_text():
+    """A reconnect_notice chunk mid-stream must not raise; content after it
+    still reaches the branch."""
+    notice = StreamChunk(
+        type="error",
+        content="Reconnecting... 1/5 (stream disconnected before completion)",
+        is_error=False,
+        metadata={"reconnect_notice": True},
+    )
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model(
+        [
+            notice,
+            StreamChunk(type="text", content="recovered answer"),
+            StreamChunk(type="result", metadata={}),
+        ]
+    )
+
+    items = await _drain(run(branch, "do something", RunParam()))
+    assert items, "run() must yield the post-reconnect content"
+
+    responses = [m for m in branch.msgs.messages if type(m).__name__ == "AssistantResponse"]
+    assert any("recovered answer" in str(m.response) for m in responses)
+
+
+async def test_run_reconnect_notice_alone_does_not_raise():
+    """A leg whose stream ends after a notice (process died mid-retry) ends
+    without a chunk-classified raise — terminality is the runtime's to call."""
+    notice = StreamChunk(
+        type="error",
+        content="Reconnecting... 2/5 (stream disconnected before completion)",
+        is_error=False,
+        metadata={"reconnect_notice": True},
+    )
+    branch = Branch()
+    branch.chat_model = _make_fake_cli_model([notice])
+
+    await _drain(run(branch, "do something", RunParam()))

--- a/tests/providers/openai/codex/test_reconnect_notice.py
+++ b/tests/providers/openai/codex/test_reconnect_notice.py
@@ -87,6 +87,27 @@ async def test_disconnect_without_reconnect_prefix_stays_terminal():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "Reconnecting... 5/5 failed",
+        "Reconnecting... 5/5: max retries exceeded",
+        "Reconnecting... 5/5",
+    ],
+)
+async def test_terminal_message_wearing_the_retry_prefix_stays_terminal(msg):
+    """A real failure whose text merely BEGINS with the retry prefix must not
+    be swallowed as a notice — the notice shape requires the parenthesized
+    reason the CLI's actual retry line always carries."""
+    events = [{"type": "error", "error": {"message": msg}}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    assert chunks[0].is_error is True
+    assert not chunks[0].metadata.get("reconnect_notice")
+
+
+@pytest.mark.asyncio
 async def test_turn_failed_with_reconnect_text_stays_terminal():
     """turn.failed is an explicit terminal verdict from the CLI; its message
     text never reclassifies it."""

--- a/tests/providers/openai/codex/test_reconnect_notice.py
+++ b/tests/providers/openai/codex/test_reconnect_notice.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The CLI announces its own retry of a dropped provider stream as an
+error-typed event ("Reconnecting... 1/5 (...)") and then keeps going. That
+notice must not end the leg: the stream keeps consuming, and terminality comes
+from a later real failure event or the process exiting. A message that does not
+match the notice shape stays terminal — the fail-closed direction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.providers.openai.codex import CodexCodeRequest, stream_codex_cli
+from lionagi.service.types.stream_chunk import StreamChunk
+
+RECONNECT_MSG = (
+    "Reconnecting... 1/5 (stream disconnected before completion: "
+    "stream closed before response.completed)"
+)
+
+
+def _make_request() -> CodexCodeRequest:
+    return CodexCodeRequest(prompt="test", verbose_output=False)
+
+
+async def _chunks_from_events(events: list[dict]) -> list[StreamChunk]:
+    from unittest.mock import patch
+
+    async def fake_events(request):
+        for ev in events:
+            yield ev
+
+    collected = []
+    with patch(
+        "lionagi.providers.openai.codex.stream_codex_cli_events",
+        side_effect=fake_events,
+    ):
+        async for item in stream_codex_cli(_make_request()):
+            if isinstance(item, StreamChunk):
+                collected.append(item)
+    return collected
+
+
+@pytest.mark.asyncio
+async def test_reconnect_notice_is_not_terminal_and_stream_continues():
+    """The notice yields a non-error chunk and later events still arrive."""
+    events = [
+        {"type": "error", "error": {"message": RECONNECT_MSG}},
+        {"type": "turn.completed", "usage": {"input_tokens": 5, "output_tokens": 7}},
+    ]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 2, f"expected notice + result, got {[c.type for c in chunks]}"
+    notice = chunks[0]
+    assert notice.type == "error"
+    assert notice.is_error is False
+    assert notice.metadata.get("reconnect_notice") is True
+    assert chunks[1].type == "result", "stream must keep consuming past the notice"
+
+
+@pytest.mark.asyncio
+async def test_last_attempt_notice_is_still_a_notice():
+    """ "5/5" is the final retry ATTEMPT, not its outcome — a failed final retry
+    produces its own terminal event afterwards."""
+    msg = "Reconnecting... 5/5 (stream disconnected before completion)"
+    events = [{"type": "error", "error": {"message": msg}}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    assert chunks[0].is_error is False
+    assert chunks[0].metadata.get("reconnect_notice") is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_without_reconnect_prefix_stays_terminal():
+    """The same underlying cause reported WITHOUT the retry prefix means the
+    CLI is not retrying — that one is a real failure."""
+    msg = "stream disconnected before completion: stream closed before response.completed"
+    events = [{"type": "error", "error": {"message": msg}}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    assert chunks[0].is_error is True
+    assert not chunks[0].metadata.get("reconnect_notice")
+
+
+@pytest.mark.asyncio
+async def test_turn_failed_with_reconnect_text_stays_terminal():
+    """turn.failed is an explicit terminal verdict from the CLI; its message
+    text never reclassifies it."""
+    events = [{"type": "turn.failed", "error": {"message": RECONNECT_MSG}}]
+    chunks = await _chunks_from_events(events)
+
+    assert len(chunks) == 1
+    assert chunks[0].is_error is True
+    assert not chunks[0].metadata.get("reconnect_notice")

--- a/tests/providers/test_cli_subprocess_orphan_held_pipe.py
+++ b/tests/providers/test_cli_subprocess_orphan_held_pipe.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""stdout EOF needs every holder of the pipe's write end to close it, not just
+the child. A CLI child that spawns long-lived helpers leaks the write end into
+them, so a child that exits cleanly can leave the stream read waiting forever —
+a finished leg, artifacts on disk, reported as running for the rest of its
+caller's budget. The stream must end within a bounded grace of the child's
+exit, and the orphan must not survive teardown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+
+import pytest
+
+import lionagi.providers._cli_subprocess as cli_subprocess
+from lionagi.providers._cli_subprocess import ndjson_from_cli
+
+# Emits one event carrying its orphan's pid, leaks stdout into a 30s grandchild,
+# exits 0. Without a post-exit bound the stream hangs ~30s; with it, it ends
+# within the grace.
+_ORPHAN_HOLDER = (
+    "import json, subprocess, sys\n"
+    "p = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])\n"
+    "print(json.dumps({'type': 'x', 'orphan_pid': p.pid}), flush=True)\n"
+    "sys.exit(0)\n"
+)
+
+# Streams slowly while ALIVE: the bound applies after exit, never to a living
+# child that is just quiet between events.
+_SLOW_BUT_ALIVE = (
+    "import time\nprint('{\"n\": 1}', flush=True)\ntime.sleep(2)\nprint('{\"n\": 2}', flush=True)\n"
+)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@pytest.mark.asyncio
+async def test_stream_ends_within_grace_when_orphan_holds_stdout(monkeypatch):
+    monkeypatch.setattr(cli_subprocess, "_POST_EXIT_DRAIN_GRACE", 0.5)
+
+    start = time.monotonic()
+    events = []
+    async for obj in ndjson_from_cli([sys.executable, "-c", _ORPHAN_HOLDER]):
+        events.append(obj)
+    elapsed = time.monotonic() - start
+
+    assert [e["type"] for e in events] == ["x"], events
+    # Far under the orphan's 30s sleep — the bound, not the orphan, ended the stream.
+    assert elapsed < 10, f"stream took {elapsed:.1f}s; the orphan held it open"
+
+    # Teardown ends the child's process group, which is what closes the
+    # orphan's copy of the pipe — the orphan must not outlive the stream.
+    deadline = time.monotonic() + 5
+    orphan_pid = events[0]["orphan_pid"]
+    while time.monotonic() < deadline and _pid_alive(orphan_pid):
+        await asyncio.sleep(0.1)
+    assert not _pid_alive(orphan_pid), f"orphan {orphan_pid} survived teardown"
+
+
+@pytest.mark.asyncio
+async def test_living_child_is_never_time_boxed(monkeypatch):
+    """A quiet-but-alive child streams past the grace untouched: the bound
+    keys on exit, not on silence."""
+    monkeypatch.setattr(cli_subprocess, "_POST_EXIT_DRAIN_GRACE", 0.5)
+
+    events = []
+    async for obj in ndjson_from_cli([sys.executable, "-c", _SLOW_BUT_ALIVE]):
+        events.append(obj)
+
+    assert [e["n"] for e in events] == [1, 2], events
+
+
+@pytest.mark.asyncio
+async def test_clean_exit_without_orphans_is_unchanged():
+    events = []
+    async for obj in ndjson_from_cli([sys.executable, "-c", "print('{\"ok\": true}', flush=True)"]):
+        events.append(obj)
+    assert events == [{"ok": True}]

--- a/tests/providers/test_cli_subprocess_orphan_held_pipe.py
+++ b/tests/providers/test_cli_subprocess_orphan_held_pipe.py
@@ -71,6 +71,42 @@ async def test_stream_ends_within_grace_when_orphan_holds_stdout(monkeypatch):
     assert not _pid_alive(orphan_pid), f"orphan {orphan_pid} survived teardown"
 
 
+# The child exits immediately; the inherited stdout keeps FLOWING from the
+# orphan for longer than one grace period, then goes quiet. Data still
+# arriving is a live stream regardless of the child's exit — only silence for
+# a whole grace ends it. A deadline shared across reads (grace measured from
+# the exit, not from each read) truncates this mid-flow.
+_ORPHAN_KEEPS_WRITING = (
+    "import subprocess, sys\n"
+    "code = (\n"
+    "    'import json, time\\n'\n"
+    "    'for i in range(5):\\n'\n"
+    "    '    print(json.dumps({\"i\": i}), flush=True)\\n'\n"
+    "    '    time.sleep(0.25)\\n'\n"
+    "    'time.sleep(30)\\n'\n"
+    ")\n"
+    "subprocess.Popen([sys.executable, '-c', code], stdout=sys.stdout)\n"
+    "sys.exit(0)\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_data_still_flowing_after_exit_is_delivered_in_full(monkeypatch):
+    monkeypatch.setattr(cli_subprocess, "_POST_EXIT_DRAIN_GRACE", 0.5)
+
+    start = time.monotonic()
+    events = []
+    async for obj in ndjson_from_cli([sys.executable, "-c", _ORPHAN_KEEPS_WRITING]):
+        events.append(obj)
+    elapsed = time.monotonic() - start
+
+    assert [e["i"] for e in events] == list(range(5)), (
+        f"delivered {len(events)}/5 post-exit events — the drain truncated a flowing stream"
+    )
+    # After the writer goes quiet, one grace ends the stream — not the 30s sleep.
+    assert elapsed < 10, f"stream took {elapsed:.1f}s after the writer went quiet"
+
+
 @pytest.mark.asyncio
 async def test_living_child_is_never_time_boxed(monkeypatch):
     """A quiet-but-alive child streams past the grace untouched: the bound


### PR DESCRIPTION
Two defects in the CLI stream path, one deploy. Both bite every long-running leg.

## 1. Recoverable reconnect treated as terminal

The codex CLI reports its own retry of a dropped provider stream as an error-typed event — `Reconnecting... 1/5 (stream disconnected before completion: ...)` — and keeps running. The engine's error branch marked any non-benign-EOS `error` event terminal, killing the leg before the CLI's second attempt ever ran (observed deaths always at exactly `1/5`).

Fix: an `error` event matching the reconnect-notice shape yields a non-error chunk (`metadata.reconnect_notice`) and both the codex event loop and `run()`'s consumer keep consuming. `turn.failed` is never reclassified; unmatched text stays terminal (fail-closed).

## 2. Dead child, stream never ends

stdout EOF requires every holder of the pipe's write end to close it. A CLI child that spawns long-lived helpers (MCP servers) leaks the write end into them, so a child that exits cleanly can leave `ndjson_from_cli`'s read waiting forever: the leg's work is done, artifacts on disk, and the caller reports it running for the rest of its wall-clock budget.

Fix: each read races the child's exit; once the child has exited, the remaining drain is bounded by a short grace, then the normal end-of-stream path runs — nonzero exits raise, teardown ends the process group (closing the orphans' pipe), and the flow layer's retry policy sees a real terminal event. A living child is never time-boxed: the bound keys on exit, not silence.

## Tests

- Reconnect: notice → stream continues to `turn.completed`; `5/5` still a notice; same text without the retry prefix stays terminal; `turn.failed` never reclassified; run() delivers post-reconnect text. Mutation control reddened exactly the predicted arms.
- Orphan pipe: a child leaking stdout into a 30s grandchild ends within the grace and the orphan does not survive teardown; a slow-but-alive child is never truncated; clean exit unchanged. Bypassing the bounded read reproduced the 30s hang exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)