### PR TITLE
perf(state): hot-path index, bounded mirror ingestion, safe chunked retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ ALL_ADRS_COMPILED.txt
 codex_review_*.md
 .lane-*.md
 .reviews/
+
+# perf-loop scratch DB copies — never staged, never committed
+/scratch/

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import logging
 import time
@@ -15,6 +16,7 @@ from typing import Any
 
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
 from lionagi.ln._json_dump import raise_if_non_finite
+from lionagi.studio.config import MIRROR_PREVIEW_CHARS
 
 from ._logging import hint, log_error, progress, warn
 
@@ -278,8 +280,15 @@ def _since_window(spec: str) -> float:
     return secs
 
 
-def _read_new_events(path: Path, state: _FileState) -> tuple[list[dict[str, Any]], int, int]:
-    """Read complete JSONL lines past the cursor; return (events, new_offset, unreadable).
+def _read_new_events(
+    path: Path, state: _FileState
+) -> tuple[list[dict[str, Any]], list[tuple[int, int, str]], int, int]:
+    """Read complete JSONL lines past the cursor.
+
+    Returns ``(events, sources, new_offset, unreadable)``. ``sources`` is the
+    per-event ``(byte_offset, byte_count, sha256)`` of each raw line, in the
+    same order as ``events`` — the basis for a resolvable mirror source pointer
+    (see ``_mirror_common.bound_mirror_content``).
 
     The cursor is NOT advanced here — the caller only commits it after the batch
     is durably mirrored, so a write failure re-reads the same lines next pass.
@@ -297,12 +306,16 @@ def _read_new_events(path: Path, state: _FileState) -> tuple[list[dict[str, Any]
         fh.seek(state.offset)
         chunk = fh.read()
     if b"\n" not in chunk:
-        return [], state.offset, 0
+        return [], [], state.offset, 0
     body, _, _ = chunk.rpartition(b"\n")
     new_offset = state.offset + len(body) + 1
-    events = []
+    events: list[dict[str, Any]] = []
+    sources: list[tuple[int, int, str]] = []
     unreadable = 0
+    pos = state.offset
     for raw in body.split(b"\n"):
+        line_offset = pos
+        pos += len(raw) + 1  # +1 for the newline consumed by split
         if not raw.strip():
             continue
         try:
@@ -312,9 +325,10 @@ def _read_new_events(path: Path, state: _FileState) -> tuple[list[dict[str, Any]
             continue
         if isinstance(obj, dict):
             events.append(obj)
+            sources.append((line_offset, len(raw), hashlib.sha256(raw).hexdigest()))
         else:
             unreadable += 1
-    return events, new_offset, unreadable
+    return events, sources, new_offset, unreadable
 
 
 _COMMAND_NOISE = ("<command-", "<local-command-")
@@ -414,7 +428,7 @@ def _first_prompt(events: list[dict[str, Any]]) -> str | None:
 async def _mirror_one(db, path: Path, state: _FileState, lineage: _Lineage) -> int:
     from lionagi.state.claude_mirror import mirror_session
 
-    events, new_offset, unreadable = _read_new_events(path, state)
+    events, sources, new_offset, unreadable = _read_new_events(path, state)
     if unreadable:
         warn(f"{path.name}: {unreadable} unreadable line(s) skipped")
     if not events:
@@ -439,6 +453,9 @@ async def _mirror_one(db, path: Path, state: _FileState, lineage: _Lineage) -> i
         model=state.model,
         name=state.name,
         status="running",
+        source_path=str(path),
+        event_sources=sources,
+        max_preview_chars=MIRROR_PREVIEW_CHARS,
     )
     # Advance the cursor only after the batch is durably mirrored, so a failed
     # write re-reads (idempotently) rather than losing the batch.
@@ -609,7 +626,7 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
     if not state.session_uid:
         state.session_uid = path.stem
 
-    records, new_offset, unreadable = _read_new_events(path, state)
+    records, sources, new_offset, unreadable = _read_new_events(path, state)
     if not records:
         state.offset = new_offset
         return 0
@@ -638,6 +655,8 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
         source_path=str(path),
         turn=state.turn,
         unparseable=unreadable,
+        event_sources=sources,
+        max_preview_chars=MIRROR_PREVIEW_CHARS,
     )
     # Advance only after a durable write, so a failed batch is re-read next pass.
     state.offset = new_offset
@@ -745,8 +764,8 @@ async def mirror_forever(
     want_claude = source in ("both", "claude")
     want_codex = source in ("both", "codex")
 
-    root = Path(root).expanduser() if root else CLAUDE_PROJECTS_DIR
-    codex_root = Path(codex_root).expanduser() if codex_root else CODEX_SESSIONS_DIR
+    root = Path(root).expanduser().resolve() if root else CLAUDE_PROJECTS_DIR
+    codex_root = Path(codex_root).expanduser().resolve() if codex_root else CODEX_SESSIONS_DIR
     if not (want_claude and root.exists()) and not (want_codex and codex_root.exists()):
         return
     since_secs = _parse_window(since) if since else None
@@ -809,9 +828,9 @@ async def _run(args: argparse.Namespace) -> int:
     want_claude = source in ("both", "claude")
     want_codex = source in ("both", "codex")
 
-    root = Path(args.root).expanduser() if args.root else CLAUDE_PROJECTS_DIR
+    root = Path(args.root).expanduser().resolve() if args.root else CLAUDE_PROJECTS_DIR
     codex_root = (
-        Path(args.codex_root).expanduser()
+        Path(args.codex_root).expanduser().resolve()
         if getattr(args, "codex_root", None)
         else CODEX_SESSIONS_DIR
     )

--- a/lionagi/state/_mirror_common.py
+++ b/lionagi/state/_mirror_common.py
@@ -4,16 +4,257 @@
 
 Both mirrors tail an external tool's transcript into StateDB, so status
 reconciliation and lineage linking are identical once the session id is known.
+
+This module also owns the bounded-preview + source-pointer codec: mirror rows
+store a bounded display preview in ``messages.content`` plus a versioned byte
+pointer into the source transcript in ``messages.node_metadata.mirror_source``,
+so the pointer allows deterministic recovery of the full content without
+duplicating it in sqlite. See ``mirror_spec.md`` for the normative contract.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 if TYPE_CHECKING:
     from .db import StateDB
 
-__all__ = ("reconcile_status", "link_lineage")
+__all__ = (
+    "reconcile_status",
+    "link_lineage",
+    "MirrorKind",
+    "MirrorSourcePointer",
+    "SourceLine",
+    "ResolutionStatus",
+    "ResolvedContent",
+    "canonical_json",
+    "content_sha256",
+    "bound_mirror_content",
+    "resolve_mirrored_content",
+)
+
+MirrorKind = Literal["claude_jsonl", "codex_jsonl"]
+
+_POINTER_KIND = "mirror_jsonl_v1"
+
+# Function-name preview never exceeds this even when the char budget is larger.
+_FUNCTION_PREVIEW_CAP = 128
+
+
+class MirrorSourcePointer(TypedDict):
+    pointer_kind: Literal["mirror_jsonl_v1"]
+    source_kind: MirrorKind
+    source_path: str
+    source_offset: int
+    source_byte_count: int
+    source_sha256: str
+    source_session_uid: str
+    message_id: str
+    content_sha256: str
+    truncated: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SourceLine:
+    value: dict[str, object]
+    source_path: str
+    source_offset: int
+    source_byte_count: int
+    source_sha256: str
+
+
+ResolutionStatus = Literal["legacy", "resolved", "preview"]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedContent:
+    content: dict[str, object]
+    status: ResolutionStatus
+    reason: str | None = None
+
+
+def canonical_json(value: object) -> str:
+    """Deterministic JSON for hashing: UTF-8, sorted keys, compact separators."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def content_sha256(content: object) -> str:
+    return hashlib.sha256(canonical_json(content).encode("utf-8")).hexdigest()
+
+
+def _truncate(text: str, limit: int) -> tuple[str, bool]:
+    limit = max(limit, 0)
+    if len(text) <= limit:
+        return text, False
+    return text[:limit], True
+
+
+def _bound_content(content: dict[str, object], max_chars: int) -> tuple[dict[str, object], bool]:
+    """Apply the per-message-class preview rule from mirror_spec.md §3.
+
+    Message classes are discriminated by which fields are present rather than
+    an exact key-set match: ``RoledMessage.to_dict(mode="db")`` includes a
+    content class's untouched-default fields (e.g. ActionResponse always
+    carries ``arguments: {}``) and omits ``None`` fields, so the live shape
+    varies per instance even though the mirror only ever populates a fixed
+    subset. Fields outside the ones this function bounds are passed through
+    unchanged, never dropped.
+    """
+    keys = set(content.keys())
+
+    if keys == {"instruction"}:
+        text, trunc = _truncate(str(content.get("instruction") or ""), max_chars)
+        return {"instruction": text}, trunc
+
+    if keys == {"assistant_response"}:
+        text, trunc = _truncate(str(content.get("assistant_response") or ""), max_chars)
+        return {"assistant_response": text}, trunc
+
+    if "function" in keys and "output" in keys:
+        # ActionResponse: function + output always present; action_request_id,
+        # error and arguments are optional/default and carried through as-is.
+        fn_cap = min(_FUNCTION_PREVIEW_CAP, max_chars)
+        fn_preview, fn_trunc = _truncate(str(content.get("function") or ""), fn_cap)
+        remaining = max(max_chars - len(fn_preview), 0)
+        out_preview, out_trunc = _truncate(str(content.get("output") or ""), remaining)
+        bounded = dict(content)
+        bounded["function"] = fn_preview
+        bounded["output"] = out_preview
+        return bounded, (fn_trunc or out_trunc)
+
+    if "function" in keys and "arguments" in keys:
+        fn_cap = min(_FUNCTION_PREVIEW_CAP, max_chars)
+        fn_preview, fn_trunc = _truncate(str(content.get("function") or ""), fn_cap)
+        remaining = max(max_chars - len(fn_preview), 0)
+        args_json = canonical_json(content.get("arguments"))
+        args_prefix, args_trunc = _truncate(args_json, remaining)
+        bounded = dict(content)
+        bounded["function"] = fn_preview
+        bounded["arguments"] = {"_mirror_preview": args_prefix, "_truncated": args_trunc}
+        return bounded, (fn_trunc or args_trunc)
+
+    # Unknown mirror-produced shape: fail bounded rather than persist unbounded.
+    prefix, _ = _truncate(canonical_json(content), max_chars)
+    return {"_mirror_preview": prefix, "_truncated": True}, True
+
+
+def bound_mirror_content(
+    content: dict[str, object],
+    message_id: str,
+    source_line: SourceLine,
+    *,
+    source_kind: MirrorKind,
+    source_session_uid: str,
+    max_preview_chars: int,
+) -> tuple[dict[str, object], MirrorSourcePointer]:
+    """Bound one message's full content to a display preview and build its pointer.
+
+    Preview slicing counts Unicode code points; the pointer's offset/byte-count
+    are the exact bytes of the source JSONL record (see mirror_spec.md §4).
+    """
+    if max_preview_chars < 0:
+        raise ValueError(f"max_preview_chars must be >= 0, got {max_preview_chars}")
+
+    preview, truncated = _bound_content(content, max_preview_chars)
+    pointer: MirrorSourcePointer = {
+        "pointer_kind": _POINTER_KIND,
+        "source_kind": source_kind,
+        "source_path": source_line.source_path,
+        "source_offset": source_line.source_offset,
+        "source_byte_count": source_line.source_byte_count,
+        "source_sha256": source_line.source_sha256,
+        "source_session_uid": source_session_uid,
+        "message_id": message_id,
+        "content_sha256": content_sha256(content),
+        "truncated": truncated,
+    }
+    return preview, pointer
+
+
+def resolve_mirrored_content(
+    row: dict[str, Any],
+    *,
+    reconstruct: Callable[[dict[str, object], str, str], dict[str, object] | None] | None = None,
+) -> ResolvedContent:
+    """Recover a mirrored row's full content from its source pointer, verifying
+    every step (mirror_spec.md §5). Never raises; degrades to the stored preview
+    with a stable ``reason`` on any mismatch — a stale/moved/rotated source must
+    never silently return content from a different file.
+
+    ``reconstruct(parsed_record, source_session_uid, message_id)`` re-runs the
+    owning adapter's mapper and returns the derived message's full content dict
+    (or ``None`` if no derived message matches ``message_id``). Adapters are not
+    wired to call this in this round (mirror_spec.md §6) — it is exercised
+    directly by tests and available for a later integration.
+    """
+    stored_content = row.get("content") or {}
+    node_metadata = row.get("node_metadata") or {}
+    pointer = node_metadata.get("mirror_source")
+
+    if not pointer:
+        return ResolvedContent(content=stored_content, status="legacy")
+
+    def _preview(reason: str) -> ResolvedContent:
+        return ResolvedContent(content=stored_content, status="preview", reason=reason)
+
+    if pointer.get("pointer_kind") != _POINTER_KIND:
+        return _preview("unsupported_pointer")
+
+    try:
+        offset = int(pointer["source_offset"])
+        byte_count = int(pointer["source_byte_count"])
+        path_str = str(pointer["source_path"])
+    except (KeyError, TypeError, ValueError):
+        return _preview("unsupported_pointer")
+
+    if offset < 0 or byte_count < 0 or not Path(path_str).is_absolute():
+        return _preview("unsupported_pointer")
+
+    path = Path(path_str)
+    try:
+        with path.open("rb") as fh:
+            fh.seek(offset)
+            raw = fh.read(byte_count)
+    except FileNotFoundError:
+        return _preview("source_missing")
+    except OSError:
+        return _preview("source_unreadable")
+
+    if len(raw) != byte_count:
+        return _preview("short_read")
+
+    if hashlib.sha256(raw).hexdigest() != pointer.get("source_sha256"):
+        return _preview("source_replaced")
+
+    try:
+        record = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _preview("invalid_json")
+    if not isinstance(record, dict):
+        return _preview("invalid_json")
+
+    if reconstruct is None:
+        return _preview("no_reconstructor")
+
+    source_session_uid = str(pointer.get("source_session_uid") or "")
+    message_id = str(pointer.get("message_id") or "")
+    try:
+        reconstructed = reconstruct(record, source_session_uid, message_id)
+    except Exception:
+        return _preview("content_mismatch")
+
+    if reconstructed is None:
+        return _preview("no_message_match")
+
+    if content_sha256(reconstructed) != pointer.get("content_sha256"):
+        return _preview("content_mismatch")
+
+    return ResolvedContent(content=reconstructed, status="resolved")
 
 
 async def reconcile_status(

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -15,6 +15,8 @@ from lionagi.protocols.messages.action_response import ActionResponse
 from lionagi.protocols.messages.assistant_response import AssistantResponse
 from lionagi.protocols.messages.instruction import Instruction
 
+from ._mirror_common import SourceLine, bound_mirror_content
+
 if TYPE_CHECKING:
     from lionagi.protocols.messages.message import RoledMessage
 
@@ -206,17 +208,42 @@ async def mirror_session(
     provider: str | None = "anthropic",
     name: str | None = None,
     status: str = "running",
+    source_path: str | None = None,
+    event_sources: list[tuple[int, int, str]] | None = None,
+    max_preview_chars: int | None = None,
 ) -> int:
     """Idempotently write a batch of Claude events for one session; returns msgs written.
-    Live/idle transitions are owned by ``reconcile_session_status``, not this writer."""
+    Live/idle transitions are owned by ``reconcile_session_status``, not this writer.
+
+    ``event_sources`` is the per-event ``(byte_offset, byte_count, sha256)`` of each
+    raw JSONL line in ``events`` (same order/length), and ``source_path`` is the
+    transcript file they came from. When both are given together with
+    ``max_preview_chars``, every message's content is bounded via
+    ``bound_mirror_content`` before it is written, with a resolvable source pointer
+    on ``node_metadata.mirror_source``. Omitting them keeps the legacy unbounded
+    write, for callers with no live transcript file behind the events.
+    """
     sid = session_db_id(session_uid)
     branch_id = _det(session_uid, "branch")
     bprog = _det(session_uid, "bprog")
     sprog = _det(session_uid, "sprog")
 
     messages: list[RoledMessage] = []
-    for ev in events:
-        messages.extend(messages_for_event(ev, session_uid, tool_names))
+    message_sources: list[SourceLine | None] = []
+    for idx, ev in enumerate(events):
+        produced = messages_for_event(ev, session_uid, tool_names)
+        src: SourceLine | None = None
+        if produced and event_sources is not None and idx < len(event_sources):
+            offset, byte_count, sha = event_sources[idx]
+            src = SourceLine(
+                value=ev,
+                source_path=source_path or "",
+                source_offset=offset,
+                source_byte_count=byte_count,
+                source_sha256=sha,
+            )
+        messages.extend(produced)
+        message_sources.extend([src] * len(produced))
 
     existing = await db.get_session(sid)
     if existing is None and not messages:
@@ -273,8 +300,21 @@ async def mirror_session(
         }
     )
 
-    for m in messages:
+    for m, src in zip(messages, message_sources, strict=False):
         md = m.to_dict(mode="db")
+        if max_preview_chars is not None and src is not None:
+            preview, pointer = bound_mirror_content(
+                md["content"],
+                md["id"],
+                src,
+                source_kind="claude_jsonl",
+                source_session_uid=session_uid,
+                max_preview_chars=max_preview_chars,
+            )
+            md["content"] = preview
+            nm = dict(md.get("node_metadata") or {})
+            nm["mirror_source"] = pointer
+            md["node_metadata"] = nm
         await db.insert_message(md)
         await db.append_to_progression(bprog, md["id"])
         await db.append_to_progression(sprog, md["id"])

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -27,6 +27,8 @@ from lionagi.protocols.messages.action_response import ActionResponse
 from lionagi.protocols.messages.assistant_response import AssistantResponse
 from lionagi.protocols.messages.instruction import Instruction
 
+from ._mirror_common import SourceLine, bound_mirror_content
+
 if TYPE_CHECKING:
     from lionagi.protocols.messages.message import RoledMessage
 
@@ -408,6 +410,8 @@ async def mirror_session(
     source_path: str | None = None,
     turn: dict[str, Any] | None = None,
     unparseable: int = 0,
+    event_sources: list[tuple[int, int, str]] | None = None,
+    max_preview_chars: int | None = None,
 ) -> tuple[int, RecordTally]:
     """Idempotently write a batch of codex records for one rollout.
 
@@ -416,6 +420,13 @@ async def mirror_session(
     file being mirrored across several passes; it is updated in place as records
     are walked. ``source_path`` is the rollout file this batch came from, stamped
     into the session's provenance so any row resolves back to its file.
+
+    ``event_sources`` is the per-record ``(byte_offset, byte_count, sha256)`` of
+    each raw JSONL line in ``records`` (same order/length). When both it and
+    ``max_preview_chars`` are given, every message's content is bounded via
+    ``bound_mirror_content`` before it is written, with a resolvable source
+    pointer on ``node_metadata.mirror_source``. Omitting them keeps the legacy
+    unbounded write, for callers with no live rollout file behind the records.
 
     Live/idle transitions are owned by ``reconcile_session_status``, not this writer.
     """
@@ -427,7 +438,8 @@ async def mirror_session(
     seen: dict[str, int] = {}
     mirrored: dict[str, int] = {}
     messages: list[RoledMessage] = []
-    for rec in records:
+    message_sources: list[SourceLine | None] = []
+    for idx, rec in enumerate(records):
         rtype = str(rec.get("type") or "<untyped>")
         seen[rtype] = seen.get(rtype, 0) + 1
         ctx = turn_context(rec)
@@ -437,7 +449,18 @@ async def mirror_session(
         produced = messages_for_record(rec, rollout_uid, tool_names, turn)
         if produced:
             mirrored[rtype] = mirrored.get(rtype, 0) + len(produced)
+            src: SourceLine | None = None
+            if event_sources is not None and idx < len(event_sources):
+                offset, byte_count, sha = event_sources[idx]
+                src = SourceLine(
+                    value=rec,
+                    source_path=source_path or "",
+                    source_offset=offset,
+                    source_byte_count=byte_count,
+                    source_sha256=sha,
+                )
             messages.extend(produced)
+            message_sources.extend([src] * len(produced))
     tally = RecordTally(seen, mirrored, unparseable)
 
     existing = await db.get_session(sid)
@@ -515,8 +538,21 @@ async def mirror_session(
         }
     )
 
-    for m in messages:
+    for m, src in zip(messages, message_sources, strict=False):
         md = m.to_dict(mode="db")
+        if max_preview_chars is not None and src is not None:
+            preview, pointer = bound_mirror_content(
+                md["content"],
+                md["id"],
+                src,
+                source_kind="codex_jsonl",
+                source_session_uid=rollout_uid,
+                max_preview_chars=max_preview_chars,
+            )
+            md["content"] = preview
+            nm = dict(md.get("node_metadata") or {})
+            nm["mirror_source"] = pointer
+            md["node_metadata"] = nm
         await db.insert_message(md)
         await db.append_to_progression(bprog, md["id"])
         await db.append_to_progression(sprog, md["id"])

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -236,6 +236,8 @@ MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
         "CREATE INDEX IF NOT EXISTS idx_sessions_run_id "
         "ON sessions(run_id) WHERE run_id IS NOT NULL",
         *_MESSAGE_POINTER_INDEXES,
+        "CREATE INDEX IF NOT EXISTS idx_branches_session_created "
+        "ON branches(session_id, created_at)",
     ),
     "postgresql": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
@@ -245,5 +247,7 @@ MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
         "CREATE INDEX IF NOT EXISTS idx_sessions_run_id "
         "ON sessions(run_id) WHERE run_id IS NOT NULL",
         *_MESSAGE_POINTER_INDEXES,
+        "CREATE INDEX IF NOT EXISTS idx_branches_session_created "
+        "ON branches(session_id, created_at)",
     ),
 }

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -329,6 +329,17 @@ CHECKPOINT_INTERVAL_SECONDS: int = int(
 )
 # Sessions/runs older than this many days (with terminal status) will be pruned.
 PRUNE_KEEP_DAYS: int = int(os.environ.get("LIONAGI_STUDIO_PRUNE_KEEP_DAYS", "30"))
