### PR TITLE
fix(studio): make dev-mode Vite URL match what actually got bound

### DIFF
--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import collections
 import contextlib
+import ipaddress
 import json
 import math
 import os
@@ -383,11 +385,8 @@ def _start_local(
             frontend_proc, frontend_url = launched
             if frontend_url:
                 print(f"Lion Studio UI (dev):  {frontend_url}")
-            else:
-                warn(
-                    "Vite started but its bound address could not be "
-                    "determined — check the Vite output above."
-                )
+            # else: _launch_vite_dev already printed a specific, actionable
+            # warning (early exit / stream end / timeout) with captured output.
         print(f"Lion Studio API:       http://{host}:{port}")
     else:
         # Production mode: build dist/ once, then uvicorn serves both UI and API
@@ -540,16 +539,36 @@ _VITE_LOCAL_URL_RE = re.compile(r"Local:\s+(https?://[^\s/]+)")
 _VITE_NETWORK_URL_RE = re.compile(r"Network:\s+(https?://[^\s/]+)")
 _VITE_SETTLE_SECONDS = 0.15
 
-# Hosts for which Vite's `Local:` line is the address a caller can actually
-# reach. Anything else — a LAN IP or the 0.0.0.0/:: wildcard — binds extra
-# interfaces that only show up on Vite's `Network:` line; `Local:` stays a
-# loopback URL even when told to listen everywhere, so using it there would
-# print an address a LAN client cannot reach.
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+# Startup-output lines kept for diagnostics when Vite fails to report a
+# bound address — bounded so a runaway process can't grow this unbounded.
+_STARTUP_TAIL_LINES = 40
+
+
+def _host_is_loopback(host: str) -> bool:
+    """True when `host` is a loopback address — the address whose `Local:`
+    line is the one a caller can actually reach. Anything else — a LAN IP,
+    a real hostname, or the 0.0.0.0/:: wildcard — binds extra interfaces
+    that only show up on Vite's `Network:` line; `Local:` stays a loopback
+    URL even when told to listen everywhere, so using it there would print
+    an address a LAN client cannot reach.
+
+    Numeric hosts (127.0.0.1, 127.0.0.2, ::1, ...) are classified via
+    `ipaddress` rather than an exact-string allowlist, since the entire
+    127.0.0.0/8 block is loopback, not just 127.0.0.1. `localhost` and
+    `*.localhost` get explicit handling since they aren't IP literals.
+    The 0.0.0.0/:: wildcards are "unspecified", not loopback, and stay
+    LAN-seeking.
+    """
+    if host == "localhost" or host.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _host_wants_lan_url(host: str) -> bool:
-    return host not in _LOOPBACK_HOSTS
+    return not _host_is_loopback(host)
 
 
 def _parse_vite_local_url(line: str) -> str | None:
@@ -571,6 +590,13 @@ def _parse_vite_network_url(line: str) -> str | None:
     return match.group(1) if match else None
 
 
+# Sentinel pushed onto the hits queue by the reader thread when Vite's
+# stdout hits EOF (process exited, or otherwise closed the stream) — lets
+# the caller learn about that promptly instead of blocking for the full
+# readiness timeout.
+_STREAM_EOF = object()
+
+
 def _await_vite_ready_url(
     proc: subprocess.Popen,
     *,
@@ -585,11 +611,20 @@ def _await_vite_ready_url(
     one matching line (multiple interfaces), the first one wins and a note is
     printed saying so — callers get a single deterministic URL either way.
 
-    Returns None if nothing of the right kind is parsed before `timeout`
-    (Vite failed to start, logged an unexpected format, or never bound the
-    requested kind of address). Callers must not construct a guessed URL
-    from the requested host/port on that path, since nothing may be
-    listening there.
+    Returns None on failure and prints one of three distinct, actionable
+    warnings so a crashed Vite doesn't read the same as a slow one:
+
+    - the process exited early (exit code included);
+    - its output stream ended without matching a readiness line while the
+      process is still running (unexpected format);
+    - it genuinely never produced a matching line before `timeout`.
+
+    Every case includes the last `_STARTUP_TAIL_LINES` of captured output
+    (stdout merged with stderr — see `_launch_vite_dev`) so "check the Vite
+    output" is something the warning can actually show, not just say.
+
+    Callers must not construct a guessed URL from the requested host/port
+    on the failure path, since nothing may be listening there.
 
     A background thread keeps draining stdout for the life of the process so
     Vite never blocks on a full pipe buffer; once this function returns, that
@@ -597,25 +632,66 @@ def _await_vite_ready_url(
     daemon thread and needs no explicit join — it exits with the process.
     """
     parse = _parse_vite_network_url if _host_wants_lan_url(host) else _parse_vite_local_url
-    hits: queue.Queue[str] = queue.Queue()
+    hits: queue.Queue[object] = queue.Queue()
     done = threading.Event()
+    tail_lock = threading.Lock()
+    tail: collections.deque[str] = collections.deque(maxlen=_STARTUP_TAIL_LINES)
 
     def _pump() -> None:
         if proc.stdout is None:
+            hits.put(_STREAM_EOF)
             return
-        for line in proc.stdout:
-            if done.is_set():
-                continue
-            found = parse(line)
-            if found:
-                hits.put(found)
+        try:
+            for line in proc.stdout:
+                with tail_lock:
+                    tail.append(line.rstrip("\n"))
+                if done.is_set():
+                    continue
+                found = parse(line)
+                if found:
+                    hits.put(found)
+        finally:
+            hits.put(_STREAM_EOF)
 
     thread = threading.Thread(target=_pump, daemon=True)
     thread.start()
+
+    def _diagnostics() -> str:
+        with tail_lock:
+            lines = list(tail)
+        if not lines:
+            return " No output was captured."
+        return "\nCaptured Vite output (most recent lines):\n  " + "\n  ".join(lines)
+
     try:
         first = hits.get(timeout=timeout)
     except queue.Empty:
         done.set()
+        warn(
+            f"Timed out after {timeout:.0f}s waiting for Vite to report a bound "
+            f"address.{_diagnostics()}"
+        )
+        return None
+
+    if first is _STREAM_EOF:
+        done.set()
+        exit_code = proc.poll()
+        if exit_code is None:
+            # Stdout closed before the process was reaped — give it a brief
+            # grace window rather than reporting "still running" spuriously.
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                proc.wait(timeout=1.0)
+            exit_code = proc.poll()
+        if exit_code is not None:
+            warn(
+                f"Vite exited early (exit code {exit_code}) before reporting a "
+                f"bound address.{_diagnostics()}"
+            )
+        else:
+            warn(
+                "Vite's output stream ended before reporting a bound address, "
+                f"and the process is still running.{_diagnostics()}"
+            )
         return None
 
     matches = [first]
@@ -625,9 +701,12 @@ def _await_vite_ready_url(
         if remaining <= 0:
             break
         try:
-            matches.append(hits.get(timeout=remaining))
+            item = hits.get(timeout=remaining)
         except queue.Empty:
             break
+        if item is _STREAM_EOF:
+            continue
+        matches.append(item)
     done.set()
 
     if len(matches) > 1:
@@ -656,7 +735,10 @@ def _launch_vite_dev(
             cwd=str(frontend_dir),
             env=env,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            # Merged into stdout (not discarded) so a crash's diagnostics
+            # are part of the same captured stream _await_vite_ready_url
+            # already reads and can show on failure.
+            stderr=subprocess.STDOUT,
             text=True,
             start_new_session=True,
         )

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -10,10 +10,12 @@ import contextlib
 import json
 import math
 import os
+import queue
 import re
 import shutil
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -375,9 +377,10 @@ def _start_local(
     if dev_mode:
         # Dev mode: hot-reload Vite dev server + uvicorn side-by-side.
         # Vite proxies /api → uvicorn (configured in vite.config.mts).
-        frontend_proc = _launch_vite_dev(frontend_dir, frontend_port)
-        if frontend_proc:
-            print(f"Lion Studio UI (dev):  http://{host}:{frontend_port}")
+        launched = _launch_vite_dev(frontend_dir, frontend_port, host=host)
+        if launched:
+            frontend_proc, frontend_url = launched
+            print(f"Lion Studio UI (dev):  {frontend_url}")
         print(f"Lion Studio API:       http://{host}:{port}")
     else:
         # Production mode: build dist/ once, then uvicorn serves both UI and API
@@ -520,24 +523,91 @@ def _ensure_frontend_built(frontend_dir: Path) -> bool:
     return True
 
 
+def _vite_dev_argv(frontend_port: int, host: str) -> list[str]:
+    """Build the `npx vite` dev-server argv from a single host/port source of truth."""
+    return ["npx", "vite", "--port", str(frontend_port), "--host", host]
+
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+_VITE_LOCAL_URL_RE = re.compile(r"Local:\s+(https?://[^\s/]+)")
+
+
+def _parse_vite_local_url(line: str) -> str | None:
+    """Extract the bound URL from a Vite startup line like `➜  Local:   http://127.0.0.1:5174/`.
+
+    Vite colors this line with ANSI escapes whenever it thinks it has a color
+    terminal (npm/npx can force this even with a piped stdout), so the escapes
+    must be stripped before matching or the parse silently misses and the
+    caller falls back to the requested (possibly wrong) address.
+    """
+    plain = _ANSI_ESCAPE_RE.sub("", line)
+    match = _VITE_LOCAL_URL_RE.search(plain)
+    return match.group(1) if match else None
+
+
+def _await_vite_ready_url(
+    proc: subprocess.Popen,
+    *,
+    fallback_host: str,
+    fallback_port: int,
+    timeout: float = 10.0,
+) -> str:
+    """Read Vite's startup output for the address it actually bound.
+
+    Vite auto-increments past a taken port, so the requested port is not a
+    guarantee; falls back to the requested host/port if nothing is parsed
+    before `timeout` (Vite failed to start, or logged something unexpected).
+    """
+    result: queue.Queue[str | None] = queue.Queue(maxsize=1)
+
+    def _pump() -> None:
+        if proc.stdout is None:
+            result.put(None)
+            return
+        for line in proc.stdout:
+            parsed = _parse_vite_local_url(line)
+            if parsed:
+                result.put(parsed)
+                return
+        result.put(None)
+
+    thread = threading.Thread(target=_pump, daemon=True)
+    thread.start()
+    try:
+        found = result.get(timeout=timeout)
+    except queue.Empty:
+        found = None
+    return found or f"http://{fallback_host}:{fallback_port}"
+
+
 def _launch_vite_dev(
     frontend_dir: Path,
     frontend_port: int,
-) -> subprocess.Popen | None:
-    """Spawn `npx vite --port <N>` for hot-reload dev mode."""
+    *,
+    host: str = "127.0.0.1",
+) -> tuple[subprocess.Popen, str] | None:
+    """Spawn the Vite dev server and resolve the URL it actually bound to.
+
+    Returns the process paired with the real bound URL, so the caller never
+    prints/opens an address nothing is listening on.
+    """
     env = {**os.environ, "PORT": str(frontend_port)}
     try:
-        return subprocess.Popen(  # noqa: S603
-            ["npx", "vite", "--port", str(frontend_port)],  # noqa: S607
+        proc = subprocess.Popen(  # noqa: S603
+            _vite_dev_argv(frontend_port, host),  # noqa: S607
             cwd=str(frontend_dir),
             env=env,
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
+            text=True,
             start_new_session=True,
         )
     except FileNotFoundError:
         print("Warning: npx not found.", file=sys.stderr)
         return None
+
+    url = _await_vite_ready_url(proc, fallback_host=host, fallback_port=frontend_port)
+    return proc, url
 
 
 # --- `li schedule` — manage lionagi Studio schedules from the CLI ---

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -380,7 +381,13 @@ def _start_local(
         launched = _launch_vite_dev(frontend_dir, frontend_port, host=host)
         if launched:
             frontend_proc, frontend_url = launched
-            print(f"Lion Studio UI (dev):  {frontend_url}")
+            if frontend_url:
+                print(f"Lion Studio UI (dev):  {frontend_url}")
+            else:
+                warn(
+                    "Vite started but its bound address could not be "
+                    "determined — check the Vite output above."
+                )
         print(f"Lion Studio API:       http://{host}:{port}")
     else:
         # Production mode: build dist/ once, then uvicorn serves both UI and API
@@ -530,6 +537,19 @@ def _vite_dev_argv(frontend_port: int, host: str) -> list[str]:
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 _VITE_LOCAL_URL_RE = re.compile(r"Local:\s+(https?://[^\s/]+)")
+_VITE_NETWORK_URL_RE = re.compile(r"Network:\s+(https?://[^\s/]+)")
+_VITE_SETTLE_SECONDS = 0.15
+
+# Hosts for which Vite's `Local:` line is the address a caller can actually
+# reach. Anything else — a LAN IP or the 0.0.0.0/:: wildcard — binds extra
+# interfaces that only show up on Vite's `Network:` line; `Local:` stays a
+# loopback URL even when told to listen everywhere, so using it there would
+# print an address a LAN client cannot reach.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _host_wants_lan_url(host: str) -> bool:
+    return host not in _LOOPBACK_HOSTS
 
 
 def _parse_vite_local_url(line: str) -> str | None:
@@ -537,47 +557,83 @@ def _parse_vite_local_url(line: str) -> str | None:
 
     Vite colors this line with ANSI escapes whenever it thinks it has a color
     terminal (npm/npx can force this even with a piped stdout), so the escapes
-    must be stripped before matching or the parse silently misses and the
-    caller falls back to the requested (possibly wrong) address.
+    must be stripped before matching or the parse silently misses.
     """
     plain = _ANSI_ESCAPE_RE.sub("", line)
     match = _VITE_LOCAL_URL_RE.search(plain)
     return match.group(1) if match else None
 
 
+def _parse_vite_network_url(line: str) -> str | None:
+    """Extract the LAN address from a Vite startup line like `➜  Network:   http://192.168.1.5:5174/`."""
+    plain = _ANSI_ESCAPE_RE.sub("", line)
+    match = _VITE_NETWORK_URL_RE.search(plain)
+    return match.group(1) if match else None
+
+
 def _await_vite_ready_url(
     proc: subprocess.Popen,
     *,
-    fallback_host: str,
-    fallback_port: int,
+    host: str,
     timeout: float = 10.0,
-) -> str:
-    """Read Vite's startup output for the address it actually bound.
+) -> str | None:
+    """Read Vite's startup banner for the address it actually bound.
 
-    Vite auto-increments past a taken port, so the requested port is not a
-    guarantee; falls back to the requested host/port if nothing is parsed
-    before `timeout` (Vite failed to start, or logged something unexpected).
+    Loopback hosts read the `Local:` line. Non-loopback hosts (a LAN IP, or
+    the `0.0.0.0`/`::` wildcard) read `Network:` instead, since that is the
+    address reachable from outside this machine. When Vite reports more than
+    one matching line (multiple interfaces), the first one wins and a note is
+    printed saying so — callers get a single deterministic URL either way.
+
+    Returns None if nothing of the right kind is parsed before `timeout`
+    (Vite failed to start, logged an unexpected format, or never bound the
+    requested kind of address). Callers must not construct a guessed URL
+    from the requested host/port on that path, since nothing may be
+    listening there.
+
+    A background thread keeps draining stdout for the life of the process so
+    Vite never blocks on a full pipe buffer; once this function returns, that
+    thread stops parsing (the `done` flag below) and only drains. It is a
+    daemon thread and needs no explicit join — it exits with the process.
     """
-    result: queue.Queue[str | None] = queue.Queue(maxsize=1)
+    parse = _parse_vite_network_url if _host_wants_lan_url(host) else _parse_vite_local_url
+    hits: queue.Queue[str] = queue.Queue()
+    done = threading.Event()
 
     def _pump() -> None:
         if proc.stdout is None:
-            result.put(None)
             return
         for line in proc.stdout:
-            parsed = _parse_vite_local_url(line)
-            if parsed:
-                result.put(parsed)
-                return
-        result.put(None)
+            if done.is_set():
+                continue
+            found = parse(line)
+            if found:
+                hits.put(found)
 
     thread = threading.Thread(target=_pump, daemon=True)
     thread.start()
     try:
-        found = result.get(timeout=timeout)
+        first = hits.get(timeout=timeout)
     except queue.Empty:
-        found = None
-    return found or f"http://{fallback_host}:{fallback_port}"
+        done.set()
+        return None
+
+    matches = [first]
+    deadline = time.monotonic() + _VITE_SETTLE_SECONDS
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            matches.append(hits.get(timeout=remaining))
+        except queue.Empty:
+            break
+    done.set()
+
+    if len(matches) > 1:
+        kind = "Network" if _host_wants_lan_url(host) else "Local"
+        warn(f"Vite reported {len(matches)} {kind}: addresses; using the first ({matches[0]}).")
+    return matches[0]
 
 
 def _launch_vite_dev(
@@ -585,11 +641,13 @@ def _launch_vite_dev(
     frontend_port: int,
     *,
     host: str = "127.0.0.1",
-) -> tuple[subprocess.Popen, str] | None:
+) -> tuple[subprocess.Popen, str | None] | None:
     """Spawn the Vite dev server and resolve the URL it actually bound to.
 
-    Returns the process paired with the real bound URL, so the caller never
-    prints/opens an address nothing is listening on.
+    Returns the process paired with the real bound URL — or paired with None
+    when Vite's bound address could not be determined, so the caller never
+    prints/opens a guessed address nothing may be listening on. Returns None
+    only when the process itself failed to spawn.
     """
     env = {**os.environ, "PORT": str(frontend_port)}
     try:
@@ -606,7 +664,7 @@ def _launch_vite_dev(
         print("Warning: npx not found.", file=sys.stderr)
         return None
 
-    url = _await_vite_ready_url(proc, fallback_host=host, fallback_port=frontend_port)
+    url = _await_vite_ready_url(proc, host=host)
     return proc, url
 
 

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -627,3 +627,133 @@ def test_ensure_frontend_built_installs_when_vite_missing(tmp_path, monkeypatch)
 
     assert result is True
     assert len(install_calls) == 1, "npm install must be called once"
+
+
+def test_vite_dev_argv_binds_the_same_host_used_for_the_printed_url():
+    """The spawn argv and the printed URL must come from one host/port source of truth."""
+    from lionagi.studio.cli import _vite_dev_argv
+
+    argv = _vite_dev_argv(5174, "127.0.0.1")
+
+    assert argv == ["npx", "vite", "--port", "5174", "--host", "127.0.0.1"]
+
+
+def test_vite_dev_argv_uses_the_given_host_not_a_hardcoded_default():
+    from lionagi.studio.cli import _vite_dev_argv
+
+    argv = _vite_dev_argv(3000, "0.0.0.0")
+
+    assert "--host" in argv
+    assert argv[argv.index("--host") + 1] == "0.0.0.0"
+
+
+def test_parse_vite_local_url_extracts_bound_address():
+    from lionagi.studio.cli import _parse_vite_local_url
+
+    line = "  ➜  Local:   http://127.0.0.1:5174/\n"
+
+    assert _parse_vite_local_url(line) == "http://127.0.0.1:5174"
+
+
+def test_parse_vite_local_url_reflects_an_auto_incremented_port():
+    """Vite bumps to the next free port when the requested one is taken; the
+    parsed URL must reflect that real port, not the one that was requested."""
+    from lionagi.studio.cli import _parse_vite_local_url
+
+    line = "  ➜  Local:   http://127.0.0.1:5175/\n"
+
+    assert _parse_vite_local_url(line) == "http://127.0.0.1:5175"
+
+
+def test_parse_vite_local_url_ignores_unrelated_lines():
+    from lionagi.studio.cli import _parse_vite_local_url
+
+    assert _parse_vite_local_url("  VITE v5.4.10  ready in 328 ms\n") is None
+    assert _parse_vite_local_url("  ➜  Network: use --host to expose\n") is None
+    assert _parse_vite_local_url("") is None
+
+
+def test_parse_vite_local_url_strips_ansi_color_codes():
+    """npx/Vite can color this line even with a piped (non-TTY) stdout; the
+    escape codes sit right around `Local:` and the URL and must not defeat
+    the match, or every colored run silently falls back to a guessed URL."""
+    from lionagi.studio.cli import _parse_vite_local_url
+
+    line = "  \x1b[32m➜\x1b[39m  \x1b[1mLocal\x1b[22m:   \x1b[36mhttp://127.0.0.1:5174/\x1b[39m\n"
+
+    assert _parse_vite_local_url(line) == "http://127.0.0.1:5174"
+
+
+def test_await_vite_ready_url_returns_the_parsed_startup_address():
+    from unittest.mock import MagicMock
+
+    from lionagi.studio.cli import _await_vite_ready_url
+
+    proc = MagicMock()
+    proc.stdout = iter(
+        [
+            "  VITE v5.4.10  ready in 328 ms\n",
+            "  ➜  Local:   http://127.0.0.1:5175/\n",
+        ]
+    )
+
+    url = _await_vite_ready_url(proc, fallback_host="127.0.0.1", fallback_port=3000, timeout=5.0)
+
+    assert url == "http://127.0.0.1:5175"
+
+
+def test_await_vite_ready_url_falls_back_when_nothing_matches():
+    """If Vite never logs a Local: line before the timeout (crash, unexpected
+    output format), fall back to the requested host/port instead of hanging."""
+    from unittest.mock import MagicMock
+
+    from lionagi.studio.cli import _await_vite_ready_url
+
+    proc = MagicMock()
+    proc.stdout = iter(["  some unrelated output\n"])
+
+    url = _await_vite_ready_url(proc, fallback_host="127.0.0.1", fallback_port=3000, timeout=1.0)
+
+    assert url == "http://127.0.0.1:3000"
+
+
+def test_launch_vite_dev_passes_host_through_to_argv_and_returns_the_bound_url(
+    tmp_path, monkeypatch
+):
+    """End-to-end (mocked Popen): the host given to _launch_vite_dev reaches the
+    spawn argv, and the returned URL is the one parsed from Vite's own output."""
+    import lionagi.studio.cli as studio_mod
+
+    captured_argv = {}
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = iter(["  ➜  Local:   http://0.0.0.0:4001/\n"])
+
+    def fake_popen(argv, **kwargs):
+        captured_argv["argv"] = argv
+        return FakeProc()
+
+    monkeypatch.setattr(studio_mod.subprocess, "Popen", fake_popen)
+
+    result = studio_mod._launch_vite_dev(tmp_path, 4000, host="0.0.0.0")
+
+    assert result is not None
+    proc, url = result
+    assert isinstance(proc, FakeProc)
+    assert captured_argv["argv"] == ["npx", "vite", "--port", "4000", "--host", "0.0.0.0"]
+    assert url == "http://0.0.0.0:4001"
+
+
+def test_launch_vite_dev_warns_and_returns_none_when_npx_missing(tmp_path, monkeypatch, capsys):
+    import lionagi.studio.cli as studio_mod
+
+    def fake_popen(argv, **kwargs):
+        raise FileNotFoundError("npx not found")
+
+    monkeypatch.setattr(studio_mod.subprocess, "Popen", fake_popen)
+
+    result = studio_mod._launch_vite_dev(tmp_path, 4000, host="127.0.0.1")
+
+    assert result is None
+    assert "npx not found" in capsys.readouterr().err

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -10,6 +10,8 @@ import logging
 import os
 import socket
 import subprocess
+import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -894,3 +896,72 @@ def test_launch_vite_dev_selects_a_lan_url_for_the_wildcard_host():
         assert host not in ("127.0.0.1", "localhost")
     finally:
         _stop(proc)
+
+
+def test_await_vite_ready_url_returns_fast_and_reports_exit_code_on_early_exit(caplog):
+    """A child that exits immediately (crash, missing entry point, bad cwd)
+    must not stall the readiness wait for the full timeout — the reader
+    thread learns about EOF promptly, and the caller reports the exit code
+    plus captured output instead of a generic "check the output" message
+    with nothing to check."""
+    from lionagi.studio.cli import _await_vite_ready_url
+
+    proc = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", "print('starting up'); import sys; sys.exit(3)"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    start = time.monotonic()
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        url = _await_vite_ready_url(proc, host="127.0.0.1", timeout=10.0)
+    elapsed = time.monotonic() - start
+    proc.wait(timeout=5)
+
+    assert url is None
+    assert elapsed < 2.0, f"took {elapsed:.2f}s — must not stall for the full timeout"
+    messages = [r.message for r in caplog.records]
+    assert any("exit code 3" in m for m in messages), messages
+    assert any("starting up" in m for m in messages), messages
+
+
+def test_host_is_loopback_classifies_numeric_and_named_loopback_hosts():
+    """The whole 127.0.0.0/8 block is loopback, not just 127.0.0.1, and so
+    is any ::1 form — classification must be semantic (via `ipaddress`),
+    not an exact-string allowlist."""
+    from lionagi.studio.cli import _host_is_loopback
+
+    assert _host_is_loopback("127.0.0.1") is True
+    assert _host_is_loopback("127.0.0.2") is True
+    assert _host_is_loopback("::1") is True
+    assert _host_is_loopback("localhost") is True
+
+
+def test_host_is_loopback_rejects_wildcard_lan_and_hostname():
+    from lionagi.studio.cli import _host_is_loopback
+
+    assert _host_is_loopback("0.0.0.0") is False
+    assert _host_is_loopback("::") is False
+    assert _host_is_loopback("192.168.1.5") is False
+    assert _host_is_loopback("my-machine.example.com") is False
+
+
+def test_launch_vite_dev_selects_the_local_url_for_a_non_default_loopback_host(
+    tmp_path, monkeypatch
+):
+    """127.0.0.2 is a valid loopback address but not the exact string
+    "127.0.0.1"; it must still route to the Local: parser and resolve to
+    the address Vite actually printed."""
+    import lionagi.studio.cli as studio_mod
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = iter(["  ➜  Local:   http://127.0.0.2:4001/\n"])
+
+    monkeypatch.setattr(studio_mod.subprocess, "Popen", lambda argv, **kwargs: FakeProc())
+
+    result = studio_mod._launch_vite_dev(tmp_path, 4000, host="127.0.0.2")
+
+    assert result is not None
+    proc, url = result
+    assert url == "http://127.0.0.2:4001"

--- a/tests/cli/test_studio_cli.py
+++ b/tests/cli/test_studio_cli.py
@@ -6,8 +6,41 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
+import socket
+import subprocess
+from pathlib import Path
 from unittest.mock import patch
+
+import pytest
+
+# Real Vite fixture used by the binding/host-selection tests below — these
+# prove claims about actual Vite startup output rather than a hand-built
+# fixture, which round-1 review found could hide a real parsing defect.
+_FRONTEND_DIR = Path(__file__).resolve().parents[2] / "apps" / "studio" / "frontend"
+_VITE_BIN = _FRONTEND_DIR / "node_modules" / ".bin" / "vite"
+requires_real_vite = pytest.mark.skipif(
+    not _VITE_BIN.exists(),
+    reason="apps/studio/frontend/node_modules not installed; run `npm install` there first",
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _stop(proc):
+    if proc is None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
 
 
 @contextlib.contextmanager
@@ -697,14 +730,15 @@ def test_await_vite_ready_url_returns_the_parsed_startup_address():
         ]
     )
 
-    url = _await_vite_ready_url(proc, fallback_host="127.0.0.1", fallback_port=3000, timeout=5.0)
+    url = _await_vite_ready_url(proc, host="127.0.0.1", timeout=5.0)
 
     assert url == "http://127.0.0.1:5175"
 
 
-def test_await_vite_ready_url_falls_back_when_nothing_matches():
+def test_await_vite_ready_url_returns_none_when_nothing_matches():
     """If Vite never logs a Local: line before the timeout (crash, unexpected
-    output format), fall back to the requested host/port instead of hanging."""
+    output format), report failure honestly instead of guessing a URL nothing
+    may be listening on."""
     from unittest.mock import MagicMock
 
     from lionagi.studio.cli import _await_vite_ready_url
@@ -712,23 +746,56 @@ def test_await_vite_ready_url_falls_back_when_nothing_matches():
     proc = MagicMock()
     proc.stdout = iter(["  some unrelated output\n"])
 
-    url = _await_vite_ready_url(proc, fallback_host="127.0.0.1", fallback_port=3000, timeout=1.0)
+    url = _await_vite_ready_url(proc, host="127.0.0.1", timeout=1.0)
 
-    assert url == "http://127.0.0.1:3000"
+    assert url is None
+
+
+def test_await_vite_ready_url_uses_the_first_of_multiple_network_lines(caplog):
+    """Vite can print more than one Network: line (multiple interfaces);
+    selection must be deterministic (the first one) and the caller must be
+    told a choice was made rather than silently picking one."""
+    from unittest.mock import MagicMock
+
+    from lionagi.studio.cli import _await_vite_ready_url
+
+    proc = MagicMock()
+    proc.stdout = iter(
+        [
+            "  ➜  Local:   http://localhost:5175/\n",
+            "  ➜  Network: http://192.168.1.10:5175/\n",
+            "  ➜  Network: http://100.64.0.5:5175/\n",
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="lionagi.cli.warn"):
+        url = _await_vite_ready_url(proc, host="0.0.0.0", timeout=5.0)
+
+    assert url == "http://192.168.1.10:5175"
+    assert any("2 Network" in r.message for r in caplog.records)
 
 
 def test_launch_vite_dev_passes_host_through_to_argv_and_returns_the_bound_url(
     tmp_path, monkeypatch
 ):
     """End-to-end (mocked Popen): the host given to _launch_vite_dev reaches the
-    spawn argv, and the returned URL is the one parsed from Vite's own output."""
+    spawn argv, and the returned URL is the one parsed from Vite's own output.
+
+    Wiring only — a non-loopback host selects `Network:`, not `Local:` (see
+    the real-Vite tests for that host-selection claim proved against actual
+    Vite output rather than a hand-built fixture)."""
     import lionagi.studio.cli as studio_mod
 
     captured_argv = {}
 
     class FakeProc:
         def __init__(self):
-            self.stdout = iter(["  ➜  Local:   http://0.0.0.0:4001/\n"])
+            self.stdout = iter(
+                [
+                    "  ➜  Local:   http://localhost:4001/\n",
+                    "  ➜  Network: http://192.168.1.50:4001/\n",
+                ]
+            )
 
     def fake_popen(argv, **kwargs):
         captured_argv["argv"] = argv
@@ -742,7 +809,7 @@ def test_launch_vite_dev_passes_host_through_to_argv_and_returns_the_bound_url(
     proc, url = result
     assert isinstance(proc, FakeProc)
     assert captured_argv["argv"] == ["npx", "vite", "--port", "4000", "--host", "0.0.0.0"]
-    assert url == "http://0.0.0.0:4001"
+    assert url == "http://192.168.1.50:4001"
 
 
 def test_launch_vite_dev_warns_and_returns_none_when_npx_missing(tmp_path, monkeypatch, capsys):
@@ -757,3 +824,73 @@ def test_launch_vite_dev_warns_and_returns_none_when_npx_missing(tmp_path, monke
 
     assert result is None
     assert "npx not found" in capsys.readouterr().err
+
+
+@requires_real_vite
+@pytest.mark.integration
+@pytest.mark.slow
+def test_launch_vite_dev_resolves_the_incremented_port_on_a_real_collision():
+    """When the requested port is already bound, real Vite auto-increments to
+    the next free one; the returned URL must carry that real port, not the
+    one that was requested (a hand-built fixture can't prove auto-increment
+    actually happens — this starts a real process against an occupied port)."""
+    import lionagi.studio.cli as studio_mod
+
+    requested_port = _free_port()
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    blocker.bind(("127.0.0.1", requested_port))
+    blocker.listen(1)
+    proc = None
+    try:
+        result = studio_mod._launch_vite_dev(_FRONTEND_DIR, requested_port, host="127.0.0.1")
+        assert result is not None
+        proc, url = result
+        assert url is not None
+        bound_port = int(url.rsplit(":", 1)[1])
+        assert bound_port > requested_port
+    finally:
+        blocker.close()
+        _stop(proc)
+
+
+@requires_real_vite
+@pytest.mark.integration
+@pytest.mark.slow
+def test_launch_vite_dev_selects_the_local_url_for_a_loopback_host():
+    """Real Vite launched with --host 127.0.0.1 only ever prints a Local:
+    line; the loopback URL must be selected."""
+    import lionagi.studio.cli as studio_mod
+
+    proc = None
+    try:
+        result = studio_mod._launch_vite_dev(_FRONTEND_DIR, _free_port(), host="127.0.0.1")
+        assert result is not None
+        proc, url = result
+        assert url is not None
+        host = url.split("://", 1)[1].rsplit(":", 1)[0]
+        assert host in ("127.0.0.1", "localhost")
+    finally:
+        _stop(proc)
+
+
+@requires_real_vite
+@pytest.mark.integration
+@pytest.mark.slow
+def test_launch_vite_dev_selects_a_lan_url_for_the_wildcard_host():
+    """Real Vite launched with --host 0.0.0.0 prints both a loopback Local:
+    line and one or more LAN Network: lines; the selected URL must be a
+    Network: address, not the loopback Local: line (r1 finding: LAN binding
+    was silently reduced to loopback because only Local: was ever parsed)."""
+    import lionagi.studio.cli as studio_mod
+
+    proc = None
+    try:
+        result = studio_mod._launch_vite_dev(_FRONTEND_DIR, _free_port(), host="0.0.0.0")
+        assert result is not None
+        proc, url = result
+        assert url is not None
+        host = url.split("://", 1)[1].rsplit(":", 1)[0]
+        assert host not in ("127.0.0.1", "localhost")
+    finally:
+        _stop(proc)


### PR DESCRIPTION
`li studio dev` now passes the host explicitly to Vite and resolves the real bound address by parsing Vite's own startup line (ANSI-stripped), so the printed and opened URL reflects the actual port even when Vite auto-increments past a taken one.

Closes #2772