### PR TITLE
feat(studio): redact sensitive fields from library and agent definition reads

### DIFF
--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -322,17 +322,19 @@ async def list_agents(arguments: dict[str, Any]) -> dict[str, Any]:
 
     rows = await anyio.to_thread.run_sync(_list_agents)
     redact = demo_mode_enabled()
-    projected = [
-        {
-            "name": row.get("name"),
-            "provider": row.get("provider") or None,
-            "model": row.get("model") or None,
-            "description": (project_agent_fields(row, redact=redact).get("description") or "")[:500]
-            or None,
-        }
-        for row in rows[: args.limit]
-        if isinstance(row.get("name"), str)
-    ]
+    projected = []
+    for row in rows[: args.limit]:
+        if not isinstance(row.get("name"), str):
+            continue
+        safe = project_agent_fields(row, redact=redact)
+        projected.append(
+            {
+                "name": row.get("name"),
+                "provider": safe.get("provider") or None,
+                "model": safe.get("model") or None,
+                "description": (safe.get("description") or "")[:500] or None,
+            }
+        )
     return {"agents": projected, "count": len(projected), "bounded": True}
 
 

--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -318,14 +318,17 @@ async def list_schedules(arguments: dict[str, Any]) -> dict[str, Any]:
 async def list_agents(arguments: dict[str, Any]) -> dict[str, Any]:
     args = ListAgentsInput.model_validate(arguments)
     from lionagi.studio.services.agents import list_agents as _list_agents
+    from lionagi.studio.services.redaction import demo_mode_enabled, project_agent_fields
 
     rows = await anyio.to_thread.run_sync(_list_agents)
