### PR TITLE
Record whether a run's end time was observed or only noticed

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -118,6 +118,25 @@ TERMINAL_SOURCE_SPAWN_FAILURE = "spawn_failure"
 TERMINAL_SOURCE_ORPHAN_REAPER = "mcp_orphan_reaper"
 TERMINAL_SOURCE_KILL = "mcp_kill"
 
+# How `finished_at` was arrived at, recorded beside it because the two answer
+# different questions and only one of them is always knowable.
+#
+# OBSERVED means the run's own end was seen: the process was killed here, the
+# terminal hook fired, the spawn failed at that moment, or the lifecycle record
+# carried a real end time.
+#
+# UPPER_BOUND means nobody saw the end and the stored value is when the end was
+# *noticed*. It is a real bound (the run had ended by then) and it is never the
+# duration. Written by the paths that cannot know better, so that "we do not
+# know when this ended" is representable instead of being replaced by a
+# confident wrong value.
+#
+# A record written before this field existed carries neither. Absent is its own
+# answer and must not be read as OBSERVED: that would restate the same guess one
+# layer up.
+FINISHED_AT_OBSERVED = "observed"
+FINISHED_AT_UPPER_BOUND = "upper_bound"
+
 # Why a guarded mutation has no record to work on: RECORD_ABSENT means the run
 # is unknown; LOCK_UNAVAILABLE means the write was refused, so a caller may retry.
 RECORD_ABSENT = "absent"
@@ -1231,6 +1250,8 @@ def _record_spawn_failure(run_id: str, exc: Exception) -> SpawnError:
         "spawn_state": "failed",
         "status": "failed",
         "finished_at": _now_iso(),
+        # The spawn failed here, so this is the end as it happened.
+        "finished_at_precision": FINISHED_AT_OBSERVED,
         "reason": reason,
         "terminal_source": TERMINAL_SOURCE_SPAWN_FAILURE,
     }
@@ -1246,6 +1267,7 @@ def _record_spawn_failure(run_id: str, exc: Exception) -> SpawnError:
             if current.get("finished_at") is None:
                 current["status"] = "failed"
                 current["finished_at"] = _now_iso()
+                current["finished_at_precision"] = FINISHED_AT_OBSERVED
                 current["terminal_source"] = TERMINAL_SOURCE_SPAWN_FAILURE
             record = current
     except OSError:
@@ -1285,9 +1307,16 @@ def _cache_lifecycle_end(
     if job is None or lifecycle is None or not lifecycle.get("terminal"):
         return job
     ended = lifecycle.get("ended_at")
+    # A lifecycle record that carries its own end time is an observation. One
+    # that does not leaves the same gap the reaper has, and the same substituted
+    # value: now, standing in for a moment nobody recorded.
+    observed_end = _iso_from_epoch(ended)
     fields = {
         "status": lifecycle.get("status", job.get("status")),
-        "finished_at": _iso_from_epoch(ended) or _now_iso(),
+        "finished_at": observed_end or _now_iso(),
+        "finished_at_precision": (
+            FINISHED_AT_OBSERVED if observed_end else FINISHED_AT_UPPER_BOUND
+        ),
         "reason_code": lifecycle.get("reason_code"),
         "terminal_source": TERMINAL_SOURCE_LIFECYCLE,
     }
@@ -1474,6 +1503,7 @@ def reap_orphan(run_id: str, *, finding: str, observed_at: str) -> ReapResult:
                 "outcome": OUTCOME_INDETERMINATE,
                 "reason_code": reason_code,
                 "finished_at": observed_at,
+                "finished_at_precision": FINISHED_AT_UPPER_BOUND,
                 "terminal_source": TERMINAL_SOURCE_ORPHAN_REAPER,
                 "terminal_evidence": {"kind": EVIDENCE_PROCESS_GONE, "finding": finding},
             }
@@ -1599,6 +1629,9 @@ def status(run_id: str) -> dict[str, Any]:
         "pid": pid,
         "submitted_at": (job or {}).get("submitted_at"),
         "finished_at": (job or {}).get("finished_at"),
