### PR TITLE
fix(studio): label artifact verification with when it was taken

### DIFF
--- a/apps/studio/frontend/src/components/runs/ExpectedArtifacts.test.ts
+++ b/apps/studio/frontend/src/components/runs/ExpectedArtifacts.test.ts
@@ -81,4 +81,73 @@ describe("ExpectedArtifacts", () => {
     expect(view.textContent).not.toContain("PENDING");
     expect(view.textContent).not.toContain("MISSING");
   });
+
+  it("shows when a recorded verdict was taken instead of presenting it as current", () => {
+    const view = renderExpectedArtifacts({
+      status: "passed",
+      checked_at: 1700000000,
+      missing_required: [],
+      missing_optional: [],
+      produced: [
+        { id: "report", path: "REPORT.md", size: 5, present: true },
+        { id: "notes", path: "NOTES.md", size: 3, present: true },
+      ],
+    });
+
+    expect(view.textContent).toContain("verified at completion,");
+    // A provisional (mid-run) reading is not a completion snapshot and must
+    // not claim one.
+    const provisionalView = renderExpectedArtifacts({
+      status: "failed",
+      checked_at: 1700000000,
+      missing_required: [],
+      missing_optional: [{ id: "notes", path: "NOTES.md", required: false }],
+      produced: [{ id: "report", path: "REPORT.md", size: 5, present: true }],
+      provisional: true,
+    });
+    expect(provisionalView.textContent).not.toContain("verified at completion,");
+  });
+
+  it("does not claim staleness for a fresh recorded verdict", () => {
+    const view = renderExpectedArtifacts({
+      status: "passed",
+      checked_at: 1700000000,
+      missing_required: [],
+      missing_optional: [],
+      produced: [{ id: "report", path: "REPORT.md", size: 5, present: true }],
+    });
+
+    expect(view.textContent).not.toContain("no longer present");
+    expect(view.textContent).not.toContain("files changed since verification");
+    expect(view.textContent).not.toContain("NO LONGER PRESENT");
+  });
+
+  it("flags a produced artifact whose file changed after verification", () => {
+    const view = renderExpectedArtifacts({
+      status: "passed",
+      checked_at: 1700000000,
+      missing_required: [],
+      missing_optional: [],
+      produced: [{ id: "report", path: "REPORT.md", size: 5, present: true }],
+      changed_since_verification: ["report"],
+    });
+
+    expect(view.textContent).toContain("files changed since verification");
+    expect(view.textContent).toContain("changed since verification");
+  });
+
+  it("flags a produced artifact whose file is no longer present", () => {
+    const view = renderExpectedArtifacts({
+      status: "passed",
+      checked_at: 1700000000,
+      missing_required: [],
+      missing_optional: [],
+      produced: [{ id: "report", path: "REPORT.md", size: 5, present: true }],
+      absent_since_verification: ["report"],
+    });
+
+    expect(view.textContent).toContain("no longer present");
+    expect(view.textContent).toContain("NO LONGER PRESENT");
+    expect(view.textContent).not.toContain("OK (5 B)");
+  });
 });

--- a/apps/studio/frontend/src/components/runs/ExpectedArtifacts.test.ts
+++ b/apps/studio/frontend/src/components/runs/ExpectedArtifacts.test.ts
@@ -150,4 +150,33 @@ describe("ExpectedArtifacts", () => {
     expect(view.textContent).toContain("NO LONGER PRESENT");
     expect(view.textContent).not.toContain("OK (5 B)");
   });
+
+  it("labels a legacy recorded verdict as staleness unknown, not fresh", () => {
+    // No staleness_check field at all — the shape of a payload recorded
+    // before the disk check existed, or a list row where the caller
+    // deliberately skipped it. It must not render the same as a verdict
+    // that was checked and came back clean.
+    const view = renderExpectedArtifacts({
+      status: "passed",
+      checked_at: 1700000000,
+      missing_required: [],
+      missing_optional: [],
+      produced: [{ id: "report", path: "REPORT.md", size: 5, present: true }],
+    });
+
+    expect(view.textContent).toContain("staleness unknown");
+  });
+
+  it("does not show staleness unknown once the disk check has run, even when clean", () => {
+    const view = renderExpectedArtifacts({
+      status: "passed",
+      checked_at: 1700000000,
+      missing_required: [],
+      missing_optional: [],
+      produced: [{ id: "report", path: "REPORT.md", size: 5, present: true }],
+      staleness_check: "checked",
+    });
+
+    expect(view.textContent).not.toContain("staleness unknown");
+  });
 });

