### PR TITLE
fix(studio): definitions save route validates agent role and mode like the agents API

### DIFF
--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -19,7 +19,7 @@ from lionagi.state.engine import mask_credentials
 
 from ..registry import studio_route
 from ._path_safety import validate_name_component
-from .agents import _is_protected_system
+from .agents import _canonicalize_casts, _is_protected_system
 
 _log = logging.getLogger("lionagi.studio")
 
@@ -285,8 +285,21 @@ async def save_definition(
     name: str,
     content: str,
     message: str | None = None,
+    *,
+    validate: bool = True,
 ) -> dict[str, Any]:
-    """Persist a definition version: DB write first, then disk (ADR-0077 D2); per-(kind, name) lock serialises concurrent saves."""
+    """Persist a definition version: DB write first, then disk (ADR-0077 D2); per-(kind, name) lock serialises concurrent saves.
+
+    ``validate`` gates the cast role/mode check below, not the system-agent
+    guard (which always runs). It defaults on for the direct save route --
+    the door a client posts arbitrary content through, and the one the agents
+    API's role/mode validation must also bind on (see ``_canonicalize_casts``
+    in ``agents.py``). ``rollback_definition`` and ``snapshot_current`` pass
+    ``validate=False``: they replay content that was already accepted once
+    (a stored version, a pre-existing disk file), and a validator tightened
+    after that content landed would make an old version un-rollback-able and
+    an existing file un-importable.
+    """
     # Validate at the service boundary — reject traversal sequences, path
     # separators, NUL, and glob metacharacters.
     validate_name_component(kind, label="kind")
