### PR TITLE
fix(studio): default run names reflect what a run actually is

### DIFF
--- a/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
@@ -9,6 +9,7 @@ import type { FleetState } from "./fleetReducer";
 import type { RunSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
 import { deriveDisplayStatus } from "@/lib/runStatus";
+import { resolveRunLabel } from "@/lib/runLabel";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -171,6 +172,17 @@ describe("fleetReducer — invocation join", () => {
     expect(s.orgUnits).toHaveLength(1);
     expect(s.orgUnits[0].id).toBe("__direct__");
     expect(s.orgUnits[0].agents).toHaveLength(1);
+  });
+
+  it("an agent row's name matches the shared resolver, never a raw playbook/agent fallback", () => {
+    const run = makeRun({
+      run_id: "r1",
+      status: "running",
+      playbook_name: "pr-merge-review",
+      agent_name: "implementer",
+    });
+    const s = dispatchOk(initialFleetState(), [], [run]);
+    expect(s.orgUnits[0].agents[0].name).toBe(resolveRunLabel(run));
   });
 
   it("invocation without runs still appears when no scope is active", () => {
@@ -449,6 +461,18 @@ describe("terminalRecentRows", () => {
     expect(rows[0].id).toBe("r79");
     expect(rows[79].id).toBe("r0");
     expect(rows.some((r) => r.id === "live")).toBe(false);
+  });
+
+  it("a recent row's name matches the shared resolver, never a raw playbook/agent fallback", () => {
+    const run = makeRun({
+      run_id: "r1",
+      status: "completed",
+      ended_at: 1_000,
+      playbook_name: "pr-merge-review",
+      agent_name: "implementer",
+    });
+    const rows = terminalRecentRows([run]);
+    expect(rows[0].name).toBe(resolveRunLabel(run));
   });
 });
 

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -27,6 +27,7 @@
 import type { RunSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
 import { deriveDisplayStatus, isEffectivelyActive, type RunStatusInput } from "@/lib/runStatus";
+import { resolveRunLabel } from "@/lib/runLabel";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -186,7 +187,7 @@ function buildOrgUnits(
     const elapsed = elapsedSec(run.started_at ?? null, nowSec);
     const row: AgentRow = {
       id: run.run_id,
-      name: run.playbook_name ?? run.agent_name ?? run.run_id.slice(-12),
+      name: resolveRunLabel(run),
       status: run.status,
       effectiveHealth: run.effective_health ?? null,
       elapsedSec: elapsed,
@@ -259,7 +260,7 @@ export function terminalRecentRows(runs: RunSummary[]): RecentRow[] {
     .sort((a, b) => (b.ended_at ?? b.started_at ?? 0) - (a.ended_at ?? a.started_at ?? 0))
     .map((r) => ({
       id: r.run_id,
-      name: r.playbook_name ?? r.agent_name ?? r.run_id.slice(-12),
+      name: resolveRunLabel(r),
       status: r.status,
       invocation_id: r.invocation_id ?? null,
       status_reason_code: r.status_reason_code,

--- a/apps/studio/frontend/src/components/library/PlaybookTemplateDetail.test.tsx
+++ b/apps/studio/frontend/src/components/library/PlaybookTemplateDetail.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * PlaybookTemplateDetail — recent-runs row naming.
+ *
+ * Every other list/board surface shows a run's resolveRunLabel() output;
+ * this list used to show the raw run_id tail instead, so the same run read
+ * as two different things depending which surface you looked at it from.
+ * Runs launched from one playbook also mostly share that playbook's name
+ * tier, so resolveRunLabel() alone collapses distinct rows to one label —
+ * the short id stays visible as a muted secondary so rows are still
+ * distinguishable at a glance.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import enMessages from "@/messages/en.json";
+import type { RunSummary } from "@/lib/types";
+import { ToastProvider } from "@/components/ui/Toast";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+const api = vi.hoisted(() => ({
+  getBuiltinPlaybookRaw: vi.fn(),
+  getWorkerRaw: vi.fn(),
+  installBuiltinPlaybook: vi.fn(),
+  launchPlaybook: vi.fn(),
+  listRuns: vi.fn(),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, ...api };
+});
+
+const { PlaybookTemplateDetail } = await import("./PlaybookTemplateDetail");
+
+function run(overrides: Partial<RunSummary> & { run_id: string }): RunSummary {
+  return {
+    status: "completed",
+    started_at: 100,
+    ended_at: 160,
+    playbook_name: "pr-merge-review",
+    agent_name: null,
+    ...overrides,
+  } as RunSummary;
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("PlaybookTemplateDetail — recent runs row", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    Object.values(api).forEach((fn) => fn.mockReset());
+    api.getBuiltinPlaybookRaw.mockResolvedValue({ data: { description: "reviews a PR" } });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function mount(runs: RunSummary[]) {
+    api.listRuns.mockResolvedValue({
+      runs,
+      page: 1,
+      per_page: 10,
+      total: runs.length,
+      total_pages: 1,
+      has_next: false,
+      has_prev: false,
+    });
+    await act(async () => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <ToastProvider>
+            <PlaybookTemplateDetail name="pr-merge-review" isBuiltin />
+          </ToastProvider>
+        </IntlProvider>,
+      );
+    });
+    await flush();
+  }
+
+  it("shows the resolved run label as the primary text, not the raw run_id tail", async () => {
+    await mount([run({ run_id: "run-abcdef0123456789", show_play_name: "ADR-0099 rollout" })]);
+    const primary = container.querySelector(".flex-1.truncate");
+    expect(primary?.textContent).toBe("ADR-0099 rollout");
+  });
+
+  it("keeps the short id visible as a muted secondary alongside the resolved label", async () => {
+    // Both runs share the same playbook_name tier, so resolveRunLabel()
+    // alone would render two identical rows -- the short id is what keeps
+    // them distinguishable.
+    await mount([run({ run_id: "run-aaaaaaaaaaaaaaaa" }), run({ run_id: "run-bbbbbbbbbbbbbbbb" })]);
+    expect(container.textContent).toContain("pr-merge-review");
+    expect(container.textContent).toContain("aaaaaaaaaaaa");
+    expect(container.textContent).toContain("bbbbbbbbbbbb");
+  });
+});

--- a/apps/studio/frontend/src/components/library/PlaybookTemplateDetail.tsx
+++ b/apps/studio/frontend/src/components/library/PlaybookTemplateDetail.tsx
@@ -29,6 +29,7 @@ import SectionLabel from "@/components/ui/SectionLabel";
 import Button from "@/components/ui/Button";
 import StatusVerdictChips from "@/components/ui/StatusVerdictChips";
 import { deriveDisplayStatus } from "@/lib/runStatus";
+import { resolveRunLabel } from "@/lib/runLabel";
 import Duration from "@/components/ui/Duration";
 import { useToast } from "@/components/ui/Toast";
 
@@ -307,6 +308,13 @@ export function PlaybookTemplateDetail({
                       statusLabel={statusLabel(deriveDisplayStatus(run))}
                     />
                     <span className="min-w-0 flex-1 truncate font-data text-[length:var(--t-sm)] text-content-secondary">
+                      {resolveRunLabel(run)}
+                    </span>
+                    {/* Every playbook run in this list shares the same playbook_name
+                        tier, so resolveRunLabel alone often collapses several rows to
+                        one identical label -- the short id stays visible as a muted
+                        secondary so rows remain distinguishable. */}
+                    <span className="shrink-0 font-data text-[length:var(--t-xs)] text-content-muted">
                       {run.run_id.slice(-12)}
                     </span>
                     <span className="shrink-0 font-data text-[length:var(--t-xs)] text-content-muted">

--- a/apps/studio/frontend/src/components/mission/LiveBoard.test.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.test.tsx
@@ -226,6 +226,27 @@ describe("LiveBoard — combined card order and view switching", () => {
     expect(rows[0].textContent).toContain("run-abcdef0123456789".slice(-16));
   });
 
+  it("table view and card view resolve the same run to the same name — no more mirror-surface gap", () => {
+    const theRun = run({
+      run_id: "run-abcdef0123456789",
+      started_at: 900,
+      playbook_name: "table-run",
+      agent_name: "implementer",
+    });
+    mount([theRun]);
+    const cardText = container.textContent ?? "";
+    expect(cardText).toContain("table-run");
+
+    const tableButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Table",
+    );
+    act(() => {
+      tableButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows[0].textContent).toContain("table-run");
+  });
+
   it("persists the view choice across remounts via localStorage", () => {
     mount([run({ run_id: "r1", started_at: 100 })]);
     const tableButton = Array.from(container.querySelectorAll("button")).find(

--- a/apps/studio/frontend/src/components/mission/LiveBoard.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.tsx
@@ -276,9 +276,7 @@ const BOARD_MAX_HEIGHT = "max-h-[420px]";
 function BoardTableRow({ card, nowSec }: { card: LiveCard; nowSec: number }) {
   const t = useTranslations("mission");
   const isRun = card.kind === "run";
-  const name = isRun
-    ? (card.run.playbook_name ?? card.run.agent_name ?? card.run.run_id.slice(-12))
-    : card.invocation.skill;
+  const name = isRun ? resolveRunLabel(card.run) : card.invocation.skill;
   const startedAt = isRun ? (card.run.started_at ?? undefined) : card.invocation.started_at;
   const elapsed = elapsedSec(startedAt, nowSec);
   const lastActivityAt = isRun

--- a/apps/studio/frontend/src/components/mission/LiveBoard.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.tsx
@@ -22,6 +22,7 @@ import Skeleton from "@/components/ui/Skeleton";
 import type { RunSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
 import { runDeepLink, invocationDeepLink } from "@/lib/runDeepLink";
+import { resolveRunLabel } from "@/lib/runLabel";
 import { runCreationKey, invocationCreationKey } from "./boardReducer";
 
 /**
@@ -69,7 +70,7 @@ function RunCard({ run, nowSec }: { run: RunSummary; nowSec: number }) {
   // Last activity falls back to started_at when no heartbeat has landed yet
   // — never to "no data", since a fresh run has always at least started.
   const lastActivity = elapsedSec(run.last_message_at ?? run.started_at ?? undefined, nowSec);
-  const name = run.playbook_name ?? run.agent_name ?? run.run_id.slice(-12);
+  const name = resolveRunLabel(run);
   // Honest staleness: a process-dead run must not render as a live one.
   // Health axis only — duration never factors into this flag.
   // TODO(unify): route through deriveDisplayStatus once status/verdict/

--- a/apps/studio/frontend/src/components/mission/RecentRuns.tsx
+++ b/apps/studio/frontend/src/components/mission/RecentRuns.tsx
@@ -17,6 +17,7 @@ import StatusVerdictChips from "@/components/ui/StatusVerdictChips";
 import Duration from "@/components/ui/Duration";
 import Skeleton from "@/components/ui/Skeleton";
 import { deriveDisplayStatus } from "@/lib/runStatus";
+import { resolveRunLabel } from "@/lib/runLabel";
 import type { RunSummary } from "@/lib/types";
 import { groupConsecutiveRecentRuns, groupSpanSec } from "./recentGroups";
 import type { RecentGroup } from "./recentGroups";
@@ -158,7 +159,7 @@ function RunRow({
   first: boolean;
   statusLabel: (status: string) => string | undefined;
 }) {
-  const name = run.playbook_name ?? run.agent_name ?? run.run_id.slice(-12);
+  const name = resolveRunLabel(run);
   const dur = durationSec(run, nowSec);
   return (
     <Link

--- a/apps/studio/frontend/src/components/mission/boardReducer.test.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.test.ts
@@ -3,6 +3,7 @@ import { boardReducer, initialBoardState } from "./boardReducer";
 import type { BoardState } from "./boardReducer";
 import type { RunSummary, ScheduleSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
+import { resolveRunLabel } from "@/lib/runLabel";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -187,6 +188,18 @@ describe("boardReducer — attention queue derivation", () => {
   it("undated failures are excluded — age unknown is not actionable", () => {
     const s = dispatchOk(initialBoardState(), [makeRun({ run_id: "undated", status: "failed" })]);
     expect(s.attentionItems).toHaveLength(0);
+  });
+
+  it("a run's attention-queue name matches the shared resolver, never a raw playbook/agent fallback", () => {
+    const run = makeRun({
+      run_id: "r1",
+      status: "failed",
+      started_at: 1_000_000 - 600,
+      playbook_name: "pr-merge-review",
+      agent_name: "implementer",
+    });
+    const s = dispatchOk(initialBoardState(), [run]);
+    expect(s.attentionItems[0].name).toBe(resolveRunLabel(run));
   });
 
   it("running + stale health appears in attention queue", () => {

--- a/apps/studio/frontend/src/components/mission/boardReducer.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.ts
@@ -10,6 +10,7 @@
 import type { RunSummary, ScheduleSummary } from "@/lib/types";
 import type { InvocationSummary } from "@/lib/api";
 import { deriveDisplayStatus, isOrphanedReason } from "@/lib/runStatus";
+import { resolveRunLabel } from "@/lib/runLabel";
 
 // ─── State shape ─────────────────────────────────────────────────────────────
 
@@ -168,7 +169,7 @@ function buildAttentionItems(
     items.push({
       id: `run:${run.run_id}`,
       kind: "run",
-      name: run.playbook_name ?? run.agent_name ?? run.run_id.slice(-8),
+      name: resolveRunLabel(run),
       reason,
       startedAt: run.started_at ?? null,
       href: `/runs/${run.run_id}`,

--- a/apps/studio/frontend/src/components/mission/recentGroups.ts
+++ b/apps/studio/frontend/src/components/mission/recentGroups.ts
@@ -15,6 +15,7 @@
  */
 
 import type { RunSummary } from "@/lib/types";
+import { resolveRunLabel } from "@/lib/runLabel";
 import { deriveDisplayStatus, type DisplayStatus } from "@/lib/runStatus";
 
 export interface RecentGroup {
@@ -25,10 +26,6 @@ export interface RecentGroup {
   name: string;
   /** Shared §0 display status for every run in the group. */
   displayStatus: DisplayStatus;
-}
-
-function runName(run: RunSummary): string {
-  return run.playbook_name ?? run.agent_name ?? run.run_id.slice(-12);
 }
 
 /**
@@ -42,7 +39,7 @@ export function groupConsecutiveRecentRuns(runs: RunSummary[]): RecentGroup[] {
   const groups: RecentGroup[] = [];
 
   for (const run of runs) {
-    const name = runName(run);
+    const name = resolveRunLabel(run);
     const displayStatus = deriveDisplayStatus(run);
     const last = groups[groups.length - 1];
 

--- a/apps/studio/frontend/src/lib/runLabel.test.ts
+++ b/apps/studio/frontend/src/lib/runLabel.test.ts
@@ -50,4 +50,34 @@ describe("resolveRunLabel", () => {
     const run = makeRun({ run_id: "r1", name: "   ", playbook_name: "reviewer" });
     expect(resolveRunLabel(run)).toBe("reviewer");
   });
+
+  it("recomputes a backend-resolved agent-role name's HH:MM in local time", () => {
+    // 2026-01-01T14:22:00Z — vite.config.mts pins the test process to TZ=UTC,
+    // so "local" and UTC agree here and the pinned digits are reproducible.
+    const run = makeRun({
+      run_id: "r1",
+      name: "implementer · 09:00",
+      agent_name: "implementer",
+      started_at: 1767277320,
+    });
+    expect(resolveRunLabel(run)).toBe("implementer · 14:22");
+  });
+
+  it("leaves a backend-resolved agent-role name alone when started_at is missing", () => {
+    const run = makeRun({
+      run_id: "r1",
+      name: "implementer · 09:00",
+      agent_name: "implementer",
+      started_at: null,
+    });
+    expect(resolveRunLabel(run)).toBe("implementer · 09:00");
+  });
+
+  it("appends a local HH:MM disambiguator to a bare agent_name fallback", () => {
+    // Parity fixture with tests/state/test_session_naming.py's
+    // agent_role_label case (started_at 1767277320.0 -> "14:22" in UTC,
+    // matching this suite's pinned TZ=UTC local time).
+    const run = makeRun({ run_id: "r1", agent_name: "implementer", started_at: 1767277320 });
+    expect(resolveRunLabel(run)).toBe("implementer · 14:22");
+  });
 });

--- a/apps/studio/frontend/src/lib/runLabel.test.ts
+++ b/apps/studio/frontend/src/lib/runLabel.test.ts
@@ -51,16 +51,17 @@ describe("resolveRunLabel", () => {
     expect(resolveRunLabel(run)).toBe("reviewer");
   });
 
-  it("recomputes a backend-resolved agent-role name's HH:MM in local time", () => {
-    // 2026-01-01T14:22:00Z — vite.config.mts pins the test process to TZ=UTC,
-    // so "local" and UTC agree here and the pinned digits are reproducible.
+  it("never rewrites a backend-resolved agent-role name, even though it could recompute HH:MM", () => {
+    // A non-empty run.name is provenance-ambiguous (it could be the backend's
+    // UTC-baked agent-role label, or a future custom name that just looks like
+    // one) so it always renders verbatim -- never mutated based on text shape.
     const run = makeRun({
       run_id: "r1",
       name: "implementer · 09:00",
       agent_name: "implementer",
       started_at: 1767277320,
     });
-    expect(resolveRunLabel(run)).toBe("implementer · 14:22");
+    expect(resolveRunLabel(run)).toBe("implementer · 09:00");
   });
 
   it("leaves a backend-resolved agent-role name alone when started_at is missing", () => {
@@ -71,6 +72,20 @@ describe("resolveRunLabel", () => {
       started_at: null,
     });
     expect(resolveRunLabel(run)).toBe("implementer · 09:00");
+  });
+
+  it("round-trips a custom stored name byte-identical, even one shaped like an agent-role label", () => {
+    // Provenance is data, not text shape: a stored name that coincidentally
+    // matches "<agent_name> · HH:MM" must still never be rewritten, and a
+    // started_at that would recompute to a *different* clock time must not
+    // leak through either.
+    const run = makeRun({
+      run_id: "r1",
+      name: "a · 14:22",
+      agent_name: "a",
+      started_at: 1767255720, // 2026-01-01T08:22:00Z -- recompute would say "08:22"
+    });
+    expect(resolveRunLabel(run)).toBe("a · 14:22");
   });
 
   it("appends a local HH:MM disambiguator to a bare agent_name fallback", () => {

--- a/apps/studio/frontend/src/lib/runLabel.test.ts
+++ b/apps/studio/frontend/src/lib/runLabel.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { resolveRunLabel } from "./runLabel";
+import type { RunSummary } from "./types";
+
+function makeRun(overrides: Partial<RunSummary> & { run_id: string }): RunSummary {
+  return {
+    status: "running",
+    playbook_name: null,
+    agent_name: null,
+    invocation_kind: null,
+    show_topic: null,
+    show_play_name: null,
+    started_at: null,
+    ...overrides,
+  } as RunSummary;
+}
+
+describe("resolveRunLabel", () => {
+  it("prefers the backend-resolved name over every other field", () => {
+    const run = makeRun({
+      run_id: "r1",
+      name: "implementer · 14:22",
+      playbook_name: "pr-merge-review",
+      agent_name: "implementer",
+    });
+    expect(resolveRunLabel(run)).toBe("implementer · 14:22");
+  });
+
+  it("falls back to show_play_name when name is absent", () => {
+    const run = makeRun({ run_id: "r1", show_play_name: "ADR-0099 rollout", playbook_name: "pb" });
+    expect(resolveRunLabel(run)).toBe("ADR-0099 rollout");
+  });
+
+  it("falls back to playbook_name when name and show_play_name are absent", () => {
+    const run = makeRun({ run_id: "r1", playbook_name: "reviewer" });
+    expect(resolveRunLabel(run)).toBe("reviewer");
+  });
+
+  it("falls back to agent_name when nothing more structured is available", () => {
+    const run = makeRun({ run_id: "r1", agent_name: "implementer" });
+    expect(resolveRunLabel(run)).toBe("implementer");
+  });
+
+  it("falls back to the last 12 chars of run_id when every field is empty", () => {
+    const run = makeRun({ run_id: "0123456789abcdef" });
+    expect(resolveRunLabel(run)).toBe("456789abcdef");
+  });
+
+  it("treats a blank/whitespace-only name as absent", () => {
+    const run = makeRun({ run_id: "r1", name: "   ", playbook_name: "reviewer" });
+    expect(resolveRunLabel(run)).toBe("reviewer");
+  });
+});

--- a/apps/studio/frontend/src/lib/runLabel.ts
+++ b/apps/studio/frontend/src/lib/runLabel.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared run display-label resolution.
+ *
+ * The backend already resolves `run.name` through the full priority chain —
+ * show/play name > playbook name > agent-role descriptor > sanitized prompt
+ * fallback (see lionagi/state/session_naming.py; a user-set label will slot
+ * in ahead of all of those once that feature exists). This is the one place
+ * every list/board surface reads that value from — LiveBoard.tsx and
+ * recentGroups.ts previously each recomputed their own (weaker, and
+ * disagreeing) fallback chain straight from playbook_name/agent_name,
+ * ignoring the resolved name the backend already sent.
+ */
+import type { RunSummary } from "./types";
+
+export function resolveRunLabel(run: RunSummary): string {
+  return (
+    run.name?.trim() ||
+    run.show_play_name?.trim() ||
+    run.playbook_name?.trim() ||
+    run.agent_name?.trim() ||
+    run.run_id.slice(-12)
+  );
+}

--- a/apps/studio/frontend/src/lib/runLabel.ts
+++ b/apps/studio/frontend/src/lib/runLabel.ts
@@ -11,18 +11,17 @@
  * to call this instead, so a run can no longer show two different names on
  * two different surfaces at once.
  *
- * The agent-role tier ("<agent> · HH:MM") is the one part of the resolved
- * name that is clock-shaped, and Studio otherwise always shows the viewer's
- * local time. The backend bakes that HH:MM in UTC so the *stored* value is
- * deterministic regardless of which machine resolved it (see
- * agent_role_label's docstring) — this function recomputes the HH:MM half
- * from `run.started_at` in the browser's local time before display, both
- * when the backend already sent a resolved agent-role name and when this
- * function falls back to building one itself from a bare `agent_name`.
+ * A non-empty `run.name` is rendered VERBATIM, never rewritten. There is no
+ * reliable way to tell a backend-resolved agent-role label ("implementer ·
+ * 14:22", baked in UTC — see agent_role_label's docstring) apart from a
+ * future user-set custom name that happens to share that shape by text
+ * alone, and a stored/custom name must never be mutated. The one place this
+ * function computes local-time HH:MM itself is its *own* fallback tier below
+ * — building a label from a bare `agent_name` + `started_at` when the
+ * backend sent no name at all, a case where this function controls the
+ * construction end to end and there is nothing stored to disagree with.
  */
 import type { RunSummary } from "./types";
-
-const AGENT_TIME_SUFFIX_RE = / · \d{2}:\d{2}$/;
 
 function localHHMM(startedAt: number | null | undefined): string | null {
   if (startedAt == null) return null;
@@ -36,15 +35,6 @@ function localHHMM(startedAt: number | null | undefined): string | null {
 export function resolveRunLabel(run: RunSummary): string {
   const backendName = run.name?.trim();
   if (backendName) {
-    const agentName = run.agent_name?.trim();
-    if (
-      agentName &&
-      backendName.startsWith(`${agentName} · `) &&
-      AGENT_TIME_SUFFIX_RE.test(backendName)
-    ) {
-      const local = localHHMM(run.started_at);
-      if (local) return `${agentName} · ${local}`;
-    }
     return backendName;
   }
 

--- a/apps/studio/frontend/src/lib/runLabel.ts
+++ b/apps/studio/frontend/src/lib/runLabel.ts
@@ -5,19 +5,60 @@
  * show/play name > playbook name > agent-role descriptor > sanitized prompt
  * fallback (see lionagi/state/session_naming.py; a user-set label will slot
  * in ahead of all of those once that feature exists). This is the one place
- * every list/board surface reads that value from — LiveBoard.tsx and
- * recentGroups.ts previously each recomputed their own (weaker, and
- * disagreeing) fallback chain straight from playbook_name/agent_name,
- * ignoring the resolved name the backend already sent.
+ * every list/board surface reads that value from — every other file under
+ * components/ that previously recomputed its own (weaker, and disagreeing)
+ * fallback chain straight from playbook_name/agent_name has been converted
+ * to call this instead, so a run can no longer show two different names on
+ * two different surfaces at once.
+ *
+ * The agent-role tier ("<agent> · HH:MM") is the one part of the resolved
+ * name that is clock-shaped, and Studio otherwise always shows the viewer's
+ * local time. The backend bakes that HH:MM in UTC so the *stored* value is
+ * deterministic regardless of which machine resolved it (see
+ * agent_role_label's docstring) — this function recomputes the HH:MM half
+ * from `run.started_at` in the browser's local time before display, both
+ * when the backend already sent a resolved agent-role name and when this
+ * function falls back to building one itself from a bare `agent_name`.
  */
 import type { RunSummary } from "./types";
 
+const AGENT_TIME_SUFFIX_RE = / · \d{2}:\d{2}$/;
+
+function localHHMM(startedAt: number | null | undefined): string | null {
+  if (startedAt == null) return null;
+  const d = new Date(startedAt * 1000);
+  if (Number.isNaN(d.getTime())) return null;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
 export function resolveRunLabel(run: RunSummary): string {
-  return (
-    run.name?.trim() ||
-    run.show_play_name?.trim() ||
-    run.playbook_name?.trim() ||
-    run.agent_name?.trim() ||
-    run.run_id.slice(-12)
-  );
+  const backendName = run.name?.trim();
+  if (backendName) {
+    const agentName = run.agent_name?.trim();
+    if (
+      agentName &&
+      backendName.startsWith(`${agentName} · `) &&
+      AGENT_TIME_SUFFIX_RE.test(backendName)
+    ) {
+      const local = localHHMM(run.started_at);
+      if (local) return `${agentName} · ${local}`;
+    }
+    return backendName;
+  }
+
+  const showPlayName = run.show_play_name?.trim();
+  if (showPlayName) return showPlayName;
+
+  const playbookName = run.playbook_name?.trim();
+  if (playbookName) return playbookName;
+
+  const agentName = run.agent_name?.trim();
+  if (agentName) {
+    const local = localHHMM(run.started_at);
+    return local ? `${agentName} · ${local}` : agentName;
+  }
+
+  return run.run_id.slice(-12);
 }

--- a/apps/studio/frontend/vite.config.mts
+++ b/apps/studio/frontend/vite.config.mts
@@ -103,5 +103,9 @@ export default defineConfig({
     // e2e/ holds Playwright specs (see playwright.config.ts) -- a different
     // test runner with its own test()/expect(), never vitest's.
     exclude: ["e2e/**", "node_modules/**"],
+    // Pins the process timezone so any test asserting a rendered clock value
+    // (e.g. runLabel's local-time disambiguator) gets the same digits on
+    // every machine and in CI, instead of only passing in the author's TZ.
+    env: { TZ: "UTC" },
   },
 });

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
 from lionagi.ln._json_dump import raise_if_non_finite
+from lionagi.state.session_naming import sanitize_prompt_name
 from lionagi.studio.config import MIRROR_PREVIEW_CHARS
 
 from ._logging import hint, log_error, progress, warn
@@ -349,11 +350,15 @@ def _derive_metadata(state: _FileState, events: list[dict[str, Any]]) -> None:
                 if model:
                     state.model = model
                     break
-    # Prefer the first real user prompt as the session name.
+    # Prefer the first real user prompt as the session name, sanitized so a
+    # prompt that folds in the framework's system-message banner doesn't
+    # leak it into the displayed name.
     if events and (state.name is None or state.name.startswith("Claude · ")):
         prompt = _first_prompt(events)
         if prompt:
-            state.name = prompt[:72]
+            sanitized = sanitize_prompt_name(prompt)
+            if sanitized:
+                state.name = sanitized
 
 
 def _peek_head(path: Path) -> tuple[str, str | None]:
@@ -555,7 +560,9 @@ def _derive_codex_metadata(state: _FileState, records: list[dict[str, Any]]) -> 
     if state.name is None:
         prompt = _first_codex_prompt(records)
         if prompt:
-            state.name = prompt[:72]
+            sanitized = sanitize_prompt_name(prompt)
+            if sanitized:
+                state.name = sanitized
 
 
 def _first_codex_prompt(records: list[dict[str, Any]]) -> str | None:

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from lionagi.state.content_pruned import CONTENT_PRUNED_KEY, pruned_content_sql
+from lionagi.state.session_naming import resolve_display_name
 
 from ._runs import RUNS_ROOT
 from ._util import EXIT_CODE_BY_STATUS
@@ -313,13 +314,19 @@ async def _collect_sessions(db: Any, *, limit: int, status: str | None) -> list[
     """
     from sqlalchemy import text
 
+    # Same columns resolve_display_name reads for the Studio API (see
+    # studio/services/sessions.py) so `li state list` names agree with the
+    # Studio UI instead of showing the raw `name` column.
+    select_cols = (
+        "id, name, status, updated_at, playbook_name, agent_name, show_play_name, started_at"
+    )
     async with db._read() as conn:
         if status:
             rows = (
                 (
                     await conn.execute(
                         text(
-                            "SELECT id, name, status, updated_at FROM sessions "
+                            f"SELECT {select_cols} FROM sessions "  # noqa: S608
                             "WHERE status = :st ORDER BY updated_at DESC LIMIT :lim"
                         ),
                         {"st": status, "lim": limit},
@@ -333,7 +340,7 @@ async def _collect_sessions(db: Any, *, limit: int, status: str | None) -> list[
                 (
                     await conn.execute(
                         text(
-                            "SELECT id, name, status, updated_at FROM sessions "
+                            f"SELECT {select_cols} FROM sessions "  # noqa: S608
                             "ORDER BY updated_at DESC LIMIT :lim"
                         ),
                         {"lim": limit},
@@ -375,7 +382,7 @@ async def _collect_sessions(db: Any, *, limit: int, status: str | None) -> list[
         collected.append(
             {
                 "id": sid,
-                "name": row["name"],
+                "name": resolve_display_name(dict(row)),
                 "status": row["status"],
                 "updated_at": row["updated_at"],
                 "branch_count": bc,

--- a/lionagi/state/session_naming.py
+++ b/lionagi/state/session_naming.py
@@ -34,7 +34,7 @@ _STRIP_PATTERNS = (_LEADING_BANNER_RE, _LEADING_MARKDOWN_RE, _LEADING_LABEL_RE)
 _MAX_STRIP_PASSES = 6
 
 
-def sanitize_prompt_name(raw: str | None, *, max_len: int = DISPLAY_NAME_MAX_LEN) -> str:
+def sanitize_prompt_name(raw: str | None, *, max_len: int = DISPLAY_NAME_MAX_LEN) -> str | None:
     """Turn raw prompt/instruction text into a short, banner-free display name.
 
     Collapses whitespace, strips a leading system-message banner / markdown
@@ -42,9 +42,18 @@ def sanitize_prompt_name(raw: str | None, *, max_len: int = DISPLAY_NAME_MAX_LEN
     at `max_len` with an ellipsis. A name is never left starting with a
     colon'd prefix like "Guidance:". Idempotent on text that is already
     clean and short.
+
+    Returns `None`, never `""`, whenever there is no usable name — both for
+    empty/whitespace-only `raw`, and for a banner-only `raw` (e.g. just
+    `"LION_SYSTEM_MESSAGE"`, with nothing left once the banner is stripped).
+    A bare `""` would be ambiguous between those two cases and easy to
+    mistake for "the display name is the empty string"; `None` reads
+    unambiguously as "nothing to show here" and is falsy the same way `""`
+    is, so every existing `if sanitized:` caller keeps falling through to
+    its own next tier without any change.
     """
     if not raw:
-        return ""
+        return None
     text = " ".join(raw.split())
     for _ in range(_MAX_STRIP_PASSES):
         for pattern in _STRIP_PATTERNS:
@@ -54,6 +63,8 @@ def sanitize_prompt_name(raw: str | None, *, max_len: int = DISPLAY_NAME_MAX_LEN
                 break
         else:
             break
+    if not text:
+        return None
     if len(text) > max_len:
         text = text[: max_len - 1].rstrip() + "…"
     return text
@@ -66,6 +77,14 @@ def agent_role_label(agent_name: str, started_at: float | None) -> str:
     lookup against sibling rows. Stable across re-reads (same started_at
     always formats the same way) and computed from UTC so it does not depend
     on the resolving machine's local timezone.
+
+    Two same-agent runs started in the same minute still collide on this
+    label — that is accepted, by design, not a bug: the row's id remains the
+    real identity everywhere it matters (links, keys, API lookups), and this
+    label exists only to make a list of cards readable at a glance. Making
+    the label itself collision-proof (seconds, a counter, a suffix of the
+    id) would make the common case noisier to read to avoid an edge case
+    nothing actually depends on for correctness.
     """
     label = agent_name.strip()
     if not label:

--- a/lionagi/state/session_naming.py
+++ b/lionagi/state/session_naming.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic display-name derivation for sessions/runs, shared between the
+write path (transcript-mirror ingestion — cli/mirror.py) and the read path
+(studio API — studio/services/sessions.py, runs.py) so both agree on what
+"prompt-shaped" and "sane display width" mean. No randomness, no DB reads:
+every function here is a pure transform over already-available fields, so a
+row's resolved name is stable across re-reads and safe to compute per row on
+a paginated list.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+DISPLAY_NAME_MAX_LEN = 80
+
+# A run's own prompt sometimes carries the framework's system-message banner
+# verbatim (e.g. a caller that folds system + instruction into one field) —
+# strip the banner token itself, then any markdown separator/heading it wraps
+# (the banner is typically followed by a "---" rule and a "# Heading"), then a
+# short "Label:" prefix (e.g. "Guidance:") wrapping the whole thing. These are
+# tried repeatedly since they nest — a "Guidance:" wrapper around a
+# "LION_SYSTEM_MESSAGE" block needs two passes to fully unwrap.
+_LEADING_BANNER_RE = re.compile(
+    r"^(?:LION_SYSTEM_MESSAGE|END_OF_LION_SYSTEM_MESSAGE)\b[\s:.\-]*",
+    re.IGNORECASE,
+)
+_LEADING_MARKDOWN_RE = re.compile(r"^(?:-{2,}|#{1,6})\s*")
+_LEADING_LABEL_RE = re.compile(r"^[A-Za-z][A-Za-z0-9 _-]{0,24}:\s*")
+_STRIP_PATTERNS = (_LEADING_BANNER_RE, _LEADING_MARKDOWN_RE, _LEADING_LABEL_RE)
+_MAX_STRIP_PASSES = 6
+
+
+def sanitize_prompt_name(raw: str | None, *, max_len: int = DISPLAY_NAME_MAX_LEN) -> str:
+    """Turn raw prompt/instruction text into a short, banner-free display name.
+
+    Collapses whitespace, strips a leading system-message banner / markdown
+    separator / "Label:" prefix (repeated — these stack), and caps the result
+    at `max_len` with an ellipsis. A name is never left starting with a
+    colon'd prefix like "Guidance:". Idempotent on text that is already
+    clean and short.
+    """
+    if not raw:
+        return ""
+    text = " ".join(raw.split())
+    for _ in range(_MAX_STRIP_PASSES):
+        for pattern in _STRIP_PATTERNS:
+            stripped = pattern.sub("", text, count=1).strip()
+            if stripped != text:
+                text = stripped
+                break
+        else:
+            break
+    if len(text) > max_len:
+        text = text[: max_len - 1].rstrip() + "…"
+    return text
+
+
+def agent_role_label(agent_name: str, started_at: float | None) -> str:
+    """Deterministic label for an agent-only session: the agent's name plus a
+    UTC HH:MM disambiguator from its own start time, so concurrent runs of the
+    same agent read as distinct cards ("implementer · 14:22") without a
+    lookup against sibling rows. Stable across re-reads (same started_at
+    always formats the same way) and computed from UTC so it does not depend
+    on the resolving machine's local timezone.
+    """
+    label = agent_name.strip()
+    if not label:
+        return label
+    if started_at is None:
+        return label
+    stamp = time.strftime("%H:%M", time.gmtime(started_at))
+    return f"{label} · {stamp}"
+
+
+def _stripped(session_row: dict[str, Any], key: str) -> str:
+    """A field's value, stripped -- '' for missing/None/whitespace-only, so a
+    blank column reads as absent instead of winning its tier with nothing."""
+    value = session_row.get(key)
+    return str(value).strip() if value else ""
+
+
+def resolve_display_name(session_row: dict[str, Any]) -> str:
+    """Priority chain for a run's displayed name:
+
+        user_label > show/play name > playbook name > agent-role descriptor
+        > sanitized prompt-derived name > short id
+
+    `user_label` has no write path anywhere in this codebase yet — it is read
+    defensively via `.get()` so a future rename feature slots into the top of
+    this chain without another reorder. Every other tier reads a field that
+    is already computed or stored on the row.
+    """
+    user_label = _stripped(session_row, "user_label")
+    if user_label:
+        return user_label
+
+    show_play_name = _stripped(session_row, "show_play_name")
+    if show_play_name:
+        return show_play_name
+
+    playbook_name = _stripped(session_row, "playbook_name")
+    if playbook_name:
+        return playbook_name
+
+    agent_name = _stripped(session_row, "agent_name")
+    if agent_name:
+        label = agent_role_label(agent_name, session_row.get("started_at"))
+        if label:
+            return label
+
+    raw_name = _stripped(session_row, "name")
+    if raw_name:
+        sanitized = sanitize_prompt_name(raw_name)
+        if sanitized:
+            return sanitized
+
+    short_id = session_row.get("id") or session_row.get("run_id") or ""
+    return str(short_id)[-12:]

--- a/lionagi/studio/services/sessions.py
+++ b/lionagi/studio/services/sessions.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException, Query
 from lionagi._errors import NotFoundError
 from lionagi.state.claude_mirror import session_db_id
 from lionagi.state.db import SESSION_TERMINAL_STATUSES
+from lionagi.state.session_naming import resolve_display_name
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
@@ -275,7 +276,10 @@ async def list_sessions(
     return [
         {
             "id": row["id"],
-            "name": row["name"],
+            # Displayed name prefers structured identity (playbook/show/agent)
+            # over the raw, possibly prompt-derived value stored on the row
+            # — see resolve_display_name().
+            "name": resolve_display_name(dict(row)),
             "created_at": row["created_at"],
             "updated_at": row["updated_at"] or 0.0,
             "node_metadata": row["node_metadata"],
@@ -794,7 +798,9 @@ async def get_session(
 
     return {
         "id": session_row["id"],
-        "name": session_row["name"],
+        # Same resolution as list_sessions() — structured identity beats
+        # the raw, possibly prompt-derived stored name.
+        "name": resolve_display_name(dict(session_row)),
         "created_at": session_row["created_at"],
         "updated_at": session_row["updated_at"],
         "playbook_name": session_row["playbook_name"],

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -203,10 +203,23 @@ def test_runs_list_project_null_filter(tmp_path, monkeypatch):
 
 
 def test_runs_list_search_matches_name_or_agent_name(tmp_path, monkeypatch):
+    # search still matches the raw stored name/agent_name columns in SQL, but
+    # the returned `name` field is the resolved display name: a session with
+    # an agent_name gets the agent-role descriptor, not its raw stored name
+    # — so the second row's displayed name is derived from its agent_name,
+    # not the "unrelated" string it was seeded with.
+    from lionagi.state.session_naming import agent_role_label
+
+    started_at = 1767277320.0  # 2026-01-01T14:22:00Z
     db_path = tmp_path / "state.db"
     sessions = [
         {"id": str(uuid.uuid4()), "name": "fix flaky login test"},
-        {"id": str(uuid.uuid4()), "name": "unrelated", "agent_name": "flaky-hunter"},
+        {
+            "id": str(uuid.uuid4()),
+            "name": "unrelated",
+            "agent_name": "flaky-hunter",
+            "started_at": started_at,
+        },
         {"id": str(uuid.uuid4()), "name": "totally different"},
     ]
     _run(_seed_sessions(db_path, sessions))
@@ -217,7 +230,7 @@ def test_runs_list_search_matches_name_or_agent_name(tmp_path, monkeypatch):
     data = r.json()
     assert data["total"] == 2
     names = {run["name"] for run in data["runs"]}
-    assert names == {"fix flaky login test", "unrelated"}
+    assert names == {"fix flaky login test", agent_role_label("flaky-hunter", started_at)}
 
 
 def test_runs_list_search_is_case_insensitive(tmp_path, monkeypatch):

--- a/tests/state/test_session_naming.py
+++ b/tests/state/test_session_naming.py
@@ -59,10 +59,18 @@ def test_sanitize_is_idempotent_on_already_clean_short_text() -> None:
     assert sanitize_prompt_name("a normal short prompt") == "a normal short prompt"
 
 
-def test_sanitize_empty_or_none_returns_empty_string() -> None:
-    assert sanitize_prompt_name(None) == ""
-    assert sanitize_prompt_name("") == ""
-    assert sanitize_prompt_name("   ") == ""
+def test_sanitize_empty_or_none_returns_none() -> None:
+    assert sanitize_prompt_name(None) is None
+    assert sanitize_prompt_name("") is None
+    assert sanitize_prompt_name("   ") is None
+
+
+def test_sanitize_banner_only_input_returns_none_not_empty_string() -> None:
+    # Nothing survives stripping -- this is the "had content, produced
+    # nothing usable" case, and must be distinguishable (via None) from the
+    # "had no content to begin with" case above.
+    assert sanitize_prompt_name("LION_SYSTEM_MESSAGE") is None
+    assert sanitize_prompt_name("Guidance: LION_SYSTEM_MESSAGE") is None
 
 
 # ── agent_role_label ──────────────────────────────────────────────────────

--- a/tests/state/test_session_naming.py
+++ b/tests/state/test_session_naming.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for lionagi.state.session_naming — display-name derivation."""
+
+from __future__ import annotations
+
+from lionagi.state.session_naming import (
+    DISPLAY_NAME_MAX_LEN,
+    agent_role_label,
+    resolve_display_name,
+    sanitize_prompt_name,
+)
+
+# ── sanitize_prompt_name ──────────────────────────────────────────────────
+
+
+def test_sanitize_strips_leading_system_message_banner() -> None:
+    raw = "LION_SYSTEM_MESSAGE\n\n---\n\n# Welcome to LIONAGI\n\nWe are an intelligence OS."
+    out = sanitize_prompt_name(raw)
+    assert not out.startswith("LION_SYSTEM_MESSAGE")
+    assert not out.startswith("#")
+    assert not out.startswith("-")
+    assert out.startswith("Welcome to LIONAGI")
+
+
+def test_sanitize_strips_a_guidance_label_wrapping_a_banner() -> None:
+    raw = "Guidance: LION_SYSTEM_MESSAGE\n\n---\n\nSome real instruction text here."
+    out = sanitize_prompt_name(raw)
+    assert not out.startswith("Guidance:")
+    assert not out.startswith("LION_SYSTEM_MESSAGE")
+    assert out.startswith("Some real instruction text")
+
+
+def test_sanitize_never_leaves_a_colond_label_prefix() -> None:
+    out = sanitize_prompt_name("Instruction: fix the null pointer bug in the parser")
+    assert not out.startswith("Instruction:")
+    assert out.startswith("fix the null pointer bug")
+
+
+def test_sanitize_collapses_internal_whitespace() -> None:
+    out = sanitize_prompt_name("fix   the\n\nbug   please")
+    assert out == "fix the bug please"
+
+
+def test_sanitize_caps_length_with_ellipsis() -> None:
+    raw = "x" * 200
+    out = sanitize_prompt_name(raw)
+    assert len(out) == DISPLAY_NAME_MAX_LEN
+    assert out.endswith("…")
+
+
+def test_sanitize_respects_custom_max_len() -> None:
+    out = sanitize_prompt_name("x" * 50, max_len=10)
+    assert len(out) == 10
+    assert out.endswith("…")
+
+
+def test_sanitize_is_idempotent_on_already_clean_short_text() -> None:
+    assert sanitize_prompt_name("a normal short prompt") == "a normal short prompt"
+
+
+def test_sanitize_empty_or_none_returns_empty_string() -> None:
+    assert sanitize_prompt_name(None) == ""
+    assert sanitize_prompt_name("") == ""
+    assert sanitize_prompt_name("   ") == ""
+
+
+# ── agent_role_label ──────────────────────────────────────────────────────
+
+
+def test_agent_role_label_appends_utc_time_disambiguator() -> None:
+    # 2026-01-01T14:22:00Z
+    started_at = 1767277320.0
+    assert agent_role_label("implementer", started_at) == "implementer · 14:22"
+
+
+def test_agent_role_label_is_deterministic_across_calls() -> None:
+    started_at = 1767277320.0
+    first = agent_role_label("implementer", started_at)
+    second = agent_role_label("implementer", started_at)
+    assert first == second
+
+
+def test_agent_role_label_disambiguates_concurrent_same_agent_runs() -> None:
+    # Two "implementer" runs starting at different times must not collide.
+    a = agent_role_label("implementer", 1767277320.0)  # 14:22 UTC
+    b = agent_role_label("implementer", 1767278040.0)  # 14:34 UTC
+    assert a != b
+    assert a.startswith("implementer")
+    assert b.startswith("implementer")
+
+
+def test_agent_role_label_falls_back_to_bare_name_without_started_at() -> None:
+    assert agent_role_label("implementer", None) == "implementer"
+
+
+# ── resolve_display_name: priority chain ──────────────────────────────────
+
+
+def test_priority_user_label_wins_over_everything() -> None:
+    row = {
+        "user_label": "my renamed run",
+        "show_play_name": "show",
+        "playbook_name": "pb",
+        "agent_name": "implementer",
+        "name": "raw",
+        "id": "abc123",
+    }
+    assert resolve_display_name(row) == "my renamed run"
+
+
+def test_priority_show_play_name_wins_over_playbook_and_agent() -> None:
+    row = {
+        "show_play_name": "ADR-0099 rollout",
+        "playbook_name": "pb",
+        "agent_name": "implementer",
+        "name": "raw",
+        "id": "abc123",
+    }
+    assert resolve_display_name(row) == "ADR-0099 rollout"
+
+
+def test_priority_playbook_name_wins_over_agent_and_raw_name() -> None:
+    row = {
+        "playbook_name": "pr-merge-review",
+        "agent_name": "implementer",
+        "name": "raw",
+        "id": "abc123",
+    }
+    assert resolve_display_name(row) == "pr-merge-review"
+
+
+def test_priority_agent_role_descriptor_wins_over_raw_name() -> None:
+    row = {
+        "agent_name": "implementer",
+        "name": "some raw prompt-derived name",
+        "started_at": 1767277320.0,
+        "id": "abc123",
+    }
+    assert resolve_display_name(row) == "implementer · 14:22"
+
+
+def test_agent_only_collision_two_concurrent_runs_resolve_to_distinct_names() -> None:
+    row_a = {"agent_name": "implementer", "started_at": 1767277320.0, "id": "a"}
+    row_b = {"agent_name": "implementer", "started_at": 1767278040.0, "id": "b"}
+    name_a = resolve_display_name(row_a)
+    name_b = resolve_display_name(row_b)
+    assert name_a != name_b
+
+
+def test_priority_sanitized_prompt_fallback_when_no_structured_identity() -> None:
+    row = {
+        "name": "LION_SYSTEM_MESSAGE\n\n---\n\n# Welcome to LIONAGI\n\nfix the bug",
+        "id": "abc123",
+    }
+    out = resolve_display_name(row)
+    assert not out.startswith("LION_SYSTEM_MESSAGE")
+    assert "fix the bug" in out
+
+
+def test_over_long_prompt_fallback_is_capped() -> None:
+    row = {"name": "x" * 300, "id": "abc123"}
+    out = resolve_display_name(row)
+    assert len(out) <= DISPLAY_NAME_MAX_LEN
+
+
+def test_priority_short_id_is_the_last_resort() -> None:
+    row = {"id": "0123456789abcdef"}
+    assert resolve_display_name(row) == "456789abcdef"
+
+
+def test_falls_back_to_run_id_key_when_id_absent() -> None:
+    row = {"run_id": "0123456789abcdef"}
+    assert resolve_display_name(row) == "456789abcdef"
+
+
+def test_blank_fields_are_treated_as_absent() -> None:
+    row = {
+        "show_play_name": "  ",
+        "playbook_name": "",
+        "agent_name": None,
+        "name": "reviewer's genuine short name",
+        "id": "abc123",
+    }
+    assert resolve_display_name(row) == "reviewer's genuine short name"


### PR DESCRIPTION
Fixes #2850.

Default session/run names leaked raw prompt text (system-banner prefixes, instruction text) into every list surface, and concurrent runs of the same agent were indistinguishable.

- New shared derivation `resolve_display_name`: manual label > show/play name > playbook name > agent-role descriptor > sanitized prompt text > short id. Structured identity always beats prompt text.
- Agent-only runs (the dominant class: ~15k of ~17k rows in a production census) get a deterministic `<agent> · HH:MM` label from the row's own start time — stable across re-reads, no sibling queries, no generated titles.
- The prompt-derived fallback strips banner/label prefixes, collapses whitespace, and caps display length; a name can no longer begin with an instruction prefix.
- Applied at display/derivation time; no stored-row migration. Mirror write paths sanitize new names going forward.
- Frontend surfaces reuse one `runLabel` helper instead of duplicating fallbacks.

Tests: 22 naming-unit tests + mirror + studio server suites green; frontend 1061 tests, tsc, eslint clean.

Tradeoff worth reviewer eyes: CLI transcript-mirror sessions carry a generic agent name, so those lists now show `claude-code · 14:22`-style labels instead of prompt-derived text — deterministic and collision-free, but less per-conversation descriptive. The sanitized-prompt tier still serves rows with no agent metadata.