### PR TITLE
fix(flow): stop reporting success when terminal nodes never ran

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -495,6 +495,7 @@ async def _teardown_common(
     extras: dict | None = None,
     identity_markers: dict | None = None,
     escalated_evidence: list[dict] | None = None,
+    failed_operation_evidence: list[dict] | None = None,
     finalize_error: dict | None = None,
     artifact_write_error: dict | None = None,
     cwd: str | None = None,
@@ -654,6 +655,24 @@ async def _teardown_common(
                         ),
                     }
                 ]
+
+    # Node-failure backstop: a DAG operation's invoke() raised
+    # and the executor recorded EventStatus.FAILED for it, but that per-node
+    # failure was folded into completed_operations right alongside genuine
+    # completions and never rolled up into the run's own status -- a run
+    # whose terminal (or any other) node died could still read as an
+    # ordinary clean completion. See lionagi/operations/flow.py's
+    # failed_operations tracking and _execute_dag's evidence collection.
+    if failed_operation_evidence and final_status == "completed":
+        from lionagi.state.reasons import RunReasons
+
+        final_status = "failed"
+        final_reason_code = RunReasons.FAILED_EXCEPTION
+        ids = [str(e.get("id", "")) for e in failed_operation_evidence]
+        final_reason_summary = (
+            f"{len(failed_operation_evidence)} operation(s) failed: {', '.join(ids)}."
+        )
+        final_evidence_refs = failed_operation_evidence
 
     # Escalation backstop: a leg that gave up mid-run via EscalationRequest without
     # an artifact contract must not read as a clean completion.
@@ -819,6 +838,7 @@ async def teardown_persist(
     exception: BaseException | None = None,
     extras: dict | None = None,
     escalated_evidence: list[dict] | None = None,
+    failed_operation_evidence: list[dict] | None = None,
     finalize_error: dict | None = None,
     artifact_write_error: dict | None = None,
     cwd: str | None = None,
@@ -842,6 +862,7 @@ async def teardown_persist(
             extras=extras,
             identity_markers=ctx.get("identity_markers"),
             escalated_evidence=escalated_evidence,
+            failed_operation_evidence=failed_operation_evidence,
             finalize_error=finalize_error,
             artifact_write_error=artifact_write_error,
             cwd=cwd,

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -662,9 +662,46 @@ async def _teardown_common(
         )
         final_evidence_refs = escalated_evidence
 
+    # Gate-rejection backstop: a gate node rejected mid-DAG (issue #2860) and the
+    # executor short-circuited its dependent subtree to skipped instead of running
+    # those nodes against the rejected baseline. That is a correct, deliberate
+    # stop, not a failure -- status stays "completed" -- but the reason code must
+    # say so explicitly rather than reading identically to a clean pass. Runs
+    # before the completion-trust gate below, alongside the node-failure and
+    # escalation backstops: a gate-rejected run typically produces no artifacts
+    # or commits either (the rejected subtree never ran), and unlike those two
+    # backstops this one deliberately leaves final_status at "completed" instead
+    # of flipping to "failed" -- so it cannot rely on the trust gate's own
+    # `final_status == "completed"` guard to skip it and must run first so its
+    # evidence is in place before that gate's no-evidence check runs.
+    if gate_rejected_evidence and final_status == "completed":
+        from lionagi.state.reasons import RunReasons
+
+        metadata = dict(metadata or {})
+        metadata["gate_rejections"] = gate_rejected_evidence
+        final_reason_code = RunReasons.COMPLETED_GATE_REJECTED
+        gate_names = ", ".join(
+            str(e.get("label") or e.get("id") or "") for e in gate_rejected_evidence
+        )
+        final_reason_summary = (
+            f"DAG completed successfully; {len(gate_rejected_evidence)} gate(s) rejected "
+            f"({gate_names}) and their dependent subtree was short-circuited instead of "
+            "running against the rejected baseline."
+        )
+        final_evidence_refs = gate_rejected_evidence
+
     # Completion-trust gate: don't accept "completed" on faith. Require a git trace
     # (commits ahead/dirty tree) or a durable assistant response as real evidence.
-    if final_status == "completed" and not (verification and verification.get("produced")):
+    # Skipped when gate_rejected_evidence fired above: a gate rejection is itself
+    # real evidence of a deliberate stop, and (unlike the node-failure/escalation
+    # backstops) it leaves final_status at "completed" rather than "failed", so
+    # without this guard the demotion below would still run and overwrite the
+    # gate-rejection reason/evidence with a plain no-evidence verdict.
+    if (
+        final_status == "completed"
+        and not gate_rejected_evidence
+        and not (verification and verification.get("produced"))
+    ):
         from lionagi.state.completion_evidence import (
             check_completion_evidence,
             has_completion_evidence,
@@ -696,27 +733,6 @@ async def _teardown_common(
                         ),
                     }
                 ]
-
-    # A gate node rejected mid-DAG (issue #2860) and the executor
-    # short-circuited its dependent subtree to skipped instead of running
-    # those nodes against the rejected baseline. That is a correct, deliberate
-    # stop, not a failure -- status stays "completed" -- but the reason code
-    # must say so explicitly rather than reading identically to a clean pass.
-    if gate_rejected_evidence and final_status == "completed":
-        from lionagi.state.reasons import RunReasons
-
-        metadata = dict(metadata or {})
-        metadata["gate_rejections"] = gate_rejected_evidence
-        final_reason_code = RunReasons.COMPLETED_GATE_REJECTED
-        gate_names = ", ".join(
-            str(e.get("label") or e.get("id") or "") for e in gate_rejected_evidence
-        )
-        final_reason_summary = (
-            f"DAG completed successfully; {len(gate_rejected_evidence)} gate(s) rejected "
-            f"({gate_names}) and their dependent subtree was short-circuited instead of "
-            "running against the rejected baseline."
-        )
-        final_evidence_refs = gate_rejected_evidence
 
     # The synthesis artifact IS the run's output. A DAG that completed but
     # whose output write raised has not delivered anything -- that is a real

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -623,6 +623,45 @@ async def _teardown_common(
                 str(entry.get("id", "")) for entry in missing
             ]
 
+    # Node-failure backstop: a DAG operation's invoke() raised
+    # and the executor recorded EventStatus.FAILED for it, but that per-node
+    # failure was folded into completed_operations right alongside genuine
+    # completions and never rolled up into the run's own status -- a run
+    # whose terminal (or any other) node died could still read as an
+    # ordinary clean completion. See lionagi/operations/flow.py's
+    # failed_operations tracking and _execute_dag's evidence collection.
+    # Runs before the completion-trust gate below: a run whose nodes all
+    # failed typically produces no artifacts or commits either, so the gate
+    # would otherwise demote it to "completed_empty" first and this failure
+    # evidence would never see a status that reflects it.
+    if failed_operation_evidence and final_status == "completed":
+        from lionagi.state.reasons import RunReasons
+
+        final_status = "failed"
+        final_reason_code = RunReasons.FAILED_EXCEPTION
+        ids = [str(e.get("id", "")) for e in failed_operation_evidence]
+        final_reason_summary = (
+            f"{len(failed_operation_evidence)} operation(s) failed: {', '.join(ids)}."
+        )
+        final_evidence_refs = failed_operation_evidence
+
+    # Escalation backstop: a leg that gave up mid-run via EscalationRequest without
+    # an artifact contract must not read as a clean completion. Also runs ahead of
+    # the completion-trust gate for the same reason as the node-failure backstop
+    # above -- an escalated run with no evidence must not be demoted to
+    # "completed_empty" before this check has a chance to run.
+    if escalated_evidence and final_status == "completed":
+        from lionagi.state.reasons import RunReasons
+
+        final_status = "failed"
+        final_reason_code = RunReasons.FAILED_ESCALATED
+        ids = [str(e.get("id", "")) for e in escalated_evidence]
+        final_reason_summary = (
+            f"{len(escalated_evidence)} operation(s) escalated without producing "
+            f"required output: {', '.join(ids)}."
+        )
+        final_evidence_refs = escalated_evidence
+
     # Completion-trust gate: don't accept "completed" on faith. Require a git trace
     # (commits ahead/dirty tree) or a durable assistant response as real evidence.
     if final_status == "completed" and not (verification and verification.get("produced")):
@@ -657,38 +696,6 @@ async def _teardown_common(
                         ),
                     }
                 ]
