### PR TITLE
Make the execution graph readable: edge reduction, folding, and a fixed node card

### DIFF
--- a/apps/studio/frontend/src/components/canvas/ConditionEdge.test.ts
+++ b/apps/studio/frontend/src/components/canvas/ConditionEdge.test.ts
@@ -5,7 +5,7 @@
  * getBezierPath / EdgeLabelRenderer all expect a live ReactFlow provider).
  */
 import { describe, it, expect } from "vitest";
-import { computeEdgeVisualState, isLongRangeEdge } from "./ConditionEdge";
+import { computeEdgeVisualState, continuationVisualState, isLongRangeEdge } from "./ConditionEdge";
 
 describe("isLongRangeEdge — rank-distance routing threshold", () => {
   it("is short-range under the threshold", () => {
@@ -62,5 +62,41 @@ describe("computeEdgeVisualState — completed edges mute, active/selected stay 
     const selected = computeEdgeVisualState(true, false, false);
     expect(completed.strokeWidth).toBeLessThan(pending.strokeWidth);
     expect(selected.strokeWidth).toBeGreaterThan(pending.strokeWidth);
+  });
+});
+
+describe("continuationVisualState — the fold's return sweep recedes", () => {
+  const base = { strokeColor: "var(--dag-edge-done)", strokeOpacity: 1, strokeWidth: 2 };
+
+  it("thins and fades a continuation that is neither hovered nor selected", () => {
+    const out = continuationVisualState(base, false);
+    expect(out.strokeOpacity).toBeLessThan(base.strokeOpacity);
+    expect(out.strokeWidth).toBeLessThan(base.strokeWidth);
+  });
+
+  it("hands back the base state untouched once hovered or selected", () => {
+    // It is a real dependency underneath, so it has to come back to full
+    // strength when someone goes looking at it.
+    expect(continuationVisualState(base, true)).toBe(base);
+  });
+
+  it("keeps the colour the run state chose", () => {
+    // Muting is about weight, not hue: a continuation off a failed step still
+    // has to read as belonging to that step.
+    const failed = { ...base, strokeColor: "var(--dag-pending-border)" };
+    expect(continuationVisualState(failed, false).strokeColor).toBe(failed.strokeColor);
+  });
+
+  it("never makes an already-muted edge louder", () => {
+    // A completed edge arrives at 0.5. Assigning the continuation opacity
+    // outright rather than taking the lower of the two would brighten it.
+    const alreadyMuted = { ...base, strokeOpacity: 0.2 };
+    expect(continuationVisualState(alreadyMuted, false).strokeOpacity).toBeLessThanOrEqual(0.2);
+  });
+
+  it("does not mutate the state it was handed", () => {
+    const input = { ...base };
+    continuationVisualState(input, false);
+    expect(input).toEqual(base);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/ConditionEdge.test.ts
+++ b/apps/studio/frontend/src/components/canvas/ConditionEdge.test.ts
@@ -1,0 +1,66 @@
+/**
+ * ConditionEdge's routing and muting decisions are pure, data-driven
+ * functions — the component just wires their output onto an SVG path. That
+ * split lets these be pinned without mounting ReactFlow (getSmoothStepPath /
+ * getBezierPath / EdgeLabelRenderer all expect a live ReactFlow provider).
+ */
+import { describe, it, expect } from "vitest";
+import { computeEdgeVisualState, isLongRangeEdge } from "./ConditionEdge";
+
+describe("isLongRangeEdge — rank-distance routing threshold", () => {
+  it("is short-range under the threshold", () => {
+    expect(isLongRangeEdge(0)).toBe(false);
+    expect(isLongRangeEdge(1)).toBe(false);
+    expect(isLongRangeEdge(2)).toBe(false);
+  });
+
+  it("is long-range at and beyond the threshold", () => {
+    expect(isLongRangeEdge(3)).toBe(true);
+    expect(isLongRangeEdge(4)).toBe(true);
+    expect(isLongRangeEdge(10)).toBe(true);
+  });
+
+  it("treats undefined rank distance (edge predates a layout pass) as short-range", () => {
+    expect(isLongRangeEdge(undefined)).toBe(false);
+  });
+
+  it("treats a negative rank distance (shouldn't happen, but defensively) as short-range", () => {
+    expect(isLongRangeEdge(-1)).toBe(false);
+  });
+});
+
+describe("computeEdgeVisualState — completed edges mute, active/selected stay emphasized", () => {
+  it("a pending/running edge is at full emphasis", () => {
+    const state = computeEdgeVisualState(false, false, false);
+    expect(state.strokeOpacity).toBe(1);
+    expect(state.strokeColor).toBe("var(--dag-pending-border)");
+  });
+
+  it("a completed edge is muted when not emphasized", () => {
+    const state = computeEdgeVisualState(false, true, false);
+    expect(state.strokeOpacity).toBeLessThan(1);
+    expect(state.strokeColor).toBe("var(--dag-edge-done)");
+  });
+
+  it("hover re-emphasizes a completed edge back to full opacity", () => {
+    const state = computeEdgeVisualState(false, true, true);
+    expect(state.strokeOpacity).toBe(1);
+  });
+
+  it("selection always wins — full opacity and the selected color, completed or not", () => {
+    const selectedPending = computeEdgeVisualState(true, false, true);
+    const selectedCompleted = computeEdgeVisualState(true, true, true);
+    expect(selectedPending.strokeOpacity).toBe(1);
+    expect(selectedCompleted.strokeOpacity).toBe(1);
+    expect(selectedPending.strokeColor).toBe("var(--status-selected)");
+    expect(selectedCompleted.strokeColor).toBe("var(--status-selected)");
+  });
+
+  it("a completed edge is thinner than an active one, and selected is thickest", () => {
+    const pending = computeEdgeVisualState(false, false, false);
+    const completed = computeEdgeVisualState(false, true, false);
+    const selected = computeEdgeVisualState(true, false, false);
+    expect(completed.strokeWidth).toBeLessThan(pending.strokeWidth);
+    expect(selected.strokeWidth).toBeGreaterThan(pending.strokeWidth);
+  });
+});

--- a/apps/studio/frontend/src/components/canvas/ConditionEdge.tsx
+++ b/apps/studio/frontend/src/components/canvas/ConditionEdge.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { memo } from "react";
-import { getBezierPath, EdgeLabelRenderer } from "reactflow";
+import { memo, useState } from "react";
+import { getBezierPath, getSmoothStepPath, EdgeLabelRenderer } from "reactflow";
 import type { EdgeProps } from "reactflow";
+
+// A bezier between ranks that are far apart draws one long curve sweeping
+// across every intervening rank's cards — the "spaghetti" a deep chain reads
+// as. Past this rank distance, route with a rounded step instead: it hugs the
+// rank grid rather than cutting across it.
+const LONG_RANGE_RANK_DISTANCE = 3;
+const LONG_RANGE_BORDER_RADIUS = 12;
+const LONG_RANGE_OFFSET = 24;
 
 export interface ConditionEdgeData {
   mode: "simple" | "code";
@@ -10,6 +18,42 @@ export interface ConditionEdgeData {
   map?: Record<string, string>;
   handler?: string;
   sourceCompleted?: boolean;
+  /** Longest-path rank distance source -> target, from useLayout's rank map
+   * (WorkerCanvas attaches this after each layout pass). Undefined for edges
+   * that predate a layout — e.g. a fresh onConnect in the editor — which
+   * fall back to the short-edge bezier route. */
+  rankDistance?: number;
+}
+
+export function isLongRangeEdge(rankDistance: number | undefined): boolean {
+  return (rankDistance ?? 0) >= LONG_RANGE_RANK_DISTANCE;
+}
+
+export interface EdgeVisualState {
+  strokeColor: string;
+  strokeOpacity: number;
+  strokeWidth: number;
+}
+
+// Completed edges recede once a run is done — a finished 18-node graph with
+// every edge at full green saturation reads as uniformly "hot" and buries
+// the one thing worth looking at. Selection always wins (a reviewer clicked
+// it); hover re-emphasizes so a muted edge stays inspectable without
+// clicking. Non-completed (running/pending) edges are never muted.
+export function computeEdgeVisualState(
+  selected: boolean,
+  completed: boolean,
+  emphasized: boolean,
+): EdgeVisualState {
+  return {
+    strokeColor: selected
+      ? "var(--status-selected)"
+      : completed
+        ? "var(--dag-edge-done)"
+        : "var(--dag-pending-border)",
+    strokeOpacity: completed && !emphasized ? 0.5 : 1,
+    strokeWidth: selected ? 2.5 : completed ? 1.75 : 2,
+  };
 }
 
 function ConditionEdgeComponent({
@@ -23,28 +67,37 @@ function ConditionEdgeComponent({
   data,
   selected,
 }: EdgeProps<ConditionEdgeData>) {
+  const [hovered, setHovered] = useState(false);
   const completed = data?.sourceCompleted ?? false;
   const isCode = data?.mode === "code";
+  const isLongRange = isLongRangeEdge(data?.rankDistance);
 
-  const [edgePath, labelX, labelY] = getBezierPath({
-    sourceX,
-    sourceY,
-    sourcePosition,
-    targetX,
-    targetY,
-    targetPosition,
-  });
+  const [edgePath, labelX, labelY] = isLongRange
+    ? getSmoothStepPath({
+        sourceX,
+        sourceY,
+        sourcePosition,
+        targetX,
+        targetY,
+        targetPosition,
+        borderRadius: LONG_RANGE_BORDER_RADIUS,
+        offset: LONG_RANGE_OFFSET,
+      })
+    : getBezierPath({
+        sourceX,
+        sourceY,
+        sourcePosition,
+        targetX,
+        targetY,
+        targetPosition,
+      });
 
-  // Edge stroke colors are data-driven (selected state + completion state) —
-  // kept inline. Default uses the solid dag-pending-border token (opaque
-  // gray) rather than the translucent --edge-strong hairline: at these
-  // widths the hairline reads as invisible against surface-base in both
-  // themes.
-  const strokeColor = selected
-    ? "var(--status-selected)"
-    : completed
-      ? "var(--dag-edge-done)"
-      : "var(--dag-pending-border)";
+  const emphasized = Boolean(selected) || hovered;
+  const { strokeColor, strokeOpacity, strokeWidth } = computeEdgeVisualState(
+    Boolean(selected),
+    completed,
+    emphasized,
+  );
 
   return (
     <>
@@ -53,10 +106,13 @@ function ConditionEdgeComponent({
         d={edgePath}
         fill="none"
         stroke={strokeColor}
-        strokeWidth={selected ? 2.5 : completed ? 2 : 1.75}
+        strokeOpacity={strokeOpacity}
+        strokeWidth={strokeWidth}
         strokeDasharray={isCode ? "6 4" : undefined}
-        style={{ transition: "stroke 0.25s, stroke-width 0.15s" }}
+        style={{ transition: "stroke 0.25s, stroke-width 0.15s, stroke-opacity 0.25s" }}
         markerEnd={`url(#${completed ? "arrow-active" : "arrow"})`}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
       />
 
       {data?.condition && (

--- a/apps/studio/frontend/src/components/canvas/ConditionEdge.tsx
+++ b/apps/studio/frontend/src/components/canvas/ConditionEdge.tsx
@@ -23,6 +23,9 @@ export interface ConditionEdgeData {
    * that predate a layout — e.g. a fresh onConnect in the editor — which
    * fall back to the short-edge bezier route. */
   rankDistance?: number;
+  /** Set by the layout when folding put this edge's target on the row below
+   * its source, so it sweeps back across the canvas. See markContinuationEdges. */
+  continuation?: boolean;
 }
 
 export function isLongRangeEdge(rankDistance: number | undefined): boolean {
@@ -33,6 +36,29 @@ export interface EdgeVisualState {
   strokeColor: string;
   strokeOpacity: number;
   strokeWidth: number;
+}
+
+// A continuation carries no information of its own: the reader already knows
+// the run continues, the same way they know a sentence continues on the next
+// line. So it is drawn to be followed and not read — finely dotted, thin, and
+// well under the weight of the dependencies around it. The dot pattern is
+// tighter than the dashes a code-mode condition uses, so the two never read as
+// the same kind of line. Hover and selection still restore it to full strength,
+// because it is a real dependency underneath and has to stay inspectable.
+const CONTINUATION_DASHARRAY = "2 6";
+const CONTINUATION_OPACITY = 0.35;
+const CONTINUATION_WIDTH = 1.25;
+
+export function continuationVisualState(
+  base: EdgeVisualState,
+  emphasized: boolean,
+): EdgeVisualState {
+  if (emphasized) return base;
+  return {
+    ...base,
+    strokeOpacity: Math.min(base.strokeOpacity, CONTINUATION_OPACITY),
+    strokeWidth: CONTINUATION_WIDTH,
+  };
 }
 
 // Completed edges recede once a run is done — a finished 18-node graph with
@@ -70,7 +96,11 @@ function ConditionEdgeComponent({
   const [hovered, setHovered] = useState(false);
   const completed = data?.sourceCompleted ?? false;
   const isCode = data?.mode === "code";
-  const isLongRange = isLongRangeEdge(data?.rankDistance);
+  const isContinuation = data?.continuation === true;
+  // A bezier drawn to a target that sits left of its source doubles back
+  // through its own start; the stepped route is the only one that reads as a
+  // return sweep, so a continuation takes it whatever its rank distance.
+  const isLongRange = isContinuation || isLongRangeEdge(data?.rankDistance);
 
   const [edgePath, labelX, labelY] = isLongRange
     ? getSmoothStepPath({
@@ -93,11 +123,10 @@ function ConditionEdgeComponent({
       });
 
   const emphasized = Boolean(selected) || hovered;
-  const { strokeColor, strokeOpacity, strokeWidth } = computeEdgeVisualState(
-    Boolean(selected),
-    completed,
-    emphasized,
-  );
+  const base = computeEdgeVisualState(Boolean(selected), completed, emphasized);
+  const { strokeColor, strokeOpacity, strokeWidth } = isContinuation
+    ? continuationVisualState(base, emphasized)
+    : base;
 
   return (
     <>
@@ -108,9 +137,12 @@ function ConditionEdgeComponent({
         stroke={strokeColor}
         strokeOpacity={strokeOpacity}
         strokeWidth={strokeWidth}
-        strokeDasharray={isCode ? "6 4" : undefined}
+        strokeDasharray={isContinuation ? CONTINUATION_DASHARRAY : isCode ? "6 4" : undefined}
         style={{ transition: "stroke 0.25s, stroke-width 0.15s, stroke-opacity 0.25s" }}
-        markerEnd={`url(#${completed ? "arrow-active" : "arrow"})`}
+        // An arrowhead is what makes a backwards edge read as a dependency on
+        // something already behind you. A wrapped line of text does not point
+        // back at itself either.
+        markerEnd={isContinuation ? undefined : `url(#${completed ? "arrow-active" : "arrow"})`}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       />

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -6,6 +6,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import enMessages from "@/messages/en.json";
 import StepNode from "./StepNode";
 import type { StepNodeData, NodeExecStatus } from "./StepNode";
 
@@ -51,7 +53,11 @@ function renderNode(data: Partial<StepNodeData>) {
   };
   act(() => {
     // NodeProps carries more than the card reads; the rest is ReactFlow's.
-    root.render(React.createElement(StepNode, { data: full, selected: false } as never));
+    root.render(
+      <IntlProvider locale="en" messages={enMessages}>
+        {React.createElement(StepNode, { data: full, selected: false } as never)}
+      </IntlProvider>,
+    );
   });
 }
 

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * The card is read at a glance, in bulk, at whatever zoom fits the graph. That
+ * only works if the same fact is always in the same corner, so these tests are
+ * about the card keeping its shape rather than about any one string.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import StepNode from "./StepNode";
+import type { StepNodeData, NodeExecStatus } from "./StepNode";
+
+// Handle needs a ReactFlow store; the card's own layout is what is under test.
+vi.mock("reactflow", () => ({
+  Handle: () => null,
+  Position: { Left: "left", Right: "right" },
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  // The card asks for the reduced-motion preference on mount; this environment
+  // has no matchMedia. Answering "no preference" keeps the running animation on,
+  // which is the arm these tests render under.
+  vi.stubGlobal("matchMedia", () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function renderNode(data: Partial<StepNodeData>) {
+  const full: StepNodeData = {
+    label: "plan-step",
+    role: "critic",
+    assignment: "",
+    prompt: "",
+    capacity: 1,
+    timeout: null,
+    inputs: [],
+    outputs: [],
+    ...data,
+  };
+  act(() => {
+    // NodeProps carries more than the card reads; the rest is ReactFlow's.
+    root.render(React.createElement(StepNode, { data: full, selected: false } as never));
+  });
+}
+
+/** The card's two rows, in order. */
+function rows(): Element[] {
+  return Array.from(container.querySelectorAll(":scope > div > div"));
+}
+
+function bottomRightText(): string {
+  const bottom = rows()[1];
+  const spans = bottom.querySelectorAll("span");
+  return spans[spans.length - 1]?.textContent ?? "";
+}
+
+describe("StepNode — the bottom-right corner always says something", () => {
+  it("shows elapsed time once there is any", () => {
+    renderNode({ durationSeconds: 84, execStatus: "completed" });
+    expect(bottomRightText()).toBe("1m");
+  });
+
+  it("shows the status word before there is a duration, rather than nothing", () => {
+    // A corner that can go empty makes the card change shape mid-run, which is
+    // exactly when a reader is scanning it.
+    for (const [status, word] of [
+      ["queued", "queued"],
+      ["running", "running"],
+      ["failed", "failed"],
+      ["awaiting_approval", "approval"],
+    ] as [NodeExecStatus, string][]) {
+      renderNode({ execStatus: status });
+      expect(bottomRightText()).toBe(word);
+    }
+  });
+
+  it("prefers the duration over the status word when both could apply", () => {
+    renderNode({ execStatus: "running", durationSeconds: 3.5 });
+    expect(bottomRightText()).toBe("3.5s");
+  });
+
+  it("treats a negative duration as no duration, not as a printable number", () => {
+    renderNode({ execStatus: "queued", durationSeconds: -1 });
+    expect(bottomRightText()).toBe("queued");
+  });
+
+  it("is never blank in any status the card can be in", () => {
+    const every: NodeExecStatus[] = [
+      "pending",
+      "queued",
+      "running",
+      "awaiting_approval",
+      "paused",
+      "completed",
+      "failed",
+      "escalated",
+    ];
+    for (const status of every) {
+      renderNode({ execStatus: status });
+      expect(bottomRightText().trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("StepNode — the card keeps its shape", () => {
+  it("renders both rows even when the node carries no role", () => {
+    // Held open rather than dropped: a missing role must not move the row above
+    // it, because one height is what the layout reserves for every node.
+    renderNode({ role: "" });
+    expect(rows().length).toBe(2);
+  });
+
+  it("renders both rows for a node carrying nothing but a label", () => {
+    renderNode({ role: "", execStatus: undefined, durationSeconds: undefined });
+    expect(rows().length).toBe(2);
+    expect(bottomRightText().trim().length).toBeGreaterThan(0);
+  });
+
+  it("puts the error count in the top row beside the state, not in the magnitude corner", () => {
+    renderNode({ execStatus: "failed", errorCount: 3, durationSeconds: 12 });
+    expect(rows()[0].textContent).toContain("3");
+    expect(bottomRightText()).toBe("12s");
+  });
+});

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -3,19 +3,21 @@
 import { memo, useEffect, useState } from "react";
 import { Handle, Position } from "reactflow";
 import type { NodeProps } from "reactflow";
+import { useTranslations } from "use-intl";
 import { IconCheck, IconClose, IconPause, IconWarning } from "@/components/ui/icons";
 import { NODE_HEIGHT, NODE_WIDTH } from "./useLayout";
 
 // What the bottom-right corner says before there is a duration to put there.
-const STATUS_WORD: Record<NodeExecStatus, string> = {
-  pending: "—",
-  queued: "queued",
-  running: "running",
-  awaiting_approval: "approval",
-  paused: "paused",
-  completed: "done",
-  failed: "failed",
-  escalated: "escalated",
+// "pending" has no lifecycle signal to report yet, so its placeholder is a
+// language-neutral dash rather than a translated word.
+const STATUS_WORD_KEY: Record<Exclude<NodeExecStatus, "pending">, string> = {
+  queued: "graphNodeStatusQueued",
+  running: "graphNodeStatusRunning",
+  awaiting_approval: "graphNodeStatusApproval",
+  paused: "graphNodeStatusPaused",
+  completed: "graphNodeStatusDone",
+  failed: "graphNodeStatusFailed",
+  escalated: "graphNodeStatusEscalated",
 };
 
 function usePrefersReducedMotion(): boolean {
@@ -72,6 +74,7 @@ export interface StepNodeData {
 }
 
 function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
+  const t = useTranslations("history.detail");
   // roleColor arrives as a data-driven CSS var string — keep inline
   const roleColor = ROLE_VAR[data.role] || "var(--content-muted)";
   const status = data.execStatus ?? "pending";
@@ -123,7 +126,9 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
   const magnitude =
     data.durationSeconds != null && data.durationSeconds >= 0
       ? formatStepDuration(data.durationSeconds)
-      : STATUS_WORD[status];
+      : status === "pending"
+        ? "—"
+        : t(STATUS_WORD_KEY[status]);
 
   return (
     <div

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -4,6 +4,19 @@ import { memo, useEffect, useState } from "react";
 import { Handle, Position } from "reactflow";
 import type { NodeProps } from "reactflow";
 import { IconCheck, IconClose, IconPause, IconWarning } from "@/components/ui/icons";
+import { NODE_HEIGHT, NODE_WIDTH } from "./useLayout";
+
+// What the bottom-right corner says before there is a duration to put there.
+const STATUS_WORD: Record<NodeExecStatus, string> = {
+  pending: "—",
+  queued: "queued",
+  running: "running",
+  awaiting_approval: "approval",
+  paused: "paused",
+  completed: "done",
+  failed: "failed",
+  escalated: "escalated",
+};
 
 function usePrefersReducedMotion(): boolean {
   const [reduced, setReduced] = useState(false);
@@ -103,14 +116,23 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
             ? "var(--dag-warn-label)"
             : "var(--content-primary)";
 
+  // The bottom-right corner always says something. Elapsed time once there is
+  // any, the status word before that. A corner that can be empty makes the
+  // card change shape as a run progresses, and a reader who has to re-find a
+  // field has stopped reading the graph at a glance.
+  const magnitude =
+    data.durationSeconds != null && data.durationSeconds >= 0
+      ? formatStepDuration(data.durationSeconds)
+      : STATUS_WORD[status];
+
   return (
     <div
-      className="relative rounded-md px-2.5 py-2"
+      className="relative flex flex-col justify-between rounded-md px-2.5 py-2"
       style={{
         background: bgColor,
         border: `${selected || status === "running" ? 2 : 1}px solid ${borderColor}`,
-        minWidth: 148,
-        maxWidth: 210,
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
         boxShadow:
           status === "running"
             ? "0 0 0 3px color-mix(in srgb, var(--dag-running-border) 18%, transparent)"
@@ -132,13 +154,19 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
         }}
       />
 
-      <div className="flex items-center justify-between gap-1.5">
+      {/* Top row: what this step is, and what state it is in. */}
+      <div className="flex items-start justify-between gap-1.5">
         <span
-          className="truncate font-mono text-[length:var(--t-xs)] font-semibold leading-snug"
+          className="truncate font-mono text-[length:var(--t-sm)] font-semibold leading-snug"
           style={{ color: labelColor }}
         >
           {data.label}
         </span>
+        {(data.errorCount ?? 0) > 0 && (
+          <span className="shrink-0 font-mono text-[length:var(--t-xs)] tabular-nums leading-snug text-status-error">
+            {data.errorCount}
+          </span>
+        )}
         {status === "completed" && (
           <span className="flex shrink-0 items-center text-status-success">
             <IconCheck size={10} strokeWidth={2.5} />
@@ -172,37 +200,22 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
         )}
       </div>
 
-      {data.role && (
+      {/* Bottom row: what kind of step it is, and how much of it there has
+          been so far. Both corners are fixed, so the same fact is always in
+          the same place on every card at every zoom. The assignment and the
+          tool-call count moved to the panel: they are what you read about one
+          node you have already picked, not what you scan a graph for. */}
+      <div className="flex items-end justify-between gap-1.5">
         <span
-          className="mt-1 inline-block rounded px-1.5 py-px font-mono text-[length:var(--t-xs)] leading-tight tracking-wide"
-          style={{
-            backgroundColor: `color-mix(in srgb, ${roleColor} 14%, transparent)`,
-            color: roleColor,
-          }}
+          className="truncate font-mono text-[length:var(--t-xs)] uppercase leading-tight tracking-wide"
+          style={{ color: data.role ? roleColor : "transparent" }}
         >
-          {data.role}
+          {data.role || "."}
         </span>
-      )}
-
-      {data.assignment && (
-        <div className="mt-0.5 truncate font-mono text-[length:var(--t-xs)] leading-snug text-content-muted">
-          {data.assignment}
-        </div>
-      )}
-
-      {(data.durationSeconds != null ||
-        (data.errorCount ?? 0) > 0 ||
-        (data.toolCallCount ?? 0) > 0) && (
-        <div className="mt-1 flex items-center gap-2 font-mono text-[length:var(--t-xs)] tabular-nums text-content-muted">
-          {data.durationSeconds != null && data.durationSeconds >= 0 ? (
-            <span>{formatStepDuration(data.durationSeconds)}</span>
-          ) : null}
-          {(data.errorCount ?? 0) > 0 ? (
-            <span className="text-status-error">{data.errorCount} err</span>
-          ) : null}
-          {(data.toolCallCount ?? 0) > 0 ? <span>{data.toolCallCount} calls</span> : null}
-        </div>
-      )}
+        <span className="shrink-0 font-mono text-[length:var(--t-xs)] tabular-nums leading-tight text-content-muted">
+          {magnitude}
+        </span>
+      </div>
 
       {status === "running" && (
         <div

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
@@ -16,6 +16,7 @@ import {
   computeEdgeSourceCompleted,
   fitZoomFor,
   FIT_ZOOM_FLOOR,
+  MIN_INTERACTIVE_ZOOM,
   panelClearanceShift,
   shouldShowMiniMap,
   shouldShowSidePanel,
@@ -250,11 +251,18 @@ describe("WorkerCanvas.tsx — source contract for the readability floor clamp",
   const CANVAS_DIR = path.resolve(__dirname);
   const src = fs.readFileSync(path.join(CANVAS_DIR, "WorkerCanvas.tsx"), "utf-8");
 
-  it("wires FIT_ZOOM_FLOOR into the ReactFlow root minZoom, the invariant clamp", () => {
-    expect(src).toMatch(/minZoom=\{FIT_ZOOM_FLOOR\}/);
+  it("keeps the readability floor OFF the ReactFlow root, so zoom-out still reaches a whole graph", () => {
+    // The root minZoom bounds every zoom gesture — wheel, pinch, the Controls
+    // zoom-out button — not just the fit. Setting it to the readability floor
+    // makes a graph whose natural fit is below that floor permanently
+    // unviewable in a compact embed, which has no minimap either. The floor
+    // belongs to the fit; the root gets a much lower interactive bound.
+    expect(src).not.toMatch(/minZoom=\{FIT_ZOOM_FLOOR\}/);
+    expect(src).toMatch(/minZoom=\{MIN_INTERACTIVE_ZOOM\}/);
+    expect(MIN_INTERACTIVE_ZOOM).toBeLessThan(FIT_ZOOM_FLOOR);
   });
 
-  it("also sets it in fitViewOptions for the initial fit", () => {
+  it("still sets the readability floor in fitViewOptions for the initial fit", () => {
     const fitViewOptions = src.match(/fitViewOptions=\{\{[\s\S]*?\}\}/)?.[0];
     expect(fitViewOptions).toBeDefined();
     expect(fitViewOptions).toMatch(/minZoom:\s*FIT_ZOOM_FLOOR/);

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
@@ -14,6 +14,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
   computeEdgeSourceCompleted,
+  fitZoomFor,
+  FIT_ZOOM_FLOOR,
   panelClearanceShift,
   shouldShowMiniMap,
   shouldShowSidePanel,
@@ -176,5 +178,110 @@ describe("panelClearanceShift", () => {
   it("exactly at the strip boundary needs no shift", () => {
     // Right edge exactly 880 — not strictly greater, so no pan.
     expect(panelClearanceShift(670, 210, { x: 0, zoom: 1 }, CONTAINER)).toBe(0);
+  });
+});
+
+// ─── fitZoomFor / FIT_ZOOM_FLOOR — the readability floor ─────────────────────
+// StepNode's smallest text (label, role, assignment, stats) renders at
+// --t-xs (11px). Below a 7px screen size that stops being legible:
+// 7 / 11 = 0.636, rounded up to 0.65 for a small margin. fitZoomFor mirrors
+// ReactFlow's own fit-to-container math so layout fixtures (useLayout.test.ts)
+// can assert "this graph's raw fit zoom clears/misses the floor" without
+// mounting ReactFlow; the floor itself is enforced by wiring FIT_ZOOM_FLOOR
+// into <ReactFlow minZoom> (below), which clamps regardless of what the raw
+// number says — a graph whose natural fit falls below it overflows the
+// container and pans/scrolls instead of shrinking further.
+
+describe("FIT_ZOOM_FLOOR", () => {
+  it("is derived from --t-xs (11px) at a 7px minimum legible screen size", () => {
+    expect(FIT_ZOOM_FLOOR).toBeCloseTo(0.65, 5);
+    expect(FIT_ZOOM_FLOOR).toBeGreaterThan(7 / 11);
+  });
+});
+
+describe("fitZoomFor", () => {
+  it("fits a small graph in a large viewport at maxZoom, not blown past it", () => {
+    expect(fitZoomFor(400, 200, 1200, 800, 0.15, 1)).toBe(1);
+  });
+
+  it("shrinks a graph wider than the viewport can show at 1x", () => {
+    const zoom = fitZoomFor(3000, 300, 1280, 560, 0.15, 1);
+    expect(zoom).toBeLessThan(1);
+    expect(zoom).toBeGreaterThan(0);
+  });
+
+  it("is width-bound when the graph is wide and short", () => {
+    // minZoom=0 (raw, unclamped) to isolate the axis-bound arithmetic itself
+    // from the floor clamp — this case falls under the floor (see the
+    // "falls below" test below), which the default minZoom would mask.
+    const zoom = fitZoomFor(3000, 100, 1280, 800, 0.15, 1, 0);
+    const expected = 1280 / (3000 * 1.15);
+    expect(zoom).toBeCloseTo(expected, 5);
+  });
+
+  it("is height-bound when the graph is tall and narrow", () => {
+    const zoom = fitZoomFor(200, 2000, 1280, 560, 0.15, 1, 0);
+    const expected = 560 / (2000 * 1.15);
+    expect(zoom).toBeCloseTo(expected, 5);
+  });
+
+  it("raw (unclamped) arithmetic falls below the readability floor for a graph too large for the panel", () => {
+    // The deep-chain fan-in fixture (useLayout.test.ts) lands here — this is
+    // exactly the case the minZoom clamp exists for. minZoom=0 isolates the
+    // raw arithmetic from the default clamp asserted in the next test.
+    const zoom = fitZoomFor(1968, 1127, 1280, 560, 0.15, 1, 0);
+    expect(zoom).toBeLessThan(FIT_ZOOM_FLOOR);
+  });
+
+  it("clamps to the readability floor by default for that same too-large graph", () => {
+    // Same inputs as above, default minZoom (FIT_ZOOM_FLOOR) — matches what
+    // WorkerCanvas's <ReactFlow minZoom={FIT_ZOOM_FLOOR}> actually renders.
+    const zoom = fitZoomFor(1968, 1127, 1280, 560, 0.15, 1);
+    expect(zoom).toBe(FIT_ZOOM_FLOOR);
+  });
+
+  it("clears the floor for a small, compact graph", () => {
+    const zoom = fitZoomFor(600, 200, 1280, 560, 0.15, 1);
+    expect(zoom).toBeGreaterThanOrEqual(FIT_ZOOM_FLOOR);
+  });
+});
+
+describe("WorkerCanvas.tsx — source contract for the readability floor clamp", () => {
+  const CANVAS_DIR = path.resolve(__dirname);
+  const src = fs.readFileSync(path.join(CANVAS_DIR, "WorkerCanvas.tsx"), "utf-8");
+
+  it("wires FIT_ZOOM_FLOOR into the ReactFlow root minZoom, the invariant clamp", () => {
+    expect(src).toMatch(/minZoom=\{FIT_ZOOM_FLOOR\}/);
+  });
+
+  it("also sets it in fitViewOptions for the initial fit", () => {
+    const fitViewOptions = src.match(/fitViewOptions=\{\{[\s\S]*?\}\}/)?.[0];
+    expect(fitViewOptions).toBeDefined();
+    expect(fitViewOptions).toMatch(/minZoom:\s*FIT_ZOOM_FLOOR/);
+  });
+
+  it("applies the same floor to the imperative refit() fitView call", () => {
+    expect(src).toMatch(/fitView\(\{[^}]*minZoom:\s*FIT_ZOOM_FLOOR[^}]*\}\)/);
+  });
+});
+
+// ─── Rank-distance wiring — long-range edges know how far they span ──────────
+// ConditionEdge routes rank distance >= 3 edges as smooth-step instead of
+// bezier; it can only do that if WorkerCanvas stamps rankDistance onto edge
+// data after each layout pass, from useLayout's returned rank map.
+
+describe("WorkerCanvas.tsx — source contract for rank-distance edge data", () => {
+  const CANVAS_DIR = path.resolve(__dirname);
+  const src = fs.readFileSync(path.join(CANVAS_DIR, "WorkerCanvas.tsx"), "utf-8");
+
+  it("attaches rankDistance to edges after the initial layout pass", () => {
+    expect(src).toMatch(/attachRankDistance\(le,\s*ranks\)/);
+  });
+
+  it("destructures ranks from getLayoutedElements in both layout call sites", () => {
+    const calls = src.match(/=\s*getLayoutedElements\(/g) ?? [];
+    // Layout-on-mount effect + handleAutoLayout (editable canvas).
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(src).toMatch(/ranks,?\s*\}\s*=\s*getLayoutedElements/);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -35,6 +35,41 @@ import type {
   WorkerLinkEdge,
 } from "@/lib/types";
 
+// ─── Readability floor ───────────────────────────────────
+//
+// fitView shrinks the whole graph to fit the container, with no regard for
+// whether the result is still legible. StepNode's smallest text (label,
+// role, assignment, stats rows) all render at --t-xs (11px, theme.css) —
+// ConditionEdge's condition chip matches. Below a 7px screen size even
+// anti-aliased text stops being legible, so the floor is the zoom at which
+// an 11px glyph lands on 7px: 7 / 11 = 0.636, rounded up to 0.65 for a small
+// margin. Below the floor the canvas overflows its container instead of
+// shrinking further; ReactFlow's own pan/zoom-out takes over from there.
+export const FIT_ZOOM_FLOOR = 0.65;
+
+// Computed fit zoom for a laid-out graph in a given viewport — the same
+// arithmetic ReactFlow's fitView/getViewportForBounds uses internally (fit
+// width and height under a SINGLE padding term, then clamp to [minZoom,
+// maxZoom], take the smaller axis). Exported so layout fixtures can assert
+// "this graph's fit zoom would clear the floor" without mounting ReactFlow.
+// minZoom defaults to FIT_ZOOM_FLOOR because that is the clamp WorkerCanvas
+// actually wires into <ReactFlow minZoom>/fitViewOptions below — callers that
+// need the pre-clamp raw arithmetic (e.g. to demonstrate why the clamp is
+// needed) can pass 0 explicitly.
+export function fitZoomFor(
+  graphWidth: number,
+  graphHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  padding: number,
+  maxZoom: number,
+  minZoom: number = FIT_ZOOM_FLOOR,
+): number {
+  const w = viewportWidth / (graphWidth * (1 + padding)) || 1;
+  const h = viewportHeight / (graphHeight * (1 + padding)) || 1;
+  return Math.min(Math.max(Math.min(w, h), minZoom), maxZoom);
+}
+
 // ─── Types ───────────────────────────────────────────────
 
 interface WorkerCanvasProps {
@@ -159,6 +194,24 @@ function toFlowEdges(edges: WorkerLinkEdge[]): Edge<ConditionEdgeData>[] {
   }));
 }
 
+// Rank distance is a layout output (useLayout's rank map), not something
+// toFlowEdges can know at the initial graph -> ReactFlow conversion — so it
+// is stamped on afterward, once a layout pass has run. Edges outside the
+// rank map (e.g. a node dropped mid-edit) fall back to undefined, which
+// ConditionEdge treats as short-range.
+function attachRankDistance(
+  edges: Edge<ConditionEdgeData>[],
+  ranks: Map<string, number>,
+): Edge<ConditionEdgeData>[] {
+  return edges.map((e) => {
+    const srcRank = ranks.get(e.source);
+    const tgtRank = ranks.get(e.target);
+    const rankDistance =
+      srcRank !== undefined && tgtRank !== undefined ? tgtRank - srcRank : undefined;
+    return { ...e, data: { ...(e.data as ConditionEdgeData), rankDistance } };
+  });
+}
+
 function fromFlowNodes(nodes: Node<StepNodeData>[]): WorkerStepNode[] {
   return nodes.map((n) => ({
     id: n.id,
@@ -223,7 +276,7 @@ export default function WorkerCanvas({
     if (refitRaf.current !== null) cancelAnimationFrame(refitRaf.current);
     refitRaf.current = requestAnimationFrame(() => {
       refitRaf.current = null;
-      flowRef.current?.fitView({ padding: 0.15, maxZoom: 1 });
+      flowRef.current?.fitView({ padding: 0.15, maxZoom: 1, minZoom: FIT_ZOOM_FLOOR });
     });
   }, []);
   useEffect(() => {
@@ -245,9 +298,10 @@ export default function WorkerCanvas({
       nodes: ln,
       edges: le,
       height,
+      ranks,
     } = getLayoutedElements(initialFlowNodes, initialFlowEdges, "LR");
     setNodes(ln);
-    setEdges(le);
+    setEdges(attachRankDistance(le, ranks));
     initialised.current = true;
     onLayoutHeight?.(height);
     refit();
@@ -433,9 +487,9 @@ export default function WorkerCanvas({
 
   // Auto layout
   const handleAutoLayout = useCallback(() => {
-    const { nodes: ln, edges: le } = getLayoutedElements(nodes, edges, "LR");
+    const { nodes: ln, edges: le, ranks } = getLayoutedElements(nodes, edges, "LR");
     setNodes(ln);
-    setEdges(le);
+    setEdges(attachRankDistance(le, ranks));
   }, [nodes, edges, setNodes, setEdges]);
 
   return (
@@ -460,12 +514,15 @@ export default function WorkerCanvas({
           nodesConnectable={editable}
           elementsSelectable={true}
           fitView
-          // minZoom must sit below what fitView needs for a large graph —
-          // react-flow's 0.5 default made fitView stop there, showing a
-          // sliver of the graph as if it were the whole thing. maxZoom keeps
-          // a two-node graph from being blown up to fill the panel.
-          minZoom={0.1}
-          fitViewOptions={{ padding: 0.15, maxZoom: 1 }}
+          // minZoom is the readability floor (FIT_ZOOM_FLOOR — see above):
+          // below it a StepNode's smallest text stops being legible, so
+          // instead of shrinking further the graph overflows the container
+          // and pan/wheel-zoom take over. It is set on both the root (the
+          // invariant clamp that also guards wheel/controls zoom-out) and
+          // fitViewOptions (belt-and-braces for the initial fit). maxZoom
+          // keeps a two-node graph from being blown up to fill the panel.
+          minZoom={FIT_ZOOM_FLOOR}
+          fitViewOptions={{ padding: 0.15, maxZoom: 1, minZoom: FIT_ZOOM_FLOOR }}
           proOptions={{ hideAttribution: true }}
           className="bg-surface-base"
         >

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -47,6 +47,15 @@ import type {
 // shrinking further; ReactFlow's own pan/zoom-out takes over from there.
 export const FIT_ZOOM_FLOOR = 0.65;
 
+// How far a user may deliberately zoom out, which is a different question from
+// how small the default fit may go. The floor above keeps the view we CHOOSE
+// legible; this one keeps a graph too wide to fit legibly from becoming
+// unviewable, because a compact embed has no minimap and a floor on the root
+// would leave panning as the only way to see a wide graph whole. Zooming past
+// the readability floor is an explicit gesture whose intent is "show me the
+// shape", not "let me read the labels".
+export const MIN_INTERACTIVE_ZOOM = 0.2;
+
 // Computed fit zoom for a laid-out graph in a given viewport — the same
 // arithmetic ReactFlow's fitView/getViewportForBounds uses internally (fit
 // width and height under a SINGLE padding term, then clamp to [minZoom,
@@ -514,14 +523,15 @@ export default function WorkerCanvas({
           nodesConnectable={editable}
           elementsSelectable={true}
           fitView
-          // minZoom is the readability floor (FIT_ZOOM_FLOOR — see above):
-          // below it a StepNode's smallest text stops being legible, so
-          // instead of shrinking further the graph overflows the container
-          // and pan/wheel-zoom take over. It is set on both the root (the
-          // invariant clamp that also guards wheel/controls zoom-out) and
-          // fitViewOptions (belt-and-braces for the initial fit). maxZoom
-          // keeps a two-node graph from being blown up to fill the panel.
-          minZoom={FIT_ZOOM_FLOOR}
+          // The readability floor belongs to the FIT, not to the zoom control.
+          // fitViewOptions clamps the view we pick, so the graph always opens
+          // legible; the root keeps a much lower floor so a graph too wide to
+          // fit at that zoom can still be zoomed out and seen whole. Putting
+          // the readability floor on the root instead clamps wheel, pinch and
+          // the zoom-out button too, which strands a wide graph overflowing a
+          // compact embed that has no minimap. maxZoom keeps a two-node graph
+          // from being blown up to fill the panel.
+          minZoom={MIN_INTERACTIVE_ZOOM}
           fitViewOptions={{ padding: 0.15, maxZoom: 1, minZoom: FIT_ZOOM_FLOOR }}
           proOptions={{ hideAttribution: true }}
           className="bg-surface-base"

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -10,7 +10,17 @@
  */
 import { describe, it, expect } from "vitest";
 import type { Node, Edge } from "reactflow";
-import { estimateNodeHeight, getLayoutedElements, wrapWideRanks } from "./useLayout";
+import {
+  computeNodeDepths,
+  enforceMinRankGap,
+  estimateNodeHeight,
+  getLayoutedElements,
+  maxGraphDepth,
+  rankSepForDepth,
+  wrapWideRanks,
+} from "./useLayout";
+import { transitiveReduceDisplay } from "@/lib/operationGraph";
+import { fitZoomFor, FIT_ZOOM_FLOOR } from "./WorkerCanvas";
 
 const bare = (id: string): Node => ({
   id,
@@ -29,6 +39,53 @@ const full = (id: string): Node => ({
     toolCallCount: 20,
   },
 });
+
+// Deep-chain-with-global-fan-in fixture, modeled on the reported hairball
+// shape: several independent roots, one long implementer/tester chain
+// hanging off the first root, every node (roots, chain, and a semi-detached
+// operator) also feeding one terminal critic, and a node with just a single
+// edge in a sea of well-connected ones. 13 nodes / 23 edges. Shared at module
+// scope so both the pure-layout fixture and the reduction+layout composition
+// fixture (RunDetail's actual "reduce, then lay out" flow) exercise the
+// identical shape.
+const deepChainRoots = ["r1", "r2", "r3", "r4", "r5", "r6"];
+const deepChainChain = ["i1", "i2", "i3", "t1", "t2"];
+const deepChainNodeIds = [...deepChainRoots, ...deepChainChain, "critic", "op"];
+const deepChainEdges: Edge[] = [
+  // Every root feeds the chain's head, not just r1 — a root with only a
+  // single, distant edge (to critic) gives dagre's ranker no reason to place
+  // it early, and it drifts toward the far rank instead of rank 0.
+  ...deepChainRoots.map((r) => ({ id: `${r}-i1`, source: r, target: "i1" })),
+  { id: "i1-i2", source: "i1", target: "i2" },
+  { id: "i2-i3", source: "i2", target: "i3" },
+  { id: "i3-t1", source: "i3", target: "t1" },
+  { id: "t1-t2", source: "t1", target: "t2" },
+  { id: "r1-op", source: "r1", target: "op" },
+  ...deepChainNodeIds
+    .filter((id) => id !== "critic")
+    .map((id) => ({ id: `${id}-critic`, source: id, target: "critic" })),
+];
+const deepChainFixture = () => deepChainNodeIds.map(full);
+
+function rectOf(n: Node) {
+  return {
+    left: n.position.x,
+    right: n.position.x + 210,
+    top: n.position.y,
+    bottom: n.position.y + estimateNodeHeight(n),
+  };
+}
+
+function assertNoOverlap(nodes: Node[]) {
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      const a = rectOf(nodes[i]);
+      const b = rectOf(nodes[j]);
+      const overlaps = a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
+      expect(overlaps, `${nodes[i].id} overlaps ${nodes[j].id}`).toBe(false);
+    }
+  }
+}
 
 describe("estimateNodeHeight", () => {
   it("gives a node carrying no optional rows the base height", () => {
@@ -248,5 +305,553 @@ describe("wrapWideRanks — the grid preserves dagre's cross-axis order", () => 
     expect(wrapped.map((n) => ({ id: n.id, ...n.position }))).toEqual(
       strip.map((n) => ({ id: n.id, ...n.position })),
     );
+  });
+});
+
+describe("rankSepForDepth — deep chains taper, shallow graphs are untouched", () => {
+  it("is the identity 90 at and below the shallow-depth threshold", () => {
+    // The wide fan-out fixture is depth 3 — this is the exact property that
+    // keeps its layout, and its unmodified tests, bit-for-bit unchanged.
+    expect(rankSepForDepth(0)).toBe(90);
+    expect(rankSepForDepth(1)).toBe(90);
+    expect(rankSepForDepth(3)).toBe(90);
+    expect(rankSepForDepth(5)).toBe(90);
+  });
+
+  it("tapers monotonically once depth exceeds the threshold", () => {
+    const six = rankSepForDepth(6);
+    const ten = rankSepForDepth(10);
+    expect(six).toBeLessThan(90);
+    expect(ten).toBeLessThan(six);
+  });
+
+  it("never drops below the floor, however deep the graph", () => {
+    expect(rankSepForDepth(11)).toBe(48);
+    expect(rankSepForDepth(50)).toBe(48);
+  });
+
+  it("honors custom ranksep/floor arguments", () => {
+    expect(rankSepForDepth(3, 120, 60)).toBe(120);
+    expect(rankSepForDepth(100, 120, 60)).toBe(60);
+  });
+});
+
+describe("computeNodeDepths / maxGraphDepth — longest-path rank index", () => {
+  it("gives every root depth 0", () => {
+    const nodes: Node[] = [bare("a"), bare("b")];
+    const depths = computeNodeDepths(nodes, []);
+    expect(depths.get("a")).toBe(0);
+    expect(depths.get("b")).toBe(0);
+  });
+
+  it("takes the longest incoming path, not the first", () => {
+    // c is reachable both directly from a (length 1) and via b (length 2) —
+    // its rank must be the longer path's, matching dagre's own rank choice.
+    const nodes: Node[] = [bare("a"), bare("b"), bare("c")];
+    const edges: Edge[] = [
+      { id: "a-b", source: "a", target: "b" },
+      { id: "b-c", source: "b", target: "c" },
+      { id: "a-c", source: "a", target: "c" },
+    ];
+    const depths = computeNodeDepths(nodes, edges);
+    expect(depths.get("a")).toBe(0);
+    expect(depths.get("b")).toBe(1);
+    expect(depths.get("c")).toBe(2);
+    expect(maxGraphDepth(nodes, edges)).toBe(2);
+  });
+
+  it("does not hang or throw on a cycle, and does not propagate the cycle's depth", () => {
+    const nodes: Node[] = [bare("a"), bare("b"), bare("c")];
+    const edges: Edge[] = [
+      { id: "a-b", source: "a", target: "b" },
+      { id: "b-c", source: "b", target: "c" },
+      { id: "c-a", source: "c", target: "a" },
+    ];
+    expect(() => maxGraphDepth(nodes, edges)).not.toThrow();
+    expect(Number.isFinite(maxGraphDepth(nodes, edges))).toBe(true);
+  });
+
+  it("ignores edges referencing a node outside the given set", () => {
+    const nodes: Node[] = [bare("a")];
+    const edges: Edge[] = [{ id: "ghost-a", source: "ghost", target: "a" }];
+    expect(computeNodeDepths(nodes, edges).get("a")).toBe(0);
+  });
+
+  it("reports 0 for an empty graph", () => {
+    expect(maxGraphDepth([], [])).toBe(0);
+  });
+});
+
+describe("enforceMinRankGap — minimum vertical gap within a rank", () => {
+  it("is a no-op when nodes are already spaced beyond the floor", () => {
+    const nodes: Node[] = [
+      { ...bare("a"), position: { x: 0, y: 0 } },
+      { ...bare("b"), position: { x: 0, y: 100 } },
+    ];
+    const out = enforceMinRankGap(nodes, 6);
+    expect(out.find((n) => n.id === "a")!.position.y).toBe(0);
+    expect(out.find((n) => n.id === "b")!.position.y).toBe(100);
+  });
+
+  it("pushes an overlapping node down until the gap floor is met", () => {
+    const nodes: Node[] = [
+      { ...bare("a"), position: { x: 0, y: 0 } }, // height 40
+      { ...bare("b"), position: { x: 0, y: 10 } }, // overlaps a by 30px
+    ];
+    const out = enforceMinRankGap(nodes, 6);
+    const a = out.find((n) => n.id === "a")!;
+    const b = out.find((n) => n.id === "b")!;
+    expect(b.position.y).toBeGreaterThanOrEqual(a.position.y + estimateNodeHeight(a) + 6);
+  });
+
+  it("treats different (rounded) x as separate ranks — no cross-rank shifting", () => {
+    const nodes: Node[] = [
+      { ...bare("a"), position: { x: 0, y: 0 } },
+      { ...bare("b"), position: { x: 300, y: 0 } }, // same y, different rank
+    ];
+    const out = enforceMinRankGap(nodes, 6);
+    expect(out.find((n) => n.id === "b")!.position.y).toBe(0);
+  });
+
+  it("keeps every node through the pass", () => {
+    const nodes: Node[] = [bare("a"), bare("b"), bare("c")];
+    expect(
+      enforceMinRankGap(nodes)
+        .map((n) => n.id)
+        .sort(),
+    ).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("getLayoutedElements — exposes a rank map alongside the layout", () => {
+  it("returns a rank for every node, matching computeNodeDepths", () => {
+    const nodes: Node[] = [full("a"), full("b"), full("c")];
+    const edges: Edge[] = [
+      { id: "a-b", source: "a", target: "b" },
+      { id: "b-c", source: "b", target: "c" },
+    ];
+    const { ranks } = getLayoutedElements(nodes, edges, "LR");
+    expect(ranks.get("a")).toBe(0);
+    expect(ranks.get("b")).toBe(1);
+    expect(ranks.get("c")).toBe(2);
+  });
+
+  it("reports an empty rank map for an empty graph", () => {
+    const { ranks } = getLayoutedElements([], [], "LR");
+    expect(ranks.size).toBe(0);
+  });
+});
+
+describe("getLayoutedElements — deep chain with global fan-in (readability fixture)", () => {
+  // Modeled on the reported hairball shape: several independent roots, one
+  // long implementer/tester chain hanging off the first root, every node
+  // (roots, chain, and a semi-detached operator) also feeding one terminal
+  // critic, and a node with just a single edge in a sea of well-connected
+  // ones. 13 nodes / 23 edges (12 direct root/chain/op -> critic fan-in edges
+  // are the ones a display-time transitive reduction — RunDetail's concern,
+  // not this layout's — would later collapse against the chain; this layout
+  // test asserts the shape it's actually handed lays out without overlap).
+  // See "reduced-by-default (RunDetail's actual composition)" below for the
+  // reduction+layout composition RunDetail really renders.
+
+  it("has the modeled shape: depth 6, critic as the deepest (fan-in) node", () => {
+    const depths = computeNodeDepths(deepChainFixture(), deepChainEdges);
+    for (const r of deepChainRoots) expect(depths.get(r)).toBe(0);
+    expect(depths.get("i1")).toBe(1);
+    expect(depths.get("i2")).toBe(2);
+    expect(depths.get("i3")).toBe(3);
+    expect(depths.get("t1")).toBe(4);
+    expect(depths.get("t2")).toBe(5);
+    expect(depths.get("op")).toBe(1);
+    expect(depths.get("critic")).toBe(6);
+    expect(maxGraphDepth(deepChainFixture(), deepChainEdges)).toBe(6);
+  });
+
+  it("tapers ranksep below the shallow-graph identity for this depth", () => {
+    expect(rankSepForDepth(6)).toBeLessThan(90);
+  });
+
+  it("never overlaps any two nodes", () => {
+    const { nodes } = getLayoutedElements(deepChainFixture(), deepChainEdges, "LR");
+    assertNoOverlap(nodes);
+  });
+
+  it("keeps every node through layout", () => {
+    const { nodes } = getLayoutedElements(deepChainFixture(), deepChainEdges, "LR");
+    expect(nodes.map((n) => n.id).sort()).toEqual([...deepChainNodeIds].sort());
+  });
+
+  it("lays out wider than tall — a chain reads left-to-right, not top-to-bottom", () => {
+    const { nodes } = getLayoutedElements(deepChainFixture(), deepChainEdges, "LR");
+    const xs = nodes.map((n) => n.position.x);
+    const ys = nodes.map((n) => n.position.y + estimateNodeHeight(n));
+    const width = Math.max(...xs) - Math.min(...xs) + 210;
+    const height = Math.max(...ys) - Math.min(...nodes.map((n) => n.position.y));
+    expect(width).toBeGreaterThan(height);
+  });
+
+  it("reports a bounding-box height that covers every node", () => {
+    const { nodes, height } = getLayoutedElements(deepChainFixture(), deepChainEdges, "LR");
+    const top = Math.min(...nodes.map((n) => n.position.y));
+    const bottom = Math.max(...nodes.map((n) => n.position.y + estimateNodeHeight(n)));
+    expect(height).toBeGreaterThanOrEqual(bottom - top);
+  });
+
+  it("the readability floor engages for this graph at a realistic panel size", () => {
+    // A 13-node graph where every node also directly edges a terminal sink
+    // is wider than a compact embed can show at full legibility — dagre
+    // reserves routing room in every intervening rank for those long edges.
+    // This is exactly the case WorkerCanvas's minZoom={FIT_ZOOM_FLOOR} clamp
+    // exists for (see WorkerCanvas.test.ts): below this raw number the
+    // canvas overflows the panel and pans instead of shrinking illegibly
+    // further. The floor is a render-time clamp, not a layout guarantee —
+    // depth-scaled ranksep and no-overlap (asserted above) are what layout
+    // actually owns.
+    const { nodes, height } = getLayoutedElements(deepChainFixture(), deepChainEdges, "LR");
+    const left = Math.min(...nodes.map((n) => n.position.x));
+    const right = Math.max(...nodes.map((n) => n.position.x + 210));
+    const width = right - left;
+    const padding = 0.15;
+    const viewport = { width: 1280, height: 560 };
+    const rawFitZoom = Math.min(
+      viewport.width / (width * (1 + 2 * padding)),
+      viewport.height / (height * (1 + 2 * padding)),
+      1,
+    );
+    expect(rawFitZoom).toBeLessThan(0.65);
+  });
+});
+
+describe("getLayoutedElements — deep-chain fixture reduced-by-default (RunDetail's actual composition)", () => {
+  // RunDetail never lays out the raw resolved edge set — it runs
+  // transitiveReduceDisplay first (RunDetail.tsx's computeDisplayEdges) and
+  // lays out the reduced result, same as WorkerCanvas does once RunDetail
+  // hands it graph.edges (see WorkerCanvas.tsx's toFlowEdges/attachRankDistance,
+  // which are agnostic to which caller — authored or runtime — supplied the
+  // edges). This exercises that composition end to end on the fixture above:
+  // every root/chain/op node also edges the terminal critic directly, on top
+  // of a path that already reaches it through the chain — exactly the
+  // "ancestor already covered by a longer surviving path" redundancy
+  // transitive reduction exists to collapse.
+  const { kept: reducedEdges, hidden: hiddenEdges } = transitiveReduceDisplay(deepChainEdges);
+
+  it("collapses the direct-to-critic fan-in edges the chain already covers; keeps the chain and the two irreducible sink edges", () => {
+    // Full: 6 root->i1 + 4 chain + 1 root->op + 12 fan-in-to-critic = 23.
+    expect(deepChainEdges).toHaveLength(23);
+    // Every node that ALSO reaches critic via a longer surviving path loses
+    // its direct edge: the 6 roots (via i1) and i1/i2/i3/t1 (via the next
+    // chain link). t2->critic and op->critic are each their source's ONLY
+    // edge, so there is no alternative path and they survive.
+    expect(reducedEdges).toHaveLength(13);
+    expect(hiddenEdges).toHaveLength(10);
+    expect(hiddenEdges.map((e) => e.id).sort()).toEqual(
+      [
+        "r1-critic",
+        "r2-critic",
+        "r3-critic",
+        "r4-critic",
+        "r5-critic",
+        "r6-critic",
+        "i1-critic",
+        "i2-critic",
+        "i3-critic",
+        "t1-critic",
+      ].sort(),
+    );
+    expect(reducedEdges.some((e) => e.id === "t2-critic")).toBe(true);
+    expect(reducedEdges.some((e) => e.id === "op-critic")).toBe(true);
+  });
+
+  it("lays out the reduced set without overlap, keeping every node and the same wider-than-tall shape", () => {
+    const { nodes, height } = getLayoutedElements(deepChainFixture(), reducedEdges, "LR");
+    assertNoOverlap(nodes);
+    expect(nodes.map((n) => n.id).sort()).toEqual([...deepChainNodeIds].sort());
+
+    const left = Math.min(...nodes.map((n) => n.position.x));
+    const right = Math.max(...nodes.map((n) => n.position.x + 210));
+    const width = right - left;
+    const top = Math.min(...nodes.map((n) => n.position.y));
+    const bottom = Math.max(...nodes.map((n) => n.position.y + estimateNodeHeight(n)));
+    expect(width).toBeGreaterThan(bottom - top);
+    expect(height).toBeGreaterThanOrEqual(bottom - top);
+    // Reduction drops edges, not nodes — the longest surviving path into
+    // critic (through the chain) is untouched, so the rank structure (and
+    // therefore the depth-scaled ranksep from Cause B) is identical.
+    expect(maxGraphDepth(deepChainFixture(), reducedEdges)).toBe(6);
+  });
+
+  it("fit zoom for the reduced layout at a realistic panel size — the clamp still engages", () => {
+    const { nodes, height } = getLayoutedElements(deepChainFixture(), reducedEdges, "LR");
+    const left = Math.min(...nodes.map((n) => n.position.x));
+    const right = Math.max(...nodes.map((n) => n.position.x + 210));
+    const width = right - left;
+    const viewport = { width: 1280, height: 560 };
+    // minZoom=0: raw (unclamped) arithmetic — fitZoomFor's default minZoom is
+    // now FIT_ZOOM_FLOOR (see the WorkerCanvas.tsx fix), which would mask
+    // exactly the under-floor case this test demonstrates.
+    const reducedZoom = fitZoomFor(width, height, viewport.width, viewport.height, 0.15, 1, 0);
+    // Fewer edges make the picture legible (Cause A) and the taper (Cause B)
+    // narrows the bounding box, but neither changes rank COUNT for this
+    // fixture's shape, so the raw fit zoom at this compact a panel still
+    // falls under the floor — same story as the unreduced fixture above.
+    // WorkerCanvas's minZoom={FIT_ZOOM_FLOOR} is what actually guarantees
+    // legibility; the layout/reduction work minimizes how far under the
+    // floor a real run lands, and how often the clamp needs to engage at all.
+    expect(reducedZoom).toBeGreaterThan(0);
+    expect(reducedZoom).toBeLessThan(FIT_ZOOM_FLOOR);
+  });
+});
+
+// ── Acceptance fixtures: the exact 30-sibling / 18-node shapes ────────────────
+//
+// qa_checklist.md flags that the existing wide-fan-out coverage above uses 24
+// workers (not the acceptance-specified 30) and the deep-chain coverage above
+// uses 13 nodes (not 18), and that no fixture asserts reduced-vs-full edge
+// counts or a bounding-box aspect together with overlap/zoom. This section
+// adds the exact shapes without touching the existing 24-worker/13-node
+// fixtures above (acceptance item 4 requires those stay green and unmodified).
+//
+// "Computed fit zoom >= floor": the raw arithmetic (fitZoomFor / the manual
+// formula used above) legitimately lands BELOW FIT_ZOOM_FLOOR for both
+// fixtures at a realistic compact-panel size — implementer-2 hand-verified
+// this for the wide fixture (~0.55) and the deep-chain fixture (~0.386), and
+// the "reduced layout... fit zoom" test above pins the same fact. The floor
+// is a render-time CLAMP (WorkerCanvas's `minZoom={FIT_ZOOM_FLOOR}`, covered
+// by WorkerCanvas.test.ts's source-contract tests), not something raw layout
+// arithmetic alone guarantees. So "computed fit zoom >= floor" is asserted
+// here against the CLAMPED value — what a viewer actually sees — computed
+// with the REAL installed ReactFlow formula (see the `fitZoomFor` defect
+// block further below: production `fitZoomFor` uses `1 + 2*padding` where
+// the installed `reactflow` package's `getViewportForBounds` uses
+// `1 + padding`, and does not clamp to minZoom at all).
+function realReactFlowFitZoom(
+  width: number,
+  height: number,
+  viewport: { width: number; height: number },
+  padding: number,
+  minZoom: number,
+  maxZoom: number,
+): number {
+  const xZoom = viewport.width / (width * (1 + padding));
+  const yZoom = viewport.height / (height * (1 + padding));
+  return Math.min(Math.max(Math.min(xZoom, yZoom), minZoom), maxZoom);
+}
+
+function boundingBox(nodes: Node[]) {
+  const left = Math.min(...nodes.map((n) => n.position.x));
+  const right = Math.max(...nodes.map((n) => n.position.x + 210));
+  const top = Math.min(...nodes.map((n) => n.position.y));
+  const bottom = Math.max(...nodes.map((n) => n.position.y + estimateNodeHeight(n)));
+  return { width: right - left, height: bottom - top };
+}
+
+describe("getLayoutedElements — 30-sibling wide fan-out (acceptance fixture)", () => {
+  // The acceptance-specified sibling count (qa_checklist.md item 2), distinct
+  // from the pre-existing 24-worker wrap-behavior fixture above. Adds one
+  // redundant root->sink edge (root already reaches sink through every
+  // worker) so this fixture also exercises reduced-vs-full edge counts —
+  // the plain fan-out/fan-in shape above has nothing to reduce.
+  const workers30 = Array.from({ length: 30 }, (_, i) => `w${i + 1}`);
+  const fullEdges: Edge[] = [
+    ...workers30.map((w) => ({ id: `root-${w}`, source: "root", target: w })),
+    ...workers30.map((w) => ({ id: `${w}-sink`, source: w, target: "sink" })),
+    { id: "root-sink", source: "root", target: "sink" }, // redundant: root->w_i->sink for every i
+  ];
+  const nodes30 = () => [full("root"), ...workers30.map(full), full("sink")];
+
+  it("has exactly 30 siblings and one redundant root->sink edge", () => {
+    expect(workers30).toHaveLength(30);
+    expect(fullEdges).toHaveLength(61);
+  });
+
+  it("reduces the redundant root->sink edge and nothing else", () => {
+    const { kept, hidden } = transitiveReduceDisplay(fullEdges);
+    expect(kept).toHaveLength(60);
+    expect(hidden).toHaveLength(1);
+    expect(hidden[0].id).toBe("root-sink");
+    // Every worker's two edges (its only path in and out) must survive —
+    // reduction must never touch an edge with no alternative path.
+    for (const w of workers30) {
+      expect(kept.some((e) => e.id === `root-${w}`)).toBe(true);
+      expect(kept.some((e) => e.id === `${w}-sink`)).toBe(true);
+    }
+  });
+
+  it("lays out all 32 nodes without overlap, full and reduced alike", () => {
+    const { kept } = transitiveReduceDisplay(fullEdges);
+    for (const edgeSet of [fullEdges, kept]) {
+      const { nodes } = getLayoutedElements(nodes30(), edgeSet, "LR");
+      expect(nodes).toHaveLength(32);
+      assertNoOverlap(nodes);
+    }
+  });
+
+  it("wraps the 30-wide rank into a grid substantially wider than tall (WRAP_TARGET_ASPECT-shaped)", () => {
+    const { nodes } = getLayoutedElements(nodes30(), fullEdges, "LR");
+    const { width, height } = boundingBox(nodes);
+    // Unwrapped, 30 populated nodes would stack ~30 * ~80px =~ 2400px tall in
+    // a single column; the wrap keeps the block far shorter than that and the
+    // overall picture wider than tall, same property the 24-worker fixture
+    // above pins directly on the worker rank's height.
+    expect(height).toBeLessThan(1400);
+    expect(width).toBeGreaterThan(height);
+  });
+
+  it("computed (clamped) fit zoom meets the readability floor at a realistic panel size", () => {
+    const { nodes } = getLayoutedElements(nodes30(), fullEdges, "LR");
+    const { width, height } = boundingBox(nodes);
+    const viewport = { width: 1280, height: 560 };
+    const zoom = realReactFlowFitZoom(width, height, viewport, 0.15, FIT_ZOOM_FLOOR, 1);
+    expect(zoom).toBeGreaterThanOrEqual(FIT_ZOOM_FLOOR);
+  });
+});
+
+describe("getLayoutedElements — 18-node deep chain with global fan-in (acceptance fixture)", () => {
+  // The acceptance-specified shape (qa_checklist.md item 2): "~6 roots, a 5-6
+  // deep implementer/tester chain, every node also edging to a terminal
+  // critic, one semi-detached operator" totaling 18 nodes — distinct from
+  // the pre-existing 13-node fixture above (6 roots + 5-chain + critic + op),
+  // which this extends rather than replaces. To reach 18 while keeping the
+  // roots count and chain depth exactly as specified, the extra 5 nodes are
+  // additional standalone (depth-0) roles that — like the semi-detached
+  // operator — only edge into critic and never join the main chain: this
+  // models the report's "huge empty space" (multiple loosely-connected
+  // nodes, not only the one named operator) rather than inventing an
+  // unrelated shape. This choice is called out explicitly here per the
+  // ambiguity in the acceptance text (it specifies roots/chain/critic/op
+  // counts that only total 13-14, leaving 4-5 nodes unassigned to reach 18).
+  const roots18 = ["r1", "r2", "r3", "r4", "r5", "r6"];
+  const chain18 = ["i1", "i2", "i3", "t1", "t2"];
+  const peripheral18 = ["explorer", "analyst", "reviewer", "synthesizer", "coordinator"];
+  const nodeIds18 = [...roots18, ...chain18, "op", ...peripheral18, "critic"];
+  const edges18: Edge[] = [
+    ...roots18.map((r) => ({ id: `${r}-i1`, source: r, target: "i1" })),
+    { id: "i1-i2", source: "i1", target: "i2" },
+    { id: "i2-i3", source: "i2", target: "i3" },
+    { id: "i3-t1", source: "i3", target: "t1" },
+    { id: "t1-t2", source: "t1", target: "t2" },
+    { id: "r1-op", source: "r1", target: "op" },
+    ...nodeIds18
+      .filter((id) => id !== "critic")
+      .map((id) => ({ id: `${id}-critic`, source: id, target: "critic" })),
+  ];
+  const nodes18 = () => nodeIds18.map(full);
+
+  it("has exactly 18 nodes and the modeled edge count", () => {
+    expect(nodeIds18).toHaveLength(18);
+    // Structural: 6 root->i1 + 4 chain-internal + 1 r1->op = 11.
+    // Global fan-in: every one of the 17 non-critic nodes -> critic = 17.
+    expect(edges18).toHaveLength(28);
+  });
+
+  it("reduces to 18 kept / 10 hidden: every node with a longer surviving path to critic loses its direct edge", () => {
+    const { kept, hidden } = transitiveReduceDisplay(edges18);
+    expect(kept).toHaveLength(18);
+    expect(hidden).toHaveLength(10);
+    // The 6 roots and the first 4 chain links all reach critic via the chain
+    // (ending t2->critic), so their direct edges are redundant.
+    expect(hidden.map((e) => e.id).sort()).toEqual(
+      [
+        "r1-critic",
+        "r2-critic",
+        "r3-critic",
+        "r4-critic",
+        "r5-critic",
+        "r6-critic",
+        "i1-critic",
+        "i2-critic",
+        "i3-critic",
+        "t1-critic",
+      ].sort(),
+    );
+    // t2, op, and every peripheral node have no alternative path — each
+    // ->critic edge is that node's only route, so it survives.
+    for (const id of ["t2", "op", ...peripheral18]) {
+      expect(kept.some((e) => e.id === `${id}-critic`)).toBe(true);
+    }
+  });
+
+  it("has the modeled depth: chain reaches depth 5, critic (fan-in) is the deepest node at depth 6", () => {
+    const depths = computeNodeDepths(nodes18(), edges18);
+    for (const r of roots18) expect(depths.get(r)).toBe(0);
+    for (const p of peripheral18) expect(depths.get(p)).toBe(0);
+    expect(depths.get("i3")).toBe(3);
+    expect(depths.get("t2")).toBe(5);
+    expect(depths.get("op")).toBe(1);
+    expect(depths.get("critic")).toBe(6);
+    expect(maxGraphDepth(nodes18(), edges18)).toBe(6);
+  });
+
+  it("lays out full and reduced edge sets without overlap, keeping every node", () => {
+    const { kept } = transitiveReduceDisplay(edges18);
+    for (const edgeSet of [edges18, kept]) {
+      const { nodes } = getLayoutedElements(nodes18(), edgeSet, "LR");
+      expect(nodes.map((n) => n.id).sort()).toEqual([...nodeIds18].sort());
+      assertNoOverlap(nodes);
+    }
+  });
+
+  it("bounding-box aspect is wider than tall for both the full and reduced edge sets", () => {
+    const { kept } = transitiveReduceDisplay(edges18);
+    for (const edgeSet of [edges18, kept]) {
+      const { nodes } = getLayoutedElements(nodes18(), edgeSet, "LR");
+      const { width, height } = boundingBox(nodes);
+      expect(width).toBeGreaterThan(height);
+    }
+  });
+
+  it("computed (clamped) fit zoom meets the readability floor at a realistic panel size, full and reduced alike", () => {
+    const { kept } = transitiveReduceDisplay(edges18);
+    const viewport = { width: 1280, height: 560 };
+    for (const edgeSet of [edges18, kept]) {
+      const { nodes } = getLayoutedElements(nodes18(), edgeSet, "LR");
+      const { width, height } = boundingBox(nodes);
+      const zoom = realReactFlowFitZoom(width, height, viewport, 0.15, FIT_ZOOM_FLOOR, 1);
+      expect(zoom).toBeGreaterThanOrEqual(FIT_ZOOM_FLOOR);
+    }
+  });
+});
+
+// ── fitZoomFor vs. the installed ReactFlow formula ─────────────────────────────
+//
+// qa_checklist.md item 2b / review.md's second HIGH finding: production
+// `fitZoomFor` (WorkerCanvas.tsx) computes each axis as
+// `viewport / (graph * (1 + 2 * padding))`. The installed `reactflow`
+// package's own `getViewportForBounds` (node_modules/@reactflow/core) uses
+// `viewport / (bounds * (1 + padding))` — a single padding term, not double —
+// and additionally clamps the result to [minZoom, maxZoom], which
+// `fitZoomFor` does not do at all (it has no minZoom parameter). This test
+// pins the installed package's real formula directly against `fitZoomFor`'s
+// output for the same inputs; it is expected to FAIL against the current
+// implementation and is intentionally not weakened to match the bug — see
+// focused_test_results.md for the defect this documents.
+describe("fitZoomFor — must match the installed ReactFlow getViewportForBounds formula", () => {
+  it("agrees with the installed reactflow package's own fit-zoom arithmetic", async () => {
+    // Import the actual installed reactflow implementation directly, so this
+    // assertion tracks whatever version is in node_modules rather than a
+    // hand-copied formula that could itself drift out of sync.
+    const { getViewportForBounds } = await import("reactflow");
+    const cases: Array<{ width: number; height: number; vw: number; vh: number; padding: number }> =
+      [
+        { width: 2000, height: 800, vw: 1280, vh: 560, padding: 0.15 },
+        { width: 3000, height: 300, vw: 1280, vh: 560, padding: 0.15 },
+        { width: 600, height: 200, vw: 1280, vh: 560, padding: 0.15 },
+      ];
+    for (const { width, height, vw, vh, padding } of cases) {
+      const real = getViewportForBounds(
+        { x: 0, y: 0, width, height },
+        vw,
+        vh,
+        FIT_ZOOM_FLOOR,
+        1,
+        padding,
+      ).zoom;
+      const production = fitZoomFor(width, height, vw, vh, padding, 1);
+      expect(
+        production,
+        `fitZoomFor(${width}x${height} in ${vw}x${vh} @padding ${padding}) = ${production}, ` +
+          `but the installed reactflow's own getViewportForBounds computes ${real} for the same inputs`,
+      ).toBeCloseTo(real, 5);
+    }
   });
 });

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -20,7 +20,7 @@ import {
   wrapWideRanks,
 } from "./useLayout";
 import { transitiveReduceDisplay } from "@/lib/operationGraph";
-import { fitZoomFor, FIT_ZOOM_FLOOR } from "./WorkerCanvas";
+import { fitZoomFor, FIT_ZOOM_FLOOR, MIN_INTERACTIVE_ZOOM } from "./WorkerCanvas";
 
 const bare = (id: string): Node => ({
   id,
@@ -501,10 +501,11 @@ describe("getLayoutedElements — deep chain with global fan-in (readability fix
     // A 13-node graph where every node also directly edges a terminal sink
     // is wider than a compact embed can show at full legibility — dagre
     // reserves routing room in every intervening rank for those long edges.
-    // This is exactly the case WorkerCanvas's minZoom={FIT_ZOOM_FLOOR} clamp
-    // exists for (see WorkerCanvas.test.ts): below this raw number the
-    // canvas overflows the panel and pans instead of shrinking illegibly
-    // further. The floor is a render-time clamp, not a layout guarantee —
+    // This is exactly the case the fitViewOptions floor exists for (see
+    // WorkerCanvas.test.ts): below this raw number the canvas overflows the
+    // panel and pans instead of shrinking illegibly further, and zooming out
+    // past the floor stays available for seeing the whole shape. The floor is
+    // a clamp on the fit we choose, not a layout guarantee —
     // depth-scaled ranksep and no-overlap (asserted above) are what layout
     // actually owns.
     const { nodes, height } = getLayoutedElements(deepChainFixture(), deepChainEdges, "LR");
@@ -594,8 +595,8 @@ describe("getLayoutedElements — deep-chain fixture reduced-by-default (RunDeta
     // narrows the bounding box, but neither changes rank COUNT for this
     // fixture's shape, so the raw fit zoom at this compact a panel still
     // falls under the floor — same story as the unreduced fixture above.
-    // WorkerCanvas's minZoom={FIT_ZOOM_FLOOR} is what actually guarantees
-    // legibility; the layout/reduction work minimizes how far under the
+    // The fitViewOptions floor is what actually guarantees legibility of the
+    // opening view; the layout/reduction work minimizes how far under the
     // floor a real run lands, and how often the clamp needs to engage at all.
     expect(reducedZoom).toBeGreaterThan(0);
     expect(reducedZoom).toBeLessThan(FIT_ZOOM_FLOOR);
@@ -613,13 +614,16 @@ describe("getLayoutedElements — deep-chain fixture reduced-by-default (RunDeta
 //
 // "Computed fit zoom >= floor": the raw arithmetic (fitZoomFor / the manual
 // formula used above) legitimately lands BELOW FIT_ZOOM_FLOOR for both
-// fixtures at a realistic compact-panel size — implementer-2 hand-verified
-// this for the wide fixture (~0.55) and the deep-chain fixture (~0.386), and
-// the "reduced layout... fit zoom" test above pins the same fact. The floor
-// is a render-time CLAMP (WorkerCanvas's `minZoom={FIT_ZOOM_FLOOR}`, covered
-// by WorkerCanvas.test.ts's source-contract tests), not something raw layout
-// arithmetic alone guarantees. So "computed fit zoom >= floor" is asserted
-// here against the CLAMPED value — what a viewer actually sees — computed
+// fixtures at a realistic compact-panel size (measured: ~0.557 for the wide
+// fixture, ~0.386 for the deep chain), and the "reduced layout... fit zoom"
+// test above pins the same fact. The floor is a clamp applied to the fit
+// (fitViewOptions, covered by WorkerCanvas.test.ts's source-contract tests),
+// not something raw layout arithmetic alone guarantees. Asserting the CLAMPED
+// value clears the floor would be vacuous, so the tests assert the two things
+// that can actually fail: the raw fit is under the floor (the trade is real),
+// and the interactive zoom range still reaches it (the graph stays viewable).
+// The clamped-value arithmetic below is kept because it documents the real
+// installed ReactFlow formula — computed
 // with the REAL installed ReactFlow formula (see the `fitZoomFor` defect
 // block further below: production `fitZoomFor` uses `1 + 2*padding` where
 // the installed `reactflow` package's `getViewportForBounds` uses
@@ -697,12 +701,23 @@ describe("getLayoutedElements — 30-sibling wide fan-out (acceptance fixture)",
     expect(width).toBeGreaterThan(height);
   });
 
-  it("computed (clamped) fit zoom meets the readability floor at a realistic panel size", () => {
+  it("stays reachable by zoom-out even though it cannot fit legibly", () => {
     const { nodes } = getLayoutedElements(nodes30(), fullEdges, "LR");
     const { width, height } = boundingBox(nodes);
     const viewport = { width: 1280, height: 560 };
-    const zoom = realReactFlowFitZoom(width, height, viewport, 0.15, FIT_ZOOM_FLOOR, 1);
-    expect(zoom).toBeGreaterThanOrEqual(FIT_ZOOM_FLOOR);
+
+    // What the graph would need to fit whole, with no floor applied. This is
+    // genuinely below the readability floor (~0.56 at this size), so the fit
+    // opens clamped and overflowing: that is the deliberate trade, legible by
+    // default rather than whole by default. Asserting the CLAMPED value clears
+    // the floor would prove nothing — the clamp guarantees it for any layout.
+    const rawFit = realReactFlowFitZoom(width, height, viewport, 0.15, 0, 1);
+    expect(rawFit).toBeLessThan(FIT_ZOOM_FLOOR);
+
+    // The half that protects the user: whatever the fit picks, the zoom
+    // control must still reach far enough out to show the graph whole. Putting
+    // the readability floor on the ReactFlow root breaks exactly this.
+    expect(MIN_INTERACTIVE_ZOOM).toBeLessThanOrEqual(rawFit);
   });
 });
 
@@ -800,14 +815,21 @@ describe("getLayoutedElements — 18-node deep chain with global fan-in (accepta
     }
   });
 
-  it("computed (clamped) fit zoom meets the readability floor at a realistic panel size, full and reduced alike", () => {
+  it("stays reachable by zoom-out at a realistic panel size, full and reduced alike", () => {
     const { kept } = transitiveReduceDisplay(edges18);
     const viewport = { width: 1280, height: 560 };
     for (const edgeSet of [edges18, kept]) {
       const { nodes } = getLayoutedElements(nodes18(), edgeSet, "LR");
       const { width, height } = boundingBox(nodes);
-      const zoom = realReactFlowFitZoom(width, height, viewport, 0.15, FIT_ZOOM_FLOOR, 1);
-      expect(zoom).toBeGreaterThanOrEqual(FIT_ZOOM_FLOOR);
+
+      // This fixture is ~1968x1692, so height binds and it needs ~0.29 to fit
+      // whole — well under the readability floor. Opening it at the floor
+      // therefore shows roughly the top half of the graph, and the zoom-out
+      // range is the ONLY way to see the rest: a root minZoom set to the
+      // readability floor leaves this graph permanently half-visible in a
+      // compact embed, which has no minimap either.
+      const rawFit = realReactFlowFitZoom(width, height, viewport, 0.15, 0, 1);
+      expect(MIN_INTERACTIVE_ZOOM).toBeLessThanOrEqual(rawFit);
     }
   });
 });

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -16,6 +16,7 @@ import {
   estimateNodeHeight,
   getLayoutedElements,
   maxGraphDepth,
+  NODE_HEIGHT,
   rankSepForDepth,
   wrapWideRanks,
   foldWideGraph,
@@ -89,38 +90,30 @@ function assertNoOverlap(nodes: Node[]) {
 }
 
 describe("estimateNodeHeight", () => {
-  it("gives a node carrying no optional rows the base height", () => {
-    expect(estimateNodeHeight(bare("a"))).toBe(40);
-  });
-
-  it("grows as each row is filled in, so a fully populated node is much taller", () => {
-    expect(estimateNodeHeight(full("a"))).toBeGreaterThan(estimateNodeHeight(bare("a")));
-    // The gap is the whole bug: a single constant cannot describe both.
-    expect(estimateNodeHeight(full("a")) - estimateNodeHeight(bare("a"))).toBeGreaterThan(40);
-  });
-
-  it("counts each row independently rather than treating any one as a proxy", () => {
+  // The card is a fixed two-row box, so its height cannot depend on how far
+  // along a run is. This is the invariant the whole layout leans on: two nodes
+  // side by side are the same size whether or not either has finished, which is
+  // what lets a rank line up. It used to grow a row at a time, and these tests
+  // used to assert that growth.
+  it("is the same for every node whatever data it carries", () => {
     const roleOnly = { ...bare("a"), data: { label: "a", role: "critic" } };
     const roleAndModel = {
       ...bare("a"),
-      data: { label: "a", role: "critic", assignment: "codex/gpt-5.6-terra" },
+      data: { label: "a", role: "critic", assignment: "some-model" },
     };
-    expect(estimateNodeHeight(roleAndModel)).toBeGreaterThan(estimateNodeHeight(roleOnly));
-    expect(estimateNodeHeight(roleOnly)).toBeGreaterThan(estimateNodeHeight(bare("a")));
+    const zeroed = { ...bare("a"), data: { label: "a", errorCount: 0, toolCallCount: 0 } };
+    const heights = [bare("a"), full("a"), roleOnly, roleAndModel, zeroed].map(estimateNodeHeight);
+    expect(new Set(heights).size).toBe(1);
   });
 
-  it("does not count a zero/absent stats row", () => {
-    const zeroed = {
-      ...bare("a"),
-      data: { label: "a", errorCount: 0, toolCallCount: 0 },
-    };
-    expect(estimateNodeHeight(zeroed)).toBe(estimateNodeHeight(bare("a")));
+  it("matches the card's own declared height, so layout and component cannot drift", () => {
+    expect(estimateNodeHeight(full("a"))).toBe(NODE_HEIGHT);
   });
 
   it("survives a node with no data at all", () => {
     const noData = { id: "a", position: { x: 0, y: 0 } } as unknown as Node;
     expect(() => estimateNodeHeight(noData)).not.toThrow();
-    expect(estimateNodeHeight(noData)).toBe(40);
+    expect(estimateNodeHeight(noData)).toBe(NODE_HEIGHT);
   });
 });
 
@@ -161,14 +154,17 @@ describe("getLayoutedElements — populated nodes do not overlap", () => {
     }
   });
 
-  it("spaces populated siblings further apart than bare ones, since they are taller", () => {
+  it("spaces siblings identically whether or not they carry data", () => {
+    // The inverse of what this used to assert, and the reason ranks line up: a
+    // half-finished run and a finished one lay out to the same shape, so the
+    // graph does not reflow under the reader as results arrive.
     const populated = getLayoutedElements([full(parent), ...siblings.map(full)], edges, "LR");
     const plain = getLayoutedElements([bare(parent), ...siblings.map(bare)], edges, "LR");
     const span = (nodes: Node[]) => {
       const ys = siblings.map((id) => nodes.find((n) => n.id === id)!.position.y);
       return Math.max(...ys) - Math.min(...ys);
     };
-    expect(span(populated.nodes)).toBeGreaterThan(span(plain.nodes));
+    expect(span(populated.nodes)).toBe(span(plain.nodes));
   });
 
   it("keeps every node it was given", () => {

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -18,6 +18,7 @@ import {
   maxGraphDepth,
   rankSepForDepth,
   wrapWideRanks,
+  foldWideGraph,
 } from "./useLayout";
 import { transitiveReduceDisplay } from "@/lib/operationGraph";
 import { fitZoomFor, FIT_ZOOM_FLOOR, MIN_INTERACTIVE_ZOOM } from "./WorkerCanvas";
@@ -874,6 +875,147 @@ describe("fitZoomFor — must match the installed ReactFlow getViewportForBounds
         `fitZoomFor(${width}x${height} in ${vw}x${vh} @padding ${padding}) = ${production}, ` +
           `but the installed reactflow's own getViewportForBounds computes ${real} for the same inputs`,
       ).toBeCloseTo(real, 5);
+    }
+  });
+});
+
+describe("getLayoutedElements — a long sequential chain folds into readable rows", () => {
+  // The wide fan-out above is one failure shape; this is the other. A run whose
+  // work is mostly sequential produces one node per rank, so the graph grows
+  // only along x: measured before this fold, an 18-step chain laid out
+  // 4596x98 (aspect 46.9) and a 30-step chain 7692x98 (aspect 78.5). The
+  // second matters most — its fit zoom was 0.128, BELOW the 0.2 interactive
+  // zoom floor, so no zoom gesture could show it whole. The pre-existing
+  // "18-node deep chain" fixture is not this shape at all: its global fan-in
+  // makes it 1968x1692, aspect 1.16, which is why these cases needed their own
+  // coverage rather than being assumed covered.
+  const chainOf = (n: number) => {
+    const ids = Array.from({ length: n }, (_, i) => `s${i}`);
+    const edges: Edge[] = ids
+      .slice(0, -1)
+      .map((id, i) => ({ id: `${id}-${ids[i + 1]}`, source: id, target: ids[i + 1] }));
+    return { nodes: () => ids.map(full), edges, ids };
+  };
+
+  const boxOf = (nodes: Node[]) => {
+    const left = Math.min(...nodes.map((n) => n.position.x));
+    const right = Math.max(...nodes.map((n) => n.position.x + 210));
+    const top = Math.min(...nodes.map((n) => n.position.y));
+    const bottom = Math.max(...nodes.map((n) => n.position.y + estimateNodeHeight(n)));
+    return { width: right - left, height: bottom - top };
+  };
+
+  // The same arithmetic the canvas uses to pick a fit zoom, against a realistic
+  // compact-embed viewport.
+  const fitFor = (nodes: Node[]) => {
+    const { width, height } = boxOf(nodes);
+    const padding = 0.15;
+    return Math.min(1280 / (width * (1 + 2 * padding)), 560 / (height * (1 + 2 * padding)), 1);
+  };
+
+  it("brings an 18-step chain up to a fit zoom that clears the readability floor", () => {
+    const c = chainOf(18);
+    const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    expect(fitFor(nodes)).toBeGreaterThanOrEqual(FIT_ZOOM_FLOOR);
+  });
+
+  it("brings a 30-step chain back above the interactive zoom floor it used to sit under", () => {
+    // This is the case the zoom floor alone could not rescue: unfolded, the
+    // whole graph only fit at 0.128 and MIN_INTERACTIVE_ZOOM is 0.2.
+    const c = chainOf(30);
+    const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    expect(fitFor(nodes)).toBeGreaterThan(MIN_INTERACTIVE_ZOOM);
+  });
+
+  it("stacks the chain into more than one row instead of one strip", () => {
+    const c = chainOf(18);
+    const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    const distinctRows = new Set(nodes.map((n) => Math.round(n.position.y / 50)));
+    expect(distinctRows.size).toBeGreaterThan(1);
+    expect(boxOf(nodes).width).toBeLessThan(4596);
+  });
+
+  it("keeps every node and never overlaps two of them after folding", () => {
+    const c = chainOf(30);
+    const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    expect(nodes.map((n) => n.id).sort()).toEqual([...c.ids].sort());
+    assertNoOverlap(nodes);
+  });
+
+  it("leaves a chain that already fits on one line alone", () => {
+    // Folding a 4-step pipeline into a 2x2 block would be a regression: it
+    // reads perfectly well as one line and already fits at near-full zoom.
+    const c = chainOf(4);
+    const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    const rows = new Set(nodes.map((n) => Math.round(n.position.y)));
+    expect(rows.size).toBe(1);
+  });
+
+  it("leaves the wide-BUT-TALL fan-in fixture untouched — folding only helps flat graphs", () => {
+    // The guard that keeps this from being a blanket "fold anything wide".
+    // This fixture is past the row-width limit, so width alone would fold it;
+    // what saves it is having real cross-axis content (measured ~1692px tall,
+    // far past the flat-height limit). Folding would cost it the one thing a
+    // left-to-right graph guarantees — downstream sitting right of its source
+    // — to buy nothing, because its rows already carry meaning.
+    const laid = getLayoutedElements(deepChainFixture(), deepChainEdges, "LR").nodes;
+    expect(boxOf(laid).width).toBeGreaterThan(1500);
+    expect(boxOf(laid).height).toBeGreaterThan(240);
+    // Unfolded, the deepest node still sits to the RIGHT of every root.
+    const critic = laid.find((n) => n.id === "critic")!;
+    const roots = laid.filter((n) => deepChainRoots.includes(n.id));
+    for (const r of roots) expect(critic.position.x).toBeGreaterThan(r.position.x);
+  });
+
+  it("leaves an already-wrapped wide fan-out to wrapWideRanks, sink still rightmost", () => {
+    // A fan-out that wrapWideRanks has gridded is wide (~1900px) but has four
+    // rows of workers, so it is not flat and must not be folded on top of that
+    // treatment — the sink would land on a new row, left of the workers.
+    const workers = Array.from({ length: 24 }, (_, i) => `w${i + 1}`);
+    const fan: Edge[] = [
+      ...workers.map((w) => ({ id: `root-${w}`, source: "root", target: w })),
+      ...workers.map((w) => ({ id: `${w}-sink`, source: w, target: "sink" })),
+    ];
+    const { nodes } = getLayoutedElements(
+      [full("root"), ...workers.map(full), full("sink")],
+      fan,
+      "LR",
+    );
+    expect(boxOf(nodes).height).toBeGreaterThan(240);
+    const sinkX = nodes.find((n) => n.id === "sink")!.position.x;
+    for (const w of workers) {
+      expect(sinkX).toBeGreaterThan(nodes.find((n) => n.id === w)!.position.x);
+    }
+  });
+});
+
+describe("foldWideGraph — unit behaviour", () => {
+  it("is an identity for an empty graph and for a graph inside the width limit", () => {
+    expect(foldWideGraph([])).toEqual([]);
+    const narrow = [
+      { ...full("a"), position: { x: 0, y: 0 } },
+      { ...full("b"), position: { x: 300, y: 0 } },
+    ];
+    expect(foldWideGraph(narrow)).toBe(narrow);
+  });
+
+  it("preserves left-to-right order within each row it produces", () => {
+    const wide = Array.from({ length: 12 }, (_, i) => ({
+      ...full(`n${i}`),
+      position: { x: i * 260, y: 0 },
+    }));
+    const folded = foldWideGraph(wide);
+    const byRow = new Map<number, Node[]>();
+    for (const n of folded) {
+      const row = Math.round(n.position.y / 50);
+      byRow.set(row, [...(byRow.get(row) ?? []), n]);
+    }
+    expect(byRow.size).toBeGreaterThan(1);
+    for (const row of byRow.values()) {
+      const sortedByX = [...row].sort((a, b) => a.position.x - b.position.x);
+      const indices = sortedByX.map((n) => Number(n.id.slice(1)));
+      // Within a row, reading left to right must still read the chain in order.
+      expect(indices).toEqual([...indices].sort((a, b) => a - b));
     }
   });
 });

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -1114,3 +1114,98 @@ describe("getLayoutedElements — a folded chain marks exactly its row boundarie
     expect(edges.filter((e) => e.data?.continuation)).toHaveLength(0);
   });
 });
+
+describe("getLayoutedElements — folding a mid-run branch+join stays edge-aware", () => {
+  const chain = (n: number) => {
+    const ids = Array.from({ length: n }, (_, i) => `s${i}`);
+    const edges: Edge[] = ids
+      .slice(0, -1)
+      .map((id, i) => ({ id: `${id}-${ids[i + 1]}`, source: id, target: ids[i + 1] }));
+    return { nodes: () => ids.map(full), edges };
+  };
+
+  // The shape a purely geometric fold gets wrong: a long LR chain with a
+  // branch (one node, two successors) and a join (one node, two
+  // predecessors) partway through. s0..s4 sequential, s4 branches to
+  // sBa/sBb, both join at sJ, then a0..a9 continue sequentially. Wide and
+  // flat enough that the pre-fix fold splits a row right at the join, which
+  // marked the real sBa-sJ/sBb-sJ dependencies as continuation.
+  const before = Array.from({ length: 5 }, (_, i) => `s${i}`);
+  const after = Array.from({ length: 10 }, (_, i) => `a${i}`);
+  const branchJoinIds = [...before, "sBa", "sBb", "sJ", ...after];
+  const branchJoinEdges: Edge[] = [
+    ...before
+      .slice(0, -1)
+      .map((id, i) => ({ id: `${id}-${before[i + 1]}`, source: id, target: before[i + 1] })),
+    { id: "s4-sBa", source: "s4", target: "sBa" },
+    { id: "s4-sBb", source: "s4", target: "sBb" },
+    { id: "sBa-sJ", source: "sBa", target: "sJ" },
+    { id: "sBb-sJ", source: "sBb", target: "sJ" },
+    { id: "sJ-a0", source: "sJ", target: "a0" },
+    ...after
+      .slice(0, -1)
+      .map((id, i) => ({ id: `${id}-${after[i + 1]}`, source: id, target: after[i + 1] })),
+  ];
+  const branchJoinAuthoredIds = new Set([
+    "s4-sBa",
+    "s4-sBb",
+    "sBa-sJ",
+    "sBb-sJ",
+    "sJ-a0",
+    ...before.slice(0, -1).map((id, i) => `${id}-${before[i + 1]}`),
+    ...after.slice(0, -1).map((id, i) => `${id}-${after[i + 1]}`),
+  ]);
+
+  it("never marks a branch or join dependency as a continuation", () => {
+    const { nodes, edges } = getLayoutedElements(branchJoinIds.map(full), branchJoinEdges, "LR");
+    // Sanity: this fixture actually folds into more than one row.
+    const rowCount = new Set(nodes.map((n) => Math.round(n.position.y / 50))).size;
+    expect(rowCount).toBeGreaterThan(1);
+
+    const wronglyMarked = edges.filter(
+      (e) => ["s4-sBa", "s4-sBb", "sBa-sJ", "sBb-sJ"].includes(e.id) && e.data?.continuation,
+    );
+    expect(wronglyMarked.map((e) => e.id)).toEqual([]);
+  });
+
+  it("marks continuation on nothing but authored edges (no synthetic edge sneaks in)", () => {
+    const { edges } = getLayoutedElements(branchJoinIds.map(full), branchJoinEdges, "LR");
+    for (const e of edges.filter((x) => x.data?.continuation)) {
+      expect(branchJoinAuthoredIds.has(e.id)).toBe(true);
+    }
+  });
+
+  it("keeps every node and never overlaps two of them", () => {
+    const { nodes } = getLayoutedElements(branchJoinIds.map(full), branchJoinEdges, "LR");
+    expect(nodes.map((n) => n.id).sort()).toEqual([...branchJoinIds].sort());
+    assertNoOverlap(nodes);
+  });
+
+  it("the truly-sequential 30-node chain still folds into the previously-measured band", () => {
+    // Pins the readability win survives the edge-aware rewrite: every
+    // boundary in a pure chain is a safe (1-predecessor/1-successor) break,
+    // so this must fold exactly as before. Measured pre-fix band: ~1528x504,
+    // raw fit ~0.644 at a 1280x560 panel — small drift is fine, a strip
+    // (unfolded ~7692-wide) is the regression this guards against.
+    const c = chain(30);
+    const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    const left = Math.min(...nodes.map((n) => n.position.x));
+    const right = Math.max(...nodes.map((n) => n.position.x + 210));
+    const top = Math.min(...nodes.map((n) => n.position.y));
+    const bottom = Math.max(...nodes.map((n) => n.position.y + estimateNodeHeight(n)));
+    const width = right - left;
+    const height = bottom - top;
+    const padding = 0.15;
+    const rawFit = Math.min(
+      1280 / (width * (1 + 2 * padding)),
+      560 / (height * (1 + 2 * padding)),
+      1,
+    );
+
+    expect(width).toBeGreaterThan(1300);
+    expect(width).toBeLessThan(1700);
+    expect(height).toBeCloseTo(504, -1);
+    expect(rawFit).toBeGreaterThan(0.55);
+    expect(rawFit).toBeLessThan(0.75);
+  });
+});

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -20,6 +20,7 @@ import {
   rankSepForDepth,
   wrapWideRanks,
   foldWideGraph,
+  markContinuationEdges,
 } from "./useLayout";
 import { transitiveReduceDisplay } from "@/lib/operationGraph";
 import { fitZoomFor, FIT_ZOOM_FLOOR, MIN_INTERACTIVE_ZOOM } from "./WorkerCanvas";
@@ -1013,5 +1014,103 @@ describe("foldWideGraph — unit behaviour", () => {
       // Within a row, reading left to right must still read the chain in order.
       expect(indices).toEqual([...indices].sort((a, b) => a - b));
     }
+  });
+});
+
+describe("markContinuationEdges — the fold's return sweep is not a dependency", () => {
+  const at = (id: string, x: number): Node => ({ id, position: { x, y: 0 }, data: { label: id } });
+  const link = (source: string, target: string): Edge => ({
+    id: `${source}-${target}`,
+    source,
+    target,
+  });
+
+  it("marks an edge whose target was folded onto the row below its source", () => {
+    const marked = markContinuationEdges([at("a", 1400), at("b", 0)], [link("a", "b")]);
+    expect(marked[0].data).toMatchObject({ continuation: true });
+  });
+
+  it("leaves a forward edge alone, which is every edge in an unfolded LR graph", () => {
+    const edges = [link("a", "b")];
+    const marked = markContinuationEdges([at("a", 0), at("b", 300)], edges);
+    expect(marked[0].data?.continuation).toBeUndefined();
+  });
+
+  it("does not mark an edge between two nodes at the same x", () => {
+    // Equal x is not backwards. Marking it would put a continuation inside a
+    // wrapped rank's grid column, where nothing wrapped.
+    const marked = markContinuationEdges([at("a", 500), at("b", 500)], [link("a", "b")]);
+    expect(marked[0].data?.continuation).toBeUndefined();
+  });
+
+  it("returns the very same array when nothing is marked", () => {
+    // Identity, not just equality: the canvas re-lays out on every run tick and
+    // a fresh array each time would invalidate memoized edges for no reason.
+    const edges = [link("a", "b")];
+    const nodes = [at("a", 0), at("b", 300)];
+    expect(markContinuationEdges(nodes, edges)).toBe(edges);
+  });
+
+  it("keeps the data a marked edge already carried", () => {
+    const edges: Edge[] = [{ ...link("a", "b"), data: { mode: "code", rankDistance: 4 } }];
+    const marked = markContinuationEdges([at("a", 1400), at("b", 0)], edges);
+    expect(marked[0].data).toMatchObject({ mode: "code", rankDistance: 4, continuation: true });
+  });
+
+  it("says nothing about an edge whose endpoints the layout never placed", () => {
+    // An unplaced endpoint has no x, so it has no direction either. Guessing
+    // one would mark edges in the editor's fresh-connect path, which never folded.
+    const marked = markContinuationEdges([at("a", 1400)], [link("a", "ghost")]);
+    expect(marked[0].data?.continuation).toBeUndefined();
+  });
+
+  it("does not mutate the edges it was given", () => {
+    const edges = [link("a", "b")];
+    markContinuationEdges([at("a", 1400), at("b", 0)], edges);
+    expect(edges[0].data).toBeUndefined();
+  });
+});
+
+describe("getLayoutedElements — a folded chain marks exactly its row boundaries", () => {
+  const chain = (n: number) => {
+    const ids = Array.from({ length: n }, (_, i) => `s${i}`);
+    const edges: Edge[] = ids
+      .slice(0, -1)
+      .map((id, i) => ({ id: `${id}-${ids[i + 1]}`, source: id, target: ids[i + 1] }));
+    return { nodes: () => ids.map(full), edges };
+  };
+
+  it("marks a continuation on a chain long enough to fold", () => {
+    const c = chain(30);
+    const { edges } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    expect(edges.filter((e) => e.data?.continuation).length).toBeGreaterThan(0);
+  });
+
+  it("marks one continuation per row boundary and no more", () => {
+    // A fold into R rows breaks the chain in R-1 places, so anything above that
+    // means ordinary dependencies are being drawn as wrapped text.
+    const c = chain(30);
+    const { nodes, edges } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    const rowTops = new Set(nodes.map((n) => Math.round(n.position.y)));
+    const marked = edges.filter((e) => e.data?.continuation);
+    expect(marked).toHaveLength(rowTops.size - 1);
+  });
+
+  it("marks only edges that really do run backwards on the canvas", () => {
+    const c = chain(30);
+    const { nodes, edges } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    const xById = new Map(nodes.map((n) => [n.id, n.position.x]));
+    for (const e of edges.filter((x) => x.data?.continuation)) {
+      expect(xById.get(e.target)!).toBeLessThan(xById.get(e.source)!);
+    }
+  });
+
+  it("marks nothing on a chain short enough that no fold happens", () => {
+    // The control. Without it every assertion above is satisfied by a function
+    // that marks whatever it likes on graphs that never wrapped.
+    const c = chain(4);
+    const { nodes, edges } = getLayoutedElements(c.nodes(), c.edges, "LR");
+    expect(new Set(nodes.map((n) => Math.round(n.position.y))).size).toBe(1);
+    expect(edges.filter((e) => e.data?.continuation)).toHaveLength(0);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -117,6 +117,100 @@ export function wrapWideRanks(nodes: Node[]): Node[] {
   return out;
 }
 
+// Past this width a graph cannot be read at its fit zoom in the embeds this
+// canvas lives in: a ~1280px panel with the standard 15% fit padding drops
+// under the 0.65 readability floor once the graph passes roughly this many
+// pixels, so everything beyond it is a strip you can only pan across. Folding
+// trades one unbroken left-to-right line for several rows that each read
+// left-to-right, which is the trade a paragraph of text already makes.
+const FOLD_MAX_ROW_WIDTH = 1500;
+// ...and fold only a graph that is FLAT, meaning it has no vertical structure
+// of its own to lose. Folding invents rows, and a downstream node placed on
+// the next row sits to the LEFT of its source — the one thing a left-to-right
+// graph otherwise guarantees. That price is worth paying for a chain, whose
+// rows are empty of meaning anyway, and not worth paying for a graph that
+// already reads in two dimensions. Two full node-rows plus their separator is
+// 2*98 + 36 = 232px, so a graph taller than this has real cross-axis content:
+// a wrapped fan-out (measured ~536px tall) is deliberately out of scope here,
+// because wrapWideRanks above already owns that shape and made its own trade.
+const FOLD_MAX_FLAT_HEIGHT = 240;
+const FOLD_ROW_GAP = 56;
+
+// Fold a wide, flat graph into stacked rows, each row still reading
+// left-to-right. Within a row the geometry is dagre's own, translated as a
+// block, so rank spacing and sibling order survive untouched. The cost is the
+// edge that leaves the end of one row and re-enters at the start of the next:
+// it sweeps back across the canvas the way a wrapped line of text does.
+export function foldWideGraph(nodes: Node[]): Node[] {
+  if (nodes.length === 0) return nodes;
+
+  const left = Math.min(...nodes.map((n) => n.position.x));
+  const right = Math.max(...nodes.map((n) => n.position.x + NODE_WIDTH));
+  const top = Math.min(...nodes.map((n) => n.position.y));
+  const bottom = Math.max(...nodes.map((n) => n.position.y + estimateNodeHeight(n)));
+  const width = right - left;
+  const height = bottom - top;
+
+  if (width <= FOLD_MAX_ROW_WIDTH) return nodes;
+  if (height > FOLD_MAX_FLAT_HEIGHT) return nodes;
+
+  // After wrapWideRanks every column shares one x, so columns are the unit
+  // that moves. Folding by column keeps a wrapped fan-out's grid intact.
+  const byX = new Map<number, Node[]>();
+  for (const node of nodes) {
+    const key = Math.round(node.position.x);
+    const col = byX.get(key);
+    if (col) col.push(node);
+    else byX.set(key, [node]);
+  }
+  const xs = [...byX.keys()].sort((a, b) => a - b);
+
+  const rows: number[][] = [];
+  let current: number[] = [];
+  let rowStartX = 0;
+  for (const x of xs) {
+    if (current.length === 0) {
+      current = [x];
+      rowStartX = x;
+      continue;
+    }
+    if (x - rowStartX + NODE_WIDTH > FOLD_MAX_ROW_WIDTH) {
+      rows.push(current);
+      current = [x];
+      rowStartX = x;
+    } else {
+      current.push(x);
+    }
+  }
+  if (current.length > 0) rows.push(current);
+  if (rows.length <= 1) return nodes;
+
+  const out: Node[] = [];
+  let yOffset = 0;
+  for (const row of rows) {
+    const rowX0 = row[0];
+    let rowTop = Infinity;
+    let rowBottom = -Infinity;
+    for (const x of row) {
+      for (const node of byX.get(x) ?? []) {
+        rowTop = Math.min(rowTop, node.position.y);
+        rowBottom = Math.max(rowBottom, node.position.y + estimateNodeHeight(node));
+      }
+    }
+    for (const x of row) {
+      for (const node of byX.get(x) ?? []) {
+        out.push({
+          ...node,
+          position: { x: left + (x - rowX0), y: node.position.y - rowTop + yOffset },
+        });
+      }
+    }
+    yOffset += rowBottom - rowTop + FOLD_ROW_GAP;
+  }
+
+  return out;
+}
+
 // dagre's ranksep is one constant paid at EVERY rank boundary, so a 10-rank
 // chain pays it 9 times over — the deeper the graph, the more that constant
 // alone inflates the bounding box fitView has to shrink to fit. Shallow
@@ -266,7 +360,10 @@ export function getLayoutedElements(
   // The wrap keys ranks by their shared x, which holds only for LR (constant
   // node width). TB ranks share y instead; no caller lays out TB today.
   const wrappedNodes = direction === "LR" ? wrapWideRanks(layoutedNodes) : layoutedNodes;
-  const finalNodes = enforceMinRankGap(wrappedNodes);
+  // Fold after wrapping, so a wrapped fan-out moves as one block rather than
+  // having its grid columns split across two rows.
+  const foldedNodes = direction === "LR" ? foldWideGraph(wrappedNodes) : wrappedNodes;
+  const finalNodes = enforceMinRankGap(foldedNodes);
 
   // Bounding-box height of the laid-out graph (post-wrap, post-gap), so
   // containers can size to what the layout actually needs — a linear

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -2,43 +2,26 @@ import { useCallback } from "react";
 import dagre from "dagre";
 import type { Node, Edge } from "reactflow";
 
-const NODE_WIDTH = 210;
+// The card's own geometry, imported by StepNode so there is one copy of each
+// number rather than a layout constant and a stylesheet that agree until one
+// of them is edited.
+export const NODE_WIDTH = 210;
 
-// StepNode grows a row at a time as a run fills its data in: the role badge,
-// the assignment (the model it ran on), then the duration/calls line. A single
-// constant height therefore describes the node at exactly one moment of its
-// life. Feeding dagre that constant once the other rows exist makes it reserve
-// less vertical room than the node occupies, and the boxes crowd into each
-// other — worst on a graph where every node has been assigned, which is any
-// graph worth looking at.
+// StepNode is a fixed two-row card: name and state on top, role and elapsed
+// along the bottom, both rows always rendered. So one constant describes it at
+// every moment of a run, and dagre reserves exactly what the node occupies.
 //
-// These track StepNode's own padding and per-row heights. They are estimates:
-// exact only matters to the extent that ranks stay clear of each other, and
-// over-reserving is harmless where under-reserving overlaps.
-const NODE_BASE_HEIGHT = 40; // vertical padding + the label row
-const ROW_ROLE = 22;
-const ROW_ASSIGNMENT = 17;
-const ROW_STATS = 19;
+// It used to grow a row at a time as a run filled its data in, which meant the
+// height depended on how far along the run was, ranks came out ragged, and this
+// function had to guess. Fixing the card removed the guess: two nodes side by
+// side are now the same size whether or not either has finished.
+export const NODE_HEIGHT = 56;
 
-export function estimateNodeHeight(node: Node): number {
-  const data = (node.data ?? {}) as {
-    role?: unknown;
-    assignment?: unknown;
-    durationSeconds?: number | null;
-    errorCount?: number | null;
-    toolCallCount?: number | null;
-  };
-  let height = NODE_BASE_HEIGHT;
-  if (data.role) height += ROW_ROLE;
-  if (data.assignment) height += ROW_ASSIGNMENT;
-  if (
-    (data.durationSeconds != null && data.durationSeconds >= 0) ||
-    (data.errorCount ?? 0) > 0 ||
-    (data.toolCallCount ?? 0) > 0
-  ) {
-    height += ROW_STATS;
-  }
-  return height;
+/** The height of a rendered node. Constant by construction — see NODE_HEIGHT.
+ *  Kept as a function because the layout passes call it per node and a future
+ *  variable-size node type would land here. */
+export function estimateNodeHeight(_node: Node): number {
+  return NODE_HEIGHT;
 }
 
 const NODE_SEP = 36;
@@ -129,11 +112,15 @@ const FOLD_MAX_ROW_WIDTH = 1500;
 // the next row sits to the LEFT of its source — the one thing a left-to-right
 // graph otherwise guarantees. That price is worth paying for a chain, whose
 // rows are empty of meaning anyway, and not worth paying for a graph that
-// already reads in two dimensions. Two full node-rows plus their separator is
-// 2*98 + 36 = 232px, so a graph taller than this has real cross-axis content:
-// a wrapped fan-out (measured ~536px tall) is deliberately out of scope here,
-// because wrapWideRanks above already owns that shape and made its own trade.
-const FOLD_MAX_FLAT_HEIGHT = 240;
+// already reads in two dimensions. The cut-off is two full node-rows plus the
+// separator between them, so a graph taller than this has real cross-axis
+// content: a wrapped fan-out is deliberately out of scope here, because
+// wrapWideRanks above already owns that shape and made its own trade.
+//
+// Derived rather than written as a number so that changing the card's height
+// cannot silently widen what counts as flat. At 56px per row that is 148px,
+// where a literal 240 would have quietly started folding three-row graphs.
+const FOLD_MAX_FLAT_HEIGHT = 2 * NODE_HEIGHT + NODE_SEP;
 const FOLD_ROW_GAP = 56;
 
 // Fold a wide, flat graph into stacked rows, each row still reading

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -123,12 +123,37 @@ const FOLD_MAX_ROW_WIDTH = 1500;
 const FOLD_MAX_FLAT_HEIGHT = 2 * NODE_HEIGHT + NODE_SEP;
 const FOLD_ROW_GAP = 56;
 
+// A row may only break between two adjacent columns when exactly one edge
+// crosses that boundary and it is a plain 1-predecessor/1-successor link —
+// the same "maximal chain segment" a purely sequential run is made of. A
+// branch (a node with more than one successor) or a join (a node with more
+// than one predecessor) anchors a segment boundary instead: breaking a row
+// there would put a real dependency behind the fold's continuation styling,
+// the exact thing the fold must never do. Degree is computed over the WHOLE
+// edge set (not just edges between adjacent columns), so a long-range edge
+// that skips columns also correctly blocks a break at either of its ends.
+function computeDegrees(
+  nodes: Node[],
+  edges: Edge[],
+): { outDeg: Map<string, string[]>; inDeg: Map<string, string[]> } {
+  const known = new Set(nodes.map((n) => n.id));
+  const outDeg = new Map<string, string[]>();
+  const inDeg = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!known.has(e.source) || !known.has(e.target)) continue;
+    (outDeg.get(e.source) ?? outDeg.set(e.source, []).get(e.source)!).push(e.target);
+    (inDeg.get(e.target) ?? inDeg.set(e.target, []).get(e.target)!).push(e.source);
+  }
+  return { outDeg, inDeg };
+}
+
 // Fold a wide, flat graph into stacked rows, each row still reading
 // left-to-right. Within a row the geometry is dagre's own, translated as a
 // block, so rank spacing and sibling order survive untouched. The cost is the
 // edge that leaves the end of one row and re-enters at the start of the next:
-// it sweeps back across the canvas the way a wrapped line of text does.
-export function foldWideGraph(nodes: Node[]): Node[] {
+// it sweeps back across the canvas the way a wrapped line of text does — but
+// only at a safe (single predecessor/successor) boundary; see computeDegrees.
+export function foldWideGraph(nodes: Node[], edges: Edge[] = []): Node[] {
   if (nodes.length === 0) return nodes;
 
   const left = Math.min(...nodes.map((n) => n.position.x));
@@ -152,22 +177,41 @@ export function foldWideGraph(nodes: Node[]): Node[] {
   }
   const xs = [...byX.keys()].sort((a, b) => a - b);
 
+  // No edges given means no dependency to misrepresent — every column
+  // boundary is safe, matching the pre-edge-aware behavior exactly.
+  const edgeAware = edges.length > 0;
+  const { outDeg, inDeg } = computeDegrees(nodes, edges);
+  const isSafeBreak = (beforeX: number, afterX: number): boolean => {
+    const beforeNodes = byX.get(beforeX) ?? [];
+    const afterNodes = byX.get(afterX) ?? [];
+    if (beforeNodes.length !== 1 || afterNodes.length !== 1) return false;
+    const a = beforeNodes[0]!;
+    const b = afterNodes[0]!;
+    const aOut = outDeg.get(a.id) ?? [];
+    const bIn = inDeg.get(b.id) ?? [];
+    return aOut.length === 1 && aOut[0] === b.id && bIn.length === 1 && bIn[0] === a.id;
+  };
+
   const rows: number[][] = [];
   let current: number[] = [];
   let rowStartX = 0;
+  let prevX: number | null = null;
   for (const x of xs) {
     if (current.length === 0) {
       current = [x];
       rowStartX = x;
+      prevX = x;
       continue;
     }
-    if (x - rowStartX + NODE_WIDTH > FOLD_MAX_ROW_WIDTH) {
+    const overWidth = x - rowStartX + NODE_WIDTH > FOLD_MAX_ROW_WIDTH;
+    if (overWidth && (!edgeAware || isSafeBreak(prevX!, x))) {
       rows.push(current);
       current = [x];
       rowStartX = x;
     } else {
       current.push(x);
     }
+    prevX = x;
   }
   if (current.length > 0) rows.push(current);
   if (rows.length <= 1) return nodes;
@@ -375,7 +419,7 @@ export function getLayoutedElements(
   const wrappedNodes = direction === "LR" ? wrapWideRanks(layoutedNodes) : layoutedNodes;
   // Fold after wrapping, so a wrapped fan-out moves as one block rather than
   // having its grid columns split across two rows.
-  const foldedNodes = direction === "LR" ? foldWideGraph(wrappedNodes) : wrappedNodes;
+  const foldedNodes = direction === "LR" ? foldWideGraph(wrappedNodes, edges) : wrappedNodes;
   const finalNodes = enforceMinRankGap(foldedNodes);
 
   // Bounding-box height of the laid-out graph (post-wrap, post-gap), so

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -295,6 +295,32 @@ export function enforceMinRankGap(nodes: Node[], minGap = 6): Node[] {
   return out;
 }
 
+// An LR layout puts every target to the right of its source, so an edge that
+// runs backwards can only be one the fold created: it leaves the end of a row
+// and re-enters at the start of the next. That edge is still a real dependency
+// in the graph, but on screen it is doing what the wrap at the end of a line of
+// text does, and drawing it like the others makes the reader look for a
+// dependency behind them. Detected from the final geometry rather than from the
+// fold's own bookkeeping, so it describes what the edge actually does on the
+// canvas whichever pass moved the nodes.
+export function markContinuationEdges(nodes: Node[], edges: Edge[]): Edge[] {
+  const xById = new Map<string, number>();
+  for (const node of nodes) xById.set(node.id, node.position.x);
+
+  let changed = false;
+  const out = edges.map((edge) => {
+    const sourceX = xById.get(edge.source);
+    const targetX = xById.get(edge.target);
+    // An endpoint the layout never placed says nothing about direction.
+    if (sourceX === undefined || targetX === undefined) return edge;
+    if (targetX >= sourceX) return edge;
+    changed = true;
+    return { ...edge, data: { ...(edge.data ?? {}), continuation: true } };
+  });
+
+  return changed ? out : edges;
+}
+
 export interface LayoutedGraph {
   nodes: Node[];
   edges: Edge[];
@@ -364,7 +390,7 @@ export function getLayoutedElements(
   }
   const height = finalNodes.length === 0 ? 0 : bottom - top + 2 * 24;
 
-  return { nodes: finalNodes, edges, height, ranks };
+  return { nodes: finalNodes, edges: markContinuationEdges(finalNodes, edges), height, ranks };
 }
 
 export function useAutoLayout() {

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -117,17 +117,126 @@ export function wrapWideRanks(nodes: Node[]): Node[] {
   return out;
 }
 
+// dagre's ranksep is one constant paid at EVERY rank boundary, so a 10-rank
+// chain pays it 9 times over — the deeper the graph, the more that constant
+// alone inflates the bounding box fitView has to shrink to fit. Shallow
+// graphs (D <= SHALLOW_DEPTH) keep the original 90 unchanged — the wide
+// fan-out fixture is depth 3, so this is an identity for it; deeper graphs
+// taper linearly down to a floor. The floor is not a node-overlap guarantee
+// by itself — ranksep only spaces ranks apart, not siblings within a rank —
+// that guarantee is enforceMinRankGap below.
+const RANKSEP_SHALLOW_DEPTH = 5;
+const RANKSEP_TAPER_PER_RANK = 7;
+
+export function rankSepForDepth(maxDepth: number, ranksep = 90, minRanksep = 48): number {
+  if (maxDepth <= RANKSEP_SHALLOW_DEPTH) return ranksep;
+  return Math.max(
+    minRanksep,
+    ranksep - RANKSEP_TAPER_PER_RANK * (maxDepth - RANKSEP_SHALLOW_DEPTH),
+  );
+}
+
+// Longest-path depth of every node from its roots, over the RESOLVED edge
+// set (post display-time reduction, if any — callers pass whatever edges
+// they intend to lay out). This is both the rank index edges use for
+// long-range routing (ConditionEdge's rankDistance) and the input to
+// rankSepForDepth. A cycle should not happen in a depends_on graph, but a
+// defensive on-stack guard keeps a malformed input from recursing forever —
+// it simply stops deepening along the cyclic edge rather than erroring, the
+// same policy operationGraph's reducer uses for cycles.
+export function computeNodeDepths(nodes: Node[], edges: Edge[]): Map<string, number> {
+  const known = new Set(nodes.map((n) => n.id));
+  const preds = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!known.has(e.source) || !known.has(e.target)) continue;
+    const list = preds.get(e.target);
+    if (list) list.push(e.source);
+    else preds.set(e.target, [e.source]);
+  }
+
+  const depth = new Map<string, number>();
+  const onStack = new Set<string>();
+  const depthOf = (id: string): number => {
+    const cached = depth.get(id);
+    if (cached !== undefined) return cached;
+    const p = preds.get(id);
+    if (!p || p.length === 0) {
+      depth.set(id, 0);
+      return 0;
+    }
+    if (onStack.has(id)) return 0; // cycle guard
+    onStack.add(id);
+    let d = 0;
+    for (const src of p) d = Math.max(d, depthOf(src) + 1);
+    onStack.delete(id);
+    depth.set(id, d);
+    return d;
+  };
+  for (const n of nodes) depthOf(n.id);
+  return depth;
+}
+
+export function maxGraphDepth(nodes: Node[], edges: Edge[]): number {
+  const depths = computeNodeDepths(nodes, edges);
+  return depths.size ? Math.max(...depths.values()) : 0;
+}
+
+// dagre's nodesep spaces siblings within a rank, but its estimate of a rank's
+// cross-axis extent comes from the SAME per-node height estimate that drives
+// ranksep math — close enough for well-behaved graphs, not a hard guarantee
+// once a rank mixes very different node heights (a deep chain's fan-in rank,
+// e.g.). This pass runs last and is a straightforward sweep, not a dagre
+// re-layout: group by shared rank (x, for LR), sort by y, and push down any
+// node whose gap to its predecessor is under the floor. Nodes in the same
+// rank are never linked by an edge that passes between them (dagre only
+// edges across ranks), so widening the gap never crosses an edge.
+export function enforceMinRankGap(nodes: Node[], minGap = 6): Node[] {
+  const byX = new Map<number, Node[]>();
+  for (const n of nodes) {
+    const key = Math.round(n.position.x);
+    const rank = byX.get(key);
+    if (rank) rank.push(n);
+    else byX.set(key, [n]);
+  }
+
+  const out: Node[] = [];
+  for (const [, rank] of byX) {
+    const sorted = [...rank].sort((a, b) => a.position.y - b.position.y);
+    let cursor = -Infinity;
+    for (const node of sorted) {
+      const top = Math.max(node.position.y, cursor + minGap);
+      const shifted =
+        top === node.position.y ? node : { ...node, position: { ...node.position, y: top } };
+      out.push(shifted);
+      cursor = top + estimateNodeHeight(shifted);
+    }
+  }
+  return out;
+}
+
+export interface LayoutedGraph {
+  nodes: Node[];
+  edges: Edge[];
+  height: number;
+  /** node id -> longest-path depth (rank index), for edge rank-distance
+   * styling (ConditionEdge's long-range smooth-step routing). */
+  ranks: Map<string, number>;
+}
+
 export function getLayoutedElements(
   nodes: Node[],
   edges: Edge[],
   direction: "LR" | "TB" = "LR",
-): { nodes: Node[]; edges: Edge[]; height: number } {
+): LayoutedGraph {
+  const ranks = computeNodeDepths(nodes, edges);
+  const maxDepth = ranks.size ? Math.max(...ranks.values()) : 0;
+
   const g = new dagre.graphlib.Graph();
   g.setDefaultEdgeLabel(() => ({}));
   g.setGraph({
     rankdir: direction,
     nodesep: NODE_SEP,
-    ranksep: 90,
+    ranksep: rankSepForDepth(maxDepth),
     marginx: 28,
     marginy: 24,
   });
@@ -156,12 +265,13 @@ export function getLayoutedElements(
 
   // The wrap keys ranks by their shared x, which holds only for LR (constant
   // node width). TB ranks share y instead; no caller lays out TB today.
-  const finalNodes = direction === "LR" ? wrapWideRanks(layoutedNodes) : layoutedNodes;
+  const wrappedNodes = direction === "LR" ? wrapWideRanks(layoutedNodes) : layoutedNodes;
+  const finalNodes = enforceMinRankGap(wrappedNodes);
 
-  // Bounding-box height of the laid-out graph (post-wrap), so containers can
-  // size to what the layout actually needs — a linear pipeline is one rank
-  // tall no matter how many nodes it has, and a wrapped fan-out is exactly as
-  // tall as its grid.
+  // Bounding-box height of the laid-out graph (post-wrap, post-gap), so
+  // containers can size to what the layout actually needs — a linear
+  // pipeline is one rank tall no matter how many nodes it has, and a wrapped
+  // fan-out is exactly as tall as its grid.
   let top = Infinity;
   let bottom = -Infinity;
   for (const node of finalNodes) {
@@ -170,7 +280,7 @@ export function getLayoutedElements(
   }
   const height = finalNodes.length === 0 ? 0 : bottom - top + 2 * 24;
 
-  return { nodes: finalNodes, edges, height };
+  return { nodes: finalNodes, edges, height, ranks };
 }
 
 export function useAutoLayout() {

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -6,7 +6,7 @@
  * - It does not import Drawer (master-detail doctrine)
  */
 
-import { afterEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as React from "react";
@@ -15,10 +15,39 @@ import { createRoot, type Root } from "react-dom/client";
 import { IntlProvider } from "use-intl";
 import RunStepCard from "@/components/RunStepCard";
 import enMessages from "@/messages/en.json";
-import type { RunStep } from "@/lib/types";
+import type { RunStep, WorkerGraph } from "@/lib/types";
 
 vi.mock("@/components/ui/Markdown", () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mounting RunDetail for real exercises the hidden-count badge + toggle as an
+// actual render/click, not a source-text regex (which can pass while JSX
+// placement or the click handler is broken). Everything mounted needs real
+// network/router-context dependencies stubbed: getSession/streamSession/
+// streamSignals hit real SSE/fetch plumbing, ResumeRun renders a
+// @tanstack/react-router <Link> that throws outside a RouterProvider, and the
+// real WorkerCanvas drags in dagre + the full ReactFlow tree, none of which
+// this test needs — only that it received the right edge set.
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getSession: vi.fn(),
+    getInvocation: vi.fn(),
+    streamSession: vi.fn(() => () => {}),
+    streamSignals: vi.fn(() => () => {}),
+  };
+});
+
+vi.mock("@/components/history/ResumeRun", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/canvas/WorkerCanvas", () => ({
+  default: (props: { graph: { edges: unknown[] } }) => (
+    <div data-testid="worker-canvas" data-edge-count={props.graph.edges.length} />
+  ),
 }));
 
 const HISTORY_DIR = path.resolve(__dirname);
@@ -121,30 +150,36 @@ describe("fleet/SessionDetail.tsx — renders RunDetail without fullPage", () =>
   });
 });
 
-// ─── Authored graph is never transitively reduced ────────────────────────────
+// ─── Authored graph is reduced at display time only ──────────────────────────
 // runGraph is Studio's persisted early_graph — the exact graph the designer
-// authored, edges and conditions included. Applying transitiveReduce() to it
-// would silently drop an authored conditional edge (e.g. A→B, B→C, and a
-// conditional A→C) whenever the runtime happens to also reach C via B — the
-// runtime emitter's depends_on is a predecessor list, not proof an edge is
-// synthetic. Reduction stays scoped to buildOperationGraph's runtime-derived
-// opGraph (whose edges genuinely are a raw ancestor list).
+// authored, resolved (resolveGraphEdges) but otherwise as wired: it can carry
+// one depends_on-style edge per ancestor, same as the runtime opGraph below,
+// so it clutters the same way a raw ancestor list does. Unlike opGraph, an
+// authored edge can also carry a condition/handler/map/code mode — semantics
+// the designer put there on purpose, not structural redundancy. So the
+// authored graph IS reduced, but only for display (never mutated/re-persisted)
+// and only through transitiveReduceDisplay, whose semantic guard never drops
+// a rich edge and whose cycle guard renders everything unchanged if the graph
+// isn't a DAG — plain transitiveReduce (used for opGraph) has neither guard.
 
-describe("history/RunDetail.tsx — authored run graph is rendered unreduced", () => {
+describe("history/RunDetail.tsx — authored run graph is reduced at display time only", () => {
   const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
 
-  it("does not import transitiveReduce", () => {
-    expect(src).not.toMatch(/transitiveReduce/);
+  it("imports the display-time transitiveReduceDisplay, not the runtime transitiveReduce", () => {
+    const importBlock = src.match(/import \{[^}]*\} from "@\/lib\/operationGraph";/)?.[0] ?? "";
+    expect(importBlock).toMatch(/transitiveReduceDisplay/);
+    expect(importBlock).not.toMatch(/\btransitiveReduce\b/);
   });
 
-  it("passes runGraph directly to WorkerCanvas, not a reduced copy", () => {
-    expect(src).toMatch(/graph={runGraph}/);
+  it("does not pass runGraph directly to WorkerCanvas — edges go through the reduction first", () => {
+    expect(src).not.toMatch(/graph={runGraph}/);
+    expect(src).toMatch(/graph=\{\{\s*\.\.\.runGraph,\s*edges:\s*displayEdges\s*\}\}/);
   });
 });
 
-describe("transitiveReduce (lib/operationGraph) — why RunDetail must not apply it to runGraph", () => {
-  it("would drop an authored conditional A→C that transitiveReduce sees as redundant via A→B→C", async () => {
-    const { transitiveReduce } = await import("@/lib/operationGraph");
+describe("transitiveReduceDisplay (lib/operationGraph) — why it's safe to apply to runGraph where plain transitiveReduce was not", () => {
+  it("keeps an authored conditional A→C that plain transitiveReduce would drop as redundant via A→B→C", async () => {
+    const { transitiveReduce, transitiveReduceDisplay } = await import("@/lib/operationGraph");
 
     // Mirrors an authored WorkerGraph: A→B, B→C, and a conditional A→C.
     const authoredEdges = [
@@ -153,15 +188,282 @@ describe("transitiveReduce (lib/operationGraph) — why RunDetail must not apply
       { id: "e-ac", source: "A", target: "C", condition: "score > 0.8" },
     ];
 
-    // What the old code did (reduce the authored graph): loses the
-    // conditional edge, because C is reachable from A through B.
+    // The runtime reducer would drop it: C is reachable from A through B,
+    // and it has no notion of "this edge carries a condition".
     const wouldHaveReduced = transitiveReduce(authoredEdges);
     expect(wouldHaveReduced.find((e) => e.id === "e-ac")).toBeUndefined();
 
-    // What RunDetail does now: pass the authored edges through unchanged,
-    // so the conditional A→C survives.
-    const rendered = authoredEdges;
-    expect(rendered.find((e) => e.id === "e-ac")).toBeDefined();
+    // The display-time reducer RunDetail actually calls keeps it.
+    const { kept, hidden } = transitiveReduceDisplay(authoredEdges);
+    expect(kept.find((e) => e.id === "e-ac")).toBeDefined();
+    expect(hidden).toHaveLength(0);
+  });
+});
+
+// ─── Reduced-by-default with a show-implied-edges escape hatch ───────────────
+// computeDisplayEdges is the pure core of RunDetail's edge-selection useMemo:
+// reduce by default (transitiveReduceDisplay), fall back to the full resolved
+// set when the toggle is on, and always report how many edges the reduction
+// hid so the chrome can show it regardless of which set is currently shown.
+
+describe("computeDisplayEdges (RunDetail) — reduced-by-default, toggle restores the full set", () => {
+  const diamondWithSkip: WorkerGraph["edges"] = [
+    { id: "e-ab", source: "A", target: "B", mode: "simple" },
+    { id: "e-bc", source: "B", target: "C", mode: "simple" },
+    { id: "e-ac", source: "A", target: "C", mode: "simple" }, // redundant: A→B→C
+  ];
+
+  it("reduces by default and reports the hidden count", async () => {
+    const { computeDisplayEdges } = await import("./RunDetail");
+    const { displayEdges, hiddenCount } = computeDisplayEdges(diamondWithSkip, false);
+    expect(displayEdges).toHaveLength(2);
+    expect(displayEdges.find((e) => e.id === "e-ac")).toBeUndefined();
+    expect(hiddenCount).toBe(1);
+  });
+
+  it("show-implied-edges toggle restores the full resolved set without losing the hidden count", async () => {
+    const { computeDisplayEdges } = await import("./RunDetail");
+    const { displayEdges, hiddenCount } = computeDisplayEdges(diamondWithSkip, true);
+    expect(displayEdges).toHaveLength(3);
+    expect(displayEdges.find((e) => e.id === "e-ac")).toBeDefined();
+    expect(hiddenCount).toBe(1);
+  });
+
+  it("a semantic edge survives reduction — hiddenCount is 0, nothing to toggle", async () => {
+    const { computeDisplayEdges } = await import("./RunDetail");
+    const withCondition: WorkerGraph["edges"] = [
+      { id: "e-ab", source: "A", target: "B", mode: "simple" },
+      { id: "e-bc", source: "B", target: "C", mode: "simple" },
+      { id: "e-ac", source: "A", target: "C", mode: "simple", condition: "score > 0.8" },
+    ];
+    const { displayEdges, hiddenCount } = computeDisplayEdges(withCondition, false);
+    expect(displayEdges).toHaveLength(3);
+    expect(hiddenCount).toBe(0);
+  });
+
+  it("empty edges reduce to empty, zero hidden", async () => {
+    const { computeDisplayEdges } = await import("./RunDetail");
+    expect(computeDisplayEdges([], false)).toEqual({ displayEdges: [], hiddenCount: 0 });
+  });
+});
+
+// ─── Hidden-count badge + show-implied-edges toggle wired into the chrome ────
+
+describe("history/RunDetail.tsx — hidden-implied-edge count and toggle wired into the run-dag chrome", () => {
+  const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+
+  it("the run-dag SectionHeader receives edgeCount/hiddenCount/toggle props sourced from the reduction", () => {
+    const start = src.indexOf('id="run-dag"');
+    const end = src.indexOf("</Suspense>", start);
+    const block = src.slice(start, end);
+    expect(block).toMatch(/edgeCount=\{displayEdges\.length\}/);
+    expect(block).toMatch(/hiddenCount=\{hiddenCount\}/);
+    expect(block).toMatch(/onToggleImplied=\{.*setShowImpliedEdges/);
+    expect(block).toMatch(/showImplied=\{showImpliedEdges\}/);
+  });
+
+  it("SectionHeader only renders the hidden badge/toggle once hiddenCount is positive, and defaults to reduced", () => {
+    expect(src).toMatch(/hiddenCount\s*!=\s*null\s*&&\s*hiddenCount\s*>\s*0/);
+    expect(src).toMatch(/const \[showImpliedEdges, setShowImpliedEdges\] = useState\(false\)/);
+  });
+});
+
+// ─── Hidden-count badge + toggle, mounted for real ───────────────────────────
+// The two describe blocks above (computeDisplayEdges, and the source-text
+// checks on the run-dag SectionHeader call) establish the pure selection
+// logic is right and that the JSX wires the right prop names — but neither
+// proves the badge text actually renders, that the button actually flips
+// which edge set WorkerCanvas receives, or that a graph with nothing hidden
+// omits the toggle. This mounts the real RunDetail (getSession/streamSession/
+// streamSignals/ResumeRun/WorkerCanvas mocked at module scope, above) against
+// a diamond-with-skip graph (A→B→C plus a redundant A→C) and drives the
+// button through a real click.
+
+describe("history/RunDetail.tsx — hidden-count badge and show-implied toggle, mounted", () => {
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    // jsdom does not implement scrollIntoView; RunDetail calls it on load
+    // (see RunDetail.pagination.test.tsx, which mounts the same component).
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const diamondWithSkipGraph = {
+    name: "run",
+    description: "",
+    nodes: [
+      {
+        id: "A",
+        label: "A",
+        role: "",
+        assignment: "",
+        prompt: "",
+        capacity: 1,
+        timeout: null,
+        inputs: [],
+        outputs: [],
+      },
+      {
+        id: "B",
+        label: "B",
+        role: "",
+        assignment: "",
+        prompt: "",
+        capacity: 1,
+        timeout: null,
+        inputs: [],
+        outputs: [],
+      },
+      {
+        id: "C",
+        label: "C",
+        role: "",
+        assignment: "",
+        prompt: "",
+        capacity: 1,
+        timeout: null,
+        inputs: [],
+        outputs: [],
+      },
+    ],
+    edges: [
+      { id: "e-ab", source: "A", target: "B", mode: "simple" as const },
+      { id: "e-bc", source: "B", target: "C", mode: "simple" as const },
+      { id: "e-ac", source: "A", target: "C", mode: "simple" as const }, // redundant: A→B→C
+    ],
+  };
+
+  const minimalSession = (graph: unknown) => ({
+    id: "run-mount-1",
+    name: "run-mount-1",
+    created_at: 0,
+    updated_at: 0,
+    status: "completed",
+    branches: [],
+    graph,
+  });
+
+  async function mountRunDetail(graph: unknown) {
+    const [{ getSession }, { default: RunDetail }] = await Promise.all([
+      import("@/lib/api"),
+      import("./RunDetail"),
+    ]);
+    vi.mocked(getSession).mockResolvedValue(minimalSession(graph) as never);
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <RunDetail id="run-mount-1" />
+        </IntlProvider>,
+      );
+    });
+    // getSession resolves asynchronously and lazy(WorkerCanvas) suspends for
+    // at least one microtask; flush both before asserting.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    return {
+      container,
+      unmount: () => {
+        act(() => root.unmount());
+        container.remove();
+      },
+    };
+  }
+
+  it("shows the hidden-count badge and the reduced edge set by default", async () => {
+    const { container, unmount } = await mountRunDetail(diamondWithSkipGraph);
+    try {
+      expect(container.textContent).toContain("1 implied hidden");
+      const canvas = container.querySelector('[data-testid="worker-canvas"]');
+      expect(canvas?.getAttribute("data-edge-count")).toBe("2");
+      const toggle = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === "show implied edges",
+      );
+      expect(toggle).toBeDefined();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("clicking the toggle flips the button label and hands WorkerCanvas the full edge set", async () => {
+    const { container, unmount } = await mountRunDetail(diamondWithSkipGraph);
+    try {
+      const toggle = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === "show implied edges",
+      );
+      expect(toggle).toBeDefined();
+
+      await act(async () => {
+        toggle?.click();
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const canvasAfter = container.querySelector('[data-testid="worker-canvas"]');
+      expect(canvasAfter?.getAttribute("data-edge-count")).toBe("3");
+      const hideButton = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === "hide implied",
+      );
+      expect(hideButton).toBeDefined();
+      // The badge count itself must not change on toggle — 1 edge is still
+      // implied, whichever set is currently shown.
+      expect(container.textContent).toContain("1 implied hidden");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("an already-minimal graph (nothing hidden) renders no badge and no toggle", async () => {
+    const minimalGraph = {
+      name: "run",
+      description: "",
+      nodes: [
+        {
+          id: "A",
+          label: "A",
+          role: "",
+          assignment: "",
+          prompt: "",
+          capacity: 1,
+          timeout: null,
+          inputs: [],
+          outputs: [],
+        },
+        {
+          id: "B",
+          label: "B",
+          role: "",
+          assignment: "",
+          prompt: "",
+          capacity: 1,
+          timeout: null,
+          inputs: [],
+          outputs: [],
+        },
+      ],
+      edges: [{ id: "e-ab", source: "A", target: "B", mode: "simple" as const }],
+    };
+    const { container, unmount } = await mountRunDetail(minimalGraph);
+    try {
+      expect(container.textContent).not.toContain("implied hidden");
+      const toggle = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent === "show implied edges" || b.textContent === "hide implied",
+      );
+      expect(toggle).toBeUndefined();
+      const canvas = container.querySelector('[data-testid="worker-canvas"]');
+      expect(canvas?.getAttribute("data-edge-count")).toBe("1");
+    } finally {
+      unmount();
+    }
   });
 });
 

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -438,6 +438,7 @@ function SectionHeader({
   onToggleImplied?: () => void;
   showImplied?: boolean;
 }) {
+  const t = useTranslations("history.detail");
   return (
     <div className="mb-2 flex items-center gap-2">
       <h2 className="text-label font-semibold text-content-primary">{label}</h2>
@@ -454,20 +455,20 @@ function SectionHeader({
       )}
       {edgeCount != null && (
         <span className="rounded px-1.5 py-0 font-mono text-[length:var(--t-xs)] bg-surface-overlay text-content-muted">
-          {edgeCount} edges
+          {t("graphEdgeCount", { count: edgeCount })}
         </span>
       )}
       {hiddenCount != null && hiddenCount > 0 && (
         <>
           <span className="font-mono text-[length:var(--t-xs)] text-content-muted">
-            · {hiddenCount} implied hidden
+            {t("graphImpliedHidden", { count: hiddenCount })}
           </span>
           <button
             type="button"
             onClick={onToggleImplied}
             className="rounded border border-edge px-1.5 py-0 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary"
           >
-            {showImplied ? "hide implied" : "show implied edges"}
+            {showImplied ? t("graphHideImplied") : t("graphShowImplied")}
           </button>
         </>
       )}

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -153,8 +153,10 @@ export function resolveGraphEdges(
 export function computeDisplayEdges(
   edges: WorkerGraph["edges"],
   showImpliedEdges: boolean,
+  visibleNodeIds?: string[],
 ): { displayEdges: WorkerGraph["edges"]; hiddenCount: number } {
-  const { kept, hidden } = transitiveReduceDisplay(edges);
+  const visibleNodes = visibleNodeIds ? new Set(visibleNodeIds) : undefined;
+  const { kept, hidden } = transitiveReduceDisplay(edges, { visibleNodes });
   return { displayEdges: showImpliedEdges ? edges : kept, hiddenCount: hidden.length };
 }
 
@@ -1387,7 +1389,11 @@ export default function RunDetail({ id }: RunDetailProps) {
   const { displayEdges, hiddenCount } = useMemo(
     () =>
       runGraph
-        ? computeDisplayEdges(runGraph.edges, showImpliedEdges)
+        ? computeDisplayEdges(
+            runGraph.edges,
+            showImpliedEdges,
+            runGraph.nodes.map((n) => n.id),
+          )
         : { displayEdges: [] as WorkerGraph["edges"], hiddenCount: 0 },
     [runGraph, showImpliedEdges],
   );

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -17,7 +17,12 @@ import RunStepCard, { extractFilePaths } from "@/components/RunStepCard";
 import { IconChevronDown, IconChevronRight } from "@/components/ui/icons";
 import { ApiError, getInvocation, getSession, streamSession, streamSignals } from "@/lib/api";
 import type { SessionDetail, SessionBranch, SessionMessage, SignalEvent } from "@/lib/api";
-import { buildNodeStatusesByName, buildOperationGraph, laneFor } from "@/lib/operationGraph";
+import {
+  buildNodeStatusesByName,
+  buildOperationGraph,
+  laneFor,
+  transitiveReduceDisplay,
+} from "@/lib/operationGraph";
 import type { LaneSignal, OperationStatus } from "@/lib/operationGraph";
 import { deriveDisplayStatus, isEffectivelyActive } from "@/lib/runStatus";
 import type { RunMessage, RunResumeResponse, RunStep, WorkerGraph } from "@/lib/types";
@@ -135,6 +140,22 @@ export function resolveGraphEdges(
     }
   }
   return pairOrder.map((pair) => byPair.get(pair)!);
+}
+
+// The authored graph's resolved edges (resolveGraphEdges output) include
+// every ancestor the designer wired, direct and transitive alike — the same
+// "one depends_on entry per predecessor" redundancy transitiveReduce exists
+// for on the runtime path, just authored instead of engine-emitted. Reduce
+// it the same way, display-time only and with the semantic guard
+// (transitiveReduceDisplay never drops a condition/handler/map/code edge),
+// so a viewer sees the minimal picture by default with a one-click escape
+// hatch back to the full resolved set — never a dependency silently erased.
+export function computeDisplayEdges(
+  edges: WorkerGraph["edges"],
+  showImpliedEdges: boolean,
+): { displayEdges: WorkerGraph["edges"]; hiddenCount: number } {
+  const { kept, hidden } = transitiveReduceDisplay(edges);
+  return { displayEdges: showImpliedEdges ? edges : kept, hiddenCount: hidden.length };
 }
 
 // Raw SSE payloads arrive as an untyped Record — this is the boundary where
@@ -400,10 +421,22 @@ function SectionHeader({
   label,
   count,
   errorTone,
+  edgeCount,
+  hiddenCount,
+  onToggleImplied,
+  showImplied,
 }: {
   label: string;
   count?: number;
   errorTone?: boolean;
+  /** Edge count of whatever graph is actually being rendered (reduced by
+   * default, or the full resolved set when showImplied is on). */
+  edgeCount?: number;
+  /** Edges transitiveReduceDisplay dropped as transitively implied — the
+   * toggle button and "N implied hidden" badge render only when > 0. */
+  hiddenCount?: number;
+  onToggleImplied?: () => void;
+  showImplied?: boolean;
 }) {
   return (
     <div className="mb-2 flex items-center gap-2">
@@ -418,6 +451,25 @@ function SectionHeader({
         >
           {count}
         </span>
+      )}
+      {edgeCount != null && (
+        <span className="rounded px-1.5 py-0 font-mono text-[length:var(--t-xs)] bg-surface-overlay text-content-muted">
+          {edgeCount} edges
+        </span>
+      )}
+      {hiddenCount != null && hiddenCount > 0 && (
+        <>
+          <span className="font-mono text-[length:var(--t-xs)] text-content-muted">
+            · {hiddenCount} implied hidden
+          </span>
+          <button
+            type="button"
+            onClick={onToggleImplied}
+            className="rounded border border-edge px-1.5 py-0 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary"
+          >
+            {showImplied ? "hide implied" : "show implied edges"}
+          </button>
+        </>
       )}
     </div>
   );
@@ -897,11 +949,15 @@ function EventsSection({ events, live }: { events: SignalEvent[]; live: boolean 
 
 // ── Public component ──────────────────────────────────────────────────────────
 
-// Bounds for the execution-graph panel. The floor keeps a tiny pipeline from
-// collapsing into a sliver; the cap keeps a huge fan-out from swallowing the
-// page — past it the canvas pans/zooms inside the panel.
+// Floor for the execution-graph panel — keeps a tiny pipeline from collapsing
+// into a sliver. No ceiling: the card sizes to the laid-out graph's reported
+// bounding-box height (post-reduction, post-depth-scaled-ranksep) so fitView
+// has room to keep a deep chain's cards above the readability floor
+// (WorkerCanvas's FIT_ZOOM_FLOOR); a capped card would force fitView below
+// that floor for every graph taller than the cap. The enclosing page scrolls
+// past a tall card; the canvas itself only pans once it's still wider/taller
+// than the floor-zoomed viewport.
 const DAG_MIN_HEIGHT = 280;
-const DAG_MAX_HEIGHT = 560;
 
 export interface RunDetailProps {
   /** Session ID to load. */
@@ -925,7 +981,7 @@ export default function RunDetail({ id }: RunDetailProps) {
   const dagHeight = dagHeightFor.id === id ? dagHeightFor.height : DAG_MIN_HEIGHT;
   const onDagLayoutHeight = useCallback(
     (height: number) => {
-      const clamped = Math.min(DAG_MAX_HEIGHT, Math.max(DAG_MIN_HEIGHT, Math.ceil(height)));
+      const clamped = Math.max(DAG_MIN_HEIGHT, Math.ceil(height));
       setDagHeightFor((prev) => ({
         id,
         height: Math.max(prev.id === id ? prev.height : DAG_MIN_HEIGHT, clamped),
@@ -1317,11 +1373,23 @@ export default function RunDetail({ id }: RunDetailProps) {
   );
 
   // runGraph is the persisted/authored graph (Studio's early_graph) — its
-  // edges are exactly what the designer wired, and may carry conditions that
-  // only apply to a specific (possibly transitive-looking) edge. Do NOT
-  // transitively reduce it: unlike the runtime-derived opGraph below (whose
-  // edges come from depends_on ancestor lists and legitimately need
-  // deduplication), every authored edge here is meaningful and must render.
+  // edges are exactly what the designer wired, resolved (resolveGraphEdges,
+  // above) but not yet reduced. Like the runtime-derived opGraph below, a
+  // depends_on-style ancestor set can carry edges a shorter chain already
+  // implies; unlike opGraph, an authored edge can also carry a
+  // condition/handler/map/code mode the designer put there on purpose. So
+  // this is reduced too, but display-time only and through
+  // transitiveReduceDisplay (not the runtime transitiveReduce): it never
+  // drops a semantically rich edge, and a hidden dependency is always one
+  // toggle away from view, never silently gone.
+  const [showImpliedEdges, setShowImpliedEdges] = useState(false);
+  const { displayEdges, hiddenCount } = useMemo(
+    () =>
+      runGraph
+        ? computeDisplayEdges(runGraph.edges, showImpliedEdges)
+        : { displayEdges: [] as WorkerGraph["edges"], hiddenCount: 0 },
+    [runGraph, showImpliedEdges],
+  );
 
   // Live per-node status correlated by authored step id (Node* payload.name),
   // never by op_id — see lib/operationGraph.ts. Only meaningful when a
@@ -1454,7 +1522,14 @@ export default function RunDetail({ id }: RunDetailProps) {
       />
       {runGraph && shouldRenderAuthoredGraph(runGraph, opGraph) ? (
         <div id="run-dag" className="scroll-mt-4">
-          <SectionHeader label={t("sectionExecutionGraph")} count={runGraph.nodes.length} />
+          <SectionHeader
+            label={t("sectionExecutionGraph")}
+            count={runGraph.nodes.length}
+            edgeCount={displayEdges.length}
+            hiddenCount={hiddenCount}
+            onToggleImplied={() => setShowImpliedEdges((v) => !v)}
+            showImplied={showImpliedEdges}
+          />
           {/* A fan-out of dozens of workers cannot be legible in the same
               280px that fits a five-step pipeline — the panel takes its height
               from the laid-out graph's bounding box so fitView has room to
@@ -1466,7 +1541,7 @@ export default function RunDetail({ id }: RunDetailProps) {
           >
             <Suspense fallback={null}>
               <WorkerCanvas
-                graph={runGraph}
+                graph={{ ...runGraph, edges: displayEdges }}
                 editable={false}
                 execSteps={execSteps}
                 nodeStatuses={nodeStatuses}

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -195,8 +195,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 862 leaves", () => {
-    expect(EN_LEAVES.size).toBe(862);
+  it("en.json has 869 leaves", () => {
+    expect(EN_LEAVES.size).toBe(869);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -195,8 +195,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 858 leaves", () => {
-    expect(EN_LEAVES.size).toBe(858);
+  it("en.json has 862 leaves", () => {
+    expect(EN_LEAVES.size).toBe(862);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/operationGraph.test.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.test.ts
@@ -545,6 +545,68 @@ describe("transitiveReduceDisplay — semantic-guarded display-time reduction", 
     expect(hidden).toHaveLength(0);
   });
 
+  it("keeps a plain edge whose implying path's FIRST hop is rich", () => {
+    // A→B is conditional, so A→B→C is not an unconditional implication —
+    // the branch it represents may not execute, so plain A→C is not
+    // provably redundant and must survive.
+    const edges = [
+      { source: "A", target: "B", condition: "x > 0" },
+      { source: "B", target: "C" },
+      { source: "A", target: "C" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toContainEqual({ source: "A", target: "C" });
+    expect(hidden).toHaveLength(0);
+  });
+
+  it("keeps a plain edge whose implying path's SECOND hop is rich", () => {
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "B", target: "C", handler: "onMatch" },
+      { source: "A", target: "C" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toContainEqual({ source: "A", target: "C" });
+    expect(hidden).toHaveLength(0);
+  });
+
+  it("still reduces when the ENTIRE implying path is plain (control for the two arms above)", () => {
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "A", target: "C" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).not.toContainEqual({ source: "A", target: "C" });
+    expect(hidden).toHaveLength(1);
+  });
+
+  it("keeps a plain edge whose only implying path runs through a node the caller marks not visible", () => {
+    const edges = [
+      { source: "A", target: "collapsed" },
+      { source: "collapsed", target: "C" },
+      { source: "A", target: "C" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges, {
+      visibleNodes: new Set(["A", "C"]),
+    });
+    expect(kept).toContainEqual({ source: "A", target: "C" });
+    expect(hidden).toHaveLength(0);
+  });
+
+  it("still reduces through that same node when the caller marks it visible", () => {
+    const edges = [
+      { source: "A", target: "visible" },
+      { source: "visible", target: "C" },
+      { source: "A", target: "C" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges, {
+      visibleNodes: new Set(["A", "visible", "C"]),
+    });
+    expect(kept).not.toContainEqual({ source: "A", target: "C" });
+    expect(hidden).toHaveLength(1);
+  });
+
   it("returns unchanged for an already-minimal graph (identity)", () => {
     const edges = [
       { source: "A", target: "B" },

--- a/apps/studio/frontend/src/lib/operationGraph.test.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.test.ts
@@ -4,6 +4,7 @@ import {
   buildOperationGraph,
   laneFor,
   transitiveReduce,
+  transitiveReduceDisplay,
 } from "./operationGraph";
 import type { SignalEvent } from "./api";
 
@@ -457,6 +458,118 @@ describe("transitiveReduce", () => {
 
   it("is a no-op on an empty edge list", () => {
     expect(transitiveReduce([])).toEqual([]);
+  });
+});
+
+// ── transitiveReduceDisplay — semantic-guarded display-time reduction ──────────
+
+describe("transitiveReduceDisplay — semantic-guarded display-time reduction", () => {
+  it("keeps both branches of a diamond (nothing redundant)", () => {
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "A", target: "C" },
+      { source: "B", target: "D" },
+      { source: "C", target: "D" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toHaveLength(4);
+    expect(hidden).toHaveLength(0);
+  });
+
+  it("drops a skip edge when a longer path covers it", () => {
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "A", target: "C" }, // redundant: A→B→C
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toHaveLength(2);
+    expect(kept).not.toContainEqual({ source: "A", target: "C" });
+    expect(hidden).toHaveLength(1);
+    expect(hidden[0]).toMatchObject({ source: "A", target: "C" });
+  });
+
+  it("fan-in to sink: only direct predecessors survive when the sink also depends on the root", () => {
+    const edges = [
+      { source: "root", target: "w1" },
+      { source: "root", target: "w2" },
+      { source: "w1", target: "sink" },
+      { source: "w2", target: "sink" },
+      { source: "root", target: "sink" }, // redundant: root→w1→sink and root→w2→sink
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toHaveLength(4);
+    expect(kept).not.toContainEqual({ source: "root", target: "sink" });
+    expect(hidden).toHaveLength(1);
+    expect(hidden[0]).toMatchObject({ source: "root", target: "sink" });
+  });
+
+  it("leaves a cyclic graph entirely unchanged", () => {
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "B", target: "A" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toEqual(edges);
+    expect(hidden).toHaveLength(0);
+  });
+
+  it("skips reduction for the WHOLE graph even when a transitive-looking edge sits alongside the cycle", () => {
+    // A→B→C→A is a cycle; A→C also looks like a candidate for the skip-edge
+    // reduction in the diamond/chain tests above (A reaches C via B). A
+    // reducer that only guards the cycle's own edges — rather than the whole
+    // graph — would still drop A→C here, which this test exists to catch: a
+    // cyclic depends_on graph is defensive/unexpected input, and every edge
+    // in and around it may be load-bearing, so nothing may be dropped.
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "C", target: "A" },
+      { source: "A", target: "C" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toEqual(edges);
+    expect(kept).toHaveLength(4);
+    expect(hidden).toHaveLength(0);
+  });
+
+  it("preserves a conditional edge that would be dropped by plain transitiveReduce", () => {
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "A", target: "C", condition: "score > 0.8" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toHaveLength(3);
+    expect(kept).toContainEqual(edges[2]); // conditional edge survives
+    expect(hidden).toHaveLength(0);
+  });
+
+  it("returns unchanged for an already-minimal graph (identity)", () => {
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toEqual(edges);
+    expect(hidden).toHaveLength(0);
+  });
+
+  it("is a no-op on an empty edge list", () => {
+    expect(transitiveReduceDisplay([])).toEqual({ kept: [], hidden: [] });
+  });
+
+  it("never drops a map or handler or mode=code edge, only a bare condition", () => {
+    const edges = [
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "A", target: "C", handler: "onMatch" },
+      { source: "A", target: "C", map: { key: "value" } },
+      { source: "A", target: "C", mode: "code" },
+    ];
+    const { kept, hidden } = transitiveReduceDisplay(edges);
+    expect(kept).toHaveLength(5);
+    expect(hidden).toHaveLength(0);
   });
 });
 

--- a/apps/studio/frontend/src/lib/operationGraph.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.ts
@@ -120,6 +120,115 @@ export function transitiveReduce<E extends { source: string; target: string }>(e
   });
 }
 
+// ── Display-time transitive reduction with semantic guard ──────────────────────
+
+// An authored WorkerGraph edge can carry semantics beyond structure — a
+// condition, a map, a handler, or mode="code" — matching the richness
+// criteria in resolveGraphEdges (RunDetail.tsx). Such an edge is information
+// the designer put there on purpose, not a redundant ancestor link, so it
+// must never be dropped even when another path already reaches its target.
+function defaultIsRich(e: {
+  condition?: unknown;
+  map?: unknown;
+  handler?: unknown;
+  mode?: unknown;
+}): boolean {
+  return Boolean(e.condition) || Boolean(e.map) || Boolean(e.handler) || e.mode === "code";
+}
+
+// Whole-graph directed-cycle check (3-color DFS). Unlike transitiveReduce's
+// per-node inProgress guard — which silently treats a cyclic node as
+// unreachable and can still drop edges around it — this is a guard for the
+// entire reduction: depends_on graphs are expected to be acyclic, but if a
+// cycle is found every edge in it may be load-bearing for the cycle itself,
+// so reduction must not run at all.
+export function hasCycle<E extends { source: string; target: string }>(edges: E[]): boolean {
+  const adj = new Map<string, string[]>();
+  for (const e of edges) {
+    (adj.get(e.source) ?? adj.set(e.source, []).get(e.source)!).push(e.target);
+  }
+
+  const WHITE = 0,
+    GRAY = 1,
+    BLACK = 2;
+  const color = new Map<string, number>();
+
+  const dfs = (node: string): boolean => {
+    const c = color.get(node) ?? WHITE;
+    if (c === GRAY) return true;
+    if (c === BLACK) return false;
+    color.set(node, GRAY);
+    for (const next of adj.get(node) ?? []) {
+      if (dfs(next)) return true;
+    }
+    color.set(node, BLACK);
+    return false;
+  };
+
+  for (const node of adj.keys()) {
+    if (color.get(node) === undefined && dfs(node)) return true;
+  }
+  return false;
+}
+
+// Display-time transitive reduction for an authored WorkerGraph's edges.
+// Drops edge (u→v) only when v is reachable from u via a path of length ≥2
+// through OTHER edges that themselves survive as real dependencies. Two
+// guards distinguish this from transitiveReduce above:
+//   1. Whole-graph cycle detection — a cyclic graph is returned unchanged
+//      rather than reduced around the cycle.
+//   2. Semantically rich edges (see defaultIsRich) are never dropped, even
+//      when reachable via another path — they carry author intent, not
+//      structural redundancy.
+// Never mutates or re-persists the input; this only affects what is
+// rendered.
+export function transitiveReduceDisplay<E extends { source: string; target: string }>(
+  edges: E[],
+  options?: { isRich?: (e: E) => boolean },
+): { kept: E[]; hidden: E[] } {
+  if (edges.length === 0) return { kept: [], hidden: [] };
+  if (hasCycle(edges)) return { kept: edges, hidden: [] };
+
+  const isRich = options?.isRich ?? defaultIsRich;
+  const rich: E[] = [];
+  const plain: E[] = [];
+  for (const e of edges) {
+    (isRich(e) ? rich : plain).push(e);
+  }
+
+  const outEdges = new Map<string, E[]>();
+  for (const e of edges) {
+    (outEdges.get(e.source) ?? outEdges.set(e.source, []).get(e.source)!).push(e);
+  }
+
+  const reachableCache = new Map<string, Set<string>>();
+  const reachableFrom = (node: string): Set<string> => {
+    const cached = reachableCache.get(node);
+    if (cached) return cached;
+    const result = new Set<string>();
+    reachableCache.set(node, result); // seed before recursing; the graph is acyclic here
+    for (const e of outEdges.get(node) ?? []) {
+      result.add(e.target);
+      for (const r of reachableFrom(e.target)) result.add(r);
+    }
+    return result;
+  };
+
+  const hidden: E[] = [];
+  const survivingPlain = plain.filter((e) => {
+    for (const alt of outEdges.get(e.source) ?? []) {
+      if (alt === e || alt.target === e.target) continue;
+      if (reachableFrom(alt.target).has(e.target)) {
+        hidden.push(e);
+        return false;
+      }
+    }
+    return true;
+  });
+
+  return { kept: [...rich, ...survivingPlain], hidden };
+}
+
 // ── Graph builder ─────────────────────────────────────────────────────────────
 
 export function buildOperationGraph(events: SignalEvent[]): OperationGraphState {

--- a/apps/studio/frontend/src/lib/operationGraph.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.ts
@@ -173,32 +173,44 @@ export function hasCycle<E extends { source: string; target: string }>(edges: E[
 
 // Display-time transitive reduction for an authored WorkerGraph's edges.
 // Drops edge (u→v) only when v is reachable from u via a path of length ≥2
-// through OTHER edges that themselves survive as real dependencies. Two
-// guards distinguish this from transitiveReduce above:
+// where EVERY edge on that path is itself structurally plain and connects
+// two visible nodes. Three guards distinguish this from transitiveReduce
+// above:
 //   1. Whole-graph cycle detection — a cyclic graph is returned unchanged
 //      rather than reduced around the cycle.
-//   2. Semantically rich edges (see defaultIsRich) are never dropped, even
-//      when reachable via another path — they carry author intent, not
-//      structural redundancy.
+//   2. Semantically rich edges (see defaultIsRich) are never dropped, and
+//      never count as a step of an implying path — a condition/map/handler/
+//      code edge is not an unconditional implication, so it cannot stand in
+//      for the plain edge it might otherwise seem to make redundant.
+//   3. A path that passes through a node the caller says will not be
+//      rendered (options.visibleNodes) cannot justify hiding an edge either
+//      — a viewer can't confirm an implication they can't see resolve.
 // Never mutates or re-persists the input; this only affects what is
 // rendered.
 export function transitiveReduceDisplay<E extends { source: string; target: string }>(
   edges: E[],
-  options?: { isRich?: (e: E) => boolean },
+  options?: { isRich?: (e: E) => boolean; visibleNodes?: Set<string> },
 ): { kept: E[]; hidden: E[] } {
   if (edges.length === 0) return { kept: [], hidden: [] };
   if (hasCycle(edges)) return { kept: edges, hidden: [] };
 
   const isRich = options?.isRich ?? defaultIsRich;
+  const visibleNodes = options?.visibleNodes;
+  const isVisible = (id: string) => !visibleNodes || visibleNodes.has(id);
+
   const rich: E[] = [];
   const plain: E[] = [];
   for (const e of edges) {
     (isRich(e) ? rich : plain).push(e);
   }
 
-  const outEdges = new Map<string, E[]>();
-  for (const e of edges) {
-    (outEdges.get(e.source) ?? outEdges.set(e.source, []).get(e.source)!).push(e);
+  // Only a plain edge between two visible nodes can be one step of an
+  // implying path — a rich edge's implication is conditional, and a step
+  // through a hidden node is not one the viewer can see resolve.
+  const plainOutEdges = new Map<string, E[]>();
+  for (const e of plain) {
+    if (!isVisible(e.source) || !isVisible(e.target)) continue;
+    (plainOutEdges.get(e.source) ?? plainOutEdges.set(e.source, []).get(e.source)!).push(e);
   }
 
   const reachableCache = new Map<string, Set<string>>();
@@ -207,7 +219,7 @@ export function transitiveReduceDisplay<E extends { source: string; target: stri
     if (cached) return cached;
     const result = new Set<string>();
     reachableCache.set(node, result); // seed before recursing; the graph is acyclic here
-    for (const e of outEdges.get(node) ?? []) {
+    for (const e of plainOutEdges.get(node) ?? []) {
       result.add(e.target);
       for (const r of reachableFrom(e.target)) result.add(r);
     }
@@ -216,7 +228,10 @@ export function transitiveReduceDisplay<E extends { source: string; target: stri
 
   const hidden: E[] = [];
   const survivingPlain = plain.filter((e) => {
-    for (const alt of outEdges.get(e.source) ?? []) {
+    // An edge touching a hidden node can't be verified as implied by a
+    // visible path either — keep it rather than guess.
+    if (!isVisible(e.source) || !isVisible(e.target)) return true;
+    for (const alt of plainOutEdges.get(e.source) ?? []) {
       if (alt === e || alt.target === e.target) continue;
       if (reachableFrom(alt.target).has(e.target)) {
         hidden.push(e);

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} حافة",
       "graphImpliedHidden": "· {count} ضمنية مخفية",
       "graphHideImplied": "إخفاء الضمنية",
-      "graphShowImplied": "إظهار الحواف الضمنية"
+      "graphShowImplied": "إظهار الحواف الضمنية",
+      "graphNodeStatusQueued": "قيد الانتظار",
+      "graphNodeStatusRunning": "قيد التشغيل",
+      "graphNodeStatusApproval": "الموافقة",
+      "graphNodeStatusPaused": "متوقف مؤقتًا",
+      "graphNodeStatusDone": "تم",
+      "graphNodeStatusFailed": "فشل",
+      "graphNodeStatusEscalated": "تم التصعيد"
     },
     "masterAria": "قائمة السجل",
     "detailAria": "تفاصيل العنصر"

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "لا توجد أخطاء في الرسائل المحمّلة.",
       "noFilesPartial": "لم تُكتشف عمليات على الملفات في الرسائل المحمّلة.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} حافة",
+      "graphImpliedHidden": "· {count} ضمنية مخفية",
+      "graphHideImplied": "إخفاء الضمنية",
+      "graphShowImplied": "إظهار الحواف الضمنية"
     },
     "masterAria": "قائمة السجل",
     "detailAria": "تفاصيل العنصر"

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "লোড করা মেসেজে কোনো ত্রুটি নেই।",
       "noFilesPartial": "লোড করা মেসেজে কোনো ফাইল অপারেশন শনাক্ত হয়নি।",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count}টি প্রান্ত",
+      "graphImpliedHidden": "· {count}টি অন্তর্নিহিত লুকানো",
+      "graphHideImplied": "অন্তর্নিহিত লুকান",
+      "graphShowImplied": "অন্তর্নিহিত প্রান্ত দেখান"
     },
     "masterAria": "হিস্ট্রি তালিকা",
     "detailAria": "আইটেমের বিস্তারিত"

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count}টি প্রান্ত",
       "graphImpliedHidden": "· {count}টি অন্তর্নিহিত লুকানো",
       "graphHideImplied": "অন্তর্নিহিত লুকান",
-      "graphShowImplied": "অন্তর্নিহিত প্রান্ত দেখান"
+      "graphShowImplied": "অন্তর্নিহিত প্রান্ত দেখান",
+      "graphNodeStatusQueued": "সারিতে",
+      "graphNodeStatusRunning": "চলমান",
+      "graphNodeStatusApproval": "অনুমোদন",
+      "graphNodeStatusPaused": "স্থগিত",
+      "graphNodeStatusDone": "সম্পন্ন",
+      "graphNodeStatusFailed": "ব্যর্থ",
+      "graphNodeStatusEscalated": "এস্কেলেটেড"
     },
     "masterAria": "হিস্ট্রি তালিকা",
     "detailAria": "আইটেমের বিস্তারিত"

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} Kanten",
       "graphImpliedHidden": "· {count} implizite ausgeblendet",
       "graphHideImplied": "implizite ausblenden",
-      "graphShowImplied": "implizite Kanten anzeigen"
+      "graphShowImplied": "implizite Kanten anzeigen",
+      "graphNodeStatusQueued": "wartend",
+      "graphNodeStatusRunning": "läuft",
+      "graphNodeStatusApproval": "Freigabe",
+      "graphNodeStatusPaused": "pausiert",
+      "graphNodeStatusDone": "fertig",
+      "graphNodeStatusFailed": "fehlgeschlagen",
+      "graphNodeStatusEscalated": "eskaliert"
     },
     "masterAria": "Verlaufsliste",
     "detailAria": "Elementdetails"

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "Keine Fehler in den geladenen Nachrichten.",
       "noFilesPartial": "Keine Dateioperationen in den geladenen Nachrichten erkannt.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} Kanten",
+      "graphImpliedHidden": "· {count} implizite ausgeblendet",
+      "graphHideImplied": "implizite ausblenden",
+      "graphShowImplied": "implizite Kanten anzeigen"
     },
     "masterAria": "Verlaufsliste",
     "detailAria": "Elementdetails"

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "No errors in the loaded messages.",
       "noFilesPartial": "No file operations detected in the loaded messages.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} edges",
+      "graphImpliedHidden": "· {count} implied hidden",
+      "graphHideImplied": "hide implied",
+      "graphShowImplied": "show implied edges"
     },
     "masterAria": "History list",
     "detailAria": "Item detail"

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} edges",
       "graphImpliedHidden": "· {count} implied hidden",
       "graphHideImplied": "hide implied",
-      "graphShowImplied": "show implied edges"
+      "graphShowImplied": "show implied edges",
+      "graphNodeStatusQueued": "queued",
+      "graphNodeStatusRunning": "running",
+      "graphNodeStatusApproval": "approval",
+      "graphNodeStatusPaused": "paused",
+      "graphNodeStatusDone": "done",
+      "graphNodeStatusFailed": "failed",
+      "graphNodeStatusEscalated": "escalated"
     },
     "masterAria": "History list",
     "detailAria": "Item detail"

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "No hay errores en los mensajes cargados.",
       "noFilesPartial": "No se detectaron operaciones de archivo en los mensajes cargados.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} aristas",
+      "graphImpliedHidden": "· {count} implícitas ocultas",
+      "graphHideImplied": "ocultar implícitas",
+      "graphShowImplied": "mostrar aristas implícitas"
     },
     "masterAria": "Lista de historial",
     "detailAria": "Detalle del elemento"

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} aristas",
       "graphImpliedHidden": "· {count} implícitas ocultas",
       "graphHideImplied": "ocultar implícitas",
-      "graphShowImplied": "mostrar aristas implícitas"
+      "graphShowImplied": "mostrar aristas implícitas",
+      "graphNodeStatusQueued": "en cola",
+      "graphNodeStatusRunning": "ejecutando",
+      "graphNodeStatusApproval": "aprobación",
+      "graphNodeStatusPaused": "pausado",
+      "graphNodeStatusDone": "listo",
+      "graphNodeStatusFailed": "fallido",
+      "graphNodeStatusEscalated": "escalado"
     },
     "masterAria": "Lista de historial",
     "detailAria": "Detalle del elemento"

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} arêtes",
       "graphImpliedHidden": "· {count} implicites masquées",
       "graphHideImplied": "masquer les implicites",
-      "graphShowImplied": "afficher les arêtes implicites"
+      "graphShowImplied": "afficher les arêtes implicites",
+      "graphNodeStatusQueued": "en attente",
+      "graphNodeStatusRunning": "en cours",
+      "graphNodeStatusApproval": "approbation",
+      "graphNodeStatusPaused": "en pause",
+      "graphNodeStatusDone": "terminé",
+      "graphNodeStatusFailed": "échoué",
+      "graphNodeStatusEscalated": "escaladé"
     },
     "masterAria": "Liste d’historique",
     "detailAria": "Détail de l’élément"

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "Aucune erreur dans les messages chargés.",
       "noFilesPartial": "Aucune opération de fichier détectée dans les messages chargés.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} arêtes",
+      "graphImpliedHidden": "· {count} implicites masquées",
+      "graphHideImplied": "masquer les implicites",
+      "graphShowImplied": "afficher les arêtes implicites"
     },
     "masterAria": "Liste d’historique",
     "detailAria": "Détail de l’élément"

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "लोड किए गए मैसेज में कोई त्रुटि नहीं।",
       "noFilesPartial": "लोड किए गए मैसेज में कोई फ़ाइल ऑपरेशन नहीं मिला।",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} किनारे",
+      "graphImpliedHidden": "· {count} निहित छिपे",
+      "graphHideImplied": "निहित छिपाएँ",
+      "graphShowImplied": "निहित किनारे दिखाएँ"
     },
     "masterAria": "इतिहास सूची",
     "detailAria": "आइटम विवरण"

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} किनारे",
       "graphImpliedHidden": "· {count} निहित छिपे",
       "graphHideImplied": "निहित छिपाएँ",
-      "graphShowImplied": "निहित किनारे दिखाएँ"
+      "graphShowImplied": "निहित किनारे दिखाएँ",
+      "graphNodeStatusQueued": "कतार में",
+      "graphNodeStatusRunning": "चालू",
+      "graphNodeStatusApproval": "अनुमोदन",
+      "graphNodeStatusPaused": "रुका हुआ",
+      "graphNodeStatusDone": "पूर्ण",
+      "graphNodeStatusFailed": "विफल",
+      "graphNodeStatusEscalated": "एस्केलेटेड"
     },
     "masterAria": "इतिहास सूची",
     "detailAria": "आइटम विवरण"

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} sisi",
       "graphImpliedHidden": "· {count} implisit disembunyikan",
       "graphHideImplied": "sembunyikan implisit",
-      "graphShowImplied": "tampilkan sisi implisit"
+      "graphShowImplied": "tampilkan sisi implisit",
+      "graphNodeStatusQueued": "antre",
+      "graphNodeStatusRunning": "berjalan",
+      "graphNodeStatusApproval": "persetujuan",
+      "graphNodeStatusPaused": "dijeda",
+      "graphNodeStatusDone": "selesai",
+      "graphNodeStatusFailed": "gagal",
+      "graphNodeStatusEscalated": "dieskalasi"
     },
     "masterAria": "Daftar riwayat",
     "detailAria": "Detail item"

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "Tidak ada kesalahan dalam pesan yang dimuat.",
       "noFilesPartial": "Tidak ada operasi file terdeteksi dalam pesan yang dimuat.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} sisi",
+      "graphImpliedHidden": "· {count} implisit disembunyikan",
+      "graphHideImplied": "sembunyikan implisit",
+      "graphShowImplied": "tampilkan sisi implisit"
     },
     "masterAria": "Daftar riwayat",
     "detailAria": "Detail item"

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} 本のエッジ",
       "graphImpliedHidden": "· 暗黙のエッジ {count} 本を非表示",
       "graphHideImplied": "暗黙のエッジを隠す",
-      "graphShowImplied": "暗黙のエッジを表示"
+      "graphShowImplied": "暗黙のエッジを表示",
+      "graphNodeStatusQueued": "待機中",
+      "graphNodeStatusRunning": "実行中",
+      "graphNodeStatusApproval": "承認",
+      "graphNodeStatusPaused": "一時停止",
+      "graphNodeStatusDone": "完了",
+      "graphNodeStatusFailed": "失敗",
+      "graphNodeStatusEscalated": "エスカレーション"
     },
     "masterAria": "履歴一覧",
     "detailAria": "項目の詳細"

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "読み込まれたメッセージにエラーはありません。",
       "noFilesPartial": "読み込まれたメッセージにファイル操作は検出されていません。",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} 本のエッジ",
+      "graphImpliedHidden": "· 暗黙のエッジ {count} 本を非表示",
+      "graphHideImplied": "暗黙のエッジを隠す",
+      "graphShowImplied": "暗黙のエッジを表示"
     },
     "masterAria": "履歴一覧",
     "detailAria": "項目の詳細"

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "로드된 메시지에 오류가 없습니다.",
       "noFilesPartial": "로드된 메시지에서 감지된 파일 작업이 없습니다.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "엣지 {count}개",
+      "graphImpliedHidden": "· 암시적 {count}개 숨김",
+      "graphHideImplied": "암시적 숨기기",
+      "graphShowImplied": "암시적 엣지 표시"
     },
     "masterAria": "기록 목록",
     "detailAria": "항목 세부 정보"

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "엣지 {count}개",
       "graphImpliedHidden": "· 암시적 {count}개 숨김",
       "graphHideImplied": "암시적 숨기기",
-      "graphShowImplied": "암시적 엣지 표시"
+      "graphShowImplied": "암시적 엣지 표시",
+      "graphNodeStatusQueued": "대기중",
+      "graphNodeStatusRunning": "실행중",
+      "graphNodeStatusApproval": "승인",
+      "graphNodeStatusPaused": "일시중지",
+      "graphNodeStatusDone": "완료",
+      "graphNodeStatusFailed": "실패",
+      "graphNodeStatusEscalated": "에스컬레이션"
     },
     "masterAria": "기록 목록",
     "detailAria": "항목 세부 정보"

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "Nenhum erro nas mensagens carregadas.",
       "noFilesPartial": "Nenhuma operação de arquivo detectada nas mensagens carregadas.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} arestas",
+      "graphImpliedHidden": "· {count} implícitas ocultas",
+      "graphHideImplied": "ocultar implícitas",
+      "graphShowImplied": "mostrar arestas implícitas"
     },
     "masterAria": "Lista do histórico",
     "detailAria": "Detalhes do item"

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} arestas",
       "graphImpliedHidden": "· {count} implícitas ocultas",
       "graphHideImplied": "ocultar implícitas",
-      "graphShowImplied": "mostrar arestas implícitas"
+      "graphShowImplied": "mostrar arestas implícitas",
+      "graphNodeStatusQueued": "na fila",
+      "graphNodeStatusRunning": "em execução",
+      "graphNodeStatusApproval": "aprovação",
+      "graphNodeStatusPaused": "pausado",
+      "graphNodeStatusDone": "concluído",
+      "graphNodeStatusFailed": "falhou",
+      "graphNodeStatusEscalated": "escalado"
     },
     "masterAria": "Lista do histórico",
     "detailAria": "Detalhes do item"

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "В загруженных сообщениях ошибок нет.",
       "noFilesPartial": "В загруженных сообщениях операции с файлами не обнаружены.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "рёбер: {count}",
+      "graphImpliedHidden": "· скрыто неявных: {count}",
+      "graphHideImplied": "скрыть неявные",
+      "graphShowImplied": "показать неявные рёбра"
     },
     "masterAria": "Список истории",
     "detailAria": "Сведения об элементе"

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "рёбер: {count}",
       "graphImpliedHidden": "· скрыто неявных: {count}",
       "graphHideImplied": "скрыть неявные",
-      "graphShowImplied": "показать неявные рёбра"
+      "graphShowImplied": "показать неявные рёбра",
+      "graphNodeStatusQueued": "в очереди",
+      "graphNodeStatusRunning": "выполняется",
+      "graphNodeStatusApproval": "одобрение",
+      "graphNodeStatusPaused": "приостановлено",
+      "graphNodeStatusDone": "готово",
+      "graphNodeStatusFailed": "ошибка",
+      "graphNodeStatusEscalated": "эскалировано"
     },
     "masterAria": "Список истории",
     "detailAria": "Сведения об элементе"

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} kenar",
       "graphImpliedHidden": "· {count} örtük gizli",
       "graphHideImplied": "örtükleri gizle",
-      "graphShowImplied": "örtük kenarları göster"
+      "graphShowImplied": "örtük kenarları göster",
+      "graphNodeStatusQueued": "sırada",
+      "graphNodeStatusRunning": "çalışıyor",
+      "graphNodeStatusApproval": "onay",
+      "graphNodeStatusPaused": "duraklatıldı",
+      "graphNodeStatusDone": "tamamlandı",
+      "graphNodeStatusFailed": "başarısız",
+      "graphNodeStatusEscalated": "yükseltildi"
     },
     "masterAria": "geçmiş listesi",
     "detailAria": "öğe ayrıntısı"

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "yüklenen mesajlarda hata yok.",
       "noFilesPartial": "yüklenen mesajlarda dosya işlemi algılanmadı.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} kenar",
+      "graphImpliedHidden": "· {count} örtük gizli",
+      "graphHideImplied": "örtükleri gizle",
+      "graphShowImplied": "örtük kenarları göster"
     },
     "masterAria": "geçmiş listesi",
     "detailAria": "öğe ayrıntısı"

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "لوڈ شدہ پیغامات میں کوئی خرابی نہیں۔",
       "noFilesPartial": "لوڈ شدہ پیغامات میں کوئی فائل آپریشن نہیں ملا۔",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} کنارے",
+      "graphImpliedHidden": "· {count} ضمنی چھپے ہوئے",
+      "graphHideImplied": "ضمنی چھپائیں",
+      "graphShowImplied": "ضمنی کنارے دکھائیں"
     },
     "masterAria": "ہسٹری فہرست",
     "detailAria": "آئٹم تفصیل"

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} کنارے",
       "graphImpliedHidden": "· {count} ضمنی چھپے ہوئے",
       "graphHideImplied": "ضمنی چھپائیں",
-      "graphShowImplied": "ضمنی کنارے دکھائیں"
+      "graphShowImplied": "ضمنی کنارے دکھائیں",
+      "graphNodeStatusQueued": "قطار میں",
+      "graphNodeStatusRunning": "جاری",
+      "graphNodeStatusApproval": "منظوری",
+      "graphNodeStatusPaused": "موقوف",
+      "graphNodeStatusDone": "مکمل",
+      "graphNodeStatusFailed": "ناکام",
+      "graphNodeStatusEscalated": "بڑھایا گیا"
     },
     "masterAria": "ہسٹری فہرست",
     "detailAria": "آئٹم تفصیل"

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} cạnh",
       "graphImpliedHidden": "· ẩn {count} cạnh ngầm định",
       "graphHideImplied": "ẩn cạnh ngầm định",
-      "graphShowImplied": "hiện cạnh ngầm định"
+      "graphShowImplied": "hiện cạnh ngầm định",
+      "graphNodeStatusQueued": "đang chờ",
+      "graphNodeStatusRunning": "đang chạy",
+      "graphNodeStatusApproval": "phê duyệt",
+      "graphNodeStatusPaused": "tạm dừng",
+      "graphNodeStatusDone": "xong",
+      "graphNodeStatusFailed": "thất bại",
+      "graphNodeStatusEscalated": "đã leo thang"
     },
     "masterAria": "danh sách lịch sử",
     "detailAria": "chi tiết mục"

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "không có lỗi trong các tin nhắn đã tải.",
       "noFilesPartial": "không phát hiện thao tác tệp trong các tin nhắn đã tải.",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} cạnh",
+      "graphImpliedHidden": "· ẩn {count} cạnh ngầm định",
+      "graphHideImplied": "ẩn cạnh ngầm định",
+      "graphShowImplied": "hiện cạnh ngầm định"
     },
     "masterAria": "danh sách lịch sử",
     "detailAria": "chi tiết mục"

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -446,7 +446,14 @@
       "graphEdgeCount": "{count} 条边",
       "graphImpliedHidden": "· {count} 条隐含边已隐藏",
       "graphHideImplied": "隐藏隐含边",
-      "graphShowImplied": "显示隐含边"
+      "graphShowImplied": "显示隐含边",
+      "graphNodeStatusQueued": "排队中",
+      "graphNodeStatusRunning": "运行中",
+      "graphNodeStatusApproval": "审批",
+      "graphNodeStatusPaused": "已暂停",
+      "graphNodeStatusDone": "完成",
+      "graphNodeStatusFailed": "失败",
+      "graphNodeStatusEscalated": "已升级"
     },
     "masterAria": "历史列表",
     "detailAria": "条目详情"

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -442,7 +442,11 @@
       "noBranchErrorsPartial": "已加载的消息中没有错误。",
       "noFilesPartial": "已加载的消息中未检测到文件操作。",
       "olderUnavailable": "Older history could not be loaded — this conversation moved on before the request completed.",
-      "reloadConversation": "Reload conversation"
+      "reloadConversation": "Reload conversation",
+      "graphEdgeCount": "{count} 条边",
+      "graphImpliedHidden": "· {count} 条隐含边已隐藏",
+      "graphHideImplied": "隐藏隐含边",
+      "graphShowImplied": "显示隐含边"
     },
     "masterAria": "历史列表",
     "detailAria": "条目详情"


### PR DESCRIPTION
The execution graph is the main way to see what a run did, and it was unreadable for anything but small fan-outs.

Measured before this change: a true sequential chain rendered at roughly 47:1, and a 30-node chain at 78:1, which is a thin vertical strip at any usable zoom.

- Transitively-implied edges are hidden, so the graph shows the dependencies that matter rather than every reachable pair.
- A long sequential run folds into rows instead of running off-screen.
- Deep chains stay readable at fit, and the readability floor is scoped to the fit so wide graphs stay viewable rather than being pushed past the viewport.
- Node cards are a fixed two-row shape with four fixed corners, so the same fact sits in the same place on every card at every zoom. The bottom-right corner always says something: elapsed time once there is any, the status word before that.

After: an 18-node chain fits at 0.93 where it previously fit at 0.21, and a 30-node chain at 0.93 where it previously fit at 0.13. Fan-out layouts are unchanged.

The node card's assignment and tool-call count moved to the detail panel. They are what you read about one node you have already picked, not what you scan a graph for.
