### PR TITLE
feat(engines): audit the clean verdict so clean reviews carry verification evidence

### DIFF
--- a/docs/reference/engines.md
+++ b/docs/reference/engines.md
@@ -137,8 +137,11 @@ Extends `Engine` with:
 | `verifier_role` | `"critic"` | Casts role for adversarial verifiers. |
 | `synthesis_role` | `"synthesizer"` | Casts role that issues the terminal `ReviewVerdict`. |
 | `verify_severities` | `("critical", "major")` | Issue severities that reactively spawn an adversarial verifier. |
+| `verify_clean` | `True` | When a run reaches quiescence with zero `VerifyResult` (clean or minor-only review), spawn one adversarial audit of the clean verdict itself. |
 | `repair_retries` | `1` | Re-prompt turns when a reviewer or verifier emits no valid event. |
 
-Pipeline shape: fan-out (one reviewer per dimension, parallel) → adversarial verify high-severity issues → quiesce → `ReviewVerdict`.
+Pipeline shape: fan-out (one reviewer per dimension, parallel) → adversarial verify high-severity issues → quiesce → clean-verdict audit if no verification ran → `ReviewVerdict`.
 
 Every dimension emits affirmatively: issues arrive as `IssueFound`, a clean dimension arrives as `DimensionClean` (dimension + one-sentence rationale). A dimension that emits nothing is therefore a transport failure, never an implicit all-clear — the verdict instruction lists affirmed-clean dimensions separately so downstream consumers can distinguish "reviewed, clean" from "reviewer never reported". Verifier arrival keys on a short engine-assigned `ref` token echoed back in the `VerifyResult`, so a paraphrased issue description does not burn repair rounds.
+
+A clean or minor-only review spawns no issue verifiers, so it would otherwise terminate with zero `VerifyResult` — indistinguishable, by evidence, from a run whose verification never happened. With `verify_clean` on, such runs get one adversarial verifier auditing the clean verdict: it must execute a concrete check against the artifact and name what it executed in its rationale, and it emits a `VerifyResult` carrying the run's clean ref. In the verdict instruction these audits are listed apart from issue verifications because their polarity is inverted: `holds=false` there refutes the review's clean verdict and weighs against approval.

--- a/lionagi/engines/review.py
+++ b/lionagi/engines/review.py
@@ -111,6 +111,15 @@ def _verify_ref(issue: IssueFound) -> str:
     return f"V-{hashlib.sha256(_verify_key(issue).encode()).hexdigest()[:8]}"
 
 
+def _clean_ref(dimensions: tuple[str, ...]) -> str:
+    """Ref token for the clean-verdict audit — one per run, derived from the
+    dimension set so the verdict stage can partition clean-audit VerifyResults
+    from issue verifications by ref alone (the ``issue`` field is model-filled
+    free text and paraphrases)."""
+    key = "verify-clean:" + ",".join(sorted(dimensions))
+    return f"V-{hashlib.sha256(key.encode()).hexdigest()[:8]}"
+
+
 def _dimension_instruction(artifact: str, dimension: str) -> str:
     return (
         f"Review the artifact below for **{dimension}** only. For each concrete "
@@ -134,6 +143,27 @@ def _verify_instruction(issue: IssueFound, ref: str) -> str:
     )
 
 
