### PR TITLE
fix(state,studio): surface unreported cost instead of counting it as $0 spend

### DIFF
--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -3949,21 +3949,38 @@ class StateDB:
         total_cost_usd / (input_tokens + output_tokens). Used for the
         budget_usd / budget_tokens pre-fire gate: mirrors count_schedule_runs
         but sums a spend column instead of counting rows.
+
+        ``total_cost_usd`` is NULL when a session's cost was never reported
+        (the engine that ran it doesn't price itself), not when the session
+        was free -- COALESCE(...,0) on the sum is still the right headline
+        total, but a schedule whose spawned sessions mostly went unreported
+        would otherwise read as cheap rather than unmeasured. ``unreported_sessions``
+        counts terminal sessions (SESSION_TERMINAL_STATUSES) with a NULL
+        total_cost_usd; a still-running session's cost is expected to be
+        unknown until it finishes and isn't counted as a gap.
         """
+        status_placeholders = ", ".join(
+            f":status{i}" for i in range(len(SESSION_TERMINAL_STATUSES))
+        )
+        params: dict[str, Any] = {"schedule_id": schedule_id}
+        params.update({f"status{i}": s for i, s in enumerate(SESSION_TERMINAL_STATUSES)})
         query = (
-            "SELECT COALESCE(SUM(s.total_cost_usd), 0) AS cost_usd, "
+            "SELECT COALESCE(SUM(s.total_cost_usd), 0) AS cost_usd, "  # noqa: S608
             "COALESCE(SUM(s.input_tokens), 0) AS input_tokens, "
-            "COALESCE(SUM(s.output_tokens), 0) AS output_tokens "
+            "COALESCE(SUM(s.output_tokens), 0) AS output_tokens, "
+            "SUM(CASE WHEN s.total_cost_usd IS NULL "
+            f"AND s.status IN ({status_placeholders}) THEN 1 ELSE 0 END) AS unreported_sessions "
             "FROM schedule_runs sr JOIN sessions s ON s.invocation_id = sr.invocation_id "
             "WHERE sr.schedule_id = :schedule_id"
         )
         async with self._read() as conn:
-            row = (await conn.execute(text(query), {"schedule_id": schedule_id})).mappings().first()
+            row = (await conn.execute(text(query), params)).mappings().first()
         if not row:
-            return {"cost_usd": 0.0, "tokens": 0}
+            return {"cost_usd": 0.0, "tokens": 0, "unreported_sessions": 0}
         return {
             "cost_usd": float(row["cost_usd"] or 0),
             "tokens": int(row["input_tokens"] or 0) + int(row["output_tokens"] or 0),
+            "unreported_sessions": int(row["unreported_sessions"] or 0),
         }
 
     # Threshold-alert metrics (studio-wide, not scoped to a single schedule's
@@ -4069,6 +4086,34 @@ class StateDB:
                 (await conn.execute(text(query), {"window_start": window_start})).mappings().first()
             )
         return float(row["n"]) if row and row["n"] is not None else 0.0
+
+    async def metric_unreported_sessions(self, metric: str, window_start: float) -> int:
+        """Count terminal sessions in the metric's window with a NULL total_cost_usd.
+
+        Companion to the ``total_cost_usd`` branch of ``metric_value()``:
+        that query's COALESCE(SUM(total_cost_usd), 0) is the right headline
+        sum but treats an unreported session's cost as zero, so a threshold
+        alert on a mostly-unreported window can silently read as "cheap"
+        instead of "unmeasured". Only ``total_cost_usd`` has a NULL/reported
+        distinction to expose -- every other metric returns 0. A still-
+        running session's cost is expected to be NULL and isn't a gap.
+        """
+        if metric != "total_cost_usd":
+            return 0
+        status_placeholders = ", ".join(
+            f":status{i}" for i in range(len(SESSION_TERMINAL_STATUSES))
+        )
+        params: dict[str, Any] = {"window_start": window_start}
+        params.update({f"status{i}": s for i, s in enumerate(SESSION_TERMINAL_STATUSES)})
+        query = (
+            "SELECT COUNT(*) AS n FROM sessions "  # noqa: S608
+            "WHERE COALESCE(ended_at, started_at, created_at) >= :window_start "
+            "AND total_cost_usd IS NULL "
+            f"AND status IN ({status_placeholders})"
+        )
+        async with self._read() as conn:
+            row = (await conn.execute(text(query), params)).mappings().first()
+        return int(row["n"]) if row and row["n"] is not None else 0
 
     async def schedule_run_streak(self, schedule_id: str) -> tuple[int, str | None]:
         """Consecutive terminal 'failed' streak and most recent status, newest-first, capped at 50 rows."""

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1509,12 +1509,32 @@ class SchedulerEngine:
         nothing to reserve or release -- both budget_usd and budget_tokens
         unset means unbounded (always False). Either configured bound
         tripping is sufficient to report exhausted.
+
+        ``spend["cost_usd"]`` is a sum of *reported* cost only -- a session
+        whose engine never priced itself contributes nothing to it, not a
+        confirmed $0. This deliberately does not force exhaustion just
+        because some sessions are unreported (that would turn a data gap
+        into an outage for schedules that are, as far as anyone can tell,
+        fine); it only makes the gap visible via a log line here and via
+        ``unreported_sessions`` in the schedule's spend rollup, so a near-
+        zero reading with many unreported sessions is legible as "unknown",
+        not silently trusted as "cheap".
         """
         budget_usd = schedule.get("budget_usd")
         budget_tokens = schedule.get("budget_tokens")
         if not budget_usd and not budget_tokens:
             return False
         spend = await self._svc.sum_schedule_spend(schedule["id"])
+        if spend.get("unreported_sessions"):
+            _log.warning(
+                "Schedule %s (%s) budget check: %d spawned session(s) never reported "
+                "cost; observed cost_usd=%.4f/tokens=%d may undercount actual spend.",
+                schedule.get("name"),
+                schedule["id"],
+                spend["unreported_sessions"],
+                spend["cost_usd"],
+                spend["tokens"],
+            )
         if budget_usd and spend["cost_usd"] >= budget_usd:
             return True
         if budget_tokens and spend["tokens"] >= budget_tokens:
@@ -1526,7 +1546,15 @@ class SchedulerEngine:
 
         Shared by the two tick-loop fire paths (_maybe_fire, _tick_github);
         fire_now() refuses instead of disabling (mirrors max_runs).
+
+        Re-reads the spend rollup (already read once by the ``_check_budget``
+        call that led here) purely to attach ``unreported_sessions`` to the
+        disable record -- a human reading why a schedule got disabled should
+        be able to tell "spend actually crossed the line" from "spend
+        crossed the line but part of it is unmeasured, so the true total may
+        be higher still".
         """
+        spend = await self._svc.sum_schedule_spend(schedule["id"])
         _log.info(
             "Schedule %s (%s) has exhausted its budget (budget_usd=%s, budget_tokens=%s); "
             "disabling instead of firing",
@@ -1550,6 +1578,7 @@ class SchedulerEngine:
             metadata={
                 "budget_usd": schedule.get("budget_usd"),
                 "budget_tokens": schedule.get("budget_tokens"),
+                "unreported_sessions": spend.get("unreported_sessions", 0),
             },
         )
         await self._svc.update_schedule(schedule["id"], enabled=0)
@@ -1558,11 +1587,13 @@ class SchedulerEngine:
         """Evaluate ``schedule["threshold_config"]`` against live metrics.
 
         Returns a breach dict (``metric``, ``op``, ``value`` = observed,
-        ``threshold`` = configured, ``window_minutes``) that renders into
-        ``{{metric}}``/``{{value}}``/``{{threshold}}`` action-prompt
-        templates (see ``_subprocess.render_action_prompt`` and the
-        github_poll precedent it already handles), or ``None`` when the
-        metric is within bounds.
+        ``threshold`` = configured, ``window_minutes``, plus
+        ``unreported_sessions``/``spend_is_partial`` when the metric is
+        ``total_cost_usd`` and some sessions in the window never reported
+        cost) that renders into ``{{metric}}``/``{{value}}``/``{{threshold}}``
+        action-prompt templates (see ``_subprocess.render_action_prompt``
+        and the github_poll precedent it already handles), or ``None`` when
+        the metric is within bounds.
         """
         config = schedule.get("threshold_config")
         if not config:
@@ -1575,13 +1606,22 @@ class SchedulerEngine:
         observed = await self._svc.metric_value(metric, window_start)
         if not _threshold.compare(op, observed, threshold_value):
             return None
-        return {
+        breach: dict[str, Any] = {
             "metric": metric,
             "op": op,
             "value": observed,
             "threshold": threshold_value,
             "window_minutes": window_minutes,
         }
+        # total_cost_usd's COALESCE(SUM(...), 0) reads an unreported session
+        # as $0 -- surface how many sessions in this same window carried no
+        # cost data at all, so a breach (or its absence) isn't mistaken for
+        # a complete reading. Every other metric has no such gap.
+        unreported = await self._svc.metric_unreported_sessions(metric, window_start)
+        if unreported:
+            breach["unreported_sessions"] = unreported
+            breach["spend_is_partial"] = True
+        return breach
 
     async def _advance_next_fire_only(self, schedule: dict, now: float) -> None:
         """Advance next_fire_at without firing the schedule's action.

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1552,9 +1552,21 @@ class SchedulerEngine:
         disable record -- a human reading why a schedule got disabled should
         be able to tell "spend actually crossed the line" from "spend
         crossed the line but part of it is unmeasured, so the true total may