+    redact = demo_mode_enabled()
     projected = [
         {
             "name": row.get("name"),
             "provider": row.get("provider") or None,
             "model": row.get("model") or None,
-            "description": (row.get("description") or "")[:500] or None,
+            "description": (project_agent_fields(row, redact=redact).get("description") or "")[:500]
+            or None,
         }
         for row in rows[: args.limit]
         if isinstance(row.get("name"), str)

--- a/lionagi/studio/services/agents.py
+++ b/lionagi/studio/services/agents.py
@@ -365,11 +365,12 @@ async def create_agent_route(
     name: str, body: Annotated[dict[str, Any], Body(default_factory=dict)]
 ) -> dict[str, Any]:
     try:
-        return await anyio.to_thread.run_sync(partial(create_agent, name, body))
+        created = await anyio.to_thread.run_sync(partial(create_agent, name, body))
     except AgentExistsError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
+    return project_agent_fields(created, redact=demo_mode_enabled())
 
 
 @studio_route("/agents/{name}", method="PUT", area="agents", name="update_agent")
@@ -384,7 +385,7 @@ async def update_agent_route(
         raise HTTPException(status_code=422, detail=str(e)) from e
     if updated is None:
         raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
-    return updated
+    return project_agent_fields(updated, redact=demo_mode_enabled())
 
 
 @studio_route("/agents/{name}", method="DELETE", area="agents", name="delete_agent")

--- a/lionagi/studio/services/agents.py
+++ b/lionagi/studio/services/agents.py
@@ -77,6 +77,24 @@ def _normalize_frontmatter(fm: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+_SCALAR_FRONTMATTER_TYPES = (str, int, float, bool, type(None))
+
+
+def _display_scalar(value: Any) -> Any:
+    """Return the display form of a scalar-shaped frontmatter value; a
+    mapping or list is returned unchanged, not ``str()``-coerced.
+
+    A ``str()`` call accepts any input, so coercing a nested mapping before
+    it reaches :func:`redaction.project_agent_fields` would turn it into a
+    plain string -- a shape the classification table's scalar check admits
+    verbatim, defeating the very check meant to catch it. Leaving a non-scalar
+    value's real shape intact lets that check see and drop it instead.
+    """
+    if isinstance(value, _SCALAR_FRONTMATTER_TYPES):
+        return str(value) if value not in (None, "") else ""
+    return value
+
+
 def _canonical_model(model: Any, provider: Any) -> str:
     model_s = str(model or "").strip()
     if not model_s:
@@ -101,8 +119,8 @@ def list_agents() -> list[dict[str, Any]]:
         entry: dict[str, Any] = {
             "name": path.stem,
             "path": public_path(path),
-            "provider": str(fm.get("provider") or ""),
-            "model": str(fm.get("model") or ""),
+            "provider": _display_scalar(fm.get("provider")),
+            "model": _display_scalar(fm.get("model")),
             "description": str(fm.get("description") or ""),
             **{k: v for k, v in fm.items() if k not in ("model", "description", "provider")},
         }
@@ -134,8 +152,8 @@ def get_agent(name: str) -> dict[str, Any] | None:
     result: dict[str, Any] = {
         "name": stem,
         "path": public_path(path),
-        "provider": str(fm.get("provider") or ""),
-        "model": str(fm.get("model") or ""),
+        "provider": _display_scalar(fm.get("provider")),
+        "model": _display_scalar(fm.get("model")),
         "system_prompt": fm.get("system_prompt") or (body if body else None),
         "guidance": fm.get("guidance") or None,
     }

--- a/lionagi/studio/services/agents.py
+++ b/lionagi/studio/services/agents.py
@@ -15,6 +15,12 @@ from lionagi.libs.frontmatter import parse_frontmatter as _parse_frontmatter
 
 from ..registry import studio_route
 from ._path_safety import public_path, safe_path_join, validate_name_component
+from .redaction import (
+    RedactedPayloadError,
+    demo_mode_enabled,
+    project_agent_fields,
+    reject_if_redacted_payload,
+)
 
 _AGENTS_ROOT = LIONAGI_HOME / "agents"
 _log = logging.getLogger(__name__)
@@ -295,6 +301,14 @@ def update_agent(name: str, data: dict[str, Any]) -> dict[str, Any] | None:
     if _is_protected_system(existing_fm):
         raise AgentProtectedError(f"Agent '{stem}' is a system agent and cannot be edited")
 
+    # While demo mode is on, a client that fetched the redacted view and posted
+    # it back unmodified must not be able to overwrite the real file with the
+    # placeholder text -- the other write path onto agent files (the generic
+    # definitions save route) carries the same guard; see redaction.py.
+    reject_if_redacted_payload(
+        data.get("system_prompt"), data.get("guidance"), data.get("description")
+    )
+
     fm: dict[str, Any] = dict(existing_fm)
     incoming = _normalize_frontmatter(data)
     _canonicalize_casts(incoming)
@@ -333,6 +347,8 @@ def update_agent(name: str, data: dict[str, Any]) -> dict[str, Any] | None:
 @studio_route("/agents/", method="GET", area="agents", name="list_agents")
 async def list_agents_route() -> dict[str, Any]:
     agents = await anyio.to_thread.run_sync(list_agents)
+    redact = demo_mode_enabled()
+    agents = [project_agent_fields(a, redact=redact) for a in agents]
     return {"agents": agents}
 
 
@@ -341,7 +357,7 @@ async def get_agent_route(name: str) -> dict[str, Any]:
     agent = await anyio.to_thread.run_sync(partial(get_agent, name))
     if agent is None:
         raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
-    return agent
+    return project_agent_fields(agent, redact=demo_mode_enabled())
 
 
 @studio_route("/agents/{name}", method="POST", area="agents", name="create_agent")
@@ -362,7 +378,7 @@ async def update_agent_route(
 ) -> dict[str, Any]:
     try:
         updated = await anyio.to_thread.run_sync(partial(update_agent, name, body))
-    except AgentProtectedError as e:
+    except (AgentProtectedError, RedactedPayloadError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -20,6 +20,13 @@ from lionagi.state.engine import mask_credentials
 from ..registry import studio_route
 from ._path_safety import validate_name_component
 from .agents import _is_protected_system
+from .redaction import (
+    RedactedPayloadError,
+    abbreviate_path,
+    demo_mode_enabled,
+    redact_agent_markdown,
+    reject_if_redacted_payload,
+)
 
 _log = logging.getLogger("lionagi.studio")
 
@@ -211,6 +218,12 @@ async def get_definition(kind: str, name: str) -> dict[str, Any] | None:
         return None
 
     content = await anyio.to_thread.run_sync(disk_file.read_text)
+    path = _relative_path(disk_file)
+
+    redact = kind == "agent" and demo_mode_enabled()
+    if redact:
+        content = redact_agent_markdown(content, redact=True)
+        path = abbreviate_path(path)
 
     # The disk half is current and correct whatever the store is, so it is
     # answered either way. The history half is null rather than empty when the
@@ -222,7 +235,7 @@ async def get_definition(kind: str, name: str) -> dict[str, Any] | None:
         return {
             "kind": kind,
             "name": name,
-            "path": _relative_path(disk_file),
+            "path": path,
             "content": content,
             "version": None,
             "versions": None,
@@ -232,7 +245,7 @@ async def get_definition(kind: str, name: str) -> dict[str, Any] | None:
     return {
         "kind": kind,
         "name": name,
-        "path": _relative_path(disk_file),
+        "path": path,
         "content": content,
         "version": versions[0]["version"] if versions else 0,
         "versions": versions,
@@ -270,11 +283,15 @@ async def get_version(kind: str, name: str, version: int) -> dict[str, Any] | No
     if not row:
         return None
 
+    content = row["content"]
+    if kind == "agent" and demo_mode_enabled():
+        content = redact_agent_markdown(content, redact=True)
+
     return {
         "kind": kind,
         "name": name,
         "version": row["version"],
-        "content": row["content"],
+        "content": content,
         "created_at": row["created_at"],
         "message": row["message"],
     }
@@ -295,6 +312,16 @@ async def save_definition(
     base = KIND_DIRS.get(kind)
     if not base:
         raise ValueError(f"Unknown kind: {kind}")
+
+    # The other write path onto agent files (PUT /agents/{name}) carries the
+    # same guard -- see agents.py's update_agent(). Refusing here too closes
+    # the bypass: this route upserts blindly (ADR-0077), so without this check
+    # a redacted payload round-tripped through this route would overwrite the
+    # real file even though the PUT route refuses the identical content.
+    if kind == "agent" and demo_mode_enabled() and not content.strip():
+        raise RedactedPayloadError("Refusing to save: content is missing while demo mode is active")
+    if kind == "agent":
+        reject_if_redacted_payload(content)
 
     from lionagi.state.db import StateDB
 
@@ -513,7 +540,7 @@ async def save_definition_route(kind: str, name: str, body: SaveBody) -> dict[st
     # service layer; catch it and return 422 instead of propagating a 500.
     try:
         return await save_definition(kind, name, body.content, body.message)
-    except PermissionError as e:
+    except (PermissionError, RedactedPayloadError) as e:
         raise HTTPException(status_code=403, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -459,7 +459,11 @@ async def snapshot_current(kind: str | None = None) -> int:
         content = await anyio.to_thread.run_sync(disk_path.read_text)
 
         if d["has_versions"]:
-            latest = await get_version(d["kind"], d["name"], d["version"])
+            # Compare against the raw stored version, not get_version()'s
+            # response-facing (possibly redacted) content -- otherwise an
+            # unchanged agent file in demo mode never matches its own
+            # redacted-placeholder comparison and gets re-snapshotted every call.
+            latest = await _read_version_row(d["kind"], d["name"], d["version"])
             if latest and latest["content"] == content:
                 continue
 

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -172,6 +172,16 @@ async def list_definitions(kind: str | None = None) -> list[dict[str, Any]]:
 
     result = await anyio.to_thread.run_sync(partial(_scan_disk, kind))
 
+    # Same policy get_definition() applies to a single record: while demo mode
+    # is on, an agent's on-disk location is abbreviated to a bare filename in
+    # every response, not just the one reached by fetching it individually.
+    if demo_mode_enabled():
+        for entry in result:
+            if entry["kind"] != "agent":
+                continue
+            entry["path"] = abbreviate_path(entry["path"])
+            entry["disk_path"] = abbreviate_path(entry["disk_path"])
+
     if result:
         from lionagi.state.db import StateDB
 
@@ -253,6 +263,30 @@ async def get_definition(kind: str, name: str) -> dict[str, Any] | None:
     }
 
 
+async def _read_version_row(kind: str, name: str, version: int) -> dict[str, Any] | None:
+    """Raw historical version row from the store, with no redaction applied.
+
+    Internal use only: :func:`get_version` (the external, response-facing
+    read) redacts what this returns before handing it to a caller.
+    :func:`rollback_definition` reads through this directly instead, because
+    a rollback has to write the real content back -- consuming already-
+    redacted content would persist the placeholder text as the new version.
+    """
+    from lionagi.state.db import StateDB
+
+    try:
+        async with StateDB() as db:
+            return await db.get_definition(kind, name, version=version)
+    except Exception as exc:  # noqa: BLE001 — any unreadable store is the same answer
+        _log.warning(
+            "definition version is unreadable for %s/%s: %s",
+            kind,
+            name,
+            mask_credentials(repr(exc)),
+        )
+        raise HistoryUnavailableError(mask_credentials(str(exc))) from exc
+
+
 async def get_version(kind: str, name: str, version: int) -> dict[str, Any] | None:
     """Get a specific historical version's content.
 
@@ -266,20 +300,7 @@ async def get_version(kind: str, name: str, version: int) -> dict[str, Any] | No
     validate_name_component(kind, label="kind")
     validate_name_component(name, label="name")
 
-    from lionagi.state.db import StateDB
-
-    try:
-        async with StateDB() as db:
-            row = await db.get_definition(kind, name, version=version)
-    except Exception as exc:  # noqa: BLE001 — any unreadable store is the same answer
-        _log.warning(
-            "definition version is unreadable for %s/%s: %s",
-            kind,
-            name,
-            mask_credentials(repr(exc)),
-        )
-        raise HistoryUnavailableError(mask_credentials(str(exc))) from exc
-
+    row = await _read_version_row(kind, name, version)
     if not row:
         return None
 
@@ -372,11 +393,19 @@ async def save_definition(
 
 
 async def rollback_definition(kind: str, name: str, target_version: int) -> dict[str, Any] | None:
-    """Restore a previous version by reading it from DB and saving it as a new version."""
+    """Restore a previous version by reading it from DB and saving it as a new version.
+
+    Reads the target version through :func:`_read_version_row`, not
+    :func:`get_version` -- the latter redacts agent content while demo mode is
+    on, and a rollback that saved that redacted text would persist the
+    placeholder as the new version instead of restoring the real one.
+    Redaction applies to what a response shows a caller, never to what a
+    write operation submits internally.
+    """
     validate_name_component(kind, label="kind")
     validate_name_component(name, label="name")
 
-    old = await get_version(kind, name, target_version)
+    old = await _read_version_row(kind, name, target_version)
     if not old:
         return None
 

--- a/lionagi/studio/services/plugins.py
+++ b/lionagi/studio/services/plugins.py
@@ -92,8 +92,16 @@ def _plugin_summary(
     name: str,
     description: str,
     source: str,
+    *,
+    redact: bool = False,
 ) -> dict[str, Any]:
-    """Build the summary dict for list_plugins() from a plugin directory."""
+    """Build the summary dict shared by list_plugins() and get_plugin().
+
+    ``redact=True`` abbreviates ``path`` to a bare filename, the same
+    projection the detail route applies -- callers of this summary (the list
+    route and the detail route) must agree on it rather than each deciding
+    independently.
+    """
     plugin_json = _read_json(plugin_dir / ".claude-plugin" / "plugin.json") or {}
     skills = _scan_skills(plugin_dir)
     agents = _scan_agents(plugin_dir)
@@ -101,6 +109,10 @@ def _plugin_summary(
     has_mcp = (plugin_dir / ".mcp.json").exists()
     if not has_mcp and plugin_json.get("mcpServers"):
         has_mcp = True
+
+    path = public_path(plugin_dir)
+    if redact and path:
+        path = abbreviate_path(path)
 
     return {
         "name": str(plugin_json.get("name") or name),
@@ -111,7 +123,7 @@ def _plugin_summary(
         "agent_count": len(agents),
         "has_hooks": has_hooks,
         "has_mcp": has_mcp,
-        "path": public_path(plugin_dir),
+        "path": path,
     }
 
 
@@ -131,7 +143,7 @@ def _plugin_detail(
     otherwise returns those agents' descriptions and the on-disk path
     unfiltered, mirroring content a sibling route already redacts.
     """
-    summary = _plugin_summary(plugin_dir, name, description, source)
+    summary = _plugin_summary(plugin_dir, name, description, source, redact=redact)
     skills = _scan_skills(plugin_dir)
     agents = _scan_agents(plugin_dir)
 
@@ -154,9 +166,6 @@ def _plugin_detail(
             pass
 
     if redact:
-        summary = dict(summary)
-        if summary.get("path"):
-            summary["path"] = abbreviate_path(summary["path"])
         agents = [project_agent_fields(a, redact=True) for a in agents]
 
     return {
@@ -246,15 +255,15 @@ def _iter_thirdparty_plugins() -> list[tuple[Path, str, str, str]]:
     return results
 
 
-def list_plugins() -> list[dict[str, Any]]:
+def list_plugins(*, redact: bool = False) -> list[dict[str, Any]]:
     """Scan marketplace/ and ~/.claude/plugins/cache/ for installed plugins."""
     out: list[dict[str, Any]] = []
 
     for plugin_dir, name, desc in _iter_marketplace_plugins():
-        out.append(_plugin_summary(plugin_dir, name, desc, "marketplace"))
+        out.append(_plugin_summary(plugin_dir, name, desc, "marketplace", redact=redact))
 
     for plugin_dir, name, desc, mp_name in _iter_thirdparty_plugins():
-        out.append(_plugin_summary(plugin_dir, name, desc, mp_name))
+        out.append(_plugin_summary(plugin_dir, name, desc, mp_name, redact=redact))
 
     return out
 
@@ -340,7 +349,7 @@ def get_plugin_agent(plugin_name: str, agent_name: str) -> dict[str, Any] | None
 
 @studio_route("/plugins", method="GET", area="plugins")
 async def list_plugins_endpoint() -> dict[str, Any]:
-    plugins = await anyio.to_thread.run_sync(list_plugins)
+    plugins = await anyio.to_thread.run_sync(partial(list_plugins, redact=demo_mode_enabled()))
     return {"plugins": plugins}
 
 

--- a/lionagi/studio/services/plugins.py
+++ b/lionagi/studio/services/plugins.py
@@ -13,6 +13,7 @@ from lionagi.libs.path_safety import has_traversal
 from ..registry import studio_route
 from ._io import read_json_file as _read_json
 from ._path_safety import public_path, safe_path_join
+from .redaction import demo_mode_enabled, project_agent_fields
 
 _THIS = Path(__file__).resolve()
 _REPO_ROOT = _THIS.parents[3]  # lionagi/studio/services/plugins.py → parents[3] = repo root
@@ -355,4 +356,7 @@ async def get_plugin_agent_endpoint(plugin_name: str, agent_name: str) -> dict[s
             status_code=404,
             detail=f"Agent {agent_name} not found in plugin {plugin_name}",
         )
-    return agent
+    # A plugin agent's markdown body is the same kind of owner-authored
+    # content as a Library agent's system prompt -- it goes through the same
+    # classification table rather than a full-content mirror one route over.
+    return project_agent_fields(agent, redact=demo_mode_enabled())

--- a/lionagi/studio/services/plugins.py
+++ b/lionagi/studio/services/plugins.py
@@ -13,7 +13,7 @@ from lionagi.libs.path_safety import has_traversal
 from ..registry import studio_route
 from ._io import read_json_file as _read_json
 from ._path_safety import public_path, safe_path_join
-from .redaction import demo_mode_enabled, project_agent_fields
+from .redaction import abbreviate_path, demo_mode_enabled, project_agent_fields
 
 _THIS = Path(__file__).resolve()
 _REPO_ROOT = _THIS.parents[3]  # lionagi/studio/services/plugins.py → parents[3] = repo root
@@ -120,8 +120,17 @@ def _plugin_detail(
     name: str,
     description: str,
     source: str,
+    *,
+    redact: bool = False,
 ) -> dict[str, Any]:
-    """Build the full detail dict for get_plugin() from a plugin directory."""
+    """Build the full detail dict for get_plugin() from a plugin directory.
+
+    ``redact=True`` projects the embedded ``agents`` records and the
+    filesystem ``path`` through the same classification table the dedicated
+    ``/plugins/{plugin}/agents/{agent}`` route already applies -- this route
+    otherwise returns those agents' descriptions and the on-disk path
+    unfiltered, mirroring content a sibling route already redacts.
+    """
     summary = _plugin_summary(plugin_dir, name, description, source)
     skills = _scan_skills(plugin_dir)
     agents = _scan_agents(plugin_dir)
@@ -143,6 +152,12 @@ def _plugin_detail(
             readme = readme_path.read_text()
         except OSError:
             pass
+
+    if redact:
+        summary = dict(summary)
+        if summary.get("path"):
+            summary["path"] = abbreviate_path(summary["path"])
+        agents = [project_agent_fields(a, redact=True) for a in agents]
 
     return {
         **summary,
@@ -244,15 +259,15 @@ def list_plugins() -> list[dict[str, Any]]:
     return out
 
 
-def get_plugin(name: str) -> dict[str, Any] | None:
+def get_plugin(name: str, *, redact: bool = False) -> dict[str, Any] | None:
     """Full plugin detail including skills, agents, hooks, mcp, readme."""
     for plugin_dir, pname, desc in _iter_marketplace_plugins():
         if pname == name:
-            return _plugin_detail(plugin_dir, pname, desc, "marketplace")
+            return _plugin_detail(plugin_dir, pname, desc, "marketplace", redact=redact)
 
     for plugin_dir, pname, desc, mp_name in _iter_thirdparty_plugins():
         if pname == name:
-            return _plugin_detail(plugin_dir, pname, desc, mp_name)
+            return _plugin_detail(plugin_dir, pname, desc, mp_name, redact=redact)
 
     return None
 
@@ -331,7 +346,7 @@ async def list_plugins_endpoint() -> dict[str, Any]:
 
 @studio_route("/plugins/{name}", method="GET", area="plugins")
 async def get_plugin_endpoint(name: str) -> dict[str, Any]:
-    plugin = await anyio.to_thread.run_sync(partial(get_plugin, name))
+    plugin = await anyio.to_thread.run_sync(partial(get_plugin, name, redact=demo_mode_enabled()))
     if not plugin:
         raise HTTPException(status_code=404, detail=f"Plugin {name} not found")
     return plugin

--- a/lionagi/studio/services/redaction.py
+++ b/lionagi/studio/services/redaction.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Server-side redaction for a demo-safe view of Library agent-profile content.
+
+Enabled by ``LIONAGI_STUDIO_DEMO_MODE``, a process-wide switch read fresh on every
+call -- never something a request can select. When on, every route that reads
+agent-profile content projects through the single classification table below
+(:data:`_SAFE_KEYS`) instead of returning frontmatter and body verbatim, so a
+screen-share or recorded demo of the Library never surfaces owner-authored
+prompts, guidance text, internal paths, or unrecognized frontmatter values.
+
+Classification is by field *name*, not by value shape or length: an unrecognized
+key is dropped even when its value is a harmless-looking bool or number, because
+what leaks is the key existing in the response at all, not any property of what
+it happens to hold this run.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+# Fields whose values are structural/categorical -- safe to pass through verbatim
+# regardless of what a profile's author put in them.
+_SAFE_KEYS = frozenset(
+    {
+        "name",
+        "provider",
+        "model",
+        "effort",
+        "reasoning_effort",
+        "permission_mode",
+        "role",
+        "mode",
+        "yolo",
+        "fast_mode",
+        "lion_system",
+        "protected",
+        "is_default",
+        "version",
+        "kind",
+        "has_versions",
+        "history_available",
+        "updated_at",
+        "created_at",
+        "saved_at",
+    }
+)
+
+# Owner-authored free text -- replaced with a structured placeholder rather than
+# passed through or silently dropped, so the field's presence still tells a
+# viewer "this profile has content here" without shipping the content itself.
+_TEXT_REDACT_KEYS = frozenset({"system_prompt", "guidance", "description", "content"})
+
+# Filesystem locations -- reduced to a bare filename rather than omitted, since
+# the name alone (already visible via "name") carries no more information than
+# the file already reveals by existing in the roster.
+_PATH_KEYS = frozenset({"path", "disk_path", "symlink_target"})
+
+# Prefix of the placeholder text produced for redacted fields. Also used to
+# detect a redacted payload bouncing back through a save request -- see
+# reject_if_redacted_payload().
+REDACTION_PLACEHOLDER_MARKER = "<redacted,"
+
+
+class RedactedPayloadError(Exception):
+    """Raised when a write submits empty or placeholder content while demo mode is on."""
+
+
+def demo_mode_enabled() -> bool:
+    """True when the server-side demo-mode switch is on.
+
+    Read fresh from the environment on every call (not cached at import time)
+    so tests can toggle it with ``monkeypatch.setenv`` and a running process
+    picks up a change without a restart. No request header, query parameter,
+    or request body ever feeds into this decision.
+    """
+    raw = os.environ.get("LIONAGI_STUDIO_DEMO_MODE", "")
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _placeholder(value: Any) -> str:
+    return f"{REDACTION_PLACEHOLDER_MARKER} {len(str(value))} chars>"
+
+
+def abbreviate_path(value: Any) -> str:
+    """Reduce a filesystem path to its bare filename -- shared by every route
+    that carries a ``path``/``disk_path``/``symlink_target`` field, whether
+    that field lives inside a profile record (:func:`project_agent_fields`)
+    or in a definitions-route envelope built around one."""
+    return Path(str(value)).name
+
+
+def project_agent_fields(entry: Mapping[str, Any], *, redact: bool) -> dict[str, Any]:
+    """Project one agent-profile record through the shared classification table.
+
+    ``redact=False`` returns a shallow copy unchanged -- the same function backs
+    both the redacted and unredacted responses, so a negative-control test that
+    flips this flag is exercising the same code path the real routes use, not a
+    parallel implementation that could drift from it.
+    """
+    if not redact:
+        return dict(entry)
+
+    out: dict[str, Any] = {}
+    for key, value in entry.items():
+        if key in _SAFE_KEYS:
+            out[key] = value
+        elif key in _PATH_KEYS:
+            if value not in (None, ""):
+                out[key] = abbreviate_path(value)
+        elif key in _TEXT_REDACT_KEYS:
+            if value not in (None, ""):
+                out[key] = _placeholder(value)
+        # Any other key -- including every unrecognized frontmatter key -- is
+        # dropped by name, whatever type its value is.
+    return out
+
+
+def redact_agent_markdown(text: str, *, redact: bool) -> str:
+    """Project a raw agent-profile markdown file (frontmatter + body) the same
+    way :func:`project_agent_fields` projects the parsed dict form.
+
+    Used by the definitions routes, which serve profile content as one
+    frontmatter+body string rather than as a pre-parsed record -- the two
+    representations of the same file must redact identically, or a route
+    reachable through ``/definitions/agent/{name}`` stays a full-fidelity
+    mirror of a route already covered.
+    """
+    if not redact:
+        return text
+
+    from lionagi.libs.frontmatter import parse_frontmatter
+
+    fm, body = parse_frontmatter(text)
+    fm = dict(fm)
+    if "reasoning_effort" in fm and "effort" not in fm:
+        fm["effort"] = fm.pop("reasoning_effort")
+
+    projected_fm = project_agent_fields(fm, redact=True)
+    body_out = _placeholder(body) if body.strip() else body
+
+    if projected_fm:
+        import yaml
+
+        fm_text = yaml.safe_dump(projected_fm, sort_keys=False, allow_unicode=True).rstrip()
+        return f"---\n{fm_text}\n---\n\n{body_out}\n" if body_out else f"---\n{fm_text}\n---\n"
+    return f"{body_out}\n" if body_out else ""
+
+
+def is_placeholder_text(value: Any) -> bool:
+    """True when a submitted value is (or contains) the redaction placeholder --
+    the signature of a redacted payload bouncing back through a save request."""
+    return isinstance(value, str) and REDACTION_PLACEHOLDER_MARKER in value
+
+
+def reject_if_redacted_payload(*values: Any) -> None:
+    """Refuse a write whose content is missing or carries the redaction
+    placeholder, while demo mode is on.
+
+    Called from every write path onto agent-profile content (the PUT
+    ``/agents/{name}`` route and the generic ``/definitions/agent/{name}``
+    save route) so a client that fetched a redacted view and posted it back
+    unmodified can never overwrite the real file on disk -- the read-side
+    switch would otherwise be a one-way door into permanent data loss.
+    """
+    if not demo_mode_enabled():
+        return
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str) and is_placeholder_text(value):
+            raise RedactedPayloadError(
+                "Refusing to save: submitted content matches the redaction "
+                "placeholder while demo mode is active"
+            )

--- a/lionagi/studio/services/redaction.py
+++ b/lionagi/studio/services/redaction.py
@@ -99,8 +99,18 @@ def abbreviate_path(value: Any) -> str:
     """Reduce a filesystem path to its bare filename -- shared by every route
     that carries a ``path``/``disk_path``/``symlink_target`` field, whether
     that field lives inside a profile record (:func:`project_agent_fields`)
-    or in a definitions-route envelope built around one."""
-    return Path(str(value)).name
+    or in a definitions-route envelope built around one.
+
+    Raises ``TypeError`` for anything that is not path-like -- a mapping or
+    list under one of these keys is not a path with an unusual shape, it is
+    unrecognized content wearing a path key's name, and ``str()``-serializing
+    it would carry that content through in the returned filename. Callers
+    that read these keys from owner-authored data (:func:`project_agent_fields`)
+    must treat the error as "drop this field", not fall back to serializing it.
+    """
+    if not isinstance(value, (str, os.PathLike)):
+        raise TypeError(f"abbreviate_path() requires a path-like value, got {type(value).__name__}")
+    return Path(value).name
 
 
 def project_agent_fields(entry: Mapping[str, Any], *, redact: bool) -> dict[str, Any]:
@@ -124,7 +134,10 @@ def project_agent_fields(entry: Mapping[str, Any], *, redact: bool) -> dict[str,
             # shape, not for whatever an owner-authored profile nested there.
         elif key in _PATH_KEYS:
             if value not in (None, ""):
-                out[key] = abbreviate_path(value)
+                try:
+                    out[key] = abbreviate_path(value)
+                except TypeError:
+                    pass  # malformed path value -- dropped, not abbreviated
         elif key in _TEXT_REDACT_KEYS:
             if value not in (None, ""):
                 out[key] = _placeholder(value)

--- a/lionagi/studio/services/redaction.py
+++ b/lionagi/studio/services/redaction.py
@@ -10,10 +10,12 @@ agent-profile content projects through the single classification table below
 screen-share or recorded demo of the Library never surfaces owner-authored
 prompts, guidance text, internal paths, or unrecognized frontmatter values.
 
-Classification is by field *name*, not by value shape or length: an unrecognized
-key is dropped even when its value is a harmless-looking bool or number, because
-what leaks is the key existing in the response at all, not any property of what
-it happens to hold this run.
+Classification starts from field *name*: an unrecognized key is dropped even
+when its value is a harmless-looking bool or number, because what leaks is the
+key existing in the response at all, not any property of what it happens to
+hold this run. A safe key's name is not enough on its own, though -- its value
+must also match the scalar shape the name implies, or a mapping/list nested
+under that key name would ride through the allowlist unexamined.
 """
 
 from __future__ import annotations
@@ -65,6 +67,13 @@ _PATH_KEYS = frozenset({"path", "disk_path", "symlink_target"})
 # reject_if_redacted_payload().
 REDACTION_PLACEHOLDER_MARKER = "<redacted,"
 
+# A safe key's value is vouched for by the classification table only when it
+# is one of these scalar types. A mapping or sequence smuggled in under a
+# safe key's name (e.g. ``role: {api_key: ...}``) is not a role -- it is
+# unrecognized content wearing a safe key's name, and gets dropped like any
+# other unrecognized value rather than passed through by the name match alone.
+_SAFE_SCALAR_TYPES = (str, int, float, bool, type(None))
+
 
 class RedactedPayloadError(Exception):
     """Raised when a write submits empty or placeholder content while demo mode is on."""
@@ -108,7 +117,11 @@ def project_agent_fields(entry: Mapping[str, Any], *, redact: bool) -> dict[str,
     out: dict[str, Any] = {}
     for key, value in entry.items():
         if key in _SAFE_KEYS:
-            out[key] = value
+            if isinstance(value, _SAFE_SCALAR_TYPES):
+                out[key] = value
+            # A mapping/sequence under a safe key is dropped, not passed
+            # through -- the allowlist vouches for the key's expected scalar
+            # shape, not for whatever an owner-authored profile nested there.
         elif key in _PATH_KEYS:
             if value not in (None, ""):
                 out[key] = abbreviate_path(value)

--- a/tests/apps_studio_server/test_library_redaction.py
+++ b/tests/apps_studio_server/test_library_redaction.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Server-side redaction for a demo-safe Library view (LIONAGI_STUDIO_DEMO_MODE).
+
+Every test plants distinct sentinel strings in a fixture agent profile and checks
+both directions in the same assertion pass wherever practical: the normal
+(switch-off) view must still serve the sentinel (a redaction bug that always
+hides content would pass a leak-only test too), and the redacted (switch-on)
+view must never serve it.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+pytest.importorskip("fastapi", reason="studio extra not installed")
+pytest.importorskip("yaml", reason="PyYAML not installed")
+
+PROMPT_SENTINEL = "PROMPT-SENTINEL-4f2c9d17"
+GUIDANCE_SENTINEL = "GUIDANCE-SENTINEL-9a1b62"
+DESCRIPTION_SENTINEL = "DESCRIPTION-SENTINEL-77eecb"
+SECRET_ENV_VALUE = "sk-ENV-SHAPED-SECRET-ab12cd34"
+
+FIXTURE_AGENT_MD = f"""\
+---
+provider: claude
+model: claude-sonnet-4-6
+role: critic
+effort: high
+permission_mode: default
+guidance: {GUIDANCE_SENTINEL}
+description: {DESCRIPTION_SENTINEL}
+internal_api_key: {SECRET_ENV_VALUE}
+lion_system: false
+---
+
+{PROMPT_SENTINEL}
+"""
+
+
+def _write_agent_md(path, content: str) -> None:
+    path.write_text(textwrap.dedent(content))
+
+
+def _make_redaction_client(tmp_path, monkeypatch):
+    """A TestClient wired to a scratch LIONAGI_HOME, both agent write paths
+    (PUT /agents/{name} and POST /definitions/agent/{name}) kept in sync, and
+    the demo-mode switch guaranteed off until a test opts in."""
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.agents as agents_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    agents_dir = fake_home / "agents"
+    playbooks_dir = fake_home / "playbooks"
+    agents_dir.mkdir()
+    playbooks_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
+    monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
+    monkeypatch.setattr(agents_mod, "_AGENTS_ROOT", agents_dir)
+    monkeypatch.delenv("LIONAGI_STUDIO_DEMO_MODE", raising=False)
+
+    from fastapi.testclient import TestClient
+
+    from lionagi.studio.app import app
+
+    return TestClient(app, base_url="http://127.0.0.1:8765"), agents_dir
+
+
+# ---------------------------------------------------------------------------
+# Prompt body: leaks in the normal view, redacted in the demo view.
+# ---------------------------------------------------------------------------
+
+
+def test_redacted_view_hides_prompt_body_normal_view_still_serves_it(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+
+    # Must-MATCH arm: with the switch off, both routes that render the profile
+    # detail still serve the real prompt body. A test that only asserted the
+    # negative below would also pass for a route that always hides content.
+    normal_detail = client.get("/api/agents/demoagent")
+    normal_definition = client.get("/api/definitions/agent/demoagent")
+    assert normal_detail.status_code == 200, normal_detail.text
+    assert normal_definition.status_code == 200, normal_definition.text
+    assert PROMPT_SENTINEL in normal_detail.text
+    assert PROMPT_SENTINEL in normal_definition.text
+
+    # Must-NOT-match arm: with the switch on, neither route leaks it.
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted_detail = client.get("/api/agents/demoagent")
+    redacted_definition = client.get("/api/definitions/agent/demoagent")
+    assert redacted_detail.status_code == 200, redacted_detail.text
+    assert redacted_definition.status_code == 200, redacted_definition.text
+    assert PROMPT_SENTINEL not in redacted_detail.text
+    assert PROMPT_SENTINEL not in redacted_definition.text
+    # The placeholder marker takes its place -- the field is present, not
+    # silently dropped, so the UI can still show "content redacted".
+    assert "<redacted," in redacted_detail.text
+    assert "<redacted," in redacted_definition.text
+
+
+# ---------------------------------------------------------------------------
+# Unrecognized, env/secret-shaped frontmatter value: dropped by key name.
+# ---------------------------------------------------------------------------
+
+
+def test_env_shaped_frontmatter_value_is_masked_in_redacted_view(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+
+    # list_agents() is the route that spreads arbitrary frontmatter keys onto
+    # the response (get_agent() already only surfaces a known set); that's
+    # the leak surface for an unrecognized, secret-shaped key.
+    normal_list = client.get("/api/agents/")
+    assert SECRET_ENV_VALUE in normal_list.text
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted_list = client.get("/api/agents/")
+    redacted_detail = client.get("/api/agents/demoagent")
+    redacted_definition = client.get("/api/definitions/agent/demoagent")
+    assert SECRET_ENV_VALUE not in redacted_list.text
+    assert SECRET_ENV_VALUE not in redacted_detail.text
+    assert SECRET_ENV_VALUE not in redacted_definition.text
+
+    entry = next(a for a in redacted_list.json()["agents"] if a["name"] == "demoagent")
+    assert "internal_api_key" not in entry
+
+
+# ---------------------------------------------------------------------------
+# Safe-by-construction fields ride through unchanged in the redacted view.
+# ---------------------------------------------------------------------------
+
+
+def test_keep_fields_survive_redaction(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+
+    list_entry = next(
+        a for a in client.get("/api/agents/").json()["agents"] if a["name"] == "demoagent"
+    )
+    for field, expected in (
+        ("name", "demoagent"),
+        ("provider", "claude"),
+        ("model", "claude-sonnet-4-6"),
+        ("role", "critic"),
+        ("effort", "high"),
+        ("permission_mode", "default"),
+    ):
+        assert list_entry.get(field) == expected, list_entry
+
+    detail = client.get("/api/agents/demoagent").json()
+    for field, expected in (
+        ("name", "demoagent"),
+        ("provider", "claude"),
+        ("model", "claude-sonnet-4-6"),
+        ("role", "critic"),
+        ("effort", "high"),
+        ("permission_mode", "default"),
+    ):
+        assert detail.get(field) == expected, detail
+
+    # Zero-curation fallback: the roster is still useful from safe fields
+    # alone even though this profile's description was owner-authored text.
+    assert DESCRIPTION_SENTINEL not in str(list_entry)
+
+
+# ---------------------------------------------------------------------------
+# A sibling route serving the same object (version history) must not be an
+# unredacted mirror one click away from the covered detail route.
+# ---------------------------------------------------------------------------
+
+
+def test_version_history_route_is_also_redacted(tmp_path, monkeypatch):
+    client, _agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+
+    save = client.post("/api/definitions/agent/versioned", json={"content": FIXTURE_AGENT_MD})
+    assert save.status_code == 200, save.text
+    version = save.json()["version"]
+
+    normal_version = client.get(f"/api/definitions/agent/versioned/versions/{version}")
+    assert normal_version.status_code == 200, normal_version.text
+    assert PROMPT_SENTINEL in normal_version.text
+    assert SECRET_ENV_VALUE in normal_version.text
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted_version = client.get(f"/api/definitions/agent/versioned/versions/{version}")
+    assert redacted_version.status_code == 200, redacted_version.text
+    assert PROMPT_SENTINEL not in redacted_version.text
+    assert GUIDANCE_SENTINEL not in redacted_version.text
+    assert SECRET_ENV_VALUE not in redacted_version.text
+
+
+# ---------------------------------------------------------------------------
+# The save path is not a bypass: a redacted payload posted back must be
+# refused, and must not touch the file on disk, while the switch is on.
+# ---------------------------------------------------------------------------
+
+
+def test_save_definition_refuses_placeholder_payload_while_demo_mode_on(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+    original_text = (agents_dir / "demoagent.md").read_text()
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    placeholder_payload = client.get("/api/definitions/agent/demoagent").json()["content"]
+    assert "<redacted," in placeholder_payload
+
+    r = client.post("/api/definitions/agent/demoagent", json={"content": placeholder_payload})
+    assert r.status_code == 403, r.text
+    assert (agents_dir / "demoagent.md").read_text() == original_text
+
+
+def test_save_definition_refuses_empty_content_while_demo_mode_on(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+    original_text = (agents_dir / "demoagent.md").read_text()
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    r = client.post("/api/definitions/agent/demoagent", json={"content": "   "})
+    assert r.status_code == 403, r.text
+    assert (agents_dir / "demoagent.md").read_text() == original_text
+
+
+def test_put_agent_refuses_placeholder_system_prompt_while_demo_mode_on(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+    original_text = (agents_dir / "demoagent.md").read_text()
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    placeholder_prompt = client.get("/api/agents/demoagent").json()["system_prompt"]
+    assert "<redacted," in placeholder_prompt
+
+    r = client.put("/api/agents/demoagent", json={"system_prompt": placeholder_prompt})
+    assert r.status_code == 403, r.text
+    assert (agents_dir / "demoagent.md").read_text() == original_text
+
+
+def test_save_definition_still_works_normally_while_demo_mode_off(tmp_path, monkeypatch):
+    """Negative control for the two refusal tests above: the guard is specific
+    to demo mode, not a general block on saving agent definitions."""
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+
+    r = client.post("/api/definitions/agent/demoagent", json={"content": "# updated content"})
+    assert r.status_code == 200, r.text
+    assert (agents_dir / "demoagent.md").read_text().strip() == "# updated content"
+
+
+# ---------------------------------------------------------------------------
+# Negative control: with the projection disabled (redact=False), the same
+# routes DO leak -- confirming the tests above exercise the projection
+# rather than passing independently of it.
+# ---------------------------------------------------------------------------
+
+
+def test_negative_control_projection_disabled_leaks_by_default(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+
+    # Demo mode is off (the fixture's default) -- every route must leak.
+    detail = client.get("/api/agents/demoagent")
+    definition = client.get("/api/definitions/agent/demoagent")
+    listing = client.get("/api/agents/")
+    assert PROMPT_SENTINEL in detail.text
+    assert PROMPT_SENTINEL in definition.text
+    assert SECRET_ENV_VALUE in listing.text
+
+
+# ---------------------------------------------------------------------------
+# Route-enumeration coverage: fails loudly when a new route is registered
+# under an area that reads agent-profile content without a redaction
+# decision having been made for it.
+# ---------------------------------------------------------------------------
+
+
+def test_route_enumeration_covers_known_agent_profile_routes():
+    from lionagi.studio.registry import iter_studio_routes, load_studio_route_modules
+
+    load_studio_route_modules()
+
+    agents_route_names = {r.name for r in iter_studio_routes(area="agents")}
+    definitions_route_names = {r.name for r in iter_studio_routes(area="definitions")}
+
+    expected_agents = {
+        "list_agents",
+        "get_agent",
+        "create_agent",
+        "update_agent",
+        "delete_agent",
+        None,  # /agents/{name}/validate is registered without an explicit name
+    }
+    expected_definitions = {
+        "list_definitions",
+        "get_definition",
+        "get_version",
+        "save_definition",
+        "rollback_definition",
+        "snapshot_current",
+    }
+
+    assert agents_route_names == expected_agents, (
+        "A route was added or removed under area='agents'. If it reads "
+        "agent-profile content, route it through "
+        "redaction.project_agent_fields() and update this expected set; "
+        "otherwise just update the set."
+    )
+    assert definitions_route_names == expected_definitions, (
+        "A route was added or removed under area='definitions'. If it reads "
+        "definition content for kind='agent', route it through "
+        "redaction.redact_agent_markdown() and update this expected set."
+    )

--- a/tests/apps_studio_server/test_library_redaction.py
+++ b/tests/apps_studio_server/test_library_redaction.py
@@ -23,6 +23,8 @@ PROMPT_SENTINEL = "PROMPT-SENTINEL-4f2c9d17"
 GUIDANCE_SENTINEL = "GUIDANCE-SENTINEL-9a1b62"
 DESCRIPTION_SENTINEL = "DESCRIPTION-SENTINEL-77eecb"
 SECRET_ENV_VALUE = "sk-ENV-SHAPED-SECRET-ab12cd34"
+NESTED_SECRET = "NESTED-SECRET-4e2a91"
+LIST_SECRET = "LIST-SECRET-7b3c05"
 
 FIXTURE_AGENT_MD = f"""\
 ---
@@ -38,6 +40,22 @@ lion_system: false
 ---
 
 {PROMPT_SENTINEL}
+"""
+
+
+FIXTURE_NESTED_SECRET_AGENT_MD = f"""\
+---
+provider: claude
+model: claude-sonnet-4-6
+role:
+  leaked: {NESTED_SECRET}
+effort:
+  - {LIST_SECRET}
+permission_mode: default
+lion_system: false
+---
+
+body text
 """
 
 
@@ -256,6 +274,230 @@ def test_save_definition_still_works_normally_while_demo_mode_off(tmp_path, monk
     r = client.post("/api/definitions/agent/demoagent", json={"content": "# updated content"})
     assert r.status_code == 200, r.text
     assert (agents_dir / "demoagent.md").read_text().strip() == "# updated content"
+
+
+# ---------------------------------------------------------------------------
+# A safe key's name is not a promise about its shape. A mapping or list
+# smuggled in under a safe key (role/effort/...) must be dropped, not passed
+# through by name match alone -- on every path that reads the allowlist.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_value_under_safe_key_is_dropped_not_passed_through(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "nestedagent.md", FIXTURE_NESTED_SECRET_AGENT_MD)
+
+    # Must-MATCH arm: with the switch off, every route that surfaces the raw
+    # frontmatter still carries the nested content.
+    normal_detail = client.get("/api/agents/nestedagent")
+    normal_list = client.get("/api/agents/")
+    normal_definition = client.get("/api/definitions/agent/nestedagent")
+    assert normal_detail.status_code == 200, normal_detail.text
+    assert normal_list.status_code == 200, normal_list.text
+    assert normal_definition.status_code == 200, normal_definition.text
+    assert NESTED_SECRET in normal_detail.text
+    assert LIST_SECRET in normal_detail.text
+    assert NESTED_SECRET in normal_list.text
+    assert LIST_SECRET in normal_list.text
+    assert NESTED_SECRET in normal_definition.text
+    assert LIST_SECRET in normal_definition.text
+
+    # Must-NOT-match arm: with the switch on, a mapping under "role" and a
+    # list under "effort" are dropped rather than passed through because
+    # their key names happen to match the safe-key allowlist.
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted_detail = client.get("/api/agents/nestedagent")
+    redacted_list = client.get("/api/agents/")
+    redacted_definition = client.get("/api/definitions/agent/nestedagent")
+    assert redacted_detail.status_code == 200, redacted_detail.text
+    assert redacted_list.status_code == 200, redacted_list.text
+    assert redacted_definition.status_code == 200, redacted_definition.text
+    for resp in (redacted_detail, redacted_list, redacted_definition):
+        assert NESTED_SECRET not in resp.text
+        assert LIST_SECRET not in resp.text
+
+
+def test_mcp_list_agents_drops_nested_secret_under_safe_key(tmp_path, monkeypatch):
+    """The Operator's MCP agent listing routes through the same allowlist as
+    the HTTP routes -- a row shaped with a nested value under a safe key
+    (whatever produced it) must not leak through this surface either."""
+    import lionagi.studio.services.agents as agents_service
+    from lionagi.studio.operator import application_mcp
+
+    from ._helpers import run_async
+
+    _make_redaction_client(tmp_path, monkeypatch)
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    monkeypatch.setattr(
+        agents_service,
+        "list_agents",
+        lambda: [
+            {
+                "name": "demoagent",
+                "provider": {"leaked": NESTED_SECRET},
+                "model": "claude-sonnet-4-6",
+                "description": "fine",
+            }
+        ],
+    )
+
+    result = run_async(application_mcp.list_agents({"limit": 10}))
+    assert result["agents"][0]["name"] == "demoagent"
+    assert result["agents"][0]["provider"] is None
+    assert result["agents"][0]["model"] == "claude-sonnet-4-6"
+    assert NESTED_SECRET not in str(result)
+
+
+# ---------------------------------------------------------------------------
+# POST /agents/{name} and PUT /agents/{name} must not return the raw service
+# result in demo mode -- a harmless metadata edit must not be a side door to
+# the full prompt/guidance the GET routes already redact.
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_update_agent_responses_are_redacted_in_demo_mode(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+
+    # Must-MATCH arm: with the switch off, both responses still carry the
+    # real content.
+    create_resp = client.post(
+        "/api/agents/newagent",
+        json={
+            "provider": "claude",
+            "model": "claude-sonnet-4-6",
+            "system_prompt": PROMPT_SENTINEL,
+        },
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    assert PROMPT_SENTINEL in create_resp.text
+
+    put_resp = client.put("/api/agents/newagent", json={"system_prompt": PROMPT_SENTINEL + "-v2"})
+    assert put_resp.status_code == 200, put_resp.text
+    assert (PROMPT_SENTINEL + "-v2") in put_resp.text
+
+    # Must-NOT-match arm: with the switch on, a metadata-only PUT (no
+    # system_prompt in the request body) must not echo back the existing
+    # prompt in full, and a POST creating a new agent with real content must
+    # not return that content either.
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    metadata_put = client.put(
+        "/api/agents/newagent", json={"description": "harmless metadata edit"}
+    )
+    assert metadata_put.status_code == 200, metadata_put.text
+    assert PROMPT_SENTINEL not in metadata_put.text
+    assert "<redacted," in metadata_put.text
+
+    create_resp2 = client.post(
+        "/api/agents/newagent2",
+        json={
+            "provider": "claude",
+            "model": "claude-sonnet-4-6",
+            "system_prompt": PROMPT_SENTINEL,
+        },
+    )
+    assert create_resp2.status_code == 200, create_resp2.text
+    assert PROMPT_SENTINEL not in create_resp2.text
+    assert "<redacted," in create_resp2.text
+
+    # Response-only redaction -- the real content is still on disk.
+    assert (PROMPT_SENTINEL + "-v2") in (agents_dir / "newagent.md").read_text()
+    assert PROMPT_SENTINEL in (agents_dir / "newagent2.md").read_text()
+
+
+# ---------------------------------------------------------------------------
+# The plugin-agent route is a full-content mirror of the same kind of
+# owner-authored markdown the Library agent routes protect -- it must not be
+# a silent bypass one path segment over.
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_agent_route_is_redacted_in_demo_mode(tmp_path, monkeypatch):
+    import lionagi.studio.services.plugins as plugins_mod
+
+    client, _agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+
+    plugin_dir = tmp_path / "fakeplugin"
+    plugin_agents_dir = plugin_dir / "agents"
+    plugin_agents_dir.mkdir(parents=True)
+    (plugin_agents_dir / "critic.md").write_text(
+        f"---\ndescription: plugin critic\n---\n\n{PROMPT_SENTINEL}\n"
+    )
+    monkeypatch.setattr(
+        plugins_mod,
+        "_find_plugin_dir_for",
+        lambda name: plugin_dir if name == "fakeplugin" else None,
+    )
+
+    normal = client.get("/api/plugins/fakeplugin/agents/critic")
+    assert normal.status_code == 200, normal.text
+    assert PROMPT_SENTINEL in normal.text
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted = client.get("/api/plugins/fakeplugin/agents/critic")
+    assert redacted.status_code == 200, redacted.text
+    assert PROMPT_SENTINEL not in redacted.text
+    assert "<redacted," in redacted.text
+
+
+# ---------------------------------------------------------------------------
+# The definitions listing carries the same path/disk_path fields the single
+# get_definition() route already abbreviates -- the listing must match it
+# instead of shipping the unabridged on-disk location for every agent.
+# ---------------------------------------------------------------------------
+
+
+def test_definitions_listing_path_is_projected_in_demo_mode(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "demoagent.md", FIXTURE_AGENT_MD)
+
+    normal = client.get("/api/definitions/")
+    assert normal.status_code == 200, normal.text
+    entry = next(
+        d for d in normal.json()["definitions"] if d["kind"] == "agent" and d["name"] == "demoagent"
+    )
+    # Must-MATCH arm: the unabridged path, not just the bare filename.
+    assert entry["path"] != "demoagent.md"
+    assert entry["path"].endswith("demoagent.md")
+    assert entry["disk_path"] != "demoagent.md"
+    assert entry["disk_path"].endswith("demoagent.md")
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted = client.get("/api/definitions/")
+    assert redacted.status_code == 200, redacted.text
+    r_entry = next(
+        d
+        for d in redacted.json()["definitions"]
+        if d["kind"] == "agent" and d["name"] == "demoagent"
+    )
+    assert r_entry["path"] == "demoagent.md"
+    assert r_entry["disk_path"] == "demoagent.md"
+
+
+# ---------------------------------------------------------------------------
+# rollback_definition() must write the real content back, not the redacted
+# placeholder that get_version() shows an external caller -- a rollback is a
+# write, and redaction applies to reads that leave the service.
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_succeeds_with_real_content_in_demo_mode(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+
+    v1 = client.post("/api/definitions/agent/rollme", json={"content": FIXTURE_AGENT_MD})
+    assert v1.status_code == 200, v1.text
+    v1_version = v1.json()["version"]
+
+    updated_content = FIXTURE_AGENT_MD.replace(PROMPT_SENTINEL, PROMPT_SENTINEL + "-v2")
+    v2 = client.post("/api/definitions/agent/rollme", json={"content": updated_content})
+    assert v2.status_code == 200, v2.text
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    rollback = client.post("/api/definitions/agent/rollme/rollback", params={"version": v1_version})
+    assert rollback.status_code == 200, rollback.text
+
+    on_disk = (agents_dir / "rollme.md").read_text()
+    assert PROMPT_SENTINEL in on_disk
+    assert "<redacted," not in on_disk
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_library_redaction.py
+++ b/tests/apps_studio_server/test_library_redaction.py
@@ -568,6 +568,51 @@ def test_plugin_detail_route_redacts_nested_agents_and_path(tmp_path, monkeypatc
 
 
 # ---------------------------------------------------------------------------
+# /api/plugins (the list route) builds each entry from the same summary the
+# detail route abbreviates -- it must agree with /api/plugins/{name} instead
+# of shipping the unabridged on-disk path one route over.
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_list_route_redacts_path_matching_detail_route(tmp_path, monkeypatch):
+    import lionagi.studio.services.plugins as plugins_mod
+
+    client, _agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+
+    plugin_dir = tmp_path / "fakeplugin4"
+    plugin_dir.mkdir(parents=True)
+    monkeypatch.setattr(
+        plugins_mod,
+        "_iter_marketplace_plugins",
+        lambda: [(plugin_dir, "fakeplugin4", "a fake plugin")],
+    )
+    monkeypatch.setattr(plugins_mod, "_iter_thirdparty_plugins", lambda: [])
+    monkeypatch.setattr(plugins_mod, "public_path", lambda p, **kw: f"marketplace/{p.name}/nested")
+
+    # Must-MATCH arm: with the switch off, the list route serves the full path.
+    normal = client.get("/api/plugins")
+    assert normal.status_code == 200, normal.text
+    normal_entry = next(p for p in normal.json()["plugins"] if p["name"] == "fakeplugin4")
+    assert normal_entry["path"] == "marketplace/fakeplugin4/nested"
+    assert normal_entry["agent_count"] == 0
+
+    # Must-NOT-match arm: with the switch on, the list route abbreviates the
+    # path the same way the detail route already does.
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted = client.get("/api/plugins")
+    assert redacted.status_code == 200, redacted.text
+    redacted_entry = next(p for p in redacted.json()["plugins"] if p["name"] == "fakeplugin4")
+    assert redacted_entry["path"] == "nested"
+    # Topology fields are untouched -- this route never leaked agent content,
+    # only the filesystem path.
+    assert redacted_entry["agent_count"] == 0
+
+    detail = client.get("/api/plugins/fakeplugin4")
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["path"] == redacted_entry["path"]
+
+
+# ---------------------------------------------------------------------------
 # A scalar-shaped safe key's guard is only as good as the value it inspects.
 # list_agents()/get_agent() used to str()-coerce provider/model *before* the
 # classification table saw them, so a nested mapping smuggled in under

--- a/tests/apps_studio_server/test_library_redaction.py
+++ b/tests/apps_studio_server/test_library_redaction.py
@@ -521,6 +521,182 @@ def test_negative_control_projection_disabled_leaks_by_default(tmp_path, monkeyp
 
 
 # ---------------------------------------------------------------------------
+# /api/plugins/{name} embeds each agent's {name, description} and the
+# plugin's on-disk path directly -- it must project both through the same
+# table the dedicated /plugins/{plugin}/agents/{agent} route already applies,
+# not mirror them unfiltered one path segment over.
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_detail_route_redacts_nested_agents_and_path(tmp_path, monkeypatch):
+    import lionagi.studio.services.plugins as plugins_mod
+
+    client, _agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+
+    plugin_dir = tmp_path / "fakeplugin3"
+    plugin_agents_dir = plugin_dir / "agents"
+    plugin_agents_dir.mkdir(parents=True)
+    (plugin_agents_dir / "critic.md").write_text(
+        f"---\ndescription: {DESCRIPTION_SENTINEL}\n---\n\nbody\n"
+    )
+    monkeypatch.setattr(
+        plugins_mod,
+        "_iter_marketplace_plugins",
+        lambda: [(plugin_dir, "fakeplugin3", "a fake plugin")],
+    )
+    monkeypatch.setattr(plugins_mod, "_iter_thirdparty_plugins", lambda: [])
+    # A deterministic, multi-segment path so the redacted response is
+    # distinguishable from a bare plugin-directory name either way.
+    monkeypatch.setattr(plugins_mod, "public_path", lambda p, **kw: f"marketplace/{p.name}/nested")
+
+    # Must-MATCH arm: with the switch off, both the agent description and the
+    # full on-disk path are served as-is.
+    normal = client.get("/api/plugins/fakeplugin3")
+    assert normal.status_code == 200, normal.text
+    assert DESCRIPTION_SENTINEL in normal.text
+    assert normal.json()["path"] == "marketplace/fakeplugin3/nested"
+
+    # Must-NOT-match arm: with the switch on, the embedded agent's
+    # description is redacted and the path is abbreviated to a bare name.
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted = client.get("/api/plugins/fakeplugin3")
+    assert redacted.status_code == 200, redacted.text
+    assert DESCRIPTION_SENTINEL not in redacted.text
+    body = redacted.json()
+    assert body["agents"][0]["name"] == "critic"
+    assert body["path"] == "nested"
+
+
+# ---------------------------------------------------------------------------
+# A scalar-shaped safe key's guard is only as good as the value it inspects.
+# list_agents()/get_agent() used to str()-coerce provider/model *before* the
+# classification table saw them, so a nested mapping smuggled in under
+# `provider` in real YAML frontmatter became a plain string the table's
+# scalar check waved through. This plants the nested value in an actual
+# on-disk agent file (not a monkeypatched, already-dict-shaped MCP row) so
+# the service layer's own coercion is what's under test.
+# ---------------------------------------------------------------------------
+
+
+def test_nested_provider_from_real_yaml_frontmatter_is_dropped(tmp_path, monkeypatch):
+    from lionagi.studio.operator import application_mcp
+
+    from ._helpers import run_async
+
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(
+        agents_dir / "nestedprovider.md",
+        f"""\
+        ---
+        provider:
+          leaked: {NESTED_SECRET}
+        model: claude-sonnet-4-6
+        lion_system: false
+        ---
+
+        body text
+        """,
+    )
+
+    normal_list = client.get("/api/agents/")
+    assert NESTED_SECRET in normal_list.text
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted_list = client.get("/api/agents/")
+    redacted_detail = client.get("/api/agents/nestedprovider")
+    assert redacted_list.status_code == 200, redacted_list.text
+    assert redacted_detail.status_code == 200, redacted_detail.text
+    assert NESTED_SECRET not in redacted_list.text
+    assert NESTED_SECRET not in redacted_detail.text
+
+    entry = next(a for a in redacted_list.json()["agents"] if a["name"] == "nestedprovider")
+    assert entry.get("provider") is None
+    assert redacted_detail.json().get("provider") is None
+
+    # Same real file, read through the Operator's MCP roster.
+    result = run_async(application_mcp.list_agents({"limit": 10}))
+    assert NESTED_SECRET not in str(result)
+    row = next(a for a in result["agents"] if a["name"] == "nestedprovider")
+    assert row["provider"] is None
+
+
+# ---------------------------------------------------------------------------
+# abbreviate_path() must refuse to str()-serialize a non-path-like value
+# rather than smuggle its content through as a "filename" -- a `path:` key
+# collides with the reserved field project_agent_fields adds for every
+# profile record.
+# ---------------------------------------------------------------------------
+
+
+def test_abbreviate_path_rejects_non_path_like_value():
+    from lionagi.studio.services.redaction import abbreviate_path
+
+    with pytest.raises(TypeError):
+        abbreviate_path({"leaked": "x"})
+    with pytest.raises(TypeError):
+        abbreviate_path(["x"])
+    assert abbreviate_path("some/dir/file.md") == "file.md"
+
+
+def test_malformed_path_frontmatter_value_is_dropped_not_serialized(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(
+        agents_dir / "pathagent.md",
+        f"""\
+        ---
+        provider: claude
+        model: claude-sonnet-4-6
+        path:
+          leaked: {NESTED_SECRET}
+        lion_system: false
+        ---
+
+        body text
+        """,
+    )
+
+    # Must-MATCH arm: with the switch off, the raw file (including its
+    # colliding `path:` frontmatter key) is served as-is.
+    normal_definition = client.get("/api/definitions/agent/pathagent")
+    assert normal_definition.status_code == 200, normal_definition.text
+    assert NESTED_SECRET in normal_definition.text
+
+    # Must-NOT-match arm: with the switch on, the malformed path value is
+    # dropped rather than str()-serialized into the response.
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    redacted_definition = client.get("/api/definitions/agent/pathagent")
+    assert redacted_definition.status_code == 200, redacted_definition.text
+    assert NESTED_SECRET not in redacted_definition.text
+
+
+# ---------------------------------------------------------------------------
+# snapshot_current() re-saves any definition whose disk content differs from
+# its latest stored version. The internal equality check must compare
+# against the raw stored content, not get_version()'s redacted response text
+# -- otherwise an unchanged agent file in demo mode never matches its own
+# redacted-placeholder comparison and gets re-snapshotted on every call.
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_current_does_not_resnapshot_unchanged_agent_in_demo_mode(tmp_path, monkeypatch):
+    client, agents_dir = _make_redaction_client(tmp_path, monkeypatch)
+    _write_agent_md(agents_dir / "snapagent.md", FIXTURE_AGENT_MD)
+
+    first = client.post("/api/definitions/snapshot", params={"kind": "agent"})
+    assert first.status_code == 200, first.text
+    assert first.json()["snapshots_created"] == 1
+
+    monkeypatch.setenv("LIONAGI_STUDIO_DEMO_MODE", "true")
+    second = client.post("/api/definitions/snapshot", params={"kind": "agent"})
+    assert second.status_code == 200, second.text
+    assert second.json()["snapshots_created"] == 0
+
+    current = client.get("/api/definitions/agent/snapagent")
+    assert current.status_code == 200, current.text
+    assert current.json()["version"] == 1
+
+
+# ---------------------------------------------------------------------------
 # Route-enumeration coverage: fails loudly when a new route is registered
 # under an area that reads agent-profile content without a redaction
 # decision having been made for it.


### PR DESCRIPTION
Agent definitions and library payloads are now served through a redaction projection so secrets-shaped values (keys, tokens, credential-bearing env blocks) never leave the API surface. Write paths reject placeholder payloads that would round-trip a redacted read back into the store.

Closes #2856