+def _verify_clean_instruction(artifact: str, clean: list[DimensionClean], ref: str) -> str:
+    claims = "\n".join(f"- {c.dimension}: {c.rationale or 'affirmed clean'}" for c in clean) or (
+        "- (no affirmative clean events on record; the review surfaced no "
+        "issues severe enough to verify)"
+    )
+    return (
+        "Adversarially audit this review's CLEAN verdict — try to REFUTE it. "
+        "You MUST execute at least one concrete check against the artifact "
+        "before answering: resolve one central claim or citation the artifact "
+        "makes, or run the check it claims passes. Your rationale MUST name "
+        "the exact command you ran or the specific claim you resolved and "
+        "what you observed — a rationale naming no executed check is invalid "
+        "and will be rejected. Emit a verify_result with issue='CLEAN: review "
+        f"affirmed no blocking issues', ref='{ref}' exactly as given, holds "
+        "(true only if the clean verdict survives your strongest refutation) "
+        "and rationale (what you executed, what you observed, why the clean "
+        "verdict does or does not hold).\n\n"
+        f"# Clean claims under audit\n{claims}\n\n# Artifact\n{artifact}"
+    )
+
+
 def _verdict_instruction(
     artifact: str,
     dimensions: tuple[str, ...],
@@ -153,10 +183,26 @@ def _verdict_instruction(
             f"\n## {i}. [{it.dimension}/{it.severity}] {it.description}"
             f"{(' @ ' + it.location) if it.location else ''}"
         )
-    if verifications:
-        parts.append(f"\n\n# Adversarial verifications ({len(verifications)})")
-        for v in verifications:
+    # Clean-verdict audits carry the run's clean ref; their polarity is the
+    # OPPOSITE of an issue verification — holds=false refutes the review's
+    # clean verdict, not an issue — so they get their own section and their
+    # own weighing guidance rather than riding the "weigh refuted issues
+    # down" line, which would read them backwards.
+    clean_ref = _clean_ref(dimensions)
+    issue_verifications = [v for v in verifications if v.ref != clean_ref]
+    clean_audits = [v for v in verifications if v.ref == clean_ref]
+    if issue_verifications:
+        parts.append(f"\n\n# Adversarial verifications ({len(issue_verifications)})")
+        for v in issue_verifications:
             parts.append(f"\n- holds={v.holds}: {v.issue} — {v.rationale}")
+    if clean_audits:
+        parts.append(f"\n\n# Clean-verdict audit ({len(clean_audits)})")
+        for v in clean_audits:
+            parts.append(f"\n- holds={v.holds}: {v.rationale}")
+        parts.append(
+            "\nIn this section holds=false means the review's CLEAN verdict "
+            "was REFUTED — weigh that AGAINST approval."
+        )
     parts.append(
         "\n\nWeigh refuted issues down. Decide APPROVE / APPROVE-WITH-FIXES / "
         "REQUEST-CHANGES / REJECT with a grounded rationale and the list of "
@@ -176,6 +222,7 @@ class ReviewEngine(Engine):
         verifier_role: str = "critic",
         synthesis_role: str = "synthesizer",
         verify_severities: tuple[str, ...] = ("critical", "major"),
+        verify_clean: bool = True,
         repair_retries: int = 1,
         **kwargs: Any,
     ) -> None:
@@ -185,6 +232,7 @@ class ReviewEngine(Engine):
         self.verifier_role = verifier_role
         self.synthesis_role = synthesis_role
         self.verify_severities = set(verify_severities)
+        self.verify_clean = verify_clean
         self.repair_retries = repair_retries
 
     # -- lifecycle --------------------------------------------------------------
@@ -227,6 +275,14 @@ class ReviewEngine(Engine):
             raise
         # Drain any adversarial verifiers spawned by high-severity issues.
         await run.wait_quiescence()
+        # A clean or minor-only review spawns no issue verifiers, so it would
+        # reach the verdict with zero VerifyResult — and a downstream evidence
+        # floor then refuses the APPROVE as evidence-empty, structurally.
+        # Gate on zero VerifyResult (not zero issues) so both shapes instead
+        # carry one adversarial audit of the clean verdict itself: positive
+        # executed evidence rather than absence.
+        if self.verify_clean and not run.by_type(VerifyResult):
+            await self._verify_clean(run, artifact, dims)
         return await self._verdict(run, artifact, dims)
 
     # -- reactions ------------------------------------------------------------
@@ -283,6 +339,28 @@ class ReviewEngine(Engine):
                 arrived=lambda: any(
                     v.ref == ref or v.issue == issue.description for v in run.by_type(VerifyResult)
                 ),
+                emits=emits,
+                retries=self.repair_retries,
+            )
+
+    async def _verify_clean(
+        self, run: EngineRun, artifact: str, dimensions: tuple[str, ...]
+    ) -> None:
+        emits = (VerifyResult,)
+        ref = _clean_ref(dimensions)
+        clean = run.by_type(DimensionClean)
+        async with run._sem:
+            verifier = await run.make_agent(
+                self.verifier_role,
+                name="verify-clean",
+                modes=["adversarial"],
+                model=self.model_for("verify"),
+                emits=emits,
+            )
+            await run.operate_with_repair(
+                verifier,
+                _verify_clean_instruction(artifact, clean, ref),
+                arrived=lambda: any(v.ref == ref for v in run.by_type(VerifyResult)),
                 emits=emits,
                 retries=self.repair_retries,
             )

