### PR TITLE
fix(studio): point Operator failure messages at evidence that exists

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -42,6 +42,7 @@ __all__ = (
     "active_run_id",
     "resolve_run_reason",
     "setup_agent_persist",
+    "find_incomplete_session_for_run",
     "teardown_persist",
     "teardown_agent_persist",
     "teardown_orchestration_persist",
@@ -1424,3 +1425,45 @@ async def setup_agent_persist(
 
                 unregister_shared_db(db)
         return None
+
+
+async def find_incomplete_session_for_run(run_id: str) -> dict | None:
+    """Recover a session row that ``setup_agent_persist()`` committed before
+    failing on a later step, terminalizing it if it is still "running".
+
+    ``setup_agent_persist()`` can call ``create_session()`` and then raise
+    inside the same setup (e.g. the following ``create_branch()``); it catches
+    that exception and returns None, so its caller sees no context but the
+    session row itself is still durable and left running forever. A caller
+    whose *run_id* is minted fresh for every attempt (never reused across a
+    resume, the way a new operator turn always is) can pass it here after
+    setup fails to recover that row -- and close it out -- instead of
+    reporting the run as never having existed. Returns None only when no
+    session was ever recorded under this run id.
+    """
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES, StateDB
+    from lionagi.state.reasons import RunReasons
+
+    db = StateDB()
+    await db.open()
+    try:
+        rows = await db.get_sessions_for_run(run_id)
+        if not rows:
+            return None
+        row = rows[-1]
+        status = row.get("status")
+        if status not in SESSION_TERMINAL_STATUSES:
+            await db.update_status(
+                "session",
+                row["id"],
+                new_status="failed",
+                reason_code=RunReasons.FAILED_EXCEPTION,
+                reason_summary="run setup failed after the session row was committed",
+                source="executor",
+                actor=row["id"],
+                expected_statuses={status},
+            )
+            row = await db.get_session(row["id"]) or row
+        return row
+    finally:
+        await db.close()

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -42,6 +42,18 @@ class ApplicationTargetConflictError(RuntimeError):
     """The exact target approved by a human is no longer current."""
 
 
+class ApplicationCommandError(RuntimeError):
+    """An application command failed; carries whatever evidence existed at the time.
+
+    ``invocation_id`` is set only once ``launch()`` has durably recorded the
+    invocation -- a failure before that point genuinely has nothing to point at.
+    """
+
+    def __init__(self, message: str, *, invocation_id: str | None = None) -> None:
+        super().__init__(message)
+        self.invocation_id = invocation_id
+
+
 async def _verify_application_target(proposal: dict[str, Any]) -> None:
     target_version = proposal.get("targetVersion")
     if target_version is None:
@@ -72,7 +84,13 @@ async def _execute_application_command(
         raise ValueError(f"Unsupported Operator application command: {command_type!r}")
     from lionagi.studio.services.launches import launch
 
-    result = await launch(command)
+    try:
+        result = await launch(command)
+    except Exception as exc:  # noqa: BLE001
+        # Nothing has been recorded yet -- validation, launch-cap, and
+        # executable-resolution failures all happen before any invocation row
+        # exists, so there is no id to hand back to the caller.
+        raise ApplicationCommandError(str(exc)) from exc
     invocation_id = result.get("invocation_id")
     if not invocation_id:
         return result
@@ -83,13 +101,18 @@ async def _execute_application_command(
     from lionagi.studio.services.invocations import get_invocation
 
     run_id = None
-    for _ in range(20):
-        detail = await get_invocation(str(invocation_id))
-        sessions = detail.get("sessions", []) if detail else []
-        if sessions:
-            run_id = sessions[0].get("id")
-            break
-        await asyncio.sleep(0.1)
+    try:
+        for _ in range(20):
+            detail = await get_invocation(str(invocation_id))
+            sessions = detail.get("sessions", []) if detail else []
+            if sessions:
+                run_id = sessions[0].get("id")
+                break
+            await asyncio.sleep(0.1)
+    except Exception as exc:  # noqa: BLE001
+        # The invocation itself is durable even though polling it failed --
+        # carry its id forward so the failure can still point at it.
+        raise ApplicationCommandError(str(exc), invocation_id=str(invocation_id)) from exc
     return {
         **result,
         "run_id": run_id,
@@ -467,16 +490,25 @@ class OperatorCoordinator:
             terminal_status = "failed"
             terminal_exc = exc
             _log.exception("Operator turn failed: %s", request_id)
+            # A canonical run only exists once setup_agent_persist() has
+            # returned (live is not None); an exception before that point --
+            # history compilation, provider selection, branch/run-dir setup --
+            # has no run to point at, so say that plainly instead of guessing.
+            if live is not None:
+                run_id = live["session_id"]
+                evidence = f"open the run at /runs/{run_id} for its status and history"
+                details: dict[str, Any] = {"runId": run_id, "href": f"/runs/{run_id}"}
+            else:
+                evidence = "no run was recorded for this turn before it failed"
+                details = {"runId": None}
             await self.store.finish_turn(
                 request_id,
                 outcome="failed",
                 error={
                     "code": "model_failure",
-                    "message": (
-                        f"The Operator engine failed ({type(exc).__name__}); "
-                        "see daemon logs for diagnostics"
-                    ),
+                    "message": (f"The Operator engine failed ({type(exc).__name__}); {evidence}."),
                     "retryable": True,
+                    "details": details,
                 },
             )
         finally:
@@ -613,17 +645,27 @@ class OperatorCoordinator:
         try:
             result = await self.command_executor(proposal["commandType"], proposal["command"])
         except Exception as exc:  # noqa: BLE001
-            public_message = (
-                f"Application command failed ({type(exc).__name__}); "
-                "see daemon logs for diagnostics"
-            )
+            # A launch that failed before recording an invocation has nothing
+            # durable to point at; one that failed after has an invocation_id
+            # attached by _execute_application_command.
+            invocation_id = getattr(exc, "invocation_id", None)
+            if invocation_id:
+                evidence = f"open invocation {invocation_id} at /invocations/{invocation_id}"
+                details: dict[str, Any] = {
+                    "invocationId": invocation_id,
+                    "href": f"/invocations/{invocation_id}",
+                }
+            else:
+                evidence = "no invocation was recorded for this command before it failed"
+                details = {"invocationId": None}
+            public_message = f"Application command failed ({type(exc).__name__}); {evidence}."
             _log.exception("Operator application command failed: %s", proposal_id)
             try:
                 proposal = await self.store.complete_proposal(
                     proposal_id,
                     status="failed",
                     error_code="service_failure",
-                    result={"message": public_message},
+                    result={"message": public_message, "details": details},
                     audit=True,
                 )
             except Exception as persist_exc:  # noqa: BLE001
@@ -648,6 +690,7 @@ class OperatorCoordinator:
                         "code": "service_failure",
                         "message": public_message,
                         "retryable": False,
+                        "details": details,
                     },
                 },
             )

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -494,10 +494,24 @@ class OperatorCoordinator:
             # returned (live is not None); an exception before that point --
             # history compilation, provider selection, branch/run-dir setup --
             # has no run to point at, so say that plainly instead of guessing.
+            # setup_agent_persist() can also commit the session row and then
+            # fail on a later step of the same setup, leaving `live` None even
+            # though a durable record exists -- recover that row before
+            # concluding nothing was recorded.
+            orphaned_session = None
+            if live is None and run_dir is not None:
+                with suppress(Exception):
+                    orphaned_session = await cli_runs.find_incomplete_session_for_run(
+                        run_dir.run_id
+                    )
             if live is not None:
                 run_id = live["session_id"]
                 evidence = f"open the run at /runs/{run_id} for its status and history"
                 details: dict[str, Any] = {"runId": run_id, "href": f"/runs/{run_id}"}
+            elif orphaned_session is not None:
+                run_id = orphaned_session["id"]
+                evidence = f"open the run at /runs/{run_id} for its status and history"
+                details = {"runId": run_id, "href": f"/runs/{run_id}"}
             else:
                 evidence = "no run was recorded for this turn before it failed"
                 details = {"runId": None}

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -39,6 +39,15 @@ class ScriptedEngine:
         return self._stream(turn)
 
 
+class FailingEngine:
+    async def _stream(self, _turn):
+        raise RuntimeError("engine exploded mid-turn")
+        yield  # pragma: no cover
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
 class BlockingEngine:
     async def _stream(self, _turn):
         await asyncio.Event().wait()
@@ -754,6 +763,225 @@ async def test_missing_claude_cli_finishes_with_public_provider_fix(tmp_path, mo
     }
     assert frames[-1]["payload"]["outcome"] == "failed"
     await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_failure_points_at_the_run_it_created(tmp_path, monkeypatch):
+    """An engine failure that happens after the canonical run exists must name it."""
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=FailingEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    await coordinator.submit(
+        cid,
+        instruction="do something that will fail",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    frames = await _wait_done(coordinator.store, cid)
+    error = next(frame for frame in frames if frame["type"] == "error")["payload"]["error"]
+    assert error["code"] == "model_failure"
+    run_id = error["details"]["runId"]
+    assert run_id
+    assert f"/runs/{run_id}" in error["message"]
+    assert error["details"]["href"] == f"/runs/{run_id}"
+    assert "daemon logs" not in error["message"]
+
+    # The pointer resolves: a real, durable run exists under that id.
+    from lionagi.state.db import StateDB
+
+    async with StateDB(readonly=True) as db:
+        session = await db.get_session(run_id)
+    assert session is not None
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_model_failure_states_absence_when_no_run_was_created(tmp_path, monkeypatch):
+    """A failure before the canonical run exists must say so, not fabricate a pointer."""
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    from lionagi.studio.operator import coordinator as coordinator_mod
+
+    def broken_history(*_args, **_kwargs):
+        raise RuntimeError("history compilation exploded")
+
+    monkeypatch.setattr(coordinator_mod, "compile_operator_history", broken_history)
+
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    await coordinator.submit(
+        cid,
+        instruction="this never reaches a run",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    frames = await _wait_done(coordinator.store, cid)
+    error = next(frame for frame in frames if frame["type"] == "error")["payload"]["error"]
+    assert error["code"] == "model_failure"
+    assert error["details"]["runId"] is None
+    assert "no run was recorded" in error["message"]
+    assert "/runs/" not in error["message"]
+    assert "daemon logs" not in error["message"]
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_application_command_failure_points_at_its_invocation(tmp_path, monkeypatch):
+    """A command failure after its invocation was recorded must name that invocation."""
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    from lionagi.state.db import StateDB
+    from lionagi.studio.operator.coordinator import ApplicationCommandError
+
+    async with StateDB() as db:
+        await db.create_invocation(
+            {
+                "id": "inv-real",
+                "skill": "launch:play",
+                "plugin": "studio_launch",
+                "prompt": None,
+                "started_at": time.time(),
+                "status": "running",
+            }
+        )
+
+    async def execute(_command_type, _command):
+        raise ApplicationCommandError("spawn died mid-flight", invocation_id="inv-real")
+
+    coordinator = OperatorCoordinator(
+        store=OperatorStore(path),
+        engine_factory=lambda: PermissionEngine("launch"),
+        command_executor=execute,
+    )
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await coordinator.submit(
+        cid,
+        instruction="launch it",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    proposal = await _wait_proposal(coordinator.store, accepted["requestId"])
+    await coordinator.decide(
+        cid,
+        proposal["id"],
+        allow=True,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=None,
+    )
+    frames = await coordinator.store.list_frames(cid)
+    tool_result = next(
+        frame
+        for frame in frames
+        if frame["type"] == "tool_result" and frame["payload"].get("callId") == proposal["id"]
+    )
+    error = tool_result["payload"]["error"]
+    assert error["code"] == "service_failure"
+    assert "/invocations/inv-real" in error["message"]
+    assert error["details"]["invocationId"] == "inv-real"
+    assert "daemon logs" not in error["message"]
+
+    async with StateDB(readonly=True) as db:
+        invocation = await db.get_invocation("inv-real")
+    assert invocation is not None
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_application_command_failure_states_absence_when_no_invocation_was_recorded(
+    tmp_path, monkeypatch
+):
+    """A command failure before any invocation exists must say so, not fabricate a pointer."""
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+
+    async def execute(_command_type, _command):
+        raise ValueError("li executable could not be resolved")
+
+    coordinator = OperatorCoordinator(
+        store=OperatorStore(path),
+        engine_factory=lambda: PermissionEngine("launch"),
+        command_executor=execute,
+    )
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await coordinator.submit(
+        cid,
+        instruction="launch it",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    proposal = await _wait_proposal(coordinator.store, accepted["requestId"])
+    await coordinator.decide(
+        cid,
+        proposal["id"],
+        allow=True,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=None,
+    )
+    frames = await coordinator.store.list_frames(cid)
+    tool_result = next(
+        frame
+        for frame in frames
+        if frame["type"] == "tool_result" and frame["payload"].get("callId") == proposal["id"]
+    )
+    error = tool_result["payload"]["error"]
+    assert error["code"] == "service_failure"
+    assert error["details"]["invocationId"] is None
+    assert "no invocation was recorded" in error["message"]
+    assert "/invocations/" not in error["message"]
+    assert "daemon logs" not in error["message"]
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_execute_application_command_failure_has_no_invocation_before_launch_returns(
+    monkeypatch,
+):
+    """launch() raising before it returns leaves no invocation id to carry forward."""
+    import lionagi.studio.services.launches as launches_mod
+    from lionagi.studio.operator.coordinator import (
+        ApplicationCommandError,
+        _execute_application_command,
+    )
+
+    async def broken_launch(_data):
+        raise ValueError("validation failed")
+
+    monkeypatch.setattr(launches_mod, "launch", broken_launch)
+
+    with pytest.raises(ApplicationCommandError) as excinfo:
+        await _execute_application_command("launch", {"action_kind": "play"})
+    assert excinfo.value.invocation_id is None
+
+
+@pytest.mark.asyncio
+async def test_execute_application_command_failure_carries_invocation_id_once_recorded(
+    monkeypatch,
+):
+    """A poll failure after launch() succeeds must still carry the recorded invocation id."""
+    import lionagi.studio.services.invocations as invocations_mod
+    import lionagi.studio.services.launches as launches_mod
+    from lionagi.studio.operator.coordinator import (
+        ApplicationCommandError,
+        _execute_application_command,
+    )
+
+    async def fake_launch(_data):
+        return {"invocation_id": "inv-42", "action_kind": "play"}
+
+    async def broken_get_invocation(_invocation_id):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(launches_mod, "launch", fake_launch)
+    monkeypatch.setattr(invocations_mod, "get_invocation", broken_get_invocation)
+
+    with pytest.raises(ApplicationCommandError) as excinfo:
+        await _execute_application_command("launch", {"action_kind": "play"})
+    assert excinfo.value.invocation_id == "inv-42"
 
 
 @pytest.mark.asyncio

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -829,6 +829,47 @@ async def test_model_failure_states_absence_when_no_run_was_created(tmp_path, mo
 
 
 @pytest.mark.asyncio
+async def test_model_failure_after_session_commit_points_at_the_orphaned_run(tmp_path, monkeypatch):
+    """Setup can commit the session row and then fail on a later step (here,
+    the branch insert): the failure message must not claim nothing was
+    recorded, and the row must not be left "running" forever."""
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    from lionagi.state.db import SESSION_TERMINAL_STATUSES, StateDB
+
+    async def broken_create_branch(self, *_args, **_kwargs):
+        raise RuntimeError("branch insert exploded")
+
+    monkeypatch.setattr(StateDB, "create_branch", broken_create_branch)
+
+    coordinator = OperatorCoordinator(store=OperatorStore(path), engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    await coordinator.submit(
+        cid,
+        instruction="setup will fail after the session row commits",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    frames = await _wait_done(coordinator.store, cid)
+    error = next(frame for frame in frames if frame["type"] == "error")["payload"]["error"]
+    assert error["code"] == "model_failure"
+    run_id = error["details"]["runId"]
+    assert run_id
+    assert f"/runs/{run_id}" in error["message"]
+    assert error["details"]["href"] == f"/runs/{run_id}"
+    assert "no run was recorded" not in error["message"]
+
+    # The pointer resolves to a real, durable, no-longer-orphaned row: the
+    # commit survived setup's failure, but it is not left "running" forever.
+    async with StateDB(readonly=True) as db:
+        session = await db.get_session(run_id)
+    assert session is not None
+    assert session["status"] in SESSION_TERMINAL_STATUSES
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_application_command_failure_points_at_its_invocation(tmp_path, monkeypatch):
     """A command failure after its invocation was recorded must name that invocation."""
     path = tmp_path / "state.db"


### PR DESCRIPTION
Operator failure frames now attach evidence pointers that actually resolve: model failures reference the recorded run (/runs/{id}) once one exists, application-command failures reference the recorded invocation, and each shape states explicitly when the failure happened before anything durable was recorded. Provider-unavailable messaging is untouched since it already gives actionable guidance.

Closes #2853