@@ -295,6 +308,12 @@ async def save_definition(
     base = KIND_DIRS.get(kind)
     if not base:
         raise ValueError(f"Unknown kind: {kind}")
+
+    from lionagi.libs.frontmatter import parse_frontmatter as _parse_fm
+
+    if kind == "agent" and validate:
+        new_fm, _ = _parse_fm(content)
+        _canonicalize_casts(dict(new_fm))
 
     from lionagi.state.db import StateDB
 
@@ -310,8 +329,6 @@ async def save_definition(
             # hold here too, or it's a bypass. Read straight off disk_file rather than
             # calling into agents.py, since that module resolves its own _AGENTS_ROOT
             # independently of this module's (test-patchable) AGENTS_DIR/KIND_DIRS.
-            from lionagi.libs.frontmatter import parse_frontmatter as _parse_fm
-
             existing_text = await anyio.to_thread.run_sync(disk_file.read_text)
             existing_fm, _ = _parse_fm(existing_text)
             if _is_protected_system(existing_fm):
@@ -377,6 +394,7 @@ async def rollback_definition(kind: str, name: str, target_version: int) -> dict
         name,
         old["content"],
         message=f"rollback to v{target_version}",
+        validate=False,
     )
 
     return {
@@ -407,7 +425,9 @@ async def snapshot_current(kind: str | None = None) -> int:
             if latest and latest["content"] == content:
                 continue
 
-        await save_definition(d["kind"], d["name"], content, message="snapshot from disk")
+        await save_definition(
+            d["kind"], d["name"], content, message="snapshot from disk", validate=False
+        )
         count += 1
 
     return count

--- a/tests/apps_studio_server/test_agents_protections.py
+++ b/tests/apps_studio_server/test_agents_protections.py
@@ -571,3 +571,81 @@ def test_definitions_save_route_allows_ordinary_agent(tmp_path, monkeypatch):
     r = client.post("/api/definitions/agent/useragent", json={"content": "# updated"})
     assert r.status_code == 200, r.text
     assert (agents_dir / "useragent.md").read_text().strip() == "# updated"
+
+
+# ---------------------------------------------------------------------------
+# The definitions save route also has to run the same cast role/mode
+# validation POST/PUT /api/agents/{name} apply -- otherwise a payload the
+# agents API rejects can still land on disk through the raw markdown door.
+# ---------------------------------------------------------------------------
+
+
+def test_definitions_save_route_rejects_unknown_role(tmp_path, monkeypatch):
+    client, agents_dir = _make_definitions_client(tmp_path, monkeypatch)
+
+    content = (
+        "---\nprovider: claude\nmodel: claude-sonnet-4-6\nrole: not-a-real-role\n---\n\nBody.\n"
+    )
+    r = client.post("/api/definitions/agent/bogus-role", json={"content": content})
+
+    assert r.status_code == 422, r.text
+    assert not (agents_dir / "bogus-role.md").exists()
+
+
+def test_definitions_save_route_rejects_unknown_mode(tmp_path, monkeypatch):
+    client, agents_dir = _make_definitions_client(tmp_path, monkeypatch)
+
+    content = (
+        "---\nprovider: claude\nmodel: claude-sonnet-4-6\nmode: not-a-real-mode\n---\n\nBody.\n"
+    )
+    r = client.post("/api/definitions/agent/bogus-mode", json={"content": content})
+
+    assert r.status_code == 422, r.text
+    assert not (agents_dir / "bogus-mode.md").exists()
+
+
+def test_definitions_save_route_rejects_same_payload_agents_api_rejects(tmp_path, monkeypatch):
+    """The exact role value POST /api/agents/{name} rejects must also be
+    rejected via the definitions route, with the same error class (422) --
+    otherwise the definitions door is a bypass for the agents door's guard."""
+    client, _ = _make_definitions_client(tmp_path, monkeypatch)
+
+    r_agents = client.post(
+        "/api/agents/via-agents-api",
+        json={"provider": "claude", "model": "claude-sonnet-4-6", "role": "not-a-real-role"},
+    )
+    assert r_agents.status_code == 422, r_agents.text
+
+    content = (
+        "---\nprovider: claude\nmodel: claude-sonnet-4-6\nrole: not-a-real-role\n---\n\nBody.\n"
+    )
+    r_defs = client.post("/api/definitions/agent/via-definitions-api", json={"content": content})
+    assert r_defs.status_code == 422, r_defs.text
+
+
+def test_definitions_save_route_allows_valid_role_and_mode(tmp_path, monkeypatch):
+    """A payload that would be accepted by the agents API still saves through
+    the definitions route -- the new guard must not reject valid casts."""
+    from lionagi.casts.pattern import list_modes, list_roles
+
+    client, agents_dir = _make_definitions_client(tmp_path, monkeypatch)
+    role = list_roles()[0]
+    mode = list_modes()[0]
+
+    content = f"---\nprovider: claude\nmodel: claude-sonnet-4-6\nrole: {role}\nmode: {mode}\n---\n\nBody.\n"
+    r = client.post("/api/definitions/agent/valid-cast", json={"content": content})
+
+    assert r.status_code == 200, r.text
+    assert (agents_dir / "valid-cast.md").read_text() == content
+
+
+def test_definitions_save_route_ignores_validation_for_non_agent_kind(tmp_path, monkeypatch):
+    """role/mode validation is agent-specific; a playbook save must not be
+    affected even though its content also happens to mention 'role'."""
+    client, _ = _make_definitions_client(tmp_path, monkeypatch)
+
+    r = client.post(
+        "/api/definitions/playbook/some-playbook",
+        json={"content": "role: not-a-real-role\nsteps: []\n"},
+    )
+    assert r.status_code == 200, r.text

--- a/tests/apps_studio_server/test_definitions.py
+++ b/tests/apps_studio_server/test_definitions.py
@@ -146,6 +146,75 @@ async def test_save_new_playbook_definition_lands_in_playbook_catalog(tmp_path, 
     assert any(entry["name"] == "new-one" for entry in catalog)
 
 
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_definition_rejects_unknown_role_by_default(tmp_path, monkeypatch):
+    """The direct save_definition() entry point validates role/mode by default --
+    the same guard the /definitions/agent/{name} route relies on."""
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    agents_dir = fake_home / "agents"
+    agents_dir.mkdir()
+    playbooks_dir = fake_home / "playbooks"
+    playbooks_dir.mkdir()
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
+    monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
+
+    with pytest.raises(ValueError, match="Unknown cast role"):
+        await defs_mod.save_definition(
+            "agent",
+            "bogus",
+            "---\nrole: not-a-real-role\n---\n\nBody.\n",
+        )
+    assert not (agents_dir / "bogus.md").exists()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_rollback_definition_succeeds_for_already_invalid_historical_version(
+    tmp_path, monkeypatch
+):
+    """A version saved before cast validation existed (or saved with
+    validate=False, e.g. by snapshot_current) must still be reachable by
+    rollback -- the validator added to guard the direct save door must not
+    make an already-malformed historical version un-restorable."""
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    agents_dir = fake_home / "agents"
+    agents_dir.mkdir()
+    playbooks_dir = fake_home / "playbooks"
+    playbooks_dir.mkdir()
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    monkeypatch.setattr(defs_mod, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(defs_mod, "PLAYBOOKS_DIR", playbooks_dir)
+    monkeypatch.setattr(defs_mod, "KIND_DIRS", {"agent": agents_dir, "playbook": playbooks_dir})
+
+    invalid_content = "---\nrole: not-a-real-role\n---\n\nOld body.\n"
+    v1 = await defs_mod.save_definition("agent", "historical", invalid_content, validate=False)
+    assert v1["version"] == 1
+
+    await defs_mod.save_definition("agent", "historical", "# valid v2 body\n")
+
+    result = await defs_mod.rollback_definition("agent", "historical", target_version=1)
+
+    assert result is not None
+    assert agents_dir.joinpath("historical.md").read_text() == invalid_content
+
+
 @pytest.mark.asyncio
 async def test_save_definition_unknown_kind_raises(tmp_path, monkeypatch):
     """save_definition() with an unknown kind must raise ValueError (not return success)."""


### PR DESCRIPTION
Saves through the definitions API now run the same cast role/mode validation the agents API applies, so a payload rejected at one door cannot enter through the other. Posted content is still stored verbatim (the validator only raises); rollback and snapshot replay accepted content with validation bypassed so history operations cannot be blocked by a validator added after that content landed.

Closes #2774