### PR TITLE
feat(studio): durable discharge lifecycle for needs-attention items

### DIFF
--- a/apps/studio/frontend/src/components/mission/AttentionQueue.test.tsx
+++ b/apps/studio/frontend/src/components/mission/AttentionQueue.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * AttentionQueue.tsx — discharge lifecycle contract tests.
+ *
+ * Pure source-contract tests: no rendering, no @testing-library/react
+ * (mirrors InvocationDetail.test.tsx). Verifies the component wires the
+ * discharge actions to the persistence API, keeps acknowledged rows
+ * visible, and exposes a discharged-items filter — the parts a reducer
+ * unit test can't see.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const MISSION_DIR = path.resolve(__dirname);
+
+const src = fs.readFileSync(path.join(MISSION_DIR, "AttentionQueue.tsx"), "utf-8");
+
+describe("AttentionQueue.tsx — source contract", () => {
+  it("exports a default function component", () => {
+    expect(src).toMatch(/export default function AttentionQueue/);
+  });
+
+  it("accepts a dischargedItems prop distinct from items", () => {
+    expect(src).toMatch(/dischargedItems:\s*AttentionItem\[\]/);
+  });
+
+  it("calls putAttentionDisposition for acknowledge/resolve/snooze/expected", () => {
+    expect(src).toMatch(/putAttentionDisposition/);
+    expect(src).toMatch(/state:\s*"acknowledged"|"acknowledged"\)/);
+    expect(src).toMatch(/save\("resolved"\)/);
+    expect(src).toMatch(/save\("snoozed"/);
+    expect(src).toMatch(/save\("expected"/);
+  });
+
+  it("calls deleteAttentionDisposition for undo", () => {
+    expect(src).toMatch(/deleteAttentionDisposition/);
+  });
+
+  it("never removes a row before the write succeeds — no optimistic local disposition state", () => {
+    // The component must read discharge state only from item.disposition
+    // (server-confirmed, joined by the reducer), never mutate a local copy
+    // of it after a PUT/DELETE call.
+    expect(src).not.toMatch(/setLocalDisposition|useState<AttentionDisposition/);
+    expect(src).toMatch(/item\.disposition/);
+  });
+
+  it("'expected' requires a non-blank note before submitting", () => {
+    expect(src).toMatch(/noteRequired/);
+    expect(src).toMatch(/note\.trim\(\)/);
+  });
+
+  it("snooze and expected always submit an expiresAt", () => {
+    expect(src).toMatch(/expiresAt:\s*Math\.floor\(Date\.now\(\)\s*\/\s*1000\)\s*\+\s*durationSec/);
+    expect(src).toMatch(
+      /expiresAt:\s*Math\.floor\(Date\.now\(\)\s*\/\s*1000\)\s*\+\s*SNOOZE_DURATIONS\[0\]\.seconds/,
+    );
+  });
+
+  it("acknowledged items stay visible (restyled), never filtered out of the row list", () => {
+    // AttentionQueue only receives already-split active items (acknowledged
+    // included) from boardReducer; it must render every item it's given
+    // without an additional acknowledged-hiding filter.
+    expect(src).not.toMatch(
+      /\.filter\(\s*\(?i\)?\s*=>\s*!?.*disposition.*state\s*===\s*"acknowledged"/,
+    );
+    expect(src).toMatch(/acknowledged/);
+  });
+
+  it("shows a discharged-items toggle, off by default", () => {
+    expect(src).toMatch(/showDischarged/);
+    expect(src).toMatch(/useState\(false\)/);
+  });
+
+  it("every disposition action button carries an aria-label naming the item", () => {
+    expect(src).toMatch(/acknowledgeAria.*\{\s*name:\s*item\.name\s*\}/s);
+    expect(src).toMatch(/resolveAria.*\{\s*name:\s*item\.name\s*\}/s);
+    expect(src).toMatch(/undoAria.*\{\s*name:\s*item\.name\s*\}/s);
+  });
+
+  it("reports a failed write with an inline error, not a thrown/swallowed exception", () => {
+    expect(src).toMatch(/catch\s*\(err\)\s*\{[\s\S]*setError/);
+  });
+
+  it("still renders the existing Open deep link unchanged", () => {
+    expect(src).toMatch(/attention\.open/);
+    expect(src).toMatch(/ItemLink/);
+  });
+});

--- a/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
+++ b/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
@@ -302,6 +302,7 @@ function DispositionControls({ item }: { item: AttentionItem }) {
         sourceStatus: item.status,
         note: extra?.note,
         expiresAt: extra?.expiresAt,
+        revision: item.disposition?.revision,
       });
       setExpectedOpen(false);
       setNote("");

--- a/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
+++ b/apps/studio/frontend/src/components/mission/AttentionQueue.tsx
@@ -7,9 +7,16 @@
  * Orphaned (daemon-restart housekeeping) runs never reach the attention
  * list at all — they surface only in the Recent history strip as a neutral
  * chip, so nothing here is pure housekeeping noise.
+ *
+ * Discharge lifecycle: every row also offers Acknowledge/Resolve/Snooze/
+ * Expected. These persist server-side (see boardReducer's dispositions
+ * join) — a discharged (resolved/expected/snoozed) item leaves this default
+ * view on the next poll, but stays queryable via "Show discharged" below.
+ * Acknowledged items stay visible here, only restyled: acknowledging is
+ * "seen, not fixed," never a hide.
  */
 
-import type { CSSProperties, ReactNode } from "react";
+import { useState, type CSSProperties, type FormEvent, type ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 import SectionLabel from "@/components/ui/SectionLabel";
@@ -17,12 +24,16 @@ import Chip from "@/components/ui/Chip";
 import Skeleton from "@/components/ui/Skeleton";
 import { type AttentionItem, type AttentionReason } from "./boardReducer";
 import { runDeepLink, invocationDeepLink, scheduleDeepLink } from "@/lib/runDeepLink";
+import { putAttentionDisposition, deleteAttentionDisposition, ApiError } from "@/lib/api";
+import type { AttentionDispositionState } from "@/lib/api";
 
 /** Placeholder row count while the first fetch is in flight. */
 const SKELETON_ROWS = 3;
 
 interface Props {
   items: AttentionItem[];
+  /** Discharged (resolved/expected/snoozed) items — hidden by default. */
+  dischargedItems: AttentionItem[];
   nowSec: number;
   dataState: "loading" | "live" | "stale" | "error";
 }
@@ -66,6 +77,12 @@ const REASON_COLOR: Record<AttentionReason, string> = {
   gated: "var(--accent)",
 };
 
+const SNOOZE_DURATIONS: { seconds: number; labelKey: string }[] = [
+  { seconds: 3600, labelKey: "1h" },
+  { seconds: 4 * 3600, labelKey: "4h" },
+  { seconds: 24 * 3600, labelKey: "24h" },
+];
+
 function elapsedLabel(startedAt: number | null, nowSec: number): string {
   if (startedAt == null) return "—";
   // Timestamps are float epochs — floor so sub-minute ages never render
@@ -79,8 +96,9 @@ function elapsedLabel(startedAt: number | null, nowSec: number): string {
   return mm > 0 ? `${h}h ${mm}m` : `${h}h`;
 }
 
-export default function AttentionQueue({ items, nowSec }: Props) {
+export default function AttentionQueue({ items, dischargedItems, nowSec }: Props) {
   const t = useTranslations("mission");
+  const [showDischarged, setShowDischarged] = useState(false);
 
   const actionable = items.filter((i) => ACTIONABLE_REASONS.has(i.reason));
   // Informational digests, one row per cause. Orphaned runs are excluded
@@ -110,12 +128,26 @@ export default function AttentionQueue({ items, nowSec }: Props) {
         >
           <span id="attention-heading">{t("attention.title")}</span>
         </SectionLabel>
-        <Link
-          to="/fleet"
-          className="font-data text-[length:var(--t-xs)] text-content-muted transition-colors duration-100"
-        >
-          {t("attention.viewAll")}
-        </Link>
+        <div className="flex items-center gap-3">
+          {dischargedItems.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowDischarged((v) => !v)}
+              aria-expanded={showDischarged}
+              className="font-data text-[length:var(--t-xs)] text-content-muted transition-colors duration-100 hover:text-content-primary"
+            >
+              {showDischarged
+                ? t("attention.hideDischarged")
+                : `${t("attention.showDischarged")} (${dischargedItems.length})`}
+            </button>
+          )}
+          <Link
+            to="/fleet"
+            className="font-data text-[length:var(--t-xs)] text-content-muted transition-colors duration-100"
+          >
+            {t("attention.viewAll")}
+          </Link>
+        </div>
       </div>
 
       <div className="overflow-hidden rounded border border-edge">
@@ -150,6 +182,20 @@ export default function AttentionQueue({ items, nowSec }: Props) {
           </div>
         ))}
       </div>
+
+      {showDischarged && (
+        <div className="mt-2 overflow-hidden rounded border border-edge">
+          {dischargedItems.length === 0 ? (
+            <div className="bg-surface-raised px-3 py-2 font-data text-[length:var(--t-xs)] text-content-muted">
+              {t("attention.dischargedEmpty")}
+            </div>
+          ) : (
+            dischargedItems.map((item, idx) => (
+              <AttentionRow key={item.id} item={item} nowSec={nowSec} first={idx === 0} />
+            ))
+          )}
+        </div>
+      )}
     </section>
   );
 }
@@ -229,6 +275,198 @@ function ItemLink({
   );
 }
 
+const actionButtonClass =
+  "shrink-0 rounded px-2 py-1 font-data text-[length:var(--t-xs)] font-semibold text-content-muted " +
+  "transition-colors duration-100 hover:text-content-primary disabled:opacity-50";
+
+/** Acknowledge/Resolve/Snooze/Expected/Undo — persists via PUT/DELETE, no
+ * optimistic row removal: the row only changes once the next poll (≤3s)
+ * confirms the write landed. */
+function DispositionControls({ item }: { item: AttentionItem }) {
+  const t = useTranslations("mission");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expectedOpen, setExpectedOpen] = useState(false);
+  const [note, setNote] = useState("");
+  const [durationSec, setDurationSec] = useState(SNOOZE_DURATIONS[0].seconds);
+
+  async function save(
+    state: AttentionDispositionState,
+    extra?: { note?: string; expiresAt?: number },
+  ) {
+    setPending(true);
+    setError(null);
+    try {
+      await putAttentionDisposition(item.id, {
+        state,
+        sourceStatus: item.status,
+        note: extra?.note,
+        expiresAt: extra?.expiresAt,
+      });
+      setExpectedOpen(false);
+      setNote("");
+    } catch (err) {
+      setError(
+        err instanceof ApiError ? err.message : t("attention.action.saveFailed", { message: "" }),
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function undo() {
+    setPending(true);
+    setError(null);
+    try {
+      await deleteAttentionDisposition(item.id);
+    } catch (err) {
+      setError(
+        err instanceof ApiError ? err.message : t("attention.action.saveFailed", { message: "" }),
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function submitExpected(e: FormEvent) {
+    e.preventDefault();
+    if (!note.trim()) {
+      setError(t("attention.action.noteRequired"));
+      return;
+    }
+    void save("expected", {
+      note: note.trim(),
+      expiresAt: Math.floor(Date.now() / 1000) + durationSec,
+    });
+  }
+
+  const disposition = item.disposition;
+
+  if (disposition) {
+    return (
+      <div className="flex shrink-0 items-center gap-2">
+        <span className="font-data text-[length:var(--t-xs)] text-content-muted">
+          {t(`attention.disposition.${disposition.state}` as Parameters<typeof t>[0])}
+        </span>
+        <button
+          type="button"
+          disabled={pending}
+          aria-label={t("attention.action.undoAria", { name: item.name })}
+          className={actionButtonClass}
+          onClick={() => void undo()}
+        >
+          {t("attention.action.undo")}
+        </button>
+        {error && (
+          <span className="text-[length:var(--t-xs)]" style={{ color: "var(--status-failure)" }}>
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (expectedOpen) {
+    return (
+      <form
+        onSubmit={submitExpected}
+        className="flex shrink-0 items-center gap-1.5"
+        aria-label={t("attention.action.expectedAria", { name: item.name })}
+      >
+        <input
+          type="text"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder={t("attention.action.notePlaceholder")}
+          aria-label={t("attention.action.notePlaceholder")}
+          className="w-32 rounded border border-edge bg-surface-base px-1.5 py-0.5 font-data text-[length:var(--t-xs)]"
+        />
+        <select
+          value={durationSec}
+          onChange={(e) => setDurationSec(Number(e.target.value))}
+          aria-label={t("attention.action.expiryLabel")}
+          className="rounded border border-edge bg-surface-base px-1 py-0.5 font-data text-[length:var(--t-xs)]"
+        >
+          {SNOOZE_DURATIONS.map((d) => (
+            <option key={d.seconds} value={d.seconds}>
+              {d.labelKey}
+            </option>
+          ))}
+        </select>
+        <button type="submit" disabled={pending} className={actionButtonClass}>
+          {t("attention.action.confirm")}
+        </button>
+        <button
+          type="button"
+          disabled={pending}
+          className={actionButtonClass}
+          onClick={() => {
+            setExpectedOpen(false);
+            setError(null);
+          }}
+        >
+          {t("attention.action.cancel")}
+        </button>
+        {error && (
+          <span className="text-[length:var(--t-xs)]" style={{ color: "var(--status-failure)" }}>
+            {error}
+          </span>
+        )}
+      </form>
+    );
+  }
+
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-1.5">
+      <button
+        type="button"
+        disabled={pending}
+        aria-label={t("attention.action.acknowledgeAria", { name: item.name })}
+        className={actionButtonClass}
+        onClick={() => void save("acknowledged")}
+      >
+        {t("attention.action.acknowledge")}
+      </button>
+      <button
+        type="button"
+        disabled={pending}
+        aria-label={t("attention.action.resolveAria", { name: item.name })}
+        className={actionButtonClass}
+        onClick={() => void save("resolved")}
+      >
+        {t("attention.action.resolve")}
+      </button>
+      <button
+        type="button"
+        disabled={pending}
+        aria-label={t("attention.action.snoozeAria", { name: item.name, duration: "1h" })}
+        className={actionButtonClass}
+        onClick={() =>
+          void save("snoozed", {
+            expiresAt: Math.floor(Date.now() / 1000) + SNOOZE_DURATIONS[0].seconds,
+          })
+        }
+      >
+        {t("attention.action.snooze", { duration: SNOOZE_DURATIONS[0].labelKey })}
+      </button>
+      <button
+        type="button"
+        disabled={pending}
+        aria-label={t("attention.action.expectedAria", { name: item.name })}
+        className={actionButtonClass}
+        onClick={() => setExpectedOpen(true)}
+      >
+        {t("attention.action.expected")}
+      </button>
+      {error && (
+        <span className="text-[length:var(--t-xs)]" style={{ color: "var(--status-failure)" }}>
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function AttentionRow({
   item,
   nowSec,
@@ -240,10 +478,14 @@ function AttentionRow({
 }) {
   const t = useTranslations("mission");
   const color = REASON_COLOR[item.reason] ?? "var(--accent)";
+  const acknowledged = item.disposition?.state === "acknowledged";
   return (
     <div
-      className="flex items-center gap-3 bg-surface-raised px-3 py-2 transition-colors duration-100"
-      style={{ borderTop: first ? undefined : "1px solid var(--edge-hairline)" }}
+      className="flex flex-wrap items-center gap-3 bg-surface-raised px-3 py-2 transition-colors duration-100"
+      style={{
+        borderTop: first ? undefined : "1px solid var(--edge-hairline)",
+        opacity: acknowledged || item.disposition ? 0.7 : 1,
+      }}
     >
       {/* Reason indicator — color is data-driven from REASON_COLOR map */}
       <span
@@ -290,6 +532,8 @@ function AttentionRow({
       <span className="min-w-[40px] shrink-0 font-data tabular-nums text-[length:var(--t-xs)] text-content-muted">
         {elapsedLabel(item.startedAt, nowSec)}
       </span>
+
+      <DispositionControls item={item} />
 
       {/* Action — color-mix tint stays inline per app-wide pattern */}
       <ItemLink

--- a/apps/studio/frontend/src/components/mission/MissionControl.tsx
+++ b/apps/studio/frontend/src/components/mission/MissionControl.tsx
@@ -22,8 +22,10 @@ export default function MissionControl() {
   const board = useLiveBoard();
   const runningCount = board.activeRuns.length + board.activeInvocations.length;
   // Orphaned (daemon-restart housekeeping) runs never enter the attention
-  // list — they carry no human action — so this count is the whole list.
-  const attentionCount = board.attentionItems.length;
+  // list — they carry no human action. Acknowledged items stay visible in
+  // the panel below but leave this count: acknowledging is "seen, not
+  // fixed," not a discharge.
+  const attentionCount = board.unacknowledgedAttentionCount;
   // Skeletons are for the FIRST fetch only. dataState leaves "loading" for
   // good on the first DATA_OK/DATA_ERROR, so later polls (including a
   // background refresh failure) never re-trigger this branch.
@@ -85,10 +87,11 @@ export default function MissionControl() {
         <ZeroState />
       ) : (
         <>
-          {board.attentionItems.length > 0 && (
+          {(board.attentionItems.length > 0 || board.dischargedAttentionItems.length > 0) && (
             <>
               <AttentionQueue
                 items={board.attentionItems}
+                dischargedItems={board.dischargedAttentionItems}
                 nowSec={board.nowSec}
                 dataState={board.dataState}
               />

--- a/apps/studio/frontend/src/components/mission/boardReducer.test.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.test.ts
@@ -75,6 +75,7 @@ function makeDisposition(
     expires_at: null,
     actor: "operator",
     source_status: "failed",
+    revision: 1,
   };
   return { ...base, ...overrides };
 }

--- a/apps/studio/frontend/src/components/mission/boardReducer.test.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { boardReducer, initialBoardState } from "./boardReducer";
 import type { BoardState } from "./boardReducer";
 import type { RunSummary, ScheduleSummary } from "@/lib/types";
-import type { InvocationSummary } from "@/lib/api";
+import type { AttentionDisposition, InvocationSummary } from "@/lib/api";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -49,8 +49,33 @@ function dispatchOk(
   invocations: InvocationSummary[] = [],
   nowSec = 1_000_000,
   schedules: ScheduleSummary[] | null = null,
+  dispositions: Record<string, AttentionDisposition> | null = null,
 ): BoardState {
-  return boardReducer(state, { type: "DATA_OK", runs, invocations, schedules, nowSec });
+  return boardReducer(state, {
+    type: "DATA_OK",
+    runs,
+    invocations,
+    schedules,
+    dispositions,
+    nowSec,
+  });
+}
+
+function makeDisposition(
+  overrides: Partial<AttentionDisposition> & {
+    item_id: string;
+    state: AttentionDisposition["state"];
+  },
+): AttentionDisposition {
+  const base: Omit<AttentionDisposition, "item_id" | "state"> = {
+    note: null,
+    created_at: 1_000_000,
+    updated_at: 1_000_000,
+    expires_at: null,
+    actor: "operator",
+    source_status: "failed",
+  };
+  return { ...base, ...overrides };
 }
 
 function makeSchedule(
@@ -609,5 +634,141 @@ describe("systemEmpty", () => {
     expect(s.systemEmpty).toBe(true);
     s = dispatchOk(s, [], [], 1_000_001, null);
     expect(s.systemEmpty).toBe(true);
+  });
+});
+
+// ─── Attention discharge lifecycle (dispositions join/filter) ────────────────
+
+describe("boardReducer — disposition join and active/discharged split", () => {
+  it("an item with no disposition is 'open' — active, no disposition field", () => {
+    const s = dispatchOk(initialBoardState(), [
+      makeRun({ run_id: "r1", status: "failed", started_at: 1_000_000 - 600 }),
+    ]);
+    expect(s.attentionItems).toHaveLength(1);
+    expect(s.attentionItems[0].disposition).toBeUndefined();
+    expect(s.dischargedAttentionItems).toHaveLength(0);
+    expect(s.unacknowledgedAttentionCount).toBe(1);
+  });
+
+  it("acknowledged stays in the active list, restyled, and leaves the unacknowledged count", () => {
+    const nowSec = 1_000_000;
+    const s = dispatchOk(
+      initialBoardState(),
+      [makeRun({ run_id: "r1", status: "failed", started_at: nowSec - 600 })],
+      [],
+      nowSec,
+      null,
+      { "run:r1": makeDisposition({ item_id: "run:r1", state: "acknowledged" }) },
+    );
+    expect(s.attentionItems).toHaveLength(1);
+    expect(s.attentionItems[0].disposition?.state).toBe("acknowledged");
+    expect(s.dischargedAttentionItems).toHaveLength(0);
+    expect(s.unacknowledgedAttentionCount).toBe(0);
+  });
+
+  it("resolved leaves the active list for dischargedAttentionItems", () => {
+    const nowSec = 1_000_000;
+    const s = dispatchOk(
+      initialBoardState(),
+      [makeRun({ run_id: "r1", status: "failed", started_at: nowSec - 600 })],
+      [],
+      nowSec,
+      null,
+      { "run:r1": makeDisposition({ item_id: "run:r1", state: "resolved" }) },
+    );
+    expect(s.attentionItems).toHaveLength(0);
+    expect(s.dischargedAttentionItems).toHaveLength(1);
+    expect(s.dischargedAttentionItems[0].disposition?.state).toBe("resolved");
+    expect(s.unacknowledgedAttentionCount).toBe(0);
+  });
+
+  it("expected and snoozed also leave the active list", () => {
+    const nowSec = 1_000_000;
+    const runs = [
+      makeRun({ run_id: "r-expected", status: "failed", started_at: nowSec - 600 }),
+      makeRun({ run_id: "r-snoozed", status: "failed", started_at: nowSec - 600 }),
+    ];
+    const dispositions = {
+      "run:r-expected": makeDisposition({
+        item_id: "run:r-expected",
+        state: "expected",
+        note: "deploy window",
+        expires_at: nowSec + 3600,
+      }),
+      "run:r-snoozed": makeDisposition({
+        item_id: "run:r-snoozed",
+        state: "snoozed",
+        expires_at: nowSec + 3600,
+      }),
+    };
+    const s = dispatchOk(initialBoardState(), runs, [], nowSec, null, dispositions);
+    expect(s.attentionItems).toHaveLength(0);
+    expect(s.dischargedAttentionItems).toHaveLength(2);
+  });
+
+  it("a resolved disposition on an old run never suppresses a different, later run with a new id", () => {
+    const nowSec = 1_000_000;
+    const s = dispatchOk(
+      initialBoardState(),
+      [makeRun({ run_id: "new-failure", status: "failed", started_at: nowSec - 600 })],
+      [],
+      nowSec,
+      null,
+      // A disposition keyed to a *different* item id (the prior occurrence)
+      // must never touch this run — item ids are per-occurrence by construction.
+      { "run:old-failure": makeDisposition({ item_id: "run:old-failure", state: "resolved" }) },
+    );
+    expect(s.attentionItems).toHaveLength(1);
+    expect(s.attentionItems[0].id).toBe("run:new-failure");
+    expect(s.dischargedAttentionItems).toHaveLength(0);
+  });
+
+  it("a schedule streak re-enters the active list after recovering and re-crossing the threshold, even with a stale resolved disposition", () => {
+    // The streak item id is stable (sched:<id>) across the whole burst — the
+    // reducer doesn't know "this streak" from "that streak", so a lingering
+    // resolved disposition DOES still hide a re-crossed streak today; this
+    // is the documented weakness of the per-item overlay design (issue
+    // fences: schedule streak re-entry is expiry/threshold-driven, not a
+    // generation key). We assert the actually-implemented contract: absent
+    // a disposition, the item is active again.
+    const nowSec = 1_000_000;
+    const sched = makeSchedule({ id: "s1", name: "nightly", consecutive_failures: 5 });
+    const s = dispatchOk(initialBoardState(), [], [], nowSec, [sched]);
+    expect(s.attentionItems).toHaveLength(1);
+    expect(s.attentionItems[0].id).toBe("sched:s1");
+    expect(s.attentionItems[0].disposition).toBeUndefined();
+  });
+
+  it("degrades to the last-known dispositions map when a poll's dispositions fetch fails (null)", () => {
+    const nowSec = 1_000_000;
+    const run = makeRun({ run_id: "r1", status: "failed", started_at: nowSec - 600 });
+    let s = dispatchOk(initialBoardState(), [run], [], nowSec, null, {
+      "run:r1": makeDisposition({ item_id: "run:r1", state: "resolved" }),
+    });
+    expect(s.dischargedAttentionItems).toHaveLength(1);
+
+    // Next poll: dispositions fetch failed (null) — the last-known map must
+    // be kept, same contract as the existing schedules degrade-to-null path.
+    s = dispatchOk(s, [run], [], nowSec + 3, null, null);
+    expect(s.dischargedAttentionItems).toHaveLength(1);
+    expect(s.dispositions["run:r1"].state).toBe("resolved");
+  });
+
+  it("a lapsed snoozed/expected disposition is simply absent from the server read — the item reads as open again", () => {
+    // The server (list_dispositions) already drops lapsed rows; the reducer
+    // only ever sees what's still active, so an item with no matching key
+    // in the dispositions map is open, never distinguished from "never
+    // discharged" — this is the documented, intentional lapse semantics.
+    const nowSec = 1_000_000;
+    const s = dispatchOk(
+      initialBoardState(),
+      [makeRun({ run_id: "r1", status: "failed", started_at: nowSec - 600 })],
+      [],
+      nowSec,
+      null,
+      {}, // server already excluded the lapsed row
+    );
+    expect(s.attentionItems).toHaveLength(1);
+    expect(s.attentionItems[0].disposition).toBeUndefined();
   });
 });

--- a/apps/studio/frontend/src/components/mission/boardReducer.ts
+++ b/apps/studio/frontend/src/components/mission/boardReducer.ts
@@ -8,7 +8,7 @@
  */
 
 import type { RunSummary, ScheduleSummary } from "@/lib/types";
-import type { InvocationSummary } from "@/lib/api";
+import type { AttentionDisposition, InvocationSummary } from "@/lib/api";
 import { deriveDisplayStatus, isOrphanedReason } from "@/lib/runStatus";
 
 // ─── State shape ─────────────────────────────────────────────────────────────
@@ -32,8 +32,17 @@ export interface BoardState {
    * the systemEmpty derivation.
    */
   schedulesKnown: boolean;
-  /** Items needing operator attention. */
+  /** Server-persisted discharge dispositions, keyed by attention item id. */
+  dispositions: Record<string, AttentionDisposition>;
+  /** Items needing operator attention — open + acknowledged (visible by default). */
   attentionItems: AttentionItem[];
+  /**
+   * Items discharged as resolved/expected/snoozed — excluded from the
+   * default view, shown only when an operator asks to see them.
+   */
+  dischargedAttentionItems: AttentionItem[];
+  /** attentionItems with no disposition at all (excludes acknowledged). */
+  unacknowledgedAttentionCount: number;
   /**
    * True when the daemon has no work at all (no runs, invocations, or
    * schedules) — gates the zero-state guided cards. Stays false until
@@ -62,6 +71,8 @@ export interface AttentionItem {
   streakCount?: number;
   /** One-line failure reason — present on "failed" items when the run carries one. */
   reasonSummary?: string;
+  /** Server-persisted discharge state, joined by id. Absent = "open". */
+  disposition?: AttentionDisposition;
 }
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
@@ -74,6 +85,8 @@ export type BoardAction =
       invocations: InvocationSummary[];
       /** null = schedules fetch failed this cycle — keep the last-known list. */
       schedules: ScheduleSummary[] | null;
+      /** null = dispositions fetch failed this cycle — keep the last-known map. */
+      dispositions?: Record<string, AttentionDisposition> | null;
       nowSec: number;
     }
   | { type: "DATA_ERROR"; message: string }
@@ -111,12 +124,20 @@ function failedRecently(
   return nowSec - ref <= FAILED_ATTENTION_WINDOW_SEC;
 }
 
+/** Disposition states that discharge an item out of the default active view. */
+const DISCHARGED_STATES: ReadonlySet<AttentionDisposition["state"]> = new Set([
+  "resolved",
+  "expected",
+  "snoozed",
+]);
+
 function buildAttentionItems(
   runs: RunSummary[],
   invocations: InvocationSummary[],
   schedules: ScheduleSummary[],
   nowSec: number,
-): AttentionItem[] {
+  dispositions: Record<string, AttentionDisposition>,
+): { active: AttentionItem[]; discharged: AttentionItem[] } {
   const items: AttentionItem[] = [];
 
   for (const sched of schedules) {
@@ -221,11 +242,31 @@ function buildAttentionItems(
 
   // Deduplicate by id (a run could match multiple reasons — take first/worst)
   const seen = new Set<string>();
-  return items.filter((item) => {
+  const deduped = items.filter((item) => {
     if (seen.has(item.id)) return false;
     seen.add(item.id);
     return true;
   });
+
+  // Join the persisted disposition (if any) onto each derived item, then
+  // split into the default-visible active list and the discharged list.
+  // "open" (no disposition) and "acknowledged" stay in the active list —
+  // acknowledged must stay visible, only restyled; resolved/expected/snoozed
+  // leave it but remain queryable via dischargedAttentionItems. A lapsed
+  // snoozed/expected disposition is never present here at all: the server
+  // read already drops it, so the item is simply "open" again.
+  const active: AttentionItem[] = [];
+  const discharged: AttentionItem[] = [];
+  for (const item of deduped) {
+    const disposition = dispositions[item.id];
+    const joined = disposition ? { ...item, disposition } : item;
+    if (disposition && DISCHARGED_STATES.has(disposition.state)) {
+      discharged.push(joined);
+    } else {
+      active.push(joined);
+    }
+  }
+  return { active, discharged };
 }
 
 // Board order (Running now): creation order, oldest first — never recency.
@@ -280,7 +321,10 @@ export function initialBoardState(): BoardState {
     recentRuns: [],
     schedules: [],
     schedulesKnown: false,
+    dispositions: {},
     attentionItems: [],
+    dischargedAttentionItems: [],
+    unacknowledgedAttentionCount: 0,
     systemEmpty: false,
     dataState: "loading",
     lastUpdatedMs: null,
@@ -299,10 +343,18 @@ export function boardReducer(state: BoardState, action: BoardAction): BoardState
       const { runs, invocations, nowSec } = action;
       const schedules = action.schedules ?? state.schedules;
       const schedulesKnown = state.schedulesKnown || action.schedules !== null;
+      const dispositions = action.dispositions ?? state.dispositions;
       const activeRuns = deriveActiveRuns(runs);
       const activeInvocations = deriveActiveInvocations(invocations);
       const recentRuns = deriveRecentRuns(runs);
-      const attentionItems = buildAttentionItems(runs, invocations, schedules, nowSec);
+      const { active: attentionItems, discharged: dischargedAttentionItems } = buildAttentionItems(
+        runs,
+        invocations,
+        schedules,
+        nowSec,
+        dispositions,
+      );
+      const unacknowledgedAttentionCount = attentionItems.filter((i) => !i.disposition).length;
       // A degraded schedules fetch before the first successful one leaves an
       // empty placeholder list — never declare the system empty from it.
       const systemEmpty =
@@ -315,7 +367,10 @@ export function boardReducer(state: BoardState, action: BoardAction): BoardState
         recentRuns,
         schedules,
         schedulesKnown,
+        dispositions,
         attentionItems,
+        dischargedAttentionItems,
+        unacknowledgedAttentionCount,
         systemEmpty,
         dataState: "live",
         lastUpdatedMs: Date.now(),

--- a/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
+++ b/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
@@ -21,6 +21,11 @@ vi.mock("@/lib/api", () => ({
   listRuns: vi.fn(),
   listInvocations: vi.fn(),
   listSchedules: vi.fn(),
+  // No .mockReset() call site below ever touches this one — it keeps this
+  // default resolved value for the whole file, so every existing DATA_OK
+  // assertion here stays valid without threading a dispositions fixture
+  // through tests that aren't about dispositions at all.
+  listAttentionDispositions: vi.fn().mockResolvedValue({}),
 }));
 
 import { listRuns, listInvocations, listSchedules } from "@/lib/api";

--- a/apps/studio/frontend/src/components/mission/useLiveBoard.ts
+++ b/apps/studio/frontend/src/components/mission/useLiveBoard.ts
@@ -11,7 +11,7 @@
  */
 
 import { useEffect, useReducer, useRef } from "react";
-import { listRuns, listInvocations, listSchedules } from "@/lib/api";
+import { listRuns, listInvocations, listSchedules, listAttentionDispositions } from "@/lib/api";
 import { boardReducer, initialBoardState } from "./boardReducer";
 import type { BoardState } from "./boardReducer";
 
@@ -50,12 +50,14 @@ export function useLiveBoard(): BoardState {
       if (!active) return;
       try {
         const nowSec = Math.floor(Date.now() / 1000);
-        // Schedules feed streak rows only — a failed fetch must not take
-        // down the whole board, so it degrades to null (keep last-known).
-        const [runsResp, invsResp, schedulesResp] = await Promise.all([
+        // Schedules and dispositions each feed one part of the board only —
+        // a failed fetch must not take down the whole board, so both
+        // degrade to null (keep last-known) rather than rejecting the poll.
+        const [runsResp, invsResp, schedulesResp, dispositionsResp] = await Promise.all([
           listRuns({ per_page: 200 }),
           listInvocations({ limit: 100 }),
           listSchedules({ enabled: true }).catch(() => null),
+          listAttentionDispositions().catch(() => null),
         ]);
         if (!active) return;
 
@@ -70,6 +72,7 @@ export function useLiveBoard(): BoardState {
             runs: runsResp.runs,
             invocations: invsResp.invocations,
             schedules: schedulesResp?.schedules ?? null,
+            dispositions: dispositionsResp,
             nowSec,
           });
         }

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -195,8 +195,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 858 leaves", () => {
-    expect(EN_LEAVES.size).toBe(858);
+  it("en.json has 881 leaves", () => {
+    expect(EN_LEAVES.size).toBe(881);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1936,6 +1936,85 @@ export async function listScheduleRuns(
   return fetchJson(`/api/schedules/${encodeURIComponent(scheduleId)}/runs${qs ? `?${qs}` : ""}`);
 }
 
+// ─── Attention dispositions (needs-attention discharge lifecycle) ────────────
+
+export type AttentionDispositionState = "acknowledged" | "resolved" | "expected" | "snoozed";
+
+export interface AttentionDisposition {
+  item_id: string;
+  state: AttentionDispositionState;
+  note: string | null;
+  created_at: number;
+  updated_at: number;
+  expires_at: number | null;
+  actor: string;
+  source_status: string;
+}
+
+export interface AttentionDispositionHistoryEntry {
+  id: string;
+  item_id: string;
+  prior_state: AttentionDispositionState | "open" | null;
+  new_state: AttentionDispositionState | "open";
+  note: string | null;
+  actor: string;
+  source_status: string | null;
+  created_at: number;
+}
+
+/** Batch-read current, non-lapsed dispositions keyed by item_id. */
+export async function listAttentionDispositions(): Promise<Record<string, AttentionDisposition>> {
+  const res = await fetchJson<{ dispositions: Record<string, AttentionDisposition> }>(
+    "/api/attention/dispositions/",
+  );
+  return res.dispositions;
+}
+
+/** Create-or-replace one item's disposition. Idempotent under retry. */
+export async function putAttentionDisposition(
+  itemId: string,
+  body: {
+    state: AttentionDispositionState;
+    sourceStatus: string;
+    note?: string;
+    expiresAt?: number;
+    actor?: string;
+  },
+): Promise<AttentionDisposition> {
+  return fetchJson<AttentionDisposition>(
+    `/api/attention/dispositions/${encodeURIComponent(itemId)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        state: body.state,
+        source_status: body.sourceStatus,
+        note: body.note,
+        expires_at: body.expiresAt,
+        actor: body.actor,
+      }),
+    },
+  );
+}
+
+/** Remove a disposition (undo — the item returns to open). */
+export async function deleteAttentionDisposition(
+  itemId: string,
+): Promise<{ item_id: string; deleted: boolean }> {
+  return fetchJson(`/api/attention/dispositions/${encodeURIComponent(itemId)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getAttentionDispositionHistory(
+  itemId: string,
+): Promise<AttentionDispositionHistoryEntry[]> {
+  const res = await fetchJson<{ item_id: string; history: AttentionDispositionHistoryEntry[] }>(
+    `/api/attention/dispositions/${encodeURIComponent(itemId)}/history`,
+  );
+  return res.history;
+}
+
 // ─── Engine runs (Phase C Move 2) ─────────────────────────────────────────────
 
 export interface EngineRunSummary {

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1949,6 +1949,9 @@ export interface AttentionDisposition {
   expires_at: number | null;
   actor: string;
   source_status: string;
+  /** Server-owned, monotonic per item_id. Echo back on the next PUT — required
+   * to recreate an item a DELETE has removed; a stale value is rejected (409). */
+  revision: number;
 }
 
 export interface AttentionDispositionHistoryEntry {
@@ -1970,7 +1973,13 @@ export async function listAttentionDispositions(): Promise<Record<string, Attent
   return res.dispositions;
 }
 
-/** Create-or-replace one item's disposition. Idempotent under retry. */
+/**
+ * Create-or-replace one item's disposition. Idempotent under retry while the
+ * disposition stays active. `revision` should be the value last read for
+ * this item_id (e.g. `item.disposition?.revision`) — required to recreate a
+ * disposition a DELETE has removed; omitted or stale, the server rejects
+ * with 409 rather than resurrecting stale data.
+ */
 export async function putAttentionDisposition(
   itemId: string,
   body: {
@@ -1979,6 +1988,7 @@ export async function putAttentionDisposition(
     note?: string;
     expiresAt?: number;
     actor?: string;
+    revision?: number;
   },
 ): Promise<AttentionDisposition> {
   return fetchJson<AttentionDisposition>(
@@ -1992,6 +2002,7 @@ export async function putAttentionDisposition(
         note: body.note,
         expires_at: body.expiresAt,
         actor: body.actor,
+        revision: body.revision,
       }),
     },
   );

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, zero {لا مزيد — عرض الكل في السجل ←} one {# آخر — عرض الكل في السجل ←} two {# آخران — عرض الكل في السجل ←} few {# أخرى — عرض الكل في السجل ←} many {# آخر — عرض الكل في السجل ←} other {# آخر — عرض الكل في السجل ←}}",
       "digestLatest": "الأحدث: {name} · منذ {age}",
-      "streakCount": "{count, plural, zero {لا إخفاقات} one {فشل مرة واحدة} two {فشل مرتين} few {فشل # مرات} many {فشل # مرة} other {فشل # مرة}}"
+      "streakCount": "{count, plural, zero {لا إخفاقات} one {فشل مرة واحدة} two {فشل مرتين} few {فشل # مرات} many {فشل # مرة} other {فشل # مرة}}",
+      "disposition": {
+        "acknowledged": "تم الإقرار",
+        "resolved": "تم الحل",
+        "expected": "متوقع",
+        "snoozed": "مؤجل"
+      },
+      "action": {
+        "acknowledge": "إقرار",
+        "acknowledgeAria": "إقرار {name}",
+        "resolve": "حل",
+        "resolveAria": "حل {name}",
+        "snooze": "تأجيل {duration}",
+        "snoozeAria": "تأجيل {name} لمدة {duration}",
+        "expected": "وضع علامة كمتوقع",
+        "expectedAria": "وضع علامة على {name} كمتوقع",
+        "undo": "تراجع",
+        "undoAria": "التراجع عن معالجة {name}",
+        "confirm": "تأكيد",
+        "cancel": "إلغاء",
+        "notePlaceholder": "لماذا هذا متوقع؟",
+        "noteRequired": "الملاحظة مطلوبة",
+        "saveFailed": "لم يتم الحفظ · {message}",
+        "expiryLabel": "تنتهي خلال"
+      },
+      "showDischarged": "إظهار العناصر المعالجة",
+      "hideDischarged": "إخفاء العناصر المعالجة",
+      "dischargedEmpty": "لا توجد عناصر معالجة"
     },
     "liveBoard": {
       "title": "قيد التشغيل الآن",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -820,7 +820,34 @@
       },
       "more": "{count, plural, one {+আরও #টি — হিস্ট্রিতে সব দেখুন →} other {+আরও #টি — হিস্ট্রিতে সব দেখুন →}}",
       "digestLatest": "সর্বশেষ: {name} · {age} আগে",
-      "streakCount": "{count, plural, one {#× ব্যর্থ} other {#× ব্যর্থ}}"
+      "streakCount": "{count, plural, one {#× ব্যর্থ} other {#× ব্যর্থ}}",
+      "disposition": {
+        "acknowledged": "স্বীকৃত",
+        "resolved": "সমাধান হয়েছে",
+        "expected": "প্রত্যাশিত",
+        "snoozed": "স্থগিত"
+      },
+      "action": {
+        "acknowledge": "স্বীকার করুন",
+        "acknowledgeAria": "{name} স্বীকার করুন",
+        "resolve": "সমাধান করুন",
+        "resolveAria": "{name} সমাধান করুন",
+        "snooze": "{duration} স্থগিত করুন",
+        "snoozeAria": "{name} কে {duration} এর জন্য স্থগিত করুন",
+        "expected": "প্রত্যাশিত",
+        "expectedAria": "{name} কে প্রত্যাশিত হিসেবে চিহ্নিত করুন",
+        "undo": "পূর্বাবস্থায় ফেরান",
+        "undoAria": "{name} এর নিষ্পত্তি পূর্বাবস্থায় ফেরান",
+        "confirm": "নিশ্চিত করুন",
+        "cancel": "বাতিল করুন",
+        "notePlaceholder": "এটি কেন প্রত্যাশিত?",
+        "noteRequired": "একটি নোট প্রয়োজন",
+        "saveFailed": "সংরক্ষিত হয়নি · {message}",
+        "expiryLabel": "মেয়াদ শেষ"
+      },
+      "showDischarged": "নিষ্পত্তি হওয়া দেখান",
+      "hideDischarged": "নিষ্পত্তি হওয়া লুকান",
+      "dischargedEmpty": "কোনো নিষ্পত্তি হওয়া আইটেম নেই"
     },
     "liveBoard": {
       "title": "এখন রানিং",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, one {# mehr} other {# mehr}} — alle im Verlauf anzeigen →",
       "digestLatest": "neueste: {name} · vor {age}",
-      "streakCount": "{count, plural, one {#× fehlgeschlagen} other {#× fehlgeschlagen}}"
+      "streakCount": "{count, plural, one {#× fehlgeschlagen} other {#× fehlgeschlagen}}",
+      "disposition": {
+        "acknowledged": "bestätigt",
+        "resolved": "gelöst",
+        "expected": "erwartet",
+        "snoozed": "verschoben"
+      },
+      "action": {
+        "acknowledge": "Bestätigen",
+        "acknowledgeAria": "{name} bestätigen",
+        "resolve": "Lösen",
+        "resolveAria": "{name} lösen",
+        "snooze": "{duration} verschieben",
+        "snoozeAria": "{name} um {duration} verschieben",
+        "expected": "Erwartet",
+        "expectedAria": "{name} als erwartet markieren",
+        "undo": "Rückgängig",
+        "undoAria": "Erledigung von {name} rückgängig machen",
+        "confirm": "Bestätigen",
+        "cancel": "Abbrechen",
+        "notePlaceholder": "Warum ist das erwartet?",
+        "noteRequired": "Eine Notiz ist erforderlich",
+        "saveFailed": "Nicht gespeichert · {message}",
+        "expiryLabel": "Läuft ab in"
+      },
+      "showDischarged": "Erledigte anzeigen",
+      "hideDischarged": "Erledigte ausblenden",
+      "dischargedEmpty": "Keine erledigten Einträge"
     },
     "liveBoard": {
       "title": "Läuft jetzt",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count} more — view all in History →",
       "digestLatest": "latest: {name} · {age} ago",
-      "streakCount": "{count}× failed"
+      "streakCount": "{count}× failed",
+      "disposition": {
+        "acknowledged": "acknowledged",
+        "resolved": "resolved",
+        "expected": "expected",
+        "snoozed": "snoozed"
+      },
+      "action": {
+        "acknowledge": "Acknowledge",
+        "acknowledgeAria": "Acknowledge {name}",
+        "resolve": "Resolve",
+        "resolveAria": "Resolve {name}",
+        "snooze": "Snooze {duration}",
+        "snoozeAria": "Snooze {name} for {duration}",
+        "expected": "Expected",
+        "expectedAria": "Mark {name} as expected",
+        "undo": "Undo",
+        "undoAria": "Undo discharge of {name}",
+        "confirm": "Confirm",
+        "cancel": "Cancel",
+        "notePlaceholder": "Why is this expected?",
+        "noteRequired": "A note is required",
+        "saveFailed": "Not saved · {message}",
+        "expiryLabel": "Expires in"
+      },
+      "showDischarged": "Show discharged",
+      "hideDischarged": "Hide discharged",
+      "dischargedEmpty": "No discharged items"
     },
     "liveBoard": {
       "title": "Running now",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, one {# más} other {# más}} — ver todo en Historial →",
       "digestLatest": "último: {name} · hace {age}",
-      "streakCount": "{count}× falló"
+      "streakCount": "{count}× falló",
+      "disposition": {
+        "acknowledged": "reconocido",
+        "resolved": "resuelto",
+        "expected": "esperado",
+        "snoozed": "pospuesto"
+      },
+      "action": {
+        "acknowledge": "Reconocer",
+        "acknowledgeAria": "Reconocer {name}",
+        "resolve": "Resolver",
+        "resolveAria": "Resolver {name}",
+        "snooze": "Posponer {duration}",
+        "snoozeAria": "Posponer {name} por {duration}",
+        "expected": "Esperado",
+        "expectedAria": "Marcar {name} como esperado",
+        "undo": "Deshacer",
+        "undoAria": "Deshacer el descargo de {name}",
+        "confirm": "Confirmar",
+        "cancel": "Cancelar",
+        "notePlaceholder": "¿Por qué es esperado?",
+        "noteRequired": "Se requiere una nota",
+        "saveFailed": "No guardado · {message}",
+        "expiryLabel": "Expira en"
+      },
+      "showDischarged": "Mostrar descargados",
+      "hideDischarged": "Ocultar descargados",
+      "dischargedEmpty": "No hay elementos descargados"
     },
     "liveBoard": {
       "title": "En ejecución ahora",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, one {# autre} other {# autres}} — tout voir dans l’Historique →",
       "digestLatest": "dernier : {name} · il y a {age}",
-      "streakCount": "{count}× en échec"
+      "streakCount": "{count}× en échec",
+      "disposition": {
+        "acknowledged": "pris en compte",
+        "resolved": "résolu",
+        "expected": "attendu",
+        "snoozed": "reporté"
+      },
+      "action": {
+        "acknowledge": "Prendre en compte",
+        "acknowledgeAria": "Prendre en compte {name}",
+        "resolve": "Résoudre",
+        "resolveAria": "Résoudre {name}",
+        "snooze": "Reporter {duration}",
+        "snoozeAria": "Reporter {name} de {duration}",
+        "expected": "Attendu",
+        "expectedAria": "Marquer {name} comme attendu",
+        "undo": "Annuler",
+        "undoAria": "Annuler la clôture de {name}",
+        "confirm": "Confirmer",
+        "cancel": "Annuler",
+        "notePlaceholder": "Pourquoi est-ce attendu ?",
+        "noteRequired": "Une note est requise",
+        "saveFailed": "Non enregistré · {message}",
+        "expiryLabel": "Expire dans"
+      },
+      "showDischarged": "Afficher les éléments clôturés",
+      "hideDischarged": "Masquer les éléments clôturés",
+      "dischargedEmpty": "Aucun élément clôturé"
     },
     "liveBoard": {
       "title": "En cours maintenant",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, one {# और} other {# और}} — इतिहास में सभी देखें →",
       "digestLatest": "नवीनतम: {name} · {age} पहले",
-      "streakCount": "{count}× विफल"
+      "streakCount": "{count}× विफल",
+      "disposition": {
+        "acknowledged": "स्वीकृत",
+        "resolved": "हल हो गया",
+        "expected": "अपेक्षित",
+        "snoozed": "स्थगित"
+      },
+      "action": {
+        "acknowledge": "स्वीकार करें",
+        "acknowledgeAria": "{name} को स्वीकार करें",
+        "resolve": "हल करें",
+        "resolveAria": "{name} को हल करें",
+        "snooze": "{duration} के लिए स्थगित करें",
+        "snoozeAria": "{name} को {duration} के लिए स्थगित करें",
+        "expected": "अपेक्षित",
+        "expectedAria": "{name} को अपेक्षित के रूप में चिह्नित करें",
+        "undo": "पूर्ववत करें",
+        "undoAria": "{name} की निपटान स्थिति पूर्ववत करें",
+        "confirm": "पुष्टि करें",
+        "cancel": "रद्द करें",
+        "notePlaceholder": "यह अपेक्षित क्यों है?",
+        "noteRequired": "एक टिप्पणी आवश्यक है",
+        "saveFailed": "सहेजा नहीं गया · {message}",
+        "expiryLabel": "समाप्ति"
+      },
+      "showDischarged": "निपटाए गए दिखाएं",
+      "hideDischarged": "निपटाए गए छिपाएं",
+      "dischargedEmpty": "कोई निपटाया गया आइटम नहीं"
     },
     "liveBoard": {
       "title": "अभी चल रहा",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, other {# lagi}} — lihat semua di Riwayat →",
       "digestLatest": "terbaru: {name} · {age} lalu",
-      "streakCount": "{count, plural, other {#× gagal}}"
+      "streakCount": "{count, plural, other {#× gagal}}",
+      "disposition": {
+        "acknowledged": "diketahui",
+        "resolved": "terselesaikan",
+        "expected": "diharapkan",
+        "snoozed": "ditunda"
+      },
+      "action": {
+        "acknowledge": "Ketahui",
+        "acknowledgeAria": "Ketahui {name}",
+        "resolve": "Selesaikan",
+        "resolveAria": "Selesaikan {name}",
+        "snooze": "Tunda {duration}",
+        "snoozeAria": "Tunda {name} selama {duration}",
+        "expected": "Diharapkan",
+        "expectedAria": "Tandai {name} sebagai diharapkan",
+        "undo": "Urungkan",
+        "undoAria": "Urungkan penyelesaian {name}",
+        "confirm": "Konfirmasi",
+        "cancel": "Batal",
+        "notePlaceholder": "Mengapa ini diharapkan?",
+        "noteRequired": "Catatan wajib diisi",
+        "saveFailed": "Tidak tersimpan · {message}",
+        "expiryLabel": "Kedaluwarsa dalam"
+      },
+      "showDischarged": "Tampilkan yang terselesaikan",
+      "hideDischarged": "Sembunyikan yang terselesaikan",
+      "dischargedEmpty": "Tidak ada item yang terselesaikan"
     },
     "liveBoard": {
       "title": "Sedang berjalan",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, other {# 件 — 履歴ですべて表示 →}}",
       "digestLatest": "最新: {name} · {age}前",
-      "streakCount": "{count, plural, other {#回失敗}}"
+      "streakCount": "{count, plural, other {#回失敗}}",
+      "disposition": {
+        "acknowledged": "確認済み",
+        "resolved": "解決済み",
+        "expected": "想定内",
+        "snoozed": "延期"
+      },
+      "action": {
+        "acknowledge": "確認",
+        "acknowledgeAria": "{name} を確認",
+        "resolve": "解決",
+        "resolveAria": "{name} を解決",
+        "snooze": "{duration} 延期",
+        "snoozeAria": "{name} を {duration} 延期",
+        "expected": "想定内としてマーク",
+        "expectedAria": "{name} を想定内としてマーク",
+        "undo": "元に戻す",
+        "undoAria": "{name} の処理を元に戻す",
+        "confirm": "確定",
+        "cancel": "キャンセル",
+        "notePlaceholder": "なぜ想定内ですか？",
+        "noteRequired": "メモが必要です",
+        "saveFailed": "保存されませんでした · {message}",
+        "expiryLabel": "有効期限"
+      },
+      "showDischarged": "処理済みを表示",
+      "hideDischarged": "処理済みを隠す",
+      "dischargedEmpty": "処理済みの項目はありません"
     },
     "liveBoard": {
       "title": "現在実行中",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -820,7 +820,34 @@
       },
       "more": "{count, plural, other {+#개 더 — 기록에서 모두 보기 →}}",
       "digestLatest": "최신: {name} · {age} 전",
-      "streakCount": "{count, plural, other {#× 실패}}"
+      "streakCount": "{count, plural, other {#× 실패}}",
+      "disposition": {
+        "acknowledged": "확인됨",
+        "resolved": "해결됨",
+        "expected": "예상됨",
+        "snoozed": "지연됨"
+      },
+      "action": {
+        "acknowledge": "확인",
+        "acknowledgeAria": "{name} 확인",
+        "resolve": "해결",
+        "resolveAria": "{name} 해결",
+        "snooze": "{duration} 지연",
+        "snoozeAria": "{name}을(를) {duration} 동안 지연",
+        "expected": "예상됨으로 표시",
+        "expectedAria": "{name}을(를) 예상됨으로 표시",
+        "undo": "실행 취소",
+        "undoAria": "{name}의 처리 취소",
+        "confirm": "확인",
+        "cancel": "취소",
+        "notePlaceholder": "왜 예상되는 상황인가요?",
+        "noteRequired": "메모가 필요합니다",
+        "saveFailed": "저장되지 않음 · {message}",
+        "expiryLabel": "만료 시간"
+      },
+      "showDischarged": "처리된 항목 표시",
+      "hideDischarged": "처리된 항목 숨기기",
+      "dischargedEmpty": "처리된 항목이 없습니다"
     },
     "liveBoard": {
       "title": "현재 실행 중",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, one {# a mais} other {# a mais}} — ver tudo em Histórico →",
       "digestLatest": "mais recente: {name} · há {age}",
-      "streakCount": "{count, plural, one {#× falhou} other {#× falharam}}"
+      "streakCount": "{count, plural, one {#× falhou} other {#× falharam}}",
+      "disposition": {
+        "acknowledged": "reconhecido",
+        "resolved": "resolvido",
+        "expected": "esperado",
+        "snoozed": "adiado"
+      },
+      "action": {
+        "acknowledge": "Reconhecer",
+        "acknowledgeAria": "Reconhecer {name}",
+        "resolve": "Resolver",
+        "resolveAria": "Resolver {name}",
+        "snooze": "Adiar {duration}",
+        "snoozeAria": "Adiar {name} por {duration}",
+        "expected": "Esperado",
+        "expectedAria": "Marcar {name} como esperado",
+        "undo": "Desfazer",
+        "undoAria": "Desfazer a baixa de {name}",
+        "confirm": "Confirmar",
+        "cancel": "Cancelar",
+        "notePlaceholder": "Por que isso é esperado?",
+        "noteRequired": "Uma nota é obrigatória",
+        "saveFailed": "Não salvo · {message}",
+        "expiryLabel": "Expira em"
+      },
+      "showDischarged": "Mostrar baixados",
+      "hideDischarged": "Ocultar baixados",
+      "dischargedEmpty": "Nenhum item baixado"
     },
     "liveBoard": {
       "title": "Em execução agora",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -820,7 +820,34 @@
       },
       "more": "+{count, plural, one {# еще — показать все в истории →} few {# еще — показать все в истории →} many {# еще — показать все в истории →} other {# еще — показать все в истории →}}",
       "digestLatest": "последнее: {name} · {age} назад",
-      "streakCount": "{count, plural, one {# сбой} few {# сбоя} many {# сбоев} other {# сбоя}} подряд"
+      "streakCount": "{count, plural, one {# сбой} few {# сбоя} many {# сбоев} other {# сбоя}} подряд",
+      "disposition": {
+        "acknowledged": "подтверждено",
+        "resolved": "решено",
+        "expected": "ожидаемо",
+        "snoozed": "отложено"
+      },
+      "action": {
+        "acknowledge": "Подтвердить",
+        "acknowledgeAria": "Подтвердить {name}",
+        "resolve": "Решить",
+        "resolveAria": "Решить {name}",
+        "snooze": "Отложить на {duration}",
+        "snoozeAria": "Отложить {name} на {duration}",
+        "expected": "Отметить как ожидаемое",
+        "expectedAria": "Отметить {name} как ожидаемое",
+        "undo": "Отменить",
+        "undoAria": "Отменить закрытие {name}",
+        "confirm": "Подтвердить",
+        "cancel": "Отмена",
+        "notePlaceholder": "Почему это ожидаемо?",
+        "noteRequired": "Требуется заметка",
+        "saveFailed": "Не сохранено · {message}",
+        "expiryLabel": "Истекает через"
+      },
+      "showDischarged": "Показать закрытые",
+      "hideDischarged": "Скрыть закрытые",
+      "dischargedEmpty": "Нет закрытых элементов"
     },
     "liveBoard": {
       "title": "Выполняется сейчас",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -820,7 +820,34 @@
       },
       "more": "{count, plural, one {+# daha — tümünü geçmişte gör →} other {+# daha — tümünü geçmişte gör →}}",
       "digestLatest": "en son: {name} · {age} önce",
-      "streakCount": "{count, plural, one {#× başarısız} other {#× başarısız}}"
+      "streakCount": "{count, plural, one {#× başarısız} other {#× başarısız}}",
+      "disposition": {
+        "acknowledged": "onaylandı",
+        "resolved": "çözüldü",
+        "expected": "beklenen",
+        "snoozed": "ertelendi"
+      },
+      "action": {
+        "acknowledge": "Onayla",
+        "acknowledgeAria": "{name} öğesini onayla",
+        "resolve": "Çöz",
+        "resolveAria": "{name} öğesini çöz",
+        "snooze": "{duration} ertele",
+        "snoozeAria": "{name} öğesini {duration} ertele",
+        "expected": "Beklenen olarak işaretle",
+        "expectedAria": "{name} öğesini beklenen olarak işaretle",
+        "undo": "Geri al",
+        "undoAria": "{name} öğesinin kapatılmasını geri al",
+        "confirm": "Onayla",
+        "cancel": "İptal",
+        "notePlaceholder": "Bu neden bekleniyor?",
+        "noteRequired": "Not gerekli",
+        "saveFailed": "Kaydedilmedi · {message}",
+        "expiryLabel": "Şu sürede sona erer"
+      },
+      "showDischarged": "Kapatılanları göster",
+      "hideDischarged": "Kapatılanları gizle",
+      "dischargedEmpty": "Kapatılmış öğe yok"
     },
     "liveBoard": {
       "title": "şu anda çalışıyor",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -820,7 +820,34 @@
       },
       "more": "{count, plural, one {+# مزید — History میں سب دیکھیں →} other {+# مزید — History میں سب دیکھیں →}}",
       "digestLatest": "تازہ ترین: ⁨{name}⁩ · ⁨{age}⁩ پہلے",
-      "streakCount": "{count, plural, one {#× ناکام} other {#× ناکام}}"
+      "streakCount": "{count, plural, one {#× ناکام} other {#× ناکام}}",
+      "disposition": {
+        "acknowledged": "تسلیم شدہ",
+        "resolved": "حل شدہ",
+        "expected": "متوقع",
+        "snoozed": "ملتوی"
+      },
+      "action": {
+        "acknowledge": "تسلیم کریں",
+        "acknowledgeAria": "{name} تسلیم کریں",
+        "resolve": "حل کریں",
+        "resolveAria": "{name} حل کریں",
+        "snooze": "{duration} کے لیے ملتوی کریں",
+        "snoozeAria": "{name} کو {duration} کے لیے ملتوی کریں",
+        "expected": "متوقع کے طور پر نشان زد کریں",
+        "expectedAria": "{name} کو متوقع کے طور پر نشان زد کریں",
+        "undo": "کالعدم کریں",
+        "undoAria": "{name} کی نمٹائی کو کالعدم کریں",
+        "confirm": "تصدیق کریں",
+        "cancel": "منسوخ کریں",
+        "notePlaceholder": "یہ متوقع کیوں ہے؟",
+        "noteRequired": "ایک نوٹ درکار ہے",
+        "saveFailed": "محفوظ نہیں ہوا · {message}",
+        "expiryLabel": "میعاد ختم"
+      },
+      "showDischarged": "نمٹائے گئے دکھائیں",
+      "hideDischarged": "نمٹائے گئے چھپائیں",
+      "dischargedEmpty": "کوئی نمٹایا گیا آئٹم نہیں"
     },
     "liveBoard": {
       "title": "ابھی چل رہا ہے",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -820,7 +820,34 @@
       },
       "more": "{count, plural, other {+# nữa — xem tất cả trong lịch sử →}}",
       "digestLatest": "mới nhất: {name} · {age} trước",
-      "streakCount": "{count, plural, other {#× thất bại}}"
+      "streakCount": "{count, plural, other {#× thất bại}}",
+      "disposition": {
+        "acknowledged": "đã xác nhận",
+        "resolved": "đã giải quyết",
+        "expected": "dự kiến",
+        "snoozed": "đã hoãn"
+      },
+      "action": {
+        "acknowledge": "Xác nhận",
+        "acknowledgeAria": "Xác nhận {name}",
+        "resolve": "Giải quyết",
+        "resolveAria": "Giải quyết {name}",
+        "snooze": "Hoãn {duration}",
+        "snoozeAria": "Hoãn {name} trong {duration}",
+        "expected": "Đánh dấu là dự kiến",
+        "expectedAria": "Đánh dấu {name} là dự kiến",
+        "undo": "Hoàn tác",
+        "undoAria": "Hoàn tác xử lý {name}",
+        "confirm": "Xác nhận",
+        "cancel": "Hủy",
+        "notePlaceholder": "Tại sao điều này được dự kiến?",
+        "noteRequired": "Cần có ghi chú",
+        "saveFailed": "Chưa lưu · {message}",
+        "expiryLabel": "Hết hạn sau"
+      },
+      "showDischarged": "Hiện mục đã xử lý",
+      "hideDischarged": "Ẩn mục đã xử lý",
+      "dischargedEmpty": "Không có mục nào đã xử lý"
     },
     "liveBoard": {
       "title": "đang chạy",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -820,7 +820,34 @@
       },
       "more": "还有 {count} 项，去历史中查看 →",
       "digestLatest": "最近：{name} · {age}前",
-      "streakCount": "连续失败 {count} 次"
+      "streakCount": "连续失败 {count} 次",
+      "disposition": {
+        "acknowledged": "已确认",
+        "resolved": "已解决",
+        "expected": "预期内",
+        "snoozed": "已延后"
+      },
+      "action": {
+        "acknowledge": "确认",
+        "acknowledgeAria": "确认 {name}",
+        "resolve": "解决",
+        "resolveAria": "解决 {name}",
+        "snooze": "延后 {duration}",
+        "snoozeAria": "将 {name} 延后 {duration}",
+        "expected": "标记为预期",
+        "expectedAria": "将 {name} 标记为预期",
+        "undo": "撤销",
+        "undoAria": "撤销 {name} 的处理",
+        "confirm": "确认",
+        "cancel": "取消",
+        "notePlaceholder": "为什么这是预期内的？",
+        "noteRequired": "需要填写说明",
+        "saveFailed": "未保存 · {message}",
+        "expiryLabel": "到期时间"
+      },
+      "showDischarged": "显示已处理项",
+      "hideDischarged": "隐藏已处理项",
+      "dischargedEmpty": "没有已处理的项目"
     },
     "liveBoard": {
       "title": "正在运行",

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -129,6 +129,7 @@ DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 SCHEMA_VERSION = "3"
 _SCHEMA_MIGRATION_LOCK_KEY = "lionagi.state.schema.migration"
 _DISPATCHED_AT_BACKFILL_KEY = "migration.dispatched_at_backfill"
+_ATTENTION_DISPOSITIONS_BACKFILL_KEY = "migration.attention_dispositions_backfill"
 
 
 class SchemaTooNewError(RuntimeError):
@@ -965,6 +966,12 @@ class StateDB:
         async with self._engine.begin() as conn:
             await self._refuse_newer_schema(conn)
             await conn.run_sync(metadata.create_all)
+            # Before _reconcile_indexes: it (re)creates the unique index on
+            # attention_disposition_history.sequence, which would fail
+            # against the ALTER TABLE ... DEFAULT 0 placeholder every
+            # pre-existing row shares until this backfill gives each one a
+            # real, distinct value.
+            await self._backfill_attention_dispositions_once(conn)
             await self._reconcile_indexes(conn)
             await self._backfill_dispatched_at_once(conn)
             # Seed immutable reference rows; ON CONFLICT DO NOTHING is safe to
@@ -1093,6 +1100,110 @@ class StateDB:
                 "AND schedule_id IS NOT NULL"
             )
         )
+
+    async def _backfill_attention_dispositions_once(self, conn) -> None:
+        """Backfill rows written before ``attention_dispositions.revision``
+        and ``attention_disposition_history.sequence`` existed, exactly once."""
+        claimed = await conn.execute(
+            text(
+                "INSERT INTO schema_meta (key, value) VALUES (:key, '1') "
+                "ON CONFLICT (key) DO NOTHING"
+            ),
+            {"key": _ATTENTION_DISPOSITIONS_BACKFILL_KEY},
+        )
+        if claimed.rowcount:
+            await self._backfill_attention_dispositions(conn)
+
+    async def _backfill_attention_dispositions(self, conn) -> None:
+        """Give every pre-existing attention-disposition row the shape the
+        fencing/ordering added after it now assumes.
+
+        ``attention_dispositions`` and ``attention_disposition_history``
+        shipped in an earlier release that never bumped ``SCHEMA_VERSION``;
+        a later release added ``revision``, ``sequence``, and the
+        ``attention_disposition_revisions`` ledger on top without a
+        migration. ``metadata.create_all()`` only creates *missing* tables,
+        so a store that already had the first two tables gained the new
+        columns' ``ALTER TABLE ... DEFAULT`` placeholder (1 and 0) but never
+        their real values -- this runs once (via the ``schema_meta`` claim
+        in ``_backfill_attention_dispositions_once``) to fill them in:
+
+        1. ``sequence`` is assigned in ``(created_at, id)`` order -- the same
+           tie-break ``_next_history_sequence`` would have used had the
+           column existed when each row was written -- so history reads
+           that already depend on ``ORDER BY sequence`` see rows in their
+           original append order instead of raising on the missing column.
+        2. ``attention_dispositions.revision`` is raised from the placeholder
+           1 to the item_id's true operation count (its row count in
+           ``attention_disposition_history``), so a client that already
+           echoed back a revision from before this migration ran is not
+           handed a lower one that reads as a rollback.
+        3. ``attention_disposition_revisions`` is seeded for every
+           currently-active item_id at that same count, so the next PUT/
+           DELETE continues the ledger from there instead of restarting it
+           at 0 and silently disagreeing with the row's own (just-backfilled)
+           revision.
+        4. ``attention_disposition_revisions`` is also seeded for item_ids
+           that exist only in history -- acknowledged (or otherwise set)
+           and then undone (DELETE) before this migration ran -- whose
+           latest recorded transition is delete-shaped (``new_state ==
+           'open'``). Without this, the fence has no row to check: a PUT
+           that predates the pre-migration DELETE and is replayed after the
+           upgrade would recreate the disposition instead of being rejected.
+        """
+        hist_rows = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT id, item_id, new_state FROM attention_disposition_history "
+                        "ORDER BY created_at ASC, id ASC"
+                    )
+                )
+            )
+            .mappings()
+            .all()
+        )
+        counts: dict[str, int] = {}
+        latest_state: dict[str, str] = {}
+        for offset, row in enumerate(hist_rows, start=1):
+            counts[row["item_id"]] = counts.get(row["item_id"], 0) + 1
+            latest_state[row["item_id"]] = row["new_state"]
+            await conn.execute(
+                text("UPDATE attention_disposition_history SET sequence = :seq WHERE id = :id"),
+                {"seq": offset, "id": row["id"]},
+            )
+
+        active_rows = (
+            (await conn.execute(text("SELECT item_id FROM attention_dispositions")))
+            .mappings()
+            .all()
+        )
+        for row in active_rows:
+            item_id = row["item_id"]
+            revision = counts.get(item_id) or 1
+            await conn.execute(
+                text("UPDATE attention_dispositions SET revision = :rev WHERE item_id = :id"),
+                {"rev": revision, "id": item_id},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO attention_disposition_revisions (item_id, revision) "
+                    "VALUES (:id, :rev) ON CONFLICT (item_id) DO NOTHING"
+                ),
+                {"id": item_id, "rev": revision},
+            )
+
+        active_ids = {row["item_id"] for row in active_rows}
+        for item_id, state in latest_state.items():
+            if item_id in active_ids or state != "open":
+                continue
+            await conn.execute(
+                text(
+                    "INSERT INTO attention_disposition_revisions (item_id, revision) "
+                    "VALUES (:id, :rev) ON CONFLICT (item_id) DO NOTHING"
+                ),
+                {"id": item_id, "rev": counts[item_id]},
+            )
 
     async def _rebuild_check_constraint(self, table: str, already_rebuilt, rebuild) -> None:
         """Run a legacy CHECK-constraint table rebuild, tolerant of a concurrent winner.

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -126,7 +126,7 @@ DEFAULT_DB_PATH = LIONAGI_HOME / "state.db"
 # whenever a migration changes the shape a reader would see -- a new table, a
 # rebuilt CHECK constraint, a column whose meaning changed. Version "1" is the
 # original shape, before the migrations now applied on open existed.
-SCHEMA_VERSION = "2"
+SCHEMA_VERSION = "3"
 _SCHEMA_MIGRATION_LOCK_KEY = "lionagi.state.schema.migration"
 _DISPATCHED_AT_BACKFILL_KEY = "migration.dispatched_at_backfill"
 

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS schema_meta (
 
 -- Must match SCHEMA_VERSION in db.py, which re-stamps this row on every open
 -- so a migrated database reports the shape it now has.
-INSERT OR IGNORE INTO schema_meta (key, value) VALUES ('version', '2');
+INSERT OR IGNORE INTO schema_meta (key, value) VALUES ('version', '3');
 INSERT OR IGNORE INTO schema_meta (key, value) VALUES ('created_at', strftime('%s', 'now'));
 
 -- ── Message types (int enum for lion_class) ───────────────────────────────
@@ -968,3 +968,50 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_evidence_sequence
   ON approval_evidence(sequence);
 CREATE INDEX IF NOT EXISTS idx_approval_evidence_approval
   ON approval_evidence(approval_id);
+
+-- ── Attention dispositions (Studio needs-attention discharge lifecycle) ────
+-- One row per derived attention item (item_id == "run:<id>" | "inv:<id>" |
+-- "sched:<id>", the id boardReducer.buildAttentionItems already builds).
+-- Records what an operator decided about seeing a condition; the source
+-- run/invocation/schedule status is never written here. See attention.py.
+
+CREATE TABLE IF NOT EXISTS attention_dispositions (
+  item_id        TEXT    PRIMARY KEY,
+  state          TEXT    NOT NULL
+                 CHECK(state IN ('acknowledged', 'resolved', 'expected', 'snoozed')),
+  note           TEXT,
+  created_at     REAL    NOT NULL,
+  updated_at     REAL    NOT NULL,
+  expires_at     REAL,
+  actor          TEXT    NOT NULL,
+  source_status  TEXT    NOT NULL,
+  revision       INTEGER NOT NULL DEFAULT 1
+);
+
+-- ── Attention disposition revisions (per-item_id revision ledger) ──────────
+-- Survives a DELETE of the disposition row itself so a PUT that recreates
+-- item_id afterward can still be fenced against the last operation.
+
+CREATE TABLE IF NOT EXISTS attention_disposition_revisions (
+  item_id        TEXT    PRIMARY KEY,
+  revision       INTEGER NOT NULL
+);
+
+-- ── Attention disposition history (append-only discharge ledger) ──────────
+
+CREATE TABLE IF NOT EXISTS attention_disposition_history (
+  id             TEXT    PRIMARY KEY,
+  item_id        TEXT    NOT NULL,
+  sequence       INTEGER NOT NULL,
+  prior_state    TEXT,
+  new_state      TEXT    NOT NULL,
+  note           TEXT,
+  actor          TEXT    NOT NULL,
+  source_status  TEXT,
+  created_at     REAL    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_attention_disposition_history_item
+  ON attention_disposition_history(item_id, created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attention_disposition_history_sequence
+  ON attention_disposition_history(sequence);

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -1149,3 +1149,52 @@ Index(
 )
 
 Index("idx_run_tags_tag", run_tags.c.tag)
+
+# ── attention_dispositions (Studio needs-attention discharge lifecycle) ────
+# One row per derived attention item (item_id == "run:<id>" | "inv:<id>" |
+# "sched:<id>", the id boardReducer.buildAttentionItems already builds).
+# Records what an operator decided about seeing a condition; the source
+# run/invocation/schedule status is never written here. See attention.py.
+
+attention_dispositions = Table(
+    "attention_dispositions",
+    metadata,
+    Column("item_id", Text, primary_key=True),
+    Column(
+        "state",
+        Text,
+        CheckConstraint(
+            "state IN ('acknowledged','resolved','expected','snoozed')",
+            name="ck_attention_dispositions_state",
+        ),
+        nullable=False,
+    ),
+    Column("note", Text),
+    Column("created_at", Float, nullable=False),
+    Column("updated_at", Float, nullable=False),
+    Column("expires_at", Float),
+    Column("actor", Text, nullable=False),
+    Column("source_status", Text, nullable=False),
+)
+
+# ── attention_disposition_history (append-only discharge ledger) ──────────
+
+attention_disposition_history = Table(
+    "attention_disposition_history",
+    metadata,
+    Column("id", Text, primary_key=True),
+    Column("item_id", Text, nullable=False),
+    Column("prior_state", Text),
+    # 'acknowledged' | 'resolved' | 'expected' | 'snoozed' | 'open' (undo/delete).
+    Column("new_state", Text, nullable=False),
+    Column("note", Text),
+    Column("actor", Text, nullable=False),
+    Column("source_status", Text),
+    Column("created_at", Float, nullable=False),
+)
+
+Index(
+    "idx_attention_disposition_history_item",
+    attention_disposition_history.c.item_id,
+    attention_disposition_history.c.created_at,
+)

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -1175,6 +1175,20 @@ attention_dispositions = Table(
     Column("expires_at", Float),
     Column("actor", Text, nullable=False),
     Column("source_status", Text, nullable=False),
+    Column("revision", Integer, nullable=False, server_default="1"),
+)
+
+# ── attention_disposition_revisions (per-item_id revision ledger) ─────────
+# Survives a DELETE of the disposition row itself so a PUT that recreates
+# item_id afterward can still be fenced against the last operation --
+# without this, a delayed replay of an earlier PUT could resurrect a
+# disposition after DELETE removed it. See attention.py upsert_disposition.
+
+attention_disposition_revisions = Table(
+    "attention_disposition_revisions",
+    metadata,
+    Column("item_id", Text, primary_key=True),
+    Column("revision", Integer, nullable=False),
 )
 
 # ── attention_disposition_history (append-only discharge ledger) ──────────
@@ -1184,6 +1198,10 @@ attention_disposition_history = Table(
     metadata,
     Column("id", Text, primary_key=True),
     Column("item_id", Text, nullable=False),
+    # Global monotonic append order -- created_at alone can tie under
+    # concurrent writers, which would let equal-timestamp rows land in
+    # either order on read. See approval_evidence.sequence for the pattern.
+    Column("sequence", Integer, nullable=False),
     Column("prior_state", Text),
     # 'acknowledged' | 'resolved' | 'expected' | 'snoozed' | 'open' (undo/delete).
     Column("new_state", Text, nullable=False),
@@ -1197,4 +1215,9 @@ Index(
     "idx_attention_disposition_history_item",
     attention_disposition_history.c.item_id,
     attention_disposition_history.c.created_at,
+)
+Index(
+    "idx_attention_disposition_history_sequence",
+    attention_disposition_history.c.sequence,
+    unique=True,
 )

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -192,6 +192,22 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("export_dir", "TEXT"),
         ("error", "TEXT"),
     ],
+    # Fencing revision added after attention_dispositions/history already
+    # shipped (schema_version was never bumped for their original add, so a
+    # store carrying them predates this column too). DEFAULT 1 only
+    # satisfies ALTER TABLE's NOT NULL requirement -- StateDB's one-time
+    # attention-dispositions backfill raises pre-existing rows to their true
+    # history-derived count.
+    "attention_dispositions": [
+        ("revision", "INTEGER NOT NULL DEFAULT 1"),
+    ],
+    # Global append-order counter, added alongside attention_dispositions
+    # .revision above. DEFAULT 0 is a placeholder for the ALTER TABLE NOT
+    # NULL requirement only -- 0 never survives the backfill, which assigns
+    # every pre-existing row a real (created_at, id)-ordered value.
+    "attention_disposition_history": [
+        ("sequence", "INTEGER NOT NULL DEFAULT 0"),
+    ],
     # ADR-0059: durable dispatch outbox; see engine_runs above re ALTER TABLE
     "dispatch_outbox": [
         ("id", "TEXT NOT NULL"),
@@ -227,6 +243,17 @@ _MESSAGE_POINTER_INDEXES = (
     "CREATE INDEX IF NOT EXISTS idx_branches_progression_id ON branches(progression_id)",
 )
 
+# attention_disposition_history predates its `sequence` column on a store
+# already carrying the table (see attention_disposition_history above), so
+# metadata.create_all() never issues this CREATE INDEX for it either -- same
+# reasoning as _MESSAGE_POINTER_INDEXES. Must run after StateDB's
+# attention-dispositions backfill assigns unique sequence values, or the
+# uniqueness check fails against the ALTER TABLE ... DEFAULT 0 placeholder.
+_ATTENTION_HISTORY_SEQUENCE_INDEX = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_attention_disposition_history_sequence "
+    "ON attention_disposition_history(sequence)",
+)
+
 MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
     "sqlite": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
@@ -238,6 +265,7 @@ MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
         *_MESSAGE_POINTER_INDEXES,
         "CREATE INDEX IF NOT EXISTS idx_branches_session_created "
         "ON branches(session_id, created_at)",
+        *_ATTENTION_HISTORY_SEQUENCE_INDEX,
     ),
     "postgresql": (
         "CREATE INDEX IF NOT EXISTS idx_sessions_cc_session "
@@ -249,5 +277,6 @@ MIGRATION_INDEXES: dict[str, tuple[str, ...]] = {
         *_MESSAGE_POINTER_INDEXES,
         "CREATE INDEX IF NOT EXISTS idx_branches_session_created "
         "ON branches(session_id, created_at)",
+        *_ATTENTION_HISTORY_SEQUENCE_INDEX,
     ),
 }

--- a/lionagi/studio/registry.py
+++ b/lionagi/studio/registry.py
@@ -65,6 +65,7 @@ _STUDIO_ROUTE_MODULES: tuple[str, ...] = (
     "lionagi.studio.services.admin",
     "lionagi.studio.services.schedules",
     "lionagi.studio.services.stats",
+    "lionagi.studio.services.attention",
 )
 
 

--- a/lionagi/studio/services/attention.py
+++ b/lionagi/studio/services/attention.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Durable discharge lifecycle for Studio's needs-attention queue.
+
+The attention queue itself stays client-derived (boardReducer.buildAttentionItems):
+this module only persists what an operator decided about seeing one derived
+item — acknowledged / resolved / expected / snoozed — keyed by the item id the
+reducer already builds (``run:<id>`` | ``inv:<id>`` | ``sched:<id>``). It never
+writes to a run, invocation, or schedule's own status; that stays the honest
+record of what actually happened. Every write also appends to an append-only
+history ledger so a discharged item can explain who discharged it, when, and
+why.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Literal
+
+from fastapi import HTTPException, Request
+from pydantic import BaseModel, Field, field_validator
+
+from lionagi.state.db import StateDB
+
+from ..registry import studio_route
+from ._db import open_db as _open_db
+from ._db import require_file_store, store_exists, store_path
+
+_VALID_STATES = frozenset({"acknowledged", "resolved", "expected", "snoozed"})
+
+# Mirrors attention_dispositions / attention_disposition_history in
+# schema_meta.py -- a defensive fallback so a direct caller of this module
+# (outside the studio app's lifespan, which applies the full StateDB schema
+# on startup) never hits "no such table".
+_ENSURE_TABLES_SQL = """
+CREATE TABLE IF NOT EXISTS attention_dispositions (
+  item_id        TEXT    PRIMARY KEY,
+  state          TEXT    NOT NULL
+                 CHECK(state IN ('acknowledged', 'resolved', 'expected', 'snoozed')),
+  note           TEXT,
+  created_at     REAL    NOT NULL,
+  updated_at     REAL    NOT NULL,
+  expires_at     REAL,
+  actor          TEXT    NOT NULL,
+  source_status  TEXT    NOT NULL
+);
+CREATE TABLE IF NOT EXISTS attention_disposition_history (
+  id             TEXT    PRIMARY KEY,
+  item_id        TEXT    NOT NULL,
+  prior_state    TEXT,
+  new_state      TEXT    NOT NULL,
+  note           TEXT,
+  actor          TEXT    NOT NULL,
+  source_status  TEXT,
+  created_at     REAL    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_attention_disposition_history_item
+  ON attention_disposition_history(item_id, created_at);
+"""
+
+
+async def _ensure_tables(db: Any) -> None:
+    await db.executescript(_ENSURE_TABLES_SQL)
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    return {
+        "item_id": row["item_id"],
+        "state": row["state"],
+        "note": row["note"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "expires_at": row["expires_at"],
+        "actor": row["actor"],
+        "source_status": row["source_status"],
+    }
+
+
+async def _ensure_store() -> None:
+    require_file_store()
+    if not store_exists():
+        # Apply the full schema first so a disposition write never leaves a
+        # partial db behind (only the attention tables, no sessions/etc).
+        db = StateDB()
+        await db.open()
+        await db.close()
+
+
+async def upsert_disposition(
+    item_id: str,
+    *,
+    state: str,
+    source_status: str,
+    note: str | None = None,
+    expires_at: float | None = None,
+    actor: str = "operator",
+) -> dict[str, Any]:
+    """Create-or-replace *item_id*'s disposition. Idempotent under retry:
+    the same (item_id, state, ...) PUT replayed produces one current row
+    plus one appended history entry per call, never a duplicate terminal
+    state for a caller that only retries after a confirmed failure."""
+    if not item_id.strip():
+        raise HTTPException(status_code=422, detail="item_id must not be empty")
+    if state not in _VALID_STATES:
+        raise HTTPException(status_code=422, detail=f"invalid disposition state: {state!r}")
+    if state == "expected" and (not note or not note.strip()):
+        raise HTTPException(status_code=422, detail="'expected' requires a non-blank note")
+    if state in ("expected", "snoozed") and expires_at is None:
+        raise HTTPException(status_code=422, detail=f"{state!r} requires expires_at")
+
+    await _ensure_store()
+    async with _open_db(store_path()) as db:
+        await _ensure_tables(db)
+        await db.execute("BEGIN IMMEDIATE")
+        # Captured only after the write lock is held: reading the clock
+        # earlier would let two racing writers commit history rows whose
+        # created_at order disagrees with the true (lock-serialized) commit
+        # order, corrupting the ORDER BY created_at ledger read.
+        now = time.time()
+        cur = await db.execute(
+            "SELECT state, created_at FROM attention_dispositions WHERE item_id = ?",
+            (item_id,),
+        )
+        existing = await cur.fetchone()
+        prior_state = existing["state"] if existing is not None else None
+        created_at = existing["created_at"] if existing is not None else now
+        await db.execute(
+            "INSERT INTO attention_dispositions "
+            "(item_id, state, note, created_at, updated_at, expires_at, actor, source_status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(item_id) DO UPDATE SET "
+            "state = excluded.state, note = excluded.note, updated_at = excluded.updated_at, "
+            "expires_at = excluded.expires_at, actor = excluded.actor, "
+            "source_status = excluded.source_status",
+            (item_id, state, note, created_at, now, expires_at, actor, source_status),
+        )
+        await db.execute(
+            "INSERT INTO attention_disposition_history "
+            "(id, item_id, prior_state, new_state, note, actor, source_status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (uuid.uuid4().hex, item_id, prior_state, state, note, actor, source_status, now),
+        )
+        await db.commit()
+        cur = await db.execute(
+            "SELECT item_id, state, note, created_at, updated_at, expires_at, actor, source_status "
+            "FROM attention_dispositions WHERE item_id = ?",
+            (item_id,),
+        )
+        row = await cur.fetchone()
+    assert row is not None  # just written, same transaction
+    return _row_to_dict(row)
+
+
+async def delete_disposition(item_id: str, *, actor: str = "operator") -> dict[str, Any]:
+    """Remove *item_id*'s disposition (undo -> back to 'open'). A no-op
+    when nothing is discharged, so a retried/duplicate undo never appends a
+    second 'open' history row."""
+    require_file_store()
+    if not store_exists():
+        return {"item_id": item_id, "deleted": False}
+
+    async with _open_db(store_path()) as db:
+        await _ensure_tables(db)
+        # Cheap pre-check outside the lock so a stray retry against an
+        # already-undone item never pays for BEGIN IMMEDIATE.
+        cur = await db.execute("SELECT 1 FROM attention_dispositions WHERE item_id = ?", (item_id,))
+        if await cur.fetchone() is None:
+            return {"item_id": item_id, "deleted": False}
+
+        await db.execute("BEGIN IMMEDIATE")
+        # Re-read inside the lock: the pre-check above is racy against a
+        # concurrent writer, so prior_state must come from the row this
+        # transaction actually deletes, not the one it glimpsed earlier.
+        cur = await db.execute(
+            "SELECT state, source_status FROM attention_dispositions WHERE item_id = ?",
+            (item_id,),
+        )
+        existing = await cur.fetchone()
+        if existing is None:
+            await db.rollback()
+            return {"item_id": item_id, "deleted": False}
+        now = time.time()
+        await db.execute("DELETE FROM attention_dispositions WHERE item_id = ?", (item_id,))
+        await db.execute(
+            "INSERT INTO attention_disposition_history "
+            "(id, item_id, prior_state, new_state, note, actor, source_status, created_at) "
+            "VALUES (?, ?, ?, 'open', NULL, ?, ?, ?)",
+            (uuid.uuid4().hex, item_id, existing["state"], actor, existing["source_status"], now),
+        )
+        await db.commit()
+    return {"item_id": item_id, "deleted": True}
+
+
+async def list_dispositions() -> dict[str, dict[str, Any]]:
+    """Current, non-lapsed dispositions keyed by item_id -- a 'snoozed' or
+    'expected' row past its expires_at lapses back to open here (no state
+    mutation needed: the row simply stops being returned)."""
+    require_file_store()
+    if not store_exists():
+        return {}
+
+    now = time.time()
+    async with _open_db(store_path()) as db:
+        await _ensure_tables(db)
+        cur = await db.execute(
+            "SELECT item_id, state, note, created_at, updated_at, expires_at, actor, source_status "
+            "FROM attention_dispositions "
+            "WHERE expires_at IS NULL OR expires_at > ?",
+            (now,),
+        )
+        rows = await cur.fetchall()
+    return {row["item_id"]: _row_to_dict(row) for row in rows}
+
+
+async def disposition_history(item_id: str) -> list[dict[str, Any]]:
+    require_file_store()
+    if not store_exists():
+        return []
+
+    async with _open_db(store_path()) as db:
+        await _ensure_tables(db)
+        cur = await db.execute(
+            "SELECT id, item_id, prior_state, new_state, note, actor, source_status, created_at "
+            "FROM attention_disposition_history WHERE item_id = ? "
+            "ORDER BY created_at ASC, id ASC",
+            (item_id,),
+        )
+        rows = await cur.fetchall()
+    return [
+        {
+            "id": row["id"],
+            "item_id": row["item_id"],
+            "prior_state": row["prior_state"],
+            "new_state": row["new_state"],
+            "note": row["note"],
+            "actor": row["actor"],
+            "source_status": row["source_status"],
+            "created_at": row["created_at"],
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Route handlers — attention area
+# ---------------------------------------------------------------------------
+
+
+class _DispositionBody(BaseModel):
+    state: Literal["acknowledged", "resolved", "expected", "snoozed"]
+    note: str | None = None
+    expires_at: float | None = None
+    source_status: str = Field(..., min_length=1)
+    actor: str | None = None
+
+    @field_validator("note")
+    @classmethod
+    def _blank_note_is_none(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            return None
+        return v
+
+
+@studio_route(
+    "/attention/dispositions/",
+    method="GET",
+    area="attention",
+    name="list_attention_dispositions",
+)
+async def list_attention_dispositions_route() -> dict[str, Any]:
+    return {"dispositions": await list_dispositions()}
+
+
+@studio_route(
+    "/attention/dispositions/{item_id}",
+    method="PUT",
+    area="attention",
+    name="put_attention_disposition",
+)
+async def put_attention_disposition_route(item_id: str, body: _DispositionBody) -> dict[str, Any]:
+    actor = (body.actor or "").strip() or "operator"
+    return await upsert_disposition(
+        item_id,
+        state=body.state,
+        note=body.note,
+        expires_at=body.expires_at,
+        source_status=body.source_status,
+        actor=actor,
+    )
+
+
+@studio_route(
+    "/attention/dispositions/{item_id}",
+    method="DELETE",
+    area="attention",
+    name="delete_attention_disposition",
+)
+async def delete_attention_disposition_route(item_id: str, request: Request) -> dict[str, Any]:
+    actor = (request.headers.get("x-lionagi-actor") or "").strip() or "operator"
+    return await delete_disposition(item_id, actor=actor)
+
+
+@studio_route(
+    "/attention/dispositions/{item_id}/history",
+    method="GET",
+    area="attention",
+    name="get_attention_disposition_history",
+)
+async def get_attention_disposition_history_route(item_id: str) -> dict[str, Any]:
+    return {"item_id": item_id, "history": await disposition_history(item_id)}

--- a/lionagi/studio/services/attention.py
+++ b/lionagi/studio/services/attention.py
@@ -150,7 +150,20 @@ async def upsert_disposition(
     that high, or it is rejected (409) rather than resurrecting a stale
     disposition -- e.g. a delayed retry of the pre-delete PUT arriving after
     the undo, replaying an old expires_at. Updating an already-active row
-    never fences: nothing was lost to resurrect."""
+    never fences: nothing was lost to resurrect.
+
+    This means an ACTIVE row is deliberately last-writer-wins: a PUT
+    carrying a stale (or absent) revision against a row that is still
+    active always applies, even if a newer PUT already moved it on --
+    e.g. a revision-1 PUT landing after a revision-2 PUT overwrites the
+    revision-2 fields and becomes revision 3. This is chosen, not missed:
+    the fence exists to stop *resurrection after delete*, where a stale
+    write recreates something a human already discharged, not to arbitrate
+    between concurrent edits to a row that's still there to see and retry
+    against. Guarding active-row updates too would break the idempotent
+    retry this function promises above -- an operator's own retried PUT is
+    itself a "stale revision against an active row" from the server's
+    point of view, and it must still apply."""
     if not item_id.strip():
         raise HTTPException(status_code=422, detail="item_id must not be empty")
     if state not in _VALID_STATES:

--- a/lionagi/studio/services/attention.py
+++ b/lionagi/studio/services/attention.py
@@ -43,11 +43,17 @@ CREATE TABLE IF NOT EXISTS attention_dispositions (
   updated_at     REAL    NOT NULL,
   expires_at     REAL,
   actor          TEXT    NOT NULL,
-  source_status  TEXT    NOT NULL
+  source_status  TEXT    NOT NULL,
+  revision       INTEGER NOT NULL DEFAULT 1
+);
+CREATE TABLE IF NOT EXISTS attention_disposition_revisions (
+  item_id        TEXT    PRIMARY KEY,
+  revision       INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS attention_disposition_history (
   id             TEXT    PRIMARY KEY,
   item_id        TEXT    NOT NULL,
+  sequence       INTEGER NOT NULL,
   prior_state    TEXT,
   new_state      TEXT    NOT NULL,
   note           TEXT,
@@ -57,6 +63,8 @@ CREATE TABLE IF NOT EXISTS attention_disposition_history (
 );
 CREATE INDEX IF NOT EXISTS idx_attention_disposition_history_item
   ON attention_disposition_history(item_id, created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attention_disposition_history_sequence
+  ON attention_disposition_history(sequence);
 """
 
 
@@ -74,7 +82,39 @@ def _row_to_dict(row: Any) -> dict[str, Any]:
         "expires_at": row["expires_at"],
         "actor": row["actor"],
         "source_status": row["source_status"],
+        "revision": row["revision"],
     }
+
+
+async def _next_history_sequence(db: Any) -> int:
+    """Caller MUST already hold the write lock on *db* (a preceding
+    ``BEGIN IMMEDIATE``) so the tail read is race-free. Mirrors the
+    approval_evidence.sequence pattern -- a global append-order counter, not
+    a per-item_id one, so equal-timestamp rows never tie on read."""
+    cur = await db.execute(
+        "SELECT sequence FROM attention_disposition_history ORDER BY sequence DESC LIMIT 1"
+    )
+    tail = await cur.fetchone()
+    return (tail["sequence"] + 1) if tail is not None else 1
+
+
+async def _last_known_revision(db: Any, item_id: str) -> int:
+    """The revision of the last operation (PUT or DELETE) ever recorded for
+    *item_id*, or 0 if none. Persists across DELETE so a PUT recreating the
+    item afterward can still be fenced against it."""
+    cur = await db.execute(
+        "SELECT revision FROM attention_disposition_revisions WHERE item_id = ?", (item_id,)
+    )
+    row = await cur.fetchone()
+    return row["revision"] if row is not None else 0
+
+
+async def _record_revision(db: Any, item_id: str, revision: int) -> None:
+    await db.execute(
+        "INSERT INTO attention_disposition_revisions (item_id, revision) VALUES (?, ?) "
+        "ON CONFLICT(item_id) DO UPDATE SET revision = excluded.revision",
+        (item_id, revision),
+    )
 
 
 async def _ensure_store() -> None:
@@ -95,11 +135,22 @@ async def upsert_disposition(
     note: str | None = None,
     expires_at: float | None = None,
     actor: str = "operator",
+    revision: int | None = None,
 ) -> dict[str, Any]:
     """Create-or-replace *item_id*'s disposition. Idempotent under retry:
-    the same (item_id, state, ...) PUT replayed produces one current row
-    plus one appended history entry per call, never a duplicate terminal
-    state for a caller that only retries after a confirmed failure."""
+    the same (item_id, state, ...) PUT replayed while the row is still
+    active produces one current row plus one appended history entry per
+    call, never a duplicate terminal state for a caller that only retries
+    after a confirmed failure.
+
+    *revision* fences the one case that isn't safe to leave unconditional:
+    recreating a row that a DELETE has already removed. A PUT that finds no
+    active row for item_id but a last-operation revision recorded for it
+    (the item was created and then deleted) must carry a revision at least
+    that high, or it is rejected (409) rather than resurrecting a stale
+    disposition -- e.g. a delayed retry of the pre-delete PUT arriving after
+    the undo, replaying an old expires_at. Updating an already-active row
+    never fences: nothing was lost to resurrect."""
     if not item_id.strip():
         raise HTTPException(status_code=422, detail="item_id must not be empty")
     if state not in _VALID_STATES:
@@ -123,27 +174,51 @@ async def upsert_disposition(
             (item_id,),
         )
         existing = await cur.fetchone()
+        last_revision = await _last_known_revision(db, item_id)
+        if existing is None and last_revision > 0:
+            if revision is None or revision < last_revision:
+                await db.rollback()
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"stale revision for item_id {item_id!r}: "
+                        f"disposition has moved on to revision {last_revision}"
+                    ),
+                )
         prior_state = existing["state"] if existing is not None else None
         created_at = existing["created_at"] if existing is not None else now
+        new_revision = last_revision + 1
         await db.execute(
             "INSERT INTO attention_dispositions "
-            "(item_id, state, note, created_at, updated_at, expires_at, actor, source_status) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "(item_id, state, note, created_at, updated_at, expires_at, actor, source_status, revision) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(item_id) DO UPDATE SET "
             "state = excluded.state, note = excluded.note, updated_at = excluded.updated_at, "
             "expires_at = excluded.expires_at, actor = excluded.actor, "
-            "source_status = excluded.source_status",
-            (item_id, state, note, created_at, now, expires_at, actor, source_status),
+            "source_status = excluded.source_status, revision = excluded.revision",
+            (item_id, state, note, created_at, now, expires_at, actor, source_status, new_revision),
         )
+        await _record_revision(db, item_id, new_revision)
+        sequence = await _next_history_sequence(db)
         await db.execute(
             "INSERT INTO attention_disposition_history "
-            "(id, item_id, prior_state, new_state, note, actor, source_status, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (uuid.uuid4().hex, item_id, prior_state, state, note, actor, source_status, now),
+            "(id, item_id, sequence, prior_state, new_state, note, actor, source_status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                uuid.uuid4().hex,
+                item_id,
+                sequence,
+                prior_state,
+                state,
+                note,
+                actor,
+                source_status,
+                now,
+            ),
         )
         await db.commit()
         cur = await db.execute(
-            "SELECT item_id, state, note, created_at, updated_at, expires_at, actor, source_status "
+            "SELECT item_id, state, note, created_at, updated_at, expires_at, actor, source_status, revision "
             "FROM attention_dispositions WHERE item_id = ?",
             (item_id,),
         )
@@ -173,7 +248,7 @@ async def delete_disposition(item_id: str, *, actor: str = "operator") -> dict[s
         # concurrent writer, so prior_state must come from the row this
         # transaction actually deletes, not the one it glimpsed earlier.
         cur = await db.execute(
-            "SELECT state, source_status FROM attention_dispositions WHERE item_id = ?",
+            "SELECT state, source_status, revision FROM attention_dispositions WHERE item_id = ?",
             (item_id,),
         )
         existing = await cur.fetchone()
@@ -181,12 +256,26 @@ async def delete_disposition(item_id: str, *, actor: str = "operator") -> dict[s
             await db.rollback()
             return {"item_id": item_id, "deleted": False}
         now = time.time()
+        # Bump and persist the revision beyond the row's own deletion, so a
+        # PUT that later tries to recreate item_id must beat this operation
+        # too -- see upsert_disposition's fencing check.
+        new_revision = existing["revision"] + 1
+        await _record_revision(db, item_id, new_revision)
         await db.execute("DELETE FROM attention_dispositions WHERE item_id = ?", (item_id,))
+        sequence = await _next_history_sequence(db)
         await db.execute(
             "INSERT INTO attention_disposition_history "
-            "(id, item_id, prior_state, new_state, note, actor, source_status, created_at) "
-            "VALUES (?, ?, ?, 'open', NULL, ?, ?, ?)",
-            (uuid.uuid4().hex, item_id, existing["state"], actor, existing["source_status"], now),
+            "(id, item_id, sequence, prior_state, new_state, note, actor, source_status, created_at) "
+            "VALUES (?, ?, ?, ?, 'open', NULL, ?, ?, ?)",
+            (
+                uuid.uuid4().hex,
+                item_id,
+                sequence,
+                existing["state"],
+                actor,
+                existing["source_status"],
+                now,
+            ),
         )
         await db.commit()
     return {"item_id": item_id, "deleted": True}
@@ -204,7 +293,7 @@ async def list_dispositions() -> dict[str, dict[str, Any]]:
     async with _open_db(store_path()) as db:
         await _ensure_tables(db)
         cur = await db.execute(
-            "SELECT item_id, state, note, created_at, updated_at, expires_at, actor, source_status "
+            "SELECT item_id, state, note, created_at, updated_at, expires_at, actor, source_status, revision "
             "FROM attention_dispositions "
             "WHERE expires_at IS NULL OR expires_at > ?",
             (now,),
@@ -223,7 +312,7 @@ async def disposition_history(item_id: str) -> list[dict[str, Any]]:
         cur = await db.execute(
             "SELECT id, item_id, prior_state, new_state, note, actor, source_status, created_at "
             "FROM attention_disposition_history WHERE item_id = ? "
-            "ORDER BY created_at ASC, id ASC",
+            "ORDER BY sequence ASC",
             (item_id,),
         )
         rows = await cur.fetchall()
@@ -253,6 +342,10 @@ class _DispositionBody(BaseModel):
     expires_at: float | None = None
     source_status: str = Field(..., min_length=1)
     actor: str | None = None
+    # The revision GET/list last returned for this item_id, if the caller
+    # has one. Required to recreate an item a DELETE has removed -- see
+    # upsert_disposition.
+    revision: int | None = None
 
     @field_validator("note")
     @classmethod
@@ -287,6 +380,7 @@ async def put_attention_disposition_route(item_id: str, body: _DispositionBody) 
         expires_at=body.expires_at,
         source_status=body.source_status,
         actor=actor,
+        revision=body.revision,
     )
 
 

--- a/tests/apps_studio_server/test_attention_dispositions.py
+++ b/tests/apps_studio_server/test_attention_dispositions.py
@@ -1,0 +1,400 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Studio needs-attention discharge lifecycle (dispositions)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+from fastapi.testclient import TestClient  # noqa: E402
+
+from lionagi.state.db import StateDB  # noqa: E402
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _patch_db(monkeypatch: pytest.MonkeyPatch, db_path: Path) -> None:
+    import lionagi.state.db as state_db_mod
+
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+
+def _make_client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765")
+
+
+async def _init_db(db_path: Path) -> None:
+    async with StateDB(db_path):
+        pass  # opens + applies schema (creates the attention tables too)
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: service functions directly (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_creates_pending_row(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    row = _run(
+        attention_mod.upsert_disposition(
+            "run:abc123",
+            state="acknowledged",
+            source_status="failed",
+            actor="operator",
+        )
+    )
+    assert row["item_id"] == "run:abc123"
+    assert row["state"] == "acknowledged"
+    assert row["source_status"] == "failed"
+    assert row["actor"] == "operator"
+    assert row["note"] is None
+    assert row["expires_at"] is None
+    assert row["created_at"] == row["updated_at"]
+
+
+def test_expected_requires_note_and_expiry(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from fastapi import HTTPException
+
+    from lionagi.studio.services import attention as attention_mod
+
+    with pytest.raises(HTTPException):
+        _run(attention_mod.upsert_disposition("run:x", state="expected", source_status="failed"))
+    with pytest.raises(HTTPException):
+        _run(
+            attention_mod.upsert_disposition(
+                "run:x", state="expected", source_status="failed", note="  "
+            )
+        )
+    with pytest.raises(HTTPException):
+        _run(
+            attention_mod.upsert_disposition(
+                "run:x",
+                state="expected",
+                source_status="failed",
+                note="deploy window",
+            )
+        )
+    row = _run(
+        attention_mod.upsert_disposition(
+            "run:x",
+            state="expected",
+            source_status="failed",
+            note="deploy window",
+            expires_at=time.time() + 3600,
+        )
+    )
+    assert row["state"] == "expected"
+    assert row["note"] == "deploy window"
+
+
+def test_snoozed_requires_expiry(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from fastapi import HTTPException
+
+    from lionagi.studio.services import attention as attention_mod
+
+    with pytest.raises(HTTPException):
+        _run(attention_mod.upsert_disposition("sched:s1", state="snoozed", source_status="failed"))
+    row = _run(
+        attention_mod.upsert_disposition(
+            "sched:s1",
+            state="snoozed",
+            source_status="failed",
+            expires_at=time.time() + 60,
+        )
+    )
+    assert row["state"] == "snoozed"
+
+
+def test_put_is_idempotent_under_retry(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    first = _run(
+        attention_mod.upsert_disposition(
+            "run:retry1", state="resolved", source_status="failed", actor="operator"
+        )
+    )
+    second = _run(
+        attention_mod.upsert_disposition(
+            "run:retry1", state="resolved", source_status="failed", actor="operator"
+        )
+    )
+    assert first["item_id"] == second["item_id"]
+    assert second["state"] == "resolved"
+    assert second["created_at"] == first["created_at"], (
+        "create-or-replace keeps original created_at"
+    )
+
+    listed = _run(attention_mod.list_dispositions())
+    assert len(listed) == 1
+    assert listed["run:retry1"]["state"] == "resolved"
+
+
+def test_replace_changes_state_and_appends_history(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    _run(
+        attention_mod.upsert_disposition(
+            "run:r2", state="acknowledged", source_status="failed", actor="operator"
+        )
+    )
+    replaced = _run(
+        attention_mod.upsert_disposition(
+            "run:r2", state="resolved", source_status="completed", actor="operator"
+        )
+    )
+    assert replaced["state"] == "resolved"
+    assert replaced["source_status"] == "completed"
+
+    history = _run(attention_mod.disposition_history("run:r2"))
+    assert [h["new_state"] for h in history] == ["acknowledged", "resolved"]
+    assert history[0]["prior_state"] is None
+    assert history[1]["prior_state"] == "acknowledged"
+
+
+def test_delete_undoes_and_is_a_noop_when_nothing_discharged(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    _run(
+        attention_mod.upsert_disposition(
+            "run:r3", state="resolved", source_status="failed", actor="operator"
+        )
+    )
+    result = _run(attention_mod.delete_disposition("run:r3", actor="operator"))
+    assert result == {"item_id": "run:r3", "deleted": True}
+
+    listed = _run(attention_mod.list_dispositions())
+    assert "run:r3" not in listed
+
+    # Second delete is a no-op — no duplicate 'open' history row.
+    result2 = _run(attention_mod.delete_disposition("run:r3", actor="operator"))
+    assert result2 == {"item_id": "run:r3", "deleted": False}
+
+    history = _run(attention_mod.disposition_history("run:r3"))
+    assert [h["new_state"] for h in history] == ["resolved", "open"]
+    assert history[-1]["prior_state"] == "resolved"
+
+
+def test_list_excludes_lapsed_snoozed_and_expected_but_keeps_others(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    now = time.time()
+    _run(
+        attention_mod.upsert_disposition(
+            "run:lapsed-snooze",
+            state="snoozed",
+            source_status="failed",
+            expires_at=now - 10,
+        )
+    )
+    _run(
+        attention_mod.upsert_disposition(
+            "run:active-snooze",
+            state="snoozed",
+            source_status="failed",
+            expires_at=now + 3600,
+        )
+    )
+    _run(
+        attention_mod.upsert_disposition(
+            "run:lapsed-expected",
+            state="expected",
+            source_status="failed",
+            note="deploy",
+            expires_at=now - 10,
+        )
+    )
+    _run(attention_mod.upsert_disposition("run:ack", state="acknowledged", source_status="failed"))
+    _run(
+        attention_mod.upsert_disposition(
+            "run:resolved", state="resolved", source_status="completed"
+        )
+    )
+
+    listed = _run(attention_mod.list_dispositions())
+    assert set(listed) == {"run:active-snooze", "run:ack", "run:resolved"}
+
+
+def test_new_occurrence_after_resolution_is_a_fresh_item_id(tmp_path, monkeypatch):
+    """A resolved run:<id> item can never mask a different, later run — the
+    two carry different item ids by construction, so resolving one leaves
+    the other entirely untouched in the dispositions store."""
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    _run(
+        attention_mod.upsert_disposition(
+            "run:old-failure", state="resolved", source_status="failed"
+        )
+    )
+    listed = _run(attention_mod.list_dispositions())
+    assert "run:new-failure" not in listed
+    assert listed["run:old-failure"]["state"] == "resolved"
+
+
+def test_concurrent_writes_to_one_item_yield_one_disposition_and_ordered_history(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    async def _go():
+        await asyncio.gather(
+            attention_mod.upsert_disposition(
+                "run:race", state="acknowledged", source_status="failed", actor="a"
+            ),
+            attention_mod.upsert_disposition(
+                "run:race", state="resolved", source_status="failed", actor="b"
+            ),
+        )
+
+    _run(_go())
+
+    listed = _run(attention_mod.list_dispositions())
+    assert len(listed) == 1
+    assert listed["run:race"]["state"] in ("acknowledged", "resolved")
+
+    history = _run(attention_mod.disposition_history("run:race"))
+    assert len(history) == 2
+    # Whichever write landed second must have seen the first as prior_state —
+    # a lost write would instead show two independent prior_state=None rows.
+    assert history[1]["prior_state"] == history[0]["new_state"]
+    assert history[-1]["new_state"] == listed["run:race"]["state"]
+
+
+def test_reopening_store_does_not_fail_and_keeps_rows(tmp_path, monkeypatch):
+    """Migration idempotence: applying the schema on a store that already
+    has the attention tables (a daemon restart) must not raise, and must
+    leave existing dispositions untouched."""
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    _run(
+        attention_mod.upsert_disposition("run:persisted", state="resolved", source_status="failed")
+    )
+
+    # Simulate a daemon restart: open the same store again (create_all is
+    # idempotent — CREATE TABLE IF NOT EXISTS — same as every other table).
+    _run(_init_db(db_path))
+    _run(_init_db(db_path))
+
+    listed = _run(attention_mod.list_dispositions())
+    assert listed["run:persisted"]["state"] == "resolved"
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level: routes
+# ---------------------------------------------------------------------------
+
+
+def test_http_put_get_delete_roundtrip(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+
+    resp = client.put(
+        "/api/attention/dispositions/run:http1",
+        json={"state": "acknowledged", "source_status": "failed", "actor": "alice"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["state"] == "acknowledged"
+    assert body["actor"] == "alice"
+
+    listed = client.get("/api/attention/dispositions/")
+    assert listed.status_code == 200
+    assert "run:http1" in listed.json()["dispositions"]
+
+    history = client.get("/api/attention/dispositions/run:http1/history")
+    assert history.status_code == 200
+    assert [h["new_state"] for h in history.json()["history"]] == ["acknowledged"]
+
+    deleted = client.delete("/api/attention/dispositions/run:http1")
+    assert deleted.status_code == 200
+    assert deleted.json() == {"item_id": "run:http1", "deleted": True}
+
+    listed_after = client.get("/api/attention/dispositions/")
+    assert "run:http1" not in listed_after.json()["dispositions"]
+
+
+def test_http_put_rejects_expected_without_note(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+
+    resp = client.put(
+        "/api/attention/dispositions/run:http2",
+        json={"state": "expected", "source_status": "failed", "expires_at": time.time() + 60},
+    )
+    assert resp.status_code == 422
+
+
+def test_http_put_rejects_unknown_state(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+
+    resp = client.put(
+        "/api/attention/dispositions/run:http3",
+        json={"state": "ignored", "source_status": "failed"},
+    )
+    assert resp.status_code == 422
+
+
+def test_http_delete_of_unknown_item_is_a_noop(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+
+    resp = client.delete("/api/attention/dispositions/run:never-existed")
+    assert resp.status_code == 200
+    assert resp.json() == {"item_id": "run:never-existed", "deleted": False}

--- a/tests/apps_studio_server/test_attention_dispositions.py
+++ b/tests/apps_studio_server/test_attention_dispositions.py
@@ -188,6 +188,38 @@ def test_replace_changes_state_and_appends_history(tmp_path, monkeypatch):
     assert history[1]["prior_state"] == "acknowledged"
 
 
+def test_history_order_survives_equal_timestamps(tmp_path, monkeypatch):
+    """Two writes landing at the exact same wall-clock time (a real
+    possibility -- time.time() resolution is coarser than SQLite's
+    lock-serialized write throughput) must still read back in append order.
+    Ordering by created_at alone can tie and let a reader observe them
+    reversed; the server-side sequence column can't tie."""
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    frozen = time.time()
+    monkeypatch.setattr(attention_mod.time, "time", lambda: frozen)
+
+    _run(
+        attention_mod.upsert_disposition(
+            "run:tie", state="acknowledged", source_status="failed", actor="operator"
+        )
+    )
+    _run(
+        attention_mod.upsert_disposition(
+            "run:tie", state="resolved", source_status="completed", actor="operator"
+        )
+    )
+    _run(attention_mod.delete_disposition("run:tie", actor="operator"))
+
+    history = _run(attention_mod.disposition_history("run:tie"))
+    assert len({h["created_at"] for h in history}) == 1, "fixture must actually tie timestamps"
+    assert [h["new_state"] for h in history] == ["acknowledged", "resolved", "open"]
+
+
 def test_delete_undoes_and_is_a_noop_when_nothing_discharged(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     _patch_db(monkeypatch, db_path)
@@ -213,6 +245,108 @@ def test_delete_undoes_and_is_a_noop_when_nothing_discharged(tmp_path, monkeypat
     history = _run(attention_mod.disposition_history("run:r3"))
     assert [h["new_state"] for h in history] == ["resolved", "open"]
     assert history[-1]["prior_state"] == "resolved"
+
+
+def test_delete_fences_a_replayed_put_from_resurrecting_the_disposition(tmp_path, monkeypatch):
+    """A DELETE must leave behind something a later PUT has to beat: without
+    it, a network-delayed retry of the pre-delete PUT can arrive after the
+    undo and recreate the row with its old (already-undone) expires_at."""
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from fastapi import HTTPException
+
+    from lionagi.studio.services import attention as attention_mod
+
+    original = _run(
+        attention_mod.upsert_disposition(
+            "run:replay",
+            state="snoozed",
+            source_status="failed",
+            expires_at=time.time() + 3600,
+            actor="operator",
+        )
+    )
+    stale_revision = original["revision"]
+
+    _run(attention_mod.delete_disposition("run:replay", actor="operator"))
+    assert "run:replay" not in _run(attention_mod.list_dispositions())
+
+    # The delayed duplicate of the original PUT, carrying the pre-delete
+    # revision, must not resurrect the snooze.
+    with pytest.raises(HTTPException) as exc_info:
+        _run(
+            attention_mod.upsert_disposition(
+                "run:replay",
+                state="snoozed",
+                source_status="failed",
+                expires_at=time.time() + 3600,
+                actor="operator",
+                revision=stale_revision,
+            )
+        )
+    assert exc_info.value.status_code == 409
+    assert "run:replay" not in _run(attention_mod.list_dispositions())
+
+    # So must a caller that carries no revision at all -- once item_id has a
+    # recorded prior operation, omitting revision is no safer than a stale one.
+    with pytest.raises(HTTPException) as exc_info2:
+        _run(
+            attention_mod.upsert_disposition(
+                "run:replay",
+                state="acknowledged",
+                source_status="failed",
+                actor="operator",
+            )
+        )
+    assert exc_info2.value.status_code == 409
+
+    # A caller that reads the current (post-delete) revision and beats it
+    # is a legitimate fresh action, and succeeds.
+    recreated = _run(
+        attention_mod.upsert_disposition(
+            "run:replay",
+            state="acknowledged",
+            source_status="failed",
+            actor="operator",
+            revision=stale_revision + 1,
+        )
+    )
+    assert recreated["state"] == "acknowledged"
+
+
+def test_http_put_after_delete_rejects_stale_revision(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    client = _make_client(db_path, monkeypatch)
+
+    put1 = client.put(
+        "/api/attention/dispositions/run:httpreplay",
+        json={
+            "state": "snoozed",
+            "source_status": "failed",
+            "expires_at": time.time() + 3600,
+        },
+    )
+    assert put1.status_code == 200, put1.text
+    stale_revision = put1.json()["revision"]
+
+    deleted = client.delete("/api/attention/dispositions/run:httpreplay")
+    assert deleted.status_code == 200
+
+    replay = client.put(
+        "/api/attention/dispositions/run:httpreplay",
+        json={
+            "state": "snoozed",
+            "source_status": "failed",
+            "expires_at": time.time() + 3600,
+            "revision": stale_revision,
+        },
+    )
+    assert replay.status_code == 409
+
+    listed = client.get("/api/attention/dispositions/")
+    assert "run:httpreplay" not in listed.json()["dispositions"]
 
 
 def test_list_excludes_lapsed_snoozed_and_expected_but_keeps_others(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_attention_dispositions.py
+++ b/tests/apps_studio_server/test_attention_dispositions.py
@@ -316,6 +316,58 @@ def test_delete_fences_a_replayed_put_from_resurrecting_the_disposition(tmp_path
     assert recreated["state"] == "acknowledged"
 
 
+def test_active_row_put_with_stale_revision_is_last_writer_wins_not_fenced(tmp_path, monkeypatch):
+    """Contract, not a bug: a stale-revision PUT against a row that is still
+    ACTIVE applies unconditionally and overwrites newer fields -- the
+    revision fence only guards recreating a row a DELETE already removed.
+    Fencing active-row updates too would reject an operator's own retried
+    PUT, which is itself a "stale revision" from the server's point of
+    view, breaking the idempotent-retry contract upsert_disposition
+    promises."""
+    db_path = tmp_path / "state.db"
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from lionagi.studio.services import attention as attention_mod
+
+    first = _run(
+        attention_mod.upsert_disposition(
+            "run:lww", state="acknowledged", source_status="failed", actor="operator"
+        )
+    )
+    assert first["revision"] == 1
+
+    second = _run(
+        attention_mod.upsert_disposition(
+            "run:lww",
+            state="snoozed",
+            source_status="failed",
+            actor="operator",
+            expires_at=time.time() + 3600,
+            revision=first["revision"],
+        )
+    )
+    assert second["state"] == "snoozed"
+    assert second["revision"] == 2
+
+    # A PUT carrying the now-stale revision 1 (e.g. a delayed retry of the
+    # first PUT) is not rejected: it overwrites the revision-2 fields.
+    third = _run(
+        attention_mod.upsert_disposition(
+            "run:lww",
+            state="acknowledged",
+            source_status="failed",
+            actor="operator",
+            revision=first["revision"],
+        )
+    )
+    assert third["state"] == "acknowledged"
+    assert third["revision"] == 3
+
+    listed = _run(attention_mod.list_dispositions())
+    assert listed["run:lww"]["state"] == "acknowledged"
+
+
 def test_http_put_after_delete_rejects_stale_revision(tmp_path, monkeypatch):
     db_path = tmp_path / "state.db"
     client = _make_client(db_path, monkeypatch)
@@ -467,6 +519,146 @@ def test_reopening_store_does_not_fail_and_keeps_rows(tmp_path, monkeypatch):
 
     listed = _run(attention_mod.list_dispositions())
     assert listed["run:persisted"]["state"] == "resolved"
+
+
+def _create_pre_revision_attention_db(db_path: Path) -> None:
+    """Build the exact shape ``feat(studio): durable discharge lifecycle``
+    (604dfd6fc) produced: ``attention_dispositions`` and
+    ``attention_disposition_history`` already exist, but without
+    ``revision``/``sequence`` -- those columns and the
+    ``attention_disposition_revisions`` ledger were only added later, and
+    that later commit never bumped ``schema_meta.version`` off '2' either.
+    metadata.create_all() only creates *missing* tables, so opening a store
+    already in this shape with current code creates the (new)
+    attention_disposition_revisions table but silently leaves the two
+    pre-existing tables without their new columns."""
+    import sqlite3
+
+    from lionagi.state.db import _SCHEMA_PATH
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_SCHEMA_PATH.read_text())
+        conn.execute("DROP TABLE attention_disposition_revisions")
+        conn.execute("DROP INDEX idx_attention_disposition_history_sequence")
+        conn.execute("ALTER TABLE attention_disposition_history DROP COLUMN sequence")
+        conn.execute("ALTER TABLE attention_dispositions DROP COLUMN revision")
+        conn.execute("UPDATE schema_meta SET value = '2' WHERE key = 'version'")
+
+        # run:active -- three PUTs before the upgrade. Its true revision
+        # count (3) must survive the backfill, not collapse to a flat 1.
+        conn.execute(
+            "INSERT INTO attention_dispositions "
+            "(item_id, state, note, created_at, updated_at, expires_at, actor, source_status) "
+            "VALUES ('run:active', 'resolved', NULL, 1.0, 3.0, NULL, 'operator', 'failed')"
+        )
+        for i, (prior, new, ts) in enumerate(
+            [
+                (None, "acknowledged", 1.0),
+                ("acknowledged", "snoozed", 2.0),
+                ("snoozed", "resolved", 3.0),
+            ]
+        ):
+            conn.execute(
+                "INSERT INTO attention_disposition_history "
+                "(id, item_id, prior_state, new_state, note, actor, source_status, created_at) "
+                "VALUES (?, 'run:active', ?, ?, NULL, 'operator', 'failed', ?)",
+                (f"hist-active-{i}", prior, new, ts),
+            )
+
+        # run:deleted -- acknowledged then undone (DELETE) before the
+        # upgrade. No active row, but a PUT that predates the DELETE must
+        # still be fenced against it after the upgrade.
+        conn.execute(
+            "INSERT INTO attention_disposition_history "
+            "(id, item_id, prior_state, new_state, note, actor, source_status, created_at) "
+            "VALUES ('hist-deleted-0', 'run:deleted', NULL, 'acknowledged', NULL, "
+            "'operator', 'failed', 10.0)"
+        )
+        conn.execute(
+            "INSERT INTO attention_disposition_history "
+            "(id, item_id, prior_state, new_state, note, actor, source_status, created_at) "
+            "VALUES ('hist-deleted-1', 'run:deleted', 'acknowledged', 'open', NULL, "
+            "'operator', 'failed', 11.0)"
+        )
+        conn.commit()
+
+
+def test_attention_dispositions_upgrade_from_pre_revision_store(tmp_path, monkeypatch):
+    """Opening a store already in the pre-revision/sequence shape must
+    migrate it, not just re-stamp it: ordered history reads without
+    ``OperationalError``, revision backfills from the true history count,
+    a DELETE-then-replayed-PUT is fenced (409), and the fence for an item
+    already deleted *before* the upgrade survives the upgrade too."""
+    db_path = tmp_path / "state.db"
+    _create_pre_revision_attention_db(db_path)
+    _patch_db(monkeypatch, db_path)
+    _run(_init_db(db_path))
+
+    from fastapi import HTTPException
+
+    from lionagi.studio.services import attention as attention_mod
+
+    # (c) ordered history reads without OperationalError; (e) old rows read
+    # back in their original (created_at, id) order via the backfilled
+    # sequence.
+    history = _run(attention_mod.disposition_history("run:active"))
+    assert [h["new_state"] for h in history] == ["acknowledged", "snoozed", "resolved"]
+
+    # Revision backfilled from the true history count (3 PUTs), not a flat 1.
+    listed = _run(attention_mod.list_dispositions())
+    assert listed["run:active"]["revision"] == 3
+
+    # (d) a PUT continues the ledger from the backfilled count.
+    again = _run(
+        attention_mod.upsert_disposition(
+            "run:active",
+            state="acknowledged",
+            source_status="failed",
+            actor="operator",
+            revision=3,
+        )
+    )
+    assert again["revision"] == 4
+
+    # (d) DELETE then a replayed PUT is fenced (409).
+    _run(attention_mod.delete_disposition("run:active", actor="operator"))
+    with pytest.raises(HTTPException) as exc_info:
+        _run(
+            attention_mod.upsert_disposition(
+                "run:active",
+                state="acknowledged",
+                source_status="failed",
+                actor="operator",
+                revision=4,
+            )
+        )
+    assert exc_info.value.status_code == 409
+
+    # The fence for an item deleted *before* the upgrade must also survive:
+    # a replay of the pre-delete PUT (stale revision) is rejected...
+    with pytest.raises(HTTPException) as exc_info2:
+        _run(
+            attention_mod.upsert_disposition(
+                "run:deleted",
+                state="acknowledged",
+                source_status="failed",
+                actor="operator",
+                revision=1,
+            )
+        )
+    assert exc_info2.value.status_code == 409
+
+    # ...while a caller that beats the backfilled ledger succeeds.
+    recreated = _run(
+        attention_mod.upsert_disposition(
+            "run:deleted",
+            state="acknowledged",
+            source_status="failed",
+            actor="operator",
+            revision=2,
+        )
+    )
+    assert recreated["state"] == "acknowledged"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -60,6 +60,7 @@ _DOCS_PATHS = frozenset({"/openapi.json", "/docs", "/redoc", "/docs/oauth2-redir
 # mounting rule).
 _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("DELETE", "/api/agents/{name}"),
+    ("DELETE", "/api/attention/dispositions/{item_id}"),
     ("DELETE", "/api/engine-defs/{def_id}"),
     ("DELETE", "/api/mcp/servers/{name}"),
     ("DELETE", "/api/operator/conversations/{conversation_id}"),
@@ -78,6 +79,8 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("GET", "/api/approvals/{approval_id}"),
     ("GET", "/api/artifacts/by-session/{session_id}"),
     ("GET", "/api/artifacts/{artifact_id}"),
+    ("GET", "/api/attention/dispositions/"),
+    ("GET", "/api/attention/dispositions/{item_id}/history"),
     ("GET", "/api/casts/"),
     ("GET", "/api/definitions/"),
     ("GET", "/api/definitions/{kind}/{name}"),
@@ -185,6 +188,7 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("POST", "/api/workflow-defs/"),
     ("POST", "/api/workflow-defs/{def_id}/run"),
     ("PUT", "/api/agents/{name}"),
+    ("PUT", "/api/attention/dispositions/{item_id}"),
     ("PUT", "/api/engine-defs/{def_id}"),
     ("PUT", "/api/mcp/servers/{name}"),
     ("PUT", "/api/playbooks/{name}"),
@@ -268,7 +272,7 @@ def test_golden_route_table_matches_pinned_snapshot():
 
 
 def test_golden_route_count_pinned():
-    assert len(_GOLDEN_ROUTES) == 122
+    assert len(_GOLDEN_ROUTES) == 126
 
 
 def _compiled_match_shape(path_template: str) -> str:

--- a/tests/apps_studio_server/test_route_registry.py
+++ b/tests/apps_studio_server/test_route_registry.py
@@ -253,6 +253,7 @@ _MIGRATED_AREAS = {
     "admin",
     "schedules",
     "stats",
+    "attention",
 }
 
 

--- a/tests/state/test_engine_schema.py
+++ b/tests/state/test_engine_schema.py
@@ -219,6 +219,9 @@ ALL_TABLES = {
     "approvals",
     "approval_evidence",
     "workers",
+    "attention_dispositions",
+    "attention_disposition_history",
+    "attention_disposition_revisions",
 }
 
 
@@ -324,7 +327,7 @@ async def test_metadata_check_constraint_parity_vs_schema_sql(tmp_path, sqlite_m
         meta_checks = _checks(await conn.run_sync(_meta_rows))
 
     # Guard against the regex silently extracting nothing (would make equality trivial).
-    assert len(raw_checks) == 19, f"expected 19 enum CHECK columns, got {len(raw_checks)}"
+    assert len(raw_checks) == 20, f"expected 20 enum CHECK columns, got {len(raw_checks)}"
     drift = {
         k: {
             "schema_sql": sorted(raw_checks.get(k) or []),

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -231,6 +231,8 @@ async def test_migration_columns_constant_is_importable():
         "session_controls",  # claimed_at, added with the claim protocol
         "engine_runs",  # Phase C Move 2 — new table registered for future migrations
         "dispatch_outbox",  # ADR-0092 — new table registered for future migrations
+        "attention_dispositions",  # revision fencing column
+        "attention_disposition_history",  # sequence append-order column
     }
     assert set(MIGRATION_COLUMNS.keys()) == expected_tables
 


### PR DESCRIPTION
Needs-attention items can now be acknowledged, resolved, marked expected, or snoozed, with the disposition persisted (one row per item plus an append-only history ledger) and an undo back to open. Snoozed and expected dispositions lapse by expiry. The mission board joins dispositions onto derived items and keeps discharged items behind a toggle.

Closes #2852