--- a/apps/studio/frontend/src/components/runs/ExpectedArtifacts.tsx
+++ b/apps/studio/frontend/src/components/runs/ExpectedArtifacts.tsx
@@ -37,6 +37,10 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
   const missingOptional = new Set((result?.missing_optional ?? []).map((p) => p.id));
   const changedSince = new Set(result?.changed_since_verification ?? []);
   const absentSince = new Set(result?.absent_since_verification ?? []);
+  // A stored verdict without a "checked" mark never had its disk currency
+  // read — a legacy payload, or a list row that skipped the filesystem
+  // check — and must not be indistinguishable from a checked-clean result.
+  const stalenessUnknown = !!result && !result.provisional && result.staleness_check !== "checked";
 
   return (
     <div id="expected-artifacts" className="scroll-mt-24">
@@ -66,6 +70,7 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
             verified at completion, {formatCheckedAt(result.checked_at)}
           </span>
         )}
+        {stalenessUnknown && <Badge tone="default">staleness unknown</Badge>}
         {absentSince.size > 0 && <Badge tone="pending">no longer present</Badge>}
         {changedSince.size > 0 && <Badge tone="pending">files changed since verification</Badge>}
       </div>

--- a/apps/studio/frontend/src/components/runs/ExpectedArtifacts.tsx
+++ b/apps/studio/frontend/src/components/runs/ExpectedArtifacts.tsx
@@ -14,6 +14,13 @@ function verificationTone(status?: string | null): "ok" | "failed" | "pending" |
   return "default";
 }
 