+# Directory to archive pruned rows to before deletion. Unset (default) preserves
+# the pre-archive prune behaviour exactly. When set, prune refuses to delete any
+# row unless the archive for that pass was written and verified first.
+_PRUNE_ARCHIVE_DIR_RAW = os.environ.get("LIONAGI_STUDIO_PRUNE_ARCHIVE_DIR", "").strip()
+PRUNE_ARCHIVE_DIR: Path | None = (
+    Path(_PRUNE_ARCHIVE_DIR_RAW).expanduser() if _PRUNE_ARCHIVE_DIR_RAW else None
+)
+# Max session ids deleted per committed chunk during prune. Bounds each
+# transaction so the write lock is released between chunks and an interrupted
+# prune keeps the chunks that already committed.
+PRUNE_CHUNK_ROWS: int = max(1, int(os.environ.get("LIONAGI_STUDIO_PRUNE_CHUNK_ROWS", "100")))
 
 # dispatch_outbox retention (ADR-0059 delta 3). Two windows: terminal-success
 # rows (delivered/acked) are low-signal once past the window, so they use a
@@ -359,3 +370,11 @@ _MIRROR_SOURCE_RAW: str = os.environ.get("LIONAGI_STUDIO_MIRROR_SOURCE", "both")
 MIRROR_SOURCE: str = (
     _MIRROR_SOURCE_RAW if _MIRROR_SOURCE_RAW in ("both", "claude", "codex") else "both"
 )
+# Bounded display preview stored in messages.content for mirror-ingested rows
+# (Unicode code points, not bytes). 0 is valid (empty preview + pointer only).
+# Negative values are a configuration error — there is no "unbounded" sentinel.
+MIRROR_PREVIEW_CHARS: int = int(os.environ.get("LIONAGI_STUDIO_MIRROR_PREVIEW_CHARS", "500"))
+if MIRROR_PREVIEW_CHARS < 0:
+    raise ValueError(
+        f"LIONAGI_STUDIO_MIRROR_PREVIEW_CHARS must be >= 0, got {MIRROR_PREVIEW_CHARS}"
+    )

--- a/lionagi/studio/services/db_maintenance.py
+++ b/lionagi/studio/services/db_maintenance.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 from sqlalchemy import text
@@ -14,10 +15,11 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 
 from lionagi._errors import LionError
 from lionagi.state.db import StateDB, state_db_file, state_db_known_absent
+from lionagi.studio.services.retention_archive import archive_chunk_id, write_archive_chunk
 
 _log = logging.getLogger(__name__)
 
-_CHUNK = 500  # max placeholders per IN-list statement
+_SQL_IN_CHUNK = 500  # placeholder bound for a single IN-list statement; not a transaction boundary
 
 
 def _q(sql: str, params: Sequence[Any]) -> tuple[Any, dict[str, Any]]:
@@ -41,8 +43,8 @@ async def _exec_chunked(
     checked beforehand. Returns total rowcount.
     """
     total = 0
-    for i in range(0, len(ids), _CHUNK):
-        chunk = ids[i : i + _CHUNK]
+    for i in range(0, len(ids), _SQL_IN_CHUNK):
+        chunk = ids[i : i + _SQL_IN_CHUNK]
         ph = ", ".join("?" * len(chunk))
         result = await conn.execute(
             *_q(f"{sql_prefix} IN ({ph}){suffix}", (*extra_params, *chunk, *suffix_params))  # noqa: S608
@@ -56,16 +58,26 @@ async def _fetch_chunked(
     sql_prefix: str,
     ids: Sequence[str],
     extra_params: Sequence[Any] = (),
+    *,
+    fetch_mappings: bool = False,
 ) -> list[Any]:
-    """SELECT *sql_prefix* + ' IN (?,?,...)' for *ids* in chunks; returns flat list."""
+    """SELECT *sql_prefix* + ' IN (?,?,...)' for *ids* in chunks; returns flat list.
+
+    With *fetch_mappings*, rows come back as plain ``dict`` (via
+    ``.mappings()``) instead of tuples — used when the caller needs full,
+    column-named rows (e.g. to archive them) rather than a single column.
+    """
     results: list[Any] = []
-    for i in range(0, len(ids), _CHUNK):
-        chunk = ids[i : i + _CHUNK]
+    for i in range(0, len(ids), _SQL_IN_CHUNK):
+        chunk = ids[i : i + _SQL_IN_CHUNK]
         ph = ", ".join("?" * len(chunk))
         result = await conn.execute(
             *_q(f"{sql_prefix} IN ({ph})", (*extra_params, *chunk))  # noqa: S608
         )
-        results.extend(result.fetchall())
+        if fetch_mappings:
+            results.extend(dict(r) for r in result.mappings().all())
+        else:
+            results.extend(result.fetchall())
     return results
 
 
@@ -89,6 +101,41 @@ _TERMINAL_SESSION_STATUSES = (
     "cancelled",
 )
 _TERMINAL_RUN_STATUSES = ("completed", "failed", "skipped", "cancelled")
+
+
+def _run_retention_predicate(cutoff: float) -> tuple[str, tuple[Any, ...]]:
+    """What makes a schedule_run prunable, mirroring the session predicate shape."""
+    placeholders = ", ".join("?" * len(_TERMINAL_RUN_STATUSES))
+    return (
+        f"status IN ({placeholders}) AND fired_at <= ?",
+        (*_TERMINAL_RUN_STATUSES, cutoff),
+    )
+
+
+_DISPATCH_SUCCESS_STATUSES = ("delivered", "acked")
+_DISPATCH_DEAD_LETTER_STATUSES = ("dead_letter", "expired")
+
+
+def _dispatch_retention_predicate(
+    success_cutoff: float, dead_letter_cutoff: float
+) -> tuple[str, tuple[Any, ...]]:
+    """What makes a dispatch_outbox row prunable: two disjoint status/window classes.
+
+    pending/delivering never qualify because neither status appears in either
+    branch of this OR.
+    """
+    success_ph = ", ".join("?" * len(_DISPATCH_SUCCESS_STATUSES))
+    dl_ph = ", ".join("?" * len(_DISPATCH_DEAD_LETTER_STATUSES))
+    return (
+        f"((status IN ({success_ph}) AND updated_at <= ?)"
+        f" OR (status IN ({dl_ph}) AND updated_at <= ?))",
+        (
+            *_DISPATCH_SUCCESS_STATUSES,
+            success_cutoff,
+            *_DISPATCH_DEAD_LETTER_STATUSES,
+            dead_letter_cutoff,
+        ),
+    )
 
 
 def _session_retention_predicate(cutoff: float) -> tuple[str, tuple[Any, ...]]:
@@ -215,6 +262,371 @@ def get_db_size_alert(size_bytes: int) -> tuple[bool, int]:
     return size_bytes >= threshold, threshold
 
 
+def _row_chunks(ids: Sequence[str], size: int) -> list[list[str]]:
+    """Split *ids* (already sorted) into stable, bounded, non-overlapping chunks."""
+    return [list(ids[i : i + size]) for i in range(0, len(ids), size)]
+
+
+async def _after_prune_chunk_committed(*, chunk_index: int, chunk_ids: list[str]) -> None:
+    """No-op extension point run after each prune chunk's transaction commits.
+
+    Exists so tests can simulate a crash between chunks (the write lock has
+    already been released and the chunk's deletes are already durable at
+    this point) without special-casing the production code path.
+    """
+    return None
+
+
+async def _prune_session_chunk(
+    conn: AsyncConnection,
+    session_ids: list[str],
+    *,
+    sess_ph: str,
+    retention_sql: str,
+    retention_params: tuple[Any, ...],
+    archive_destination: Path | None,
+    archive_id: str,
+) -> int:
+    """Archive-then-delete one chunk of candidate session ids in the caller's transaction.
+
+    Runs the same lock/recheck/soft-FK-nullify/delete/orphan-cleanup sequence
+    ``prune_old_data`` always had, scoped to this chunk only. When
+    *archive_destination* is set, the chunk's doomed rows (sessions, branches,
+    progressions, messages) are durably archived before any DELETE statement
+    runs; a failed archive write raises and the caller's transaction rolls
+    back, so this chunk's rows are refused rather than lost. Returns the
+    number of sessions actually deleted (0 if the chunk raced empty on
+    recheck).
+    """
+    if not session_ids:
+        return 0
+
+    session_ids = sorted(set(session_ids))
+
+    # Lock every candidate row for the rest of the transaction before its
+    # status is read — see the module-level design note on this race; the
+    # same hazard applies per chunk as it did to the whole set in the
+    # pre-chunking version of this function.
+    await _exec_chunked(
+        conn,
+        "UPDATE sessions SET updated_at = updated_at WHERE id",
+        session_ids,
+    )
+
+    # Recheck under lock, narrowed to this chunk's ids.
+    rows = await _fetch_chunked(
+        conn,
+        f"SELECT id FROM sessions WHERE {retention_sql} AND id",  # noqa: S608
+        session_ids,
+        retention_params,
+    )
+    session_ids = sorted({r[0] for r in rows})
+    if not session_ids:
+        return 0
+
+    # Capture child ids BEFORE archiving or deleting anything.
+    rows = await _fetch_chunked(conn, "SELECT progression_id FROM sessions WHERE id", session_ids)
+    session_prog_ids = [r[0] for r in rows if r[0] is not None]
+
+    rows = await _fetch_chunked(
+        conn, "SELECT progression_id FROM branches WHERE session_id", session_ids
+    )
+    branch_prog_ids = [r[0] for r in rows if r[0] is not None]
+
+    candidate_prog_ids = sorted({*session_prog_ids, *branch_prog_ids})
+
+    coll_msg_ids: list[str] = []
+    if candidate_prog_ids:
+        rows = await _fetch_chunked(
+            conn,
+            "SELECT value FROM progressions, json_each(progressions.collection)"
+            " WHERE value IS NOT NULL AND progressions.id",
+            candidate_prog_ids,
+        )
+        coll_msg_ids = [r[0] for r in rows]
+
+    # schema.sql: sessions.first_msg_id / last_msg_id REFERENCES messages(id)
+    rows = await _fetch_chunked(
+        conn,
+        "SELECT first_msg_id FROM sessions WHERE first_msg_id IS NOT NULL AND id",
+        session_ids,
+    )
+    session_first_ids = [r[0] for r in rows]
+    rows = await _fetch_chunked(
+        conn,
+        "SELECT last_msg_id FROM sessions WHERE last_msg_id IS NOT NULL AND id",
+        session_ids,
+    )
+    session_last_ids = [r[0] for r in rows]
+
+    # schema.sql: branches.system_msg_id REFERENCES messages(id)
+    rows = await _fetch_chunked(
+        conn,
+        "SELECT system_msg_id FROM branches WHERE system_msg_id IS NOT NULL AND session_id",
+        session_ids,
+    )
+    branch_sys_ids = [r[0] for r in rows]
+
+    candidate_msg_ids = sorted(
+        {*coll_msg_ids, *session_first_ids, *session_last_ids, *branch_sys_ids}
+    )
+
+    if archive_destination is not None:
+        # Archive-before-delete: durably write this chunk's doomed rows first.
+        # A failed write raises ArchiveWriteError, the caller's `async with
+        # db.transaction()` rolls back, and NOTHING in this chunk is deleted
+        # -- refusal without deletion on archive failure.
+        session_rows = await _fetch_chunked(
+            conn, "SELECT * FROM sessions WHERE id", session_ids, fetch_mappings=True
+        )
+        branch_rows = await _fetch_chunked(
+            conn,
+            "SELECT * FROM branches WHERE session_id",
+            session_ids,
+            fetch_mappings=True,
+        )
+        progression_rows = (
+            await _fetch_chunked(
+                conn,
+                "SELECT * FROM progressions WHERE id",
+                candidate_prog_ids,
+                fetch_mappings=True,
+            )
+            if candidate_prog_ids
+            else []
+        )
+        message_rows = (
+            await _fetch_chunked(
+                conn,
+                "SELECT * FROM messages WHERE id",
+                candidate_msg_ids,
+                fetch_mappings=True,
+            )
+            if candidate_msg_ids
+            else []
+        )
+        # Preimages of soft-FK rows this chunk is about to NULLIFY (not
+        # delete) below -- captured before the nullify so a restore can
+        # recover the original session linkage instead of leaving these
+        # rows permanently orphaned.
+        preimage_rows: dict[str, list[dict[str, Any]]] = {}
+        for table in ("artifacts", "plays", "team_messages", "dispatch_outbox"):
+            preimage_rows[table] = await _fetch_chunked(
+                conn,
+                f"SELECT * FROM {table} WHERE session_id",  # noqa: S608
+                session_ids,
+                fetch_mappings=True,
+            )
+
+        write_archive_chunk(
+            archive_destination,
+            archive_id,
+            {
+                "sessions": session_rows,
+                "branches": branch_rows,
+                "progressions": progression_rows,
+                "messages": message_rows,
+            },
+            preimages=preimage_rows,
+        )
+
+    # Every destructive statement carries the terminal condition itself —
+    # see the module-level design note; the same reasoning applies per chunk.
+    still_terminal = f" AND session_id IN (SELECT id FROM sessions WHERE status IN ({sess_ph}))"  # noqa: S608
+
+    for table in ("artifacts", "plays", "team_messages", "dispatch_outbox"):
+        await _exec_chunked(
+            conn,
+            f"UPDATE {table} SET session_id = NULL WHERE session_id",  # noqa: S608
+            session_ids,
+            suffix=still_terminal,
+            suffix_params=_TERMINAL_SESSION_STATUSES,
+        )
+    await _exec_chunked(
+        conn,
+        "DELETE FROM status_transitions WHERE entity_type = 'session' AND entity_id",
+        session_ids,
+        suffix=(
+            f" AND entity_id IN (SELECT id FROM sessions WHERE status IN ({sess_ph}))"  # noqa: S608
+        ),
+        suffix_params=_TERMINAL_SESSION_STATUSES,
+    )
+    # branches cascade automatically via FK ON DELETE CASCADE
+    sessions_pruned = await _exec_chunked(
+        conn,
+        f"DELETE FROM sessions WHERE status IN ({sess_ph}) AND id",  # noqa: S608
+        session_ids,
+        _TERMINAL_SESSION_STATUSES,
+    )
+
+    survivors = await _fetch_chunked(conn, "SELECT id FROM sessions WHERE id", session_ids)
+    if survivors:
+        raise PruneRaceError(
+            "session(s) "
+            + ", ".join(sorted(str(r[0]) for r in survivors))
+            + " stopped being terminal while their history was being removed; "
+            "nothing was pruned"
+        )
+
+    # Targeted orphan cleanup scoped to this chunk's lineage only.
+    if candidate_prog_ids:
+        for i in range(0, len(candidate_prog_ids), _SQL_IN_CHUNK):
+            chunk = candidate_prog_ids[i : i + _SQL_IN_CHUNK]
+            ph = ", ".join("?" * len(chunk))
+            sql = (
+                f"DELETE FROM progressions WHERE id IN ({ph})"  # noqa: S608
+                " AND id NOT IN ("
+                "  SELECT progression_id FROM sessions WHERE progression_id IS NOT NULL"
+                "  UNION"
+                "  SELECT progression_id FROM branches WHERE progression_id IS NOT NULL"
+                ")"
+            )
+            await conn.execute(*_q(sql, chunk))
+
+    if candidate_msg_ids:
+        for i in range(0, len(candidate_msg_ids), _SQL_IN_CHUNK):
+            chunk = candidate_msg_ids[i : i + _SQL_IN_CHUNK]
+            ph = ", ".join("?" * len(chunk))
+            sql = (
+                f"DELETE FROM messages WHERE id IN ({ph})"  # noqa: S608
+                " AND id NOT IN ("
+                "  SELECT value FROM progressions, json_each(progressions.collection)"
+                "  WHERE value IS NOT NULL"
+                "  UNION"
+                "  SELECT first_msg_id FROM sessions WHERE first_msg_id IS NOT NULL"
+                "  UNION"
+                "  SELECT last_msg_id FROM sessions WHERE last_msg_id IS NOT NULL"
+                "  UNION"
+                "  SELECT system_msg_id FROM branches WHERE system_msg_id IS NOT NULL"
+                ")"
+            )
+            await conn.execute(*_q(sql, chunk))
+
+    return sessions_pruned
+
+
+async def _prune_run_chunk(
+    conn: AsyncConnection,
+    run_ids: list[str],
+    *,
+    run_ph: str,
+    retention_sql: str,
+    retention_params: tuple[Any, ...],
+    archive_destination: Path | None,
+    archive_id: str,
+) -> int:
+    """Archive-then-delete one chunk of candidate schedule_run ids in the caller's transaction.
+
+    Same shape as :func:`_prune_session_chunk`: lock, recheck under lock,
+    archive the rechecked rows (if configured), nullify children that
+    reference this chunk's ids, then delete only the rechecked ids. A failed
+    archive write raises and the caller's transaction rolls back, so nothing
+    in this chunk is deleted.
+    """
+    if not run_ids:
+        return 0
+
+    run_ids = sorted(set(run_ids))
+
+    await _exec_chunked(conn, "UPDATE schedule_runs SET fired_at = fired_at WHERE id", run_ids)
+
+    rows = await _fetch_chunked(
+        conn,
+        f"SELECT id FROM schedule_runs WHERE {retention_sql} AND id",  # noqa: S608
+        run_ids,
+        retention_params,
+    )
+    run_ids = sorted({r[0] for r in rows})
+    if not run_ids:
+        return 0
+
+    if archive_destination is not None:
+        run_rows = await _fetch_chunked(
+            conn, "SELECT * FROM schedule_runs WHERE id", run_ids, fetch_mappings=True
+        )
+        # Preimages of soft-FK rows this chunk is about to NULLIFY below.
+        chain_child_rows = await _fetch_chunked(
+            conn, "SELECT * FROM schedule_runs WHERE chain_parent_id", run_ids, fetch_mappings=True
+        )
+        dispatch_child_rows = await _fetch_chunked(
+            conn,
+            "SELECT * FROM dispatch_outbox WHERE schedule_run_id",
+            run_ids,
+            fetch_mappings=True,
+        )
+        write_archive_chunk(
+            archive_destination,
+            archive_id,
+            {"schedule_runs": run_rows},
+            preimages={
+                "schedule_runs": chain_child_rows,
+                "dispatch_outbox": dispatch_child_rows,
+            },
+        )
+
+    await _exec_chunked(
+        conn, "UPDATE schedule_runs SET chain_parent_id = NULL WHERE chain_parent_id", run_ids
+    )
+    await _exec_chunked(
+        conn, "UPDATE dispatch_outbox SET schedule_run_id = NULL WHERE schedule_run_id", run_ids
+    )
+
+    return await _exec_chunked(
+        conn,
+        f"DELETE FROM schedule_runs WHERE status IN ({run_ph}) AND id",  # noqa: S608
+        run_ids,
+        _TERMINAL_RUN_STATUSES,
+    )
+
+
+async def _prune_dispatch_chunk(
+    conn: AsyncConnection,
+    dispatch_ids: list[str],
+    *,
+    retention_sql: str,
+    retention_params: tuple[Any, ...],
+    archive_destination: Path | None,
+    archive_id: str,
+) -> int:
+    """Archive-then-delete one chunk of candidate dispatch_outbox ids in the caller's transaction.
+
+    Same archive-before-delete contract as the session and run chunk
+    helpers. pending/delivering rows never enter *dispatch_ids* because they
+    never satisfy *retention_sql*.
+    """
+    if not dispatch_ids:
+        return 0
+
+    dispatch_ids = sorted(set(dispatch_ids))
+
+    await _exec_chunked(
+        conn, "UPDATE dispatch_outbox SET updated_at = updated_at WHERE id", dispatch_ids
+    )
+
+    rows = await _fetch_chunked(
+        conn,
+        f"SELECT id FROM dispatch_outbox WHERE {retention_sql} AND id",  # noqa: S608
+        dispatch_ids,
+        retention_params,
+    )
+    dispatch_ids = sorted({r[0] for r in rows})
+    if not dispatch_ids:
+        return 0
+
+    if archive_destination is not None:
+        dispatch_rows = await _fetch_chunked(
+            conn, "SELECT * FROM dispatch_outbox WHERE id", dispatch_ids, fetch_mappings=True
+        )
+        write_archive_chunk(archive_destination, archive_id, {"dispatch_outbox": dispatch_rows})
+
+    return await _exec_chunked(
+        conn,
+        f"DELETE FROM dispatch_outbox WHERE {retention_sql} AND id",  # noqa: S608
+        dispatch_ids,
+        retention_params,
+    )
+
+
 async def prune_old_data(
     *,
     keep_days: int | None = None,
@@ -222,14 +634,26 @@ async def prune_old_data(
     dispatch_dead_letter_keep_days: int | None = None,
     actor: str = "studio_db_maintenance",
 ) -> dict[str, int]:
-    """Remove terminal sessions/runs/dispatches older than their keep windows, in one transaction.
+    """Archive-then-prune terminal sessions/runs/dispatches older than their keep windows.
 
-    FK safety: soft-FK children (artifacts/plays/team_messages/dispatch_outbox) are
-    nullified before DELETE since they lack CASCADE.
+    All three root kinds -- sessions, schedule_runs, dispatch_outbox -- are
+    pruned the same way: each group of at most ``PRUNE_CHUNK_ROWS`` candidate
+    ids is archived (if ``PRUNE_ARCHIVE_DIR`` is set) and deleted in its own
+    short transaction, so the write lock is released between chunks and an
+    interrupted run keeps every chunk that already committed. No monolithic
+    retention transaction remains for any of the three. A chunk's archive
+    write is durably committed before that chunk's DELETE runs; a failed
+    archive write raises and aborts the remainder of the whole prune pass
+    (later chunks, and later root kinds, are never attempted), while every
+    chunk that already committed stays deleted. FK safety: soft-FK children
+    (artifacts/plays/team_messages/dispatch_outbox) are nullified before
+    DELETE since they lack CASCADE.
     """
     from lionagi.studio.config import (
         DISPATCH_RETENTION_DEAD_LETTER_DAYS,
         DISPATCH_RETENTION_SUCCESS_DAYS,
+        PRUNE_ARCHIVE_DIR,
+        PRUNE_CHUNK_ROWS,
         PRUNE_KEEP_DAYS,
     )
 
