### PR TITLE
fix(mirror): link escalation-leg CLI transcripts to their parent run

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -1441,6 +1441,13 @@ async def setup_orchestration_persist(
             "artifacts_path": artifacts_path,
             "artifact_contract": artifact_contract,
             "identity_markers": _identity_markers,
+            # The RESOLVED project (explicit arg, or detect_project() fallback) —
+            # what the session row above actually got, not the caller's raw
+            # argument. Anything downstream attributing other data to this run's
+            # project (e.g. an escalation-leg mirror link) must read this, not
+            # re-derive or pass through the unresolved `project` parameter.
+            "project": _proj,
+            "project_source": _proj_src,
         }
 
         # Bind to the already-open DB so signals write without a per-signal open.
@@ -1593,6 +1600,12 @@ async def start_live_persist(
         extra_node_metadata=extra_node_metadata,
     )
     env._live_persist = ctx
+    # The resolved project (what the session row actually got — explicit arg or
+    # detect_project() fallback), for anything downstream that needs to attribute
+    # more data to this run's project (e.g. an escalation-leg mirror link). `ctx`
+    # is None when persistence setup itself failed, and `project` unresolved
+    # then too since setup never got to resolving it.
+    env._project = ctx.get("project") if ctx else None
 
 
 async def stop_live_persist(

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -9,6 +9,7 @@ import contextlib
 import json
 import logging
 import os
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1468,8 +1469,18 @@ async def _execute_dag(
             for _t in _survivors:
                 _t.cancel()
             if _survivors:
-                with contextlib.suppress(Exception):
+                # A survivor that itself swallows cancellation (or blocks in
+                # sync code) would otherwise hang this await forever — bound
+                # the wait too, and abandon whatever is still alive after it
+                # rather than let a single stuck link task block teardown.
+                with contextlib.suppress(Exception), move_on_after(2):
                     await _asyncio.gather(*_survivors, return_exceptions=True)
+                _abandoned = [t for t in _survivors if not t.done()]
+                if _abandoned:
+                    _warn(
+                        f"abandoned {len(_abandoned)} escalation-link task(s) "
+                        "still alive after cancellation grace period"
+                    )
 
         # Completion observers schedule persistence writes synchronously but the
         # writes themselves are async. Drain them while the live DB is still open.
@@ -1491,20 +1502,37 @@ async def _execute_dag(
                     # db/session teardown (teardown_persist) only runs after this
                     # function returns, so draining here, not firing untracked, is
                     # what keeps a late retry from writing into a store this run
-                    # has already closed. But a cancellation can also land on
-                    # *this* task after run_dag() already returned — the shield
-                    # above stops anyio-mediated cancellation, not a direct
-                    # cancel() on this task — so _dag_cancelled is False and this
-                    # gather is the one that would otherwise hang unbounded.
-                    # Catch that arrival and fall through to the same
-                    # grace+cancel path, then re-raise so the caller still
-                    # observes the cancellation.
-                    with contextlib.suppress(Exception):
-                        try:
-                            await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
-                        except _asyncio.CancelledError:
-                            await _drain_escalation_links_bounded()
-                            raise
+                    # has already closed.
+                    #
+                    # A cancellation can also land on *this* task after
+                    # run_dag() already returned — the CancelScope shield above
+                    # only stops anyio-mediated cancellation, not a direct
+                    # cancel() on this task — so _dag_cancelled stays False and
+                    # this is the await that would otherwise take it. gather()
+                    # only settles its own cancellation once every child
+                    # actually finishes, so a link task that swallows the one
+                    # cancel it's handed (or blocks past it) would leave a bare
+                    # `await gather(...)` parked here forever — asyncio.shield
+                    # lets this await raise promptly instead of waiting on the
+                    # children, which keep running in the background for
+                    # _drain_escalation_links_bounded() to actually finish off.
+                    # Re-raise afterward so the caller still observes the
+                    # cancellation — unless the try body already raised a real
+                    # exception, in which case that exception is what the
+                    # caller was waiting on and must win; a cancellation that
+                    # only landed during this teardown drain must not silently
+                    # replace it.
+                    _in_flight_exc = sys.exc_info()[1]
+                    try:
+                        with contextlib.suppress(Exception):
+                            await _asyncio.shield(
+                                _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
+                            )
+                    except _asyncio.CancelledError as _late_cancel:
+                        await _drain_escalation_links_bounded()
+                        if _in_flight_exc is not None:
+                            raise _in_flight_exc from _late_cancel
+                        raise
     t_exec_elapsed = time.monotonic() - t_exec
 
     op_results = dag_result.get("operation_results", {})

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1454,6 +1454,23 @@ async def _execute_dag(
                 await _exch_task
             # Route any final outbox sends left over after the last collect tick.
             await _exchange.collect_all()
+
+        async def _drain_escalation_links_bounded() -> None:
+            # An escalation-link row is nice-to-have attribution, not run
+            # data — losing one to cancellation is acceptable, but a hung
+            # link write (stuck DB call) blocking teardown indefinitely is
+            # not. Give in-flight links a short grace period to land
+            # normally, then cancel whatever is left and wait for it to
+            # actually unwind before returning.
+            with contextlib.suppress(Exception), move_on_after(2):
+                await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
+            _survivors = [t for t in _escalation_link_tasks if not t.done()]
+            for _t in _survivors:
+                _t.cancel()
+            if _survivors:
+                with contextlib.suppress(Exception):
+                    await _asyncio.gather(*_survivors, return_exceptions=True)
+
         # Completion observers schedule persistence writes synchronously but the
         # writes themselves are async. Drain them while the live DB is still open.
         with CancelScope(shield=True):
@@ -1465,28 +1482,29 @@ async def _execute_dag(
                     await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
             if _escalation_link_tasks:
                 if _dag_cancelled:
-                    # An escalation-link row is nice-to-have attribution, not
-                    # run data — losing one on cancellation is acceptable, but
-                    # a hung link write (stuck DB call) blocking teardown
-                    # indefinitely is not. Give in-flight links a short grace
-                    # period to land normally, then cancel whatever is left
-                    # and wait for it to actually unwind before returning.
-                    with contextlib.suppress(Exception), move_on_after(2):
-                        await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
-                    _survivors = [t for t in _escalation_link_tasks if not t.done()]
-                    for _t in _survivors:
-                        _t.cancel()
-                    if _survivors:
-                        with contextlib.suppress(Exception):
-                            await _asyncio.gather(*_survivors, return_exceptions=True)
+                    # Cancellation already landed while run_dag() was running,
+                    # so go straight to the bounded path.
+                    await _drain_escalation_links_bounded()
                 else:
                     # Bounded by _ESCALATION_LINK_RETRIES * _ESCALATION_LINK_RETRY_INTERVAL
-                    # (a few seconds worst case) — the outer db/session teardown
-                    # (teardown_persist) only runs after this function returns, so
-                    # draining here, not firing untracked, is what keeps a late retry
-                    # from writing into a store this run has already closed.
+                    # (a few seconds worst case) in the happy path — the outer
+                    # db/session teardown (teardown_persist) only runs after this
+                    # function returns, so draining here, not firing untracked, is
+                    # what keeps a late retry from writing into a store this run
+                    # has already closed. But a cancellation can also land on
+                    # *this* task after run_dag() already returned — the shield
+                    # above stops anyio-mediated cancellation, not a direct
+                    # cancel() on this task — so _dag_cancelled is False and this
+                    # gather is the one that would otherwise hang unbounded.
+                    # Catch that arrival and fall through to the same
+                    # grace+cancel path, then re-raise so the caller still
+                    # observes the cancellation.
                     with contextlib.suppress(Exception):
-                        await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
+                        try:
+                            await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
+                        except _asyncio.CancelledError:
+                            await _drain_escalation_links_bounded()
+                            raise
     t_exec_elapsed = time.monotonic() - t_exec
 
     op_results = dag_result.get("operation_results", {})

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1412,6 +1412,7 @@ async def _execute_dag(
     _ctl_task = _asyncio.ensure_future(_control_poll_loop())
     _exchange = getattr(env, "exchange", None)
     _exch_task = _asyncio.ensure_future(_exchange.run(0.5)) if _exchange is not None else None
+    _dag_cancelled = False
     try:
         dag_result = await eng_run.run_dag(
             env.builder.get_graph(),
@@ -1437,6 +1438,9 @@ async def _execute_dag(
             spawn_branch_setup=_spawn_branch_setup if reactive else None,
             on_op_complete=_on_op_complete,
         )
+    except _asyncio.CancelledError:
+        _dag_cancelled = True
+        raise
     finally:
         _hb_task.cancel()
         _ctl_task.cancel()
@@ -1460,13 +1464,29 @@ async def _execute_dag(
                 with contextlib.suppress(Exception):
                     await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
             if _escalation_link_tasks:
-                # Bounded by _ESCALATION_LINK_RETRIES * _ESCALATION_LINK_RETRY_INTERVAL
-                # (a few seconds worst case) — the outer db/session teardown
-                # (teardown_persist) only runs after this function returns, so
-                # draining here, not firing untracked, is what keeps a late retry
-                # from writing into a store this run has already closed.
-                with contextlib.suppress(Exception):
-                    await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
+                if _dag_cancelled:
+                    # An escalation-link row is nice-to-have attribution, not
+                    # run data — losing one on cancellation is acceptable, but
+                    # a hung link write (stuck DB call) blocking teardown
+                    # indefinitely is not. Give in-flight links a short grace
+                    # period to land normally, then cancel whatever is left
+                    # and wait for it to actually unwind before returning.
+                    with contextlib.suppress(Exception), move_on_after(2):
+                        await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
+                    _survivors = [t for t in _escalation_link_tasks if not t.done()]
+                    for _t in _survivors:
+                        _t.cancel()
+                    if _survivors:
+                        with contextlib.suppress(Exception):
+                            await _asyncio.gather(*_survivors, return_exceptions=True)
+                else:
+                    # Bounded by _ESCALATION_LINK_RETRIES * _ESCALATION_LINK_RETRY_INTERVAL
+                    # (a few seconds worst case) — the outer db/session teardown
+                    # (teardown_persist) only runs after this function returns, so
+                    # draining here, not firing untracked, is what keeps a late retry
+                    # from writing into a store this run has already closed.
+                    with contextlib.suppress(Exception):
+                        await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
     t_exec_elapsed = time.monotonic() - t_exec
 
     op_results = dag_result.get("operation_results", {})

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -942,6 +942,7 @@ async def _execute_dag(
     _executor_ref: dict[str, object] = {}
     _checkpoint_tasks: list = []
     _branch_status_tasks: list = []
+    _escalation_link_tasks: list = []
 
     _checkpoint_writer: CheckpointWriter | None = None
     if checkpoint_config is not None:
@@ -1321,7 +1322,7 @@ async def _execute_dag(
                 _ESCALATION_LINK_RETRIES,
             )
 
-        _asyncio.ensure_future(_do())
+        _escalation_link_tasks.append(_asyncio.ensure_future(_do()))
 
     def _on_op_complete(node: Any) -> None:
         """ReactiveExecutor.on_op_complete callback: called for every completed node."""
@@ -1458,6 +1459,14 @@ async def _execute_dag(
             if _checkpoint_tasks:
                 with contextlib.suppress(Exception):
                     await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
+            if _escalation_link_tasks:
+                # Bounded by _ESCALATION_LINK_RETRIES * _ESCALATION_LINK_RETRY_INTERVAL
+                # (a few seconds worst case) — the outer db/session teardown
+                # (teardown_persist) only runs after this function returns, so
+                # draining here, not firing untracked, is what keeps a late retry
+                # from writing into a store this run has already closed.
+                with contextlib.suppress(Exception):
+                    await _asyncio.gather(*_escalation_link_tasks, return_exceptions=True)
     t_exec_elapsed = time.monotonic() - t_exec
 
     op_results = dag_result.get("operation_results", {})
@@ -2033,11 +2042,11 @@ async def _run_flow(
     if resume_checkpoint is not None and resume_checkpoint.get("session_id"):
         _extra_node_metadata["resumed_from"] = resume_checkpoint["session_id"]
 
-    # Stashed for _execute_dag's escalation-mirror-link hook, which runs deeper in
-    # the call chain than this run's resolved project — not a declared env field,
-    # same as `_escalated_evidence`/`_finalize_extras` below.
-    env._project = project
-
+    # start_live_persist resolves `project` (explicit arg, or detect_project()
+    # fallback) and stashes the RESOLVED value on env._project — what the
+    # session row actually gets — for _execute_dag's escalation-mirror-link
+    # hook, which runs deeper in the call chain and must inherit the same
+    # project the run itself was attributed, not re-guess from cwd.
     await start_live_persist(
         env,
         invocation_kind=_invocation_kind,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -151,6 +151,14 @@ _CONTROL_POLL_INTERVAL = 2.0
 # tick here rather than let later controls overtake it in the DB.
 _CONTROL_UNSTAMPED = "unstamped"
 
+# ── Escalation mirror linking — attributes an escalated leg's CLI transcript
+# back to this run instead of leaving it an unlinked, misattributed session.
+# The transcript mirror may run in another process and lag behind this run's
+# own completion, so the link write gets a few bounded retries rather than
+# firing once and giving up.
+_ESCALATION_LINK_RETRIES = 5
+_ESCALATION_LINK_RETRY_INTERVAL = 1.0
+
 # ── Team lifecycle (done-signal / wakeup rounds / quiescence) ───────────────
 # Driven by ReactiveExecutor's on_op_complete hook, not a poll loop (which
 # would race the executor's task-group teardown) — see TeamLifecycleCoordinator.
@@ -1258,6 +1266,68 @@ async def _execute_dag(
                 f"woke {', '.join(sorted(state.pending_targets))}"
             )
 
+    def _link_escalation_mirror(node: Any) -> None:
+        """Attribute an escalation child's CLI transcript to this run.
+
+        No-ops for anything that isn't an escalation child (no ``escalated_from``
+        metadata) or that didn't run on a CLI engine (``provider_session_id`` unset —
+        API-provider retries have nothing for the transcript mirror to link). The
+        session uid a CLI engine reports is the same one the mirror keys its session
+        row by, so it is the only thing this run and a detached mirror sweep share.
+        """
+        metadata = getattr(node, "metadata", None)
+        parent_op_id = metadata.get("escalated_from") if metadata else None
+        if not parent_op_id:
+            return
+        chat_model = getattr(getattr(node, "_branch", None), "chat_model", None)
+        session_uid = getattr(chat_model, "provider_session_id", None) if chat_model else None
+        if not session_uid:
+            return
+        ctx = getattr(env, "_live_persist", None)
+        db = ctx.get("db") if ctx else None
+        if db is None:
+            return
+        escalated_label = metadata.get("escalated_from_name") or parent_op_id[:8]
+        display_name = f"escalation of {escalated_label}"
+        project = getattr(env, "_project", None)
+        project_source = "escalation_parent" if project else None
+
+        async def _do() -> None:
+            from lionagi.state.claude_mirror import link_escalation_session
+
+            for attempt in range(_ESCALATION_LINK_RETRIES):
+                if attempt:
+                    await _asyncio.sleep(_ESCALATION_LINK_RETRY_INTERVAL)
+                try:
+                    linked = await link_escalation_session(
+                        db,
+                        session_uid=session_uid,
+                        run_id=env.run.run_id,
+                        name=display_name,
+                        project=project,
+                        project_source=project_source,
+                        parent_op_id=parent_op_id,
+                    )
+                except Exception:  # noqa: BLE001 — a link failure must not affect the run
+                    logger.exception(
+                        "escalation mirror link failed for session %s", session_uid[:8]
+                    )
+                    return
+                if linked:
+                    return
+            logger.warning(
+                "escalation mirror link: no mirrored session for %s after %d retries",
+                session_uid[:8],
+                _ESCALATION_LINK_RETRIES,
+            )
+
+        _asyncio.ensure_future(_do())
+
+    def _on_op_complete(node: Any) -> None:
+        """ReactiveExecutor.on_op_complete callback: called for every completed node."""
+        _link_escalation_mirror(node)
+        _on_team_op_complete(node)
+
     async def _control_poll_loop() -> None:
         while True:
             await _asyncio.sleep(_CONTROL_POLL_INTERVAL)
@@ -1364,7 +1434,7 @@ async def _execute_dag(
                 register_branch_hook(env._live_persist, branch) if env._live_persist else None
             ),
             spawn_branch_setup=_spawn_branch_setup if reactive else None,
-            on_op_complete=_on_team_op_complete if _team_coordinator is not None else None,
+            on_op_complete=_on_op_complete,
         )
     finally:
         _hb_task.cancel()
@@ -1962,6 +2032,11 @@ async def _run_flow(
     _extra_node_metadata: dict = {"run_id": env.run.run_id}
     if resume_checkpoint is not None and resume_checkpoint.get("session_id"):
         _extra_node_metadata["resumed_from"] = resume_checkpoint["session_id"]
+
+    # Stashed for _execute_dag's escalation-mirror-link hook, which runs deeper in
+    # the call chain than this run's resolved project — not a declared env field,
+    # same as `_escalated_evidence`/`_finalize_extras` below.
+    env._project = project
 
     await start_live_persist(
         env,

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -936,6 +936,10 @@ class ReactiveExecutor(DependencyAwareExecutor):
             }
             child = create_operation(emitter.operation, parameters=child_params)
             child.metadata["escalated_from"] = op_id
+            # Readable label for anything attributing this child's work back to the
+            # node it retries (e.g. mirroring a CLI engine's transcript) — cheaper to
+            # carry now than to re-derive `name` from a stale emitter reference later.
+            child.metadata["escalated_from_name"] = name
             if self._accept_node(child, emitter_id=emitter_id, independent=True):
                 self._escalated_ids.add(emitter_id)
         elif route == "notify":

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -363,3 +363,51 @@ async def link_session_lineage(
         parent_uid=parent_uid,
         parent_event_uuid=parent_event_uuid,
     )
+
+
+async def link_escalation_session(
+    db: StateDB,
+    *,
+    session_uid: str,
+    run_id: str,
+    name: str,
+    project: str | None,
+    project_source: str | None,
+    parent_op_id: str,
+) -> bool:
+    """Attribute a mirrored CLI transcript to the run whose escalation spawned it.
+
+    A flow escalation (``operations.flow._schedule_escalation``) retries a node on a
+    higher-tier CLI engine as an in-session child op; the engine's own transcript is
+    mirrored independently (by this module, possibly in another process) under a
+    session uid the mirror has no way to connect back to the run. The escalation call
+    site learns that uid once the child op's branch reports it
+    (``branch.chat_model.provider_session_id``) and calls this to stamp the link —
+    overwriting the mirror's cwd-guessed ``project`` and first-prompt-derived ``name``,
+    which are wrong for an escalation leg by construction: its transcript's ``cwd`` is
+    the leg's scratch workspace, not a project, and its first prompt is the injected
+    escalation guidance, not a task description. The mirror never revisits either
+    field once a session row exists, so this write is never clobbered by a later sweep.
+
+    Returns ``False`` if the mirror hasn't created the session row yet — the escalation
+    call site is expected to retry for a bounded window rather than lose the link,
+    since which side writes first is a race with no fixed winner.
+    """
+    sid = session_db_id(session_uid)
+    existing = await db.get_session(sid)
+    if existing is None:
+        return False
+    meta = dict(existing.get("node_metadata") or {})
+    meta["escalated_from_session"] = parent_op_id
+    fields: dict[str, Any] = {
+        "name": name,
+        "run_id": run_id,
+        "node_metadata": json.dumps(meta),
+    }
+    # An unresolved run project is not evidence the mirror's cwd guess is wrong —
+    # leave it alone rather than overwrite a real (if imprecise) value with NULL.
+    if project:
+        fields["project"] = project
+        fields["project_source"] = project_source
+    await db.update_session(sid, **fields)
+    return True

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -226,6 +226,7 @@ _VALID_STATUS_SOURCES: frozenset[str] = frozenset({"executor", "agent", "admin",
 _SESSION_COLUMNS = frozenset(
     {
         "cc_session_id",
+        "run_id",
         "name",
         "user",
         "node_metadata",

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2593,14 +2593,24 @@ async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
     temp_db_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Round-4 regression: the round-3 fix only bounds the drain when
-    cancellation lands *during* ``run_dag()`` (caught by the ``except
-    asyncio.CancelledError`` that sets ``_dag_cancelled``). If ``run_dag()``
-    already returned and cancellation instead lands while ``_execute_dag``
-    is inside the finally's own (until now unguarded) drain gather, that
-    except never ran, ``_dag_cancelled`` stays False, and the drain took the
-    normal unbounded gather — hanging just like the round-3 bug, just from a
-    later arrival window."""
+    """A cancellation landing on ``_execute_dag`` itself after ``run_dag()``
+    already returned lands while the finally is inside its own drain
+    gather, where the except that sets ``_dag_cancelled`` never ran — so
+    that flag stays False, and this is the branch that must bound the
+    drain on its own, not just when cancellation lands mid-``run_dag()``.
+
+    A link task that responds to a *single* cancellation is not enough to
+    exercise this: ``asyncio.gather()``'s own cancellation only needs the
+    one child to unwind once, so a bare, unguarded gather already handles
+    it without any except/drain machinery. This link task instead swallows
+    the *first* cancellation it receives and only unwinds on a second one —
+    a bare gather with no except and no bounded drain genuinely hangs
+    forever on a single external cancel against a task like this, because
+    ``asyncio.gather()`` doesn't settle its own cancellation until every
+    child actually finishes, and a raw ``Task.cancel()`` only delivers once.
+    Verified by temporarily reverting the shield+drain handling below back
+    to that bare-gather shape and running this exact test: it timed out at
+    the 8s deadline instead of finishing at ~2s."""
     import time
     from types import SimpleNamespace
     from unittest.mock import patch
@@ -2625,13 +2635,18 @@ async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
     link_started = asyncio.Event()
     link_cancelled = asyncio.Event()
 
-    async def _hanging_link(*a, **k):
+    async def _swallow_once_link(*a, **k):
         link_started.set()
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            link_cancelled.set()
-            raise
+        swallowed = False
+        while True:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                if not swallowed:
+                    swallowed = True
+                    continue
+                link_cancelled.set()
+                raise
 
     plan_result = _PlanResult(
         assignments=[TaskAssignment(task="do it", assignee="worker")],
@@ -2660,7 +2675,7 @@ async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
 
     engine_run = SimpleNamespace(run_dag=run_dag)
     with (
-        patch("lionagi.state.claude_mirror.link_escalation_session", _hanging_link),
+        patch("lionagi.state.claude_mirror.link_escalation_session", _swallow_once_link),
         patch.object(PlanningEngine, "new_run", return_value=engine_run),
     ):
         execute_task = asyncio.create_task(
@@ -2674,13 +2689,221 @@ async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
 
         start = time.monotonic()
         with pytest.raises(asyncio.CancelledError):
-            await asyncio.wait_for(execute_task, timeout=5)
+            await asyncio.wait_for(execute_task, timeout=8)
         elapsed = time.monotonic() - start
 
-    assert elapsed < 5, (
+    assert elapsed < 6, (
         f"teardown took {elapsed}s — a late-arriving cancellation still hangs the drain"
     )
     assert link_cancelled.is_set()
+    await stop_live_persist(env, status="completed")
+
+
+async def test_execute_dag_bounds_escalation_link_drain_survivor_await(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``_drain_escalation_links_bounded`` gives in-flight links a grace
+    period, then cancels whatever survived and awaits the survivors — that
+    second await used to have no bound at all, so a link task that never
+    responds to that cancellation would hang it forever, the same class of
+    bug the grace period was added to fix in the first place, just moved
+    one step later. The fix bounds that second await too (a second short
+    grace window) and abandons anything still alive after it, logging how
+    many.
+
+    Caveat verified while building this test: this specific link task
+    (needs two cancellation deliveries to unwind) exercises the full drain
+    sequence — grace-period gather, explicit cancel of survivors, second
+    bounded gather — end to end, and the whole thing stays comfortably
+    inside the hard deadline below. It does not, on its own, prove the
+    second window's *bound* is load-bearing for this exact shape: anyio's
+    cancel scope keeps re-delivering cancellation for as long as a task
+    keeps re-suspending on a fresh awaitable, so a finite swallow count
+    (however large) tends to resolve inside the *first* grace window rather
+    than surviving into the second. A link task that never responds to
+    cancellation at all defeats both grace windows identically (confirmed
+    empirically: neither the first nor the second `move_on_after` returns
+    control while such a task stays alive) — there is no way to construct a
+    task that reliably survives window one but is bounded by window two, so
+    this test cannot safely isolate that distinction. What it does verify:
+    the drain sequence introduced by this fix does not regress a link task
+    that needs more than a single cancellation to unwind, and the
+    abandonment logic
+    does not itself hang anything."""
+    import time
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.engines import PlanningEngine
+    from lionagi.operations.node import create_operation
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    node = create_operation("operate", parameters={})
+    node.metadata["escalated_from"] = "parent-op-1"
+    node.metadata["escalated_from_name"] = "worker"
+    node._branch = SimpleNamespace(
+        chat_model=SimpleNamespace(provider_session_id="cli-session-xyz")
+    )
+
+    link_started = asyncio.Event()
+    link_cancelled = asyncio.Event()
+
+    async def _swallow_once_link(*a, **k):
+        link_started.set()
+        swallowed = False
+        while True:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                if not swallowed:
+                    swallowed = True
+                    continue
+                link_cancelled.set()
+                raise
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["test/model"],
+    )
+
+    async def run_dag(graph, **kwargs):
+        on_op_complete = kwargs.get("on_op_complete")
+        if on_op_complete is not None:
+            on_op_complete(node)
+        # Hangs until _execute_dag's own task is cancelled from outside —
+        # cancellation lands *during* run_dag(), so _dag_cancelled is True
+        # and the drain goes straight through _drain_escalation_links_bounded.
+        await asyncio.Event().wait()
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    with (
+        patch("lionagi.state.claude_mirror.link_escalation_session", _swallow_once_link),
+        patch.object(PlanningEngine, "new_run", return_value=engine_run),
+    ):
+        execute_task = asyncio.create_task(
+            _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+        )
+        await link_started.wait()
+        execute_task.cancel()
+
+        start = time.monotonic()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(execute_task, timeout=8)
+        elapsed = time.monotonic() - start
+
+    assert elapsed < 6, (
+        f"teardown took {elapsed}s — the escalation-link survivor await is unbounded again"
+    )
+    assert link_cancelled.is_set()
+    await stop_live_persist(env, status="completed")
+
+
+async def test_execute_dag_late_cancellation_does_not_clobber_dag_exception(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The finally's escalation-link drain re-raises a ``CancelledError``
+    that lands during the drain itself. When ``run_dag()`` raised a real
+    exception (not a cancellation) and *that* exception is what's
+    propagating through the finally, a cancellation landing during the
+    drain must not silently replace it — the caller was waiting on the real
+    failure, not a teardown-time cancellation that has nothing to do with
+    why the run actually failed."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.engines import PlanningEngine
+    from lionagi.operations.node import create_operation
+
+    class _DagBoomError(RuntimeError):
+        pass
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    node = create_operation("operate", parameters={})
+    node.metadata["escalated_from"] = "parent-op-1"
+    node.metadata["escalated_from_name"] = "worker"
+    node._branch = SimpleNamespace(
+        chat_model=SimpleNamespace(provider_session_id="cli-session-xyz")
+    )
+
+    link_started = asyncio.Event()
+
+    async def _hanging_link(*a, **k):
+        link_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["test/model"],
+    )
+
+    async def run_dag(graph, **kwargs):
+        on_op_complete = kwargs.get("on_op_complete")
+        if on_op_complete is not None:
+            on_op_complete(node)
+        # A real dag failure, not a cancellation — _dag_cancelled stays
+        # False, so the finally's escalation-link drain takes the same
+        # "else" branch the late-cancellation tests above exercise.
+        raise _DagBoomError("worker failed for real")
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    with (
+        patch("lionagi.state.claude_mirror.link_escalation_session", _hanging_link),
+        patch.object(PlanningEngine, "new_run", return_value=engine_run),
+    ):
+        execute_task = asyncio.create_task(
+            _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+        )
+        # _DagBoomError is already propagating through the finally by the
+        # time the link task gets scheduled to run (it's created from
+        # on_op_complete before run_dag raises); cancelling here lands
+        # while that exception is in flight through the drain.
+        await link_started.wait()
+        execute_task.cancel()
+
+        with pytest.raises(_DagBoomError):
+            await asyncio.wait_for(execute_task, timeout=8)
+
     await stop_live_persist(env, status="completed")
 
 

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2502,6 +2502,93 @@ async def test_execute_dag_drains_escalation_link_retries_before_teardown(
     ]
 
 
+async def test_execute_dag_bounds_escalation_link_drain_on_cancellation(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Round-3 regression: when ``_execute_dag`` itself is cancelled, the
+    shielded finally used to gather ``_escalation_link_tasks`` with no cancel
+    and no timeout — a link write that never returns (hung DB call, stuck
+    await) blocked teardown forever. The drain must now be bounded on the
+    cancellation path: give an in-flight link a short grace period, then
+    cancel it and confirm it actually unwinds before returning."""
+    import time
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.engines import PlanningEngine
+    from lionagi.operations.node import create_operation
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    node = create_operation("operate", parameters={})
+    node.metadata["escalated_from"] = "parent-op-1"
+    node.metadata["escalated_from_name"] = "worker"
+    node._branch = SimpleNamespace(
+        chat_model=SimpleNamespace(provider_session_id="cli-session-xyz")
+    )
+
+    link_started = asyncio.Event()
+    link_cancelled = asyncio.Event()
+
+    async def _hanging_link(*a, **k):
+        link_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            link_cancelled.set()
+            raise
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["test/model"],
+    )
+
+    async def run_dag(graph, **kwargs):
+        on_op_complete = kwargs.get("on_op_complete")
+        if on_op_complete is not None:
+            on_op_complete(node)
+        # Hangs until _execute_dag's own task is cancelled from outside.
+        await asyncio.Event().wait()
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    with (
+        patch("lionagi.state.claude_mirror.link_escalation_session", _hanging_link),
+        patch.object(PlanningEngine, "new_run", return_value=engine_run),
+    ):
+        execute_task = asyncio.create_task(
+            _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+        )
+        await link_started.wait()
+        execute_task.cancel()
+
+        start = time.monotonic()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(execute_task, timeout=5)
+        elapsed = time.monotonic() - start
+
+    assert elapsed < 5, f"teardown took {elapsed}s — the escalation-link drain is unbounded again"
+    assert link_cancelled.is_set()
+    await stop_live_persist(env, status="completed")
+
+
 async def test_flow_timeout_shields_completed_branch_status_until_commit(
     temp_db_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -103,6 +103,51 @@ async def test_start_creates_session_and_registers_hook_on_orc_branch(
     await stop_live_persist(env, status="completed")
 
 
+async def test_start_live_persist_stashes_resolved_project_not_raw_arg(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Round-2 regression: env._project must carry the RESOLVED project (what
+    the session row actually gets — explicit arg or detect_project()
+    fallback), not the caller's raw argument. The common case is a run whose
+    project came from detection rather than an explicit --project flag;
+    before this fix, anything reading env._project (e.g. the
+    escalation-mirror-link hook) would see the unresolved raw value —- None
+    here — instead of what the session row actually recorded."""
+    monkeypatch.setattr(
+        "lionagi.cli._project.detect_project",
+        lambda cwd=None: ("acme/widget", "git_remote"),
+    )
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", project=None)
+    try:
+        ctx = env._live_persist
+        assert ctx is not None
+        async with StateDB() as db:
+            s = await db.get_session(ctx["session_id"])
+        assert s["project"] == "acme/widget"
+        assert env._project == "acme/widget"
+    finally:
+        await stop_live_persist(env, status="completed")
+
+
+async def test_start_live_persist_stashes_explicit_project_verbatim(
+    temp_db_path: Path,
+):
+    """The explicit-argument path: env._project must match what was passed,
+    same as the session row — the resolved and raw values coincide here, but
+    the read must still go through the resolved value, not bypass it."""
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", project="explicit/proj")
+    try:
+        ctx = env._live_persist
+        assert ctx is not None
+        assert env._project == "explicit/proj"
+    finally:
+        await stop_live_persist(env, status="completed")
+
+
 async def test_orchestration_manifest_tracks_start_and_terminal_status(
     temp_db_path: Path, tmp_path: Path
 ):
@@ -2369,6 +2414,92 @@ async def test_execute_dag_drains_inflight_branch_status_before_teardown(
 
     assert events.index("write-finished") < events.index("teardown-started")
     assert env._live_persist is None
+
+
+async def test_execute_dag_drains_escalation_link_retries_before_teardown(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Round-2 regression: the escalation-mirror-link retry loop used to fire
+    as an untracked task (bare ``_asyncio.ensure_future``, nothing awaited it)
+    — a retry still sleeping when ``_execute_dag`` returned could go on to
+    write into a db that ``stop_live_persist`` had already closed. It is now
+    tracked in ``_escalation_link_tasks`` and drained in the same shielded
+    finally block as ``_branch_status_tasks``/``_checkpoint_tasks``, so every
+    retry must finish before ``_execute_dag`` returns — never after."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate import flow as flow_module
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.engines import PlanningEngine
+    from lionagi.operations.node import create_operation
+
+    monkeypatch.setattr(flow_module, "_ESCALATION_LINK_RETRIES", 3)
+    monkeypatch.setattr(flow_module, "_ESCALATION_LINK_RETRY_INTERVAL", 0.02)
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    node = create_operation("operate", parameters={})
+    node.metadata["escalated_from"] = "parent-op-1"
+    node.metadata["escalated_from_name"] = "worker"
+    node._branch = SimpleNamespace(
+        chat_model=SimpleNamespace(provider_session_id="cli-session-xyz")
+    )
+
+    events: list[str] = []
+
+    async def _spy_link(*a, **k):
+        # The mirror row never appears — every retry must actually run.
+        events.append("link-attempt")
+        return False
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["test/model"],
+    )
+
+    async def run_dag(graph, **kwargs):
+        on_op_complete = kwargs.get("on_op_complete")
+        if on_op_complete is not None:
+            on_op_complete(node)
+        return {"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    with (
+        patch("lionagi.state.claude_mirror.link_escalation_session", _spy_link),
+        patch.object(PlanningEngine, "new_run", return_value=engine_run),
+    ):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+    events.append("execute-dag-returned")
+    await stop_live_persist(env, status="completed")
+    events.append("teardown-finished")
+
+    # All three retries ran to exhaustion, entirely before _execute_dag
+    # returned — none leaked past it into (or after) teardown.
+    assert events == [
+        "link-attempt",
+        "link-attempt",
+        "link-attempt",
+        "execute-dag-returned",
+        "teardown-finished",
+    ]
 
 
 async def test_flow_timeout_shields_completed_branch_status_until_commit(

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2589,6 +2589,101 @@ async def test_execute_dag_bounds_escalation_link_drain_on_cancellation(
     await stop_live_persist(env, status="completed")
 
 
+async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Round-4 regression: the round-3 fix only bounds the drain when
+    cancellation lands *during* ``run_dag()`` (caught by the ``except
+    asyncio.CancelledError`` that sets ``_dag_cancelled``). If ``run_dag()``
+    already returned and cancellation instead lands while ``_execute_dag``
+    is inside the finally's own (until now unguarded) drain gather, that
+    except never ran, ``_dag_cancelled`` stays False, and the drain took the
+    normal unbounded gather — hanging just like the round-3 bug, just from a
+    later arrival window."""
+    import time
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.engines import PlanningEngine
+    from lionagi.operations.node import create_operation
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    node = create_operation("operate", parameters={})
+    node.metadata["escalated_from"] = "parent-op-1"
+    node.metadata["escalated_from_name"] = "worker"
+    node._branch = SimpleNamespace(
+        chat_model=SimpleNamespace(provider_session_id="cli-session-xyz")
+    )
+
+    link_started = asyncio.Event()
+    link_cancelled = asyncio.Event()
+
+    async def _hanging_link(*a, **k):
+        link_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            link_cancelled.set()
+            raise
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["test/model"],
+    )
+
+    async def run_dag(graph, **kwargs):
+        on_op_complete = kwargs.get("on_op_complete")
+        if on_op_complete is not None:
+            on_op_complete(node)
+        # Returns normally — unlike the round-3 test, cancellation has not
+        # landed yet, so the except that sets _dag_cancelled never fires.
+        return {"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    with (
+        patch("lionagi.state.claude_mirror.link_escalation_session", _hanging_link),
+        patch.object(PlanningEngine, "new_run", return_value=engine_run),
+    ):
+        execute_task = asyncio.create_task(
+            _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+        )
+        # run_dag() has already returned by the time the link task starts
+        # (it's scheduled from the on_op_complete callback inside run_dag),
+        # so cancelling here lands inside the finally's own drain gather.
+        await link_started.wait()
+        execute_task.cancel()
+
+        start = time.monotonic()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(execute_task, timeout=5)
+        elapsed = time.monotonic() - start
+
+    assert elapsed < 5, (
+        f"teardown took {elapsed}s — a late-arriving cancellation still hangs the drain"
+    )
+    assert link_cancelled.is_set()
+    await stop_live_persist(env, status="completed")
+
+
 async def test_flow_timeout_shields_completed_branch_status_until_commit(
     temp_db_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/orchestrate/test_run_flow_inner.py
+++ b/tests/cli/orchestrate/test_run_flow_inner.py
@@ -161,6 +161,11 @@ def _assert_run_dag_contract(env, *, expected_max_concurrent: int = 2) -> None:
     assert graph is env.builder.get_graph()
     on_branch_created = kwargs.pop("on_branch_created")
     assert callable(on_branch_created)
+    # Always wired now (not just for team-mode runs) — it's also how an
+    # escalation child's CLI transcript gets linked back to this run; it no-ops
+    # for a plain (non-team, non-escalation) node.
+    on_op_complete = kwargs.pop("on_op_complete")
+    assert callable(on_op_complete)
     assert kwargs == {
         "reactive": False,
         "spawn_type": None,
@@ -171,7 +176,6 @@ def _assert_run_dag_contract(env, *, expected_max_concurrent: int = 2) -> None:
         "executor_ref": {},
         "context": None,
         "spawn_branch_setup": None,
-        "on_op_complete": None,
     }
 
 

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -385,6 +385,193 @@ async def test_mirror_session_is_idempotent(temp_db_path: Path) -> None:
     assert first == second  # no duplicate appends
 
 
+# ── link_escalation_session: escalation-leg mirror attribution ──────────────
+
+
+@pytest.mark.asyncio
+async def test_link_escalation_session_overwrites_orphan_attribution(
+    temp_db_path: Path,
+) -> None:
+    """The mirror already created the orphan (cwd-guessed project, first-prompt
+    name) before the escalation call site learned the CLI session id — the
+    common case, since the mirror polls continuously while the leg is running.
+    The link write must override both, and stamp a pointer back to the parent op.
+    """
+    from lionagi.state.claude_mirror import link_escalation_session
+
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            project="gate-runner-4",
+            project_source="cwd_dir",
+            name="Guidance: |-\n  LION_SYSTEM_MESSAGE",
+            status="running",
+        )
+        before = await db.get_session(session_db_id(SID))
+        assert before["run_id"] is None
+        assert before["project"] == "gate-runner-4"
+
+        linked = await link_escalation_session(
+            db,
+            session_uid=SID,
+            run_id="run-20260806-abc123",
+            name="escalation of gate-runner-4",
+            project="acme/widget",
+            project_source="escalation_parent",
+            parent_op_id="parent-op-1",
+        )
+        after = await db.get_session(session_db_id(SID))
+
+    assert linked is True
+    assert after["run_id"] == "run-20260806-abc123"
+    assert after["project"] == "acme/widget"
+    assert after["project_source"] == "escalation_parent"
+    assert after["name"] == "escalation of gate-runner-4"
+    assert after["node_metadata"]["escalated_from_session"] == "parent-op-1"
+
+
+@pytest.mark.asyncio
+async def test_link_escalation_session_leaves_project_alone_when_run_project_unknown(
+    temp_db_path: Path,
+) -> None:
+    """An unresolved run project is not evidence the mirror's cwd guess is wrong
+    — name/run_id/pointer still get linked, but project is left as the mirror's
+    best-effort value rather than overwritten with NULL."""
+    from lionagi.state.claude_mirror import link_escalation_session
+
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            project="gate-runner-4",
+            project_source="cwd_dir",
+            name="Guidance: |-\n  LION_SYSTEM_MESSAGE",
+            status="running",
+        )
+
+        linked = await link_escalation_session(
+            db,
+            session_uid=SID,
+            run_id="run-20260806-abc123",
+            name="escalation of gate-runner-4",
+            project=None,
+            project_source=None,
+            parent_op_id="parent-op-1",
+        )
+        after = await db.get_session(session_db_id(SID))
+
+    assert linked is True
+    assert after["run_id"] == "run-20260806-abc123"
+    assert after["name"] == "escalation of gate-runner-4"
+    assert after["project"] == "gate-runner-4"
+    assert after["project_source"] == "cwd_dir"
+
+
+@pytest.mark.asyncio
+async def test_link_escalation_session_returns_false_when_row_missing(
+    temp_db_path: Path,
+) -> None:
+    """The escalation call site can learn the CLI session id before the mirror's
+    next sweep has even created the row; the caller is expected to retry rather
+    than lose the link, so this must report the miss, not raise or fabricate a row."""
+    from lionagi.state.claude_mirror import link_escalation_session
+
+    async with StateDB() as db:
+        linked = await link_escalation_session(
+            db,
+            session_uid=SID,
+            run_id="run-20260806-abc123",
+            name="escalation of gate-runner-4",
+            project="acme/widget",
+            project_source="escalation_parent",
+            parent_op_id="parent-op-1",
+        )
+        row = await db.get_session(session_db_id(SID))
+
+    assert linked is False
+    assert row is None
+
+
+@pytest.mark.asyncio
+async def test_link_escalation_session_survives_a_later_mirror_pass(
+    temp_db_path: Path,
+) -> None:
+    """A later mirror pass replays its own (still cwd/first-prompt-derived, in
+    the poller's in-memory _FileState) name/project on every call — mirror_session
+    must not let that clobber a link already recorded, since the mirror has no
+    way to know the row it is about to rewrite was already linked."""
+    from lionagi.state.claude_mirror import link_escalation_session
+
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            project="gate-runner-4",
+            project_source="cwd_dir",
+            name="Guidance: |-\n  LION_SYSTEM_MESSAGE",
+            status="running",
+        )
+        await link_escalation_session(
+            db,
+            session_uid=SID,
+            run_id="run-20260806-abc123",
+            name="escalation of gate-runner-4",
+            project="acme/widget",
+            project_source="escalation_parent",
+            parent_op_id="parent-op-1",
+        )
+
+        # Next mirror poll pass: same stale in-memory name/project, more events.
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            project="gate-runner-4",
+            project_source="cwd_dir",
+            name="Guidance: |-\n  LION_SYSTEM_MESSAGE",
+            status="running",
+        )
+        after = await db.get_session(session_db_id(SID))
+
+    assert after["run_id"] == "run-20260806-abc123"
+    assert after["project"] == "acme/widget"
+    assert after["name"] == "escalation of gate-runner-4"
+
+
+@pytest.mark.asyncio
+async def test_non_escalation_transcript_gets_ordinary_cwd_attribution(
+    temp_db_path: Path,
+) -> None:
+    """A top-level (non-escalation) CLI leg is never handed to
+    link_escalation_session, so its cwd-derived project and first-prompt name
+    are the mirror's own, unmodified best-effort attribution."""
+    async with StateDB() as db:
+        await mirror_session(
+            db,
+            session_uid=SID,
+            events=_conversation(),
+            tool_names={},
+            project="acme/widget",
+            project_source="cwd",
+            name="do the thing",
+            status="running",
+        )
+        row = await db.get_session(session_db_id(SID))
+
+    assert row["run_id"] is None
+    assert row["project"] == "acme/widget"
+    assert row["name"] == "do the thing"
+    assert (row.get("node_metadata") or {}).get("escalated_from_session") is None
+
+
 @pytest.mark.asyncio
 async def test_reconcile_flips_running_to_completed_when_idle(temp_db_path: Path) -> None:
     async with StateDB() as db:

--- a/tests/operations/test_escalation_routing.py
+++ b/tests/operations/test_escalation_routing.py
@@ -102,6 +102,33 @@ async def test_escalation_higher_tier_emits_node_escalated_signal():
     assert isinstance(sig.escalation_request, EscalationRequest)
 
 
+@pytest.mark.asyncio
+async def test_escalation_child_carries_readable_name_and_parent_pointer():
+    """The higher_tier child op is stamped with both `escalated_from` (the
+    parent op id) and `escalated_from_name` (a readable label) — a caller
+    outside operations/ (e.g. attributing the child's CLI transcript back to
+    the node it retries) needs the label without re-deriving it from a
+    possibly-stale reference to the parent op."""
+
+    async def cheap(**kw):
+        return EscalationRequest(reason="too hard", context={"route": "higher_tier"})
+
+    session = _session(cheap=cheap)
+
+    builder = OperationGraphBuilder()
+    parent_id = builder.add_operation("cheap", node_id="cheap")
+    graph = builder.get_graph()
+
+    await flow(session, graph, reactive=True)
+
+    child = next(
+        n
+        for n in graph.internal_nodes.values()
+        if isinstance(n, Operation) and n.metadata.get("escalated_from") == str(parent_id)
+    )
+    assert child.metadata["escalated_from_name"] == "cheap"
+
+
 # ---------------------------------------------------------------------------
 # give_up: signals without re-spawning
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2859.

When a flow op escalates to a higher tier and the escalated leg runs via a CLI engine, the transcript mirror created a second, orphan session: no run id, a name taken from the first words of the guidance prompt, and a project guessed from the leg's working directory. These orphans cluttered the session list and could not be traced back to their run.

- The escalation scheduler now stamps a readable `escalated_from_name` beside the existing parent pointer.
- The DAG executor wires an op-completion hook (previously team-mode only) that links the mirrored session by the CLI session id both sides share, with bounded retries since the mirror can lag in a separate process.
- Linked sessions get `run_id`, an "escalation of <node>" name, and the parent run's project (left untouched when the parent's own project is unresolved). Unlinkable transcripts stay as they are rather than being guessed at.
- `update_session` learns to write `run_id`, which was create-only and would have silently blocked the backfill.

Tests: mirror link unit tests (overwrite, survives later mirror pass, missing row, unresolved project), escalation metadata stamping, executor contract test updated. Known gap: coverage is unit-level on both halves; no single end-to-end test spans the live executor plus a real CLI transcript.