+function formatCheckedAt(checkedAt: number): string {
+  return new Date(checkedAt * 1000).toLocaleString([], {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
 export interface ExpectedArtifactsProps {
   contract?: ArtifactContract | null;
   verification?: ArtifactVerification | null;
@@ -28,10 +35,12 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
   const producedById = new Map((result?.produced ?? []).map((p) => [p.id, p]));
   const missingRequired = new Set((result?.missing_required ?? []).map((p) => p.id));
   const missingOptional = new Set((result?.missing_optional ?? []).map((p) => p.id));
+  const changedSince = new Set(result?.changed_since_verification ?? []);
+  const absentSince = new Set(result?.absent_since_verification ?? []);
 
   return (
     <div id="expected-artifacts" className="scroll-mt-24">
-      <div className="mb-2 flex items-center gap-2">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
         <h2 className="text-label font-semibold text-content-primary">Expected artifacts</h2>
         <span className="rounded bg-surface-overlay px-1.5 py-0 font-mono text-[length:var(--t-xs)] text-content-muted">
           {expected.length}
@@ -50,6 +59,15 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
             <Badge tone={verificationTone(result.status)}>Verified: {result.status}</Badge>
           )
         )}
+        {result && !result.provisional && (
+          // A recorded verdict is a snapshot taken at run completion — show
+          // when it was taken rather than let the badge read as current state.
+          <span className="text-[length:var(--t-xs)] text-content-muted">
+            verified at completion, {formatCheckedAt(result.checked_at)}
+          </span>
+        )}
+        {absentSince.size > 0 && <Badge tone="pending">no longer present</Badge>}
+        {changedSince.size > 0 && <Badge tone="pending">files changed since verification</Badge>}
       </div>
       <div className="rounded border border-edge bg-surface-raised px-3 py-2 shadow-card">
         <ul className="flex flex-col divide-y divide-edge-subtle">
@@ -62,20 +80,26 @@ export default function ExpectedArtifacts({ contract, verification }: ExpectedAr
               !result?.provisional &&
               (missingRequired.has(entry.id) || missingOptional.has(entry.id));
             const required = entry.required !== false;
-            const statusTone = produced
-              ? "ok"
-              : missing && required
-                ? "failed"
+            const noLongerPresent = produced && absentSince.has(entry.id);
+            const changedOnDisk = produced && !noLongerPresent && changedSince.has(entry.id);
+            const statusTone = noLongerPresent
+              ? "pending"
+              : produced
+                ? "ok"
+                : missing && required
+                  ? "failed"
+                  : missing
+                    ? "pending"
+                    : "default";
+            const statusLabel = noLongerPresent
+              ? "NO LONGER PRESENT"
+              : produced
+                ? `OK (${formatBytes(produced.size)})${changedOnDisk ? " — changed since verification" : ""}`
                 : missing
-                  ? "pending"
-                  : "default";
-            const statusLabel = produced
-              ? `OK (${formatBytes(produced.size)})`
-              : missing
-                ? "MISSING"
-                : notRecorded
-                  ? "NOT RECORDED"
-                  : "PENDING";
+                  ? "MISSING"
+                  : notRecorded
+                    ? "NOT RECORDED"
+                    : "PENDING";
             return (
               <li
                 key={entry.id}

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -49,6 +49,12 @@ export interface ArtifactVerificationResult {
   /** A reading taken while the run is still going, rather than the recorded
    *  verdict it was judged on. Artifacts may still appear. */
   provisional?: boolean;
+  /** Artifact ids whose file mtime is later than `checked_at` — the recorded
+   *  verdict may no longer match what is on disk now. */
+  changed_since_verification?: string[];
+  /** Artifact ids the recorded verdict found present that no longer exist
+   *  on disk. */
+  absent_since_verification?: string[];
 }
 
 export interface ArtifactVerificationNotRecorded {

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -55,6 +55,12 @@ export interface ArtifactVerificationResult {
   /** Artifact ids the recorded verdict found present that no longer exist
    *  on disk. */
   absent_since_verification?: string[];
+  /** Whether a read-time disk check ran against this stored verdict.
+   *  "checked" means changed/absent_since_verification are authoritative
+   *  (even if both empty). Missing or "unknown" means no check ran — a
+   *  legacy payload, or a list view that skips the filesystem read — and
+   *  must not be presented as a current-state confirmation. */
+  staleness_check?: "unknown" | "checked";
 }
 
 export interface ArtifactVerificationNotRecorded {

--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -51,6 +51,11 @@ class VerificationResult(TypedDict):
     produced: list[ProducedArtifact]
 
 
+class StaleMarkers(TypedDict):
+    changed_since_verification: list[str]
+    absent_since_verification: list[str]
+
+
 def _safe_join(root: str, rel: str) -> str:
     """Join rel under root, rejecting absolute paths, globs, '..', and escapes."""
     if not isinstance(rel, str) or not rel or rel.startswith("/") or "\x00" in rel:
@@ -285,3 +290,48 @@ def missing_artifact_evidence(missing: list[dict[str, Any]]) -> list[dict[str, s
         }
         for entry in missing
     ]
+
+
+def stale_artifact_markers(
+    verification: dict[str, Any], *, artifacts_root: str | None
+) -> StaleMarkers | None:
+    """Cheaply flag whether a recorded verdict's produced artifacts may no
+    longer match what was on disk at `checked_at`.
+
+    This never re-verifies pass/fail — it only checks mtime and presence for
+    the artifacts the recorded verdict already found, so a caller can label
+    the verdict's currency instead of presenting a completion-time snapshot
+    as current state. Returns None when nothing looks stale.
+    """
+    if not artifacts_root:
+        return None
+    checked_at = verification.get("checked_at")
+    produced = verification.get("produced")
+    if not isinstance(checked_at, (int, float)) or not isinstance(produced, list):
+        return None
+
+    root = os.path.realpath(artifacts_root)
+    changed: list[str] = []
+    absent: list[str] = []
+    for entry in produced:
+        if not isinstance(entry, dict):
+            continue
+        artifact_id = entry.get("id")
+        rel_path = entry.get("path")
+        if not artifact_id or not rel_path:
+            continue
+        try:
+            full = _safe_join(root, rel_path)
+        except ArtifactPathError:
+            continue
+        try:
+            mtime = os.path.getmtime(full)
+        except OSError:
+            absent.append(artifact_id)
+            continue
+        if mtime > checked_at:
+            changed.append(artifact_id)
+
+    if not changed and not absent:
+        return None
+    return {"changed_since_verification": changed, "absent_since_verification": absent}

--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -52,6 +52,7 @@ class VerificationResult(TypedDict):
 
 
 class StaleMarkers(TypedDict):
+    staleness_check: Literal["checked"]
     changed_since_verification: list[str]
     absent_since_verification: list[str]
 
@@ -298,10 +299,20 @@ def stale_artifact_markers(
     """Cheaply flag whether a recorded verdict's produced artifacts may no
     longer match what was on disk at `checked_at`.
 
-    This never re-verifies pass/fail — it only checks mtime and presence for
-    the artifacts the recorded verdict already found, so a caller can label
-    the verdict's currency instead of presenting a completion-time snapshot
-    as current state. Returns None when nothing looks stale.
+    This never re-verifies pass/fail — it only checks mtime+size and presence
+    for the artifacts the recorded verdict already found, so a caller can
+    label the verdict's currency instead of presenting a completion-time
+    snapshot as current state. Comparing size alongside mtime (both already
+    available from a single `stat()` call, so this stays a cheap read-time
+    check rather than a re-verify) narrows, though does not close, the
+    false-negative window a bare mtime check would have against a rewrite
+    that preserves both mtime and size.
+
+    Returns None only when the check cannot be performed at all — no
+    `artifacts_root`, or a verdict missing the `checked_at`/`produced` fields
+    the check needs (e.g. a payload recorded before this check existed). The
+    caller uses that to report an explicit unknown state rather than
+    silently treating an unchecked verdict as clean.
     """
     if not artifacts_root:
         return None
@@ -325,13 +336,17 @@ def stale_artifact_markers(
         except ArtifactPathError:
             continue
         try:
-            mtime = os.path.getmtime(full)
+            stat_result = os.stat(full)
         except OSError:
             absent.append(artifact_id)
             continue
-        if mtime > checked_at:
+        declared_size = entry.get("size")
+        size_changed = isinstance(declared_size, int) and stat_result.st_size != declared_size
+        if stat_result.st_mtime > checked_at or size_changed:
             changed.append(artifact_id)
 
-    if not changed and not absent:
-        return None
-    return {"changed_since_verification": changed, "absent_since_verification": absent}
+    return {
+        "staleness_check": "checked",
+        "changed_since_verification": changed,
+        "absent_since_verification": absent,
+    }

--- a/lionagi/studio/services/artifact_verification.py
+++ b/lionagi/studio/services/artifact_verification.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from lionagi.state.artifact_verifier import ArtifactPathError, verify_artifact_contract
+from lionagi.state.artifact_verifier import (
+    ArtifactPathError,
+    stale_artifact_markers,
+    verify_artifact_contract,
+)
 from lionagi.state.db import SESSION_TERMINAL_STATUSES
 
 __all__ = ("provisional_artifact_verification", "resolve_artifact_verification")
@@ -52,8 +56,15 @@ def resolve_artifact_verification(
     """Resolve the artifact-verification display state.
 
     Stored verdicts win; terminal verdict absence is represented explicitly.
+    A stored verdict is a snapshot taken at run completion (`checked_at`) —
+    it is labeled, not re-verified, against current disk state so a caller
+    can tell a completion-time reading from current truth.
     """
     if stored is not None:
+        if isinstance(stored, dict) and stored.get("status") != "not_recorded":
+            markers = stale_artifact_markers(stored, artifacts_root=artifacts_path)
+            if markers:
+                return {**stored, **markers}
         return stored
     if not contract:
         return None

--- a/lionagi/studio/services/artifact_verification.py
+++ b/lionagi/studio/services/artifact_verification.py
@@ -63,8 +63,9 @@ def resolve_artifact_verification(
     if stored is not None:
         if isinstance(stored, dict) and stored.get("status") != "not_recorded":
             markers = stale_artifact_markers(stored, artifacts_root=artifacts_path)
-            if markers:
+            if markers is not None:
                 return {**stored, **markers}
+            return {**stored, "staleness_check": "unknown"}
         return stored
     if not contract:
         return None

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -246,7 +246,10 @@ async def test_get_run_passes_artifact_json_fields(patched_runs_svc):
 
     assert result is not None
     assert result["artifact_contract_json"] == contract
-    assert result["artifact_verification_json"] == verification
+    resolved = result["artifact_verification_json"]
+    assert {k: v for k, v in resolved.items() if k != "staleness_check"} == verification
+    # `verification` has no checked_at/produced, so staleness cannot be derived.
+    assert resolved["staleness_check"] == "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -403,7 +403,10 @@ async def test_get_session_preserves_a_stored_terminal_verdict(patched_sessions_
     result = await svc.get_session("sess-recorded-verdict")
 
     assert result is not None
-    assert result["artifact_verification_json"] == verdict
+    resolved = result["artifact_verification_json"]
+    assert {k: v for k, v in resolved.items() if k != "staleness_check"} == verdict
+    # No artifacts_path was seeded, so staleness cannot be checked against disk.
+    assert resolved["staleness_check"] == "unknown"
 
 
 async def test_get_session_keeps_verification_null_when_no_contract_exists(patched_sessions_db):
@@ -678,7 +681,10 @@ async def test_list_sessions_preserves_a_stored_verdict(patched_sessions_db):
 
     rows = await svc.list_sessions()
 
-    assert rows[0]["artifact_verification_json"] == stored
+    resolved = rows[0]["artifact_verification_json"]
+    assert {k: v for k, v in resolved.items() if k != "staleness_check"} == stored
+    # `stored` has no checked_at/produced, so staleness cannot be derived.
+    assert resolved["staleness_check"] == "unknown"
 
 
 async def test_list_sessions_does_not_read_the_artifacts_directory(patched_sessions_db, tmp_path):

--- a/tests/state/test_artifact_verifier.py
+++ b/tests/state/test_artifact_verifier.py
@@ -13,6 +13,7 @@ from lionagi.state.artifact_verifier import (
     missing_artifact_evidence,
     missing_artifact_summary,
     resolve_artifact_contract,
+    stale_artifact_markers,
     validate_artifact_contract,
     verify_artifact_contract,
 )
@@ -579,3 +580,69 @@ def test_the_reported_run_shape_now_passes_end_to_end(tmp_path):
     assert result["missing_required"] == []
     assert result["missing_optional"] == []
     assert len(result["produced"]) == 5
+
+
+# ── stale_artifact_markers ────────────────────────────────────────────────────
+#
+# A stored verification is a snapshot taken at run completion. These markers
+# never re-verify pass/fail; they only flag, via mtime and presence, whether
+# the artifacts that snapshot found may no longer match what is on disk now.
+
+
+class TestStaleArtifactMarkers:
+    def test_a_fresh_snapshot_has_no_staleness(self, tmp_path):
+        (tmp_path / "report.md").write_text("content")
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+
+        assert stale_artifact_markers(result, artifacts_root=str(tmp_path)) is None
+
+    def test_a_file_touched_after_checked_at_is_flagged_changed(self, tmp_path):
+        artifact = tmp_path / "report.md"
+        artifact.write_text("content")
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+
+        later = result["checked_at"] + 100
+        os.utime(artifact, (later, later))
+
+        markers = stale_artifact_markers(result, artifacts_root=str(tmp_path))
+        assert markers is not None
+        assert markers["changed_since_verification"] == ["report"]
+        assert markers["absent_since_verification"] == []
+
+    def test_a_file_removed_after_verification_is_flagged_absent(self, tmp_path):
+        artifact = tmp_path / "report.md"
+        artifact.write_text("content")
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+
+        artifact.unlink()
+
+        markers = stale_artifact_markers(result, artifacts_root=str(tmp_path))
+        assert markers is not None
+        assert markers["absent_since_verification"] == ["report"]
+        assert markers["changed_since_verification"] == []
+
+    def test_no_artifacts_root_produces_no_markers(self, tmp_path):
+        (tmp_path / "report.md").write_text("content")
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+
+        assert stale_artifact_markers(result, artifacts_root=None) is None
+        assert stale_artifact_markers(result, artifacts_root="") is None
+
+    def test_a_missing_required_artifact_is_not_reported_as_stale(self, tmp_path):
+        # It was never produced, so there is nothing on disk to have changed —
+        # that is `missing_required`'s claim to make, not this one's.
+        contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+
+        assert stale_artifact_markers(result, artifacts_root=str(tmp_path)) is None
+
+    def test_malformed_verification_produces_no_markers(self, tmp_path):
+        assert stale_artifact_markers({}, artifacts_root=str(tmp_path)) is None
+        assert (
+            stale_artifact_markers({"checked_at": "not-a-number"}, artifacts_root=str(tmp_path))
+            is None
+        )

--- a/tests/state/test_artifact_verifier.py
+++ b/tests/state/test_artifact_verifier.py
@@ -590,12 +590,16 @@ def test_the_reported_run_shape_now_passes_end_to_end(tmp_path):
 
 
 class TestStaleArtifactMarkers:
-    def test_a_fresh_snapshot_has_no_staleness(self, tmp_path):
+    def test_a_fresh_snapshot_is_marked_checked_with_no_staleness(self, tmp_path):
         (tmp_path / "report.md").write_text("content")
         contract = {"expected": [{"id": "report", "path": "report.md"}]}
         result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
 
-        assert stale_artifact_markers(result, artifacts_root=str(tmp_path)) is None
+        markers = stale_artifact_markers(result, artifacts_root=str(tmp_path))
+        assert markers is not None
+        assert markers["staleness_check"] == "checked"
+        assert markers["changed_since_verification"] == []
+        assert markers["absent_since_verification"] == []
 
     def test_a_file_touched_after_checked_at_is_flagged_changed(self, tmp_path):
         artifact = tmp_path / "report.md"
@@ -638,7 +642,28 @@ class TestStaleArtifactMarkers:
         contract = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
         result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
 
-        assert stale_artifact_markers(result, artifacts_root=str(tmp_path)) is None
+        markers = stale_artifact_markers(result, artifacts_root=str(tmp_path))
+        assert markers is not None
+        assert markers["staleness_check"] == "checked"
+        assert markers["changed_since_verification"] == []
+        assert markers["absent_since_verification"] == []
+
+    def test_a_size_change_with_preserved_mtime_is_flagged_changed(self, tmp_path):
+        # A rewrite that preserves mtime defeats a bare mtime comparison; the
+        # comparator also compares size (from the same stat() call) so this
+        # false-negative window is narrowed rather than left silent.
+        artifact = tmp_path / "report.md"
+        artifact.write_text("content")
+        contract = {"expected": [{"id": "report", "path": "report.md"}]}
+        result = verify_artifact_contract(contract, artifacts_root=str(tmp_path))
+        original_mtime = os.path.getmtime(artifact)
+
+        artifact.write_text("content, but a fair bit longer than before")
+        os.utime(artifact, (original_mtime, original_mtime))
+
+        markers = stale_artifact_markers(result, artifacts_root=str(tmp_path))
+        assert markers is not None
+        assert markers["changed_since_verification"] == ["report"]
 
     def test_malformed_verification_produces_no_markers(self, tmp_path):
         assert stale_artifact_markers({}, artifacts_root=str(tmp_path)) is None

--- a/tests/studio/test_resolve_artifact_verification_staleness.py
+++ b/tests/studio/test_resolve_artifact_verification_staleness.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A stored artifact-verification verdict is a completion-time snapshot;
+`resolve_artifact_verification` labels it with disk currency rather than
+presenting it as an unqualified current-state answer."""
+
+from __future__ import annotations
+
+import os
+
+from lionagi.state.artifact_verifier import verify_artifact_contract
+from lionagi.studio.services.artifact_verification import resolve_artifact_verification
+
+CONTRACT = {"expected": [{"id": "report", "path": "report.md", "required": True}]}
+
+
+def _recorded_verdict(tmp_path):
+    (tmp_path / "report.md").write_text("content")
+    return verify_artifact_contract(CONTRACT, artifacts_root=str(tmp_path))
+
+
+def test_a_fresh_recorded_verdict_carries_no_staleness_markers(tmp_path):
+    stored = _recorded_verdict(tmp_path)
+
+    resolved = resolve_artifact_verification(
+        stored, status="completed", contract=CONTRACT, artifacts_path=str(tmp_path)
+    )
+
+    assert resolved["checked_at"] == stored["checked_at"]
+    assert "changed_since_verification" not in resolved
+    assert "absent_since_verification" not in resolved
+
+
+def test_a_file_changed_after_the_recorded_verdict_is_labeled(tmp_path):
+    stored = _recorded_verdict(tmp_path)
+    artifact = tmp_path / "report.md"
+    later = stored["checked_at"] + 100
+    os.utime(artifact, (later, later))
+
+    resolved = resolve_artifact_verification(
+        stored, status="completed", contract=CONTRACT, artifacts_path=str(tmp_path)
+    )
+
+    assert resolved["changed_since_verification"] == ["report"]
+    # The recorded status itself is untouched — this labels currency, it
+    # never re-judges pass/fail.
+    assert resolved["status"] == stored["status"]
+
+
+def test_a_file_removed_after_the_recorded_verdict_is_labeled_absent(tmp_path):
+    stored = _recorded_verdict(tmp_path)
+    (tmp_path / "report.md").unlink()
+
+    resolved = resolve_artifact_verification(
+        stored, status="completed", contract=CONTRACT, artifacts_path=str(tmp_path)
+    )
+
+    assert resolved["absent_since_verification"] == ["report"]
+
+
+def test_no_artifacts_path_skips_the_disk_check(tmp_path):
+    """The paginated list surface passes artifacts_path=None deliberately to
+    avoid a filesystem walk per row; staleness labeling must respect that."""
+    stored = _recorded_verdict(tmp_path)
+    (tmp_path / "report.md").unlink()
+
+    resolved = resolve_artifact_verification(
+        stored, status="completed", contract=CONTRACT, artifacts_path=None
+    )
+
+    assert resolved is stored
+    assert "absent_since_verification" not in resolved
+
+
+def test_not_recorded_status_is_returned_unlabeled(tmp_path):
+    stored = {"status": "not_recorded"}
+
+    resolved = resolve_artifact_verification(
+        stored, status="completed", contract=CONTRACT, artifacts_path=str(tmp_path)
+    )
+
+    assert resolved == {"status": "not_recorded"}

--- a/tests/studio/test_resolve_artifact_verification_staleness.py
+++ b/tests/studio/test_resolve_artifact_verification_staleness.py
@@ -20,7 +20,7 @@ def _recorded_verdict(tmp_path):
     return verify_artifact_contract(CONTRACT, artifacts_root=str(tmp_path))
 
 
-def test_a_fresh_recorded_verdict_carries_no_staleness_markers(tmp_path):
+def test_a_fresh_recorded_verdict_is_marked_checked_with_no_staleness_markers(tmp_path):
     stored = _recorded_verdict(tmp_path)
 
     resolved = resolve_artifact_verification(
@@ -28,8 +28,9 @@ def test_a_fresh_recorded_verdict_carries_no_staleness_markers(tmp_path):
     )
 
     assert resolved["checked_at"] == stored["checked_at"]
-    assert "changed_since_verification" not in resolved
-    assert "absent_since_verification" not in resolved
+    assert resolved["staleness_check"] == "checked"
+    assert resolved["changed_since_verification"] == []
+    assert resolved["absent_since_verification"] == []
 
 
 def test_a_file_changed_after_the_recorded_verdict_is_labeled(tmp_path):
@@ -59,9 +60,10 @@ def test_a_file_removed_after_the_recorded_verdict_is_labeled_absent(tmp_path):
     assert resolved["absent_since_verification"] == ["report"]
 
 
-def test_no_artifacts_path_skips_the_disk_check(tmp_path):
+def test_no_artifacts_path_skips_the_disk_check_and_reports_unknown(tmp_path):
     """The paginated list surface passes artifacts_path=None deliberately to
-    avoid a filesystem walk per row; staleness labeling must respect that."""
+    avoid a filesystem walk per row; staleness labeling must respect that —
+    and must say the check was skipped rather than imply a clean result."""
     stored = _recorded_verdict(tmp_path)
     (tmp_path / "report.md").unlink()
 
@@ -69,8 +71,26 @@ def test_no_artifacts_path_skips_the_disk_check(tmp_path):
         stored, status="completed", contract=CONTRACT, artifacts_path=None
     )
 
-    assert resolved is stored
+    assert resolved["staleness_check"] == "unknown"
+    assert resolved["status"] == stored["status"]
     assert "absent_since_verification" not in resolved
+    # The stored dict itself is never mutated.
+    assert "staleness_check" not in stored
+
+
+def test_a_legacy_verdict_missing_checked_at_resolves_unknown_not_fresh(tmp_path):
+    # A payload recorded before `checked_at`/`produced` existed on the
+    # verdict cannot be disk-checked at all; it must read as unknown, never
+    # be indistinguishable from a verdict that was checked and came back
+    # clean.
+    stored = {"status": "passed", "produced": [{"id": "report", "path": "report.md", "size": 5}]}
+
+    resolved = resolve_artifact_verification(
+        stored, status="completed", contract=CONTRACT, artifacts_path=str(tmp_path)
+    )
+
+    assert resolved["staleness_check"] == "unknown"
+    assert resolved["status"] == "passed"
 
 
 def test_not_recorded_status_is_returned_unlabeled(tmp_path):


### PR DESCRIPTION
The run detail presented a completion-time artifact-verification snapshot as if it were current state. The verdict now carries its own timestamp (verified at completion) plus cheap staleness markers: artifacts whose files changed on disk since the snapshot are flagged, and artifacts no longer present are flagged. No re-verification happens — the honest label is the fix. The new fields are pure additions to the verification payload, composing with the MCP job detail surface without collision.

Closes #2760