-
-    # Node-failure backstop: a DAG operation's invoke() raised
-    # and the executor recorded EventStatus.FAILED for it, but that per-node
-    # failure was folded into completed_operations right alongside genuine
-    # completions and never rolled up into the run's own status -- a run
-    # whose terminal (or any other) node died could still read as an
-    # ordinary clean completion. See lionagi/operations/flow.py's
-    # failed_operations tracking and _execute_dag's evidence collection.
-    if failed_operation_evidence and final_status == "completed":
-        from lionagi.state.reasons import RunReasons
-
-        final_status = "failed"
-        final_reason_code = RunReasons.FAILED_EXCEPTION
-        ids = [str(e.get("id", "")) for e in failed_operation_evidence]
-        final_reason_summary = (
-            f"{len(failed_operation_evidence)} operation(s) failed: {', '.join(ids)}."
-        )
-        final_evidence_refs = failed_operation_evidence
-
-    # Escalation backstop: a leg that gave up mid-run via EscalationRequest without
-    # an artifact contract must not read as a clean completion.
-    if escalated_evidence and final_status == "completed":
-        from lionagi.state.reasons import RunReasons
-
-        final_status = "failed"
-        final_reason_code = RunReasons.FAILED_ESCALATED
-        ids = [str(e.get("id", "")) for e in escalated_evidence]
-        final_reason_summary = (
-            f"{len(escalated_evidence)} operation(s) escalated without producing "
-            f"required output: {', '.join(ids)}."
-        )
-        final_evidence_refs = escalated_evidence
 
     # A gate node rejected mid-DAG (issue #2860) and the executor
     # short-circuited its dependent subtree to skipped instead of running

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -1604,6 +1604,7 @@ async def stop_live_persist(
     ctx = env._live_persist
     extras = getattr(env, "_finalize_extras", None)
     escalated_evidence = getattr(env, "_escalated_evidence", None)
+    failed_operation_evidence = getattr(env, "_failed_operation_evidence", None)
     finalize_error = getattr(env, "_finalize_error", None)
     artifact_write_error = getattr(env, "_artifact_write_error", None)
     final_status = await teardown_persist(
@@ -1612,6 +1613,7 @@ async def stop_live_persist(
         exception=exception,
         extras=extras,
         escalated_evidence=escalated_evidence,
+        failed_operation_evidence=failed_operation_evidence,
         finalize_error=finalize_error,
         artifact_write_error=artifact_write_error,
         cwd=env.cwd,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1430,6 +1430,30 @@ async def _execute_dag(
         prior_evidence = getattr(env, "_escalated_evidence", None) or []
         env._escalated_evidence = [*prior_evidence, *escalated_evidence]
 
+    # Node-failure evidence: an operation's invoke() raised and
+    # DependencyAwareExecutor recorded EventStatus.FAILED for it, but that
+    # per-node failure was folded into completed_operations right alongside
+    # genuine completions and never rolled up into the run's own status --
+    # a run whose terminal (or any other) node died could still read as an
+    # ordinary clean completion. Mirrors the escalation evidence above: name
+    # the failed op(s) here, let stop_live_persist flip status/reason.
+    failed_op_ids = {str(x) for x in dag_result.get("failed_operations", [])}
+    failed_evidence = [
+        {"kind": "failed_operation", "id": agent_ids[i], "label": assignments[i].assignee}
+        for i in range(len(assignments))
+        if str(node_ids[i]) in failed_op_ids
+    ]
+    for spawned_nid in sorted(failed_op_ids - known_node_strs):
+        graph_node = graph_nodes.get(spawned_nid)
+        spawn_id = graph_node.metadata.get("spawn_id") if graph_node is not None else None
+        evidence_id = spawn_id or spawned_nid
+        failed_evidence.append(
+            {"kind": "failed_operation", "id": evidence_id, "label": evidence_id}
+        )
+    if failed_evidence:
+        prior_failed_evidence = getattr(env, "_failed_operation_evidence", None) or []
+        env._failed_operation_evidence = [*prior_failed_evidence, *failed_evidence]
+
     agent_results: list[dict] = []
 
     def _record_result(result: dict) -> None:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1454,6 +1454,34 @@ async def _execute_dag(
         prior_failed_evidence = getattr(env, "_failed_operation_evidence", None) or []
         env._failed_operation_evidence = [*prior_failed_evidence, *failed_evidence]
 
+    # Lost-node evidence: a node in the fixed initial plan (node_ids /
+    # assignments, indexed 1:1) whose result never landed in
+    # operation_results at all -- distinct from a node that ran and failed
+    # (already caught above) or was legitimately never meant to run. Every
+    # other accounted-for fate is excluded explicitly: an edge-condition skip
+    # is named in skipped_operations; a leg that gave up via EscalationRequest
+    # is named in escalated_operations and already fails the run through the
+    # escalated-evidence backstop above with its own, more specific reason;
+    # a reactive/budget-refused spawn was never a planned node to begin with
+    # (dropped_spawns never touches node_ids). A cancelled run never reaches
+    # this line -- run_dag raises and the whole evidence block above is
+    # skipped -- so no separate check is needed for it. What remains here is
+    # a node the plan expected but execution never observed in any of those
+    # ways; treat it as a failure with its own evidence rather than letting
+    # it render as "(no response)" below.
+    skipped_op_ids = {str(x) for x in dag_result.get("skipped_operations", [])}
+    observed_op_ids = {str(k) for k in op_results}
+    lost_evidence = [
+        {"kind": "lost_operation", "id": agent_ids[i], "label": assignments[i].assignee}
+        for i in range(len(assignments))
+        if str(node_ids[i]) not in observed_op_ids
+        and str(node_ids[i]) not in skipped_op_ids
+        and str(node_ids[i]) not in escalated_op_ids
+    ]
+    if lost_evidence:
+        prior_failed_evidence = getattr(env, "_failed_operation_evidence", None) or []
+        env._failed_operation_evidence = [*prior_failed_evidence, *lost_evidence]
+
     agent_results: list[dict] = []
 
     def _record_result(result: dict) -> None:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1482,6 +1482,33 @@ async def _execute_dag(
         prior_failed_evidence = getattr(env, "_failed_operation_evidence", None) or []
         env._failed_operation_evidence = [*prior_failed_evidence, *lost_evidence]
 
+    # Lost-spawn evidence: mirrors the lost-node check above, but for the
+    # reactive surface. spawned_ids (when the executor reports it) is the
+    # roster of every node _accept_node actually accepted into the graph --
+    # spawned_operations is only a running count and can't answer "which
+    # nodes were accepted" on its own. An accepted spawn that reached a
+    # terminal EventStatus (e.g. CANCELLED) without ever producing a result
+    # is absent from operation_results, failed_operations, and
+    # skipped_operations alike; without this check it would also read as a
+    # clean completion. A spawn the executor refused to accept in the first
+    # place (dropped_spawns) never enters spawned_ids, so it stays excluded
+    # here exactly as dropped_spawns already is above.
+    spawned_ids = {str(x) for x in dag_result.get("spawned_ids", [])}
+    lost_spawn_ids = (
+        spawned_ids - observed_op_ids - skipped_op_ids - escalated_op_ids - failed_op_ids
+    )
+    lost_spawn_evidence = []
+    for spawned_nid in sorted(lost_spawn_ids):
+        graph_node = graph_nodes.get(spawned_nid)
+        spawn_id = graph_node.metadata.get("spawn_id") if graph_node is not None else None
+        evidence_id = spawn_id or spawned_nid
+        lost_spawn_evidence.append(
+            {"kind": "lost_operation", "id": evidence_id, "label": evidence_id}
+        )
+    if lost_spawn_evidence:
+        prior_failed_evidence = getattr(env, "_failed_operation_evidence", None) or []
+        env._failed_operation_evidence = [*prior_failed_evidence, *lost_spawn_evidence]
+
     agent_results: list[dict] = []
 
     def _record_result(result: dict) -> None:

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -1095,8 +1095,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
                 )
                 return False
 
-            self._spawn_count += 1
-            self._spawned_ids.add(child.id)
+            if newly_added:
+                self._spawn_count += 1
+                self._spawned_ids.add(child.id)
 
         if newly_added:
             # Store edge info in metadata so on_progress callbacks can attach it

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -139,6 +139,12 @@ class DependencyAwareExecutor:
         self.completion_events = {}
         self.operation_branches = {}
         self.skipped_operations = set()
+        # Distinct from skipped_operations: an op whose invoke() raised, kept
+        # separate from completed_operations (which still includes it, for
+        # back-compat -- a FAILED op still produced an (error) result) so a
+        # caller can tell a dead node from a genuine completion without
+        # inspecting every result value by hand.
+        self.failed_operations = set()
         self._op_start_times = {}
         self._pause_event: ConcurrencyEvent | None = None
         # Fire-and-forget flow signal tasks, retained until each finishes so a
@@ -193,6 +199,7 @@ class DependencyAwareExecutor:
             "operation_results": self.results,
             "final_context": self.context.content,
             "skipped_operations": list(self.skipped_operations),
+            "failed_operations": list(self.failed_operations),
         }
 
         self._validate_execution_results(result)
@@ -434,6 +441,7 @@ class DependencyAwareExecutor:
 
                 elif operation.execution.status == EventStatus.FAILED:
                     self.results[operation.id] = {"error": str(operation.execution.error)}
+                    self.failed_operations.add(operation.id)
                     if self.on_progress:
                         self.on_progress(str(operation.id), branch_name, "failed", elapsed)
                     if self.verbose:
@@ -452,6 +460,7 @@ class DependencyAwareExecutor:
             # Defensive net for unexpected flow-level errors; invoke() already handles FAILED status.
             if operation.id not in self.results:
                 self.results[operation.id] = {"error": str(e)}
+            self.failed_operations.add(operation.id)
 
             if self.verbose:
                 logger.error("Operation %s failed: %s", str(operation.id)[:8], e)
@@ -777,6 +786,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
             "operation_results": self.results,
             "final_context": self.context.content,
             "skipped_operations": list(self.skipped_operations),
+            "failed_operations": list(self.failed_operations),
             "spawned_operations": self._spawn_count,
             "escalated_operations": list(self._escalated_ids),
             "dropped_spawns": self._dropped_spawns,

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -789,6 +789,13 @@ class ReactiveExecutor(DependencyAwareExecutor):
             "skipped_operations": list(self.skipped_operations),
             "failed_operations": list(self.failed_operations),
             "spawned_operations": self._spawn_count,
+            # The roster of every node _accept_node actually accepted into
+            # the graph -- distinct from spawned_operations, which is only a
+            # running count and can't tell a caller which ids to reconcile
+            # against its own outcome sets (a node that reached a terminal
+            # status like CANCELLED with no result is still in this roster
+            # even though it never lands in results/failed/skipped).
+            "spawned_ids": list(self._spawned_ids),
             "escalated_operations": list(self._escalated_ids),
             "dropped_spawns": self._dropped_spawns,
         }

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -421,6 +421,7 @@ class DependencyAwareExecutor:
                             operation.execution.status = EventStatus.FAILED
                             operation.execution.error = error
                             self.results[operation.id] = {"error": str(error)}
+                            self.failed_operations.add(operation.id)
                             if self.on_progress:
                                 self.on_progress(str(operation.id), branch_name, "failed", elapsed)
                             if self.verbose:

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1640,6 +1640,45 @@ async def test_stop_escalated_evidence_wins_over_completed_empty_demotion(
     assert s["status_reason_code"] == "run.failed.escalated"
 
 
+async def test_stop_gate_rejected_evidence_wins_over_completed_empty_demotion(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """Same masking hazard as the node-failure and escalation backstops above,
+    but for a gate that rejected mid-DAG: the rejected subtree is
+    short-circuited and typically produces no commits, no dirty tree, no
+    artifacts. Unlike those two backstops, a gate rejection is a deliberate,
+    correct stop -- final status must stay 'completed' -- but its evidence
+    must survive; the completion-trust gate must not overwrite it with a
+    plain no-evidence 'completed_empty' verdict."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    env = _minimal_env()
+    env.cwd = str(repo)
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    env._gate_rejected_evidence = [
+        {"kind": "gate_rejected", "id": "reviewer", "label": "reviewer-gate"}
+    ]
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "completed", "gate rejection is a deliberate stop, not a failure"
+    assert s["status_reason_code"] == "run.completed.gate_rejected"
+    assert "reviewer-gate" in (s["status_reason_summary"] or "")
+    refs = s["status_evidence_refs"] or []
+    assert any(r.get("id") == "reviewer" for r in refs), (
+        "gate-rejection evidence must survive the no-evidence demotion"
+    )
+
+
 async def test_stop_commits_ahead_of_base_stays_completed(
     temp_db_path: Path,
     tmp_path: Path,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2553,3 +2553,186 @@ async def test_execute_dag_escalation_backstop_catches_reactively_spawned_node(
     assert s is not None
     assert s["status"] == "failed"
     assert s["status_reason_code"] == "run.failed.escalated"
+
+
+# ── Node-failure backstop ──────────────────────────────────────────────────────
+#
+# A flow whose final node died could still report succeeded: an operation's
+# invoke() raised, DependencyAwareExecutor caught it and set that node's own
+# status to FAILED, but the DAG-level result folded it into
+# completed_operations right alongside genuine completions and never rolled
+# the per-node failure up into the run's own status. These tests pin the
+# fix at both the _execute_dag plumbing layer and the teardown status flip.
+
+
+async def test_execute_dag_records_failed_operation_evidence(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A node's own invoke() failure (DependencyAwareExecutor's
+    failed_operations, distinct from completed_operations) must be named in
+    env._failed_operation_evidence so stop_live_persist can fail the run
+    loud instead of it reading as an ordinary clean completion."""
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+    ctx = env._live_persist
+    assert ctx is not None
+
+    assignments = [
+        TaskAssignment(task="do first", assignee="worker"),
+        TaskAssignment(task="do last (dies)", assignee="reviewer"),
+    ]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["first", "last"],
+        dep_indices=[[], [0]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0", "node-1"],
+        known_nodes={"node-0", "node-1"},
+        deps_by_node={"node-0": [], "node-1": ["node-0"]},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5", "codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        return {
+            "operation_results": {
+                "node-0": "first ok",
+                "node-1": {
+                    "error": (
+                        "Failed to stream API call: CLI subprocess exited "
+                        "with code 1 and wrote nothing to stderr"
+                    )
+                },
+            },
+            "spawned_operations": 0,
+            "escalated_operations": [],
+            "failed_operations": ["node-1"],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert env._failed_operation_evidence == [
+        {"kind": "failed_operation", "id": "last", "label": "reviewer"}
+    ]
+    # An escalation-free, ordinary FAILED node must not also read as an
+    # escalation -- these are different failure modes with different reasons.
+    assert getattr(env, "_escalated_evidence", None) is None
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed"
+    assert s["status_reason_code"] == "run.failed.exception"
+
+    import json as _json
+
+    evidence = s["status_evidence_refs"]
+    evidence = _json.loads(evidence) if isinstance(evidence, str) else evidence
+    assert any(e.get("id") == "last" for e in evidence)
+
+
+async def test_dead_terminal_node_flips_completed_to_failed_end_to_end(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """True end-to-end repro of a flow whose terminal node dies: a two-node
+    DAG (first -> last) run through the REAL DependencyAwareExecutor, where
+    the terminal node raises exactly the kind of error a dead CLI subprocess
+    produces. Before the fix, this session's own status ended 'completed'
+    even though its terminal node never produced a result -- indistinguishable
+    from a run that actually passed its gate."""
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.flow import flow as _real_flow
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+    ctx = env._live_persist
+    assert ctx is not None
+
+    async def first(**kw):
+        return "first ok"
+
+    async def last(**kw):
+        raise RuntimeError(
+            "Failed to stream API call: CLI subprocess exited with code 1 "
+            "and wrote nothing to stderr"
+        )
+
+    env.session.register_operation("first", first)
+    env.session.register_operation("last", last)
+
+    builder = OperationGraphBuilder()
+    first_id = builder.add_operation("first", depends_on=[])
+    last_id = builder.add_operation("last", depends_on=[first_id])
+    graph = builder.get_graph()
+
+    assignments = [
+        TaskAssignment(task="do first", assignee="worker"),
+        TaskAssignment(task="do last (dies)", assignee="reviewer"),
+    ]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["first", "last"],
+        dep_indices=[[], [0]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[first_id, last_id],
+        known_nodes={first_id, last_id},
+        deps_by_node={first_id: [], last_id: ["first"]},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5", "codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        # The real executor, not a hand-built dict -- proves the rollup
+        # itself end-to-end, not just the _execute_dag plumbing around it.
+        return await _real_flow(env.session, graph, parallel=False, verbose=False)
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert env._failed_operation_evidence == [
+        {"kind": "failed_operation", "id": "last", "label": "reviewer"}
+    ]
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed", "a dead terminal node must not read as a clean completion"
+    assert s["status_reason_code"] == "run.failed.exception"

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2736,3 +2736,204 @@ async def test_dead_terminal_node_flips_completed_to_failed_end_to_end(
     assert s is not None
     assert s["status"] == "failed", "a dead terminal node must not read as a clean completion"
     assert s["status_reason_code"] == "run.failed.exception"
+
+
+# A planned node that never produced a result at all -- absent from
+# operation_results, not in failed_operations (no invoke() ever raised) and
+# not in skipped_operations (no edge condition short-circuited it) -- read as
+# an ordinary "(no response)" entry with the run's own status untouched.
+# These tests pin the reconciliation between the fixed initial plan
+# (dag_state.node_ids) and what the executor actually observed.
+
+
+async def test_execute_dag_records_lost_operation_evidence_for_missing_result(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A two-node plan where only node-0 shows up in operation_results (the
+    executor never produced a result -- completed, failed, or skipped -- for
+    node-1) must be named in env._failed_operation_evidence so the run fails
+    loud instead of reading as run.completed.ok."""
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+    ctx = env._live_persist
+    assert ctx is not None
+
+    assignments = [
+        TaskAssignment(task="do first", assignee="worker"),
+        TaskAssignment(task="do last (never runs)", assignee="reviewer"),
+    ]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["first", "last"],
+        dep_indices=[[], [0]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0", "node-1"],
+        known_nodes={"node-0", "node-1"},
+        deps_by_node={"node-0": [], "node-1": ["node-0"]},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5", "codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        return {
+            "operation_results": {"node-0": "first ok"},
+            "spawned_operations": 0,
+            "escalated_operations": [],
+            "failed_operations": [],
+            "skipped_operations": [],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert env._failed_operation_evidence == [
+        {"kind": "lost_operation", "id": "last", "label": "reviewer"}
+    ]
+    assert getattr(env, "_escalated_evidence", None) is None
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed", "a missing planned node must not read as a clean completion"
+    assert s["status_reason_code"] == "run.failed.exception"
+
+
+async def test_execute_dag_skipped_node_does_not_trip_lost_operation_evidence(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """node-1 absent from operation_results is NOT a lost node when the
+    executor named it in skipped_operations -- an ordinary edge-condition
+    skip is a legitimate, non-failing outcome and must not fail the run."""
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+
+    assignments = [
+        TaskAssignment(task="do first", assignee="worker"),
+        TaskAssignment(task="skip me", assignee="reviewer"),
+    ]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["first", "skipped"],
+        dep_indices=[[], [0]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0", "node-1"],
+        known_nodes={"node-0", "node-1"},
+        deps_by_node={"node-0": [], "node-1": ["node-0"]},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5", "codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        return {
+            "operation_results": {"node-0": "first ok"},
+            "spawned_operations": 0,
+            "escalated_operations": [],
+            "failed_operations": [],
+            "skipped_operations": ["node-1"],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert not getattr(env, "_failed_operation_evidence", None)
+
+    await stop_live_persist(env, status="completed")
+
+
+async def test_execute_dag_dropped_spawn_does_not_trip_lost_operation_evidence(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A reactively spawned node that got dropped (budget/cycle refusal) was
+    never a planned node -- it must not surface as a lost planned node just
+    because its id shows up somewhere in the DAG result. Reconciliation is
+    scoped to dag_state.node_ids only."""
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+
+    assignments = [
+        TaskAssignment(task="do first", assignee="worker"),
+        TaskAssignment(task="do last", assignee="reviewer"),
+    ]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["first", "last"],
+        dep_indices=[[], [0]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0", "node-1"],
+        known_nodes={"node-0", "node-1"},
+        deps_by_node={"node-0": [], "node-1": ["node-0"]},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5", "codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        return {
+            "operation_results": {"node-0": "first ok", "node-1": "last ok"},
+            "spawned_operations": 0,
+            "escalated_operations": [],
+            "failed_operations": [],
+            "skipped_operations": [],
+            "dropped_spawns": [
+                {"reason": "max_spawn_exceeded", "assignee": "reviewer", "op_id": "spawn-99"}
+            ],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert not getattr(env, "_failed_operation_evidence", None)
+
+    await stop_live_persist(env, status="completed")

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -3032,6 +3032,103 @@ async def test_execute_dag_cancelled_spawn_records_lost_operation_evidence(
     assert s["status_reason_code"] == "run.failed.exception"
 
 
+async def test_execute_dag_reinjected_initial_node_yields_one_lost_operation_entry(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """One level up from the executor-level regression: an on_op_complete
+    hook that re-injects the SAME already-cancelled initial node through the
+    public inject() API used to pollute spawned_ids with that node's own id
+    (_accept_node bumped the roster/counter even though the node was already
+    in the graph, not newly added). With that pollution, the lost node was
+    named twice -- once by the fixed-size planned-node check
+    (dag_state.node_ids, by plan index) and once by the spawned_ids check (by
+    id) -- since neither check excludes ids the other has already claimed.
+    Fixed at the source (_accept_node no longer counts a re-injected existing
+    node as a spawn), so only the planned-node check fires."""
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.flow import flow as _real_flow
+    from lionagi.protocols.generic.event import EventStatus
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+    ctx = env._live_persist
+    assert ctx is not None
+
+    async def spawner(**kw):
+        return "should not run"
+
+    env.session.register_operation("spawner", spawner)
+
+    builder = OperationGraphBuilder()
+    spawner_id = builder.add_operation("spawner", depends_on=[])
+    graph = builder.get_graph()
+    env.builder = builder
+    initial_op = next(iter(graph.internal_nodes.values()))
+    initial_op.execution.status = EventStatus.CANCELLED
+
+    assignments = [TaskAssignment(task="do it", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["first"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[spawner_id],
+        known_nodes={spawner_id},
+        deps_by_node={spawner_id: []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    executor_ref: dict = {}
+    injected_once = {"done": False}
+
+    def on_op_complete(node):
+        if injected_once["done"]:
+            return
+        injected_once["done"] = True
+        # Re-inject the SAME already-in-graph, already-cancelled initial
+        # node through the public inject() API.
+        executor_ref["executor"].inject(node, independent=True)
+
+    async def _run_dag_result():
+        # The real executor, not a hand-built dict -- proves the rollup
+        # against genuine ReactiveExecutor state, not just the reconciliation
+        # plumbing around it.
+        return await _real_flow(
+            env.session,
+            graph,
+            reactive=True,
+            executor_ref=executor_ref,
+            on_op_complete=on_op_complete,
+        )
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    lost_entries = [
+        e for e in (env._failed_operation_evidence or []) if e["kind"] == "lost_operation"
+    ]
+    assert len(lost_entries) == 1
+
+    await stop_live_persist(env, status="completed")
+
+
 async def test_execute_dag_run_level_cancellation_skips_reconciliation_entirely(
     temp_db_path: Path,
     tmp_path: Path,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -1576,6 +1576,70 @@ async def test_stop_no_artifact_no_commits_flips_to_completed_empty(
     assert v is None
 
 
+async def test_stop_failed_operation_evidence_wins_over_completed_empty_demotion(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A run whose nodes all failed typically produces no commits, no dirty
+    tree, and no artifacts either -- the same shape as a legitimate no-op
+    leg. The node-failure backstop must see the failure evidence before the
+    completion-trust gate gets a chance to demote the run to
+    'completed_empty' and bury it."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    env = _minimal_env()
+    env.cwd = str(repo)
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    env._failed_operation_evidence = [
+        {"kind": "failed_operation", "id": "last", "label": "reviewer"}
+    ]
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed", "failure evidence must outrank the no-evidence demotion"
+    assert s["status_reason_code"] == "run.failed.exception"
+    assert "last" in (s["status_reason_summary"] or "")
+
+
+async def test_stop_escalated_evidence_wins_over_completed_empty_demotion(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """Same masking hazard as the node-failure backstop above, but for a leg
+    that gave up via EscalationRequest: no commits, no dirty tree, no
+    artifacts -- the escalation backstop must see the evidence before the
+    completion-trust gate demotes the run to 'completed_empty'."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    env = _minimal_env()
+    env.cwd = str(repo)
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    env._escalated_evidence = [
+        {"kind": "escalated_operation", "id": "worker", "label": "cannot proceed"}
+    ]
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed", "escalation evidence must outrank the no-evidence demotion"
+    assert s["status_reason_code"] == "run.failed.escalated"
+
+
 async def test_stop_commits_ahead_of_base_stays_completed(
     temp_db_path: Path,
     tmp_path: Path,

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2937,3 +2937,149 @@ async def test_execute_dag_dropped_spawn_does_not_trip_lost_operation_evidence(
     assert not getattr(env, "_failed_operation_evidence", None)
 
     await stop_live_persist(env, status="completed")
+
+
+async def test_execute_dag_cancelled_spawn_records_lost_operation_evidence(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A reactively accepted spawn whose EventStatus reaches CANCELLED
+    before producing a result is absent from operation_results,
+    failed_operations, AND skipped_operations -- it was genuinely accepted
+    into the graph (unlike a dropped_spawns entry), so spawned_operations
+    (a count) reports it but none of the outcome sets do. Reconciling the
+    executor's spawned_ids roster -- the accept-time roster of every node
+    _accept_node actually let in, real ReactiveExecutor state rather than a
+    re-derived counter -- against operation_results/failed/skipped/escalated
+    must still name it as lost, closing the same false-success class as a
+    missing planned node."""
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.operations.node import create_operation
+    from lionagi.protocols.generic.event import EventStatus
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+    ctx = env._live_persist
+    assert ctx is not None
+
+    # A real Graph carrying the accepted-then-cancelled spawn, exactly what
+    # env.builder.get_graph() would hold after a genuine ReactiveExecutor
+    # run accepted this node via _accept_node before it hit a terminal
+    # CANCELLED status with no response.
+    builder = OperationGraphBuilder()
+    cancelled_child = create_operation("follow_up", parameters={})
+    cancelled_child.execution.status = EventStatus.CANCELLED
+    cancelled_child.metadata["spawn_id"] = "spawn-1"
+    cancelled_child.metadata["assignee"] = "reviewer"
+    builder.graph.add_node(cancelled_child)
+    env.builder = builder
+    cancelled_id = str(cancelled_child.id)
+
+    assignments = [TaskAssignment(task="do first", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["first"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_result():
+        return {
+            "operation_results": {"node-0": "first ok"},
+            "spawned_operations": 1,
+            "spawned_ids": [cancelled_id],
+            "escalated_operations": [],
+            "failed_operations": [],
+            "skipped_operations": [],
+            "dropped_spawns": [],
+        }
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_result())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert env._failed_operation_evidence == [
+        {"kind": "lost_operation", "id": "spawn-1", "label": "spawn-1"}
+    ]
+
+    await stop_live_persist(env, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s is not None
+    assert s["status"] == "failed", (
+        "a cancelled-but-accepted spawn must not read as a clean completion"
+    )
+    assert s["status_reason_code"] == "run.failed.exception"
+
+
+async def test_execute_dag_run_level_cancellation_skips_reconciliation_entirely(
+    temp_db_path: Path,
+    tmp_path: Path,
+):
+    """A user-killed run (run_dag itself raises CancelledError, not a
+    per-node terminal status) must not additionally accrue lost-node/
+    lost-spawn evidence -- the whole evidence block, including both
+    reconciliation checks, sits after the awaited run_dag call and is never
+    reached when that call raises instead of returning."""
+    from unittest.mock import MagicMock, patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+
+    env = _minimal_env()
+    artifacts_dir = tmp_path / "artifacts"
+    await start_live_persist(env, invocation_kind="flow", artifacts_path=str(artifacts_dir))
+
+    assignments = [TaskAssignment(task="do first", assignee="worker")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["first"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+
+    async def _run_dag_raises():
+        raise asyncio.CancelledError()
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = MagicMock(return_value=_run_dag_raises())
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        with pytest.raises(asyncio.CancelledError):
+            await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert not getattr(env, "_failed_operation_evidence", None)
+
+    await stop_live_persist(env, status="cancelled")

--- a/tests/operations/test_flow_failure_rollup.py
+++ b/tests/operations/test_flow_failure_rollup.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A DAG whose terminal node raises must be able to say so:
+DependencyAwareExecutor/ReactiveExecutor caught the exception, set the
+node's own status to FAILED, and recorded an error result for it -- but
+never rolled that per-node failure up into a distinguishable place in the
+returned dict, so a caller had no way to tell a dead node from a completed
+one without inspecting every result value by hand."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.operations import flow
+from lionagi.operations.builder import OperationGraphBuilder
+from lionagi.session.session import Session
+
+
+def _session_with_ops(**ops):
+    """A Session whose default branch resolves the given named operations."""
+    from lionagi.session.branch import Branch
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    for name, fn in ops.items():
+        session.register_operation(name, fn)
+    return session
+
+
+def _build_chain_graph(builder: OperationGraphBuilder) -> dict[str, str]:
+    """first -> last, a minimal chain where the terminal node is the one
+    that dies."""
+    first_id = builder.add_operation("first", depends_on=[])
+    last_id = builder.add_operation("last", depends_on=[first_id])
+    return {"first": first_id, "last": last_id}
+
+
+def _make_ops(executed: list[str]):
+    async def first(**kw):
+        executed.append("first")
+        return "first ok"
+
+    async def last(**kw):
+        executed.append("last")
+        raise RuntimeError("CLI subprocess exited with code 1 and wrote nothing to stderr")
+
+    return {"first": first, "last": last}
+
+
+@pytest.mark.asyncio
+async def test_dead_terminal_node_is_rolled_up_as_failed():
+    """The failing node must be visible via a dedicated failed_operations
+    list; completed_operations keeps its existing (deliberate, tested)
+    meaning of 'the executor produced a result for this op, whatever it
+    was' -- see test_flow_operation_error_handling in test_flow.py."""
+    executed: list[str] = []
+    session = _session_with_ops(**_make_ops(executed))
+    builder = OperationGraphBuilder()
+    ids = _build_chain_graph(builder)
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    assert "first" in executed
+    assert "last" in executed
+    assert ids["last"] in result["failed_operations"]
+    assert ids["first"] not in result["failed_operations"]
+    # Back-compat: completed_operations is unchanged (a FAILED op still
+    # produced a (error) result, which is what that list has always meant).
+    assert ids["last"] in result["completed_operations"]
+
+
+@pytest.mark.asyncio
+async def test_dead_terminal_node_is_rolled_up_as_failed_reactive():
+    """Same rollup under the reactive (self-expanding) executor."""
+    executed: list[str] = []
+    session = _session_with_ops(**_make_ops(executed))
+    builder = OperationGraphBuilder()
+    ids = _build_chain_graph(builder)
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True, verbose=False)
+
+    assert ids["last"] in result["failed_operations"]
+    assert ids["first"] not in result["failed_operations"]
+    assert ids["last"] in result["completed_operations"]
+
+
+@pytest.mark.asyncio
+async def test_skipped_operation_is_not_reported_as_failed():
+    """A node skipped by an ordinary edge-condition short-circuit is a
+    different outcome from a node that raised; failed_operations must stay
+    orthogonal to skipped_operations."""
+    from lionagi.protocols.graph.edge import Edge, EdgeCondition
+
+    class AlwaysFalseCondition(EdgeCondition):
+        async def apply(self, context: dict) -> bool:
+            return False
+
+    executed: list[str] = []
+
+    async def first(**kw):
+        executed.append("first")
+        return "first ok"
+
+    async def never(**kw):
+        executed.append("never")
+        return "should not run"
+
+    session = _session_with_ops(first=first, never=never)
+    builder = OperationGraphBuilder()
+    first_id = builder.add_operation("first", depends_on=[])
+    never_id = builder.add_operation("never", depends_on=[])
+    graph = builder.get_graph()
+    graph.add_edge(Edge(head=first_id, tail=never_id, condition=AlwaysFalseCondition()))
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    assert "never" not in executed
+    assert never_id in result["skipped_operations"]
+    assert never_id not in result["failed_operations"]

--- a/tests/operations/test_flow_failure_rollup.py
+++ b/tests/operations/test_flow_failure_rollup.py
@@ -122,3 +122,34 @@ async def test_skipped_operation_is_not_reported_as_failed():
     assert "never" not in executed
     assert never_id in result["skipped_operations"]
     assert never_id not in result["failed_operations"]
+
+
+@pytest.mark.asyncio
+async def test_non_mapping_response_context_is_rolled_up_as_failed():
+    """An operation that completes but returns a non-Mapping response
+    ``context`` is flipped to EventStatus.FAILED by the post-invoke
+    validation guard -- that guard must land the op in failed_operations
+    the same as an op whose invoke() itself raised, not bypass the rollup
+    it exists to feed."""
+    executed: list[str] = []
+
+    async def first(**kw):
+        executed.append("first")
+        return "first ok"
+
+    async def bad_context(**kw):
+        executed.append("last")
+        return {"context": "not-a-mapping"}
+
+    session = _session_with_ops(first=first, last=bad_context)
+    builder = OperationGraphBuilder()
+    ids = _build_chain_graph(builder)
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, parallel=False, verbose=False)
+
+    assert "first" in executed
+    assert "last" in executed
+    assert ids["last"] in result["failed_operations"]
+    assert ids["first"] not in result["failed_operations"]
+    assert ids["last"] in result["completed_operations"]

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -399,6 +399,40 @@ def test_cycle_injection_rejected():
     assert set(dropped[0]) == {"reason", "assignee", "emitter_id", "op_id"}
 
 
+def test_reinjecting_existing_node_does_not_pollute_spawned_ids():
+    """Re-injecting a node that is already in the graph (e.g. a caller
+    re-submitting a cancelled initial op via the public inject() API) must
+    not read as a new spawn. ``_accept_node`` only adds the node to the
+    graph when it is not already present (``newly_added``), but used to bump
+    the spawn counter and add the node's id to ``_spawned_ids``
+    unconditionally -- landing an initial plan node's own id in the
+    spawned-node roster with no result/failed/skipped/escalated outcome to
+    show for it."""
+    from lionagi.operations.flow import ReactiveExecutor
+    from lionagi.protocols.graph.graph import Graph
+
+    session = _session_with_ops()
+    graph = Graph()
+    initial = create_operation("op", parameters={})
+    graph.add_node(initial)
+
+    executor = ReactiveExecutor(session, graph)
+    executor._running = True
+
+    class _DummyTG:
+        def start_soon(self, *a, **k):
+            pass
+
+    executor._tg = _DummyTG()
+
+    # `initial` is already a node in the graph -- inject() re-accepts it
+    # (returns True, same as a genuinely new spawn) but must not count or
+    # roster it as one.
+    assert executor.inject(initial, independent=True) is True
+    assert executor._spawn_count == 0
+    assert initial.id not in executor._spawned_ids
+
+
 def test_builder_error_recorded_as_dropped_spawn():
     """A node_builder exception is recorded with reason + error, not just logged."""
     from lionagi.operations.flow import ReactiveExecutor

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -70,6 +70,51 @@ async def test_spawn_injects_node_into_running_graph():
 
 
 @pytest.mark.asyncio
+async def test_cancelled_spawn_is_named_in_spawned_ids_roster():
+    """An accepted spawn whose EventStatus is already CANCELLED by the time
+    the executor gets to run it (e.g. a quiescence/budget cutoff mid-run)
+    produces no entry in operation_results, failed_operations, or
+    skipped_operations -- ``_execute_operation``'s terminal-status fast path
+    just marks the completion event and returns. ``spawned_operations`` (a
+    count) still reports it, but a caller reconciling outcomes needs to know
+    *which* node that was: ``spawned_ids`` is the accept-time roster that
+    answers that, independent of whatever terminal fate the node reached."""
+
+    async def spawner(**kw):
+        return SpawnRequest(instruction="follow-up", independent=True)
+
+    session = _session_with_ops(spawner=spawner)
+
+    def node_builder(req: SpawnRequest, emitter: Operation) -> Operation:
+        from lionagi.protocols.generic.event import EventStatus
+
+        child = create_operation("follow_up", parameters={})
+        # Simulate the child already having reached a terminal CANCELLED
+        # status before the executor's own dependency wait/dispatch runs.
+        child.execution.status = EventStatus.CANCELLED
+        return child
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("spawner")
+    graph = builder.get_graph()
+
+    result = await flow(session, graph, reactive=True, node_builder=node_builder)
+
+    assert result["spawned_operations"] == 1
+    assert len(result["spawned_ids"]) == 1
+    cancelled_id = result["spawned_ids"][0]
+
+    # The false-success gap this fix closes: the cancelled child is in none
+    # of the outcome sets a naive reconciliation would check.
+    assert cancelled_id not in result["operation_results"]
+    assert cancelled_id not in result["failed_operations"]
+    assert cancelled_id not in result["skipped_operations"]
+    assert cancelled_id not in result["escalated_operations"]
+    # ...yet it is unambiguously present in the accept-time roster.
+    assert cancelled_id in result["spawned_ids"]
+
+
+@pytest.mark.asyncio
 async def test_recursive_spawn_until_condition():
     """A node can spawn a node that spawns again — the DAG grows transitively."""
     counter = {"n": 0}


### PR DESCRIPTION
A flow whose DAG lost nodes before execution could finish green while declared work never happened. The executor now reconciles the planned node set against the executed set and folds unexecuted nodes into the run outcome, with CLI-level repro tests proven to fail against the pre-fix code.

Closes #2834