### PR TITLE
fix(studio): validate MCP server config against the merged result

### DIFF
--- a/lionagi/studio/services/mcp_servers.py
+++ b/lionagi/studio/services/mcp_servers.py
@@ -345,7 +345,20 @@ def _merge_config(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, 
     not wipe the env block it never saw. ``env`` merges key-by-key; a `None`
     value for a key removes it (the client's explicit way to drop a secret
     without knowing its value). Any other field replaces wholesale when
-    present, and a `None`/empty value removes it.
+    present, and only an explicit `None` removes it -- a wrong-typed falsy
+    value (``""``, ``[]``) is *not* treated as "key absent": it is written
+    into the merged config as-is and left for ``_validate_shape`` to reject,
+    the same way a raw, unmerged config would. Laundering a malformed value
+    into "absent" here would make it validate by accident.
+
+    ``args`` is the one exception to "`None` removes it": unlike ``timeout``
+    (where `None` means "no timeout", a value ``_validate_shape`` accepts),
+    the shape check has no such reading for ``args`` -- it must always be a
+    list, empty or not. Treating ``args: null`` as "key absent" would delete
+    a malformed value into a *valid* one (the default ``[]``) instead of
+    leaving it for the shape check to reject, so it is written through like
+    any other wrong-typed value; the typed empty list is the actual way to
+    clear it.
 
     A transport switch drops every field belonging to the transport being
     left, not just the one that names it. The shape check only requires
@@ -359,13 +372,15 @@ def _merge_config(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, 
         if key not in patch:
             continue
         value = patch[key]
-        if value in (None, ""):
+        if value is None and key != "args":
             merged.pop(key, None)
         else:
             merged[key] = value
 
     if "env" in patch:
-        incoming_env = patch["env"] or {}
+        incoming_env = patch["env"]
+        if incoming_env is None:
+            incoming_env = {}
         if isinstance(incoming_env, dict):
             merged_env = dict(existing.get("env") or {})
             for env_key, env_value in incoming_env.items():
@@ -375,10 +390,10 @@ def _merge_config(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, 
                     merged_env[env_key] = env_value
             merged["env"] = merged_env
         else:
-            # Not a mapping at all (e.g. a string or a number) -- pass it
-            # through untouched so `_validate_shape`'s own env type check
-            # reports it as an ordinary shape error, instead of this merge
-            # crashing on `.items()` before validation ever runs.
+            # Not a mapping at all (e.g. a string, a list, or a number) --
+            # pass it through untouched so `_validate_shape`'s own env type
+            # check reports it as an ordinary shape error, instead of this
+            # merge crashing on `.items()` before validation ever runs.
             merged["env"] = incoming_env
 
     if patch.get("url"):

--- a/lionagi/studio/services/mcp_servers.py
+++ b/lionagi/studio/services/mcp_servers.py
@@ -311,7 +311,12 @@ def get_server(name: str) -> dict[str, Any] | None:
 
 
 def register_server(name: str, config: dict[str, Any], *, enabled: bool = True) -> dict[str, Any]:
-    errors = _validate_shape(name, config)
+    # Registering is `update_server`'s merge onto an empty base rather than a
+    # second, separately-invented rule: a `None` env value means "key absent"
+    # here exactly as it does for an existing server, and `validate_config`
+    # already validates new names the same way (see its docstring).
+    merged = _merge_config({}, config)
+    errors = _validate_shape(name, merged)
     if errors:
         raise McpServerError("; ".join(errors))
 
@@ -322,7 +327,7 @@ def register_server(name: str, config: dict[str, Any], *, enabled: bool = True) 
 
         now = time.time()
         servers[name] = {
-            "config": config,
+            "config": merged,
             "enabled": enabled,
             "created_at": now,
             "updated_at": now,
@@ -361,13 +366,20 @@ def _merge_config(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, 
 
     if "env" in patch:
         incoming_env = patch["env"] or {}
-        merged_env = dict(existing.get("env") or {})
-        for env_key, env_value in incoming_env.items():
-            if env_value is None:
-                merged_env.pop(env_key, None)
-            else:
-                merged_env[env_key] = env_value
-        merged["env"] = merged_env
+        if isinstance(incoming_env, dict):
+            merged_env = dict(existing.get("env") or {})
+            for env_key, env_value in incoming_env.items():
+                if env_value is None:
+                    merged_env.pop(env_key, None)
+                else:
+                    merged_env[env_key] = env_value
+            merged["env"] = merged_env
+        else:
+            # Not a mapping at all (e.g. a string or a number) -- pass it
+            # through untouched so `_validate_shape`'s own env type check
+            # reports it as an ordinary shape error, instead of this merge
+            # crashing on `.items()` before validation ever runs.
+            merged["env"] = incoming_env
 
     if patch.get("url"):
         for key in _STDIO_ONLY_FIELDS:

--- a/lionagi/studio/services/mcp_servers.py
+++ b/lionagi/studio/services/mcp_servers.py
@@ -478,11 +478,22 @@ async def check_server_connection(name: str) -> dict[str, Any] | None:
 async def validate_config(
     name: str, config: dict[str, Any], *, check_connection: bool = False
 ) -> dict[str, Any]:
-    """Validate a config before it is saved. Shape is always checked;
-    connection is only attempted when the caller opts in, and the response
-    says explicitly whether it was -- a shape check that silently claimed to
-    prove a server works would be worse than no check at all."""
-    errors = _validate_shape(name, config)
+    """Validate a config before it is saved. ``config`` is a patch, not
+    necessarily a complete config -- an edit can carry a `None` env value
+    that means "delete this key", which never stands alone as a usable
+    shape. ``update_server`` merges a patch onto the stored config before
+    validating it; this runs the same merge so validation checks what would
+    actually be persisted, not the raw patch. A server that does not exist
+    yet merges onto an empty config, which is exactly the shape a save
+    would produce for a first-time registration.
+
+    Shape is always checked; connection is only attempted when the caller
+    opts in, and the response says explicitly whether it was -- a shape
+    check that silently claimed to prove a server works would be worse than
+    no check at all."""
+    existing = (_load_registry().get(name) or {}).get("config") or {}
+    merged = _merge_config(existing, config)
+    errors = _validate_shape(name, merged)
     result: dict[str, Any] = {
         "ok": not errors,
         "errors": errors or None,
@@ -491,7 +502,7 @@ async def validate_config(
         "connection_error": None,
     }
     if not errors and check_connection:
-        outcome = await _attempt_connection(config)
+        outcome = await _attempt_connection(merged)
         result["connection_checked"] = True
         result["connection_ok"] = outcome["ok"]
         result["connection_error"] = outcome["error"]

--- a/lionagi/studio/services/mcp_servers.py
+++ b/lionagi/studio/services/mcp_servers.py
@@ -139,11 +139,13 @@ def _sync_mcp_json(servers: dict[str, dict[str, Any]]) -> None:
 # ---------------------------------------------------------------------------
 
 
-# Which fields belong to which transport. The shape check below reads a
-# config's stdio fields only when it has a command and its http fields only
-# when it has a url, so these are the sets a transport switch has to clear --
-# keep them in step with the two branches of _validate_shape. `timeout` and
-# `alwaysAllow` are deliberately in neither: they apply to both transports.
+# Which fields belong to which transport. `_merge_config` clears these -- the
+# ones the patch itself did not supply -- when a save declares the other
+# transport, so a stale command/args/env or url does not survive a switch.
+# `_validate_shape` checks `command`/`url` only for the transport that names
+# them, but `args`/`env` shape-check unconditionally regardless of transport.
+# `timeout` and `alwaysAllow` are deliberately in neither set: they apply to
+# both transports.
 _STDIO_ONLY_FIELDS = ("command", "args", "env")
 _HTTP_ONLY_FIELDS = ("url",)
 
@@ -170,17 +172,21 @@ def _validate_shape(name: str, config: dict[str, Any]) -> list[str]:
             "config must specify either 'command' (stdio transport) or 'url' (http transport)"
         )
 
-    if has_command:
-        if not isinstance(config.get("command"), str):
-            errors.append("'command' must be a string")
-        args = config.get("args", [])
-        if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
-            errors.append("'args' must be a list of strings")
-        env = config.get("env", {})
-        if not isinstance(env, dict) or not all(
-            isinstance(k, str) and isinstance(v, str) for k, v in env.items()
-        ):
-            errors.append("'env' must be an object mapping string names to string values")
+    if has_command and not isinstance(config.get("command"), str):
+        errors.append("'command' must be a string")
+
+    # `args`/`env` are checked whenever either key is present in the config,
+    # not only for a stdio transport: a malformed value is malformed whether
+    # or not the selected transport happens to read it, and this validator
+    # is the only place that sees the config before it reaches disk.
+    args = config.get("args", [])
+    if not isinstance(args, list) or not all(isinstance(a, str) for a in args):
+        errors.append("'args' must be a list of strings")
+    env = config.get("env", {})
+    if not isinstance(env, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in env.items()
+    ):
+        errors.append("'env' must be an object mapping string names to string values")
 
     if has_url:
         url = config.get("url")
@@ -360,12 +366,17 @@ def _merge_config(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, 
     any other wrong-typed value; the typed empty list is the actual way to
     clear it.
 
-    A transport switch drops every field belonging to the transport being
-    left, not just the one that names it. The shape check only requires
-    exactly one of ``command``/``url``, so an http entry that kept the old
-    ``args`` and ``env`` would still validate -- and the derived ``.mcp.json``
-    would then hand every reader a set of stdio arguments and secrets that
-    the chosen transport never uses.
+    A transport switch drops every *leftover* field belonging to the
+    transport being left, not just the one that names it. The shape check
+    only requires exactly one of ``command``/``url``, so an http entry that
+    kept the old ``args`` and ``env`` would still validate -- and the derived
+    ``.mcp.json`` would then hand every reader a set of stdio arguments and
+    secrets that the chosen transport never uses. This only clears fields the
+    patch itself did not touch: a field the caller explicitly supplied in the
+    same patch (well-formed or not) is left for `_validate_shape` to judge on
+    its own merits instead of being silently discarded before validation
+    ever sees it -- otherwise a malformed ``env`` sent alongside a fresh
+    ``url`` would vanish rather than being rejected.
     """
     merged = dict(existing)
     for key in ("command", "args", "url", "timeout", "alwaysAllow"):
@@ -398,10 +409,12 @@ def _merge_config(existing: dict[str, Any], patch: dict[str, Any]) -> dict[str, 
 
     if patch.get("url"):
         for key in _STDIO_ONLY_FIELDS:
-            merged.pop(key, None)
+            if key not in patch:
+                merged.pop(key, None)
     if patch.get("command"):
         for key in _HTTP_ONLY_FIELDS:
-            merged.pop(key, None)
+            if key not in patch:
+                merged.pop(key, None)
 
     return merged
 

--- a/tests/apps_studio_server/test_mcp_servers.py
+++ b/tests/apps_studio_server/test_mcp_servers.py
@@ -640,6 +640,84 @@ def test_route_validate_malformed(mcp_client):
 
 
 # ---------------------------------------------------------------------------
+# Validate/Save parity -- Validate must accept exactly the edits Save
+# accepts. Save (PUT) merges a patch onto the stored config; a Validate that
+# shape-checks the raw patch instead rejects perfectly ordinary partial
+# edits (e.g. one that only changes `args`) and, worse, the env-deletion
+# patch Save requires to drop a key (an explicit `null` value, since a
+# client never sees secret values to resend them).
+# ---------------------------------------------------------------------------
+
+
+_PARITY_PATCH_CORPUS = [
+    ("env_deletion", {"env": {"API_KEY": None}}),
+    ("env_omitted", {"args": ["-m", "different_module"]}),
+    ("full_config", {"command": "python3", "args": ["-m", "srv"], "env": {"OTHER": "v"}}),
+    ("invalid_nested_types", {"env": {"KEY": 5}}),
+    ("unknown_field", {"totally_unknown_field": "whatever", "args": ["-m", "srv"]}),
+]
+
+
+@pytest.mark.parametrize("case_name,patch", _PARITY_PATCH_CORPUS)
+def test_route_validate_and_save_agree_on_the_same_patch(mcp_client, case_name, patch):
+    """The same patch corpus driven through both endpoints must agree on
+    accept vs reject, so a merge-semantics field handled by one and not the
+    other fails this test instead of shipping as a live divergence."""
+    mcp_client.post("/api/mcp/servers/", json={"name": "myserver", **STDIO_CONFIG})
+
+    validate_resp = mcp_client.post(
+        "/api/mcp/servers/myserver/validate", json={"name": "myserver", **patch}
+    )
+    assert validate_resp.status_code == 200
+    validate_body = validate_resp.json()
+
+    save_resp = mcp_client.put("/api/mcp/servers/myserver", json=patch)
+
+    assert validate_body["ok"] == (save_resp.status_code == 200), (
+        f"{case_name}: validate ok={validate_body['ok']!r} "
+        f"(errors={validate_body.get('errors')!r}) but save status="
+        f"{save_resp.status_code} ({save_resp.text})"
+    )
+
+
+def test_route_env_deletion_patch_validate_and_save_parity_end_to_end(mcp_client):
+    """The concrete regression this fixes: the exact edit Save performs
+    (deleting an env key via an explicit `null`) must validate successfully,
+    and the key must actually be gone after the save that follows."""
+    mcp_client.post("/api/mcp/servers/", json={"name": "myserver", **STDIO_CONFIG})
+
+    validate_resp = mcp_client.post(
+        "/api/mcp/servers/myserver/validate",
+        json={"name": "myserver", "env": {"API_KEY": None}},
+    )
+    assert validate_resp.status_code == 200
+    assert validate_resp.json()["ok"] is True
+
+    save_resp = mcp_client.put("/api/mcp/servers/myserver", json={"env": {"API_KEY": None}})
+    assert save_resp.status_code == 200
+    assert "API_KEY" not in save_resp.json()["env_keys"]
+
+
+def test_validate_create_time_null_env_against_empty_base_is_key_absent(tmp_path, monkeypatch):
+    """A server that does not exist yet has nothing to merge onto but an
+    empty config, so a null env value there means "the key was never
+    added" -- the same outcome the merge produces for an existing server --
+    rather than the shape error a literal `None` would otherwise trip."""
+    _point_registry_at(tmp_path, monkeypatch)
+
+    result = asyncio.run(
+        mcp_mod.validate_config(
+            "brand-new",
+            {"command": "python3", "env": {"API_KEY": None}},
+            check_connection=False,
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["errors"] is None
+
+
+# ---------------------------------------------------------------------------
 # A stored status belongs to the configuration it sits on -- the connection
 # check refuses to write one for a configuration it never probed, and an
 # ordinary edit must not leave one behind for a configuration it replaced.

--- a/tests/apps_studio_server/test_mcp_servers.py
+++ b/tests/apps_studio_server/test_mcp_servers.py
@@ -56,6 +56,15 @@ def test_validate_shape_rejects_bad_env_values():
     assert any("'env'" in e for e in errors)
 
 
+def test_merge_config_rejects_non_dict_env_without_crashing():
+    """A malformed env patch (a string, not a mapping) must reach
+    `_validate_shape`'s ordinary type check as a normal shape error, not
+    crash `_merge_config`'s per-key iteration with an AttributeError."""
+    merged = mcp_mod._merge_config({"command": "python3"}, {"env": "not-a-dict"})
+    errors = mcp_mod._validate_shape("myserver", merged)
+    assert any("'env'" in e for e in errors)
+
+
 def test_validate_shape_rejects_bad_url():
     errors = mcp_mod._validate_shape("myserver", {"url": "not-a-url"})
     assert any("'url'" in e for e in errors)
@@ -138,6 +147,19 @@ def test_register_malformed_config_raises(tmp_path, monkeypatch):
 
     with pytest.raises(mcp_mod.McpServerError):
         mcp_mod.register_server("bad", {"command": "python3", "url": "https://x"})
+
+
+def test_register_create_time_null_env_against_empty_base_is_key_absent(tmp_path, monkeypatch):
+    """Register (save) must apply the same null-env-as-deletion normalization
+    `validate_config` already applies at create time -- merging the incoming
+    config onto an empty base -- so a null env value on a brand-new server
+    means "key absent" everywhere, instead of the raw-config shape check
+    rejecting what validate already approved."""
+    _point_registry_at(tmp_path, monkeypatch)
+
+    created = mcp_mod.register_server("brand-new", {"command": "python3", "env": {"API_KEY": None}})
+
+    assert created["env_keys"] == []
 
 
 def test_update_nonexistent_returns_none(tmp_path, monkeypatch):
@@ -655,6 +677,9 @@ _PARITY_PATCH_CORPUS = [
     ("full_config", {"command": "python3", "args": ["-m", "srv"], "env": {"OTHER": "v"}}),
     ("invalid_nested_types", {"env": {"KEY": 5}}),
     ("unknown_field", {"totally_unknown_field": "whatever", "args": ["-m", "srv"]}),
+    ("env_not_a_dict", {"env": "not-a-dict"}),
+    ("env_int", {"env": 5}),
+    ("env_list", {"env": []}),
 ]
 
 
@@ -662,21 +687,56 @@ _PARITY_PATCH_CORPUS = [
 def test_route_validate_and_save_agree_on_the_same_patch(mcp_client, case_name, patch):
     """The same patch corpus driven through both endpoints must agree on
     accept vs reject, so a merge-semantics field handled by one and not the
-    other fails this test instead of shipping as a live divergence."""
+    other fails this test instead of shipping as a live divergence. Every
+    entry is also checked for a 5xx -- a validator that crashes on the input
+    it exists to judge is a standing property this corpus enforces, not a
+    one-off assertion for the malformed-env cases alone."""
     mcp_client.post("/api/mcp/servers/", json={"name": "myserver", **STDIO_CONFIG})
 
     validate_resp = mcp_client.post(
         "/api/mcp/servers/myserver/validate", json={"name": "myserver", **patch}
     )
-    assert validate_resp.status_code == 200
+    assert validate_resp.status_code < 500, (
+        f"{case_name}: validate returned {validate_resp.status_code} ({validate_resp.text})"
+    )
     validate_body = validate_resp.json()
 
     save_resp = mcp_client.put("/api/mcp/servers/myserver", json=patch)
+    assert save_resp.status_code < 500, (
+        f"{case_name}: save returned {save_resp.status_code} ({save_resp.text})"
+    )
 
     assert validate_body["ok"] == (save_resp.status_code == 200), (
         f"{case_name}: validate ok={validate_body['ok']!r} "
         f"(errors={validate_body.get('errors')!r}) but save status="
         f"{save_resp.status_code} ({save_resp.text})"
+    )
+
+
+@pytest.mark.parametrize("case_name,patch", _PARITY_PATCH_CORPUS)
+def test_route_validate_and_register_agree_at_create_time(mcp_client, case_name, patch):
+    """The same corpus again, but merged onto an empty base (a name that does
+    not exist yet) instead of onto an already-stored config -- validate and
+    register must still agree, and neither may 500 on a malformed patch."""
+    name = f"fresh-{case_name}"
+
+    validate_resp = mcp_client.post(
+        "/api/mcp/servers/" + name + "/validate", json={"name": name, **patch}
+    )
+    assert validate_resp.status_code < 500, (
+        f"{case_name}: validate returned {validate_resp.status_code} ({validate_resp.text})"
+    )
+    validate_body = validate_resp.json()
+
+    register_resp = mcp_client.post("/api/mcp/servers/", json={"name": name, **patch})
+    assert register_resp.status_code < 500, (
+        f"{case_name}: register returned {register_resp.status_code} ({register_resp.text})"
+    )
+
+    assert validate_body["ok"] == (register_resp.status_code == 201), (
+        f"{case_name}: validate ok={validate_body['ok']!r} "
+        f"(errors={validate_body.get('errors')!r}) but register status="
+        f"{register_resp.status_code} ({register_resp.text})"
     )
 
 

--- a/tests/apps_studio_server/test_mcp_servers.py
+++ b/tests/apps_studio_server/test_mcp_servers.py
@@ -680,6 +680,9 @@ _PARITY_PATCH_CORPUS = [
     ("env_not_a_dict", {"env": "not-a-dict"}),
     ("env_int", {"env": 5}),
     ("env_list", {"env": []}),
+    ("env_empty_string", {"env": ""}),
+    ("args_null", {"args": None}),
+    ("timeout_empty_string", {"timeout": ""}),
 ]
 
 
@@ -756,6 +759,90 @@ def test_route_env_deletion_patch_validate_and_save_parity_end_to_end(mcp_client
     save_resp = mcp_client.put("/api/mcp/servers/myserver", json={"env": {"API_KEY": None}})
     assert save_resp.status_code == 200
     assert "API_KEY" not in save_resp.json()["env_keys"]
+
+
+@pytest.mark.parametrize(
+    "case_name,patch",
+    [
+        ("env_list", {"command": "python3", "env": []}),
+        ("env_empty_string", {"command": "python3", "env": ""}),
+        ("args_null", {"command": "python3", "args": None}),
+        ("timeout_empty_string", {"command": "python3", "timeout": ""}),
+    ],
+)
+def test_create_time_malformed_falsy_values_are_rejected_not_laundered(
+    mcp_client, case_name, patch
+):
+    """The regression this fixes: a falsy but wrong-typed value (`[]`/`""`
+    where env wants a mapping, a bare `None` where args wants a list, `""`
+    where timeout wants a number) must reach `_validate_shape` and fail it,
+    not be normalized into "key absent" by the merge before validation ever
+    runs. Both endpoints must actually reject -- not just agree with each
+    other, which parity alone would not catch if both silently accepted."""
+    name = f"fresh-{case_name}"
+
+    validate_resp = mcp_client.post(
+        f"/api/mcp/servers/{name}/validate", json={"name": name, **patch}
+    )
+    assert validate_resp.status_code == 200
+    assert validate_resp.json()["ok"] is False, f"{case_name}: validate accepted {patch!r}"
+    assert validate_resp.json()["errors"]
+
+    register_resp = mcp_client.post("/api/mcp/servers/", json={"name": name, **patch})
+    assert register_resp.status_code == 400, (
+        f"{case_name}: register accepted {patch!r} ({register_resp.text})"
+    )
+
+
+def test_update_env_empty_list_is_rejected_not_silently_ignored(tmp_path, monkeypatch):
+    """Before this fix, `env: []` on an update was normalized to `{}` by
+    `patch["env"] or {}` and merged as a no-op -- the existing env survived
+    untouched and the save reported success, silently diverging from
+    validate (which already rejected a non-dict env). That divergence is
+    closed deliberately, as a tightening: update now rejects the same
+    malformed value validate always did, and the config on disk is
+    untouched by the rejected patch."""
+    registry_path, _ = _point_registry_at(tmp_path, monkeypatch)
+    mcp_mod.register_server("myserver", STDIO_CONFIG)
+
+    result = asyncio.run(mcp_mod.validate_config("myserver", {"env": []}, check_connection=False))
+    assert result["ok"] is False
+
+    with pytest.raises(mcp_mod.McpServerError):
+        mcp_mod.update_server("myserver", {"env": []})
+
+    on_disk = json.loads(registry_path.read_text())
+    assert on_disk["servers"]["myserver"]["config"]["env"] == STDIO_CONFIG["env"]
+
+
+def test_update_env_null_top_level_is_a_no_op_not_a_wipe(tmp_path, monkeypatch):
+    """A bare `env: null` carries no individual keys to delete, unlike
+    `env: {KEY: null}` -- it leaves the existing env untouched. This is
+    distinct from `env: []`, a malformed container that is now rejected
+    outright rather than silently normalized to the same no-op."""
+    registry_path, _ = _point_registry_at(tmp_path, monkeypatch)
+    mcp_mod.register_server("myserver", STDIO_CONFIG)
+
+    updated = mcp_mod.update_server("myserver", {"env": None})
+
+    assert updated["env_keys"] == ["API_KEY"]
+    on_disk = json.loads(registry_path.read_text())
+    assert on_disk["servers"]["myserver"]["config"]["env"] == STDIO_CONFIG["env"]
+
+
+def test_update_args_null_is_rejected_not_treated_as_absent(tmp_path, monkeypatch):
+    """Unlike `timeout`, `_validate_shape` has no reading of `args: null` as
+    valid -- args must always be a list. So, unlike `timeout: null` (which
+    clears the field), `args: null` is written through to the shape check
+    and rejected, on update exactly as it is on create."""
+    registry_path, _ = _point_registry_at(tmp_path, monkeypatch)
+    mcp_mod.register_server("myserver", STDIO_CONFIG)
+
+    with pytest.raises(mcp_mod.McpServerError):
+        mcp_mod.update_server("myserver", {"args": None})
+
+    on_disk = json.loads(registry_path.read_text())
+    assert on_disk["servers"]["myserver"]["config"]["args"] == STDIO_CONFIG["args"]
 
 
 def test_validate_create_time_null_env_against_empty_base_is_key_absent(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_mcp_servers.py
+++ b/tests/apps_studio_server/test_mcp_servers.py
@@ -794,6 +794,98 @@ def test_create_time_malformed_falsy_values_are_rejected_not_laundered(
     )
 
 
+# ---------------------------------------------------------------------------
+# URL-transport parity -- `_validate_shape` used to gate every args/env shape
+# check behind `has_command`, so a URL config (no `command` at all) skipped
+# them outright; `_merge_config` separately laundered a fresh url+malformed
+# patch by popping the stdio-only fields before `_validate_shape` ever saw
+# them. Both mechanisms are covered here, for both create-time (url and the
+# malformed field in the same request) and update-time (a patch that edits
+# only the malformed field on an already-registered url server, never
+# resending `url`) -- the two shapes each mechanism above was specific to.
+# ---------------------------------------------------------------------------
+
+_URL_MALFORMED_PATCH_CORPUS = [
+    ("env_list", {"env": []}),
+    ("env_empty_string", {"env": ""}),
+    ("env_int", {"env": 0}),
+    ("env_false", {"env": False}),
+    ("args_null", {"args": None}),
+    ("args_empty_string", {"args": ""}),
+    ("args_dict", {"args": {}}),
+]
+
+
+@pytest.mark.parametrize("case_name,patch", _URL_MALFORMED_PATCH_CORPUS)
+def test_url_transport_create_time_malformed_args_env_are_rejected(mcp_client, case_name, patch):
+    """`timeout` already rejected regardless of transport; this is the same
+    guarantee for `args`/`env` on a server that has no `command` at all."""
+    name = f"url-fresh-{case_name}"
+    body = {"name": name, **URL_CONFIG, **patch}
+
+    validate_resp = mcp_client.post(f"/api/mcp/servers/{name}/validate", json=body)
+    assert validate_resp.status_code == 200
+    assert validate_resp.json()["ok"] is False, f"{case_name}: validate accepted {patch!r}"
+    assert validate_resp.json()["errors"]
+
+    register_resp = mcp_client.post("/api/mcp/servers/", json=body)
+    assert register_resp.status_code == 400, (
+        f"{case_name}: register accepted {patch!r} ({register_resp.text})"
+    )
+    assert mcp_client.get("/api/mcp/servers/").json()["servers"] == []
+
+
+@pytest.mark.parametrize("case_name,patch", _URL_MALFORMED_PATCH_CORPUS)
+def test_url_transport_update_time_malformed_args_env_are_rejected(
+    mcp_client, tmp_path, case_name, patch
+):
+    """The shape the create-time corpus above cannot exercise: a save that
+    edits only `args`/`env` on an already-registered url server without
+    resending `url`, so `_merge_config`'s transport-switch pop (keyed on
+    `patch.get("url")`) never fires and the malformed value would otherwise
+    sit in `merged` unexamined by a `has_command`-gated check."""
+    mcp_client.post("/api/mcp/servers/", json={"name": "myserver", **URL_CONFIG})
+    registry_path = tmp_path / "mcp_servers.json"
+    before = json.loads(registry_path.read_text())
+
+    validate_resp = mcp_client.post(
+        "/api/mcp/servers/myserver/validate", json={"name": "myserver", **patch}
+    )
+    assert validate_resp.status_code == 200
+    assert validate_resp.json()["ok"] is False, f"{case_name}: validate accepted {patch!r}"
+
+    save_resp = mcp_client.put("/api/mcp/servers/myserver", json=patch)
+    assert save_resp.status_code == 400, f"{case_name}: save accepted {patch!r} ({save_resp.text})"
+
+    after = json.loads(registry_path.read_text())
+    assert after == before, f"{case_name}: registry bytes changed on a rejected save"
+
+
+def test_url_transport_well_formed_env_accepted_at_create_time(mcp_client):
+    """The pin for the inert-field question: a well-formed `env` on a URL
+    server is never read by the http transport, but it is not malformed --
+    the norm elsewhere in this service is to accept and store a well-formed
+    inert field rather than reject it, and this is that case for `env`."""
+    resp = mcp_client.post(
+        "/api/mcp/servers/",
+        json={"name": "myserver", **URL_CONFIG, "env": {"TOKEN": "value"}},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["env_keys"] == ["TOKEN"]
+
+
+def test_url_transport_well_formed_env_accepted_on_update_without_url(mcp_client):
+    """Same pin, but as a save that edits only `env` on an already-registered
+    url server without resending `url` -- the shape the transport-switch pop
+    in `_merge_config` must leave alone because the patch itself supplied it."""
+    mcp_client.post("/api/mcp/servers/", json={"name": "myserver", **URL_CONFIG})
+
+    resp = mcp_client.put("/api/mcp/servers/myserver", json={"env": {"TOKEN": "value"}})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["env_keys"] == ["TOKEN"]
+
+
 def test_update_env_empty_list_is_rejected_not_silently_ignored(tmp_path, monkeypatch):
     """Before this fix, `env: []` on an update was normalized to `{}` by
     `patch["env"] or {}` and merged as a no-op -- the existing env survived


### PR DESCRIPTION
POST /api/mcp/servers/{name}/validate rejected the null env value that PUT requires for deleting a key: Save merges the patch while Validate checked the raw patch against complete-config shape rules, so the Validate button refused the exact edit Save performs.

Validate now loads the existing entry (empty base when the server does not exist yet), applies the same merge Save uses, and validates the merged result — answering the question the operator is actually asking. A parity test drives both endpoints with the same patch corpus (env deletion, omitted env, full config, invalid nested types, unknown fields) so the next divergence fails instead of shipping.

Closes #2771