+        # Whether finished_at is the end or only a bound on it. Null on records
+        # written before the field existed, which is not the same as "observed".
+        "finished_at_precision": (job or {}).get("finished_at_precision"),
         "notify_delivery": (job or {}).get("notify_delivery"),
         "mcp_config": (job or {}).get("mcp_config"),
         "mcp_config_source": (job or {}).get("mcp_config_source"),
@@ -1693,6 +1726,8 @@ def _mark_killed(job: dict[str, Any]) -> WriteResult:
         else:
             current["status"] = "killed"
             current["finished_at"] = _now_iso()
+            # The kill happened here, so the end is observed rather than noticed.
+            current["finished_at_precision"] = FINISHED_AT_OBSERVED
             current["terminal_source"] = TERMINAL_SOURCE_KILL
         return WriteResult(current, guard.state)
 
@@ -2114,6 +2149,7 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
                 "spawn_state": st["spawn_state"],
                 "submitted_at": st["submitted_at"],
                 "finished_at": st["finished_at"],
+                "finished_at_precision": st["finished_at_precision"],
                 "terminal_source": st["terminal_source"],
                 "record_state": st["record_state"],
                 "notify_delivery_state": _notify_delivery_state(st["notify_delivery"]),
@@ -2303,6 +2339,8 @@ def mark_terminal(run_id: str, cli_status: str) -> WriteResult:
         job["status"] = cli_status
         job["cli_status"] = cli_status
         job["finished_at"] = _now_iso()
+        # The hook fires as the run ends, so this is the end as it happened.
+        job["finished_at_precision"] = FINISHED_AT_OBSERVED
         job["terminal_source"] = TERMINAL_SOURCE_HOOK
         return WriteResult(job, guard.state)
 

--- a/tests/mcp/test_finished_at_precision.py
+++ b/tests/mcp/test_finished_at_precision.py
@@ -121,6 +121,25 @@ class TestALifecycleRecordWithoutAnEndTime:
         assert out["finished_at_precision"] == jobs.FINISHED_AT_UPPER_BOUND
 
 
+class TestASpawnFailureRecordsAnObservation:
+    """`_record_spawn_failure` has two write arms — no record yet for this run
+    (the directory is reserved but `job.json` never landed) and a record that
+    already exists with `finished_at=None` — and both must stamp "observed":
+    the caller that caught the failed spawn watched it happen just now.
+    """
+
+    def test_the_file_create_arm_records_an_observation(self, sandbox):
+        rid = jobs.new_run_id()
+        config.job_dir(rid).mkdir(parents=True)
+        jobs._record_spawn_failure(rid, OSError(8, "Exec format error"))
+        assert _precision(rid) == jobs.FINISHED_AT_OBSERVED
+
+    def test_the_merge_existing_arm_records_an_observation(self, sandbox):
+        rid = _started()
+        jobs._record_spawn_failure(rid, OSError(8, "Exec format error"))
+        assert _precision(rid) == jobs.FINISHED_AT_OBSERVED
+
+
 class TestThePathsThatWatchedItEnd:
     def test_a_kill_records_an_observation(self, sandbox, monkeypatch, no_delivery):
         rid = _started()
@@ -143,6 +162,29 @@ class TestReadingItBack:
         """
         rid = _started(status="completed", finished_at="2026-07-25T01:00:00+00:00")
         assert _precision(rid) is None
+
+    def test_status_reports_a_legacy_record_as_unknown(self, sandbox):
+        """The public reader, not just the raw record, must say "unknown".
+
+        `status()` reads `finished_at_precision` with `.get()` (jobs.py:1634), so
+        a record written before the field existed must still come back through
+        the real function with the value None rather than raising or defaulting.
+        """
+        rid = _started(status="completed", finished_at="2026-07-25T01:00:00+00:00")
+        st = jobs.status(rid)
+        assert st["finished_at"] == "2026-07-25T01:00:00+00:00"
+        assert st["finished_at_precision"] is None
+
+    def test_list_jobs_reports_a_legacy_record_as_unknown(self, sandbox):
+        """`list_jobs()` copies the field from `status()` (jobs.py:2152) — a
+        legacy record must flow through without a KeyError and with precision
+        None in the row, not just in the underlying `status()` call.
+        """
+        rid = _started(status="completed", finished_at="2026-07-25T01:00:00+00:00")
+        rows = jobs.list_jobs()
+        row = next(r for r in rows if r["run_id"] == rid)
+        assert row["finished_at"] == "2026-07-25T01:00:00+00:00"
+        assert row["finished_at_precision"] is None
 
     def test_every_terminal_path_answers(self, sandbox, monkeypatch, no_delivery):
         """A field only some writers set is a field a reader cannot use.

