### PR TITLE
fix(flow): short-circuit dependents of a rejected gate node

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -497,6 +497,7 @@ async def _teardown_common(
     escalated_evidence: list[dict] | None = None,
     finalize_error: dict | None = None,
     artifact_write_error: dict | None = None,
+    gate_rejected_evidence: list[dict] | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
     defer_terminal: bool = False,
@@ -669,6 +670,27 @@ async def _teardown_common(
         )
         final_evidence_refs = escalated_evidence
 
+    # A gate node rejected mid-DAG (issue #2860) and the executor
+    # short-circuited its dependent subtree to skipped instead of running
+    # those nodes against the rejected baseline. That is a correct, deliberate
+    # stop, not a failure -- status stays "completed" -- but the reason code
+    # must say so explicitly rather than reading identically to a clean pass.
+    if gate_rejected_evidence and final_status == "completed":
+        from lionagi.state.reasons import RunReasons
+
+        metadata = dict(metadata or {})
+        metadata["gate_rejections"] = gate_rejected_evidence
+        final_reason_code = RunReasons.COMPLETED_GATE_REJECTED
+        gate_names = ", ".join(
+            str(e.get("label") or e.get("id") or "") for e in gate_rejected_evidence
+        )
+        final_reason_summary = (
+            f"DAG completed successfully; {len(gate_rejected_evidence)} gate(s) rejected "
+            f"({gate_names}) and their dependent subtree was short-circuited instead of "
+            "running against the rejected baseline."
+        )
+        final_evidence_refs = gate_rejected_evidence
+
     # The synthesis artifact IS the run's output. A DAG that completed but
     # whose output write raised has not delivered anything -- that is a real
     # failure of the run, not a best-effort finalize hiccup, so this flips
@@ -821,6 +843,7 @@ async def teardown_persist(
     escalated_evidence: list[dict] | None = None,
     finalize_error: dict | None = None,
     artifact_write_error: dict | None = None,
+    gate_rejected_evidence: list[dict] | None = None,
     cwd: str | None = None,
     engine_session_uid: str | None = None,
     defer_terminal: bool = False,
@@ -844,6 +867,7 @@ async def teardown_persist(
             escalated_evidence=escalated_evidence,
             finalize_error=finalize_error,
             artifact_write_error=artifact_write_error,
+            gate_rejected_evidence=gate_rejected_evidence,
             cwd=cwd,
             engine_session_uid=engine_session_uid,
             defer_terminal=defer_terminal,

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -1606,6 +1606,7 @@ async def stop_live_persist(
     escalated_evidence = getattr(env, "_escalated_evidence", None)
     finalize_error = getattr(env, "_finalize_error", None)
     artifact_write_error = getattr(env, "_artifact_write_error", None)
+    gate_rejected_evidence = getattr(env, "_gate_rejected_evidence", None)
     final_status = await teardown_persist(
         ctx,
         status=status,
@@ -1614,6 +1615,7 @@ async def stop_live_persist(
         escalated_evidence=escalated_evidence,
         finalize_error=finalize_error,
         artifact_write_error=artifact_write_error,
+        gate_rejected_evidence=gate_rejected_evidence,
         cwd=env.cwd,
     )
     env._run_manifest["status"] = final_status

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -349,6 +349,31 @@ async def _resolve_invocation_terminal_flow(
                     metadata,
                 )
             if all(s == "completed" for s in child_statuses):
+                # A "completed" child may still carry COMPLETED_GATE_REJECTED
+                # (a gate rejected mid-DAG and short-circuited its dependent
+                # subtree) — surface that at the invocation level too, or it
+                # flattens back to a plain clean-pass COMPLETED_OK and the
+                # distinction this reason code exists for is lost.
+                gate_rejected = [
+                    s
+                    for s in sessions
+                    if str(s.get("status_reason_code") or "") == RunReasons.COMPLETED_GATE_REJECTED
+                ]
+                if gate_rejected:
+                    gate_metadata = dict(metadata)
+                    gate_metadata["gate_rejected_session_ids"] = [
+                        s["id"] for s in gate_rejected if s.get("id")
+                    ]
+                    return (
+                        "completed",
+                        RunReasons.COMPLETED_GATE_REJECTED,
+                        "Flow completed successfully, but a gate rejected "
+                        "mid-DAG in at least one child session and its "
+                        "dependent subtree was short-circuited instead of "
+                        "running against the rejected baseline.",
+                        [{"kind": "session", "id": s["id"]} for s in gate_rejected if s.get("id")],
+                        gate_metadata,
+                    )
                 # A "completed" child may still carry COMPLETED_FINALIZE_ERROR
                 # (a guarded best-effort teardown step failed) — surface that
                 # degraded reason at the invocation level rather than hiding it.
@@ -1440,9 +1465,14 @@ async def _execute_dag(
     gate_rejected_evidence = [
         {"kind": "gate_rejected_operation", "id": agent_ids[i], "label": assignments[i].assignee}
         for i in range(len(assignments))
-        if node_ids[i] in gate_rejected_op_ids
+        # node_ids holds Operation UUIDs, not strings, despite the `list[str]`
+        # annotation -- compare on the string form so a planned (non-spawned)
+        # gate is recognized here instead of falling through to the spawned
+        # branch below and losing its assignee label.
+        if str(node_ids[i]) in gate_rejected_op_ids
     ]
-    for spawned_nid in sorted(gate_rejected_op_ids - known_nodes):
+    known_node_strs_for_gates = {str(n) for n in known_nodes}
+    for spawned_nid in sorted(gate_rejected_op_ids - known_node_strs_for_gates):
         graph_node = graph_nodes.get(spawned_nid)
         spawn_id = graph_node.metadata.get("spawn_id") if graph_node is not None else None
         evidence_id = spawn_id or spawned_nid

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1430,6 +1430,29 @@ async def _execute_dag(
         prior_evidence = getattr(env, "_escalated_evidence", None) or []
         env._escalated_evidence = [*prior_evidence, *escalated_evidence]
 
+    # Gate-reject evidence (issue #2860): a mid-DAG gate node returned a
+    # REJECT verdict and the executor short-circuited its dependent subtree
+    # to skipped rather than let it run against the rejected baseline. This
+    # names the rejecting gate(s), not the (possibly many) skipped
+    # dependents, so `stop_live_persist` can record a "completed but gate
+    # rejected" reason instead of a plain clean-pass one.
+    gate_rejected_op_ids = {str(x) for x in dag_result.get("gate_rejected_operations", [])}
+    gate_rejected_evidence = [
+        {"kind": "gate_rejected_operation", "id": agent_ids[i], "label": assignments[i].assignee}
+        for i in range(len(assignments))
+        if node_ids[i] in gate_rejected_op_ids
+    ]
+    for spawned_nid in sorted(gate_rejected_op_ids - known_nodes):
+        graph_node = graph_nodes.get(spawned_nid)
+        spawn_id = graph_node.metadata.get("spawn_id") if graph_node is not None else None
+        evidence_id = spawn_id or spawned_nid
+        gate_rejected_evidence.append(
+            {"kind": "gate_rejected_operation", "id": evidence_id, "label": evidence_id}
+        )
+    if gate_rejected_evidence:
+        prior_gate_evidence = getattr(env, "_gate_rejected_evidence", None) or []
+        env._gate_rejected_evidence = [*prior_gate_evidence, *gate_rejected_evidence]
+
     agent_results: list[dict] = []
 
     def _record_result(result: dict) -> None:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1437,9 +1437,13 @@ async def _execute_dag(
     escalated_evidence = [
         {"kind": "escalated_operation", "id": agent_ids[i], "label": assignments[i].assignee}
         for i in range(len(assignments))
-        if node_ids[i] in escalated_op_ids
+        # node_ids holds Operation UUIDs, not strings, despite the `list[str]`
+        # annotation -- compare on the string form so a planned (non-spawned)
+        # escalated op is recognized here instead of falling through to the
+        # spawned branch below and losing its assignee label.
+        if str(node_ids[i]) in escalated_op_ids
     ]
-    for spawned_nid in sorted(escalated_op_ids - known_nodes):
+    for spawned_nid in sorted(escalated_op_ids - known_node_strs):
         # Surface the stamped spawn_id (e.g. "spawn-3") instead of the
         # internal UUID, matching the artifact dirs/contract entries produced.
         graph_node = graph_nodes.get(spawned_nid)

--- a/lionagi/operations/builder.py
+++ b/lionagi/operations/builder.py
@@ -45,6 +45,7 @@ class OperationGraphBuilder:
         node_id: str | None = None,
         depends_on: list[str] | None = None,
         inherit_context: bool = False,
+        is_gate: bool = False,
         branch=None,
         **parameters,
     ) -> str:
@@ -64,12 +65,21 @@ class OperationGraphBuilder:
         Passing `None` for a fan silently serializes it: `sequential` edges are
         ordinary predecessors at execution time, so every worker waits for the
         one added before it.
+
+        `is_gate=True` opts this node into the flow executor's gate-reject
+        contract (see `lionagi/operations/flow.py`): if its result carries a
+        top-level `gate_verdict="reject"`, every downstream dependent is
+        short-circuited to skipped instead of running against the baseline
+        this node just rejected.
         """
         node = create_operation(operation=operation, parameters=parameters)
 
         if inherit_context and depends_on:
             node.metadata["inherit_context"] = True
             node.metadata["primary_dependency"] = depends_on[0]
+
+        if is_gate:
+            node.metadata["is_gate"] = True
 
         self.graph.add_node(node)
         self._operations[node.id] = node

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -564,6 +564,11 @@ class DependencyAwareExecutor:
         has_valid_path = False
         gate_reason: dict[str, Any] | None = None
 
+        # Every incoming edge must be inspected before honoring a valid path:
+        # the veto is "any incoming path through a rejected gate", not "the
+        # first-listed valid edge wins" -- a node with a valid non-gate edge
+        # listed before its rejected-gate edge must still be vetoed, so this
+        # never exits early on `has_valid_path=True`.
         for edge_id in incoming_edge_ids:
             edge = self.graph.internal_edges[edge_id]
             if edge.head in self.completion_events:
@@ -579,6 +584,12 @@ class DependencyAwareExecutor:
             if edge.head in self.skipped_operations:
                 continue
 
+            if has_valid_path:
+                # Already know this node has a valid path; still scanning
+                # remaining edges for a possible gate veto, so skip the
+                # redundant condition evaluation.
+                continue
+
             result_value = self.results.get(edge.head)
             if result_value is not None and not isinstance(result_value, str | int | float | bool):
                 result_value = to_dict(result_value, recursive=True)
@@ -588,7 +599,6 @@ class DependencyAwareExecutor:
 
             if await edge.check_condition(ctx):
                 has_valid_path = True
-                break
 
         if gate_reason is not None:
             self._skip_reasons[operation.id] = gate_reason

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -45,6 +45,20 @@ logger = logging.getLogger(__name__)
 
 UNLIMITED_CONCURRENCY = int(os.environ.get("LIONAGI_MAX_CONCURRENCY", "10000"))
 
+# Gate-reject contract (issue #2860). A playbook-authored node opts into gate
+# semantics by setting ``operation.metadata["is_gate"] = True`` (e.g. via
+# ``OperationGraphBuilder.add_operation(..., is_gate=True)``). Once that node
+# completes, its result is inspected for a top-level ``"gate_verdict"`` key;
+# if the value is the string "reject" (case-insensitive), every direct and
+# transitive dependent of the gate is short-circuited to SKIPPED instead of
+# running against the baseline the gate just rejected. A node that isn't
+# marked ``is_gate``, or a gate whose result has no ``gate_verdict`` key (or
+# any value other than "reject"), changes nothing -- this keeps flows with no
+# gate nodes byte-identical to before.
+GATE_VERDICT_KEY = "gate_verdict"
+GATE_VERDICT_REJECT = "reject"
+SKIP_REASON_UPSTREAM_GATE_REJECT = "upstream_gate_reject"
+
 # Tracks which Operation a reactive task is running (per-task contextvar).
 _CURRENT_OP: contextvars.ContextVar = contextvars.ContextVar("reactive_current_op", default=None)
 
@@ -139,6 +153,15 @@ class DependencyAwareExecutor:
         self.completion_events = {}
         self.operation_branches = {}
         self.skipped_operations = set()
+        # Gate-reject bookkeeping (see the module-level contract comment).
+        # ``_gate_rejections``: op_id of a completed ``is_gate`` node -> the
+        # reason payload to attribute to anything downstream of it.
+        # ``_skip_reasons``: op_id of any node this executor decided to skip
+        # because of a (possibly transitive) upstream gate reject -> the same
+        # payload, so a grandchild inherits the original gate's identity
+        # rather than just "my parent was skipped".
+        self._gate_rejections: dict[Any, dict[str, Any]] = {}
+        self._skip_reasons: dict[Any, dict[str, Any]] = {}
         self._op_start_times = {}
         self._pause_event: ConcurrencyEvent | None = None
         # Fire-and-forget flow signal tasks, retained until each finishes so a
@@ -193,11 +216,26 @@ class DependencyAwareExecutor:
             "operation_results": self.results,
             "final_context": self.context.content,
             "skipped_operations": list(self.skipped_operations),
+            **self._gate_result_fields(),
         }
 
         self._validate_execution_results(result)
 
         return result
+
+    def _gate_result_fields(self) -> dict[str, Any]:
+        """``gate_rejected_operations``: ``is_gate`` nodes whose result carried
+        a REJECT verdict. ``gate_short_circuited_operations``: nodes skipped
+        (directly or transitively) as a consequence -- a subset of
+        ``skipped_operations``. Both empty when no gate ever rejected, so a
+        caller checking ``bool(result["gate_rejected_operations"])`` sees no
+        change for flows with no gate nodes."""
+        return {
+            "gate_rejected_operations": [str(op_id) for op_id in self._gate_rejections],
+            "gate_short_circuited_operations": [
+                str(op_id) for op_id in self._skip_reasons if op_id in self.skipped_operations
+            ],
+        }
 
     async def _preallocate_all_branches(self):
         """Pre-allocate branches to eliminate runtime locking."""
@@ -348,6 +386,22 @@ class DependencyAwareExecutor:
                 operation.execution.status = EventStatus.SKIPPED
                 self.skipped_operations.add(operation.id)
 
+                gate_reason = self._skip_reasons.get(operation.id)
+                if gate_reason is not None:
+                    # Visible, not silently absent: the metadata is there for
+                    # any caller walking `graph.internal_nodes`, and the same
+                    # payload lands in operation_results so it shows up
+                    # wherever a completed operation's result would.
+                    operation.metadata["skip_reason_code"] = gate_reason["reason_code"]
+                    operation.metadata["skip_reason_gate_id"] = gate_reason["gate_id"]
+                    operation.metadata["skip_reason_gate_name"] = gate_reason["gate_name"]
+                    self.results[operation.id] = {
+                        "skipped": True,
+                        "reason_code": gate_reason["reason_code"],
+                        "gate_id": gate_reason["gate_id"],
+                        "gate_name": gate_reason["gate_name"],
+                    }
+
                 if self.verbose:
                     logger.debug(
                         "Skipping operation due to edge conditions: %s",
@@ -432,6 +486,9 @@ class DependencyAwareExecutor:
                     if self.verbose:
                         logger.debug("Completed operation: %s (%.1fs)", ref_id, elapsed)
 
+                    if operation.metadata.get("is_gate"):
+                        self._record_gate_verdict(operation)
+
                 elif operation.execution.status == EventStatus.FAILED:
                     self.results[operation.id] = {"error": str(operation.execution.error)}
                     if self.on_progress:
@@ -459,8 +516,43 @@ class DependencyAwareExecutor:
         finally:
             self.completion_events[operation.id].set()
 
+    def _record_gate_verdict(self, operation: Operation) -> None:
+        """Called on a completed ``is_gate`` operation; records a REJECT
+        verdict (see the module-level gate-reject contract) so
+        ``_check_edge_conditions`` can veto this gate's dependents. A result
+        with no ``gate_verdict`` key, or any value other than "reject",
+        leaves ``_gate_rejections`` untouched -- the gate completed normally
+        and nothing downstream is affected."""
+        result = operation.response
+        if result is not None and not isinstance(result, str | int | float | bool):
+            result = to_dict(result, recursive=True)
+        if not isinstance(result, Mapping):
+            return
+
+        verdict = result.get(GATE_VERDICT_KEY)
+        if not isinstance(verdict, str) or verdict.strip().lower() != GATE_VERDICT_REJECT:
+            return
+
+        ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
+        self._gate_rejections[operation.id] = {
+            "reason_code": SKIP_REASON_UPSTREAM_GATE_REJECT,
+            "gate_id": str(operation.id),
+            "gate_name": ref_id,
+        }
+
     async def _check_edge_conditions(self, operation: Operation) -> bool:
-        """Return True if at least one valid incoming path exists or no edges; False if all incoming edges failed."""
+        """Return True if at least one valid incoming path exists or no edges; False if all incoming edges failed.
+
+        A gate reject is an absolute veto layered on top of that: if any
+        incoming edge traces back (directly or transitively) to a rejecting
+        gate, this operation is skipped regardless of any other otherwise
+        valid incoming path -- a node must never run against a baseline one
+        of its ancestors just rejected. The veto is recorded in
+        ``self._skip_reasons`` so a caller skipped for this reason (and, in
+        turn, that caller's own dependents) can be tagged and so this
+        propagates transitively via the existing `skipped_operations` check
+        below without extra bookkeeping.
+        """
         # Snapshot before awaiting: iterating the live adjacency dict across
         # an await would raise RuntimeError if reactive injection attaches an
         # edge mid-wait. A dependency added after the snapshot is deferred
@@ -470,11 +562,19 @@ class DependencyAwareExecutor:
             return True
 
         has_valid_path = False
+        gate_reason: dict[str, Any] | None = None
 
         for edge_id in incoming_edge_ids:
             edge = self.graph.internal_edges[edge_id]
             if edge.head in self.completion_events:
                 await self.completion_events[edge.head].wait()
+
+            upstream_reason = self._skip_reasons.get(edge.head) or self._gate_rejections.get(
+                edge.head
+            )
+            if upstream_reason is not None:
+                gate_reason = gate_reason or upstream_reason
+                continue
 
             if edge.head in self.skipped_operations:
                 continue
@@ -489,6 +589,10 @@ class DependencyAwareExecutor:
             if await edge.check_condition(ctx):
                 has_valid_path = True
                 break
+
+        if gate_reason is not None:
+            self._skip_reasons[operation.id] = gate_reason
+            return False
 
         return has_valid_path
 
@@ -780,6 +884,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
             "spawned_operations": self._spawn_count,
             "escalated_operations": list(self._escalated_ids),
             "dropped_spawns": self._dropped_spawns,
+            **self._gate_result_fields(),
         }
         self._validate_execution_results(result)
         return result

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -66,6 +66,11 @@ class RunReasons:
     COMPLETED_EMPTY_NO_EVIDENCE = "run.completed_empty.no_evidence"
     # DAG's own result stands even when a post-completion finalize step raised
     COMPLETED_FINALIZE_ERROR = "run.completed.finalize_error"
+    # a gate node rejected mid-DAG (issue #2860) and its dependent subtree was
+    # short-circuited to skipped rather than run against the rejected
+    # baseline -- the run genuinely completed, so status stays "completed",
+    # but the reason distinguishes it from a clean pass
+    COMPLETED_GATE_REJECTED = "run.completed.gate_rejected"
     # unlike COMPLETED_FINALIZE_ERROR, a raised write failure is a real failure
     # (status -> failed); distinct from FAILED_MISSING_ARTIFACT's post-hoc gap
     FAILED_ARTIFACT_WRITE = "run.failed.artifact_write"

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2404,6 +2404,83 @@ async def test_execute_dag_gate_rejected_evidence_survives_uuid_node_ids(
     assert s["status_reason_code"] == "run.completed.gate_rejected"
 
 
+async def test_execute_dag_escalation_evidence_survives_uuid_node_ids(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """Same shape as test_execute_dag_gate_rejected_evidence_survives_uuid_node_ids,
+    one screen up: dag_state.node_ids holds real Operation UUIDs, and
+    dag_result["escalated_operations"] holds their str() form. Comparing
+    node_ids[i] to that string set directly is always False for a UUID, so a
+    planned escalated worker's evidence entry was silently reclassified as a
+    "spawned" node and lost its agent label. This must not regress."""
+    from unittest.mock import MagicMock, patch
+    from uuid import uuid4
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+    ctx = env._live_persist
+    assert ctx is not None
+
+    worker_node_id = uuid4()
+    assignments = [TaskAssignment(task="do the risky thing", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[worker_node_id],
+        known_nodes={worker_node_id},
+        deps_by_node={worker_node_id: []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        return {
+            "operation_results": {},
+            "spawned_operations": 0,
+            "escalated_operations": [str(worker_node_id)],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        exec_result = await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    # The planned "worker", not a synthesized UUID-as-label placeholder.
+    assert exec_result.escalated_agent_ids == ["worker"]
+    assert env._escalated_evidence == [
+        {"kind": "escalated_operation", "id": "worker", "label": "worker"}
+    ]
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.escalated"
+
+    import json as _json
+
+    evidence = s["status_evidence_refs"]
+    evidence = _json.loads(evidence) if isinstance(evidence, str) else evidence
+    assert any(e.get("id") == "worker" for e in evidence)
+
+
 async def test_execute_dag_drains_inflight_branch_status_before_teardown(
     temp_db_path: Path,
     tmp_path: Path,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1913,6 +1913,46 @@ async def test_missing_artifact_session_failure_propagates_to_invocation_status(
     assert inv_row["status"] == "failed"
 
 
+async def test_gate_rejection_reason_survives_child_to_invocation_resolution(
+    temp_db_path: Path,
+):
+    """A child session that completed with a gate reject (status stays
+    "completed", status_reason_code=COMPLETED_GATE_REJECTED) must carry that
+    reason code through _resolve_invocation_terminal_flow's "all children
+    completed" branch. That branch previously only special-cased
+    COMPLETED_FINALIZE_ERROR and flattened every other completed reason to a
+    plain COMPLETED_OK, silently erasing the gate-reject distinction at the
+    invocation level -- the layer a status-reader (Studio, `li status`)
+    actually queries.
+    """
+    from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
+    from lionagi.state.reasons import RunReasons
+
+    invocation_id = "inv-gate-reject"
+    async with StateDB() as db:
+        await db.create_invocation({"id": invocation_id, "skill": "flow", "started_at": 0.0})
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow", invocation_id=invocation_id)
+    ctx = env._live_persist
+    assert ctx is not None
+    env._gate_rejected_evidence = [
+        {"kind": "gate_rejected_operation", "id": "reviewer", "label": "reviewer"}
+    ]
+
+    assert await stop_live_persist(env, status="completed") == "completed"
+
+    async with StateDB() as db:
+        session = await db.get_session(ctx["session_id"])
+    assert session["status_reason_code"] == RunReasons.COMPLETED_GATE_REJECTED
+
+    _status, reason_code, _summary, evidence, _metadata = await _resolve_invocation_terminal_flow(
+        invocation_id, fallback_status="completed"
+    )
+    assert reason_code == RunReasons.COMPLETED_GATE_REJECTED
+    assert any(entry.get("id") == ctx["session_id"] for entry in evidence)
+
+
 async def test_all_legs_completed_resolves_invocation_completed(
     temp_db_path: Path,
     tmp_path: Path,
@@ -2292,6 +2332,76 @@ async def test_execute_dag_escalation_without_artifact_declaration_fails_loud(
     evidence = s["status_evidence_refs"]
     evidence = _json.loads(evidence) if isinstance(evidence, str) else evidence
     assert any(e.get("id") == "worker" for e in evidence)
+
+
+async def test_execute_dag_gate_rejected_evidence_survives_uuid_node_ids(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """dag_state.node_ids holds real Operation UUIDs (not the plain strings
+    other _execute_dag tests stub in), and dag_result["gate_rejected_operations"]
+    holds their str() form -- exactly what the real executor/builder produce.
+    Comparing node_ids[i] to that string set directly is always False for a
+    UUID, so a planned gate's evidence entry was silently reclassified as a
+    "spawned" node and lost its agent label. This must not regress."""
+    from unittest.mock import MagicMock, patch
+    from uuid import uuid4
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+    ctx = env._live_persist
+    assert ctx is not None
+
+    gate_node_id = uuid4()
+    assignments = [TaskAssignment(task="review the design", assignee="reviewer")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["reviewer"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[gate_node_id],
+        known_nodes={gate_node_id},
+        deps_by_node={gate_node_id: []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        return {
+            "operation_results": {gate_node_id: {"gate_verdict": "reject"}},
+            "spawned_operations": 0,
+            "gate_rejected_operations": [str(gate_node_id)],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    # The planned "reviewer" gate, not a synthesized "spawn-N" placeholder.
+    assert env._gate_rejected_evidence == [
+        {"kind": "gate_rejected_operation", "id": "reviewer", "label": "reviewer"}
+    ]
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed"
+    assert s["status_reason_code"] == "run.completed.gate_rejected"
 
 
 async def test_execute_dag_drains_inflight_branch_status_before_teardown(

--- a/tests/operations/test_flow_gate_reject.py
+++ b/tests/operations/test_flow_gate_reject.py
@@ -267,3 +267,199 @@ async def test_flow_with_no_gate_nodes_is_unaffected():
     assert result["skipped_operations"] == []
     assert result["gate_rejected_operations"] == []
     assert result["gate_short_circuited_operations"] == []
+
+
+@pytest.mark.asyncio
+async def test_reject_vetoes_diamond_even_when_another_path_is_valid():
+    """A diamond graph where one incoming edge traces to a rejected gate and
+    the other doesn't: the veto wins over the otherwise-valid path."""
+    executed: list[str] = []
+
+    async def root(**_kw):
+        executed.append("root")
+        return "root"
+
+    async def gate(**_kw):
+        executed.append("gate")
+        return {"gate_verdict": "reject"}
+
+    async def around(**_kw):
+        executed.append("around")
+        return "around"
+
+    async def join(**_kw):
+        executed.append("join")
+        return "join"
+
+    session = _session_with_ops(root=root, gate=gate, around=around, join=join)
+    builder = OperationGraphBuilder()
+    root_id = builder.add_operation("root", depends_on=[])
+    gate_id = builder.add_operation("gate", depends_on=[root_id], is_gate=True)
+    around_id = builder.add_operation("around", depends_on=[root_id])
+    join_id = builder.add_operation("join", depends_on=[gate_id, around_id])
+
+    result = await flow(session, builder.get_graph(), parallel=True)
+
+    assert executed == ["root", "gate", "around"]
+    assert join_id in result["skipped_operations"]
+    assert result["operation_results"][join_id]["gate_id"] == str(gate_id)
+
+
+@pytest.mark.asyncio
+async def test_reject_vetoes_diamond_when_valid_path_is_listed_first():
+    """Same diamond as above with the incoming edges built in the opposite
+    order: the veto must not depend on incoming-edge insertion/scan order --
+    the executor must scan every incoming edge before honoring a valid one."""
+    executed: list[str] = []
+
+    async def root(**_kw):
+        executed.append("root")
+        return "root"
+
+    async def gate(**_kw):
+        executed.append("gate")
+        return {"gate_verdict": "reject"}
+
+    async def around(**_kw):
+        executed.append("around")
+        return "around"
+
+    async def join(**_kw):
+        executed.append("join")
+        return "join"
+
+    session = _session_with_ops(root=root, gate=gate, around=around, join=join)
+    builder = OperationGraphBuilder()
+    root_id = builder.add_operation("root", depends_on=[])
+    gate_id = builder.add_operation("gate", depends_on=[root_id], is_gate=True)
+    around_id = builder.add_operation("around", depends_on=[root_id])
+    join_id = builder.add_operation("join", depends_on=[around_id, gate_id])
+
+    result = await flow(session, builder.get_graph(), parallel=True)
+
+    assert "join" not in executed
+    assert join_id in result["skipped_operations"]
+
+
+@pytest.mark.asyncio
+async def test_reject_is_recorded_before_dependents_can_pass_the_barrier():
+    """A dependent must not be able to enter its body while the gate whose
+    verdict it depends on is still running."""
+    import anyio
+
+    gate_started = anyio.Event()
+    gate_finished = anyio.Event()
+    executed: list[str] = []
+
+    async def gate(**_kw):
+        gate_started.set()
+        await anyio.sleep(0.02)
+        executed.append("gate")
+        gate_finished.set()
+        return {"gate_verdict": "reject"}
+
+    async def dependent(**_kw):
+        assert gate_finished.is_set()
+        executed.append("dependent")
+        return "must not run"
+
+    session = _session_with_ops(gate=gate, dependent=dependent)
+    builder = OperationGraphBuilder()
+    gate_id = builder.add_operation("gate", depends_on=[], is_gate=True)
+    dependent_id = builder.add_operation("dependent", depends_on=[gate_id])
+
+    result = await flow(session, builder.get_graph(), parallel=True)
+
+    assert gate_started.is_set()
+    assert executed == ["gate"]
+    assert dependent_id in result["skipped_operations"]
+
+
+@pytest.mark.asyncio
+async def test_reactive_spawn_attached_to_rejected_gate_is_skipped():
+    """A SpawnRequest that a rejected gate emits as a dependent child inherits
+    the gate veto instead of running against the rejected baseline."""
+    from lionagi.casts.emission import SpawnRequest
+    from lionagi.operations import Operation
+    from lionagi.operations.node import create_operation
+
+    executed: list[str] = []
+
+    async def gate(**_kw):
+        executed.append("gate")
+        return {
+            "gate_verdict": "reject",
+            "spawn": SpawnRequest(instruction="follow-up", independent=False),
+        }
+
+    async def child(**_kw):
+        executed.append("child")
+        return "must not run"
+
+    session = _session_with_ops(gate=gate, child=child)
+
+    def node_builder(_req: SpawnRequest, _emitter: Operation) -> Operation:
+        return create_operation("child", parameters={})
+
+    builder = OperationGraphBuilder()
+    gate_id = builder.add_operation("gate", depends_on=[], is_gate=True)
+
+    result = await flow(
+        session,
+        builder.get_graph(),
+        reactive=True,
+        node_builder=node_builder,
+    )
+
+    assert executed == ["gate"]
+    assert result["spawned_operations"] == 1
+    assert len(result["gate_short_circuited_operations"]) == 1
+    assert result["gate_short_circuited_operations"][0] != str(gate_id)
+
+
+@pytest.mark.asyncio
+async def test_multiple_gates_long_chain_and_gate_depending_on_gate():
+    """Two independent rejecting gates, a gate that itself depends on a
+    rejected gate, and a long dependent chain: rejection sources, a
+    dependent gate, and deep transitive propagation all compose correctly."""
+    executed: list[str] = []
+
+    async def reject_a(**_kw):
+        executed.append("reject_a")
+        return {"gate_verdict": "reject"}
+
+    async def reject_b(**_kw):
+        executed.append("reject_b")
+        return {"gate_verdict": "reject"}
+
+    async def dependent_gate(**_kw):
+        executed.append("dependent_gate")
+        return {"gate_verdict": "reject"}
+
+    async def work(**_kw):
+        executed.append("work")
+        return "must not run"
+
+    session = _session_with_ops(
+        reject_a=reject_a,
+        reject_b=reject_b,
+        dependent_gate=dependent_gate,
+        work=work,
+    )
+    builder = OperationGraphBuilder()
+    gate_a = builder.add_operation("reject_a", depends_on=[], is_gate=True)
+    gate_b = builder.add_operation("reject_b", depends_on=[], is_gate=True)
+    dependent = builder.add_operation("dependent_gate", depends_on=[gate_a], is_gate=True)
+    join = builder.add_operation("work", depends_on=[gate_a, gate_b])
+    tail = join
+    for _ in range(20):
+        tail = builder.add_operation("work", depends_on=[tail])
+
+    result = await flow(session, builder.get_graph(), parallel=True)
+
+    assert set(executed) == {"reject_a", "reject_b"}
+    assert set(result["gate_rejected_operations"]) == {str(gate_a), str(gate_b)}
+    assert dependent in result["skipped_operations"]
+    skipped = {str(node_id) for node_id in result["skipped_operations"]}
+    assert all(node_id in skipped for node_id in result["gate_short_circuited_operations"])
+    assert tail in result["skipped_operations"]

--- a/tests/operations/test_flow_gate_reject.py
+++ b/tests/operations/test_flow_gate_reject.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gate-reject short-circuit (issue #2860): a gate node's REJECT verdict must
+stop its dependent subtree from running against the rejected baseline,
+without touching independent siblings or non-gate flows."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.operations import flow
+from lionagi.operations.builder import OperationGraphBuilder
+from lionagi.session.session import Session
+
+
+def _session_with_ops(**ops):
+    """A Session whose default branch resolves the given named operations."""
+    from lionagi.session.branch import Branch
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    for name, fn in ops.items():
+        session.register_operation(name, fn)
+    return session
+
+
+def _build_gate_graph(builder: OperationGraphBuilder) -> dict[str, str]:
+    """producer -> gate(is_gate) -> dep1 -> dep2, plus an unrelated
+    sibling -> sibling_child chain that never touches the gate."""
+    producer_id = builder.add_operation("producer", depends_on=[])
+    gate_id = builder.add_operation("gate", node_id="gate", depends_on=[producer_id], is_gate=True)
+    dep1_id = builder.add_operation("dep1", depends_on=[gate_id])
+    dep2_id = builder.add_operation("dep2", depends_on=[dep1_id])
+    sibling_id = builder.add_operation("sibling", depends_on=[])
+    sibling_child_id = builder.add_operation("sibling_child", depends_on=[sibling_id])
+    return {
+        "producer": producer_id,
+        "gate": gate_id,
+        "dep1": dep1_id,
+        "dep2": dep2_id,
+        "sibling": sibling_id,
+        "sibling_child": sibling_child_id,
+    }
+
+
+def _make_ops(executed: list[str], *, verdict: str = "reject"):
+    async def producer(**kw):
+        executed.append("producer")
+        return {"baseline": "v1"}
+
+    async def gate(**kw):
+        executed.append("gate")
+        return {"gate_verdict": verdict, "findings": "design flaw at step 10"}
+
+    async def dep1(**kw):
+        executed.append("dep1")
+        return "dep1 ran against the baseline"
+
+    async def dep2(**kw):
+        executed.append("dep2")
+        return "dep2 ran against the baseline"
+
+    async def sibling(**kw):
+        executed.append("sibling")
+        return "sibling ran"
+
+    async def sibling_child(**kw):
+        executed.append("sibling_child")
+        return "sibling_child ran"
+
+    return {
+        "producer": producer,
+        "gate": gate,
+        "dep1": dep1,
+        "dep2": dep2,
+        "sibling": sibling,
+        "sibling_child": sibling_child,
+    }
+
+
+@pytest.mark.asyncio
+async def test_gate_reject_short_circuits_dependents_not_siblings():
+    """(i) downstream nodes never execute, (ii) they carry the skip reason,
+    (iii) independent siblings still execute."""
+    executed: list[str] = []
+    session = _session_with_ops(**_make_ops(executed))
+    builder = OperationGraphBuilder()
+    ids = _build_gate_graph(builder)
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    # (i) never executed
+    assert "dep1" not in executed
+    assert "dep2" not in executed
+    assert ids["dep1"] not in result["completed_operations"]
+    assert ids["dep2"] not in result["completed_operations"]
+    assert ids["dep1"] in result["skipped_operations"]
+    assert ids["dep2"] in result["skipped_operations"]
+
+    # the gate itself ran and produced its verdict
+    assert "producer" in executed
+    assert "gate" in executed
+    assert ids["gate"] in result["completed_operations"]
+    assert result["gate_rejected_operations"] == [str(ids["gate"])]
+    assert sorted(result["gate_short_circuited_operations"]) == sorted(
+        [str(ids["dep1"]), str(ids["dep2"])]
+    )
+
+    # (ii) skip reason surfaces on both the metadata and the result entry,
+    # and the transitively-skipped dep2 still points at the ORIGINAL gate.
+    for dep_key in ("dep1", "dep2"):
+        node = graph.internal_nodes[ids[dep_key]]
+        assert node.metadata["skip_reason_code"] == "upstream_gate_reject"
+        assert node.metadata["skip_reason_gate_id"] == str(ids["gate"])
+        assert node.metadata["skip_reason_gate_name"] == "gate"
+
+        res_entry = result["operation_results"][ids[dep_key]]
+        assert res_entry["skipped"] is True
+        assert res_entry["reason_code"] == "upstream_gate_reject"
+        assert res_entry["gate_id"] == str(ids["gate"])
+
+    # (iii) independent siblings unaffected
+    assert "sibling" in executed
+    assert "sibling_child" in executed
+    assert ids["sibling"] in result["completed_operations"]
+    assert ids["sibling_child"] in result["completed_operations"]
+
+
+@pytest.mark.asyncio
+async def test_gate_reject_short_circuits_reactive_executor():
+    """Same short-circuit behavior under the reactive (self-expanding) executor."""
+    executed: list[str] = []
+    session = _session_with_ops(**_make_ops(executed))
+    builder = OperationGraphBuilder()
+    ids = _build_gate_graph(builder)
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True, verbose=False)
+
+    assert "dep1" not in executed
+    assert "dep2" not in executed
+    assert ids["dep1"] in result["skipped_operations"]
+    assert ids["dep2"] in result["skipped_operations"]
+    assert result["gate_rejected_operations"] == [str(ids["gate"])]
+
+    assert "sibling" in executed
+    assert "sibling_child" in executed
+
+
+@pytest.mark.asyncio
+async def test_gate_reject_is_case_insensitive():
+    """The contract's reject marker tolerates case/whitespace variance."""
+    executed: list[str] = []
+    session = _session_with_ops(**_make_ops(executed, verdict="  REJECT  "))
+    builder = OperationGraphBuilder()
+    ids = _build_gate_graph(builder)
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    assert "dep1" not in executed
+    assert ids["dep1"] in result["skipped_operations"]
+
+
+@pytest.mark.asyncio
+async def test_non_reject_gate_verdict_changes_nothing():
+    """A gate that approves (or any verdict != 'reject') must not skip anything."""
+    executed: list[str] = []
+    session = _session_with_ops(**_make_ops(executed, verdict="approve"))
+    builder = OperationGraphBuilder()
+    ids = _build_gate_graph(builder)
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    assert "dep1" in executed
+    assert "dep2" in executed
+    assert result["skipped_operations"] == []
+    assert result["gate_rejected_operations"] == []
+    assert result["gate_short_circuited_operations"] == []
+
+
+@pytest.mark.asyncio
+async def test_gate_without_verdict_field_changes_nothing():
+    """Design constraint #2: a gate whose result has no gate_verdict key at
+    all (missing field, not just a non-reject value) leaves the flow untouched."""
+    executed: list[str] = []
+
+    async def gate_no_verdict(**kw):
+        executed.append("gate")
+        return {"summary": "looks fine, no structured verdict emitted"}
+
+    ops = _make_ops(executed)
+    ops["gate"] = gate_no_verdict
+    session = _session_with_ops(**ops)
+    builder = OperationGraphBuilder()
+    ids = _build_gate_graph(builder)
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    assert "dep1" in executed
+    assert "dep2" in executed
+    assert result["skipped_operations"] == []
+    assert result["gate_rejected_operations"] == []
+
+
+@pytest.mark.asyncio
+async def test_unmarked_node_with_reject_shaped_result_is_not_a_gate():
+    """A node that is NOT flagged is_gate must not trigger short-circuiting
+    even if its result happens to contain a gate_verdict='reject' key --
+    detection is the explicit is_gate flag, never string-sniffing the result."""
+    executed: list[str] = []
+
+    async def producer(**kw):
+        executed.append("producer")
+        # Coincidentally shaped like a gate reject, but this node was never
+        # marked is_gate, so it must not be treated as one.
+        return {"gate_verdict": "reject", "baseline": "v1"}
+
+    async def dep1(**kw):
+        executed.append("dep1")
+        return "dep1 ran"
+
+    session = _session_with_ops(producer=producer, dep1=dep1)
+    builder = OperationGraphBuilder()
+    producer_id = builder.add_operation("producer", depends_on=[])
+    dep1_id = builder.add_operation("dep1", depends_on=[producer_id])  # NOT is_gate
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    assert "dep1" in executed
+    assert dep1_id in result["completed_operations"]
+    assert result["skipped_operations"] == []
+    assert result["gate_rejected_operations"] == []
+
+
+@pytest.mark.asyncio
+async def test_flow_with_no_gate_nodes_is_unaffected():
+    """A flow with no is_gate nodes at all behaves exactly as before: the new
+    result keys are present but empty, nothing is skipped."""
+    executed: list[str] = []
+
+    async def step_a(**kw):
+        executed.append("a")
+        return "a"
+
+    async def step_b(**kw):
+        executed.append("b")
+        return "b"
+
+    session = _session_with_ops(step_a=step_a, step_b=step_b)
+    builder = OperationGraphBuilder()
+    a_id = builder.add_operation("step_a", depends_on=[])
+    b_id = builder.add_operation("step_b", depends_on=[a_id])
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    assert executed == ["a", "b"]
+    assert sorted(result["completed_operations"]) == sorted([a_id, b_id])
+    assert result["skipped_operations"] == []
+    assert result["gate_rejected_operations"] == []
+    assert result["gate_short_circuited_operations"] == []


### PR DESCRIPTION
Fixes #2860.

A flow DAG containing a gate node that returns a rejection verdict mid-run previously executed all downstream dependents anyway — 18 no-op steps over an unchanged baseline in the observed case, twice in two runs. Nothing conditioned the subtree on the verdict.

Contract (explicit, no prose sniffing):
- A gate marks itself: `OperationGraphBuilder.add_operation(..., is_gate=True)` sets `operation.metadata["is_gate"]`.
- A rejection is a top-level `gate_verdict: "reject"` key in the gate's response (case-insensitive). Missing key or any other value changes nothing.

Behavior:
- A rejection vetoes transitively: any node whose ancestry crosses a rejecting gate is skipped with `skip_reason_code=upstream_gate_reject` plus the gate's id/name, visible in operation results and the event stream. Independent siblings still execute.
- Flow results gain `gate_rejected_operations` and `gate_short_circuited_operations`; run teardown records a distinct `completed_gate_rejected` reason code so a short-circuited run is distinguishable from a clean pass.
- Flows without gate nodes behave identically to before.

Tests: 7-case fixture flow (rejection short-circuits transitively, siblings unaffected, non-gate flows unchanged, malformed verdicts ignored); full operations/cli/state suites green.

Known scope cut: bounded retry-to-upstream (route the findings back to the producer) is not in this PR — short-circuit is the minimum viable behavior; the on_progress callback's lack of a distinct 'skipped' lane is pre-existing and untouched.