@@ -246,248 +670,108 @@ async def prune_old_data(
     cutoff = time.time() - keep_days * 86400.0
     sess_ph = ", ".join("?" * len(_TERMINAL_SESSION_STATUSES))
     run_ph = ", ".join("?" * len(_TERMINAL_RUN_STATUSES))
+    retention_sql, retention_params = _session_retention_predicate(cutoff)
 
     sessions_pruned = 0
     runs_pruned = 0
+    session_archive_ids: list[str] = []
+    run_archive_ids: list[str] = []
+    dispatch_archive_ids: list[str] = []
 
     async with StateDB() as db:
+        # ── find session IDs to prune (read-only candidate selection) ──────
         async with db.transaction() as conn:
-            # ── find session IDs to prune ─────────────────────────────────
-            # First of the predicate's two reads: candidate selection, over every
-            # session rather than a known set of ids.
-            retention_sql, retention_params = _session_retention_predicate(cutoff)
             sql = f"SELECT id FROM sessions WHERE {retention_sql}"  # noqa: S608
             rows = (await conn.execute(*_q(sql, retention_params))).fetchall()
-            session_ids = [r[0] for r in rows]
+            session_ids = sorted({r[0] for r in rows})
 
-            if session_ids:
-                session_ids = sorted(set(session_ids))
-
-                # Lock every candidate row for the rest of the transaction
-                # before its status is read. A write to a row is what takes the
-                # lock on both backends: postgresql locks the rows themselves,
-                # sqlite escalates the whole transaction to a write, which is
-                # the same guarantee at a coarser grain. The value is left
-                # exactly as it was — this statement exists for the lock.
-                #
-                # Reading the status without holding the rows would only move
-                # the window rather than close it. A session can leave a
-                # terminal status at any time (resuming a branch returns it to
-                # running), so a resume that commits after an unlocked read is
-                # still free to land between two of the destructive statements
-                # below, which is how a session ends up keeping its row and
-                # losing the associations already cleared for it.
-                await _exec_chunked(
+        # ── archive-then-delete in bounded, independently committed chunks ─
+        for chunk_index, chunk_ids in enumerate(_row_chunks(session_ids, PRUNE_CHUNK_ROWS)):
+            archive_id = archive_chunk_id(cutoff=cutoff, chunk_index=chunk_index)
+            async with db.transaction() as conn:
+                chunk_pruned = await _prune_session_chunk(
                     conn,
-                    "UPDATE sessions SET updated_at = updated_at WHERE id",
-                    session_ids,
+                    chunk_ids,
+                    sess_ph=sess_ph,
+                    retention_sql=retention_sql,
+                    retention_params=retention_params,
+                    archive_destination=PRUNE_ARCHIVE_DIR,
+                    archive_id=archive_id,
                 )
+            # Outside the transaction: this chunk has already committed and its
+            # write lock has already been released. A crash here (or in the
+            # next chunk's setup) keeps every chunk committed so far -- the
+            # hook exists so tests can simulate exactly that interruption
+            # point without it rolling back the chunk that just landed.
+            sessions_pruned += chunk_pruned
+            # An archive is only ever written when the chunk actually deleted
+            # something (see _prune_session_chunk: an empty post-recheck
+            # chunk returns before write_archive_chunk runs), so chunk_pruned
+            # tracks archive existence exactly.
+            if PRUNE_ARCHIVE_DIR is not None and chunk_pruned:
+                session_archive_ids.append(archive_id)
+            await _after_prune_chunk_committed(chunk_index=chunk_index, chunk_ids=chunk_ids)
 
-                # Second of the predicate's two reads: the recheck under lock,
-                # narrowed to the candidate ids. Now that the rows are held, both
-                # conditions are re-read so a session that came back to life or
-                # received recent activity before the lock drops out.
-                rows = await _fetch_chunked(
+        # ── schedule_run retention: archive-then-delete in bounded, ────────
+        # independently committed chunks (ADR-R3 shape, applied to runs).
+        run_retention_sql, run_retention_params = _run_retention_predicate(cutoff)
+        async with db.transaction() as conn:
+            sql = f"SELECT id FROM schedule_runs WHERE {run_retention_sql}"  # noqa: S608
+            rows = (await conn.execute(*_q(sql, run_retention_params))).fetchall()
+            run_ids = sorted({r[0] for r in rows})
+
+        for chunk_index, chunk_ids in enumerate(_row_chunks(run_ids, PRUNE_CHUNK_ROWS)):
+            archive_id = archive_chunk_id(cutoff=cutoff, chunk_index=chunk_index, kind="run")
+            async with db.transaction() as conn:
+                chunk_pruned = await _prune_run_chunk(
                     conn,
-                    f"SELECT id FROM sessions WHERE {retention_sql} AND id",  # noqa: S608
-                    session_ids,
-                    retention_params,
+                    chunk_ids,
+                    run_ph=run_ph,
+                    retention_sql=run_retention_sql,
+                    retention_params=run_retention_params,
+                    archive_destination=PRUNE_ARCHIVE_DIR,
+                    archive_id=archive_id,
                 )
-                session_ids = sorted({r[0] for r in rows})
+            # Same lock-release semantics as the session chunk loop above:
+            # this chunk has already committed by the time we get here.
+            runs_pruned += chunk_pruned
+            if PRUNE_ARCHIVE_DIR is not None and chunk_pruned:
+                run_archive_ids.append(archive_id)
+            await _after_prune_chunk_committed(chunk_index=chunk_index, chunk_ids=chunk_ids)
 
-            if session_ids:
-                # Capture child ids BEFORE deleting anything.
-                rows = await _fetch_chunked(
-                    conn,
-                    "SELECT progression_id FROM sessions WHERE id",
-                    session_ids,
-                )
-                session_prog_ids = [r[0] for r in rows if r[0] is not None]
+        # ── dispatch_outbox retention (ADR-0059 delta 3): two separate ─────
+        # windows for success vs dead-lettered, same chunked archive-then-
+        # delete shape; pending/delivering are never in either window.
+        dispatch_success_cutoff = time.time() - dispatch_success_keep_days * 86400.0
+        dispatch_dead_letter_cutoff = time.time() - dispatch_dead_letter_keep_days * 86400.0
+        dispatch_retention_sql, dispatch_retention_params = _dispatch_retention_predicate(
+            dispatch_success_cutoff, dispatch_dead_letter_cutoff
+        )
+        async with db.transaction() as conn:
+            sql = f"SELECT id FROM dispatch_outbox WHERE {dispatch_retention_sql}"  # noqa: S608
+            rows = (await conn.execute(*_q(sql, dispatch_retention_params))).fetchall()
+            dispatch_ids = sorted({r[0] for r in rows})
 
-                rows = await _fetch_chunked(
-                    conn,
-                    "SELECT progression_id FROM branches WHERE session_id",
-                    session_ids,
-                )
-                branch_prog_ids = [r[0] for r in rows if r[0] is not None]
-
-                candidate_prog_ids = sorted({*session_prog_ids, *branch_prog_ids})
-
-                coll_msg_ids: list[str] = []
-                if candidate_prog_ids:
-                    rows = await _fetch_chunked(
-                        conn,
-                        "SELECT value FROM progressions, json_each(progressions.collection)"
-                        " WHERE value IS NOT NULL AND progressions.id",
-                        candidate_prog_ids,
-                    )
-                    coll_msg_ids = [r[0] for r in rows]
-
-                # schema.sql: sessions.first_msg_id / last_msg_id REFERENCES messages(id)
-                rows = await _fetch_chunked(
-                    conn,
-                    "SELECT first_msg_id FROM sessions WHERE first_msg_id IS NOT NULL AND id",
-                    session_ids,
-                )
-                session_first_ids = [r[0] for r in rows]
-                rows = await _fetch_chunked(
-                    conn,
-                    "SELECT last_msg_id FROM sessions WHERE last_msg_id IS NOT NULL AND id",
-                    session_ids,
-                )
-                session_last_ids = [r[0] for r in rows]
-
-                # schema.sql: branches.system_msg_id REFERENCES messages(id)
-                rows = await _fetch_chunked(
-                    conn,
-                    "SELECT system_msg_id FROM branches WHERE system_msg_id IS NOT NULL AND session_id",
-                    session_ids,
-                )
-                branch_sys_ids = [r[0] for r in rows]
-
-                candidate_msg_ids = sorted(
-                    {*coll_msg_ids, *session_first_ids, *session_last_ids, *branch_sys_ids}
-                )
-
-                # Every destructive statement carries the terminal condition
-                # itself. Checking it once above and then running a sequence of
-                # writes would protect only whichever statement happens to be
-                # last: a session that reopens partway through would keep its
-                # row and lose the history and associations already removed,
-                # which is a worse outcome than the one being prevented.
-                still_terminal = (
-                    f" AND session_id IN (SELECT id FROM sessions WHERE status IN ({sess_ph}))"  # noqa: S608
-                )
-
-                # Nullify soft FKs (no CASCADE) before deleting sessions.
-                for table in ("artifacts", "plays", "team_messages", "dispatch_outbox"):
-                    # dispatch_outbox.session_id is a plain FK (no CASCADE) —
-                    # nullify before the parent DELETE or the prune aborts on
-                    # the FK constraint.
-                    await _exec_chunked(
-                        conn,
-                        f"UPDATE {table} SET session_id = NULL WHERE session_id",  # noqa: S608
-                        session_ids,
-                        suffix=still_terminal,
-                        suffix_params=_TERMINAL_SESSION_STATUSES,
-                    )
-                await _exec_chunked(
-                    conn,
-                    "DELETE FROM status_transitions WHERE entity_type = 'session' AND entity_id",
-                    session_ids,
-                    suffix=(
-                        f" AND entity_id IN (SELECT id FROM sessions WHERE status IN ({sess_ph}))"  # noqa: S608
-                    ),
-                    suffix_params=_TERMINAL_SESSION_STATUSES,
-                )
-                # branches cascade automatically via FK ON DELETE CASCADE
-                # The status predicate rides the delete itself, not only the
-                # read above it: on a backend where concurrent transactions can
-                # commit between the two, the statement that removes the row is
-                # the only place the condition is guaranteed to still hold.
-                sessions_pruned = await _exec_chunked(
-                    conn,
-                    f"DELETE FROM sessions WHERE status IN ({sess_ph}) AND id",  # noqa: S608
-                    session_ids,
-                    _TERMINAL_SESSION_STATUSES,
-                )
-
-                # The delete is where a session that reopened mid-sequence
-                # would show up: its row survives while the statements above
-                # have already cleared its history and associations. The lock
-                # taken before the re-read is what prevents that, and this is
-                # the check that it held. Raising abandons the transaction,
-                # so the pass either applies whole or leaves the row exactly as
-                # it was; the next pass drops the resumed session at selection.
-                survivors = await _fetch_chunked(
-                    conn, "SELECT id FROM sessions WHERE id", session_ids
-                )
-                if survivors:
-                    raise PruneRaceError(
-                        "session(s) "
-                        + ", ".join(sorted(str(r[0]) for r in survivors))
-                        + " stopped being terminal while their history was being removed; "
-                        "nothing was pruned"
-                    )
-
-                # Targeted orphan cleanup scoped to pruned lineage only — avoids a
-                # newborn-orphan race where _persist.py commits a progression before
-                # the session row exists.
-                if candidate_prog_ids:
-                    for i in range(0, len(candidate_prog_ids), _CHUNK):
-                        chunk = candidate_prog_ids[i : i + _CHUNK]
-                        ph = ", ".join("?" * len(chunk))
-                        sql = (
-                            f"DELETE FROM progressions WHERE id IN ({ph})"  # noqa: S608
-                            " AND id NOT IN ("
-                            "  SELECT progression_id FROM sessions WHERE progression_id IS NOT NULL"
-                            "  UNION"
-                            "  SELECT progression_id FROM branches WHERE progression_id IS NOT NULL"
-                            ")"
-                        )
-                        await conn.execute(*_q(sql, chunk))
-
-                if candidate_msg_ids:
-                    for i in range(0, len(candidate_msg_ids), _CHUNK):
-                        chunk = candidate_msg_ids[i : i + _CHUNK]
-                        ph = ", ".join("?" * len(chunk))
-                        sql = (
-                            f"DELETE FROM messages WHERE id IN ({ph})"  # noqa: S608
-                            " AND id NOT IN ("
-                            "  SELECT value FROM progressions, json_each(progressions.collection)"
-                            "  WHERE value IS NOT NULL"
-                            "  UNION"
-                            "  SELECT first_msg_id FROM sessions WHERE first_msg_id IS NOT NULL"
-                            "  UNION"
-                            "  SELECT last_msg_id FROM sessions WHERE last_msg_id IS NOT NULL"
-                            "  UNION"
-                            "  SELECT system_msg_id FROM branches WHERE system_msg_id IS NOT NULL"
-                            ")"
-                        )
-                        await conn.execute(*_q(sql, chunk))
-
-            # Nullify chain_parent_id for child runs whose parent will be deleted.
-            upd_sql = (
-                "UPDATE schedule_runs SET chain_parent_id = NULL WHERE chain_parent_id IN "  # noqa: S608
-                f"(SELECT id FROM schedule_runs WHERE status IN ({run_ph}) AND fired_at <= ?)"
+        dispatch_purged = 0
+        for chunk_index, chunk_ids in enumerate(_row_chunks(dispatch_ids, PRUNE_CHUNK_ROWS)):
+            archive_id = archive_chunk_id(
+                cutoff=dispatch_success_cutoff, chunk_index=chunk_index, kind="dispatch"
             )
-            await conn.execute(*_q(upd_sql, (*_TERMINAL_RUN_STATUSES, cutoff)))
-            # Same plain-FK hazard as dispatch_outbox.session_id above.
-            disp_upd_sql = (
-                "UPDATE dispatch_outbox SET schedule_run_id = NULL WHERE schedule_run_id IN "  # noqa: S608
-                f"(SELECT id FROM schedule_runs WHERE status IN ({run_ph}) AND fired_at <= ?)"
-            )
-            await conn.execute(*_q(disp_upd_sql, (*_TERMINAL_RUN_STATUSES, cutoff)))
-            del_sql = f"DELETE FROM schedule_runs WHERE status IN ({run_ph}) AND fired_at <= ?"  # noqa: S608
-            runs_pruned = (
-                await conn.execute(*_q(del_sql, (*_TERMINAL_RUN_STATUSES, cutoff)))
-            ).rowcount
-
-            # dispatch_outbox retention (ADR-0059 delta 3): two separate windows for
-            # success vs dead-lettered; pending/delivering are never in either list.
-            dispatch_success_cutoff = time.time() - dispatch_success_keep_days * 86400.0
-            dispatch_dead_letter_cutoff = time.time() - dispatch_dead_letter_keep_days * 86400.0
-            success_purged = (
-                await conn.execute(
-                    *_q(
-                        "DELETE FROM dispatch_outbox WHERE status IN ('delivered', 'acked')"
-                        " AND updated_at <= ?",
-                        (dispatch_success_cutoff,),
-                    )
+            async with db.transaction() as conn:
+                chunk_purged = await _prune_dispatch_chunk(
+                    conn,
+                    chunk_ids,
+                    retention_sql=dispatch_retention_sql,
+                    retention_params=dispatch_retention_params,
+                    archive_destination=PRUNE_ARCHIVE_DIR,
+                    archive_id=archive_id,
                 )
-            ).rowcount
-            dead_letter_purged = (
-                await conn.execute(
-                    *_q(
-                        "DELETE FROM dispatch_outbox WHERE status IN ('dead_letter', 'expired')"
-                        " AND updated_at <= ?",
-                        (dispatch_dead_letter_cutoff,),
-                    )
-                )
-            ).rowcount
-            dispatch_purged = success_purged + dead_letter_purged
+            dispatch_purged += chunk_purged
+            if PRUNE_ARCHIVE_DIR is not None and chunk_purged:
+                dispatch_archive_ids.append(archive_id)
+            await _after_prune_chunk_committed(chunk_index=chunk_index, chunk_ids=chunk_ids)
 
-        # Runs after the prune transaction commits — insert_admin_event opens its own
+        # Runs after the prune transactions commit — insert_admin_event opens its own
         # write transaction; nesting would self-deadlock on the sqlite write lock.
         await db.insert_admin_event(
             action="prune",
@@ -499,6 +783,12 @@ async def prune_old_data(
                 "dispatch_success_keep_days": dispatch_success_keep_days,
                 "dispatch_dead_letter_keep_days": dispatch_dead_letter_keep_days,
                 "dispatch_purged": dispatch_purged,
+                "archived": PRUNE_ARCHIVE_DIR is not None,
+                "archive_ids": {
+                    "sessions": session_archive_ids,
+                    "runs": run_archive_ids,
+                    "dispatch": dispatch_archive_ids,
+                },
             },
             actor=actor,
         )

--- a/lionagi/studio/services/retention_archive.py
+++ b/lionagi/studio/services/retention_archive.py
@@ -79,6 +79,21 @@ def _decode_row(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _declare_zip64(zf: zipfile.ZipFile, member_name: str) -> None:
+    """Raise *member_name*'s central-directory version fields to ZIP64 (4.5).
+
+    ``force_zip64=True`` shapes only the member's LOCAL header; CPython
+    computes the central-directory ``extract_version`` independently at close
+    and leaves a small member at 2.0 — so an archive of small members would
+    carry ZIP64 local headers that its own central directory disclaims. The
+    close-time record writer takes ``max(min_version, zinfo.extract_version)``,
+    so raising the attributes here is sufficient and survives close.
+    """
+    zinfo = zf.getinfo(member_name)
+    zinfo.extract_version = max(zinfo.extract_version, zipfile.ZIP64_VERSION)
+    zinfo.create_version = max(zinfo.create_version, zipfile.ZIP64_VERSION)
+
+
 def _write_member_stream(
     zf: zipfile.ZipFile, member_name: str, rows: Sequence[Mapping[str, Any]]
 ) -> tuple[int, str]:
@@ -99,6 +114,7 @@ def _write_member_stream(
             fh.write(line)
             hasher.update(line)
             count += 1
+    _declare_zip64(zf, member_name)
     return count, hasher.hexdigest()
 
 
@@ -172,6 +188,7 @@ def write_archive_chunk(
             )
             with zf.open(_MANIFEST_NAME, mode="w", force_zip64=True) as fh:
                 fh.write(manifest_bytes)
+            _declare_zip64(zf, _MANIFEST_NAME)
 
         fd = os.open(tmp_path, os.O_RDONLY)
         try:

--- a/lionagi/studio/services/retention_archive.py
+++ b/lionagi/studio/services/retention_archive.py
@@ -68,36 +68,49 @@ def _json_default(value: Any) -> Any:
     return str(value)
 
 
-def _encode_row(row: Mapping[str, Any]) -> dict[str, Any]:
-    """Escape column values that would collide with the bytes marker.
+def _encode_value(v: Any) -> Any:
+    """Escape values that would collide with the codec markers, at any depth.
 
     On backends whose driver deserializes JSON columns (asyncpg returns
-    ``dict`` for JSON/JSONB), a legitimate stored value of exactly
-    ``{"__bytes_b64__": ...}`` would otherwise be misread as encoded bytes
-    on restore. Wrapping any dict whose sole key is one of the markers makes
-    the encoding unambiguous; ``_decode_row`` unwraps exactly one level.
+    ``dict``/``list`` for JSON/JSONB), a legitimate stored value of exactly
+    ``{"__bytes_b64__": ...}`` (or the escape wrapper itself) would otherwise
+    be misread on restore. Escaping must reach every depth because
+    ``json.dumps(default=_json_default)`` converts ``bytes`` into marker
+    dicts at every depth — a shallow escape paired with the deep bytes
+    conversion would leave nested collisions ambiguous.
     """
-    return {
-        k: (
-            {_ESCAPE_MARKER: v}
-            if isinstance(v, dict) and (set(v) == {_BYTES_MARKER} or set(v) == {_ESCAPE_MARKER})
-            else v
-        )
-        for k, v in row.items()
-    }
+    if isinstance(v, dict):
+        encoded = {k: _encode_value(x) for k, x in v.items()}
+        if set(v) == {_BYTES_MARKER} or set(v) == {_ESCAPE_MARKER}:
+            return {_ESCAPE_MARKER: encoded}
+        return encoded
+    if isinstance(v, (list, tuple)):
+        return [_encode_value(x) for x in v]
+    return v
+
+
+def _encode_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Apply :func:`_encode_value` to every column of one row."""
+    return {k: _encode_value(v) for k, v in row.items()}
 
 
 def _decode_value(v: Any) -> Any:
+    """Invert :func:`_encode_value` / :func:`_json_default`, at any depth."""
     if isinstance(v, dict):
-        if set(v) == {_BYTES_MARKER}:
+        if set(v) == {_BYTES_MARKER} and isinstance(v[_BYTES_MARKER], str):
             return base64.b64decode(v[_BYTES_MARKER])
-        if set(v) == {_ESCAPE_MARKER}:
-            return v[_ESCAPE_MARKER]
+        if set(v) == {_ESCAPE_MARKER} and isinstance(v[_ESCAPE_MARKER], dict):
+            # The wrapped dict IS the (marker-shaped) user value: decode its
+            # children but never re-interpret the dict itself as a marker.
+            return {k: _decode_value(x) for k, x in v[_ESCAPE_MARKER].items()}
+        return {k: _decode_value(x) for k, x in v.items()}
+    if isinstance(v, list):
+        return [_decode_value(x) for x in v]
     return v
 
 
 def _decode_row(row: dict[str, Any]) -> dict[str, Any]:
-    """Invert :func:`_encode_row` / :func:`_json_default` marker wrapping."""
+    """Apply :func:`_decode_value` to every column of one row."""
     return {k: _decode_value(v) for k, v in row.items()}
 
 

--- a/lionagi/studio/services/retention_archive.py
+++ b/lionagi/studio/services/retention_archive.py
@@ -32,6 +32,7 @@ from typing import Any
 _FORMAT_VERSION = 1
 _MANIFEST_NAME = "manifest.json"
 _BYTES_MARKER = "__bytes_b64__"
+_ESCAPE_MARKER = "__archive_escaped__"
 
 
 class ArchiveWriteError(Exception):
@@ -67,16 +68,37 @@ def _json_default(value: Any) -> Any:
     return str(value)
 
 
-def _decode_row(row: dict[str, Any]) -> dict[str, Any]:
-    """Invert :func:`_json_default`'s bytes marker back into raw ``bytes``."""
+def _encode_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Escape column values that would collide with the bytes marker.
+
+    On backends whose driver deserializes JSON columns (asyncpg returns
+    ``dict`` for JSON/JSONB), a legitimate stored value of exactly
+    ``{"__bytes_b64__": ...}`` would otherwise be misread as encoded bytes
+    on restore. Wrapping any dict whose sole key is one of the markers makes
+    the encoding unambiguous; ``_decode_row`` unwraps exactly one level.
+    """
     return {
         k: (
-            base64.b64decode(v[_BYTES_MARKER])
-            if isinstance(v, dict) and set(v) == {_BYTES_MARKER}
+            {_ESCAPE_MARKER: v}
+            if isinstance(v, dict) and (set(v) == {_BYTES_MARKER} or set(v) == {_ESCAPE_MARKER})
             else v
         )
         for k, v in row.items()
     }
+
+
+def _decode_value(v: Any) -> Any:
+    if isinstance(v, dict):
+        if set(v) == {_BYTES_MARKER}:
+            return base64.b64decode(v[_BYTES_MARKER])
+        if set(v) == {_ESCAPE_MARKER}:
+            return v[_ESCAPE_MARKER]
+    return v
+
+
+def _decode_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Invert :func:`_encode_row` / :func:`_json_default` marker wrapping."""
+    return {k: _decode_value(v) for k, v in row.items()}
 
 
 def _declare_zip64(zf: zipfile.ZipFile, member_name: str) -> None:
@@ -108,7 +130,9 @@ def _write_member_stream(
     with zf.open(member_name, mode="w", force_zip64=True) as fh:
         for r in rows:
             line = (
-                json.dumps(dict(r), default=_json_default, sort_keys=True, separators=(",", ":"))
+                json.dumps(
+                    _encode_row(r), default=_json_default, sort_keys=True, separators=(",", ":")
+                )
                 + "\n"
             ).encode("utf-8")
             fh.write(line)

--- a/lionagi/studio/services/retention_archive.py
+++ b/lionagi/studio/services/retention_archive.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Self-verifying ZIP64 archival of rows a prune chunk is about to delete.
+
+Each call publishes one self-contained ``.zip`` file containing a
+``manifest.json`` (format version, per-table row counts, per-member SHA-256
+digests) plus one ``rows/<table>.jsonl`` member per non-empty table. Rows are
+canonical UTF-8 JSON (``sort_keys=True``, compact separators), one per line.
+
+Publication is crash-safe: the archive is built in a temp file in the
+destination directory, fsynced, digest-verified by reopening it, atomically
+renamed into place, the destination directory fsynced, then verified again by
+reopening the *final* path. A partially written or unverifiable archive never
+appears under its final name, so a crash or corruption mid-write leaves
+nothing a caller could mistake for a completed, trustworthy archive. Filenames
+are unique per chunk and never reused, so a rerun after interruption cannot
+overwrite an already-published archive.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import uuid
+import zipfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+_FORMAT_VERSION = 1
+_MANIFEST_NAME = "manifest.json"
+_BYTES_MARKER = "__bytes_b64__"
+
+
+class ArchiveWriteError(Exception):
+    """Raised when a prune chunk's archive could not be durably written.
+
+    Callers must treat this as a hard refusal: no delete for the chunk that
+    failed to archive may proceed.
+    """
+
+
+class ArchiveVerificationError(ArchiveWriteError):
+    """Raised when a published archive fails digest/row-count re-verification.
+
+    A subclass of :class:`ArchiveWriteError` so existing callers that only
+    catch the base class still refuse deletion on a verification failure.
+    """
+
+
+def archive_chunk_id(*, cutoff: float, chunk_index: int, kind: str = "prune") -> str:
+    """Build a unique, append-only archive id for one prune chunk."""
+    return f"{kind}-{int(cutoff)}-{chunk_index:06d}-{uuid.uuid4().hex[:8]}"
+
+
+def _json_default(value: Any) -> Any:
+    """Preserve BLOB columns exactly (base64) instead of stringifying their repr.
+
+    ``json.dumps`` calls this only for values it cannot serialize natively;
+    for SQLite BLOB columns that is ``bytes``/``bytearray``. Anything else
+    falls back to ``str`` as before.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        return {_BYTES_MARKER: base64.b64encode(bytes(value)).decode("ascii")}
+    return str(value)
+
+
+def _decode_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Invert :func:`_json_default`'s bytes marker back into raw ``bytes``."""
+    return {
+        k: (
+            base64.b64decode(v[_BYTES_MARKER])
+            if isinstance(v, dict) and set(v) == {_BYTES_MARKER}
+            else v
+        )
+        for k, v in row.items()
+    }
+
+
+def _write_member_stream(
+    zf: zipfile.ZipFile, member_name: str, rows: Sequence[Mapping[str, Any]]
+) -> tuple[int, str]:
+    """Stream *rows* into zip member *member_name* one line at a time.
+
+    Never holds the member's full JSONL payload as a single ``bytes`` object
+    -- each row is encoded, written, and hashed in turn -- so peak memory for
+    a member is one row, not the whole table. Returns ``(row_count, sha256_hex)``.
+    """
+    hasher = hashlib.sha256()
+    count = 0
+    with zf.open(member_name, mode="w", force_zip64=True) as fh:
+        for r in rows:
+            line = (
+                json.dumps(dict(r), default=_json_default, sort_keys=True, separators=(",", ":"))
+                + "\n"
+            ).encode("utf-8")
+            fh.write(line)
+            hasher.update(line)
+            count += 1
+    return count, hasher.hexdigest()
+
+
+def _cleanup_path(path: Path) -> None:
+    try:
+        if path.exists():
+            path.unlink()
+    except OSError:
+        pass
+
+
+def write_archive_chunk(
+    destination: Path,
+    archive_id: str,
+    tables: Mapping[str, Sequence[Mapping[str, Any]]],
+    preimages: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
+) -> Path:
+    """Durably publish *tables* (table name -> rows) as one ZIP64-capable archive.
+
+    *preimages* (table name -> rows) captures the pre-mutation state of rows
+    that a caller is about to NULLIFY (soft-FK columns) rather than delete --
+    e.g. ``artifacts``/``plays``/``team_messages``/``dispatch_outbox`` rows
+    whose ``session_id`` a session-prune chunk is about to null out. They are
+    written as sibling ``preimages/<table>.jsonl`` members alongside the
+    ``rows/<table>.jsonl`` members for deleted rows, so a restore can recover
+    the original linkage instead of leaving those rows permanently orphaned.
+
+    Writes to a temp file in *destination*, fsyncs it, verifies it can be
+    reopened and its digests recomputed, renames it atomically to the final
+    path, fsyncs the destination directory, then verifies the *published*
+    file the same way. Raises :class:`ArchiveWriteError` (or the
+    :class:`ArchiveVerificationError` subclass) on any failure and leaves no
+    partial or unverifiable file under the final name -- including when the
+    failure is detected only after the rename, in which case the published
+    path is removed too.
+    """
+    preimages = preimages or {}
+    final_path = destination / f"{archive_id}.zip"
+    tmp_path = destination / f".{archive_id}.tmp"
+    renamed = False
+
+    try:
+        members_meta: dict[str, dict[str, Any]] = {}
+        with zipfile.ZipFile(
+            tmp_path, mode="w", compression=zipfile.ZIP_DEFLATED, allowZip64=True
+        ) as zf:
+            # Stream each member's rows straight into the zip entry (see
+            # _write_member_stream) instead of building the full JSONL bytes
+            # up front -- peak memory is one row, not one table. Every entry
+            # (including the manifest, written last since it depends on the
+            # digests computed here) uses force_zip64=True so the archive is
+            # genuinely ZIP64 (version-needed-to-extract 4.5), not merely
+            # "ZIP64-capable" in name only via writestr's size-triggered default.
+            for prefix, group in (("rows", tables), ("preimages", preimages)):
+                for name, rows in group.items():
+                    if not rows:
+                        continue
+                    member_name = f"{prefix}/{name}.jsonl"
+                    count, digest = _write_member_stream(zf, member_name, rows)
+                    members_meta[member_name] = {"rows": count, "sha256": digest}
+
+            manifest = {
+                "format_version": _FORMAT_VERSION,
+                "archive_id": archive_id,
+                "row_counts": {name: len(rows) for name, rows in tables.items()},
+                "preimage_row_counts": {name: len(rows) for name, rows in preimages.items()},
+                "members": members_meta,
+            }
+            manifest_bytes = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+            with zf.open(_MANIFEST_NAME, mode="w", force_zip64=True) as fh:
+                fh.write(manifest_bytes)
+
+        fd = os.open(tmp_path, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+        # Verify the staged archive before it is ever visible under its final
+        # name: a mismatch here means the destination never had a publish to
+        # roll back.
+        verify_archive_chunk(tmp_path)
+
+        os.replace(tmp_path, final_path)
+        renamed = True
+        dir_fd = os.open(destination, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+        # Reopen-and-verify the *published* file per the archive contract:
+        # a successful close/rename does not by itself prove a readable,
+        # digest-correct artifact.
+        verify_archive_chunk(final_path)
+    except ArchiveVerificationError:
+        _cleanup_path(final_path if renamed else tmp_path)
+        raise
+    except OSError as exc:
+        _cleanup_path(final_path if renamed else tmp_path)
+        raise ArchiveWriteError(
+            f"failed to write archive {archive_id!r} to {destination}: {exc}"
+        ) from exc
+    except Exception as exc:
+        # Any other failure (e.g. a bad row that can't be JSON-encoded) must
+        # still leave no partial file behind under either name.
+        _cleanup_path(final_path if renamed else tmp_path)
+        raise ArchiveWriteError(
+            f"failed to write archive {archive_id!r} to {destination}: {exc}"
+        ) from exc
+
+    return final_path
+
+
+def verify_archive_chunk(path: Path) -> dict[str, Any]:
+    """Reopen an archive and confirm its CRCs, digests, and row counts match its manifest.
+
+    Returns the decoded manifest on success. Raises
+    :class:`ArchiveVerificationError` on any CRC failure, unknown format
+    version, digest mismatch, or row-count mismatch.
+    """
+    try:
+        with zipfile.ZipFile(path, mode="r") as zf:
+            bad_member = zf.testzip()
+            if bad_member is not None:
+                raise ArchiveVerificationError(
+                    f"archive {path} failed CRC check on member {bad_member!r}"
+                )
+            manifest = json.loads(zf.read(_MANIFEST_NAME).decode("utf-8"))
+            if manifest.get("format_version") != _FORMAT_VERSION:
+                raise ArchiveVerificationError(
+                    f"archive {path} has unsupported format_version "
+                    f"{manifest.get('format_version')!r}"
+                )
+            for member_name, meta in manifest.get("members", {}).items():
+                payload = zf.read(member_name)
+                digest = hashlib.sha256(payload).hexdigest()
+                if digest != meta.get("sha256"):
+                    raise ArchiveVerificationError(
+                        f"archive {path} member {member_name!r} digest mismatch"
+                    )
+                row_count = payload.count(b"\n") if payload else 0
+                if row_count != meta.get("rows"):
+                    raise ArchiveVerificationError(
+                        f"archive {path} member {member_name!r} row-count mismatch"
+                    )
+    except ArchiveVerificationError:
+        raise
+    except (zipfile.BadZipFile, KeyError, OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ArchiveVerificationError(f"archive {path} failed verification: {exc}") from exc
+    return manifest
+
+
+def _read_members(
+    zf: zipfile.ZipFile, names: set[str], row_counts: Mapping[str, int], prefix: str
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for name in row_counts:
+        member_name = f"{prefix}/{name}.jsonl"
+        if member_name not in names:
+            result[name] = []
+            continue
+        raw = zf.read(member_name).decode("utf-8")
+        result[name] = [_decode_row(json.loads(line)) for line in raw.splitlines() if line]
+    return result
+
+
+def read_archive_chunk(path: Path) -> dict[str, Any]:
+    """Decode a ``.zip`` archive written by :func:`write_archive_chunk`.
+
+    Returns ``{"archive_id", "row_counts", "tables": {name: [row, ...]},
+    "preimages": {name: [row, ...]}}``. ``preimages`` is ``{}`` for archives
+    written before soft-FK preimage capture existed.
+    """
+    with zipfile.ZipFile(path, mode="r") as zf:
+        manifest = json.loads(zf.read(_MANIFEST_NAME).decode("utf-8"))
+        names = set(zf.namelist())
+        tables = _read_members(zf, names, manifest.get("row_counts", {}), "rows")
+        preimages = _read_members(zf, names, manifest.get("preimage_row_counts", {}), "preimages")
+    return {
+        "archive_id": manifest["archive_id"],
+        "row_counts": manifest["row_counts"],
+        "tables": tables,
+        "preimages": preimages,
+    }

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -14,6 +14,7 @@ import pytest
 
 import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB
+from lionagi.studio.services.retention_archive import ArchiveWriteError
 
 from ._helpers import run_async
 
@@ -579,6 +580,35 @@ def test_prune_writes_admin_event(tmp_path, monkeypatch):
     assert events[0]["action"] == "prune"
 
 
+def test_prune_admin_event_includes_archive_ids(tmp_path, monkeypatch):
+    """The prune admin event must name which archives it wrote, per root kind,
+    so an operator can locate the receipt for what got deleted without
+    grepping the archive directory."""
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=archive_dir, chunk_rows=100)
+
+    old_ts = time.time() - 40 * 86400
+    run_async(_make_session_in(db_path, status="completed", started_at=old_ts))
+    run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    async def check():
+        async with StateDB(db_path) as db:
+            return await db.list_admin_events(action="prune", limit=5)
+
+    events = run_async(check())
+    details = _details(events[0])
+    archive_ids = details["archive_ids"]
+    assert len(archive_ids["sessions"]) == 1
+    assert archive_ids["runs"] == []
+    assert archive_ids["dispatch"] == []
+    assert (archive_dir / f"{archive_ids['sessions'][0]}.zip").exists()
+
+
 def test_prune_old_schedule_runs(tmp_path, monkeypatch):
     """Prune removes old terminal schedule_runs; preserves running ones."""
     from lionagi.studio.services import db_maintenance as maint
@@ -788,3 +818,230 @@ def test_prune_old_data_endpoint(tmp_path, monkeypatch):
 async def _make_session_in(db_path: Path, *, status: str, started_at: float) -> str:
     async with StateDB(db_path) as db:
         return await _make_session(db, status=status, started_at=started_at)
+
+
+def _patch_prune_config(monkeypatch, *, archive_dir: Path | None, chunk_rows: int) -> None:
+    from lionagi.studio.services import db_maintenance as maint
+
+    monkeypatch.setattr(maint, "PRUNE_ARCHIVE_DIR", archive_dir, raising=False)
+    monkeypatch.setattr(maint, "PRUNE_CHUNK_ROWS", chunk_rows, raising=False)
+    # prune_old_data() imports these lazily from config each call; patch the
+    # source module too (see the identical pattern in test_retention_archive.py).
+    import lionagi.studio.config as cfg
+
+    monkeypatch.setattr(cfg, "PRUNE_ARCHIVE_DIR", archive_dir)
+    monkeypatch.setattr(cfg, "PRUNE_CHUNK_ROWS", chunk_rows)
+
+
+# ── schedule_run / dispatch_outbox chunking + whole-plan safety ────────────
+
+
+def test_schedule_run_retention_is_chunked_and_archived(tmp_path, monkeypatch):
+    """schedule_run deletion is bounded per PRUNE_CHUNK_ROWS, each chunk archived first."""
+    from lionagi.studio.services import db_maintenance as maint
+    from lionagi.studio.services.retention_archive import read_archive_chunk
+
+    db_path = tmp_path / "state.db"
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=archive_dir, chunk_rows=2)
+
+    old_ts = time.time() - 40 * 86400
+
+    seen_chunks: list[list[str]] = []
+    original = maint._prune_run_chunk
+
+    async def spy(conn, run_ids, **kwargs):
+        seen_chunks.append(sorted(run_ids))
+        return await original(conn, run_ids, **kwargs)
+
+    monkeypatch.setattr(maint, "_prune_run_chunk", spy)
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return [
+                await _make_schedule_run(db, status="completed", fired_at=old_ts) for _ in range(5)
+            ]
+
+    ids = run_async(seed())
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    assert result["runs_pruned"] == 5
+    assert [len(c) for c in seen_chunks] == [2, 2, 1]
+    flat = [i for c in seen_chunks for i in c]
+    assert sorted(flat) == sorted(ids)
+    assert len(flat) == len(set(flat))
+
+    run_archives = [p for p in archive_dir.glob("run-*.zip")]
+    assert len(run_archives) == 3  # one per committed chunk
+    archived_ids: set[str] = set()
+    for path in run_archives:
+        decoded = read_archive_chunk(path)
+        archived_ids.update(row["id"] for row in decoded["tables"]["schedule_runs"])
+    assert archived_ids == set(ids)
+
+
+def test_session_prune_archives_preimages_of_nullified_soft_fk_rows(tmp_path, monkeypatch):
+    """artifacts/dispatch_outbox rows whose session_id gets NULLIFIED by a
+    session prune must have their pre-nullify state captured as a
+    ``preimages/<table>.jsonl`` member -- otherwise a restore permanently
+    orphans them (round-1 critic MAJ finding)."""
+    from lionagi.dispatch import enqueue_dispatch
+    from lionagi.studio.services import db_maintenance as maint
+    from lionagi.studio.services.retention_archive import read_archive_chunk
+
+    db_path = tmp_path / "state.db"
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=archive_dir, chunk_rows=100)
+
+    old_ts = time.time() - 40 * 86400
+    recent_ts = time.time() - 1 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            sid = await _make_session(db, status="completed", started_at=old_ts)
+            artifact_id = await db.insert_artifact(
+                kind="note", name="n1", content={"x": 1}, session_id=sid
+            )
+            dispatch_id = await enqueue_dispatch(
+                db, kind="terminal_notify", deliver_to="seat-1", session_id=sid
+            )
+            # young dispatch: survives its own retention window, but its
+            # session_id soft-FK still gets nullified when the session dies.
+            await db.execute(
+                "UPDATE dispatch_outbox SET updated_at = ? WHERE id = ?",
+                (recent_ts, dispatch_id),
+            )
+        return sid, artifact_id, dispatch_id
+
+    sid, artifact_id, dispatch_id = run_async(seed())
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+    assert result["sessions_pruned"] == 1
+
+    session_archives = list(archive_dir.glob("prune-*.zip"))
+    assert len(session_archives) == 1
+    decoded = read_archive_chunk(session_archives[0])
+
+    archived_artifact_preimages = {r["id"]: r for r in decoded["preimages"]["artifacts"]}
+    assert archived_artifact_preimages[artifact_id]["session_id"] == sid
+
+    archived_dispatch_preimages = {r["id"]: r for r in decoded["preimages"]["dispatch_outbox"]}
+    assert archived_dispatch_preimages[dispatch_id]["session_id"] == sid
+
+    async def check():
+        async with StateDB(db_path) as db:
+            dispatch_row = await db.fetch_one(
+                "SELECT session_id FROM dispatch_outbox WHERE id = ?", (dispatch_id,)
+            )
+            artifact_row = await db.fetch_one(
+                "SELECT session_id FROM artifacts WHERE id = ?", (artifact_id,)
+            )
+            return dispatch_row, artifact_row
+
+    dispatch_row, artifact_row = run_async(check())
+    # Confirm the actual nullify happened -- the preimage records what these
+    # rows looked like *before* this, not instead of it.
+    assert dispatch_row["session_id"] is None
+    assert artifact_row["session_id"] is None
+
+
+def test_dispatch_retention_is_chunked_and_archived(tmp_path, monkeypatch):
+    """dispatch_outbox deletion is bounded per PRUNE_CHUNK_ROWS, each chunk archived first."""
+    from lionagi.studio.services import db_maintenance as maint
+    from lionagi.studio.services.retention_archive import read_archive_chunk
+
+    db_path = tmp_path / "state.db"
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=archive_dir, chunk_rows=2)
+
+    old_ts = time.time() - 10 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return [
+                await _make_dispatch(db, status="delivered", updated_at=old_ts) for _ in range(5)
+            ]
+
+    ids = run_async(seed())
+    result = run_async(maint.prune_old_data(dispatch_success_keep_days=7, actor="test"))
+
+    assert result["dispatch_purged"] == 5
+
+    dispatch_archives = list(archive_dir.glob("dispatch-*.zip"))
+    assert len(dispatch_archives) == 3  # ceil(5/2)
+    archived_ids: set[str] = set()
+    for path in dispatch_archives:
+        decoded = read_archive_chunk(path)
+        archived_ids.update(row["id"] for row in decoded["tables"]["dispatch_outbox"])
+    assert archived_ids == set(ids)
+
+    async def remaining():
+        async with StateDB(db_path) as db:
+            rows = await db.fetch_all("SELECT id FROM dispatch_outbox")
+            return {r["id"] for r in rows}
+
+    assert run_async(remaining()) == set()
+
+
+def test_run_chunk_archive_failure_aborts_dispatch_and_keeps_session_deletes(tmp_path, monkeypatch):
+    """Mid-plan archive failure: sessions already chunked+deleted stay deleted,
+    the failing run chunk is refused, and dispatch retention (later in the
+    plan) is never attempted."""
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=archive_dir, chunk_rows=100)
+
+    old_ts = time.time() - 40 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            sid = await _make_session(db, status="completed", started_at=old_ts)
+            run_id = await _make_schedule_run(db, status="completed", fired_at=old_ts)
+            dispatch_id = await _make_dispatch(db, status="delivered", updated_at=old_ts)
+        return sid, run_id, dispatch_id
+
+    sid, run_id, dispatch_id = run_async(seed())
+
+    original_write = maint.write_archive_chunk
+
+    def flaky_write(destination, archive_id, tables, preimages=None):
+        if "schedule_runs" in tables:
+            raise ArchiveWriteError("simulated run-chunk archive failure")
+        return original_write(destination, archive_id, tables, preimages=preimages)
+
+    monkeypatch.setattr(maint, "write_archive_chunk", flaky_write)
+
+    with pytest.raises(ArchiveWriteError):
+        run_async(maint.prune_old_data(keep_days=30, dispatch_success_keep_days=7, actor="test"))
+
+    async def check():
+        async with StateDB(db_path) as db:
+            session_row = await db.get_session(sid)
+            run_row = await db.fetch_one("SELECT id FROM schedule_runs WHERE id = ?", (run_id,))
+            dispatch_row = await db.fetch_one(
+                "SELECT id FROM dispatch_outbox WHERE id = ?", (dispatch_id,)
+            )
+        return session_row, run_row, dispatch_row
+
+    session_row, run_row, dispatch_row = run_async(check())
+    # Session chunk committed before the run chunk ever started: stays deleted.
+    assert session_row is None
+    # Run chunk's archive failed: its delete never ran, row survives.
+    assert run_row is not None
+    # Dispatch retention runs after schedule_run retention in the plan and
+    # was never reached.
+    assert dispatch_row is not None
+
+    # No run/dispatch archives exist; the one session archive that succeeded does.
+    assert list(archive_dir.glob("run-*.zip")) == []
+    assert list(archive_dir.glob("dispatch-*.zip")) == []
+    assert len(list(archive_dir.glob("prune-*.zip"))) == 1

--- a/tests/apps_studio_server/test_retention_archive.py
+++ b/tests/apps_studio_server/test_retention_archive.py
@@ -1,0 +1,441 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for archive-then-prune retention: archive gate, refusal-on-failure,
+unchanged no-archive behaviour, and bounded per-chunk commits."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import lionagi.state.db as state_db_mod
+from lionagi.state.db import StateDB
+from lionagi.studio.services.retention_archive import (
+    ArchiveVerificationError,
+    ArchiveWriteError,
+    read_archive_chunk,
+    verify_archive_chunk,
+    write_archive_chunk,
+)
+
+from ._helpers import run_async
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _make_session(db: StateDB, *, status: str, started_at: float) -> str:
+    pid = str(uuid.uuid4())
+    sid = str(uuid.uuid4())
+    await db.create_progression(pid)
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": pid,
+            "name": f"s-{status}-{sid[:6]}",
+            "status": status,
+            "started_at": started_at,
+            "updated_at": started_at,
+        }
+    )
+    return sid
+
+
+def _patch_db(monkeypatch, db_path: Path) -> None:
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+
+def _patch_prune_config(monkeypatch, *, archive_dir: Path | None, chunk_rows: int) -> None:
+    from lionagi.studio.services import db_maintenance as maint
+
+    monkeypatch.setattr(maint, "PRUNE_ARCHIVE_DIR", archive_dir, raising=False)
+    monkeypatch.setattr(maint, "PRUNE_CHUNK_ROWS", chunk_rows, raising=False)
+    import lionagi.studio.config as cfg
+
+    monkeypatch.setattr(cfg, "PRUNE_ARCHIVE_DIR", archive_dir)
+    monkeypatch.setattr(cfg, "PRUNE_CHUNK_ROWS", chunk_rows)
+
+
+# ── retention_archive module unit tests ─────────────────────────────────────
+
+
+def test_write_archive_chunk_is_zip64_capable_and_round_trips(tmp_path):
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    tables = {
+        "sessions": [{"id": "s1", "status": "completed"}],
+        "messages": [{"id": "m1", "content": "x" * 1000}],
+    }
+    path = write_archive_chunk(dest, "prune-1-000000-abcd1234", tables)
+
+    assert path.exists()
+    assert path.suffix == ".zip"
+    assert not (dest / ".prune-1-000000-abcd1234.tmp").exists()
+
+    with zipfile.ZipFile(path) as zf:
+        assert zf.testzip() is None
+        names = set(zf.namelist())
+        assert "manifest.json" in names
+        assert "rows/sessions.jsonl" in names
+        assert "rows/messages.jsonl" in names
+        manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
+        assert manifest["format_version"] == 1
+        assert manifest["archive_id"] == "prune-1-000000-abcd1234"
+        assert manifest["row_counts"] == {"sessions": 1, "messages": 1}
+        for member_name in ("rows/sessions.jsonl", "rows/messages.jsonl"):
+            payload = zf.read(member_name)
+            expected_digest = hashlib.sha256(payload).hexdigest()
+            assert manifest["members"][member_name]["sha256"] == expected_digest
+            assert manifest["members"][member_name]["rows"] == payload.count(b"\n")
+
+    decoded = read_archive_chunk(path)
+    assert decoded["tables"]["sessions"] == tables["sessions"]
+    assert decoded["tables"]["messages"] == tables["messages"]
+    assert decoded["row_counts"] == {"sessions": 1, "messages": 1}
+
+
+def test_write_archive_chunk_members_are_genuinely_zip64_not_nominal(tmp_path):
+    """Every member must be written with force_zip64=True (version-needed-to-extract
+    45), not merely allowZip64=True on the archive, which only opts a member into
+    ZIP64 once it individually crosses the size threshold."""
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    path = write_archive_chunk(dest, "prune-1-000000-zip64chk", {"sessions": [{"id": "s1"}]})
+
+    with zipfile.ZipFile(path) as zf:
+        for name in zf.namelist():
+            zi = zf.getinfo(name)
+            assert zi.extract_version >= 45, f"{name} was not written force_zip64"
+
+
+def test_write_archive_chunk_round_trips_blob_columns_exactly(tmp_path):
+    """A BLOB column (e.g. messages.embedding) must survive archive+restore as
+    the exact same bytes, not the Python repr of a ``bytes`` object."""
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    raw = b"\x9a\x99\x19@\x00\xffnot-utf8\xf0"
+    tables = {"messages": [{"id": "m1", "embedding": raw}]}
+    path = write_archive_chunk(dest, "prune-1-000000-blob0001", tables)
+
+    decoded = read_archive_chunk(path)
+    assert decoded["tables"]["messages"][0]["embedding"] == raw
+    assert isinstance(decoded["tables"]["messages"][0]["embedding"], bytes)
+
+
+def test_write_archive_chunk_captures_preimages_as_sibling_members(tmp_path):
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    tables = {"sessions": [{"id": "s1", "status": "completed"}]}
+    preimages = {"artifacts": [{"id": "a1", "session_id": "s1"}]}
+    path = write_archive_chunk(dest, "prune-1-000000-preimg01", tables, preimages=preimages)
+
+    with zipfile.ZipFile(path) as zf:
+        names = set(zf.namelist())
+        assert "preimages/artifacts.jsonl" in names
+        manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
+        assert manifest["preimage_row_counts"] == {"artifacts": 1}
+
+    decoded = read_archive_chunk(path)
+    assert decoded["preimages"]["artifacts"] == preimages["artifacts"]
+    assert decoded["tables"]["sessions"] == tables["sessions"]
+
+
+def test_write_archive_chunk_removes_published_file_on_post_rename_verify_failure(
+    tmp_path, monkeypatch
+):
+    """If verification of the *published* (post-rename) file fails, the
+    final path must not be left behind under its final name."""
+    import lionagi.studio.services.retention_archive as ra_mod
+
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    archive_id = "prune-1-000000-badpost1"
+
+    real_verify = ra_mod.verify_archive_chunk
+    calls = {"n": 0}
+
+    def flaky_verify(path):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            # second call is the post-rename verification of the final path
+            raise ArchiveVerificationError("simulated post-rename corruption")
+        return real_verify(path)
+
+    monkeypatch.setattr(ra_mod, "verify_archive_chunk", flaky_verify)
+
+    with pytest.raises(ArchiveVerificationError):
+        write_archive_chunk(dest, archive_id, {"sessions": [{"id": "a"}]})
+
+    assert not (dest / f"{archive_id}.zip").exists()
+    assert not (dest / f".{archive_id}.tmp").exists()
+
+
+def test_verify_archive_chunk_detects_digest_tampering(tmp_path):
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    archive_id = "prune-1-000000-tampered"
+    path = write_archive_chunk(dest, archive_id, {"sessions": [{"id": "a"}]})
+
+    # Verified as published.
+    manifest = verify_archive_chunk(path)
+    assert manifest["members"]["rows/sessions.jsonl"]["rows"] == 1
+
+    # Rewrite the row payload without updating the manifest digest.
+    with zipfile.ZipFile(path, "a") as zf:
+        zf.writestr("rows/sessions.jsonl", '{"id":"tampered-row"}\n')
+
+    with pytest.raises(ArchiveVerificationError):
+        verify_archive_chunk(path)
+
+
+def test_write_archive_chunk_never_overwrites_existing_file(tmp_path):
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    archive_id = "prune-1-000000-fixedid1"
+    write_archive_chunk(dest, archive_id, {"sessions": [{"id": "a"}]})
+    with pytest.raises(ArchiveWriteError):
+        # os.replace would silently clobber a plain file; simulate a
+        # "final path is a directory" collision so the second write cannot
+        # be mistaken for a legitimate overwrite.
+        (dest / f"{archive_id}.zip").unlink()
+        (dest / f"{archive_id}.zip").mkdir()
+        write_archive_chunk(dest, archive_id, {"sessions": [{"id": "b"}]})
+
+
+def test_write_archive_chunk_missing_destination_raises_and_leaves_no_tmp(tmp_path):
+    dest = tmp_path / "does-not-exist"
+    with pytest.raises(ArchiveWriteError):
+        write_archive_chunk(dest, "prune-1-000000-deadbeef", {"sessions": []})
+    assert not dest.exists()
+
+
+# ── prune_old_data integration: archive gate + chunking ────────────────────
+
+
+def test_unset_archive_dir_preserves_no_archive_contract(tmp_path, monkeypatch):
+    """No LIONAGI_STUDIO_PRUNE_ARCHIVE_DIR configured -> unchanged behaviour, no files written."""
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=None, chunk_rows=100)
+
+    old_ts = time.time() - 40 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return await _make_session(db, status="completed", started_at=old_ts)
+
+    sid = run_async(seed())
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    assert result == {"sessions_pruned": 1, "runs_pruned": 0, "dispatch_purged": 0}
+    assert list(tmp_path.glob("**/*.zip")) == []
+
+    async def remaining():
+        async with StateDB(db_path) as db:
+            return await db.get_session(sid)
+
+    assert run_async(remaining()) is None
+
+
+def test_archive_before_delete_writes_compressed_receipt_for_pruned_rows(tmp_path, monkeypatch):
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=archive_dir, chunk_rows=100)
+
+    old_ts = time.time() - 40 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return await _make_session(db, status="completed", started_at=old_ts)
+
+    sid = run_async(seed())
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    assert result["sessions_pruned"] == 1
+    archives = sorted(archive_dir.glob("*.zip"))
+    assert len(archives) == 1
+    decoded = read_archive_chunk(archives[0])
+    archived_ids = {row["id"] for row in decoded["tables"]["sessions"]}
+    assert archived_ids == {sid}
+
+    async def remaining():
+        async with StateDB(db_path) as db:
+            return await db.get_session(sid)
+
+    assert run_async(remaining()) is None
+
+
+def test_archive_write_failure_refuses_deletion_for_that_chunk(tmp_path, monkeypatch):
+    """A failing archive write must not delete the rows it failed to archive."""
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    # A file, not a directory: every write_archive_chunk call inside prune
+    # raises ArchiveWriteError (open() on a path whose parent is a file).
+    archive_dir = tmp_path / "not-a-dir"
+    archive_dir.write_text("blocked")
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=archive_dir, chunk_rows=100)
+
+    old_ts = time.time() - 40 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return await _make_session(db, status="completed", started_at=old_ts)
+
+    sid = run_async(seed())
+
+    with pytest.raises(Exception):
+        run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    async def remaining():
+        async with StateDB(db_path) as db:
+            return await db.get_session(sid)
+
+    # Refused: the session that failed to archive is still present.
+    assert run_async(remaining()) is not None
+
+
+def test_chunk_selection_is_stable_and_bounded(tmp_path, monkeypatch):
+    """PRUNE_CHUNK_ROWS=2 over 5 candidates -> chunks of [2, 2, 1], no id repeats."""
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=None, chunk_rows=2)
+
+    old_ts = time.time() - 40 * 86400
+    seen_chunks: list[list[str]] = []
+    original = maint._prune_session_chunk
+
+    async def spy(conn, session_ids, **kwargs):
+        seen_chunks.append(sorted(session_ids))
+        return await original(conn, session_ids, **kwargs)
+
+    monkeypatch.setattr(maint, "_prune_session_chunk", spy)
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return [
+                await _make_session(db, status="completed", started_at=old_ts) for _ in range(5)
+            ]
+
+    ids = run_async(seed())
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    assert result["sessions_pruned"] == 5
+    assert [len(c) for c in seen_chunks] == [2, 2, 1]
+    flat = [i for c in seen_chunks for i in c]
+    assert sorted(flat) == sorted(ids)
+    assert len(flat) == len(set(flat))
+
+
+def test_interrupt_after_n_chunks_keeps_completed_chunks(tmp_path, monkeypatch):
+    """An exception after N chunks commit must leave those N chunks' deletions in place."""
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=None, chunk_rows=1)
+
+    old_ts = time.time() - 40 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return [
+                await _make_session(db, status="completed", started_at=old_ts) for _ in range(3)
+            ]
+
+    ids = run_async(seed())
+
+    calls = {"n": 0}
+
+    async def flaky_after_commit(*, chunk_index, chunk_ids):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("simulated interruption after 2 committed chunks")
+
+    monkeypatch.setattr(maint, "_after_prune_chunk_committed", flaky_after_commit)
+
+    with pytest.raises(RuntimeError):
+        run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    async def remaining_ids():
+        async with StateDB(db_path) as db:
+            rows = await db.fetch_all("SELECT id FROM sessions")
+            return {r["id"] for r in rows}
+
+    rem = run_async(remaining_ids())
+    # Exactly 2 of the 3 sessions were pruned: their chunks already committed
+    # (and released the write lock) before the interruption hook fired; the
+    # 3rd chunk, never attempted, survives.
+    assert len(rem) == 1
+    assert rem.issubset(set(ids))
+
+
+def test_rerun_after_interruption_prunes_only_remaining_and_keeps_prior_archives(
+    tmp_path, monkeypatch
+):
+    from lionagi.studio.services import db_maintenance as maint
+
+    db_path = tmp_path / "state.db"
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    _patch_db(monkeypatch, db_path)
+    _patch_prune_config(monkeypatch, archive_dir=archive_dir, chunk_rows=1)
+
+    old_ts = time.time() - 40 * 86400
+
+    async def seed():
+        async with StateDB(db_path) as db:
+            return [
+                await _make_session(db, status="completed", started_at=old_ts) for _ in range(3)
+            ]
+
+    ids = run_async(seed())
+
+    calls = {"n": 0}
+
+    async def flaky_after_commit(*, chunk_index, chunk_ids):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("simulated interruption")
+
+    monkeypatch.setattr(maint, "_after_prune_chunk_committed", flaky_after_commit)
+    with pytest.raises(RuntimeError):
+        run_async(maint.prune_old_data(keep_days=30, actor="test"))
+
+    archives_after_interrupt = sorted(archive_dir.glob("*.zip"))
+    assert len(archives_after_interrupt) == 2
+
+    # Rerun cleanly (no injected failure): only the remaining session is pruned.
+    async def noop_after_commit(*, chunk_index, chunk_ids):
+        return None
+
+    monkeypatch.setattr(maint, "_after_prune_chunk_committed", noop_after_commit)
+    result = run_async(maint.prune_old_data(keep_days=30, actor="test"))
+    assert result["sessions_pruned"] == 1
+
+    # Prior archives are untouched; a new one was added for the rerun.
+    archives_after_rerun = sorted(archive_dir.glob("*.zip"))
+    assert len(archives_after_rerun) == 3
+    for old in archives_after_interrupt:
+        assert old in archives_after_rerun
+
+    async def remaining_ids():
+        async with StateDB(db_path) as db:
+            rows = await db.fetch_all("SELECT id FROM sessions")
+            return {r["id"] for r in rows}
+
+    assert run_async(remaining_ids()) == set()

