### PR TITLE
fix(state): backfill invocation linkage on a resumed session

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -1229,6 +1229,14 @@ async def setup_agent_persist(
 
             existing_msg_ids = set(await db.get_progression(branch_prog_id))
 
+            if invocation_id and existing_session.get("invocation_id") != invocation_id:
+                # A resume reopens this row rather than inserting a new one,
+                # so the ON CONFLICT DO NOTHING branch below never runs for
+                # it and this leg's invocation_id would otherwise be
+                # dropped. Backfill the same linkage a brand-new session
+                # gets at insert time.
+                await db.attach_session_invocation(session_id, invocation_id)
+
             # The adopted row's drain declaration is rewritten by the reopen
             # above, in the same statement that installs this leg's process
             # markers. Nothing to do here for a row that was terminal.

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2296,15 +2296,25 @@ class StateDB:
         one that finds the link already current) does not double-count.
         Repointing away from a prior invocation also decrements that
         invocation's count, so it stops claiming a session it no longer has.
+
+        On PostgreSQL the prior-invocation read takes ``FOR UPDATE``: SQLite's
+        ``_tx()`` already serializes writers with its own write lock plus
+        ``BEGIN IMMEDIATE``, so a second attach cannot even start its SELECT
+        until the first has committed. PostgreSQL at READ COMMITTED has no
+        such serialization — a second concurrent attach could read the same
+        prior invocation_id a first attach is about to repoint away from,
+        then decrement that stale value after its own UPDATE's WHERE clause
+        re-evaluates against the row the first attach already moved.
+        Locking the row before reading it forces the second attach to block
+        until the first commits, so it re-reads the invocation the first
+        attach actually left the session on.
         """
         now = time.time()
         async with self._tx() as conn:
-            prev_row = (
-                await conn.execute(
-                    text("SELECT invocation_id FROM sessions WHERE id = :sid"),
-                    {"sid": session_id},
-                )
-            ).first()
+            prev_query = "SELECT invocation_id FROM sessions WHERE id = :sid"
+            if self.dialect == "postgresql":
+                prev_query += " FOR UPDATE"
+            prev_row = (await conn.execute(text(prev_query), {"sid": session_id})).first()
             prev_invocation_id = prev_row[0] if prev_row else None
 
             result = await conn.execute(

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2269,6 +2269,35 @@ class StateDB:
                 session.get("project_source") or "git_remote",
             )
 
+    async def attach_session_invocation(self, session_id: str, invocation_id: str) -> None:
+        """Point an existing session row at *invocation_id*.
+
+        ``create_session``'s ``INSERT ... ON CONFLICT (id) DO NOTHING`` only
+        links a session to its invocation at the moment the row is first
+        inserted; a resume reopens that same row instead of inserting a new
+        one, so its invocation_id would otherwise never be recorded. This is
+        the same sessions.invocation_id + invocations.session_count linkage
+        applied to a row that already exists, guarded so a repeat call (or
+        one that finds the link already current) does not double-count.
+        """
+        now = time.time()
+        async with self._tx() as conn:
+            result = await conn.execute(
+                text(
+                    "UPDATE sessions SET invocation_id = :inv_id, updated_at = :now "
+                    "WHERE id = :sid AND (invocation_id IS NULL OR invocation_id != :inv_id)"
+                ),
+                {"inv_id": invocation_id, "now": now, "sid": session_id},
+            )
+            if result.rowcount:
+                await conn.execute(
+                    text(
+                        "UPDATE invocations SET session_count = session_count + 1, "
+                        "updated_at = :now WHERE id = :inv_id"
+                    ),
+                    {"now": now, "inv_id": invocation_id},
+                )
+
     async def get_session(self, session_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:
             row = (

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2269,6 +2269,21 @@ class StateDB:
                 session.get("project_source") or "git_remote",
             )
 
+    @staticmethod
+    def _decrement_invocation_session_count_sql(dialect: str) -> str:
+        # SQLite MAX(a,b) is a scalar greatest; Postgres MAX() is an aggregate,
+        # so the 2-arg scalar form must be GREATEST() there. Floor at zero so
+        # a stale or out-of-order decrement never reports a negative count.
+        if dialect == "sqlite":
+            return (
+                "UPDATE invocations SET session_count = MAX(session_count - 1, 0), "
+                "updated_at = :now WHERE id = :inv_id"
+            )
+        return (
+            "UPDATE invocations SET session_count = GREATEST(session_count - 1, 0), "
+            "updated_at = :now WHERE id = :inv_id"
+        )
+
     async def attach_session_invocation(self, session_id: str, invocation_id: str) -> None:
         """Point an existing session row at *invocation_id*.
 