-        be higher still".
+        be higher still". The reread is annotation only: if it fails, the
+        disable and the skip record must still land, with the count marked
+        unknown rather than the enforcement aborted.
         """
-        spend = await self._svc.sum_schedule_spend(schedule["id"])
+        try:
+            spend = await self._svc.sum_schedule_spend(schedule["id"])
+        except Exception:
+            _log.warning(
+                "Could not re-read the spend rollup for schedule %s while "
+                "disabling it for budget exhaustion; recording the "
+                "unreported-session count as unknown",
+                schedule["id"],
+                exc_info=True,
+            )
+            spend = {}
         _log.info(
             "Schedule %s (%s) has exhausted its budget (budget_usd=%s, budget_tokens=%s); "
             "disabling instead of firing",
@@ -1578,7 +1590,7 @@ class SchedulerEngine:
             metadata={
                 "budget_usd": schedule.get("budget_usd"),
                 "budget_tokens": schedule.get("budget_tokens"),
-                "unreported_sessions": spend.get("unreported_sessions", 0),
+                "unreported_sessions": spend.get("unreported_sessions"),
             },
         )
         await self._svc.update_schedule(schedule["id"], enabled=0)

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -44,6 +44,8 @@ class SchedulerStateService(Protocol):
 
     async def metric_value(self, metric: str, window_start: float) -> float: ...
 
+    async def metric_unreported_sessions(self, metric: str, window_start: float) -> int: ...
+
     async def create_schedule_run(self, run: dict[str, Any]) -> None: ...
 
     async def create_schedule_run_and_advance(
@@ -139,6 +141,10 @@ class _DBSchedulerStateService:
     async def metric_value(self, metric: str, window_start: float) -> float:
         async with StateDB() as db:
             return await db.metric_value(metric, window_start)
+
+    async def metric_unreported_sessions(self, metric: str, window_start: float) -> int:
+        async with StateDB() as db:
+            return await db.metric_unreported_sessions(metric, window_start)
 
     async def create_schedule_run(self, run: dict[str, Any]) -> None:
         async with StateDB() as db:

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -421,10 +421,27 @@ async def list_schedules(
         for row in rows:
             if row.get("max_runs"):
                 row["remaining_runs"] = max(row["max_runs"] - used_by_id[row["id"]], 0)
+            if row.get("budget_usd") or row.get("budget_tokens"):
+                await _attach_spend(db, row)
             streak, last_status = streaks_by_id[row["id"]]
             row["consecutive_failures"] = streak
             row["last_status"] = last_status
     return rows
+
+
+async def _attach_spend(db: StateDB, row: dict[str, Any]) -> None:
+    """Attach the spend rollup to *row* in place, for schedules with a configured budget.
+
+    ``spend_is_partial`` (derived from ``unreported_sessions``) is what a caller/UI
+    should branch on to render "unknown/partial" instead of trusting ``spend_usd``
+    as a complete total -- see sum_schedule_spend's docstring for why an unreported
+    session's cost is not the same as a $0 one.
+    """
+    spend = await db.sum_schedule_spend(row["id"])
+    row["spend_usd"] = spend["cost_usd"]
+    row["spend_tokens"] = spend["tokens"]
+    row["unreported_sessions"] = spend["unreported_sessions"]
+    row["spend_is_partial"] = spend["unreported_sessions"] > 0
 
 
 async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
@@ -438,6 +455,8 @@ async def get_schedule(schedule_id: str) -> dict[str, Any] | None:
         if row.get("max_runs"):
             used = await db.count_schedule_runs(schedule_id, chain_depth=0)
             row["remaining_runs"] = max(row["max_runs"] - used, 0)
+        if row.get("budget_usd") or row.get("budget_tokens"):
+            await _attach_spend(db, row)
         streak, last_status = await db.schedule_run_streak(schedule_id)
         row["consecutive_failures"] = streak
         row["last_status"] = last_status

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -809,6 +809,52 @@ def test_schedules_detail_response_shape(tmp_path, monkeypatch):
     assert sorted(r.json().keys()) == _SCHEDULE_DETAIL_KEYS
 
 
+def test_schedules_detail_response_shape_with_budget_configured(tmp_path, monkeypatch):
+    """A schedule with budget_usd/budget_tokens configured additionally surfaces
+    the spend rollup (spend_usd, spend_tokens, unreported_sessions,
+    spend_is_partial). These keys are gated on a configured budget -- the
+    base _SCHEDULE_DETAIL_KEYS gate above uses a schedule with no budget
+    configured, so it's unaffected by this addition. Blessed deliberately
+    here rather than left to silently drift into the pinned shape."""
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+
+    async def _create() -> str:
+        import lionagi.studio.services.schedules as schedules_mod
+
+        created = await schedules_mod.create_schedule(
+            {
+                "name": f"gate-budget-{uuid.uuid4().hex[:8]}",
+                "trigger_type": "cron",
+                "cron_expr": "0 18 * * *",
+                "action_kind": "agent",
+                "action_prompt": "ping",
+                "budget_usd": 5.0,
+            }
+        )
+        return created["id"]
+
+    schedule_id = run_async(_create())
+    client = _make_client()
+
+    r = client.get(f"/api/schedules/{schedule_id}")
+    assert r.status_code == 200
+    body = r.json()
+    assert sorted(body.keys()) == sorted(
+        [
+            *_SCHEDULE_DETAIL_KEYS,
+            "spend_usd",
+            "spend_tokens",
+            "unreported_sessions",
+            "spend_is_partial",
+        ]
+    )
+    assert body["spend_usd"] == 0.0
+    assert body["spend_tokens"] == 0
+    assert body["unreported_sessions"] == 0
+    assert body["spend_is_partial"] is False
+
+
 def test_schedules_detail_404_shape(tmp_path, monkeypatch):
     _patch_db(monkeypatch, tmp_path / "state.db")
     client = _make_client()

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -232,6 +232,39 @@ async def test_maybe_fire_disables_and_records_when_over_budget():
 
 
 @pytest.mark.asyncio
+async def test_disable_still_lands_when_the_annotation_reread_fails():
+    """The rollup reread only annotates the disable record; a failure there
+    must not abort the disable or the skipped-run write."""
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.sum_schedule_spend = AsyncMock(
+        side_effect=[
+            {"cost_usd": 10.0, "tokens": 0, "unreported_sessions": 0},
+            RuntimeError("second read failed"),
+        ]
+    )
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(budget_usd=10.0, next_fire_at=1000.0)
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._maybe_fire(schedule, now=1000.0)
+
+    mock_tracked.assert_not_called()
+    svc.update_schedule.assert_awaited_once_with("sched-001", enabled=0)
+    svc.create_schedule_run.assert_awaited_once()
+    (run_payload,), _ = svc.create_schedule_run.await_args
+    assert run_payload["trigger_context"]["budget_exhausted"] is True
+    budget_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.kwargs.get("reason_code") == "schedule.budget.exhausted"
+    ]
+    assert budget_calls
+    assert budget_calls[0].kwargs["metadata"]["unreported_sessions"] is None
+
+
+@pytest.mark.asyncio
 async def test_maybe_fire_fires_normally_when_under_budget():
     from lionagi.studio.scheduler.engine import SchedulerEngine
 

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -554,6 +554,7 @@ async def test_spawned_cli_session_is_included_in_schedule_spend(tmp_path, monke
     assert await state.sum_schedule_spend(schedule_id) == {
         "cost_usd": pytest.approx(2.5),
         "tokens": 150,
+        "unreported_sessions": 0,
     }
 
     await state.close()
@@ -614,6 +615,7 @@ async def test_sum_schedule_spend_aggregates_across_sessions():
 
     assert spend["cost_usd"] == pytest.approx(1.5 + 3.0)
     assert spend["tokens"] == (100 + 50) + (200 + 100)
+    assert spend["unreported_sessions"] == 0
 
     await state.close()
 
@@ -636,7 +638,76 @@ async def test_sum_schedule_spend_zero_for_schedule_with_no_runs():
     )
 
     spend = await state.sum_schedule_spend("sched-spend-empty")
-    assert spend == {"cost_usd": 0.0, "tokens": 0}
+    assert spend == {"cost_usd": 0.0, "tokens": 0, "unreported_sessions": 0}
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_sum_schedule_spend_counts_unreported_terminal_sessions():
+    """A terminal session with NULL total_cost_usd is unreported, not free.
+
+    Regression coverage for the bug this fix addresses: before, COALESCE(SUM(...), 0)
+    let an unreported session's cost silently disappear into the $0 headline total
+    with no trace it had ever run. unreported_sessions is the trace.
+    """
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await state.create_schedule(
+        {
+            "id": "sched-spend-unreported",
+            "name": "spend-unreported",
+            "trigger_type": "interval",
+            "interval_sec": 60,
+            "action_kind": "agent",
+        }
+    )
+
+    # s0: reported cost. s1: terminal (completed) but never reported cost --
+    # counts as unreported. s2: still running -- unreported cost is expected
+    # and must NOT count as a gap.
+    statuses_and_costs = [
+        ("completed", 1.5),
+        ("completed", None),
+        ("running", None),
+    ]
+    for i, (status, cost) in enumerate(statuses_and_costs):
+        inv_id = f"inv-unrep-{i}"
+        await state.create_invocation({"id": inv_id, "skill": "agent", "started_at": 1.0})
+        await state.create_schedule_run(
+            {
+                "id": f"run-unrep-{i}",
+                "schedule_id": "sched-spend-unreported",
+                "invocation_id": inv_id,
+                "trigger_context": {},
+                "action_kind": "agent",
+                "action_args": [],
+                "status": "completed",
+                "chain_depth": 0,
+                "fired_at": 1.0,
+            }
+        )
+        prog_id = f"prog-unrep-{i}"
+        await state.create_progression(prog_id)
+        sess_id = f"sess-unrep-{i}"
+        await state.create_session(
+            {
+                "id": sess_id,
+                "progression_id": prog_id,
+                "status": status,
+                "invocation_id": inv_id,
+            }
+        )
+        if cost is not None:
+            await state.update_session(sess_id, total_cost_usd=cost)
+
+    spend = await state.sum_schedule_spend("sched-spend-unreported")
+
+    assert spend["cost_usd"] == pytest.approx(1.5)
+    assert spend["unreported_sessions"] == 1
 
     await state.close()
 

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -54,6 +54,7 @@ def _make_svc() -> AsyncMock:
     svc.count_schedule_runs = AsyncMock(return_value=0)
     svc.sum_schedule_spend = AsyncMock(return_value={"cost_usd": 0.0, "tokens": 0})
     svc.metric_value = AsyncMock(return_value=0.0)
+    svc.metric_unreported_sessions = AsyncMock(return_value=0)
     svc.get_invocation = AsyncMock(return_value=None)
     svc.compute_files_overlap = AsyncMock(return_value={"count": 0, "top": []})
     return svc
@@ -225,6 +226,43 @@ async def test_evaluate_threshold_breach_returns_breach_dict_when_over():
         "value": 42.0,
         "threshold": 10.0,
         "window_minutes": 15,
+    }
+    svc.metric_unreported_sessions.assert_awaited_once_with("total_cost_usd", 5000.0 - 15 * 60)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_threshold_breach_flags_partial_spend_when_sessions_unreported():
+    """A total_cost_usd breach whose window has unreported sessions must say so.
+
+    Regression coverage: COALESCE(SUM(total_cost_usd), 0) treats an unreported
+    session as $0, so a breach dict with no unreported_sessions/spend_is_partial
+    keys would read as a complete, trustworthy total even when it isn't.
+    """
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.metric_value = AsyncMock(return_value=42.0)
+    svc.metric_unreported_sessions = AsyncMock(return_value=3)
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        threshold_config={
+            "metric": "total_cost_usd",
+            "op": "gte",
+            "value": 10.0,
+            "window_minutes": 15,
+        }
+    )
+
+    breach = await engine._evaluate_threshold_breach(schedule, now=5000.0)
+
+    assert breach == {
+        "metric": "total_cost_usd",
+        "op": "gte",
+        "value": 42.0,
+        "threshold": 10.0,
+        "window_minutes": 15,
+        "unreported_sessions": 3,
+        "spend_is_partial": True,
     }
 
 
@@ -822,6 +860,62 @@ async def test_metric_value_total_cost_usd_sums_only_in_window():
 
     total = await state.metric_value("total_cost_usd", window_start=50.0)
     assert total == pytest.approx(4.0)
+
+    await state.close()
+
+
+@pytest.mark.asyncio
+async def test_metric_unreported_sessions_counts_null_cost_terminal_sessions_in_window():
+    """A terminal session in the window with NULL total_cost_usd is unreported.
+
+    Regression coverage: metric_value("total_cost_usd", ...) sums
+    COALESCE(total_cost_usd, 0), so this session's absence is invisible to
+    it -- metric_unreported_sessions is the only thing that surfaces it.
+    """
+    from lionagi.state.db import StateDB
+
+    state = StateDB(":memory:")
+    await state.open()
+
+    await _make_session(state, "s1", status="completed", ended_at=100.0, total_cost_usd=1.5)
+    # s2 never got a total_cost_usd update -- terminal but unreported.
+    await state.create_progression("prog-s2")
+    await state.create_session(
+        {
+            "id": "s2",
+            "progression_id": "prog-s2",
+            "status": "completed",
+            "started_at": 99.0,
+            "ended_at": 110.0,
+        }
+    )
+    # s3-running: unreported cost is expected mid-flight, not a gap.
+    await state.create_progression("prog-s3")
+    await state.create_session(
+        {
+            "id": "s3-running",
+            "progression_id": "prog-s3",
+            "status": "running",
+            "started_at": 105.0,
+        }
+    )
+    # s4-before-window: unreported but outside the window.
+    await state.create_progression("prog-s4")
+    await state.create_session(
+        {
+            "id": "s4-before-window",
+            "progression_id": "prog-s4",
+            "status": "completed",
+            "started_at": 9.0,
+            "ended_at": 10.0,
+        }
+    )
+
+    unreported = await state.metric_unreported_sessions("total_cost_usd", window_start=50.0)
+    assert unreported == 1
+
+    other_metric = await state.metric_unreported_sessions("failed_sessions", window_start=50.0)
+    assert other_metric == 0
 
     await state.close()
 


### PR DESCRIPTION
Fixes #2857.

Budget and spend rollups used `COALESCE(SUM(total_cost_usd), 0)`, silently reading unreported cost (NULL) as $0. A schedule whose sessions never reported cost looked free, so budget enforcement passed on missing data.

- `sum_schedule_spend` and a new `metric_unreported_sessions` companion now count terminal sessions in the rollup window that never reported cost.
- Budget checks, budget-exhaustion disable, and threshold-breach evaluation carry the partial-data condition through logs, skipped-run metadata, and breach payloads.
- Schedule detail/list APIs expose `spend_usd`, `spend_tokens`, `unreported_sessions`, `spend_is_partial` for budgeted schedules (mirrors the existing `remaining_runs` pattern).
- Headline totals are unchanged: the sum of known costs stays the displayed number; the fix makes the missing-data condition visible rather than inventing numbers.

Tests: db-layer rollup tests with seeded NULL-cost sessions, scheduler budget/threshold suites, API-shape gate updated deliberately.