--- a/tests/apps_studio_server/test_retention_archive.py
+++ b/tests/apps_studio_server/test_retention_archive.py
@@ -136,6 +136,11 @@ def test_write_archive_chunk_does_not_misread_marker_shaped_json_as_bytes(tmp_pa
     dest.mkdir()
     marker_shaped = {"__bytes_b64__": "aGVsbG8="}
     escape_shaped = {"__archive_escaped__": {"nested": True}}
+    # Collisions and real bytes below the top level: json.dumps converts
+    # bytes into marker dicts at every depth, so escape/decode must be just
+    # as deep or nested values become ambiguous.
+    nested = {"refs": [marker_shaped, {"deep": escape_shaped}], "ok": 1}
+    nested_bytes = [b"\x00\x01", {"inner": b"\xfe"}]
     real_bytes = b"\x00\xff"
     tables = {
         "sessions": [
@@ -143,6 +148,8 @@ def test_write_archive_chunk_does_not_misread_marker_shaped_json_as_bytes(tmp_pa
                 "id": "s1",
                 "status_evidence_refs": marker_shaped,
                 "artifact_contract_json": escape_shaped,
+                "artifact_verification_json": nested,
+                "nested_blobs": nested_bytes,
                 "blob_col": real_bytes,
             }
         ]
@@ -153,6 +160,10 @@ def test_write_archive_chunk_does_not_misread_marker_shaped_json_as_bytes(tmp_pa
     assert row["status_evidence_refs"] == marker_shaped
     assert isinstance(row["status_evidence_refs"], dict)
     assert row["artifact_contract_json"] == escape_shaped
+    assert row["artifact_verification_json"] == nested
+    assert row["nested_blobs"] == [b"\x00\x01", {"inner": b"\xfe"}]
+    assert isinstance(row["nested_blobs"][0], bytes)
+    assert isinstance(row["nested_blobs"][1]["inner"], bytes)
     assert row["blob_col"] == real_bytes
     assert isinstance(row["blob_col"], bytes)
 

--- a/tests/apps_studio_server/test_retention_archive.py
+++ b/tests/apps_studio_server/test_retention_archive.py
@@ -127,6 +127,36 @@ def test_write_archive_chunk_round_trips_blob_columns_exactly(tmp_path):
     assert isinstance(decoded["tables"]["messages"][0]["embedding"], bytes)
 
 
+def test_write_archive_chunk_does_not_misread_marker_shaped_json_as_bytes(tmp_path):
+    """A JSON column whose stored value is literally ``{"__bytes_b64__": ...}``
+    (drivers like asyncpg hand JSON/JSONB columns back as dicts) must restore
+    as that dict, not be silently decoded into bytes. The escape wrapper must
+    itself round-trip when a value collides with it."""
+    dest = tmp_path / "archive"
+    dest.mkdir()
+    marker_shaped = {"__bytes_b64__": "aGVsbG8="}
+    escape_shaped = {"__archive_escaped__": {"nested": True}}
+    real_bytes = b"\x00\xff"
+    tables = {
+        "sessions": [
+            {
+                "id": "s1",
+                "status_evidence_refs": marker_shaped,
+                "artifact_contract_json": escape_shaped,
+                "blob_col": real_bytes,
+            }
+        ]
+    }
+    path = write_archive_chunk(dest, "prune-1-000000-coll0001", tables)
+
+    row = read_archive_chunk(path)["tables"]["sessions"][0]
+    assert row["status_evidence_refs"] == marker_shaped
+    assert isinstance(row["status_evidence_refs"], dict)
+    assert row["artifact_contract_json"] == escape_shaped
+    assert row["blob_col"] == real_bytes
+    assert isinstance(row["blob_col"], bytes)
+
+
 def test_write_archive_chunk_captures_preimages_as_sibling_members(tmp_path):
     dest = tmp_path / "archive"
     dest.mkdir()

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -24,6 +25,7 @@ from lionagi.cli.mirror import (
     _seed_lineage,
     _since_window,
 )
+from lionagi.state._mirror_common import SourceLine
 from lionagi.state.claude_mirror import (
     _det,
     messages_for_event,
@@ -739,21 +741,23 @@ def test_read_new_events_buffers_partial_line(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\n{"a":2}\n{"a":3')  # last line incomplete
     state = _FileState(session_uid="x")
-    first, new_offset, _ = _read_new_events(path, state)
+    first, sources, new_offset, _ = _read_new_events(path, state)
     assert [e["a"] for e in first] == [1, 2]
+    assert len(sources) == len(first)
     state.offset = new_offset  # caller commits the cursor only after a durable mirror
     # Complete the dangling line; the next read picks up only the new event.
     with path.open("a") as fh:
         fh.write("}\n")
-    second, _, _ = _read_new_events(path, state)
+    second, sources2, _, _ = _read_new_events(path, state)
     assert [e["a"] for e in second] == [3]
+    assert len(sources2) == len(second)
 
 
 def test_read_new_events_resets_on_truncation(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\n')
     state = _FileState(session_uid="x", offset=9999)  # offset past EOF
-    out, _, _ = _read_new_events(path, state)
+    out, _, _, _ = _read_new_events(path, state)
     assert [e["a"] for e in out] == [1]
 
 
@@ -761,7 +765,7 @@ def test_read_new_events_skips_corrupt_lines(tmp_path: Path) -> None:
     path = tmp_path / "t.jsonl"
     path.write_text('{"a":1}\nnot json\n{"a":2}\n')
     state = _FileState(session_uid="x")
-    out, _, unreadable = _read_new_events(path, state)
+    out, _, _, unreadable = _read_new_events(path, state)
     assert [e["a"] for e in out] == [1, 2]
     # The dropped line is reported, not silently absorbed: a damaged transcript
     # and an uninteresting one must not read the same downstream.
@@ -775,7 +779,7 @@ def test_read_new_events_skips_non_dict_json_without_losing_followers(tmp_path: 
     path = tmp_path / "t.jsonl"
     path.write_text('[]\n{"a":1}\n42\n{"a":2}\n')
     state = _FileState(session_uid="x")
-    out, _, unreadable = _read_new_events(path, state)
+    out, _, _, unreadable = _read_new_events(path, state)
     assert [e["a"] for e in out] == [1, 2]
     assert unreadable == 2  # both the bare list and the bare scalar
 
@@ -1562,3 +1566,630 @@ async def test_a_failed_prior_stem_absorption_also_leaves_the_file_eligible(tmp_
         assert state.orchestrated
 
     assert calls == [uid, stem, uid, stem], f"absorption ids across both passes: {calls}"
+
+
+# ── Bounded preview + source pointer codec (mirror_spec.md) ──────────────────
+
+
+def _source_line_for(raw: bytes, path: Path) -> SourceLine:
+    from lionagi.state._mirror_common import SourceLine
+
+    return SourceLine(
+        value=json.loads(raw),
+        source_path=str(path),
+        source_offset=0,
+        source_byte_count=len(raw),
+        source_sha256=hashlib.sha256(raw).hexdigest(),
+    )
+
+
+def test_bound_mirror_content_default_truncates_long_instruction():
+    from lionagi.state._mirror_common import bound_mirror_content
+
+    long_text = "x" * 600
+    content = {"instruction": long_text}
+    line = SourceLine(
+        value={},
+        source_path="/tmp/t.jsonl",
+        source_offset=0,
+        source_byte_count=10,
+        source_sha256="a" * 64,
+    )
+    preview, pointer = bound_mirror_content(
+        content,
+        "msg-1",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    assert preview == {"instruction": "x" * 500}
+    assert pointer["truncated"] is True
+    assert pointer["pointer_kind"] == "mirror_jsonl_v1"
+    assert pointer["message_id"] == "msg-1"
+
+
+def test_bound_mirror_content_zero_stores_empty_preview_with_valid_pointer():
+    from lionagi.state._mirror_common import bound_mirror_content
+
+    content = {"assistant_response": "hello world"}
+    line = SourceLine(
+        value={},
+        source_path="/tmp/t.jsonl",
+        source_offset=5,
+        source_byte_count=20,
+        source_sha256="b" * 64,
+    )
+    preview, pointer = bound_mirror_content(
+        content,
+        "msg-2",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=0,
+    )
+    assert preview == {"assistant_response": ""}
+    assert pointer["truncated"] is True
+    assert pointer["source_offset"] == 5
+    assert pointer["source_byte_count"] == 20
+
+
+def test_bound_mirror_content_exact_boundary_not_truncated():
+    from lionagi.state._mirror_common import bound_mirror_content
+
+    text = "y" * 500
+    line = SourceLine(
+        value={},
+        source_path="/tmp/t.jsonl",
+        source_offset=0,
+        source_byte_count=1,
+        source_sha256="c" * 64,
+    )
+    preview, pointer = bound_mirror_content(
+        {"assistant_response": text},
+        "msg-3",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    assert preview == {"assistant_response": text}
+    assert pointer["truncated"] is False
+
+
+def test_bound_mirror_content_short_content_unchanged_and_not_truncated():
+    from lionagi.state._mirror_common import bound_mirror_content
+
+    line = SourceLine(
+        value={},
+        source_path="/tmp/t.jsonl",
+        source_offset=0,
+        source_byte_count=1,
+        source_sha256="d" * 64,
+    )
+    preview, pointer = bound_mirror_content(
+        {"assistant_response": "short"},
+        "msg-4",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    assert preview == {"assistant_response": "short"}
+    assert pointer["truncated"] is False
+
+
+def test_bound_mirror_content_negative_budget_rejected():
+    from lionagi.state._mirror_common import bound_mirror_content
+
+    line = SourceLine(
+        value={},
+        source_path="/tmp/t.jsonl",
+        source_offset=0,
+        source_byte_count=1,
+        source_sha256="e" * 64,
+    )
+    with pytest.raises(ValueError):
+        bound_mirror_content(
+            {"assistant_response": "x"},
+            "msg-5",
+            line,
+            source_kind="claude_jsonl",
+            source_session_uid="sess-1",
+            max_preview_chars=-1,
+        )
+
+
+def test_bound_mirror_content_action_request_bounds_arguments_and_caps_function():
+    from lionagi.state._mirror_common import bound_mirror_content, canonical_json
+
+    content = {"function": "z" * 200, "arguments": {"payload": "w" * 900}}
+    line = SourceLine(
+        value={},
+        source_path="/tmp/t.jsonl",
+        source_offset=0,
+        source_byte_count=1,
+        source_sha256="f" * 64,
+    )
+    preview, pointer = bound_mirror_content(
+        content,
+        "msg-6",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    assert len(preview["function"]) == 128
+    assert preview["arguments"]["_truncated"] is True
+    assert pointer["truncated"] is True
+
+
+def test_bound_mirror_content_metadata_merge_preserves_lion_class():
+    from lionagi.state._mirror_common import bound_mirror_content
+
+    line = SourceLine(
+        value={},
+        source_path="/tmp/t.jsonl",
+        source_offset=0,
+        source_byte_count=1,
+        source_sha256="0" * 64,
+    )
+    _, pointer = bound_mirror_content(
+        {"assistant_response": "hi"},
+        "msg-7",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    node_metadata = {"lion_class": "AssistantResponse", "mirror_source": pointer}
+    assert node_metadata["lion_class"] == "AssistantResponse"
+    assert node_metadata["mirror_source"]["message_id"] == "msg-7"
+
+
+def test_resolve_mirrored_content_legacy_row_without_pointer_unchanged():
+    from lionagi.state._mirror_common import resolve_mirrored_content
+
+    row = {"content": {"assistant_response": "hi"}, "node_metadata": {"lion_class": "X"}}
+    resolved = resolve_mirrored_content(row)
+    assert resolved.status == "legacy"
+    assert resolved.content == row["content"]
+
+
+def test_resolve_mirrored_content_round_trip_claude_assistant_response(tmp_path):
+    """bound -> resolve reconstructs the exact full content via the real Claude
+    adapter mapper, proving the pointer/hash/offset chain is internally consistent."""
+    from lionagi.state._mirror_common import bound_mirror_content, resolve_mirrored_content
+
+    session_uid = "sess-roundtrip"
+    event = {
+        "type": "assistant",
+        "uuid": "evt-1",
+        "timestamp": "2026-08-01T00:00:00Z",
+        "message": {"content": [{"type": "text", "text": "z" * 700}]},
+    }
+    raw = json.dumps(event).encode("utf-8")
+    path = tmp_path / "transcript.jsonl"
+    path.write_bytes(raw + b"\n")
+
+    msgs = messages_for_event(event, session_uid, {})
+    assert len(msgs) == 1
+    md = msgs[0].to_dict(mode="db")
+
+    line = _source_line_for(raw, path)
+    preview, pointer = bound_mirror_content(
+        md["content"],
+        md["id"],
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid=session_uid,
+        max_preview_chars=500,
+    )
+    assert pointer["truncated"] is True
+    row = {"content": preview, "node_metadata": {"mirror_source": pointer}}
+
+    def reconstruct(record, source_session_uid, message_id):
+        for m in messages_for_event(record, source_session_uid, {}):
+            if str(m.id) == message_id:
+                return m.to_dict(mode="db")["content"]
+        return None
+
+    resolved = resolve_mirrored_content(row, reconstruct=reconstruct)
+    assert resolved.status == "resolved"
+    assert resolved.content == md["content"]
+
+
+def test_resolve_mirrored_content_source_missing_falls_back_to_preview(tmp_path):
+    from lionagi.state._mirror_common import bound_mirror_content, resolve_mirrored_content
+
+    path = tmp_path / "gone.jsonl"
+    raw = b'{"a": 1}'
+    path.write_bytes(raw)
+    line = _source_line_for(raw, path)
+    preview, pointer = bound_mirror_content(
+        {"assistant_response": "hi"},
+        "msg-8",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    path.unlink()
+    row = {"content": preview, "node_metadata": {"mirror_source": pointer}}
+    resolved = resolve_mirrored_content(row, reconstruct=lambda *a: None)
+    assert resolved.status == "preview"
+    assert resolved.reason == "source_missing"
+    assert resolved.content == preview
+
+
+def test_resolve_mirrored_content_source_replaced_hash_mismatch(tmp_path):
+    from lionagi.state._mirror_common import bound_mirror_content, resolve_mirrored_content
+
+    path = tmp_path / "replaced.jsonl"
+    raw = b'{"a": 1}'
+    path.write_bytes(raw)
+    line = _source_line_for(raw, path)
+    preview, pointer = bound_mirror_content(
+        {"assistant_response": "hi"},
+        "msg-9",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    path.write_bytes(b'{"a": 2}')  # same length, different bytes -> sha mismatch
+    row = {"content": preview, "node_metadata": {"mirror_source": pointer}}
+    resolved = resolve_mirrored_content(row, reconstruct=lambda *a: None)
+    assert resolved.status == "preview"
+    assert resolved.reason == "source_replaced"
+
+
+def test_resolve_mirrored_content_short_read_falls_back_to_preview(tmp_path):
+    from lionagi.state._mirror_common import bound_mirror_content, resolve_mirrored_content
+
+    path = tmp_path / "short.jsonl"
+    raw = b'{"a": 1}'
+    path.write_bytes(raw)
+    line = _source_line_for(raw, path)
+    preview, pointer = bound_mirror_content(
+        {"assistant_response": "hi"},
+        "msg-10",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    path.write_bytes(raw[:3])  # now shorter than the recorded byte range
+    row = {"content": preview, "node_metadata": {"mirror_source": pointer}}
+    resolved = resolve_mirrored_content(row, reconstruct=lambda *a: None)
+    assert resolved.status == "preview"
+    assert resolved.reason == "short_read"
+
+
+def test_resolve_mirrored_content_unsupported_pointer_version(tmp_path):
+    from lionagi.state._mirror_common import resolve_mirrored_content
+
+    row = {
+        "content": {"assistant_response": "hi"},
+        "node_metadata": {
+            "mirror_source": {
+                "pointer_kind": "mirror_jsonl_v2",
+                "source_offset": 0,
+                "source_byte_count": 1,
+                "source_path": "/tmp/whatever.jsonl",
+                "source_sha256": "0" * 64,
+            }
+        },
+    }
+    resolved = resolve_mirrored_content(row)
+    assert resolved.status == "preview"
+    assert resolved.reason == "unsupported_pointer"
+
+
+def test_resolve_mirrored_content_no_message_match_falls_back(tmp_path):
+    from lionagi.state._mirror_common import bound_mirror_content, resolve_mirrored_content
+
+    path = tmp_path / "t.jsonl"
+    raw = b'{"a": 1}'
+    path.write_bytes(raw)
+    line = _source_line_for(raw, path)
+    preview, pointer = bound_mirror_content(
+        {"assistant_response": "hi"},
+        "msg-11",
+        line,
+        source_kind="claude_jsonl",
+        source_session_uid="sess-1",
+        max_preview_chars=500,
+    )
+    row = {"content": preview, "node_metadata": {"mirror_source": pointer}}
+    resolved = resolve_mirrored_content(row, reconstruct=lambda *a: None)
+    assert resolved.status == "preview"
+    assert resolved.reason == "no_message_match"
+
+
+def test_config_negative_preview_chars_rejected(monkeypatch):
+    import importlib
+
+    from lionagi.studio import config as config_mod
+
+    monkeypatch.setenv("LIONAGI_STUDIO_MIRROR_PREVIEW_CHARS", "-1")
+    with pytest.raises(ValueError):
+        importlib.reload(config_mod)
+    monkeypatch.delenv("LIONAGI_STUDIO_MIRROR_PREVIEW_CHARS", raising=False)
+    importlib.reload(config_mod)
+
+
+def test_config_omitted_preview_chars_defaults_to_500(monkeypatch):
+    import importlib
+
+    monkeypatch.delenv("LIONAGI_STUDIO_MIRROR_PREVIEW_CHARS", raising=False)
+    from lionagi.studio import config as config_mod
+
+    importlib.reload(config_mod)
+    assert config_mod.MIRROR_PREVIEW_CHARS == 500
+
+
+# ── Live-path mirror bounding: oversized ingestion through the three real
+# writers (claude_mirror.py, codex_mirror.py, cli/mirror.py). A unit test on
+# the codec alone (above) does not prove these are wired; each test here
+# writes an oversized transcript to disk and reads the row back out of a real
+# StateDB after it went through the module's own tailer, never constructing
+# the pointer by hand. ──────────────────────────────────────────────────────
+
+_OVERSIZED_TEXT = "z" * 5000  # far beyond MIRROR_PREVIEW_CHARS default (500)
+
+
+def _claude_oversized_file(root: Path, uid: str) -> Path:
+    path = root / "-proj" / f"{uid}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "type": "user",
+        "uuid": f"{uid}-u",
+        "timestamp": "2026-08-05T00:00:00.000Z",
+        "sessionId": uid,
+        "message": {"role": "user", "content": [{"type": "text", "text": _OVERSIZED_TEXT}]},
+    }
+    path.write_text(json.dumps(event) + "\n")
+    return path
+
+
+def _codex_oversized_file(root: Path, uid: str) -> Path:
+    path = root / f"rollout-{uid}.jsonl"
+    root.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "type": "session_meta",
+        "timestamp": "2026-08-05T00:00:00Z",
+        "payload": {"id": uid, "session_id": uid, "cwd": "/x", "originator": "Codex Desktop"},
+    }
+    user = {
+        "type": "response_item",
+        "timestamp": "2026-08-05T00:00:01Z",
+        "payload": {
+            "type": "message",
+            "role": "user",
+            "id": "m1",
+            "content": [{"text": _OVERSIZED_TEXT}],
+        },
+    }
+    path.write_text("".join(json.dumps(e) + "\n" for e in (meta, user)))
+    return path
+
+
+@pytest.mark.asyncio
+async def test_live_claude_ingest_bounds_oversized_message_via_one_pass(
+    temp_db_path: Path, tmp_path: Path
+) -> None:
+    """`_one_pass` (claude_mirror.py's live ingestion sweep) must write a bounded
+    preview plus a resolvable source pointer for an oversized message, not the
+    raw unbounded text."""
+    from lionagi.state._mirror_common import resolve_mirrored_content
+
+    uid = "0199dddd-0000-0000-0000-000000000001"
+    root = tmp_path / "projects"
+    path = _claude_oversized_file(root, uid)
+
+    async with StateDB() as db:
+        await _one_pass(db, root, {}, {}, since=None, live_window=300)
+        branch_id = _det(uid, "branch")
+        rows = await db.get_branch_messages(branch_id)
+
+    assert len(rows) == 1
+    row = rows[0]
+    stored = row["content"]["instruction"]
+    assert stored != _OVERSIZED_TEXT
+    assert len(stored) < len(_OVERSIZED_TEXT)
+    pointer = row["node_metadata"]["mirror_source"]
+    assert pointer["truncated"] is True
+    assert pointer["source_path"] == str(path)
+    assert pointer["pointer_kind"] == "mirror_jsonl_v1"
+
+    def _reconstruct(record, session_uid, message_id):
+        for m in messages_for_event(record, session_uid, {}):
+            if str(m.id) == message_id:
+                return m.to_dict(mode="db")["content"]
+        return None
+
+    resolved = resolve_mirrored_content(row, reconstruct=_reconstruct)
+    assert resolved.status == "resolved"
+    assert resolved.content["instruction"] == _OVERSIZED_TEXT
+
+
+@pytest.mark.asyncio
+async def test_live_codex_ingest_bounds_oversized_message_via_mirror_one_codex(
+    tmp_path: Path,
+) -> None:
+    """`_mirror_one_codex` (codex_mirror.py's live ingestion path) must write a
+    bounded preview plus a resolvable source pointer for an oversized message."""
+    from lionagi.cli.mirror import _mirror_one_codex
+    from lionagi.state._mirror_common import resolve_mirrored_content
+    from lionagi.state.codex_mirror import _det as codex_det
+    from lionagi.state.codex_mirror import messages_for_record
+
+    uid = "0199dddd-0000-0000-0000-000000000002"
+    root = tmp_path / "codex"
+    path = _codex_oversized_file(root, uid)
+    state = _FileState(session_uid="")
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        written = await _mirror_one_codex(db, path, state, {})
+        branch_id = codex_det(uid, "branch")
+        rows = await db.get_branch_messages(branch_id)
+
+    assert written == 1
+    assert len(rows) == 1
+    row = rows[0]
+    stored = row["content"]["instruction"]
+    assert stored != _OVERSIZED_TEXT
+    assert len(stored) < len(_OVERSIZED_TEXT)
+    pointer = row["node_metadata"]["mirror_source"]
+    assert pointer["truncated"] is True
+    assert pointer["source_path"] == str(path)
+
+    def _reconstruct(record, session_uid, message_id):
+        for m in messages_for_record(record, session_uid, {}):
+            if str(m.id) == message_id:
+                return m.to_dict(mode="db")["content"]
+        return None
+
+    resolved = resolve_mirrored_content(row, reconstruct=_reconstruct)
+    assert resolved.status == "resolved"
+    assert resolved.content["instruction"] == _OVERSIZED_TEXT
+
+
+@pytest.mark.asyncio
+async def test_live_cli_mirror_run_once_bounds_oversized_message_end_to_end(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The `li mirror --once` entry point (`_run` in cli/mirror.py) must produce
+    a bounded, resolvable row through the full CLI codepath — argument parsing,
+    state persistence and both the claude and codex passes — not just through
+    the lower-level per-file helpers exercised by the other two live tests."""
+    import argparse
+
+    from lionagi.cli import mirror as mirror_mod
+    from lionagi.state._mirror_common import resolve_mirrored_content
+
+    monkeypatch.setattr(mirror_mod, "_OFFSETS_PATH", tmp_path / "offsets.json")
+
+    uid = "0199dddd-0000-0000-0000-000000000003"
+    root = tmp_path / "projects"
+    path = _claude_oversized_file(root, uid)
+    codex_root = tmp_path / "codex_root"
+    codex_root.mkdir()
+
+    args = argparse.Namespace(
+        root=str(root),
+        codex_root=str(codex_root),
+        source="claude",
+        since=None,
+        once=True,
+        interval=0.01,
+        live_window=300.0,
+    )
+    rc = await mirror_mod._run(args)
+
+    async with StateDB() as db:
+        branch_id = _det(uid, "branch")
+        rows = await db.get_branch_messages(branch_id)
+
+    assert rc == 0
+    assert len(rows) == 1
+    row = rows[0]
+    stored = row["content"]["instruction"]
+    assert stored != _OVERSIZED_TEXT
+    assert len(stored) < len(_OVERSIZED_TEXT)
+    pointer = row["node_metadata"]["mirror_source"]
+    assert pointer["truncated"] is True
+    assert pointer["source_path"] == str(path)
+
+    def _reconstruct(record, session_uid, message_id):
+        for m in messages_for_event(record, session_uid, {}):
+            if str(m.id) == message_id:
+                return m.to_dict(mode="db")["content"]
+        return None
+
+    resolved = resolve_mirrored_content(row, reconstruct=_reconstruct)
+    assert resolved.status == "resolved"
+    assert resolved.content["instruction"] == _OVERSIZED_TEXT
+
+
+@pytest.mark.asyncio
+async def test_live_cli_mirror_run_once_relative_root_produces_resolvable_pointer(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A relative ``--root`` must still resolve to an absolute source pointer.
+
+    Regression for the mirror review finding: ``_run`` only called
+    ``expanduser()`` on ``args.root``, so a relative root stored a
+    non-absolute ``source_path`` that ``resolve_mirrored_content`` rejects as
+    ``unsupported_pointer`` even though the row itself was correctly bounded.
+    """
+    import argparse
+
+    from lionagi.cli import mirror as mirror_mod
+    from lionagi.state._mirror_common import resolve_mirrored_content
+
+    monkeypatch.setattr(mirror_mod, "_OFFSETS_PATH", tmp_path / "offsets.json")
+    monkeypatch.chdir(tmp_path)
+
+    uid = "0199dddd-0000-0000-0000-000000000004"
+    root = tmp_path / "relative-root" / "projects"
+    path = _claude_oversized_file(root, uid)
+    codex_root = tmp_path / "codex_root"
+    codex_root.mkdir()
+
+    args = argparse.Namespace(
+        root="relative-root/projects",
+        codex_root=str(codex_root),
+        source="claude",
+        since=None,
+        once=True,
+        interval=0.01,
+        live_window=300.0,
+    )
+    rc = await mirror_mod._run(args)
+
+    async with StateDB() as db:
+        branch_id = _det(uid, "branch")
+        rows = await db.get_branch_messages(branch_id)
+
+    assert rc == 0
+    assert len(rows) == 1
+    row = rows[0]
+    pointer = row["node_metadata"]["mirror_source"]
+    assert Path(pointer["source_path"]).is_absolute()
+    assert pointer["source_path"] == str(path.resolve())
+
+    def _reconstruct(record, session_uid, message_id):
+        for m in messages_for_event(record, session_uid, {}):
+            if str(m.id) == message_id:
+                return m.to_dict(mode="db")["content"]
+        return None
+
+    resolved = resolve_mirrored_content(row, reconstruct=_reconstruct)
+    assert resolved.status == "resolved"
+    assert resolved.content["instruction"] == _OVERSIZED_TEXT
+
+
+def test_grep_evidence_live_mirror_paths_call_bound_mirror_content() -> None:
+    """Regression guard for the round-1 gate finding ("zero callers"): the two
+    writers must call the bounding codec directly, and the CLI tailer that
+    feeds them must thread the source-pointer data (byte offsets + the
+    preview-chars budget) into every live write."""
+    root = Path(__file__).resolve().parents[2] / "lionagi"
+    codec_callers = {
+        root / "state" / "claude_mirror.py": "claude_mirror.py",
+        root / "state" / "codex_mirror.py": "codex_mirror.py",
+    }
+    missing = [
+        label
+        for path, label in codec_callers.items()
+        if "bound_mirror_content" not in path.read_text()
+    ]
+    assert not missing, f"bound_mirror_content has zero callers in: {missing}"
+
+    cli_text = (root / "cli" / "mirror.py").read_text()
+    assert "max_preview_chars" in cli_text and "event_sources" in cli_text, (
+        "cli/mirror.py does not thread the mirror bounding budget/source pointers "
+        "into mirror_session()"
+    )

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -400,6 +400,60 @@ async def test_statedb_upgrade_adds_cc_session_lookup_index(tmp_path: Path) -> N
     assert any("idx_sessions_cc_session" in detail for detail in details), details
 
 
+async def test_statedb_upgrade_adds_branches_session_created_index(tmp_path: Path) -> None:
+    """Existing databases gain the covering index for the session-detail branch
+    listing (ORDER BY created_at) after the index migration runs."""
+    from sqlalchemy import text
+
+    from lionagi.state.db import StateDB
+
+    db_path = tmp_path / "pre-branches-index.db"
+    with sqlite3.connect(db_path) as conn:
+        from lionagi.state.db import _SCHEMA_PATH
+
+        # schema.sql does not declare this index (it is only added via
+        # MIGRATION_INDEXES), so a fresh executescript already stands in for
+        # an "existing database" that predates this migration.
+        conn.executescript(_SCHEMA_PATH.read_text())
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        await state.create_progression("progression-idx")
+        await state.execute(
+            "INSERT INTO sessions (id, created_at, progression_id, updated_at) "
+            "VALUES (:id, :created_at, :progression_id, :updated_at)",
+            {
+                "id": "session-idx",
+                "created_at": 1.0,
+                "progression_id": "progression-idx",
+                "updated_at": 1.0,
+            },
+        )
+        async with state._read() as conn:
+            indexes = (await conn.execute(text("PRAGMA index_list(branches)"))).mappings().all()
+            plan = (
+                (
+                    await conn.execute(
+                        text(
+                            "EXPLAIN QUERY PLAN SELECT id, name, created_at FROM branches "
+                            "WHERE session_id = :session_id ORDER BY created_at"
+                        ),
+                        {"session_id": "session-idx"},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+    finally:
+        await state.close()
+
+    assert "idx_branches_session_created" in {row["name"] for row in indexes}
+    details = [row["detail"] for row in plan]
+    assert any("idx_branches_session_created" in detail for detail in details), details
+    assert not any("USE TEMP B-TREE" in detail for detail in details), details
+
+
 def test_concurrent_statedb_opens_reconcile_cc_session_column(tmp_path: Path) -> None:
     """Concurrent first opens tolerate another process winning the ALTER race."""
     db_path = tmp_path / "concurrent-pre-cc-session.db"

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -430,13 +430,30 @@ async def test_statedb_upgrade_adds_branches_session_created_index(tmp_path: Pat
                 "updated_at": 1.0,
             },
         )
+        # Populate branches so the EXPLAIN runs against a table with rows —
+        # a plan over an empty table is weaker evidence that the index is
+        # actually chosen for the shape the listing query uses.
+        for i in range(3):
+            await state.execute(
+                "INSERT INTO branches (id, created_at, session_id, progression_id) "
+                "VALUES (:id, :created_at, :session_id, :progression_id)",
+                {
+                    "id": f"branch-idx-{i}",
+                    "created_at": float(i),
+                    "session_id": "session-idx",
+                    "progression_id": "progression-idx",
+                },
+            )
         async with state._read() as conn:
             indexes = (await conn.execute(text("PRAGMA index_list(branches)"))).mappings().all()
+            # Same query shape as the live branch listing (SELECT * ... ORDER BY
+            # created_at): the index's win is the equality seek plus sort
+            # elimination, not covering — SELECT * can never be index-only.
             plan = (
                 (
                     await conn.execute(
                         text(
-                            "EXPLAIN QUERY PLAN SELECT id, name, created_at FROM branches "
+                            "EXPLAIN QUERY PLAN SELECT * FROM branches "
                             "WHERE session_id = :session_id ORDER BY created_at"
                         ),
                         {"session_id": "session-idx"},


### PR DESCRIPTION
## What

Three backend performance/durability lanes for Studio's state store, each independently verified before landing:

1. **Composite index** `idx_branches_session_created` on `(session_id, created_at)` for branch listing by session (equality seek + sort elimination; the live query is `SELECT *`, so covering is not the mechanism) (sqlite + postgres, `CREATE INDEX IF NOT EXISTS`, additive). Eliminates a temp B-tree on the session-detail hot path — before/after EXPLAIN and latency evidence on an 18K-session / 1.7M-message fixture.
2. **Bounded mirror ingestion**: message content is capped through a pointer/preview codec on every live ingestion path (Claude mirror, Codex mirror, CLI mirror). Oversized content stays resolvable; stored rows are bounded. Live-path tests ingest oversized messages through each real path and assert the stored row is bounded.
3. **Safe chunked retention**: archive-then-prune per chunk with whole-plan abort on archive failure (later chunks stay undeleted), schedule/dispatch retention chunked the same way as messages (no monolithic transactions remain), archives as self-verifying ZIP64 with manifest + per-member digests. ZIP64 is declared in the central directory for every member, matching the local headers on every Python — not only once a member crosses the size threshold.

## Tests

Retention/archive/migration/prune: 109 passed. Mirror paths: 120 passed. Digest tampering, whole-plan abort, blob round-trip, and genuine-ZIP64 arms included. Pre-existing unrelated failures (postgres-adapter env, daemon duplicate-route) reproduce on clean base and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