--- a/tests/engines/test_review.py
+++ b/tests/engines/test_review.py
@@ -12,6 +12,9 @@ from lionagi.engines.review import (
     IssueFound,
     ReviewEngine,
     VerifyResult,
+    _clean_ref,
+    _verdict_instruction,
+    _verify_clean_instruction,
     _verify_instruction,
     _verify_ref,
 )
@@ -254,3 +257,177 @@ def test_verify_instruction_names_the_ref_field():
     assert "claim: sqli" in text
     # Deterministic: the same issue always gets the same token.
     assert _verify_ref(issue) == ref
+
+
+# -- clean-verdict audit ------------------------------------------------------
+# A clean or minor-only review spawns no issue verifiers, so it used to reach
+# the verdict with zero VerifyResult — and a downstream evidence floor then
+# refused the APPROVE as evidence-empty, structurally, on every clean run.
+# The engine now audits its own clean verdict: one adversarial verifier that
+# must execute a real check and emit a VerifyResult carrying the run's clean
+# ref, so a clean verdict ships positive evidence instead of absence.
+
+
+class _RoutedEmitter:
+    """operate() emits the event registered for this agent's name, once."""
+
+    def __init__(self, run, name: str, event):
+        self.name = name
+        self._run = run
+        self._event = event
+        self.calls: list[str] = []
+
+    async def operate(self, *, instruction: str):
+        self.calls.append(instruction)
+        if self._event is not None and len(self.calls) == 1:
+            await self._run.emit(self._event)
+        return None
+
+
+def _routing_make(run, events_by_name: dict, made: list, verdict_capture: dict | None = None):
+    async def fake_make(role, *, name=None, **kw):
+        made.append(name or role)
+        if name == "verdict":
+
+            class _Synth:
+                name = "verdict"
+
+                async def operate(self, *, instruction: str):
+                    if verdict_capture is not None:
+                        verdict_capture["instruction"] = instruction
+                    return "APPROVE"
+
+            return _Synth()
+        return _RoutedEmitter(run, name or role, events_by_name.get(name))
+
+    return fake_make
+
+
+@pytest.mark.asyncio
+async def test_clean_review_emits_a_clean_audit_verify_result():
+    dims = ("correctness", "security")
+    eng = ReviewEngine(dimensions=dims)
+    run = eng.new_run()
+    ref = _clean_ref(dims)
+    made: list = []
+    run.make_agent = _routing_make(
+        run,
+        {
+            "review-correctness": DimensionClean(dimension="correctness", rationale="checked"),
+            "review-security": DimensionClean(dimension="security", rationale="checked"),
+            "verify-clean": VerifyResult(
+                issue="CLEAN: review affirmed no blocking issues",
+                ref=ref,
+                holds=True,
+                rationale="ran the suite named in the artifact; 12 passed",
+            ),
+        },
+        made,
+    )
+    await eng._run(run, "ARTIFACT")
+    assert "verify-clean" in made
+    results = run.by_type(VerifyResult)
+    assert len(results) == 1 and results[0].ref == ref
+
+
+@pytest.mark.asyncio
+async def test_minor_only_review_also_gets_the_clean_audit():
+    # Minor issues spawn no issue verifier, so without the audit this run
+    # would carry zero VerifyResult exactly like a clean one.
+    dims = ("correctness",)
+    eng = ReviewEngine(dimensions=dims)
+    run = eng.new_run()
+    ref = _clean_ref(dims)
+    made: list = []
+    run.make_agent = _routing_make(
+        run,
+        {
+            "review-correctness": IssueFound(
+                dimension="correctness", description="nit", severity="minor"
+            ),
+            "verify-clean": VerifyResult(issue="CLEAN: minor-only", ref=ref, holds=True),
+        },
+        made,
+    )
+    await eng._run(run, "ARTIFACT")
+    assert "verify-clean" in made
+    assert any(v.ref == ref for v in run.by_type(VerifyResult))
+
+
+@pytest.mark.asyncio
+async def test_issue_path_spawns_no_clean_audit():
+    # A critical issue produces a real issue verification — the clean audit
+    # must not fire on top of it.
+    dims = ("security",)
+    eng = ReviewEngine(dimensions=dims)
+    run = eng.new_run()
+    issue = IssueFound(dimension="security", description="sqli", severity="critical")
+    made: list = []
+    run.make_agent = _routing_make(
+        run,
+        {
+            "review-security": issue,
+            "verify-security": VerifyResult(issue="sqli", ref=_verify_ref(issue), holds=True),
+        },
+        made,
+    )
+    await eng._run(run, "ARTIFACT")
+    assert "verify-security" in made
+    assert "verify-clean" not in made
+
+
+@pytest.mark.asyncio
+async def test_verify_clean_off_switch_restores_old_behavior():
+    dims = ("correctness",)
+    eng = ReviewEngine(dimensions=dims, verify_clean=False)
+    run = eng.new_run()
+    made: list = []
+    run.make_agent = _routing_make(
+        run,
+        {"review-correctness": DimensionClean(dimension="correctness")},
+        made,
+    )
+    await eng._run(run, "ARTIFACT")
+    assert "verify-clean" not in made
+    assert run.by_type(VerifyResult) == []
+
+
+def test_verify_clean_instruction_mandates_an_executed_check():
+    dims = ("correctness", "security")
+    ref = _clean_ref(dims)
+    clean = [DimensionClean(dimension="correctness", rationale="looked sound")]
+    text = _verify_clean_instruction("ARTIFACT-BODY", clean, ref)
+    assert f"ref='{ref}'" in text
+    assert "MUST execute" in text
+    assert "naming no executed check is invalid" in text
+    assert "ARTIFACT-BODY" in text  # the verifier gets the artifact to check against
+    assert "correctness: looked sound" in text
+    # Deterministic per dimension set, distinct across sets.
+    assert _clean_ref(dims) == ref
+    assert _clean_ref(("other",)) != ref
+
+
+def test_verdict_instruction_inverts_polarity_for_refuted_clean_audit():
+    # The generic guidance says "weigh refuted issues down" — read onto a
+    # clean audit, that polarity is backwards: holds=false there REFUTES the
+    # clean verdict. The clean-audit section must carry its own AGAINST-
+    # approval guidance, and it must appear only when a clean audit exists.
+    dims = ("correctness",)
+    refuted = VerifyResult(
+        issue="CLEAN: review affirmed no blocking issues",
+        ref=_clean_ref(dims),
+        holds=False,
+        rationale="ran the suite; 2 tests fail",
+    )
+    with_audit = _verdict_instruction("ART", dims, [], [refuted], [])
+    assert "Clean-verdict audit" in with_audit
+    assert "weigh that AGAINST approval" in with_audit
+    assert "ran the suite; 2 tests fail" in with_audit
+
+    # An ordinary issue verification must NOT be routed into the audit
+    # section or given the inverted guidance.
+    issue = IssueFound(dimension="security", description="sqli", severity="critical")
+    ordinary = VerifyResult(issue="sqli", ref=_verify_ref(issue), holds=False)
+    without_audit = _verdict_instruction("ART", dims, [issue], [ordinary], [])
+    assert "Clean-verdict audit" not in without_audit
+    assert "weigh that AGAINST approval" not in without_audit


### PR DESCRIPTION
## Problem

A clean or minor-only review spawns no issue verifiers — the verify stage only reacts to critical/major `IssueFound` — so the run reaches its verdict with zero `VerifyResult`. By evidence, that is indistinguishable from a run whose verification never happened, and any downstream consumer requiring positive verification evidence refuses every clean APPROVE, structurally.

## Change

When a run reaches quiescence with no `VerifyResult`, spawn one adversarial verifier auditing the clean verdict itself:

- Must execute a concrete check against the artifact and name what it executed in its rationale.
- Emits a `VerifyResult` carrying a run-level clean ref (same echo-token arrival mechanics as issue verifiers).
- Gate is zero-`VerifyResult`, not zero-issues, so the minor-only shape is covered too.
- The verdict instruction lists clean audits apart from issue verifications: their polarity is inverted (`holds=false` refutes the clean verdict, weighing against approval).
- `verify_clean=True` default; off switch restores prior behavior. Engine-side only.

## Tests

Clean path, minor-only path, issue path (no double-spawn), off switch, mandatory executed-check wording, inverted polarity. The polarity arm is mutation-checked: removing the guidance line makes the arm fail on its outcome assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)