--- a/tests/mcp/test_finished_at_precision.py
+++ b/tests/mcp/test_finished_at_precision.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`finished_at` says when a run ended; this says whether anyone saw it end.
+
+Two of the paths that end a run cannot know the end time. They write the moment
+the end was *noticed*, which is a real upper bound and is not a duration. Stored
+in the same field as an observed end and with nothing to tell them apart, a
+noticed time reads as a run that took that long, and it reads that way in one
+direction only: too slow, never too fast.
+
+So the precision is recorded beside the value, by the path that knows which it
+is. These tests are about every terminal path answering, and about the two that
+must answer "upper_bound" being the two that actually do.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lionagi.mcp import _notify_hook, config, jobs
+
+_SPAWNED_AT = 1_700_000_000.0
+
+
+@pytest.fixture
+def sandbox(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(config, "li_command", lambda: ["echo"])
+    monkeypatch.setattr(jobs, "_read_lifecycle", lambda run_id: None)
+    return tmp_path
+
+
+@pytest.fixture
+def no_delivery(monkeypatch):
+    def _fake(run_id, job, status, **kw):
+        return {"attempted": True, "ok": True, "exit_code": 0, "error": None, "command": "notify"}
+
+    monkeypatch.setattr(_notify_hook, "deliver_terminal_notice", _fake)
+
+
+def _started(**fields: Any) -> str:
+    rid = jobs.new_run_id()
+    base: dict[str, Any] = {
+        "run_id": rid,
+        "pid": 4242,
+        "pid_create_time": _SPAWNED_AT,
+        "pgid": 4242,
+        "kind": "flow",
+        "label": "a-label",
+        "status": "running",
+        "spawn_state": "started",
+        "submitted_at": "2026-07-25T00:00:00+00:00",
+        "finished_at": None,
+        "log": None,
+    }
+    base.update(fields)
+    jobs._write_job(base)
+    return rid
+
+
+def _precision(run_id: str) -> str | None:
+    return jobs._read_job(run_id).get("finished_at_precision")
+
+
+class TestTheReaperSaysItOnlyNoticed:
+    def test_a_reaped_run_records_an_upper_bound_not_an_observation(
+        self, sandbox, monkeypatch, no_delivery
+    ):
+        # Nobody watched this process exit. The stored time is when the loss was
+        # established, so it bounds the end rather than being it.
+        monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+        rid = _started()
+        result = jobs.reap_orphan(
+            rid, finding=jobs.FINDING_PID_ABSENT, observed_at="2026-07-25T02:00:00+00:00"
+        )
+
+        assert result.won_transition is True
+        assert _precision(rid) == jobs.FINISHED_AT_UPPER_BOUND
+
+    def test_it_still_records_the_bound_it_has(self, sandbox, monkeypatch, no_delivery):
+        """Positive control: the bound is real and is still written.
+
+        Marking the value untrusted must not turn into dropping it, which would
+        leave a terminal run with no end time at all.
+        """
+        monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+        rid = _started()
+        jobs.reap_orphan(
+            rid, finding=jobs.FINDING_PID_ABSENT, observed_at="2026-07-25T02:00:00+00:00"
+        )
+
+        assert jobs._read_job(rid)["finished_at"] == "2026-07-25T02:00:00+00:00"
+
+
+class TestALifecycleRecordWithoutAnEndTime:
+    """The same gap as the reaper's, reached by a different path.
+
+    `_cache_lifecycle_end` prefers the lifecycle record's own end time and falls
+    back to now when there is none. The fallback is the same substitution, so it
+    gets the same answer.
+    """
+
+    def test_an_end_time_in_the_record_is_an_observation(self, sandbox, monkeypatch, no_delivery):
+        rid = _started()
+        job = jobs._read_job(rid)
+        out = jobs._cache_lifecycle_end(
+            job, {"terminal": True, "status": "completed", "ended_at": _SPAWNED_AT + 60}
+        )
+        assert out["finished_at_precision"] == jobs.FINISHED_AT_OBSERVED
+
+    def test_a_record_with_no_end_time_falls_back_and_says_so(
+        self, sandbox, monkeypatch, no_delivery
+    ):
+        rid = _started()
+        job = jobs._read_job(rid)
+        out = jobs._cache_lifecycle_end(job, {"terminal": True, "status": "completed"})
+        assert out["finished_at"] is not None
+        assert out["finished_at_precision"] == jobs.FINISHED_AT_UPPER_BOUND
+
+
+class TestThePathsThatWatchedItEnd:
+    def test_a_kill_records_an_observation(self, sandbox, monkeypatch, no_delivery):
+        rid = _started()
+        monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+        jobs._mark_killed(jobs._read_job(rid))
+        assert _precision(rid) == jobs.FINISHED_AT_OBSERVED
+
+    def test_the_terminal_hook_records_an_observation(self, sandbox, no_delivery):
+        rid = _started()
+        jobs.mark_terminal(rid, "completed")
+        assert _precision(rid) == jobs.FINISHED_AT_OBSERVED
+
+
+class TestReadingItBack:
+    def test_a_record_written_before_the_field_existed_reads_as_unknown(self, sandbox):
+        """Absent is its own answer.
+
+        Defaulting it to "observed" would restate the same confident guess one
+        layer up, on exactly the records that carry it.
+        """
+        rid = _started(status="completed", finished_at="2026-07-25T01:00:00+00:00")
+        assert _precision(rid) is None
+
+    def test_every_terminal_path_answers(self, sandbox, monkeypatch, no_delivery):
+        """A field only some writers set is a field a reader cannot use.
+
+        Stated as a set so a new terminal path that forgets it fails here rather
+        than shipping a silent null.
+        """
+        monkeypatch.setattr(jobs, "_pid_alive", lambda pid: False)
+        answers = {}
+
+        reaped = _started()
+        jobs.reap_orphan(
+            reaped, finding=jobs.FINDING_PID_ABSENT, observed_at="2026-07-25T02:00:00+00:00"
+        )
+        answers["reaper"] = _precision(reaped)
+
+        killed = _started()
+        jobs._mark_killed(jobs._read_job(killed))
+        answers["kill"] = _precision(killed)
+
+        hooked = _started()
+        jobs.mark_terminal(hooked, "completed")
+        answers["hook"] = _precision(hooked)
+
+        assert None not in answers.values(), answers
+        assert answers["reaper"] == jobs.FINISHED_AT_UPPER_BOUND
+        assert answers["kill"] == jobs.FINISHED_AT_OBSERVED
+        assert answers["hook"] == jobs.FINISHED_AT_OBSERVED


### PR DESCRIPTION
Closes #2835.

Two of the paths that end a run cannot know when it ended.

- The orphan reaper writes the moment the loss was established.
- The lifecycle cache falls back to now when the lifecycle record carries no end time of its own.

Both values are real upper bounds and neither is a duration. They were stored in the same field as an observed end, with nothing to tell them apart, so a consumer reading `finished_at` to answer "how long did this take" got a guess. The error only runs one way, toward slower than reality.

The way it shows up in data is one reaper pass stamping everything it found, which leaves several unrelated runs sharing a single implausible maximum to within a fraction of a minute.

`finished_at_precision` is now written beside the value by the path that knows which it is: `observed` where the end was seen (kill, terminal hook, spawn failure, a lifecycle record with a real end time), `upper_bound` where it was only noticed. It is surfaced on the job status and job list results.

Two details that are deliberate:

- Every terminal writer sets it. A field only some writers set is a field a reader cannot use, so a new terminal path that forgets it fails the test rather than shipping a silent null.
- A record written before the field existed reads as null, not as `observed`. Defaulting it would restate the same confident guess one layer up, on exactly the records that carry it.

The second writer, the lifecycle fallback, was not in the original report. It was found by checking every site that writes `finished_at` rather than only the one named.