@@ -2279,9 +2294,19 @@ class StateDB:
         the same sessions.invocation_id + invocations.session_count linkage
         applied to a row that already exists, guarded so a repeat call (or
         one that finds the link already current) does not double-count.
+        Repointing away from a prior invocation also decrements that
+        invocation's count, so it stops claiming a session it no longer has.
         """
         now = time.time()
         async with self._tx() as conn:
+            prev_row = (
+                await conn.execute(
+                    text("SELECT invocation_id FROM sessions WHERE id = :sid"),
+                    {"sid": session_id},
+                )
+            ).first()
+            prev_invocation_id = prev_row[0] if prev_row else None
+
             result = await conn.execute(
                 text(
                     "UPDATE sessions SET invocation_id = :inv_id, updated_at = :now "
@@ -2290,6 +2315,11 @@ class StateDB:
                 {"inv_id": invocation_id, "now": now, "sid": session_id},
             )
             if result.rowcount:
+                if prev_invocation_id and prev_invocation_id != invocation_id:
+                    await conn.execute(
+                        text(self._decrement_invocation_session_count_sql(self.dialect)),
+                        {"now": now, "inv_id": prev_invocation_id},
+                    )
                 await conn.execute(
                     text(
                         "UPDATE invocations SET session_count = session_count + 1, "

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -352,6 +352,12 @@ async def test_a_resumed_leg_links_its_session_to_its_own_invocation(temp_db_pat
         sessions = await db.list_sessions_for_invocation("resume-inv")
         assert [s["id"] for s in sessions] == [second["session_id"]]
 
+        # The invocation the session left behind must stop claiming it, or
+        # the lifecycle reaper's session_count == 0 check never fires for it.
+        first_invocation = await db.get_invocation("first-inv")
+        assert first_invocation["session_count"] == 0
+        assert await db.list_sessions_for_invocation("first-inv") == []
+
 
 @pytest.mark.asyncio
 async def test_a_resume_whose_session_is_pruned_mid_setup_still_records_itself(

--- a/tests/cli/test_resume_reopens_session.py
+++ b/tests/cli/test_resume_reopens_session.py
@@ -320,6 +320,40 @@ async def test_a_session_deleted_while_the_resume_waited_is_not_an_error(temp_db
 
 
 @pytest.mark.asyncio
+async def test_a_resumed_leg_links_its_session_to_its_own_invocation(temp_db_path):
+    """Issue #2767: a resumed leg reopens the branch's existing session row
+    instead of inserting a new one, so create_session's ON CONFLICT DO
+    NOTHING never runs for it and the resume's invocation_id was silently
+    dropped. The invocation that actually drove the resume must still be
+    able to find the session it drove.
+    """
+    from lionagi import Branch
+    from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
+
+    branch = Branch(name="resumed")
+    async with StateDB() as db:
+        await db.create_invocation({"id": "first-inv", "skill": "agent", "started_at": 1.0})
+        await db.create_invocation({"id": "resume-inv", "skill": "resume:agent", "started_at": 2.0})
+
+        first = await setup_agent_persist(
+            branch, agent_name="implementer", invocation_id="first-inv"
+        )
+        assert first is not None
+        await teardown_agent_persist(first, status="completed")
+
+        second = await setup_agent_persist(
+            branch, agent_name="implementer", invocation_id="resume-inv"
+        )
+        assert second is not None
+        assert second["session_id"] == first["session_id"], "resume must reuse the same session"
+
+        resumed_invocation = await db.get_invocation("resume-inv")
+        assert resumed_invocation["session_count"] == 1
+        sessions = await db.list_sessions_for_invocation("resume-inv")
+        assert [s["id"] for s in sessions] == [second["session_id"]]
+
+
+@pytest.mark.asyncio
 async def test_a_resume_whose_session_is_pruned_mid_setup_still_records_itself(
     temp_db_path, monkeypatch
 ):

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -1289,3 +1289,101 @@ async def test_postgres_teardown_gives_up_rather_than_deadlocking_after_it_holds
         assert await db.get_message(msg) is not None
     finally:
         await db.close()
+
+
+# ── Postgres leg: attach_session_invocation's prior-invocation read races ────
+# a concurrent repoint (round-2 review of PR #2884). SQLite serializes this
+# through its own write lock plus BEGIN IMMEDIATE; PostgreSQL at READ
+# COMMITTED does not, so the prior-invocation SELECT takes FOR UPDATE there.
+
+
+async def test_postgres_attach_session_invocation_decrements_off_the_value_a_concurrent_repoint_left(
+    pg_url,
+):
+    """A concurrent attach must decrement the invocation another attach's
+    still-open transaction actually left the session on, not the value it
+    read before that transaction committed.
+
+    A holder connection takes the session row's lock and repoints it
+    old -> mid — the same statements ``attach_session_invocation`` runs —
+    without committing, standing in for a first attach still in flight. A
+    concurrent ``attach_session_invocation(sid, new)`` call must block on
+    that lock (proving the fix takes it at all) rather than reading old's
+    invocation_id straight through; once the holder commits, it must resolve
+    against mid. Without the ``FOR UPDATE`` fix, the unlocked SELECT would
+    read old immediately (the holder hasn't committed yet), block later on
+    the UPDATE's implicit row lock instead, and decrement old after its own
+    WHERE clause re-evaluates against the post-commit row — leaving mid's
+    count stale at 1, exactly the round-2 finding.
+    """
+    import asyncio
+
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    db = StateDB(url=pg_url)
+    await db.open()
+    try:
+        assert db.dialect == "postgresql"
+        old, mid, new = _uid(), _uid(), _uid()
+        now = time.time()
+        for inv_id in (old, mid, new):
+            await db.create_invocation({"id": inv_id, "skill": "show", "started_at": now})
+
+        prog = _uid()
+        await db.create_progression(prog)
+        sid = _uid()
+        await db.create_session(
+            {"id": sid, "progression_id": prog, "status": "running", "invocation_id": old}
+        )
+        assert (await db.get_invocation(old))["session_count"] == 1
+
+        engine = create_async_engine(pg_url)
+        try:
+            async with engine.connect() as holder:
+                async with holder.begin():
+                    await holder.execute(
+                        _text("SELECT invocation_id FROM sessions WHERE id = :sid FOR UPDATE"),
+                        {"sid": sid},
+                    )
+                    await holder.execute(
+                        _text("UPDATE sessions SET invocation_id = :mid WHERE id = :sid"),
+                        {"mid": mid, "sid": sid},
+                    )
+                    await holder.execute(
+                        _text(
+                            "UPDATE invocations SET session_count = "
+                            "GREATEST(session_count - 1, 0) WHERE id = :old"
+                        ),
+                        {"old": old},
+                    )
+                    await holder.execute(
+                        _text(
+                            "UPDATE invocations SET session_count = session_count + 1 "
+                            "WHERE id = :mid"
+                        ),
+                        {"mid": mid},
+                    )
+
+                    second = asyncio.create_task(db.attach_session_invocation(sid, new))
+                    with pytest.raises(asyncio.TimeoutError):
+                        await asyncio.wait_for(asyncio.shield(second), timeout=1.5)
+                    assert not second.done(), (
+                        "the concurrent attach did not block on the row lock — "
+                        "the FOR UPDATE fix is not being taken"
+                    )
+                # holder's transaction commits here, releasing the lock the
+                # blocked attach is waiting on.
+
+                await asyncio.wait_for(second, timeout=10)
+        finally:
+            await engine.dispose()
+
+        assert (await db.get_invocation(old))["session_count"] == 0
+        assert (await db.get_invocation(mid))["session_count"] == 0
+        assert (await db.get_invocation(new))["session_count"] == 1
+        assert await db.list_sessions_for_invocation(old) == []
+        assert await db.list_sessions_for_invocation(mid) == []
+        assert [r["id"] for r in await db.list_sessions_for_invocation(new)] == [sid]
+    finally:
+        await db.close()

--- a/tests/state/test_invocations.py
+++ b/tests/state/test_invocations.py
@@ -173,6 +173,52 @@ async def test_session_without_invocation_id_is_unaffected(db: StateDB):
     assert fetched["invocation_id"] is None
 
 
+# ── attach_session_invocation (resume backfill, issue #2767) ──────────────────
+
+
+async def test_attach_session_invocation_links_an_unlinked_session(db: StateDB):
+    """A session created with no invocation_id (or a resume reopening a row
+    created before this leg's invocation existed) can be backfilled onto one,
+    the same way create_session links a brand-new row."""
+    inv = await _make_invocation(db)
+    session = await _make_session(db, invocation_id=None, status="running")
+
+    await db.attach_session_invocation(session["id"], inv["id"])
+
+    assert (await db.get_session(session["id"]))["invocation_id"] == inv["id"]
+    assert (await db.get_invocation(inv["id"]))["session_count"] == 1
+    rows = await db.list_sessions_for_invocation(inv["id"])
+    assert [r["id"] for r in rows] == [session["id"]]
+
+
+async def test_attach_session_invocation_relinks_a_resumed_session(db: StateDB):
+    """The resume case: a session already attributed to the invocation that
+    originally created it is re-pointed at the invocation that resumed it,
+    so the resume's own invocation record can find the session it drove."""
+    original = await _make_invocation(db)
+    resume = await _make_invocation(db)
+    session = await _make_session(db, invocation_id=original["id"], status="running")
+
+    await db.attach_session_invocation(session["id"], resume["id"])
+
+    assert (await db.get_session(session["id"]))["invocation_id"] == resume["id"]
+    assert (await db.get_invocation(resume["id"]))["session_count"] == 1
+    assert [r["id"] for r in await db.list_sessions_for_invocation(resume["id"])] == [session["id"]]
+
+
+async def test_attach_session_invocation_is_a_noop_when_already_current(db: StateDB):
+    """Calling it again with the same invocation_id must not double-count —
+    the same idempotence create_session's ON CONFLICT DO NOTHING gives a
+    brand-new row."""
+    inv = await _make_invocation(db)
+    session = await _make_session(db, invocation_id=inv["id"], status="running")
+
+    await db.attach_session_invocation(session["id"], inv["id"])
+    await db.attach_session_invocation(session["id"], inv["id"])
+
+    assert (await db.get_invocation(inv["id"]))["session_count"] == 1
+
+
 # ── List + filter ─────────────────────────────────────────────────────────────
 
 

--- a/tests/state/test_invocations.py
+++ b/tests/state/test_invocations.py
@@ -194,7 +194,9 @@ async def test_attach_session_invocation_links_an_unlinked_session(db: StateDB):
 async def test_attach_session_invocation_relinks_a_resumed_session(db: StateDB):
     """The resume case: a session already attributed to the invocation that
     originally created it is re-pointed at the invocation that resumed it,
-    so the resume's own invocation record can find the session it drove."""
+    so the resume's own invocation record can find the session it drove —
+    and the invocation it left behind stops claiming a session it no longer
+    has, so the lifecycle reaper's session_count == 0 check still fires."""
     original = await _make_invocation(db)
     resume = await _make_invocation(db)
     session = await _make_session(db, invocation_id=original["id"], status="running")
@@ -204,6 +206,31 @@ async def test_attach_session_invocation_relinks_a_resumed_session(db: StateDB):
     assert (await db.get_session(session["id"]))["invocation_id"] == resume["id"]
     assert (await db.get_invocation(resume["id"]))["session_count"] == 1
     assert [r["id"] for r in await db.list_sessions_for_invocation(resume["id"])] == [session["id"]]
+
+    assert (await db.get_invocation(original["id"]))["session_count"] == 0
+    assert await db.list_sessions_for_invocation(original["id"]) == []
+
+
+async def test_attach_session_invocation_chain_resume_only_decrements_the_immediate_prior(
+    db: StateDB,
+):
+    """A session resumed twice — old -> mid -> new. The mid invocation is
+    itself vacated when the session leaves it for new, so it must land back
+    at zero rather than staying inflated because it was never the FIRST
+    invocation in the chain."""
+    old = await _make_invocation(db)
+    mid = await _make_invocation(db)
+    new = await _make_invocation(db)
+    session = await _make_session(db, invocation_id=old["id"], status="running")
+
+    await db.attach_session_invocation(session["id"], mid["id"])
+    await db.attach_session_invocation(session["id"], new["id"])
+
+    assert (await db.get_invocation(old["id"]))["session_count"] == 0
+    assert (await db.get_invocation(mid["id"]))["session_count"] == 0
+    assert (await db.get_invocation(new["id"]))["session_count"] == 1
+    assert await db.list_sessions_for_invocation(mid["id"]) == []
+    assert [r["id"] for r in await db.list_sessions_for_invocation(new["id"])] == [session["id"]]
 
 
 async def test_attach_session_invocation_is_a_noop_when_already_current(db: StateDB):


### PR DESCRIPTION
A resumed run reuses its existing session row, so the resume's invocation id was silently dropped: the invocation reported zero sessions even though the session persisted. The reuse path now attaches the session to the resuming invocation with the same rowcount-gated counter mechanism the create path uses, with a regression test proven to fail before the fix.

Closes #2767