### PR TITLE
feat(studio): readable execution-graph progress with stable node identity

### DIFF
--- a/apps/studio/frontend/src/components/canvas/StepNode.test.ts
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.ts
@@ -1,0 +1,109 @@
+/**
+ * computeNodeVisualStyle — status precedence at the readability zoom floor.
+ *
+ * At the minimum fit zoom (0.1) a node card renders too small to read label
+ * text or the pulse-ring animation reliably, so the precedence between
+ * running/completed/failed/pending must survive on non-animation cues alone:
+ * border weight and a left-edge status rail color. This file pins that
+ * contract without mounting React Flow.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { computeNodeVisualStyle } from "./StepNode";
+import type { NodeExecStatus } from "./StepNode";
+
+describe("computeNodeVisualStyle", () => {
+  it("running is the strongest: thickest border and a non-transparent rail", () => {
+    const running = computeNodeVisualStyle("running", false);
+    expect(running.borderWidth).toBe(3);
+    expect(running.railColor).not.toBe("transparent");
+  });
+
+  it("pending recedes: thinnest border and no rail color", () => {
+    const pending = computeNodeVisualStyle("pending", false);
+    expect(pending.borderWidth).toBe(1);
+    expect(pending.railColor).toBe("transparent");
+  });
+
+  it("queued renders identically to pending — a correctness distinction, not a visual one", () => {
+    expect(computeNodeVisualStyle("queued", false)).toEqual(
+      computeNodeVisualStyle("pending", false),
+    );
+  });
+
+  it("running strictly outweighs pending in border weight", () => {
+    const running = computeNodeVisualStyle("running", false);
+    const pending = computeNodeVisualStyle("pending", false);
+    expect(running.borderWidth).toBeGreaterThan(pending.borderWidth);
+  });
+
+  it("completed is moderate: thicker than pending, and its own rail color", () => {
+    const completed = computeNodeVisualStyle("completed", false);
+    const pending = computeNodeVisualStyle("pending", false);
+    expect(completed.borderWidth).toBeGreaterThan(pending.borderWidth);
+    expect(completed.borderWidth).toBeLessThanOrEqual(3);
+    expect(completed.railColor).not.toBe("transparent");
+  });
+
+  it("failed and escalated read as the same failure-pool visual", () => {
+    expect(computeNodeVisualStyle("failed", false)).toEqual(
+      computeNodeVisualStyle("escalated", false),
+    );
+  });
+
+  it("running, completed, and failed are all mutually distinguishable by color at any zoom", () => {
+    const running = computeNodeVisualStyle("running", false);
+    const completed = computeNodeVisualStyle("completed", false);
+    const failed = computeNodeVisualStyle("failed", false);
+    const colors = [running, completed, failed].map((v) => `${v.borderColor}|${v.railColor}`);
+    expect(new Set(colors).size).toBe(3);
+  });
+
+  it("running outweighs completed in border weight, so the frontier draws the eye first", () => {
+    const running = computeNodeVisualStyle("running", false);
+    const completed = computeNodeVisualStyle("completed", false);
+    expect(running.borderWidth).toBeGreaterThan(completed.borderWidth);
+  });
+
+  it("awaiting_approval and paused share the warn visual, distinct from pending", () => {
+    const awaiting = computeNodeVisualStyle("awaiting_approval", false);
+    const paused = computeNodeVisualStyle("paused", false);
+    const pending = computeNodeVisualStyle("pending", false);
+    expect(awaiting).toEqual(paused);
+    expect(awaiting.railColor).not.toBe(pending.railColor);
+  });
+
+  it("every status produces a defined, non-empty rail entry (transparent counts as defined)", () => {
+    const statuses: NodeExecStatus[] = [
+      "pending",
+      "queued",
+      "running",
+      "awaiting_approval",
+      "paused",
+      "completed",
+      "failed",
+      "escalated",
+    ];
+    for (const status of statuses) {
+      const visual = computeNodeVisualStyle(status, false);
+      expect(visual.railColor).toBeTruthy();
+      expect(visual.borderWidth).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe("StepNode.tsx — source contract for the status rail + reduced-motion", () => {
+  const CANVAS_DIR = path.resolve(__dirname);
+  const src = fs.readFileSync(path.join(CANVAS_DIR, "StepNode.tsx"), "utf-8");
+
+  it("renders a left-edge status rail driven by the visual style, not a static class", () => {
+    expect(src).toMatch(/background: visual\.railColor/);
+  });
+
+  it("gates the pulse animation on prefers-reduced-motion, keeping the rail/border cues animation-free", () => {
+    expect(src).toMatch(/usePrefersReducedMotion/);
+    expect(src).toMatch(/reducedMotion \? "" : " animate-pulse"/);
+  });
+});

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -73,15 +73,24 @@ export interface StepNodeData {
   toolCallCount?: number;
 }
 
-function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
-  const t = useTranslations("history.detail");
-  // roleColor arrives as a data-driven CSS var string — keep inline
-  const roleColor = ROLE_VAR[data.role] || "var(--content-muted)";
-  const status = data.execStatus ?? "pending";
-  const reducedMotion = usePrefersReducedMotion();
-  const isTerminalError = status === "failed" || status === "escalated";
+// Non-animation precedence cues (border weight + a left-edge status rail)
+// that must remain readable at the minimum fit zoom (0.1), where the pulse
+// ring and label text are effectively invisible. running is strongest (3px
+// border, brightest rail), completed/failed/warn are moderate and mutually
+// distinguishable by color alone (2px, distinct rail hue), pending/queued
+// recede (1px, no rail) so they never compete with completed work for
+// attention. Exported so StepNode.test.ts can assert the precedence
+// contract without mounting React Flow.
+export interface NodeVisualStyle {
+  borderWidth: number;
+  borderColor: string;
+  bgColor: string;
+  labelColor: string;
+  railColor: string;
+}
 
-  // These colors derive from status data (dag-* tokens) — keep inline
+export function computeNodeVisualStyle(status: NodeExecStatus, selected: boolean): NodeVisualStyle {
+  const isTerminalError = status === "failed" || status === "escalated";
   const isWarn = status === "awaiting_approval" || status === "paused";
 
   const borderColor =
@@ -119,6 +128,34 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
             ? "var(--dag-warn-label)"
             : "var(--content-primary)";
 
+  const borderWidth =
+    status === "running" ? 3 : status === "completed" || isTerminalError || isWarn ? 2 : 1;
+
+  const railColor =
+    status === "running"
+      ? "var(--dag-running-border)"
+      : status === "completed"
+        ? "var(--dag-completed-border)"
+        : isTerminalError
+          ? "var(--dag-failed-border)"
+          : isWarn
+            ? "var(--dag-warn-border)"
+            : "transparent";
+
+  return { borderWidth, borderColor, bgColor, labelColor, railColor };
+}
+
+function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
+  const t = useTranslations("history.detail");
+  // roleColor arrives as a data-driven CSS var string — keep inline
+  const roleColor = ROLE_VAR[data.role] || "var(--content-muted)";
+  const status = data.execStatus ?? "pending";
+  const reducedMotion = usePrefersReducedMotion();
+
+  // These derive from status data (dag-* tokens) — keep inline
+  const visual = computeNodeVisualStyle(status, !!selected);
+  const borderWidth = selected ? Math.max(visual.borderWidth, 2) : visual.borderWidth;
+
   // The bottom-right corner always says something. Elapsed time once there is
   // any, the status word before that. A corner that can be empty makes the
   // card change shape as a run progresses, and a reader who has to re-find a
@@ -134,8 +171,8 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
     <div
       className="relative flex flex-col justify-between rounded-md px-2.5 py-2"
       style={{
-        background: bgColor,
-        border: `${selected || status === "running" ? 2 : 1}px solid ${borderColor}`,
+        background: visual.bgColor,
+        border: `${borderWidth}px solid ${visual.borderColor}`,
         width: NODE_WIDTH,
         height: NODE_HEIGHT,
         boxShadow:
@@ -147,6 +184,16 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
         transition: "border-color 0.15s, background 0.15s, box-shadow 0.15s",
       }}
     >
+      {/* Status rail — a left-edge color bar that survives the readability
+          zoom floor even when the card is too small to read text or icons.
+          A span, not a div: the card's rows() test selects direct div
+          children of this card as its two content rows, and the rail is
+          decorative chrome, not a third row. */}
+      <span
+        className="pointer-events-none absolute inset-y-0 left-0 block rounded-l-md"
+        style={{ width: 3, background: visual.railColor }}
+      />
+
       <Handle
         type="target"
         position={Position.Left}
@@ -163,7 +210,7 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
       <div className="flex items-start justify-between gap-1.5">
         <span
           className="truncate font-mono text-[length:var(--t-sm)] font-semibold leading-snug"
-          style={{ color: labelColor }}
+          style={{ color: visual.labelColor }}
         >
           {data.label}
         </span>

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
@@ -17,10 +17,13 @@ import {
   fitZoomFor,
   FIT_ZOOM_FLOOR,
   MIN_INTERACTIVE_ZOOM,
+  computeEffectiveNodeStatuses,
+  computeFollowCenter,
   panelClearanceShift,
   shouldShowMiniMap,
   shouldShowSidePanel,
 } from "./WorkerCanvas";
+import type { NodeExecStatus } from "./StepNode";
 
 describe("computeEdgeSourceCompleted", () => {
   it("uses the legacy completedMap when nodeStatuses is undefined", () => {
@@ -291,5 +294,194 @@ describe("WorkerCanvas.tsx — source contract for rank-distance edge data", () 
     // Layout-on-mount effect + handleAutoLayout (editable canvas).
     expect(calls.length).toBeGreaterThanOrEqual(2);
     expect(src).toMatch(/ranks,?\s*\}\s*=\s*getLayoutedElements/);
+  });
+});
+
+// ─── computeEffectiveNodeStatuses — legacy fallback + reconciliation ─────────
+// The single per-node status derivation WorkerCanvas feeds to both the flow
+// nodes' execStatus and the stage/follow-mode computations: nodeStatuses
+// (live) wins per node, absent nodes fall back to the legacy
+// execSteps/currentStep derivation, and the WHOLE resulting map is then run
+// through reconcileNodeStatuses so a node can never render "running" once a
+// descendant is terminal, and a terminal run never leaves a node looking
+// like live work just because no signal ever arrived for it.
+
+describe("computeEffectiveNodeStatuses", () => {
+  const ids = ["a", "b", "c"];
+  const edges = [
+    { source: "a", target: "b" },
+    { source: "b", target: "c" },
+  ];
+
+  it("nodeStatuses wins per node over the legacy fallback", () => {
+    const result = computeEffectiveNodeStatuses(
+      ids,
+      edges,
+      { a: "running", b: "pending", c: "pending" },
+      [],
+      null,
+      false,
+    );
+    expect(result.a).toBe("running");
+  });
+
+  it("falls back to currentStep, then execSteps completedMap, then pending", () => {
+    // b has no descendant terminal here (its only descendant is c, and c is
+    // not in edges from b) — use a disjoint pair so descendant-suppression
+    // doesn't interfere with proving the plain fallback precedence.
+    const disjointEdges = [{ source: "x", target: "y" }];
+    const result = computeEffectiveNodeStatuses(
+      ["a", "b", "c"],
+      disjointEdges,
+      undefined,
+      [{ step: "c", status: "completed" }],
+      "b",
+      false,
+    );
+    expect(result).toEqual({ a: "pending", b: "running", c: "completed" });
+  });
+
+  it("suppresses a stale 'running' ancestor once a descendant is terminal, live or not", () => {
+    const result = computeEffectiveNodeStatuses(
+      ids,
+      edges,
+      { a: "running", b: "running", c: "completed" },
+      [],
+      null,
+      false,
+    );
+    // b's descendant c is terminal → b can no longer read "running".
+    expect(result.b).toBe("completed");
+    // a's descendant chain (b→c) also reaches a terminal node.
+    expect(result.a).toBe("completed");
+  });
+
+  it("on a terminal run, a node with no signal at all reads as unknown (pending), not active", () => {
+    const result = computeEffectiveNodeStatuses(
+      ids,
+      edges,
+      { a: "completed" },
+      [],
+      null,
+      true, // done
+    );
+    // b and c never got a signal; the run is done, so they must not look
+    // like live work — they collapse to "pending" (absence of information).
+    expect(result.b).toBe("pending");
+    expect(result.c).toBe("pending");
+  });
+
+  it("on a terminal run, a node stuck 'queued'/'running' with no terminal signal collapses to pending", () => {
+    const result = computeEffectiveNodeStatuses(
+      ids,
+      edges,
+      { a: "completed", b: "running", c: "queued" },
+      [],
+      null,
+      true,
+    );
+    expect(result.b).toBe("pending");
+    expect(result.c).toBe("pending");
+  });
+
+  it("terminal statuses (completed/failed/escalated) pass through untouched on a done run", () => {
+    const result = computeEffectiveNodeStatuses(
+      ids,
+      edges,
+      { a: "completed", b: "failed", c: "escalated" },
+      [],
+      null,
+      true,
+    );
+    expect(result).toEqual({ a: "completed", b: "failed", c: "escalated" });
+  });
+});
+
+// ─── computeFollowCenter — viewport target for follow mode ───────────────────
+
+describe("computeFollowCenter", () => {
+  it("returns null when nothing is running", () => {
+    const nodes = [{ id: "a", position: { x: 0, y: 0 } }];
+    const statuses: Record<string, NodeExecStatus> = { a: "completed" };
+    expect(computeFollowCenter(nodes, statuses)).toBeNull();
+  });
+
+  it("centers on the single running node, accounting for its size", () => {
+    const nodes = [{ id: "a", position: { x: 100, y: 200 }, width: 210, height: 60 }];
+    const statuses: Record<string, NodeExecStatus> = { a: "running" };
+    expect(computeFollowCenter(nodes, statuses)).toEqual({ x: 100 + 105, y: 200 + 30 });
+  });
+
+  it("uses default dimensions when a node has no measured width/height yet", () => {
+    const nodes = [{ id: "a", position: { x: 0, y: 0 } }];
+    const statuses: Record<string, NodeExecStatus> = { a: "running" };
+    expect(computeFollowCenter(nodes, statuses)).toEqual({ x: 105, y: 30 });
+  });
+
+  it("averages the centroid across multiple running nodes", () => {
+    const nodes = [
+      { id: "a", position: { x: 0, y: 0 }, width: 200, height: 40 },
+      { id: "b", position: { x: 200, y: 0 }, width: 200, height: 40 },
+    ];
+    const statuses: Record<string, NodeExecStatus> = { a: "running", b: "running" };
+    const center = computeFollowCenter(nodes, statuses);
+    expect(center).toEqual({ x: (100 + 300) / 2, y: 20 });
+  });
+
+  it("ignores non-running nodes when computing the centroid", () => {
+    const nodes = [
+      { id: "a", position: { x: 0, y: 0 }, width: 200, height: 40 },
+      { id: "b", position: { x: 1000, y: 1000 }, width: 200, height: 40 },
+    ];
+    const statuses: Record<string, NodeExecStatus> = { a: "running", b: "completed" };
+    expect(computeFollowCenter(nodes, statuses)).toEqual({ x: 100, y: 20 });
+  });
+});
+
+// ─── Source contract — new behaviors wired into the component itself ────────
+// Mounting React Flow in vitest is heavy and not how this file tests
+// WorkerCanvas elsewhere (see the MiniMap source-contract test above); these
+// assert the component actually calls the primitives the behavior tests
+// above exercise in isolation, and exposes the props/controls the contract
+// requires.
+
+describe("WorkerCanvas.tsx — source contract for progress/follow/selection wiring", () => {
+  const CANVAS_DIR = path.resolve(__dirname);
+  const src = fs.readFileSync(path.join(CANVAS_DIR, "WorkerCanvas.tsx"), "utf-8");
+
+  it("declares live/done/onNodeSelect props", () => {
+    expect(src).toMatch(/live\?: boolean/);
+    expect(src).toMatch(/done\?: boolean/);
+    expect(src).toMatch(/onNodeSelect\?: \(nodeId: string\) => void/);
+  });
+
+  it("fires onNodeSelect from the node click handler", () => {
+    expect(src).toMatch(/onNodeSelect\?\.\(typedNode\.id\)/);
+  });
+
+  it("reserves layout height via computeReservedHeight, not the raw bbox height", () => {
+    expect(src).toMatch(/computeReservedHeight\(/);
+  });
+
+  it("wires the follow-mode reducer and shouldAutoCenter gate", () => {
+    expect(src).toMatch(
+      /useReducer\(\s*followModeReducer,\s*initialFollowModeState\(live, done\),?\s*\)/,
+    );
+    expect(src).toMatch(/shouldAutoCenter\(followState, live, done\)/);
+  });
+
+  it("dispatches manual_interaction on onMoveStart (react-flow's pan/zoom-start hook)", () => {
+    expect(src).toMatch(/onMoveStart=\{onMoveStart\}/);
+    expect(src).toMatch(/dispatchFollow\(\{ type: "manual_interaction" \}\)/);
+  });
+
+  it("renders a visible Follow toggle that survives a manual interruption", () => {
+    expect(src).toMatch(/dispatchFollow\(\{ type: "toggle" \}\)/);
+    expect(src).toMatch(/followState\.following \? "Following" : "Follow"/);
+  });
+
+  it("derives the stage badge from computeStagePosition over the authored edges", () => {
+    expect(src).toMatch(/computeStagePosition\(/);
+    expect(src).toMatch(/Rank \{stagePosition\.stage\} of \{stagePosition\.totalStages\}/);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import ReactFlow, {
   Background,
   Controls,
@@ -25,7 +25,10 @@ import ConditionEdgeComponent from "./ConditionEdge";
 import type { ConditionEdgeData } from "./ConditionEdge";
 import SidePanel from "./SidePanel";
 import type { Selection } from "./SidePanel";
-import { getLayoutedElements } from "./useLayout";
+import { getLayoutedElements, computeReservedHeight } from "./useLayout";
+import { followModeReducer, initialFollowModeState, shouldAutoCenter } from "./followMode";
+import { reconcileNodeStatuses, computeStagePosition } from "@/lib/execGraphProgress";
+import type { GraphEdge } from "@/lib/execGraphProgress";
 
 import type {
   AgentProfileSummary,
@@ -105,10 +108,81 @@ interface WorkerCanvasProps {
    * panel). Suppresses the MiniMap — at that size it reads as a floating
    * cluster of gray nodes rather than a useful overview. */
   compact?: boolean;
-  /** Reports the laid-out graph's bounding-box height (px) after each layout,
-   * so an embedding container can size itself to the graph's real shape
-   * instead of guessing from node count. */
+  /** Reports the graph's SCALED rendered height (px, via computeReservedHeight
+   * over the layout bbox and the container's available width) after each
+   * layout and on container resize, so an embedding container reserves the
+   * height the graph will actually draw instead of the unscaled bbox. */
   onLayoutHeight?: (height: number) => void;
+  /** True while the run is actively streaming. Gates follow-mode's default-on
+   * behavior and the visible Follow toggle; RunDetail wires this once it
+   * adopts follow mode — omitted callers simply never see it activate. */
+  live?: boolean;
+  /** True once the run has reached a terminal state. Forces follow mode off
+   * permanently and collapses any node with no terminal signal to "pending"
+   * (absence of information) rather than leaving it looking like live work. */
+  done?: boolean;
+  /** Fired on node click with the authored node id, in addition to the
+   * existing side-panel selection — lets an embedding container (e.g.
+   * RunDetail) correlate the click to a branch without WorkerCanvas knowing
+   * about branches. */
+  onNodeSelect?: (nodeId: string) => void;
+}
+
+function graphEdgesOf(edges: WorkerLinkEdge[]): GraphEdge[] {
+  return edges.map((e) => ({ source: e.source, target: e.target }));
+}
+
+// Combines the live nodeStatuses signal with the legacy execSteps/currentStep
+// fallback (same precedence WorkerCanvas has always used per node), then
+// applies the shared reconciliation invariants over the WHOLE resulting map:
+// a node cannot still read "running" once a descendant has reached a
+// terminal state, and — once the run is done — any status that never reached
+// a terminal state collapses to "pending", i.e. unknown/no-telemetry rather
+// than active. Exported so this can be tested without mounting React Flow.
+export function computeEffectiveNodeStatuses(
+  graphNodeIds: string[],
+  graphEdges: GraphEdge[],
+  nodeStatuses: Record<string, NodeExecStatus> | undefined,
+  execSteps: Array<{ step: string; status: string }>,
+  currentStep: string | null | undefined,
+  done: boolean,
+): Record<string, NodeExecStatus> {
+  const completedIds = new Set(
+    execSteps.filter((s) => s.status === "completed").map((s) => s.step),
+  );
+  const base: Record<string, NodeExecStatus> = {};
+  for (const id of graphNodeIds) {
+    const live = nodeStatuses?.[id];
+    if (live) base[id] = live;
+    else if (id === currentStep) base[id] = "running";
+    else if (completedIds.has(id)) base[id] = "completed";
+    else base[id] = "pending";
+  }
+  return reconcileNodeStatuses(graphNodeIds, graphEdges, base, done);
+}
+
+// The point the viewport should center on to keep the running frontier in
+// view: the centroid of every node currently "running" (post-reconciliation
+// status), in graph coordinates. null when nothing is running — a caller
+// must not auto-pan in that case. Pure so follow-mode centering logic is
+// testable without mounting React Flow.
+export function computeFollowCenter(
+  nodes: Array<{
+    id: string;
+    position: { x: number; y: number };
+    width?: number | null;
+    height?: number | null;
+  }>,
+  statuses: Record<string, NodeExecStatus>,
+): { x: number; y: number } | null {
+  const running = nodes.filter((n) => statuses[n.id] === "running");
+  if (running.length === 0) return null;
+  const xs = running.map((n) => n.position.x + (n.width ?? 210) / 2);
+  const ys = running.map((n) => n.position.y + (n.height ?? 60) / 2);
+  return {
+    x: xs.reduce((a, b) => a + b, 0) / xs.length,
+    y: ys.reduce((a, b) => a + b, 0) / ys.length,
+  };
 }
 
 // ─── Conversion helpers ─────────────────────────────────
@@ -261,6 +335,9 @@ export default function WorkerCanvas({
   onChange,
   compact = false,
   onLayoutHeight,
+  live = false,
+  done = false,
+  onNodeSelect,
 }: WorkerCanvasProps) {
   const initialised = useRef(false);
 
@@ -270,6 +347,10 @@ export default function WorkerCanvas({
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [selection, setSelection] = useState<Selection>({ type: "none" });
+  // Bounding box of the most recent layout — kept in a ref (not state) so the
+  // resize observer can recompute the reserved height without re-running the
+  // layout effect itself.
+  const layoutBBoxRef = useRef<{ width: number; height: number } | null>(null);
 
   // The fitView PROP fits once, on init — before an async graph load has laid
   // anything out, and before an embedding container has grown to the layout's
@@ -296,29 +377,59 @@ export default function WorkerCanvas({
   useEffect(() => {
     const el = containerRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(refit);
+    const observer = new ResizeObserver(() => {
+      refit();
+      const bbox = layoutBBoxRef.current;
+      if (bbox) {
+        onLayoutHeight?.(computeReservedHeight(bbox.width, bbox.height, el.clientWidth));
+      }
+    });
     observer.observe(el);
     return () => observer.disconnect();
-  }, [refit]);
+  }, [refit, onLayoutHeight]);
 
-  // Layout on mount or when graph changes
+  // Layout on mount or when graph changes. The layout returns the UNSCALED
+  // bbox; onLayoutHeight reports the SCALED height (via computeReservedHeight,
+  // using the same width-constrained-fit-zoom math fitView itself applies)
+  // so an embedding container reserves exactly the height the graph will
+  // actually draw, never the raw bbox that leaves dead space below a wide,
+  // width-constrained graph.
   useEffect(() => {
     const {
       nodes: ln,
       edges: le,
       height,
       ranks,
+      width,
     } = getLayoutedElements(initialFlowNodes, initialFlowEdges, "LR");
     setNodes(ln);
     setEdges(attachRankDistance(le, ranks));
     initialised.current = true;
-    onLayoutHeight?.(height);
+    layoutBBoxRef.current = { width, height };
+    const containerWidth = containerRef.current?.clientWidth ?? 0;
+    onLayoutHeight?.(computeReservedHeight(width, height, containerWidth));
     refit();
   }, [initialFlowNodes, initialFlowEdges, setNodes, setEdges, onLayoutHeight, refit]);
 
-  // Apply execution status to nodes. nodeStatuses (live signal-derived, keyed
-  // by authored step id) takes priority per node; nodes it doesn't cover fall
-  // back to the legacy execSteps/currentStep derivation.
+  // The combined per-node status map: nodeStatuses (live signal-derived)
+  // takes priority per node, nodes it doesn't cover fall back to the legacy
+  // execSteps/currentStep derivation, and the whole map is then reconciled
+  // (descendant-terminal suppression + terminal-run unknown-status collapse)
+  // before it ever reaches a node's execStatus. Pure derivation from props —
+  // memoized rather than pushed into state from an effect.
+  const effectiveStatuses = useMemo(() => {
+    if (execSteps.length === 0 && !currentStep && !nodeStatuses) return {};
+    return computeEffectiveNodeStatuses(
+      graph.nodes.map((n) => n.id),
+      graphEdgesOf(graph.edges),
+      nodeStatuses,
+      execSteps,
+      currentStep,
+      done,
+    );
+  }, [execSteps, currentStep, nodeStatuses, done, graph.nodes, graph.edges]);
+
+  // Apply the effective status map to the laid-out flow nodes/edges.
   useEffect(() => {
     if (execSteps.length === 0 && !currentStep && !nodeStatuses) return;
 
@@ -327,18 +438,10 @@ export default function WorkerCanvas({
     );
 
     setNodes((nds) =>
-      nds.map((n) => {
-        let status: StepNodeData["execStatus"] = "pending";
-        const live = nodeStatuses?.[n.id];
-        if (live) status = live;
-        else if (n.id === currentStep) status = "running";
-        else if (completedMap.has(n.id)) status = "completed";
-
-        return {
-          ...n,
-          data: { ...n.data, execStatus: status },
-        };
-      }),
+      nds.map((n) => ({
+        ...n,
+        data: { ...n.data, execStatus: effectiveStatuses[n.id] ?? "pending" },
+      })),
     );
 
     setEdges((eds) =>
@@ -350,7 +453,59 @@ export default function WorkerCanvas({
         },
       })),
     );
-  }, [execSteps, currentStep, nodeStatuses, setNodes, setEdges]);
+  }, [execSteps, currentStep, nodeStatuses, effectiveStatuses, setNodes, setEdges]);
+
+  // ── Stage / rank position — honest under transitive reduction because it
+  // is derived from the authored edge set, never the displayed one. ──
+  const stagePosition = useMemo(
+    () =>
+      computeStagePosition(
+        graph.nodes.map((n) => n.id),
+        graphEdgesOf(graph.edges),
+        effectiveStatuses,
+        done,
+      ),
+    [graph.nodes, graph.edges, effectiveStatuses, done],
+  );
+
+  // ── Follow mode — auto-center the running frontier while live, disabled
+  // permanently for the run by any manual pan/zoom, never on a finished run.
+  const [followState, dispatchFollow] = useReducer(
+    followModeReducer,
+    initialFollowModeState(live, done),
+  );
+  const runStateRef = useRef({ live, done });
+  useEffect(() => {
+    if (runStateRef.current.live !== live || runStateRef.current.done !== done) {
+      dispatchFollow({ type: "run_state_changed", live, done });
+      runStateRef.current = { live, done };
+    }
+  }, [live, done]);
+
+  const onMoveStart = useCallback(() => {
+    dispatchFollow({ type: "manual_interaction" });
+  }, []);
+
+  const followTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (followTimerRef.current) clearTimeout(followTimerRef.current);
+    };
+  }, []);
+  useEffect(() => {
+    if (!shouldAutoCenter(followState, live, done)) return;
+    const center = computeFollowCenter(nodes, effectiveStatuses);
+    if (!center) return;
+    if (followTimerRef.current) clearTimeout(followTimerRef.current);
+    followTimerRef.current = setTimeout(() => {
+      dispatchFollow({ type: "programmatic_pan_start" });
+      const zoom = flowRef.current?.getZoom() ?? 1;
+      flowRef.current?.setCenter(center.x, center.y, { duration: 500, zoom });
+      followTimerRef.current = setTimeout(() => {
+        dispatchFollow({ type: "programmatic_pan_end" });
+      }, 550);
+    }, 500);
+  }, [followState, live, done, nodes, effectiveStatuses]);
 
   // Emit changes to parent
   useEffect(() => {
@@ -396,8 +551,9 @@ export default function WorkerCanvas({
       } else {
         setSelection({ type: "node", id: typedNode.id, data: typedNode.data });
       }
+      onNodeSelect?.(typedNode.id);
     },
-    [execSteps, editable, panClearOfPanel],
+    [execSteps, editable, panClearOfPanel, onNodeSelect],
   );
 
   // Edge click
@@ -517,6 +673,7 @@ export default function WorkerCanvas({
           onNodeClick={onNodeClick}
           onEdgeClick={onEdgeClick}
           onPaneClick={onPaneClick}
+          onMoveStart={onMoveStart}
           nodeTypes={nodeTypes}
           edgeTypes={edgeTypes}
           nodesDraggable={true}
@@ -571,6 +728,28 @@ export default function WorkerCanvas({
             </defs>
           </svg>
         </ReactFlow>
+
+        {/* Stage / rank position — derived from the authored edge set, so
+            reduction never changes it. Rendered whenever the graph has at
+            least one stage. */}
+        {stagePosition.totalStages > 0 && (
+          <div className="pointer-events-none absolute left-2 top-2 z-10 rounded border border-edge bg-surface-raised/90 px-1.5 py-0.5 font-mono text-[length:var(--t-xs)] text-content-secondary shadow-card">
+            Rank {stagePosition.stage} of {stagePosition.totalStages}
+          </div>
+        )}
+
+        {/* Follow toggle — visible any time the run is live, regardless of
+            follow's current state, so a manually-interrupted follow always
+            has a way back on. */}
+        {live && (
+          <button
+            type="button"
+            onClick={() => dispatchFollow({ type: "toggle" })}
+            className="absolute right-2 top-2 z-10 rounded-md border border-edge bg-surface-raised/90 px-2 py-1 text-[length:var(--t-xs)] font-medium text-content-secondary shadow-card hover:bg-surface-overlay hover:text-content-primary"
+          >
+            {followState.following ? "Following" : "Follow"}
+          </button>
+        )}
 
         {/* Toolbar */}
         {editable && (

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -25,7 +25,8 @@ import ConditionEdgeComponent from "./ConditionEdge";
 import type { ConditionEdgeData } from "./ConditionEdge";
 import SidePanel from "./SidePanel";
 import type { Selection } from "./SidePanel";
-import { getLayoutedElements, computeReservedHeight } from "./useLayout";
+import { getLayoutedElements, computeReservedHeight, FIT_ZOOM_FLOOR } from "./useLayout";
+export { FIT_ZOOM_FLOOR };
 import { followModeReducer, initialFollowModeState, shouldAutoCenter } from "./followMode";
 import { reconcileNodeStatuses, computeStagePosition } from "@/lib/execGraphProgress";
 import type { GraphEdge } from "@/lib/execGraphProgress";
@@ -38,17 +39,9 @@ import type {
   WorkerLinkEdge,
 } from "@/lib/types";
 
-// ─── Readability floor ───────────────────────────────────
-//
-// fitView shrinks the whole graph to fit the container, with no regard for
-// whether the result is still legible. StepNode's smallest text (label,
-// role, assignment, stats rows) all render at --t-xs (11px, theme.css) —
-// ConditionEdge's condition chip matches. Below a 7px screen size even
-// anti-aliased text stops being legible, so the floor is the zoom at which
-// an 11px glyph lands on 7px: 7 / 11 = 0.636, rounded up to 0.65 for a small
-// margin. Below the floor the canvas overflows its container instead of
-// shrinking further; ReactFlow's own pan/zoom-out takes over from there.
-export const FIT_ZOOM_FLOOR = 0.65;
+// FIT_ZOOM_FLOOR lives in useLayout.ts (imported and re-exported above) so
+// the reservation arithmetic there and the fitView clamp here share one
+// constant instead of drifting onto two different floors.
 
 // How far a user may deliberately zoom out, which is a different question from
 // how small the default fit may go. The floor above keeps the view we CHOOSE

--- a/apps/studio/frontend/src/components/canvas/followMode.test.ts
+++ b/apps/studio/frontend/src/components/canvas/followMode.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  followModeReducer,
+  initialFollowModeState,
+  shouldAutoCenter,
+  type FollowModeState,
+} from "./followMode";
+
+describe("initialFollowModeState", () => {
+  it("follows by default on a live, unfinished run", () => {
+    expect(initialFollowModeState(true, false)).toEqual({
+      following: true,
+      isProgrammaticPan: false,
+    });
+  });
+
+  it("does not follow when the run is not live", () => {
+    expect(initialFollowModeState(false, false).following).toBe(false);
+  });
+
+  it("does not follow a run that is already done", () => {
+    expect(initialFollowModeState(true, true).following).toBe(false);
+  });
+});
+
+describe("followModeReducer — manual interruption", () => {
+  it("a genuine manual pan/zoom disables follow", () => {
+    const state: FollowModeState = { following: true, isProgrammaticPan: false };
+    const next = followModeReducer(state, { type: "manual_interaction" });
+    expect(next.following).toBe(false);
+  });
+
+  it("an auto-pan's own onMoveEnd (isProgrammaticPan=true) does not count as manual", () => {
+    const state: FollowModeState = { following: true, isProgrammaticPan: true };
+    const next = followModeReducer(state, { type: "manual_interaction" });
+    expect(next.following).toBe(true);
+  });
+
+  it("manual interruption persists across further non-toggle actions", () => {
+    let state: FollowModeState = { following: true, isProgrammaticPan: false };
+    state = followModeReducer(state, { type: "manual_interaction" });
+    state = followModeReducer(state, { type: "run_state_changed", live: true, done: false });
+    expect(state.following).toBe(false);
+  });
+});
+
+describe("followModeReducer — toggle re-enables", () => {
+  it("toggle flips off->on", () => {
+    const state: FollowModeState = { following: false, isProgrammaticPan: false };
+    expect(followModeReducer(state, { type: "toggle" }).following).toBe(true);
+  });
+
+  it("toggle flips on->off", () => {
+    const state: FollowModeState = { following: true, isProgrammaticPan: false };
+    expect(followModeReducer(state, { type: "toggle" }).following).toBe(false);
+  });
+});
+
+describe("followModeReducer — a completed run never auto-moves", () => {
+  it("run_state_changed with done=true forces following off even if it was on", () => {
+    const state: FollowModeState = { following: true, isProgrammaticPan: false };
+    const next = followModeReducer(state, { type: "run_state_changed", live: false, done: true });
+    expect(next.following).toBe(false);
+  });
+
+  it("toggling on a done run does not make shouldAutoCenter true", () => {
+    let state: FollowModeState = { following: false, isProgrammaticPan: false };
+    state = followModeReducer(state, { type: "toggle" });
+    expect(state.following).toBe(true); // the toggle itself is honest about state...
+    expect(shouldAutoCenter(state, false, true)).toBe(false); // ...but done gates the actual auto-pan
+  });
+
+  it("run_state_changed with done=false leaves an already-off follow state off", () => {
+    const state: FollowModeState = { following: false, isProgrammaticPan: false };
+    const next = followModeReducer(state, { type: "run_state_changed", live: true, done: false });
+    expect(next.following).toBe(false);
+  });
+});
+
+describe("followModeReducer — programmatic pan bracket", () => {
+  it("start sets isProgrammaticPan, end clears it", () => {
+    let state: FollowModeState = { following: true, isProgrammaticPan: false };
+    state = followModeReducer(state, { type: "programmatic_pan_start" });
+    expect(state.isProgrammaticPan).toBe(true);
+    state = followModeReducer(state, { type: "programmatic_pan_end" });
+    expect(state.isProgrammaticPan).toBe(false);
+  });
+});
+
+describe("shouldAutoCenter", () => {
+  it("true only when following, live, and not done", () => {
+    const state: FollowModeState = { following: true, isProgrammaticPan: false };
+    expect(shouldAutoCenter(state, true, false)).toBe(true);
+    expect(shouldAutoCenter(state, false, false)).toBe(false);
+    expect(shouldAutoCenter(state, true, true)).toBe(false);
+  });
+
+  it("false when not following even if live and not done", () => {
+    const state: FollowModeState = { following: false, isProgrammaticPan: false };
+    expect(shouldAutoCenter(state, true, false)).toBe(false);
+  });
+});

--- a/apps/studio/frontend/src/components/canvas/followMode.test.ts
+++ b/apps/studio/frontend/src/components/canvas/followMode.test.ts
@@ -11,6 +11,7 @@ describe("initialFollowModeState", () => {
     expect(initialFollowModeState(true, false)).toEqual({
       following: true,
       isProgrammaticPan: false,
+      manuallyReleased: false,
     });
   });
 
@@ -25,19 +26,31 @@ describe("initialFollowModeState", () => {
 
 describe("followModeReducer — manual interruption", () => {
   it("a genuine manual pan/zoom disables follow", () => {
-    const state: FollowModeState = { following: true, isProgrammaticPan: false };
+    const state: FollowModeState = {
+      following: true,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     const next = followModeReducer(state, { type: "manual_interaction" });
     expect(next.following).toBe(false);
   });
 
   it("an auto-pan's own onMoveEnd (isProgrammaticPan=true) does not count as manual", () => {
-    const state: FollowModeState = { following: true, isProgrammaticPan: true };
+    const state: FollowModeState = {
+      following: true,
+      isProgrammaticPan: true,
+      manuallyReleased: false,
+    };
     const next = followModeReducer(state, { type: "manual_interaction" });
     expect(next.following).toBe(true);
   });
 
   it("manual interruption persists across further non-toggle actions", () => {
-    let state: FollowModeState = { following: true, isProgrammaticPan: false };
+    let state: FollowModeState = {
+      following: true,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     state = followModeReducer(state, { type: "manual_interaction" });
     state = followModeReducer(state, { type: "run_state_changed", live: true, done: false });
     expect(state.following).toBe(false);
@@ -46,40 +59,92 @@ describe("followModeReducer — manual interruption", () => {
 
 describe("followModeReducer — toggle re-enables", () => {
   it("toggle flips off->on", () => {
-    const state: FollowModeState = { following: false, isProgrammaticPan: false };
+    const state: FollowModeState = {
+      following: false,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     expect(followModeReducer(state, { type: "toggle" }).following).toBe(true);
   });
 
   it("toggle flips on->off", () => {
-    const state: FollowModeState = { following: true, isProgrammaticPan: false };
+    const state: FollowModeState = {
+      following: true,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     expect(followModeReducer(state, { type: "toggle" }).following).toBe(false);
   });
 });
 
 describe("followModeReducer — a completed run never auto-moves", () => {
   it("run_state_changed with done=true forces following off even if it was on", () => {
-    const state: FollowModeState = { following: true, isProgrammaticPan: false };
+    const state: FollowModeState = {
+      following: true,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     const next = followModeReducer(state, { type: "run_state_changed", live: false, done: true });
     expect(next.following).toBe(false);
   });
 
   it("toggling on a done run does not make shouldAutoCenter true", () => {
-    let state: FollowModeState = { following: false, isProgrammaticPan: false };
+    let state: FollowModeState = {
+      following: false,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     state = followModeReducer(state, { type: "toggle" });
     expect(state.following).toBe(true); // the toggle itself is honest about state...
     expect(shouldAutoCenter(state, false, true)).toBe(false); // ...but done gates the actual auto-pan
   });
+});
 
-  it("run_state_changed with done=false leaves an already-off follow state off", () => {
-    const state: FollowModeState = { following: false, isProgrammaticPan: false };
+describe("followModeReducer — the normal first live transition (RunDetail mounts false/false, then goes live)", () => {
+  it("run_state_changed false->live true enables follow when the user never released it", () => {
+    const state: FollowModeState = {
+      following: false,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
+    const next = followModeReducer(state, { type: "run_state_changed", live: true, done: false });
+    expect(next.following).toBe(true);
+  });
+
+  it("run_state_changed false->live true stays off if the user already manually released follow", () => {
+    let state: FollowModeState = {
+      following: true,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
+    state = followModeReducer(state, { type: "manual_interaction" });
+    expect(state.following).toBe(false);
     const next = followModeReducer(state, { type: "run_state_changed", live: true, done: false });
     expect(next.following).toBe(false);
+  });
+
+  it("full sequence: mount false/false -> live true enables follow -> manual pan releases -> re-mounting live true does not resurrect it", () => {
+    let state = initialFollowModeState(false, false);
+    expect(state.following).toBe(false);
+
+    state = followModeReducer(state, { type: "run_state_changed", live: true, done: false });
+    expect(state.following).toBe(true);
+
+    state = followModeReducer(state, { type: "manual_interaction" });
+    expect(state.following).toBe(false);
+
+    state = followModeReducer(state, { type: "run_state_changed", live: true, done: false });
+    expect(state.following).toBe(false);
   });
 });
 
 describe("followModeReducer — programmatic pan bracket", () => {
   it("start sets isProgrammaticPan, end clears it", () => {
-    let state: FollowModeState = { following: true, isProgrammaticPan: false };
+    let state: FollowModeState = {
+      following: true,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     state = followModeReducer(state, { type: "programmatic_pan_start" });
     expect(state.isProgrammaticPan).toBe(true);
     state = followModeReducer(state, { type: "programmatic_pan_end" });
@@ -89,14 +154,22 @@ describe("followModeReducer — programmatic pan bracket", () => {
 
 describe("shouldAutoCenter", () => {
   it("true only when following, live, and not done", () => {
-    const state: FollowModeState = { following: true, isProgrammaticPan: false };
+    const state: FollowModeState = {
+      following: true,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     expect(shouldAutoCenter(state, true, false)).toBe(true);
     expect(shouldAutoCenter(state, false, false)).toBe(false);
     expect(shouldAutoCenter(state, true, true)).toBe(false);
   });
 
   it("false when not following even if live and not done", () => {
-    const state: FollowModeState = { following: false, isProgrammaticPan: false };
+    const state: FollowModeState = {
+      following: false,
+      isProgrammaticPan: false,
+      manuallyReleased: false,
+    };
     expect(shouldAutoCenter(state, true, false)).toBe(false);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/followMode.ts
+++ b/apps/studio/frontend/src/components/canvas/followMode.ts
@@ -1,0 +1,69 @@
+// Pure state machine for "follow the run" (WorkerCanvas REQUIREMENT 4):
+// during a live run the viewport may auto-pan to keep the running frontier
+// in view, but ANY manual pan/zoom disables follow for the rest of that run,
+// with a visible way to re-enable; a finished run never auto-moves. Kept
+// framework-free (no React, no ReactFlow types) so the transition table is
+// unit-testable without mounting a canvas; a `useReducer(followModeReducer,
+// initialFollowModeState(...))` in WorkerCanvas is the intended wiring.
+
+export interface FollowModeState {
+  following: boolean;
+  /** True while a `setCenter` call this state machine initiated is in
+   * flight — used to tell an auto-pan's own `onMoveEnd` apart from the
+   * user's hands on the wheel. */
+  isProgrammaticPan: boolean;
+}
+
+export type FollowModeAction =
+  | { type: "run_state_changed"; live: boolean; done: boolean }
+  | { type: "manual_interaction" }
+  | { type: "toggle" }
+  | { type: "programmatic_pan_start" }
+  | { type: "programmatic_pan_end" };
+
+// Follow defaults on for a live, unfinished run and off otherwise — matching
+// the contract's "true by default when live && !done".
+export function initialFollowModeState(live: boolean, done: boolean): FollowModeState {
+  return { following: live && !done, isProgrammaticPan: false };
+}
+
+export function followModeReducer(
+  state: FollowModeState,
+  action: FollowModeAction,
+): FollowModeState {
+  switch (action.type) {
+    case "run_state_changed":
+      // A run reaching its terminal state always turns follow off — a
+      // finished run must never auto-move. Going live does not force
+      // following back on by itself: a fresh run re-initializes via
+      // initialFollowModeState instead, so a viewer's earlier manual
+      // interruption is never silently overridden mid-run.
+      return action.done ? { ...state, following: false } : state;
+
+    case "manual_interaction":
+      // A pan/zoom this state machine did not itself initiate is the
+      // user's hands on the wheel — that always wins for the rest of the
+      // run, until an explicit toggle or a fresh run re-initializes.
+      if (state.isProgrammaticPan) return state;
+      return { ...state, following: false };
+
+    case "toggle":
+      return { ...state, following: !state.following };
+
+    case "programmatic_pan_start":
+      return { ...state, isProgrammaticPan: true };
+
+    case "programmatic_pan_end":
+      return { ...state, isProgrammaticPan: false };
+
+    default:
+      return state;
+  }
+}
+
+// Whether the caller should issue an auto-center call right now. Centralizes
+// the live/done gating so a caller cannot auto-pan a finished run just
+// because `following` was left true from a stale state update.
+export function shouldAutoCenter(state: FollowModeState, live: boolean, done: boolean): boolean {
+  return state.following && live && !done;
+}

--- a/apps/studio/frontend/src/components/canvas/followMode.ts
+++ b/apps/studio/frontend/src/components/canvas/followMode.ts
@@ -12,6 +12,11 @@ export interface FollowModeState {
    * flight — used to tell an auto-pan's own `onMoveEnd` apart from the
    * user's hands on the wheel. */
   isProgrammaticPan: boolean;
+  /** True once the viewer has deliberately turned follow off (manual
+   * pan/zoom, or toggling it off) — tracked separately from `following`
+   * so a false->live transition can tell "never turned on yet" apart from
+   * "the viewer turned it off" and only auto-enable in the former case. */
+  manuallyReleased: boolean;
 }
 
 export type FollowModeAction =
@@ -24,7 +29,7 @@ export type FollowModeAction =
 // Follow defaults on for a live, unfinished run and off otherwise — matching
 // the contract's "true by default when live && !done".
 export function initialFollowModeState(live: boolean, done: boolean): FollowModeState {
-  return { following: live && !done, isProgrammaticPan: false };
+  return { following: live && !done, isProgrammaticPan: false, manuallyReleased: false };
 }
 
 export function followModeReducer(
@@ -34,21 +39,32 @@ export function followModeReducer(
   switch (action.type) {
     case "run_state_changed":
       // A run reaching its terminal state always turns follow off — a
-      // finished run must never auto-move. Going live does not force
-      // following back on by itself: a fresh run re-initializes via
-      // initialFollowModeState instead, so a viewer's earlier manual
-      // interruption is never silently overridden mid-run.
-      return action.done ? { ...state, following: false } : state;
+      // finished run must never auto-move.
+      if (action.done) return { ...state, following: false };
+      // A run going live for the first time (mount always inits false/false,
+      // since getSession's initial fetch never marks an active run live —
+      // see RunDetail) is the normal path, not a resumed one: turn follow on
+      // unless the viewer has already released it this run, mirroring
+      // initialFollowModeState's own "true by default when live && !done".
+      if (action.live && !state.following && !state.manuallyReleased) {
+        return { ...state, following: true };
+      }
+      return state;
 
     case "manual_interaction":
       // A pan/zoom this state machine did not itself initiate is the
       // user's hands on the wheel — that always wins for the rest of the
       // run, until an explicit toggle or a fresh run re-initializes.
       if (state.isProgrammaticPan) return state;
-      return { ...state, following: false };
+      return { ...state, following: false, manuallyReleased: true };
 
-    case "toggle":
-      return { ...state, following: !state.following };
+    case "toggle": {
+      const following = !state.following;
+      // Toggling on is an activation, not a release: clear the flag so a
+      // later live transition isn't stuck off. Toggling off is a deliberate
+      // release, same as a manual pan.
+      return { ...state, following, manuallyReleased: following ? false : true };
+    }
 
     case "programmatic_pan_start":
       return { ...state, isProgrammaticPan: true };

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -22,11 +22,12 @@ import {
   foldWideGraph,
   markContinuationEdges,
   DAG_MAX_ZOOM,
-  DAG_MIN_ZOOM,
+  DAG_FIT_PADDING,
+  FIT_ZOOM_FLOOR,
   computeReservedHeight,
 } from "./useLayout";
 import { transitiveReduceDisplay } from "@/lib/operationGraph";
-import { fitZoomFor, FIT_ZOOM_FLOOR, MIN_INTERACTIVE_ZOOM } from "./WorkerCanvas";
+import { fitZoomFor, MIN_INTERACTIVE_ZOOM } from "./WorkerCanvas";
 
 const bare = (id: string): Node => ({
   id,
@@ -1243,9 +1244,12 @@ describe("computeReservedHeight — width-constrained rendered-height reservatio
   });
 
   it("matches the fit-zoom arithmetic exactly for a width-constrained graph", () => {
-    const bboxWidth = 3000;
+    // Numbers chosen so the unclamped fit zoom clears FIT_ZOOM_FLOOR (0.65)
+    // but stays below DAG_MAX_ZOOM (1) — genuinely width-constrained, not
+    // floor- or ceiling-clamped.
+    const bboxWidth = 1200;
     const bboxHeight = 600;
-    const containerWidth = 700;
+    const containerWidth = 1000;
     const expectedZoom = containerWidth / (bboxWidth * 1.15);
     expect(computeReservedHeight(bboxWidth, bboxHeight, containerWidth)).toBeCloseTo(
       bboxHeight * expectedZoom,
@@ -1265,14 +1269,25 @@ describe("computeReservedHeight — width-constrained rendered-height reservatio
     expect(reserved).toBeCloseTo(900, 5);
   });
 
-  it("never scales below the readability zoom floor (DAG_MIN_ZOOM), however wide the graph", () => {
+  it("never scales below the readability zoom floor the canvas actually clamps to (FIT_ZOOM_FLOOR), however wide the graph", () => {
     // An extremely wide graph into a narrow container: fitView cannot zoom
-    // out past DAG_MIN_ZOOM, so the panel must not reserve less than that.
+    // out past FIT_ZOOM_FLOOR (WorkerCanvas's own clamp), so the panel must
+    // not reserve less than that — reserving at a lower floor leaves most of
+    // what the canvas actually renders outside the panel.
     const bboxWidth = 100_000;
     const bboxHeight = 500;
     const containerWidth = 400;
     const reserved = computeReservedHeight(bboxWidth, bboxHeight, containerWidth);
-    expect(reserved).toBeCloseTo(bboxHeight * DAG_MIN_ZOOM, 5);
+    expect(reserved).toBeCloseTo(bboxHeight * FIT_ZOOM_FLOOR, 5);
+  });
+
+  it("matches the canvas's real fit height for an under-fit graph (10,000x10,000 in a 711px panel)", () => {
+    // Regression for the reservation/canvas floor divergence: the reservation
+    // must render the same height the canvas actually fits to, not a smaller
+    // one computed against a different, lower floor.
+    const reserved = computeReservedHeight(10_000, 10_000, 711);
+    const canvasZoom = fitZoomFor(10_000, 10_000, 711, Infinity, DAG_FIT_PADDING, DAG_MAX_ZOOM);
+    expect(reserved).toBeCloseTo(10_000 * canvasZoom, 5);
   });
 
   it("never scales above DAG_MAX_ZOOM even for a tiny bbox in a huge container", () => {

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -21,6 +21,9 @@ import {
   wrapWideRanks,
   foldWideGraph,
   markContinuationEdges,
+  DAG_MAX_ZOOM,
+  DAG_MIN_ZOOM,
+  computeReservedHeight,
 } from "./useLayout";
 import { transitiveReduceDisplay } from "@/lib/operationGraph";
 import { fitZoomFor, FIT_ZOOM_FLOOR, MIN_INTERACTIVE_ZOOM } from "./WorkerCanvas";
@@ -1207,5 +1210,99 @@ describe("getLayoutedElements — folding a mid-run branch+join stays edge-aware
     expect(height).toBeCloseTo(504, -1);
     expect(rawFit).toBeGreaterThan(0.55);
     expect(rawFit).toBeLessThan(0.75);
+  });
+});
+
+describe("getLayoutedElements — reports a bounding-box width alongside height", () => {
+  it("reports zero width for an empty graph", () => {
+    expect(getLayoutedElements([], [], "LR").width).toBe(0);
+  });
+
+  it("reports a positive width for a populated graph", () => {
+    const { width } = getLayoutedElements(
+      [full("a"), full("b")],
+      [{ id: "a-b", source: "a", target: "b" }],
+      "LR",
+    );
+    expect(width).toBeGreaterThan(0);
+  });
+});
+
+describe("computeReservedHeight — width-constrained rendered-height reservation", () => {
+  // The dead-height bug: getLayoutedElements reports the UNSCALED bbox
+  // height, but a wide graph renders width-constrained at a smaller zoom —
+  // so a container reserving the raw bbox height reserves far more than the
+  // graph ever draws. computeReservedHeight must report what will actually
+  // render, given the bbox and the real container width.
+
+  it("shrinks the reserved height for a width-constrained (very wide) graph", () => {
+    // 3000px-wide bbox into a 700px container is far below zoom 1.
+    const reserved = computeReservedHeight(3000, 600, 700);
+    expect(reserved).toBeLessThan(600);
+    expect(reserved).toBeGreaterThan(0);
+  });
+
+  it("matches the fit-zoom arithmetic exactly for a width-constrained graph", () => {
+    const bboxWidth = 3000;
+    const bboxHeight = 600;
+    const containerWidth = 700;
+    const expectedZoom = containerWidth / (bboxWidth * 1.15);
+    expect(computeReservedHeight(bboxWidth, bboxHeight, containerWidth)).toBeCloseTo(
+      bboxHeight * expectedZoom,
+      5,
+    );
+  });
+
+  it("reserves the full reported height for a graph that fits entirely (zoom would clamp to 1)", () => {
+    // A narrow, short bbox well inside the container never needs to shrink —
+    // fitView's maxZoom of 1 caps it there, not beyond.
+    const reserved = computeReservedHeight(200, 150, 1200);
+    expect(reserved).toBeCloseTo(150, 5);
+  });
+
+  it("is height-constrained (not width-constrained) for a tall narrow graph — full reported height, zoom 1", () => {
+    const reserved = computeReservedHeight(150, 900, 1200);
+    expect(reserved).toBeCloseTo(900, 5);
+  });
+
+  it("never scales below the readability zoom floor (DAG_MIN_ZOOM), however wide the graph", () => {
+    // An extremely wide graph into a narrow container: fitView cannot zoom
+    // out past DAG_MIN_ZOOM, so the panel must not reserve less than that.
+    const bboxWidth = 100_000;
+    const bboxHeight = 500;
+    const containerWidth = 400;
+    const reserved = computeReservedHeight(bboxWidth, bboxHeight, containerWidth);
+    expect(reserved).toBeCloseTo(bboxHeight * DAG_MIN_ZOOM, 5);
+  });
+
+  it("never scales above DAG_MAX_ZOOM even for a tiny bbox in a huge container", () => {
+    const reserved = computeReservedHeight(50, 40, 5000);
+    expect(reserved).toBeCloseTo(40 * DAG_MAX_ZOOM, 5);
+  });
+
+  it("degrades to the raw height rather than dividing by zero on a degenerate bbox/container", () => {
+    expect(computeReservedHeight(0, 500, 700)).toBe(500);
+    expect(computeReservedHeight(500, 0, 700)).toBe(0);
+    expect(computeReservedHeight(500, 500, 0)).toBe(500);
+  });
+
+  it("end-to-end: a real wrapped fan-out's reserved height is materially smaller than its raw height at a realistic panel width", () => {
+    const workers = Array.from({ length: 24 }, (_, i) => `w${i + 1}`);
+    const nodes: Node[] = [
+      { id: "root", position: { x: 0, y: 0 }, data: { label: "root", role: "analyst" } },
+      ...workers.map((id) => ({
+        id,
+        position: { x: 0, y: 0 },
+        data: { label: id, role: "analyst" },
+      })),
+      { id: "sink", position: { x: 0, y: 0 }, data: { label: "sink", role: "analyst" } },
+    ];
+    const edges: Edge[] = [
+      ...workers.map((w) => ({ id: `root-${w}`, source: "root", target: w })),
+      ...workers.map((w) => ({ id: `${w}-sink`, source: w, target: "sink" })),
+    ];
+    const { height, width } = getLayoutedElements(nodes, edges, "LR");
+    const reserved = computeReservedHeight(width, height, 711); // measured RunDetail panel width
+    expect(reserved).toBeLessThan(height);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -379,11 +379,24 @@ export interface LayoutedGraph {
 // fitView is width-constrained for any graph wider than its container (true
 // of almost every real run graph), so the zoom actually applied is clamped
 // to what dagre's own container-fit contract already uses in WorkerCanvas:
-// padding 0.15, min 0.1 ("the readability zoom floor" — a wider graph never
-// renders smaller than this), max 1 (never zoomed in past 1:1 to fit).
+// padding 0.15, max 1 (never zoomed in past 1:1 to fit). The floor is
+// FIT_ZOOM_FLOOR below — defined here (not in WorkerCanvas.tsx, which
+// imports from this module) so the reservation arithmetic and the canvas's
+// actual fitView clamp can never diverge onto two different floors.
 export const DAG_FIT_PADDING = 0.15;
-export const DAG_MIN_ZOOM = 0.1;
 export const DAG_MAX_ZOOM = 1;
+
+// ─── Readability floor ───────────────────────────────────
+//
+// fitView shrinks the whole graph to fit the container, with no regard for
+// whether the result is still legible. StepNode's smallest text (label,
+// role, assignment, stats rows) all render at --t-xs (11px, theme.css) —
+// ConditionEdge's condition chip matches. Below a 7px screen size even
+// anti-aliased text stops being legible, so the floor is the zoom at which
+// an 11px glyph lands on 7px: 7 / 11 = 0.636, rounded up to 0.65 for a small
+// margin. Below the floor the canvas overflows its container instead of
+// shrinking further; ReactFlow's own pan/zoom-out takes over from there.
+export const FIT_ZOOM_FLOOR = 0.65;
 
 // getLayoutedElements (below) reports the graph's UNSCALED bounding-box
 // size. A container that reserves height at that value reserves for a shape
@@ -400,7 +413,7 @@ export function computeReservedHeight(
 ): number {
   if (bboxWidth <= 0 || bboxHeight <= 0 || containerWidth <= 0) return bboxHeight;
   const fitZoom = containerWidth / (bboxWidth * (1 + DAG_FIT_PADDING));
-  const zoom = Math.min(DAG_MAX_ZOOM, Math.max(DAG_MIN_ZOOM, fitZoom));
+  const zoom = Math.min(DAG_MAX_ZOOM, Math.max(FIT_ZOOM_FLOOR, fitZoom));
   return bboxHeight * zoom;
 }
 

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -372,6 +372,36 @@ export interface LayoutedGraph {
   /** node id -> longest-path depth (rank index), for edge rank-distance
    * styling (ConditionEdge's long-range smooth-step routing). */
   ranks: Map<string, number>;
+  /** UNSCALED bounding-box width, for computeReservedHeight callers. */
+  width: number;
+}
+
+// fitView is width-constrained for any graph wider than its container (true
+// of almost every real run graph), so the zoom actually applied is clamped
+// to what dagre's own container-fit contract already uses in WorkerCanvas:
+// padding 0.15, min 0.1 ("the readability zoom floor" — a wider graph never
+// renders smaller than this), max 1 (never zoomed in past 1:1 to fit).
+export const DAG_FIT_PADDING = 0.15;
+export const DAG_MIN_ZOOM = 0.1;
+export const DAG_MAX_ZOOM = 1;
+
+// getLayoutedElements (below) reports the graph's UNSCALED bounding-box
+// size. A container that reserves height at that value reserves for a shape
+// the graph never actually draws: at the zoom fitView will actually apply —
+// width-constrained and clamped to the same floor/ceiling WorkerCanvas uses
+// — the rendered height is smaller. Given the bbox and the container width
+// the panel will actually have, this returns the height that will actually
+// render, so a wide graph does not leave the rest of its reserved panel
+// empty.
+export function computeReservedHeight(
+  bboxWidth: number,
+  bboxHeight: number,
+  containerWidth: number,
+): number {
+  if (bboxWidth <= 0 || bboxHeight <= 0 || containerWidth <= 0) return bboxHeight;
+  const fitZoom = containerWidth / (bboxWidth * (1 + DAG_FIT_PADDING));
+  const zoom = Math.min(DAG_MAX_ZOOM, Math.max(DAG_MIN_ZOOM, fitZoom));
+  return bboxHeight * zoom;
 }
 
 export function getLayoutedElements(
@@ -428,13 +458,24 @@ export function getLayoutedElements(
   // fan-out is exactly as tall as its grid.
   let top = Infinity;
   let bottom = -Infinity;
+  let left = Infinity;
+  let right = -Infinity;
   for (const node of finalNodes) {
     top = Math.min(top, node.position.y);
     bottom = Math.max(bottom, node.position.y + estimateNodeHeight(node));
+    left = Math.min(left, node.position.x);
+    right = Math.max(right, node.position.x + NODE_WIDTH);
   }
   const height = finalNodes.length === 0 ? 0 : bottom - top + 2 * 24;
+  const width = finalNodes.length === 0 ? 0 : right - left + 2 * 28;
 
-  return { nodes: finalNodes, edges: markContinuationEdges(finalNodes, edges), height, ranks };
+  return {
+    nodes: finalNodes,
+    edges: markContinuationEdges(finalNodes, edges),
+    height,
+    width,
+    ranks,
+  };
 }
 
 export function useAutoLayout() {

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -1477,3 +1477,336 @@ describe("history/RunDetail.tsx — a collapsed pair keeps its richer edge", () 
     expect(out.map((e) => e.id)).toEqual(["cond", "other"]);
   });
 });
+
+// ─── Graph-node drill-down: matching ───────────────────────────────────────
+// Graph nodes are keyed by authored role/assignment name (WorkerStepNode.id);
+// branches carry agent_name, falling back to name, then an id prefix — see
+// implementation_brief.md and the measured RunDetail.tsx:335 formula. Both
+// match arms (a node WITH a branch, a node WITHOUT one) are exercised here.
+
+function makeBranch(overrides: Partial<import("@/lib/api").SessionBranch>) {
+  return {
+    id: "abcdef1234567890",
+    name: "",
+    created_at: 0,
+    messages: [],
+    ...overrides,
+  } as import("@/lib/api").SessionBranch;
+}
+
+describe("history/RunDetail.tsx — matchGraphNodeToBranch (graph-node drill-down)", () => {
+  it("match arm: resolves by agent_name first", async () => {
+    const { matchGraphNodeToBranch } = await import("./RunDetail");
+    const branches = [
+      makeBranch({ id: "b1", name: "analyst-role", agent_name: "analyst" }),
+      makeBranch({ id: "b2", name: "analyst", agent_name: null }),
+    ];
+    const match = matchGraphNodeToBranch("analyst", branches);
+    expect(match?.id).toBe("b1");
+  });
+
+  it("match arm: falls back to name when no agent_name matches", async () => {
+    const { matchGraphNodeToBranch } = await import("./RunDetail");
+    const branches = [
+      makeBranch({ id: "b1", name: "other", agent_name: "someone-else" }),
+      makeBranch({ id: "b2", name: "tester", agent_name: null }),
+    ];
+    const match = matchGraphNodeToBranch("tester", branches);
+    expect(match?.id).toBe("b2");
+  });
+
+  it("match arm: falls back to an 8-char id prefix when neither agent_name nor name matches", async () => {
+    const { matchGraphNodeToBranch } = await import("./RunDetail");
+    const branches = [makeBranch({ id: "9e5f593fabcdef01", name: "", agent_name: null })];
+    const match = matchGraphNodeToBranch("9e5f593f", branches);
+    expect(match?.id).toBe("9e5f593fabcdef01");
+  });
+
+  it("unmatched arm: returns null when nothing resolves — the explicit no-branch case", async () => {
+    const { matchGraphNodeToBranch } = await import("./RunDetail");
+    const branches = [makeBranch({ id: "b1", name: "tester", agent_name: "tester" })];
+    expect(matchGraphNodeToBranch("nonexistent-role", branches)).toBeNull();
+  });
+
+  it("matched branch resolves to the SAME key branchToRunStep uses (stepKeyForBranch identity)", async () => {
+    const { matchGraphNodeToBranch, stepKeyForBranch, branchToRunStep } =
+      await import("./RunDetail");
+    const branch = makeBranch({ id: "b1", name: "reviewer", agent_name: "reviewer" });
+    const match = matchGraphNodeToBranch("reviewer", [branch]);
+    expect(match).not.toBeNull();
+    const key = stepKeyForBranch(match!);
+    const step = branchToRunStep(branch, "completed");
+    // The drill-down expands/highlights expandedSteps.has(key) and scrolls to
+    // `#step-${key}` — both must agree with what RunStepCard actually renders.
+    expect(key).toBe(step.step);
+  });
+});
+
+// ─── Header-source identity + terminal no-signal presentation ─────────────
+// The progress summary and the graph nodes must derive from the exact same
+// reconciled status map, and a node with no lifecycle signal on a finished
+// run must never present as "running".
+
+describe("history/RunDetail.tsx — computeReconciledNodeStatuses / computeProgressCountsForGraph", () => {
+  const graph = {
+    nodes: [
+      { id: "a" },
+      { id: "b" },
+      { id: "c" },
+    ] as unknown as import("@/lib/types").WorkerGraph["nodes"],
+    edges: [{ source: "a", target: "b" }] as unknown as import("@/lib/types").WorkerGraph["edges"],
+  };
+
+  it("terminal no-signal presentation: an isolated node stuck 'running' on a DONE run reads pending, never running", async () => {
+    const { computeReconciledNodeStatuses } = await import("./RunDetail");
+    // "c" has no outgoing edges (no descendant to trigger suppression) and no
+    // terminal signal was ever recorded for it — on a done run that must
+    // read as absence of information ("pending"), never as live work.
+    const reconciled = computeReconciledNodeStatuses(graph, { c: "running" }, true);
+    expect(reconciled?.c).toBe("pending");
+  });
+
+  it("descendant-terminal suppression corrects a stale 'running' reading to 'completed' before the terminal-run collapse runs", async () => {
+    const { computeReconciledNodeStatuses } = await import("./RunDetail");
+    // "a" still reads "running" but its descendant "b" already completed —
+    // "a" could not still be running, so it resolves to "completed" (a
+    // terminal status), not "pending".
+    const reconciled = computeReconciledNodeStatuses(graph, { a: "running", b: "completed" }, true);
+    expect(reconciled?.a).toBe("completed");
+  });
+
+  it("descendant-terminal suppression holds even on a still-live run (not done-gated)", async () => {
+    const { computeReconciledNodeStatuses } = await import("./RunDetail");
+    const reconciled = computeReconciledNodeStatuses(
+      graph,
+      { a: "running", b: "completed" },
+      false,
+    );
+    expect(reconciled?.a).toBe("completed");
+  });
+
+  it("header-source identity: counts are derived from the exact reconciled map, so they cannot diverge from what the graph would render", async () => {
+    const { computeReconciledNodeStatuses, computeProgressCountsForGraph } =
+      await import("./RunDetail");
+    const reconciled = computeReconciledNodeStatuses(graph, { a: "running", b: "completed" }, true);
+    const counts = computeProgressCountsForGraph(graph, reconciled);
+    // Same map both consumers would read: a→completed (descendant
+    // suppression, since b already completed), b→completed, c→pending (no
+    // entry, default — collapse leaves it as-is since it was never active).
+    expect(counts).toMatchObject({ total: 3, completed: 2, running: 0, pending: 1, failed: 0 });
+    expect(counts?.hasFailure).toBe(false);
+  });
+
+  it("hasFailure trips the unmissable-failure header tone when any node is failed or escalated", async () => {
+    const { computeReconciledNodeStatuses, computeProgressCountsForGraph } =
+      await import("./RunDetail");
+    const reconciled = computeReconciledNodeStatuses(graph, { a: "escalated" }, true);
+    const counts = computeProgressCountsForGraph(graph, reconciled);
+    expect(counts?.hasFailure).toBe(true);
+    expect(counts?.failed).toBe(1);
+  });
+
+  it("returns undefined/null gracefully when there is no run graph yet", async () => {
+    const { computeReconciledNodeStatuses, computeProgressCountsForGraph } =
+      await import("./RunDetail");
+    expect(computeReconciledNodeStatuses(null, undefined, false)).toBeUndefined();
+    expect(computeProgressCountsForGraph(null, undefined)).toBeNull();
+  });
+});
+
+// ─── Expand / close wiring + full-content-width placement ─────────────────
+// Source-text checks mirroring the existing wiring-assertion style in this
+// file (e.g. "authored run graph is rendered unreduced" above) — the
+// behavior itself (open/close/Escape) is a DOM-event state machine that is
+// exercised end-to-end by the pure reducer style tests above and by manual
+// verification (documented in run_detail_implementation.md); these pin the
+// wiring so a refactor can't silently drop the close paths.
+
+describe("history/RunDetail.tsx — execution-graph expand/close wiring", () => {
+  const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+
+  it("Escape closes the expanded graph overlay", () => {
+    expect(src).toMatch(/event\.key === "Escape"/);
+    expect(src).toMatch(/setGraphExpanded\(false\)/);
+  });
+
+  it("an explicit close button also closes the overlay", () => {
+    expect(src).toMatch(/onClick={\(\) => setGraphExpanded\(false\)}/);
+  });
+
+  it("the expand control opens the overlay", () => {
+    expect(src).toMatch(/onClick={\(\) => setGraphExpanded\(true\)}/);
+  });
+
+  it("the run-dag panel is not constrained narrower than its flex parent (full-content-width placement)", () => {
+    expect(src).toMatch(/id="run-dag" className="w-full scroll-mt-4"/);
+  });
+
+  it("both the inline and expanded WorkerCanvas embeds read nodeStatuses from the same reconciled map", () => {
+    const occurrences = src.match(/nodeStatuses={reconciledNodeStatuses}/g) ?? [];
+    expect(occurrences.length).toBe(2);
+    // No remaining callsite passes the raw (unreconciled) map to the graph.
+    expect(src).not.toMatch(/nodeStatuses={nodeStatuses}/);
+  });
+
+  it("the progress summary bar renders from the same progressCounts used by both graph embeds", () => {
+    const occurrences = src.match(/<ProgressSummaryBar counts={progressCounts}/g) ?? [];
+    expect(occurrences.length).toBe(2);
+  });
+});
+
+// ─── Unmatched-node explicit state ─────────────────────────────────────────
+
+describe("history/RunDetail.tsx — unmatched graph-node click shows an explicit state", () => {
+  const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+
+  it("a click that resolves no branch sets unmatchedNodeId instead of silently no-opping", () => {
+    expect(src).toMatch(/setUnmatchedNodeId\(nodeId\)/);
+  });
+
+  it("renders the explicit no-branch state when unmatchedNodeId is set", () => {
+    expect(src).toMatch(/data-testid="run-dag-unmatched-node"/);
+    expect(src).toMatch(/t\("nodeNoBranch", \{ node: unmatchedNodeId \}\)/);
+  });
+
+  it("a subsequent matched click clears the no-branch state", () => {
+    expect(src).toMatch(/setUnmatchedNodeId\(null\)/);
+  });
+});
+
+// ─── Follow-mode wiring (live/done) into WorkerCanvas ──────────────────────
+//
+// WorkerCanvas's follow-mode reducer (initialFollowModeState(live, done)) and
+// its "Follow"/"Following" toggle (gated on `live`, see WorkerCanvas.tsx) are
+// dead in production unless RunDetail actually passes its own `live`/`done`
+// state down as props — both default to `false` in WorkerCanvas, so an
+// embed that omits them behaves as an already-finished, never-live run no
+// matter what the session is actually doing. RunDetail already computes
+// `live`/`done` (used a few lines below for `OperationGraphSection`), so this
+// pins that the SAME values reach every WorkerCanvas embed too.
+
+describe("history/RunDetail.tsx — WorkerCanvas live/done wiring for follow-mode", () => {
+  const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+  const workerCanvasBlocks = src.match(/<WorkerCanvas[^]*?\/>/g) ?? [];
+
+  it("finds both the inline and expanded WorkerCanvas embeds to check", () => {
+    expect(workerCanvasBlocks.length).toBe(2);
+  });
+
+  it("every WorkerCanvas embed passes the run's live state, so follow-mode can activate on a live run", () => {
+    for (const block of workerCanvasBlocks) {
+      expect(block).toMatch(/\blive={/);
+    }
+  });
+
+  it("every WorkerCanvas embed passes the run's done state, so follow-mode is force-disabled on a finished run", () => {
+    for (const block of workerCanvasBlocks) {
+      expect(block).toMatch(/\bdone={/);
+    }
+  });
+});
+
+// ─── Expanded-overlay status persistence (onLayoutHeight stability) ───────
+//
+// WorkerCanvas's layout effect lists `onLayoutHeight` in its dependency
+// array (see WorkerCanvas.tsx), so a fresh inline arrow passed on every
+// RunDetail rerender re-triggers a bare relayout that clears execStatus
+// until the separate status-application effect happens to also rerun. An
+// inline `() => {}` at the expanded call site reproduced exactly this: the
+// expanded graph flashed to all-pending while the inline panel kept
+// completed/running styling. Both embeds must reference a stable
+// (useCallback/useRef-backed) identifier, never an inline arrow.
+
+describe("history/RunDetail.tsx — WorkerCanvas onLayoutHeight is a stable reference", () => {
+  const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+  const workerCanvasBlocks = src.match(/<WorkerCanvas[^]*?\/>/g) ?? [];
+
+  it("finds both WorkerCanvas embeds", () => {
+    expect(workerCanvasBlocks.length).toBe(2);
+  });
+
+  it("no embed passes an inline arrow function as onLayoutHeight — that identity churns every render and re-triggers WorkerCanvas's layout effect, clobbering execStatus", () => {
+    for (const block of workerCanvasBlocks) {
+      const match = block.match(/onLayoutHeight={([^}]*)}/);
+      expect(match).not.toBeNull();
+      expect(match![1]).not.toMatch(/=>/);
+    }
+  });
+
+  it("the expanded embed's onLayoutHeight identifier is declared via useCallback so it is stable across rerenders", () => {
+    const expandedBlockIndex = src.indexOf("closeExpandedGraph");
+    const expandedWorkerCanvas = workerCanvasBlocks.find(
+      (b) => src.indexOf(b) > expandedBlockIndex,
+    );
+    expect(expandedWorkerCanvas).toBeDefined();
+    const match = expandedWorkerCanvas!.match(/onLayoutHeight={(\w+)}/);
+    expect(match).not.toBeNull();
+    const identifier = match![1];
+    expect(src).toMatch(new RegExp(`const ${identifier} = useCallback\\(`));
+  });
+});
+
+// ─── Dag panel height policy (floor / grow-only) ────────────────────────────
+//
+// computeReservedHeight (useLayout.ts) reports the EXACT height a graph will
+// render at its applied zoom, and that helper is unit-tested in isolation.
+// But the production panel (dagHeight, driven by onDagLayoutHeight below)
+// intentionally does not always reserve that exact number: it floors to
+// DAG_MIN_HEIGHT, with no ceiling (a capped card would force fitView below
+// the readability floor for a graph taller than the cap — the enclosing page
+// scrolls past a tall card instead), and — for a given run id — only ever
+// grows, never shrinks, so a mid-stream layout that computes a smaller
+// height than what's already committed does not shrink the panel underneath
+// the reader. This test pins that policy directly against the real
+// onDagLayoutHeight reducer logic (mirrored here byte-for-byte from source,
+// since the closure isn't exported), not just against computeReservedHeight.
+
+describe("history/RunDetail.tsx — the dag panel height policy is floor/grow-only", () => {
+  const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+  const DAG_MIN_HEIGHT = 280;
+
+  it("pins the floor constant the policy tests below assume", () => {
+    expect(src).toMatch(/const DAG_MIN_HEIGHT = 280;/);
+  });
+
+  it("onDagLayoutHeight floors the incoming computeReservedHeight value, then only grows the committed height for the run id, with no ceiling", () => {
+    expect(src).toMatch(/const clamped = Math\.max\(DAG_MIN_HEIGHT, Math\.ceil\(height\)\);/);
+    expect(src).toMatch(
+      /height: Math\.max\(prev\.id === id \? prev\.height : DAG_MIN_HEIGHT, clamped\),/,
+    );
+  });
+
+  // Reference implementation matching the source above, so the *behavior* —
+  // not just the presence of the lines — is pinned.
+  function reduce(
+    prev: { id: string; height: number },
+    id: string,
+    height: number,
+  ): { id: string; height: number } {
+    const clamped = Math.max(DAG_MIN_HEIGHT, Math.ceil(height));
+    return { id, height: Math.max(prev.id === id ? prev.height : DAG_MIN_HEIGHT, clamped) };
+  }
+
+  it("a layout below the floor is floored, not passed through", () => {
+    const result = reduce({ id: "run-1", height: DAG_MIN_HEIGHT }, "run-1", 120);
+    expect(result.height).toBe(DAG_MIN_HEIGHT);
+  });
+
+  it("a layout far above the floor is passed through — no ceiling", () => {
+    const result = reduce({ id: "run-1", height: DAG_MIN_HEIGHT }, "run-1", 4000);
+    expect(result.height).toBe(4000);
+  });
+
+  it("a later smaller layout for the SAME run never shrinks the committed height (grow-only mid-stream)", () => {
+    const grown = reduce({ id: "run-1", height: DAG_MIN_HEIGHT }, "run-1", 420);
+    expect(grown.height).toBe(420);
+    const shrunk = reduce(grown, "run-1", 300);
+    expect(shrunk.height).toBe(420);
+  });
+
+  it("switching to a DIFFERENT run id resets the floor instead of carrying over the previous run's committed height", () => {
+    const grown = reduce({ id: "run-1", height: DAG_MIN_HEIGHT }, "run-1", 420);
+    const nextRun = reduce(grown, "run-2", 150);
+    expect(nextRun.height).toBe(DAG_MIN_HEIGHT);
+  });
+});

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -1495,14 +1495,44 @@ function makeBranch(overrides: Partial<import("@/lib/api").SessionBranch>) {
 }
 
 describe("history/RunDetail.tsx — matchGraphNodeToBranch (graph-node drill-down)", () => {
-  it("match arm: resolves by agent_name first", async () => {
+  it("match arm: resolves by exact branch name first, ahead of agent_name", async () => {
+    // branch.name is unique/durable per session; agent_name is a role label
+    // shared by every branch with that role. An exact name match must win
+    // even when a different branch's agent_name also matches the node id.
     const { matchGraphNodeToBranch } = await import("./RunDetail");
     const branches = [
       makeBranch({ id: "b1", name: "analyst-role", agent_name: "analyst" }),
       makeBranch({ id: "b2", name: "analyst", agent_name: null }),
     ];
     const match = matchGraphNodeToBranch("analyst", branches);
+    expect(match?.id).toBe("b2");
+  });
+
+  it("match arm: falls back to agent_name only when exactly one branch carries it", async () => {
+    const { matchGraphNodeToBranch } = await import("./RunDetail");
+    const branches = [makeBranch({ id: "b1", name: "analyst-role", agent_name: "analyst" })];
+    const match = matchGraphNodeToBranch("analyst", branches);
     expect(match?.id).toBe("b1");
+  });
+
+  it("match arm: two branches sharing a role's agent_name is ambiguous — resolves via the unique branch name instead, regardless of list order", async () => {
+    // The reviewer's duplicate-implementer scenario: {name:"implementer-2",
+    // agent_name:"implementer"} ordered before the branch whose exact name
+    // is the clicked node id. agent_name alone can't disambiguate (both
+    // branches carry it) — the exact name match must win, and win the same
+    // way whichever order the branches list arrives in.
+    const { matchGraphNodeToBranch } = await import("./RunDetail");
+    const forward = [
+      makeBranch({ id: "b1", name: "implementer-2", agent_name: "implementer" }),
+      makeBranch({ id: "b2", name: "implementer", agent_name: "implementer" }),
+    ];
+    expect(matchGraphNodeToBranch("implementer", forward)?.id).toBe("b2");
+
+    const reversed = [
+      makeBranch({ id: "b2", name: "implementer", agent_name: "implementer" }),
+      makeBranch({ id: "b1", name: "implementer-2", agent_name: "implementer" }),
+    ];
+    expect(matchGraphNodeToBranch("implementer", reversed)?.id).toBe("b2");
   });
 
   it("match arm: falls back to name when no agent_name matches", async () => {

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -16,6 +16,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { useTranslations } from "use-intl";
 import InvocationSection from "@/components/history/InvocationDetail";
 import OperationGraphSection from "@/components/history/OperationGraphSection";
@@ -37,6 +38,13 @@ import { deriveDisplayStatus, deriveVerdict, isEffectivelyActive } from "@/lib/r
 import type { Verdict } from "@/lib/runStatus";
 import type { RunMessage, RunResumeResponse, RunStep, WorkerGraph } from "@/lib/types";
 import type { NodeExecStatus } from "@/components/canvas/StepNode";
+import {
+  deriveProgressCounts,
+  computeElapsedSeconds,
+  formatElapsed,
+  reconcileNodeStatuses,
+} from "@/lib/execGraphProgress";
+import type { ProgressCounts } from "@/lib/execGraphProgress";
 
 const WorkerCanvas = lazy(() => import("@/components/canvas/WorkerCanvas"));
 
@@ -249,6 +257,61 @@ export function mergeCompletedSession(
   return { ...previous, ...fresh, branches };
 }
 
+// The BranchesSection identity every branch renders under (RunStepCard's
+// `id="step-${step.step}"` anchor and expandedSteps entry). Factored out so
+// the graph drill-down (matchGraphNodeToBranch → this) and the step list
+// (branchToRunStep → this) can never key a branch two different ways.
+export function stepKeyForBranch(branch: SessionBranch): string {
+  return branch.name || branch.id.slice(0, 8);
+}
+
+// Execution-graph nodes are keyed by authored role/assignment name
+// (WorkerStepNode.id); branches carry agent_name, falling back to name, then
+// an id prefix. Try each field in that priority order across the branch
+// list — first match wins.
+export function matchGraphNodeToBranch(
+  nodeId: string,
+  branches: SessionBranch[],
+): SessionBranch | null {
+  return (
+    branches.find((b) => b.agent_name === nodeId) ??
+    branches.find((b) => b.name === nodeId) ??
+    branches.find((b) => b.id.slice(0, 8) === nodeId) ??
+    null
+  );
+}
+
+// Single source of truth for BOTH the always-visible progress summary and
+// the graph nodes' own coloring (WorkerCanvas's nodeStatuses prop): both
+// callers pass the SAME reconciled map returned here, so they cannot
+// diverge. Applies the terminal-run invariants (descendant-terminal
+// suppression, unknown-status collapse on a done run) from
+// lib/execGraphProgress before either consumer sees the map.
+export function computeReconciledNodeStatuses(
+  runGraph: Pick<WorkerGraph, "nodes" | "edges"> | null,
+  nodeStatuses: Record<string, NodeExecStatus> | undefined,
+  done: boolean,
+): Record<string, NodeExecStatus> | undefined {
+  if (!runGraph) return nodeStatuses;
+  return reconcileNodeStatuses(
+    runGraph.nodes.map((n) => n.id),
+    runGraph.edges.map((e) => ({ source: e.source, target: e.target })),
+    nodeStatuses,
+    done,
+  );
+}
+
+export function computeProgressCountsForGraph(
+  runGraph: Pick<WorkerGraph, "nodes"> | null,
+  reconciledStatuses: Record<string, NodeExecStatus> | undefined,
+): ProgressCounts | null {
+  if (!runGraph) return null;
+  return deriveProgressCounts(
+    runGraph.nodes.map((n) => n.id),
+    reconciledStatuses,
+  );
+}
+
 export function branchToRunStep(
   branch: SessionBranch,
   status: string,
@@ -362,7 +425,7 @@ export function branchToRunStep(
     (options ? null : Math.max(branch.message_total ?? 0, runMessages.length));
 
   return {
-    step: branch.name || branch.id.slice(0, 8),
+    step: stepKeyForBranch(branch),
     status,
     result: {
       agent: branch.agent_name ?? branch.name ?? branch.id.slice(0, 8),
@@ -491,6 +554,57 @@ function SectionHeader({
   );
 }
 
+// ── Execution-graph progress summary ────────────────────────────────────────
+// Always visible beside the graph header — never scrolled out of view or
+// hidden behind a click — so a viewer answers "how far along, what's
+// running, did anything fail" without touching the graph. counts is derived
+// from the exact reconciled status map passed to WorkerCanvas's
+// nodeStatuses prop (see reconciledNodeStatuses above), so this bar can
+// never disagree with what the graph nodes render.
+
+function ProgressSummaryBar({
+  counts,
+  elapsedLabel,
+  t,
+}: {
+  counts: ProgressCounts;
+  elapsedLabel: string;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const pending = counts.pending + counts.queued + counts.awaitingApproval + counts.paused;
+  return (
+    <div
+      data-testid="run-progress-summary"
+      role={counts.hasFailure ? "alert" : undefined}
+      className={`mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 rounded border px-3 py-1.5 font-mono text-[length:var(--t-xs)] ${
+        counts.hasFailure
+          ? "border-status-error bg-status-error-bg text-status-error"
+          : "border-edge bg-surface-raised text-content-secondary"
+      }`}
+    >
+      <span>
+        {t("progressTotal")} {counts.total}
+      </span>
+      <span>
+        {t("progressCompleted")} {counts.completed}
+      </span>
+      <span>
+        {t("progressRunning")} {counts.running}
+      </span>
+      <span className={counts.hasFailure ? "font-semibold" : undefined}>
+        {counts.hasFailure ? "⚠ " : ""}
+        {t("progressFailed")} {counts.failed}
+      </span>
+      <span>
+        {t("progressPending")} {pending}
+      </span>
+      <span className="ml-auto">
+        {t("progressElapsed")} {elapsedLabel}
+      </span>
+    </div>
+  );
+}
+
 // ── Overview section ──────────────────────────────────────────────────────────
 
 interface OverviewData {
@@ -595,6 +709,7 @@ function BranchesSection({
   onLoadOlder,
   olderMessagesRemaining,
   loadingOlder,
+  highlightedStepKey,
 }: {
   steps: RunStep[];
   live: boolean;
@@ -606,6 +721,10 @@ function BranchesSection({
   onLoadOlder?: () => void;
   olderMessagesRemaining?: number;
   loadingOlder?: boolean;
+  /** The step (RunStepCard) a graph-node drill-down just resolved to — ringed
+   * so the click's target is unmistakable. Cleared automatically after the
+   * pulse. */
+  highlightedStepKey?: string | null;
 }) {
   const t = useTranslations("history.detail");
   return (
@@ -628,18 +747,27 @@ function BranchesSection({
           </div>
         ) : (
           steps.map((step) => (
-            <RunStepCard
+            <div
               key={step.step}
-              step={step}
-              expanded={expandedSteps.has(step.step)}
-              onToggleExpand={onToggleExpand}
-              runId={runId}
-              artifactRoot={artifactRoot}
-              runFiles={runFiles}
-              onLoadOlder={onLoadOlder}
-              olderMessagesRemaining={olderMessagesRemaining}
-              loadingOlder={loadingOlder}
-            />
+              data-highlighted={step.step === highlightedStepKey || undefined}
+              className={
+                step.step === highlightedStepKey
+                  ? "rounded ring-2 ring-accent ring-offset-2 ring-offset-surface-base transition-shadow"
+                  : undefined
+              }
+            >
+              <RunStepCard
+                step={step}
+                expanded={expandedSteps.has(step.step)}
+                onToggleExpand={onToggleExpand}
+                runId={runId}
+                artifactRoot={artifactRoot}
+                runFiles={runFiles}
+                onLoadOlder={onLoadOlder}
+                olderMessagesRemaining={olderMessagesRemaining}
+                loadingOlder={loadingOlder}
+              />
+            </div>
           ))
         )}
       </div>
@@ -1199,6 +1327,17 @@ export function EventsSection({
 // that floor for every graph taller than the cap. The enclosing page scrolls
 // past a tall card; the canvas itself only pans once it's still wider/taller
 // than the floor-zoomed viewport.
+//
+// This is an intentional floor/grow-only POLICY, not a best-effort
+// approximation of computeReservedHeight's exact number: a mid-run layout
+// that computes a smaller height than what's already committed is NOT
+// applied (growing then shrinking the panel mid-stream would jump the page
+// under the reader — see onDagLayoutHeight below), and a computed height
+// below DAG_MIN_HEIGHT is floored rather than passed through. So the panel
+// height can legitimately exceed the graph's actual rendered height for a
+// run that shrank its layout after growing it, or for one that never
+// exceeded the floor. Pinned by
+// "the dag panel height policy is floor/grow-only" in RunDetail.test.tsx.
 const DAG_MIN_HEIGHT = 280;
 
 export interface RunDetailProps {
@@ -1233,9 +1372,23 @@ export default function RunDetail({ id }: RunDetailProps) {
   );
   const [live, setLive] = useState(false);
   const [done, setDone] = useState(false);
+  // Stable no-op: the expanded overlay doesn't drive the inline panel's
+  // height, but an inline arrow here would be a fresh reference every render
+  // and re-trigger WorkerCanvas's layout effect, resetting execStatus on
+  // every unrelated RunDetail rerender.
+  const noopLayoutHeight = useCallback(() => {}, []);
   const [error, setError] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
+  // Graph-node drill-down: the branch a click resolved to (scrolled +
+  // highlighted below), or the node id a click found NO branch for (shown as
+  // an explicit not-started/no-branch state instead of a silent no-op).
+  const [highlightedStepKey, setHighlightedStepKey] = useState<string | null>(null);
+  const [unmatchedNodeId, setUnmatchedNodeId] = useState<string | null>(null);
+  // Full-width expand overlay for the execution graph — closed by its own
+  // button or Escape; never by anything else, so a stray keypress elsewhere
+  // can't dismiss it.
+  const [graphExpanded, setGraphExpanded] = useState(false);
   const [signalEvents, setSignalEvents] = useState<SignalEvent[]>([]);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const loadingOlderRef = useRef(false);
@@ -1426,6 +1579,57 @@ export default function RunDetail({ id }: RunDetailProps) {
       return updated;
     });
   }, []);
+
+  // Graph-node drill-down. ReactFlow renders each node wrapper with a
+  // `data-id` attribute (its own internals, not StepNode/WorkerCanvas
+  // markup we own) — delegating the click here means the graph can be wired
+  // to the branch list without adding a callback prop to WorkerCanvas.
+  const handleGraphNodeClick = useCallback(
+    (nodeId: string) => {
+      const match = matchGraphNodeToBranch(nodeId, session?.branches ?? []);
+      if (!match) {
+        setUnmatchedNodeId(nodeId);
+        setHighlightedStepKey(null);
+        return;
+      }
+      setUnmatchedNodeId(null);
+      const key = stepKeyForBranch(match);
+      setExpandedSteps((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
+      setHighlightedStepKey(key);
+    },
+    [session],
+  );
+
+  const handleDagPanelClick = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      const target = (event.target as HTMLElement).closest<HTMLElement>(
+        ".react-flow__node[data-id]",
+      );
+      const nodeId = target?.dataset.id;
+      if (nodeId) handleGraphNodeClick(nodeId);
+    },
+    [handleGraphNodeClick],
+  );
+
+  // A finished drill-down highlight fades on its own rather than lingering
+  // until the next click — it is a "look here" pulse, not a persistent
+  // selection state.
+  useEffect(() => {
+    if (!highlightedStepKey) return;
+    const el = document.getElementById(`step-${highlightedStepKey}`);
+    el?.scrollIntoView({ behavior: "smooth", block: "center" });
+    const timer = setTimeout(() => setHighlightedStepKey(null), 2500);
+    return () => clearTimeout(timer);
+  }, [highlightedStepKey]);
+
+  useEffect(() => {
+    if (!graphExpanded) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setGraphExpanded(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [graphExpanded]);
 
   const hiddenOlderCount = useMemo(() => {
     // The cursor gates the arithmetic instead of sitting beside it. The
@@ -1643,6 +1847,33 @@ export default function RunDetail({ id }: RunDetailProps) {
     return result;
   }, [runGraph, signalEvents]);
 
+  // The SAME reconciled map feeds both the always-visible progress summary
+  // and the graph nodes below (WorkerCanvas nodeStatuses prop) — one source,
+  // so the header can never disagree with what a node renders. Reconciling
+  // here (rather than trusting the raw signal-derived map) also applies the
+  // terminal-run invariants: a node cannot still read "running" once a
+  // descendant has reached a terminal status, and once the run itself is
+  // done, any node with no terminal signal collapses to "pending" (absence
+  // of information) instead of visually reading as live work.
+  const reconciledNodeStatuses = useMemo(
+    () => computeReconciledNodeStatuses(runGraph, nodeStatuses, done),
+    [runGraph, nodeStatuses, done],
+  );
+
+  const progressCounts = useMemo(
+    () => computeProgressCountsForGraph(runGraph, reconciledNodeStatuses),
+    [runGraph, reconciledNodeStatuses],
+  );
+
+  // Elapsed wall-clock ticks once a second only while the run is actually
+  // live; a finished or not-yet-loaded run has nothing left to advance.
+  const [elapsedNow, setElapsedNow] = useState<number>(() => Date.now() / 1000);
+  useEffect(() => {
+    if (!live || done) return;
+    const interval = setInterval(() => setElapsedNow(Date.now() / 1000), 1000);
+    return () => clearInterval(interval);
+  }, [live, done]);
+
   if (error) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -1686,6 +1917,7 @@ export default function RunDetail({ id }: RunDetailProps) {
   const partialWindow = session.branches.some((b) => (b.message_total ?? 0) > b.messages.length);
   const durationSec =
     startRef != null && endRef != null ? Math.max(0, Math.round(endRef - startRef)) : null;
+  const elapsedLabel = formatElapsed(computeElapsedSeconds(startRef, endRef, elapsedNow));
   const loadedToolCallCount = steps.reduce((n, s) => {
     return n + (s.messages ?? []).filter((m) => m.role === "tool_call").length;
   }, 0);
@@ -1760,7 +1992,7 @@ export default function RunDetail({ id }: RunDetailProps) {
         verification={session.artifact_verification_json}
       />
       {runGraph && shouldRenderAuthoredGraph(runGraph, opGraph) ? (
-        <div id="run-dag" className="scroll-mt-4">
+        <div id="run-dag" className="w-full scroll-mt-4">
           <SectionHeader
             label={t("sectionExecutionGraph")}
             count={runGraph.nodes.length}
@@ -1768,27 +2000,101 @@ export default function RunDetail({ id }: RunDetailProps) {
             hiddenCount={hiddenCount}
             onToggleImplied={() => setShowImpliedEdges((v) => !v)}
             showImplied={showImpliedEdges}
+            trailing={
+              <button
+                type="button"
+                onClick={() => setGraphExpanded(true)}
+                aria-label={t("expandGraph")}
+                className="ml-auto rounded border border-edge px-2 py-0.5 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary"
+              >
+                {t("expandGraph")}
+              </button>
+            }
           />
+          {progressCounts && (
+            <ProgressSummaryBar counts={progressCounts} elapsedLabel={elapsedLabel} t={t} />
+          )}
+          {unmatchedNodeId && (
+            <div
+              role="status"
+              data-testid="run-dag-unmatched-node"
+              className="mt-2 rounded border border-edge bg-surface-overlay px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary"
+            >
+              {t("nodeNoBranch", { node: unmatchedNodeId })}
+            </div>
+          )}
           {/* A fan-out of dozens of workers cannot be legible in the same
               280px that fits a five-step pipeline — the panel takes its height
               from the laid-out graph's bounding box so fitView has room to
               keep nodes readable, and a linear pipeline stays short no matter
-              how many steps it has. */}
+              how many steps it has. Full content width: no max-width wrapper
+              constrains this panel narrower than its flex parent. */}
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- delegates to ReactFlow's own node buttons (WorkerCanvas/StepNode own their keyboard handling); this div only reads the bubbled click's data-id */}
           <div
             style={{ height: dagHeight }}
-            className="rounded border border-edge bg-surface-raised shadow-card overflow-hidden"
+            className="mt-2 w-full rounded border border-edge bg-surface-raised shadow-card overflow-hidden"
+            onClick={handleDagPanelClick}
           >
             <Suspense fallback={null}>
               <WorkerCanvas
                 graph={{ ...runGraph, edges: displayEdges }}
                 editable={false}
                 execSteps={execSteps}
-                nodeStatuses={nodeStatuses}
+                nodeStatuses={reconciledNodeStatuses}
                 compact
                 onLayoutHeight={onDagLayoutHeight}
+                live={live}
+                done={done}
               />
             </Suspense>
           </div>
+          {graphExpanded && (
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-label={t("sectionExecutionGraph")}
+              className="fixed inset-4 z-50 flex flex-col rounded border border-edge bg-surface-raised shadow-card"
+            >
+              <div className="flex items-center justify-between gap-2 border-b border-edge px-3 py-2">
+                <SectionHeader
+                  label={t("sectionExecutionGraph")}
+                  count={runGraph.nodes.length}
+                  edgeCount={displayEdges.length}
+                  hiddenCount={hiddenCount}
+                  onToggleImplied={() => setShowImpliedEdges((v) => !v)}
+                  showImplied={showImpliedEdges}
+                />
+                <button
+                  type="button"
+                  onClick={() => setGraphExpanded(false)}
+                  aria-label={t("collapseGraph")}
+                  className="rounded border border-edge px-2 py-0.5 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary"
+                >
+                  {t("closeExpandedGraph")}
+                </button>
+              </div>
+              {progressCounts && (
+                <div className="px-3 pt-2">
+                  <ProgressSummaryBar counts={progressCounts} elapsedLabel={elapsedLabel} t={t} />
+                </div>
+              )}
+              {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- see note on the inline panel's identical delegation above */}
+              <div className="min-h-0 flex-1 p-3" onClick={handleDagPanelClick}>
+                <Suspense fallback={null}>
+                  <WorkerCanvas
+                    graph={{ ...runGraph, edges: displayEdges }}
+                    editable={false}
+                    execSteps={execSteps}
+                    nodeStatuses={reconciledNodeStatuses}
+                    compact
+                    onLayoutHeight={noopLayoutHeight}
+                    live={live}
+                    done={done}
+                  />
+                </Suspense>
+              </div>
+            </div>
+          )}
         </div>
       ) : (
         opGraph.nodes.length > 0 && (
@@ -1838,6 +2144,7 @@ export default function RunDetail({ id }: RunDetailProps) {
         onLoadOlder={handleLoadOlder}
         olderMessagesRemaining={hiddenOlderCount}
         loadingOlder={loadingOlder}
+        highlightedStepKey={highlightedStepKey}
       />
       <ErrorsSection errors={errors} partial={partialWindow} gateOutcome={gateOutcome} />
       <FilesSection files={runFiles} partial={partialWindow} />

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -266,19 +266,26 @@ export function stepKeyForBranch(branch: SessionBranch): string {
 }
 
 // Execution-graph nodes are keyed by authored role/assignment name
-// (WorkerStepNode.id); branches carry agent_name, falling back to name, then
-// an id prefix. Try each field in that priority order across the branch
-// list — first match wins.
+// (WorkerStepNode.id). branch.name is the durable, unique identity a
+// session assigns per branch; agent_name is only a role label shared by
+// every branch filling that role (e.g. two "implementer" branches from a
+// fan-out), so trying it first can match the WRONG branch whenever a role
+// repeats. Prefer the unique identity first: exact branch name, then an id
+// prefix, and only fall back to agent_name when exactly one branch carries
+// it — with two or more candidates it cannot disambiguate, so it does not
+// guess.
 export function matchGraphNodeToBranch(
   nodeId: string,
   branches: SessionBranch[],
 ): SessionBranch | null {
-  return (
-    branches.find((b) => b.agent_name === nodeId) ??
-    branches.find((b) => b.name === nodeId) ??
-    branches.find((b) => b.id.slice(0, 8) === nodeId) ??
-    null
-  );
+  const byName = branches.find((b) => b.name === nodeId);
+  if (byName) return byName;
+
+  const byIdPrefix = branches.find((b) => b.id.slice(0, 8) === nodeId);
+  if (byIdPrefix) return byIdPrefix;
+
+  const byAgentName = branches.filter((b) => b.agent_name === nodeId);
+  return byAgentName.length === 1 ? byAgentName[0] : null;
 }
 
 // Single source of truth for BOTH the always-visible progress summary and

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -201,8 +201,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 929 leaves", () => {
-    expect(EN_LEAVES.size).toBe(929);
+  it("en.json has 939 leaves", () => {
+    expect(EN_LEAVES.size).toBe(939);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/execGraphProgress.test.ts
+++ b/apps/studio/frontend/src/lib/execGraphProgress.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeAuthoredLayers,
+  computeElapsedSeconds,
+  computeStagePosition,
+  deriveProgressCounts,
+  formatElapsed,
+  reconcileNodeStatuses,
+} from "./execGraphProgress";
+import { transitiveReduce } from "./operationGraph";
+import type { NodeExecStatus } from "@/components/canvas/StepNode";
+
+const ALL_EIGHT_STATES: NodeExecStatus[] = [
+  "pending",
+  "queued",
+  "running",
+  "awaiting_approval",
+  "paused",
+  "completed",
+  "failed",
+  "escalated",
+];
+
+// ── deriveProgressCounts ────────────────────────────────────────────────────
+
+describe("deriveProgressCounts — summary counts from the canonical status source", () => {
+  it("buckets a mixed graph carrying every one of the 8 states", () => {
+    const nodeIds = ALL_EIGHT_STATES.map((_, i) => `n${i}`);
+    const statuses: Record<string, NodeExecStatus> = {};
+    ALL_EIGHT_STATES.forEach((s, i) => (statuses[`n${i}`] = s));
+
+    const counts = deriveProgressCounts(nodeIds, statuses);
+
+    expect(counts.total).toBe(8);
+    expect(counts.pending).toBe(1);
+    expect(counts.queued).toBe(1);
+    expect(counts.running).toBe(1);
+    expect(counts.awaitingApproval).toBe(1);
+    expect(counts.paused).toBe(1);
+    expect(counts.completed).toBe(1);
+    // failed + escalated collapse into one failure pool
+    expect(counts.failed).toBe(2);
+    expect(counts.hasFailure).toBe(true);
+  });
+
+  it("sums every bucket back to total on a mixed graph", () => {
+    const nodeIds = ALL_EIGHT_STATES.map((_, i) => `n${i}`);
+    const statuses: Record<string, NodeExecStatus> = {};
+    ALL_EIGHT_STATES.forEach((s, i) => (statuses[`n${i}`] = s));
+    const counts = deriveProgressCounts(nodeIds, statuses);
+    const sum =
+      counts.pending +
+      counts.queued +
+      counts.running +
+      counts.awaitingApproval +
+      counts.paused +
+      counts.completed +
+      counts.failed;
+    expect(sum).toBe(counts.total);
+  });
+
+  it("yields all-zero counts for empty input", () => {
+    const counts = deriveProgressCounts([], {});
+    expect(counts).toEqual({
+      total: 0,
+      pending: 0,
+      queued: 0,
+      running: 0,
+      awaitingApproval: 0,
+      paused: 0,
+      completed: 0,
+      failed: 0,
+      hasFailure: false,
+    });
+  });
+
+  it("defaults a node with no entry in the status map to pending, same as WorkerCanvas", () => {
+    const counts = deriveProgressCounts(["a", "b"], { a: "completed" });
+    expect(counts.pending).toBe(1);
+    expect(counts.completed).toBe(1);
+    expect(counts.total).toBe(2);
+  });
+
+  it("treats a fully successful run as hasFailure=false", () => {
+    const counts = deriveProgressCounts(["a", "b"], { a: "completed", b: "completed" });
+    expect(counts.hasFailure).toBe(false);
+  });
+
+  it("flags failure from escalated alone, not only failed", () => {
+    const counts = deriveProgressCounts(["a"], { a: "escalated" });
+    expect(counts.hasFailure).toBe(true);
+    expect(counts.failed).toBe(1);
+  });
+});
+
+// ── computeElapsedSeconds / formatElapsed ───────────────────────────────────
+
+describe("computeElapsedSeconds — elapsed derivation", () => {
+  it("returns null when the run has not started", () => {
+    expect(computeElapsedSeconds(null, null, 100)).toBeNull();
+  });
+
+  it("uses now as the end for a live (unfinished) run", () => {
+    expect(computeElapsedSeconds(10, null, 42)).toBe(32);
+  });
+
+  it("uses ended_at once the run has finished, ignoring now", () => {
+    expect(computeElapsedSeconds(10, 25, 9999)).toBe(15);
+  });
+
+  it("never returns negative elapsed for a clock skew edge case", () => {
+    expect(computeElapsedSeconds(50, null, 10)).toBe(0);
+  });
+});
+
+describe("formatElapsed", () => {
+  it("renders sub-hour elapsed as mm:ss", () => {
+    expect(formatElapsed(65)).toBe("01:05");
+  });
+
+  it("renders hour-plus elapsed with an hour segment", () => {
+    expect(formatElapsed(3725)).toBe("1:02:05");
+  });
+
+  it("renders the null (not-started) case as a placeholder, not a crash", () => {
+    expect(formatElapsed(null)).toBe("--:--");
+  });
+
+  it("treats NaN and Infinity as invalid display inputs", () => {
+    expect(formatElapsed(NaN)).toBe("--:--");
+    expect(formatElapsed(Infinity)).toBe("--:--");
+    expect(formatElapsed(-Infinity)).toBe("--:--");
+  });
+
+  it("treats a negative duration as an invalid display input", () => {
+    expect(formatElapsed(-5)).toBe("--:--");
+  });
+});
+
+// ── reconcileNodeStatuses — descendant-terminal suppression + terminal-run collapse ──
+
+describe("reconcileNodeStatuses — terminal-run unknown status", () => {
+  it("a node with no signal at all renders as pending on a terminal run", () => {
+    const result = reconcileNodeStatuses(["a", "b"], [], { a: "completed" }, true);
+    expect(result.b).toBe("pending");
+  });
+
+  it("collapses any lingering non-terminal status to pending once the run is done", () => {
+    const statuses: Record<string, NodeExecStatus> = {
+      a: "queued",
+      b: "awaiting_approval",
+      c: "paused",
+    };
+    const result = reconcileNodeStatuses(["a", "b", "c"], [], statuses, true);
+    expect(result.a).toBe("pending");
+    expect(result.b).toBe("pending");
+    expect(result.c).toBe("pending");
+  });
+
+  it("leaves terminal statuses untouched once the run is done", () => {
+    const statuses: Record<string, NodeExecStatus> = {
+      a: "completed",
+      b: "failed",
+      c: "escalated",
+    };
+    const result = reconcileNodeStatuses(["a", "b", "c"], [], statuses, true);
+    expect(result).toEqual(statuses);
+  });
+
+  it("does not touch a live (not-done) run's legitimate non-terminal statuses", () => {
+    const statuses: Record<string, NodeExecStatus> = { a: "queued", b: "awaiting_approval" };
+    const result = reconcileNodeStatuses(["a", "b"], [], statuses, false);
+    expect(result.a).toBe("queued");
+    expect(result.b).toBe("awaiting_approval");
+  });
+});
+
+describe("reconcileNodeStatuses — descendant-terminal suppression of stale running display", () => {
+  // source -> mid -> sink, mirroring the measured defect: 5 root/mid nodes
+  // stuck "running" forever while their descendants had already finished.
+  const edges = [
+    { source: "source", target: "mid" },
+    { source: "mid", target: "sink" },
+  ];
+
+  it("a running node whose descendant completed is not shown as running (terminal run)", () => {
+    const statuses: Record<string, NodeExecStatus> = {
+      source: "running",
+      mid: "running",
+      sink: "completed",
+    };
+    const result = reconcileNodeStatuses(["source", "mid", "sink"], edges, statuses, true);
+    expect(result.source).not.toBe("running");
+    expect(result.mid).not.toBe("running");
+    expect(["completed", "pending"]).toContain(result.source);
+    expect(["completed", "pending"]).toContain(result.mid);
+  });
+
+  it("holds on a still-live run too — the invariant is not done-gated", () => {
+    const statuses: Record<string, NodeExecStatus> = {
+      source: "running",
+      mid: "running",
+      sink: "completed",
+    };
+    const result = reconcileNodeStatuses(["source", "mid", "sink"], edges, statuses, false);
+    expect(result.source).not.toBe("running");
+    expect(result.mid).not.toBe("running");
+  });
+
+  it("does not suppress a genuinely running node with no terminal descendant", () => {
+    const statuses: Record<string, NodeExecStatus> = {
+      source: "completed",
+      mid: "running",
+      sink: "pending",
+    };
+    const result = reconcileNodeStatuses(["source", "mid", "sink"], edges, statuses, false);
+    expect(result.mid).toBe("running");
+  });
+
+  it("looks through multiple hops, not just direct children", () => {
+    const chain = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+      { source: "c", target: "d" },
+    ];
+    const statuses: Record<string, NodeExecStatus> = {
+      a: "running",
+      b: "running",
+      c: "running",
+      d: "completed",
+    };
+    const result = reconcileNodeStatuses(["a", "b", "c", "d"], chain, statuses, false);
+    expect(result.a).not.toBe("running");
+    expect(result.b).not.toBe("running");
+    expect(result.c).not.toBe("running");
+  });
+
+  it("survives a cyclic edge list without hanging (defensive — graph is expected acyclic)", () => {
+    const cyclic = [
+      { source: "a", target: "b" },
+      { source: "b", target: "a" },
+    ];
+    const statuses: Record<string, NodeExecStatus> = { a: "running", b: "running" };
+    expect(() => reconcileNodeStatuses(["a", "b"], cyclic, statuses, false)).not.toThrow();
+  });
+});
+
+// ── computeAuthoredLayers / computeStagePosition ────────────────────────────
+
+describe("computeAuthoredLayers", () => {
+  it("returns one stage for an empty graph", () => {
+    expect(computeAuthoredLayers([], [])).toEqual([]);
+  });
+
+  it("returns one stage for a single node", () => {
+    expect(computeAuthoredLayers(["a"], [])).toEqual([["a"]]);
+  });
+
+  it("assigns ranks 1..5 for a linear pipeline of 5 nodes", () => {
+    const nodeIds = ["a", "b", "c", "d", "e"];
+    const edges = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+      { source: "c", target: "d" },
+      { source: "d", target: "e" },
+    ];
+    const layers = computeAuthoredLayers(nodeIds, edges);
+    expect(layers.map((l) => l.length)).toEqual([1, 1, 1, 1, 1]);
+    expect(layers).toEqual([["a"], ["b"], ["c"], ["d"], ["e"]]);
+  });
+
+  it("places diamond branches sharing a rank on the same layer", () => {
+    // a -> {b, c} -> d
+    const nodeIds = ["a", "b", "c", "d"];
+    const edges = [
+      { source: "a", target: "b" },
+      { source: "a", target: "c" },
+      { source: "b", target: "d" },
+      { source: "c", target: "d" },
+    ];
+    const layers = computeAuthoredLayers(nodeIds, edges);
+    expect(layers[0]).toEqual(["a"]);
+    expect(new Set(layers[1])).toEqual(new Set(["b", "c"]));
+    expect(layers[2]).toEqual(["d"]);
+  });
+
+  it("keeps ranks-of-record unchanged after transitive reduction of the same edges", () => {
+    // a -> b -> c, plus a redundant a -> c edge (implied by the path above).
+    const nodeIds = ["a", "b", "c"];
+    const fullEdges = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+      { source: "a", target: "c" },
+    ];
+    const reduced = transitiveReduce(fullEdges);
+    expect(reduced.length).toBeLessThan(fullEdges.length); // sanity: reduction actually dropped one
+
+    const layersFull = computeAuthoredLayers(nodeIds, fullEdges);
+    const layersReduced = computeAuthoredLayers(nodeIds, reduced);
+    const depthOf = (layers: string[][], id: string) => layers.findIndex((l) => l.includes(id));
+    for (const id of nodeIds) {
+      expect(depthOf(layersReduced, id)).toBe(depthOf(layersFull, id));
+    }
+  });
+});
+
+describe("computeStagePosition", () => {
+  const linear = {
+    nodeIds: ["a", "b", "c", "d", "e"],
+    edges: [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+      { source: "c", target: "d" },
+      { source: "d", target: "e" },
+    ],
+  };
+
+  it("reports one stage for an empty graph", () => {
+    expect(computeStagePosition([], [], {}, false)).toEqual({ stage: 0, totalStages: 0 });
+  });
+
+  it("reports one stage for a single node", () => {
+    expect(computeStagePosition(["a"], [], { a: "running" }, false)).toEqual({
+      stage: 1,
+      totalStages: 1,
+    });
+  });
+
+  it("is at rank 3 of 5 when the middle node of a linear pipeline is running", () => {
+    const statuses: Record<string, NodeExecStatus> = {
+      a: "completed",
+      b: "completed",
+      c: "running",
+      d: "pending",
+      e: "pending",
+    };
+    expect(computeStagePosition(linear.nodeIds, linear.edges, statuses, false)).toEqual({
+      stage: 3,
+      totalStages: 5,
+    });
+  });
+
+  it("reports the final stage once the run is done", () => {
+    const statuses: Record<string, NodeExecStatus> = {
+      a: "completed",
+      b: "completed",
+      c: "completed",
+      d: "completed",
+      e: "completed",
+    };
+    expect(computeStagePosition(linear.nodeIds, linear.edges, statuses, true)).toEqual({
+      stage: 5,
+      totalStages: 5,
+    });
+  });
+});

--- a/apps/studio/frontend/src/lib/execGraphProgress.ts
+++ b/apps/studio/frontend/src/lib/execGraphProgress.ts
@@ -1,0 +1,282 @@
+// Shared, framework-free state primitives for the execution-graph progress
+// surface (progress summary counts, elapsed timer, descendant-terminal
+// status reconciliation, and stage/rank position). Every function here reads
+// from the SAME canonical status source the graph nodes render from
+// (`Record<string, NodeExecStatus>`, keyed by authored node id, as built by
+// `buildNodeStatusesByName` in `./operationGraph.ts`) — a header or badge
+// built from these functions cannot disagree with what a node displays,
+// because both derive from one map.
+import type { NodeExecStatus } from "@/components/canvas/StepNode";
+
+export type NodeStatusMap = Record<string, NodeExecStatus>;
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+}
+
+// ── Progress summary counts ─────────────────────────────────────────────────
+
+export interface ProgressCounts {
+  total: number;
+  pending: number;
+  queued: number;
+  running: number;
+  awaitingApproval: number;
+  paused: number;
+  completed: number;
+  /** failed + escalated, counted as one failure pool per the design brief. */
+  failed: number;
+  hasFailure: boolean;
+}
+
+function emptyCounts(total = 0): ProgressCounts {
+  return {
+    total,
+    pending: 0,
+    queued: 0,
+    running: 0,
+    awaitingApproval: 0,
+    paused: 0,
+    completed: 0,
+    failed: 0,
+    hasFailure: false,
+  };
+}
+
+// nodeIds is the authored node id list (the total a viewer expects to see);
+// statuses only covers nodes with live signal correlation — a node absent
+// from it defaults to "pending", exactly as WorkerCanvas does for graph
+// nodes, so the header and the nodes can never diverge on what "no signal"
+// means.
+export function deriveProgressCounts(
+  nodeIds: string[],
+  statuses: NodeStatusMap | undefined,
+): ProgressCounts {
+  const counts = emptyCounts(nodeIds.length);
+  for (const id of nodeIds) {
+    const status = statuses?.[id] ?? "pending";
+    switch (status) {
+      case "pending":
+        counts.pending++;
+        break;
+      case "queued":
+        counts.queued++;
+        break;
+      case "running":
+        counts.running++;
+        break;
+      case "awaiting_approval":
+        counts.awaitingApproval++;
+        break;
+      case "paused":
+        counts.paused++;
+        break;
+      case "completed":
+        counts.completed++;
+        break;
+      case "failed":
+      case "escalated":
+        counts.failed++;
+        break;
+    }
+  }
+  counts.hasFailure = counts.failed > 0;
+  return counts;
+}
+
+// ── Elapsed wall-clock ───────────────────────────────────────────────────────
+
+// `now` is passed in rather than read internally so this stays pure and
+// testable; a live caller re-derives it on a 1s interval.
+export function computeElapsedSeconds(
+  startedAt: number | null | undefined,
+  endedAt: number | null | undefined,
+  now: number,
+): number | null {
+  if (startedAt == null) return null;
+  const end = endedAt ?? now;
+  return Math.max(0, end - startedAt);
+}
+
+export function formatElapsed(seconds: number | null): string {
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return "--:--";
+  const total = Math.floor(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const mm = String(m).padStart(2, "0");
+  const ss = String(s).padStart(2, "0");
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+// ── Descendant-terminal suppression + terminal-run collapse ────────────────
+
+const TERMINAL_STATUSES = new Set<NodeExecStatus>(["completed", "failed", "escalated"]);
+const NON_TERMINAL_ACTIVE_STATUSES = new Set<NodeExecStatus>([
+  "queued",
+  "running",
+  "awaiting_approval",
+  "paused",
+]);
+
+function buildDescendantIndex(nodeIds: string[], edges: GraphEdge[]): Map<string, Set<string>> {
+  const known = new Set(nodeIds);
+  const outEdges = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!known.has(e.source) || !known.has(e.target)) continue;
+    (outEdges.get(e.source) ?? outEdges.set(e.source, []).get(e.source)!).push(e.target);
+  }
+
+  const cache = new Map<string, Set<string>>();
+  const inProgress = new Set<string>();
+  const descendantsOf = (id: string): Set<string> => {
+    const cached = cache.get(id);
+    if (cached) return cached;
+    if (inProgress.has(id)) return new Set(); // cycle guard — graph is expected acyclic
+    inProgress.add(id);
+    const result = new Set<string>();
+    for (const next of outEdges.get(id) ?? []) {
+      result.add(next);
+      for (const d of descendantsOf(next)) result.add(d);
+    }
+    inProgress.delete(id);
+    cache.set(id, result);
+    return result;
+  };
+
+  const index = new Map<string, Set<string>>();
+  for (const id of nodeIds) index.set(id, descendantsOf(id));
+  return index;
+}
+
+// Two invariants a viewer actually relies on, applied in order:
+//
+// 1. Descendant-terminal suppression (holds regardless of `done`): a node
+//    cannot still be "running" once a descendant has reached a terminal
+//    state — the descendant could not have started without this node's
+//    output, so the stale "running" reading is corrected to "completed".
+// 2. Terminal-run collapse (only once `done`): after the run itself has
+//    ended, no node may present as still in flight. Any status that is
+//    still non-terminal at that point means "no terminal signal was ever
+//    recorded for this node" — which must read as absence of information
+//    ("pending"), never be left looking like live work.
+export function reconcileNodeStatuses(
+  nodeIds: string[],
+  edges: GraphEdge[],
+  statuses: NodeStatusMap | undefined,
+  done: boolean,
+): NodeStatusMap {
+  const base: NodeStatusMap = {};
+  for (const id of nodeIds) base[id] = statuses?.[id] ?? "pending";
+
+  const descendants = buildDescendantIndex(nodeIds, edges);
+  const afterSuppression: NodeStatusMap = { ...base };
+  for (const id of nodeIds) {
+    if (afterSuppression[id] !== "running") continue;
+    let hasTerminalDescendant = false;
+    for (const d of descendants.get(id) ?? []) {
+      if (TERMINAL_STATUSES.has(base[d]!)) {
+        hasTerminalDescendant = true;
+        break;
+      }
+    }
+    if (hasTerminalDescendant) afterSuppression[id] = "completed";
+  }
+
+  if (!done) return afterSuppression;
+
+  const final: NodeStatusMap = {};
+  for (const id of nodeIds) {
+    const status = afterSuppression[id]!;
+    final[id] = NON_TERMINAL_ACTIVE_STATUSES.has(status) ? "pending" : status;
+  }
+  return final;
+}
+
+// ── Stage / rank position ───────────────────────────────────────────────────
+
+// Longest-path layering over the AUTHORED edge set (never the transitively
+// reduced one) so the stage-of-record stays honest under reduction — display
+// edges may drop, ranks-of-record never do. Mirrors
+// OperationGraphSection.computeLayers, generalized from OperationNode/opId to
+// bare node ids so it can run over a planned WorkerGraph.
+export function computeAuthoredLayers(nodeIds: string[], edges: GraphEdge[]): string[][] {
+  if (nodeIds.length === 0) return [];
+
+  const known = new Set(nodeIds);
+  const predsByNode = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!known.has(e.source) || !known.has(e.target)) continue;
+    (predsByNode.get(e.target) ?? predsByNode.set(e.target, []).get(e.target)!).push(e.source);
+  }
+
+  const depthCache = new Map<string, number>();
+  const onStack = new Set<string>();
+  const depthOf = (id: string): number => {
+    const cached = depthCache.get(id);
+    if (cached !== undefined) return cached;
+    const preds = predsByNode.get(id);
+    if (!preds || preds.length === 0) {
+      depthCache.set(id, 0);
+      return 0;
+    }
+    if (onStack.has(id)) return 0; // cycle guard — graph is expected acyclic
+    onStack.add(id);
+    let depth = 0;
+    for (const p of preds) depth = Math.max(depth, depthOf(p) + 1);
+    onStack.delete(id);
+    depthCache.set(id, depth);
+    return depth;
+  };
+
+  const depths = nodeIds.map((id) => depthOf(id));
+  const maxDepth = Math.max(...depths);
+  const layers: string[][] = Array.from({ length: maxDepth + 1 }, () => []);
+  nodeIds.forEach((id, i) => layers[depths[i]!]!.push(id));
+  return layers;
+}
+
+export interface StagePosition {
+  /** 1-based; 0 when there are no nodes at all. */
+  stage: number;
+  totalStages: number;
+}
+
+// Live stage = the layer containing the highest-numbered running node; once
+// `done`, the last layer with a completed node (or the final stage if none
+// is marked completed — e.g. a run that failed before any node finished
+// still reports the deepest reachable stage as "reached").
+export function computeStagePosition(
+  nodeIds: string[],
+  edges: GraphEdge[],
+  statuses: NodeStatusMap | undefined,
+  done: boolean,
+): StagePosition {
+  const layers = computeAuthoredLayers(nodeIds, edges);
+  const totalStages = layers.length;
+  if (totalStages === 0) return { stage: 0, totalStages: 0 };
+
+  const statusOf = (id: string): NodeExecStatus => statuses?.[id] ?? "pending";
+
+  if (done) {
+    for (let i = layers.length - 1; i >= 0; i--) {
+      if (layers[i]!.some((id) => statusOf(id) === "completed")) {
+        return { stage: i + 1, totalStages };
+      }
+    }
+    return { stage: totalStages, totalStages };
+  }
+
+  for (let i = layers.length - 1; i >= 0; i--) {
+    if (layers[i]!.some((id) => statusOf(id) === "running")) {
+      return { stage: i + 1, totalStages };
+    }
+  }
+  for (let i = layers.length - 1; i >= 0; i--) {
+    if (layers[i]!.some((id) => statusOf(id) === "completed")) {
+      return { stage: i + 1, totalStages };
+    }
+  }
+  return { stage: 1, totalStages };
+}

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "متوقف مؤقتًا",
       "graphNodeStatusDone": "تم",
       "graphNodeStatusFailed": "فشل",
-      "graphNodeStatusEscalated": "تم التصعيد"
+      "graphNodeStatusEscalated": "تم التصعيد",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "قائمة السجل",
     "detailAria": "تفاصيل العنصر"

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "স্থগিত",
       "graphNodeStatusDone": "সম্পন্ন",
       "graphNodeStatusFailed": "ব্যর্থ",
-      "graphNodeStatusEscalated": "এস্কেলেটেড"
+      "graphNodeStatusEscalated": "এস্কেলেটেড",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "হিস্ট্রি তালিকা",
     "detailAria": "আইটেমের বিস্তারিত"

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "pausiert",
       "graphNodeStatusDone": "fertig",
       "graphNodeStatusFailed": "fehlgeschlagen",
-      "graphNodeStatusEscalated": "eskaliert"
+      "graphNodeStatusEscalated": "eskaliert",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "Verlaufsliste",
     "detailAria": "Elementdetails"

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "paused",
       "graphNodeStatusDone": "done",
       "graphNodeStatusFailed": "failed",
-      "graphNodeStatusEscalated": "escalated"
+      "graphNodeStatusEscalated": "escalated",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "History list",
     "detailAria": "Item detail"

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "pausado",
       "graphNodeStatusDone": "listo",
       "graphNodeStatusFailed": "fallido",
-      "graphNodeStatusEscalated": "escalado"
+      "graphNodeStatusEscalated": "escalado",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "Lista de historial",
     "detailAria": "Detalle del elemento"

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "en pause",
       "graphNodeStatusDone": "terminé",
       "graphNodeStatusFailed": "échoué",
-      "graphNodeStatusEscalated": "escaladé"
+      "graphNodeStatusEscalated": "escaladé",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "Liste d’historique",
     "detailAria": "Détail de l’élément"

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "रुका हुआ",
       "graphNodeStatusDone": "पूर्ण",
       "graphNodeStatusFailed": "विफल",
-      "graphNodeStatusEscalated": "एस्केलेटेड"
+      "graphNodeStatusEscalated": "एस्केलेटेड",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "इतिहास सूची",
     "detailAria": "आइटम विवरण"

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "dijeda",
       "graphNodeStatusDone": "selesai",
       "graphNodeStatusFailed": "gagal",
-      "graphNodeStatusEscalated": "dieskalasi"
+      "graphNodeStatusEscalated": "dieskalasi",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "Daftar riwayat",
     "detailAria": "Detail item"

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "一時停止",
       "graphNodeStatusDone": "完了",
       "graphNodeStatusFailed": "失敗",
-      "graphNodeStatusEscalated": "エスカレーション"
+      "graphNodeStatusEscalated": "エスカレーション",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "履歴一覧",
     "detailAria": "項目の詳細"

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "일시중지",
       "graphNodeStatusDone": "완료",
       "graphNodeStatusFailed": "실패",
-      "graphNodeStatusEscalated": "에스컬레이션"
+      "graphNodeStatusEscalated": "에스컬레이션",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "기록 목록",
     "detailAria": "항목 세부 정보"

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "pausado",
       "graphNodeStatusDone": "concluído",
       "graphNodeStatusFailed": "falhou",
-      "graphNodeStatusEscalated": "escalado"
+      "graphNodeStatusEscalated": "escalado",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "Lista do histórico",
     "detailAria": "Detalhes do item"

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "приостановлено",
       "graphNodeStatusDone": "готово",
       "graphNodeStatusFailed": "ошибка",
-      "graphNodeStatusEscalated": "эскалировано"
+      "graphNodeStatusEscalated": "эскалировано",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "Список истории",
     "detailAria": "Сведения об элементе"

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "duraklatıldı",
       "graphNodeStatusDone": "tamamlandı",
       "graphNodeStatusFailed": "başarısız",
-      "graphNodeStatusEscalated": "yükseltildi"
+      "graphNodeStatusEscalated": "yükseltildi",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "geçmiş listesi",
     "detailAria": "öğe ayrıntısı"

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "موقوف",
       "graphNodeStatusDone": "مکمل",
       "graphNodeStatusFailed": "ناکام",
-      "graphNodeStatusEscalated": "بڑھایا گیا"
+      "graphNodeStatusEscalated": "بڑھایا گیا",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "ہسٹری فہرست",
     "detailAria": "آئٹم تفصیل"

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "tạm dừng",
       "graphNodeStatusDone": "xong",
       "graphNodeStatusFailed": "thất bại",
-      "graphNodeStatusEscalated": "đã leo thang"
+      "graphNodeStatusEscalated": "đã leo thang",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "danh sách lịch sử",
     "detailAria": "chi tiết mục"

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -462,7 +462,17 @@
       "graphNodeStatusPaused": "已暂停",
       "graphNodeStatusDone": "完成",
       "graphNodeStatusFailed": "失败",
-      "graphNodeStatusEscalated": "已升级"
+      "graphNodeStatusEscalated": "已升级",
+      "progressTotal": "Total",
+      "progressCompleted": "Completed",
+      "progressRunning": "Running",
+      "progressFailed": "Failed",
+      "progressPending": "Pending",
+      "progressElapsed": "Elapsed",
+      "expandGraph": "Expand execution graph",
+      "collapseGraph": "Collapse execution graph",
+      "closeExpandedGraph": "Close",
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
     },
     "masterAria": "历史列表",
     "detailAria": "条目详情"

--- a/lionagi/cli/orchestrate/_common.py
+++ b/lionagi/cli/orchestrate/_common.py
@@ -323,14 +323,22 @@ def _build_worker_operate_node(
     context: list,
     messenger_bound: bool,
     depends_on: list[str] | None = None,
+    node_id: str | None = None,
 ) -> str:
     """Add the static `operate` node for a worker branch (shared by fanout.py
     and flow.py); passes `actions=True` only when the messenger tool is bound.
+
+    `node_id`, when given, becomes the node's `reference_id` in metadata —
+    the identity the executor's queued/started/terminal signals resolve to.
+    Without it, the queued signal falls back to the operation's UUID prefix
+    while the started signal falls back to the branch name, so the same op
+    is announced under two different names.
     """
     return builder.add_operation(
         "operate",
         branch=branch,
         depends_on=depends_on,
+        node_id=node_id,
         instruction=instruction,
         context=context,
         **({"actions": True} if messenger_bound else {}),

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -329,6 +329,7 @@ async def _run_fanout_inner(
             instruction=ta.task,
             context=ctx,
             messenger_bound=messenger_bound,
+            node_id=wname,
         )
         fanned_nodes.append(node)
         fanned_labels.append(w_model)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -689,6 +689,7 @@ async def _build_dag(
             instruction=instruction,
             context=ctx,
             messenger_bound=messenger_bound,
+            node_id=agent_ids[i],
         )
         node_ids.append(node)
 

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -43,13 +43,19 @@ def _build_node_edge_meta(graph: Any) -> dict[str, dict]:
 @contextlib.asynccontextmanager
 async def flow_progress_signals(
     session: Any, graph: Any
-) -> AsyncIterator[Callable[[str, str, str, float], None]]:
+) -> AsyncIterator[Callable[[str, str, str, float, bool], None]]:
     """Yield an ``on_progress`` callback that persists node-lifecycle signals; awaits
     every emitted signal on exit so observers finish before the caller reads what they wrote."""
     emits: list[asyncio.Future] = []
     node_edge_meta = _build_node_edge_meta(graph)
 
-    def _on_progress(op_id: str, name: str, status: str, elapsed: float) -> None:
+    def _on_progress(
+        op_id: str,
+        name: str,
+        status: str,
+        elapsed: float,
+        name_is_fallback: bool = True,
+    ) -> None:
         meta = node_edge_meta.setdefault(op_id, {})
         parent_id = meta.get("parent_id")
         depends_on = meta.get("depends_on", [])
@@ -59,14 +65,15 @@ async def flow_progress_signals(
         # started/completed/failed calls reuse it even if a branch-naming hook
         # (spawn_branch_setup) later renames the operation's cloned branch --
         # the branch name is a display concern, not the correlation key.
-        # A name that equals the op_id's own 8-char prefix is flow.py's "no
-        # reference_id / no branch bound yet" placeholder (see execute()'s
-        # queued-time fallback), not a genuine name -- pinning it would freeze
-        # a placeholder over the real display name a later signal resolves.
+        # Whether a name is a placeholder ("no reference_id / no branch bound
+        # yet", see flow.py's _display_name/_branch_display_name) is decided
+        # structurally by the producer and passed in via name_is_fallback --
+        # never inferred here by comparing against op_id's prefix, since a
+        # genuine authored name can coincide with that prefix by chance.
         sig_name = meta.get("name")
         if sig_name is None:
             sig_name = name
-            if name != op_id[:8]:
+            if not name_is_fallback:
                 meta["name"] = sig_name
         if status == "queued":
             sig: Any = NodeQueued(

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -50,12 +50,17 @@ async def flow_progress_signals(
     node_edge_meta = _build_node_edge_meta(graph)
 
     def _on_progress(op_id: str, name: str, status: str, elapsed: float) -> None:
-        meta = node_edge_meta.get(op_id) or {}
+        meta = node_edge_meta.setdefault(op_id, {})
         parent_id = meta.get("parent_id")
         depends_on = meta.get("depends_on", [])
         # Prefer the authored node id so every lifecycle signal maps back to the
         # designer DAG; fall back to the executor's name (engine's own ops, reactive spawns).
+        # Pinned here (first call for this op_id, always "queued") so later
+        # started/completed/failed calls reuse it even if a branch-naming hook
+        # (spawn_branch_setup) later renames the operation's cloned branch --
+        # the branch name is a display concern, not the correlation key.
         sig_name = meta.get("name") or name
+        meta["name"] = sig_name
         if status == "queued":
             sig: Any = NodeQueued(
                 op_id=op_id, name=sig_name, parent_id=parent_id, depends_on=depends_on
@@ -88,14 +93,17 @@ async def flow_progress_signals(
             emits.append(asyncio.ensure_future(session.emit(sig)))
 
     # Keep node_edge_meta current as reactive spawns add nodes after start.
+    # Updates the entry in place rather than replacing it -- op_id was already
+    # queued (in the same synchronous admission call that emits this signal),
+    # which may have already pinned "name"; a wholesale replacement here would
+    # drop it and reopen the started/terminal name-split this guards against.
     def _on_spawned(sig: Any, _ctx: Any) -> None:
-        if sig.op_id and sig.parent_id is not None:
-            node_edge_meta[sig.op_id] = {
-                "parent_id": sig.parent_id,
-                "depends_on": [sig.parent_id],
-            }
-        elif sig.op_id:
-            node_edge_meta.setdefault(sig.op_id, {"parent_id": None, "depends_on": []})
+        if not sig.op_id:
+            return
+        entry = node_edge_meta.setdefault(sig.op_id, {"parent_id": None, "depends_on": []})
+        if sig.parent_id is not None:
+            entry["parent_id"] = sig.parent_id
+            entry["depends_on"] = [sig.parent_id]
 
     session.observe(NodeSpawned, handler=_on_spawned)
     try:

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -55,12 +55,19 @@ async def flow_progress_signals(
         depends_on = meta.get("depends_on", [])
         # Prefer the authored node id so every lifecycle signal maps back to the
         # designer DAG; fall back to the executor's name (engine's own ops, reactive spawns).
-        # Pinned here (first call for this op_id, always "queued") so later
+        # Pin the first GENUINELY resolved name for this op_id so later
         # started/completed/failed calls reuse it even if a branch-naming hook
         # (spawn_branch_setup) later renames the operation's cloned branch --
         # the branch name is a display concern, not the correlation key.
-        sig_name = meta.get("name") or name
-        meta["name"] = sig_name
+        # A name that equals the op_id's own 8-char prefix is flow.py's "no
+        # reference_id / no branch bound yet" placeholder (see execute()'s
+        # queued-time fallback), not a genuine name -- pinning it would freeze
+        # a placeholder over the real display name a later signal resolves.
+        sig_name = meta.get("name")
+        if sig_name is None:
+            sig_name = name
+            if name != op_id[:8]:
+                meta["name"] = sig_name
         if status == "queued":
             sig: Any = NodeQueued(
                 op_id=op_id, name=sig_name, parent_id=parent_id, depends_on=depends_on

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -54,7 +54,7 @@ async def flow_progress_signals(
         name: str,
         status: str,
         elapsed: float,
-        name_is_fallback: bool = True,
+        name_is_fallback: bool,
     ) -> None:
         meta = node_edge_meta.setdefault(op_id, {})
         parent_id = meta.get("parent_id")
@@ -70,6 +70,16 @@ async def flow_progress_signals(
         # structurally by the producer and passed in via name_is_fallback --
         # never inferred here by comparing against op_id's prefix, since a
         # genuine authored name can coincide with that prefix by chance.
+        #
+        # name_is_fallback has no default: this is an internal seam with an
+        # enumerable, all-internal caller set (the four lifecycle producers in
+        # operations/flow.py, all of which already pass the bit explicitly).
+        # "Unknown provenance" isn't a real state a caller can be in here, so
+        # there is no safe value to default to -- treating an untagged call as
+        # fallback silently produced the exact split-identity bug this guards
+        # against for a caller whose first name happened to be authored.
+        # Requiring the keyword makes a caller that doesn't know its own
+        # provenance fail loudly (TypeError) instead of guessing wrong.
         sig_name = meta.get("name")
         if sig_name is None:
             sig_name = name

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -169,6 +169,10 @@ class DependencyAwareExecutor:
         self._gate_rejections: dict[Any, dict[str, Any]] = {}
         self._skip_reasons: dict[Any, dict[str, Any]] = {}
         self._op_start_times = {}
+        # Identity bookkeeping so every started operation gets exactly one
+        # terminal on_progress signal, whichever exit path it takes.
+        self._started_ops: set = set()
+        self._terminal_emitted: set = set()
         self._pause_event: ConcurrencyEvent | None = None
         # Fire-and-forget flow signal tasks, retained until each finishes so a
         # weakly referenced task can't disappear before it runs.
@@ -373,6 +377,45 @@ class DependencyAwareExecutor:
 
         self._emit_best_effort(_factory)
 
+    def _emit_terminal_once(
+        self, operation: Operation, branch_name: str, status: str, elapsed: float
+    ) -> None:
+        """Emit a terminal on_progress signal for `operation` at most once.
+
+        Every call site that reaches a terminal outcome (completed, failed,
+        skipped, cancelled, or an unexpected flow-level error) goes through
+        here, so a race between two exit paths for the same operation can
+        never announce two terminal signals for one identity.
+        """
+        if operation.id in self._terminal_emitted:
+            return
+        self._terminal_emitted.add(operation.id)
+        if self.on_progress:
+            self.on_progress(str(operation.id), branch_name, status, elapsed)
+
+    def _emit_abandoned_terminal(self, operation: Operation) -> None:
+        """Safety net for cancellation and unexpected flow-level errors.
+
+        If `operation` already emitted "started" but execution left
+        `_execute_operation` through the CancelledError or generic-Exception
+        handler without going through the normal completed/failed paths, the
+        node would otherwise render as perpetually running. Emit a "failed"
+        terminal (there is no separate cancelled/abandoned signal kind) so
+        every start still gets exactly one terminal outcome. No-op if this
+        operation never started, or a terminal was already emitted for it.
+        """
+        if operation.id not in self._started_ops:
+            return
+        if operation.id in self._terminal_emitted:
+            return
+        import time as _time
+
+        ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
+        branch = self.operation_branches.get(operation.id, self.session.default_branch)
+        branch_name = getattr(branch, "name", None) or ref_id
+        elapsed = _time.monotonic() - self._op_start_times.get(operation.id, _time.monotonic())
+        self._emit_terminal_once(operation, branch_name, "failed", elapsed)
+
     async def _execute_operation(self, operation: Operation, limiter: CapacityLimiter):
         if operation.execution.status in Event._TERMINAL_STATUSES:
             if self.verbose:
@@ -415,11 +458,10 @@ class DependencyAwareExecutor:
                         str(operation.id)[:8],
                     )
 
-                if self.on_progress:
-                    ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
-                    branch = self.operation_branches.get(operation.id, self.session.default_branch)
-                    branch_name = getattr(branch, "name", None) or ref_id
-                    self.on_progress(str(operation.id), branch_name, "failed", 0.0)
+                ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
+                branch = self.operation_branches.get(operation.id, self.session.default_branch)
+                branch_name = getattr(branch, "name", None) or ref_id
+                self._emit_terminal_once(operation, branch_name, "failed", 0.0)
 
                 self.completion_events[operation.id].set()
                 return
@@ -445,6 +487,7 @@ class DependencyAwareExecutor:
                 import time as _time
 
                 self._op_start_times[operation.id] = _time.monotonic()
+                self._started_ops.add(operation.id)
 
                 if self.on_progress:
                     self.on_progress(str(operation.id), branch_name, "started", 0)
@@ -476,8 +519,7 @@ class DependencyAwareExecutor:
                             operation.execution.error = error
                             self.results[operation.id] = {"error": str(error)}
                             self.failed_operations.add(operation.id)
-                            if self.on_progress:
-                                self.on_progress(str(operation.id), branch_name, "failed", elapsed)
+                            self._emit_terminal_once(operation, branch_name, "failed", elapsed)
                             if self.verbose:
                                 logger.error(
                                     "Operation %s failed (%.1fs): %s",
@@ -489,8 +531,7 @@ class DependencyAwareExecutor:
 
                         deep_update(self.context.content, dict(response_context))
 
-                    if self.on_progress:
-                        self.on_progress(str(operation.id), branch_name, "completed", elapsed)
+                    self._emit_terminal_once(operation, branch_name, "completed", elapsed)
                     if self.verbose:
                         logger.debug("Completed operation: %s (%.1fs)", ref_id, elapsed)
 
@@ -500,8 +541,7 @@ class DependencyAwareExecutor:
                 elif operation.execution.status == EventStatus.FAILED:
                     self.results[operation.id] = {"error": str(operation.execution.error)}
                     self.failed_operations.add(operation.id)
-                    if self.on_progress:
-                        self.on_progress(str(operation.id), branch_name, "failed", elapsed)
+                    self._emit_terminal_once(operation, branch_name, "failed", elapsed)
                     if self.verbose:
                         logger.error(
                             "Operation %s failed (%.1fs): %s",
@@ -512,6 +552,11 @@ class DependencyAwareExecutor:
 
         except (get_cancelled_exc_class(), KeyboardInterrupt, SystemExit):
             self.completion_events[operation.id].set()
+            # Cancellation (task-group teardown, timeout, abandonment) skips
+            # the normal completed/failed paths above; emit the terminal
+            # this started operation is still owed so it never renders as
+            # perpetually running.
+            self._emit_abandoned_terminal(operation)
             raise
 
         except Exception as e:
@@ -522,6 +567,8 @@ class DependencyAwareExecutor:
 
             if self.verbose:
                 logger.error("Operation %s failed: %s", str(operation.id)[:8], e)
+
+            self._emit_abandoned_terminal(operation)
 
         finally:
             self.completion_events[operation.id].set()

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -8,6 +8,7 @@ not build their own executor."""
 import asyncio
 import contextlib
 import contextvars
+import inspect
 import logging
 import math
 import os
@@ -145,6 +146,9 @@ class DependencyAwareExecutor:
         self._alcall = alcall_params or AlcallParams()
         self._default_branch = default_branch
         self.on_progress = None
+        # Cached once per executor: does the installed on_progress callback
+        # accept the name_is_fallback provenance kwarg? None = not yet probed.
+        self._on_progress_accepts_fallback: bool | None = None
         # Persistence-only seam: invoked with every branch cloned during
         # pre-allocation, so a caller can wire persistence onto branches that
         # didn't exist when it set up the session's initial ones.
@@ -208,8 +212,8 @@ class DependencyAwareExecutor:
         nodes = [n for n in self.graph.internal_nodes.values() if isinstance(n, Operation)]
         if self.on_progress:
             for node in nodes:
-                _name = node.metadata.get("reference_id", str(node.id)[:8])
-                self.on_progress(str(node.id), _name, "queued", 0.0)
+                _name, _fallback = self._display_name(node)
+                self._emit_progress(str(node.id), _name, "queued", 0.0, _fallback)
         async with create_task_group() as tg:
             self._tg = tg
             try:
@@ -377,8 +381,61 @@ class DependencyAwareExecutor:
 
         self._emit_best_effort(_factory)
 
+    def _display_name(self, operation: Operation) -> tuple[str, bool]:
+        """Resolve a lifecycle-signal display name before a branch is bound:
+        the authored ``reference_id`` if the caller set one, else the op_id's
+        own 8-char prefix as a last resort. Returns ``(name, is_fallback)`` so
+        callers know whether the name is genuine without re-deriving it from
+        string equality against the op_id prefix (a real name can coincide
+        with that prefix by chance).
+        """
+        ref_id = operation.metadata.get("reference_id")
+        if ref_id is not None:
+            return ref_id, False
+        return str(operation.id)[:8], True
+
+    def _branch_display_name(self, operation: Operation, branch: Any) -> tuple[str, bool]:
+        """Resolve a lifecycle-signal display name once a branch is bound:
+        the branch's own name if one was ever assigned (even by a hook that
+        runs after queue-time), else the same fallback as ``_display_name``.
+        Returns ``(name, is_fallback)``.
+        """
+        branch_name = getattr(branch, "name", None)
+        if branch_name:
+            return branch_name, False
+        return self._display_name(operation)
+
+    def _emit_progress(
+        self, op_id: str, name: str, status: str, elapsed: float, name_is_fallback: bool
+    ) -> None:
+        """Invoke ``self.on_progress`` with the name-provenance bit, if the
+        installed callback accepts it. Older callbacks (only 4 positional
+        params, no ``**kwargs``) get the original call shape so they keep
+        working unchanged; the provenance bit is additive, not required.
+        """
+        if not self.on_progress:
+            return
+        if self._on_progress_accepts_fallback is None:
+            try:
+                params = inspect.signature(self.on_progress).parameters.values()
+                self._on_progress_accepts_fallback = any(
+                    p.name == "name_is_fallback" or p.kind is inspect.Parameter.VAR_KEYWORD
+                    for p in params
+                )
+            except (TypeError, ValueError):
+                self._on_progress_accepts_fallback = False
+        if self._on_progress_accepts_fallback:
+            self.on_progress(op_id, name, status, elapsed, name_is_fallback=name_is_fallback)
+        else:
+            self.on_progress(op_id, name, status, elapsed)
+
     def _emit_terminal_once(
-        self, operation: Operation, branch_name: str, status: str, elapsed: float
+        self,
+        operation: Operation,
+        branch_name: str,
+        status: str,
+        elapsed: float,
+        name_is_fallback: bool,
     ) -> None:
         """Emit a terminal on_progress signal for `operation` at most once.
 
@@ -390,8 +447,7 @@ class DependencyAwareExecutor:
         if operation.id in self._terminal_emitted:
             return
         self._terminal_emitted.add(operation.id)
-        if self.on_progress:
-            self.on_progress(str(operation.id), branch_name, status, elapsed)
+        self._emit_progress(str(operation.id), branch_name, status, elapsed, name_is_fallback)
 
     def _emit_abandoned_terminal(self, operation: Operation) -> None:
         """Safety net for cancellation and unexpected flow-level errors.
@@ -410,11 +466,10 @@ class DependencyAwareExecutor:
             return
         import time as _time
 
-        ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
         branch = self.operation_branches.get(operation.id, self.session.default_branch)
-        branch_name = getattr(branch, "name", None) or ref_id
+        branch_name, name_is_fallback = self._branch_display_name(operation, branch)
         elapsed = _time.monotonic() - self._op_start_times.get(operation.id, _time.monotonic())
-        self._emit_terminal_once(operation, branch_name, "failed", elapsed)
+        self._emit_terminal_once(operation, branch_name, "failed", elapsed, name_is_fallback)
 
     async def _execute_operation(self, operation: Operation, limiter: CapacityLimiter):
         if operation.execution.status in Event._TERMINAL_STATUSES:
@@ -458,10 +513,9 @@ class DependencyAwareExecutor:
                         str(operation.id)[:8],
                     )
 
-                ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
                 branch = self.operation_branches.get(operation.id, self.session.default_branch)
-                branch_name = getattr(branch, "name", None) or ref_id
-                self._emit_terminal_once(operation, branch_name, "failed", 0.0)
+                branch_name, name_is_fallback = self._branch_display_name(operation, branch)
+                self._emit_terminal_once(operation, branch_name, "failed", 0.0, name_is_fallback)
 
                 self.completion_events[operation.id].set()
                 return
@@ -480,19 +534,17 @@ class DependencyAwareExecutor:
             async with limiter:
                 self._prepare_operation(operation)
 
-                ref_id = operation.metadata.get("reference_id", str(operation.id)[:8])
                 branch = self.operation_branches.get(operation.id, self.session.default_branch)
-                branch_name = getattr(branch, "name", None) or ref_id
+                branch_name, name_is_fallback = self._branch_display_name(operation, branch)
 
                 import time as _time
 
                 self._op_start_times[operation.id] = _time.monotonic()
                 self._started_ops.add(operation.id)
 
-                if self.on_progress:
-                    self.on_progress(str(operation.id), branch_name, "started", 0)
+                self._emit_progress(str(operation.id), branch_name, "started", 0, name_is_fallback)
                 if self.verbose:
-                    logger.debug("Executing operation: %s", ref_id)
+                    logger.debug("Executing operation: %s", branch_name)
 
                 operation._branch = branch
                 self._render_pending_operator_steers(operation)
@@ -512,18 +564,20 @@ class DependencyAwareExecutor:
                         response_context = operation.response["context"]
                         if not isinstance(response_context, Mapping):
                             error = TypeError(
-                                f"Operation {ref_id} response['context'] must be a Mapping, "
+                                f"Operation {branch_name} response['context'] must be a Mapping, "
                                 f"got {type(response_context).__name__}."
                             )
                             operation.execution.status = EventStatus.FAILED
                             operation.execution.error = error
                             self.results[operation.id] = {"error": str(error)}
                             self.failed_operations.add(operation.id)
-                            self._emit_terminal_once(operation, branch_name, "failed", elapsed)
+                            self._emit_terminal_once(
+                                operation, branch_name, "failed", elapsed, name_is_fallback
+                            )
                             if self.verbose:
                                 logger.error(
                                     "Operation %s failed (%.1fs): %s",
-                                    ref_id,
+                                    branch_name,
                                     elapsed,
                                     error,
                                 )
@@ -531,9 +585,11 @@ class DependencyAwareExecutor:
 
                         deep_update(self.context.content, dict(response_context))
 
-                    self._emit_terminal_once(operation, branch_name, "completed", elapsed)
+                    self._emit_terminal_once(
+                        operation, branch_name, "completed", elapsed, name_is_fallback
+                    )
                     if self.verbose:
-                        logger.debug("Completed operation: %s (%.1fs)", ref_id, elapsed)
+                        logger.debug("Completed operation: %s (%.1fs)", branch_name, elapsed)
 
                     if operation.metadata.get("is_gate"):
                         self._record_gate_verdict(operation)
@@ -541,11 +597,13 @@ class DependencyAwareExecutor:
                 elif operation.execution.status == EventStatus.FAILED:
                     self.results[operation.id] = {"error": str(operation.execution.error)}
                     self.failed_operations.add(operation.id)
-                    self._emit_terminal_once(operation, branch_name, "failed", elapsed)
+                    self._emit_terminal_once(
+                        operation, branch_name, "failed", elapsed, name_is_fallback
+                    )
                     if self.verbose:
                         logger.error(
                             "Operation %s failed (%.1fs): %s",
-                            ref_id,
+                            branch_name,
                             elapsed,
                             operation.execution.error,
                         )
@@ -931,8 +989,8 @@ class ReactiveExecutor(DependencyAwareExecutor):
                 self._tg = tg
                 for node in initial:
                     if self.on_progress:
-                        _name = node.metadata.get("reference_id", str(node.id)[:8])
-                        self.on_progress(str(node.id), _name, "queued", 0.0)
+                        _name, _fallback = self._display_name(node)
+                        self._emit_progress(str(node.id), _name, "queued", 0.0, _fallback)
                     tg.start_soon(self._run_tracked, node)
         finally:
             self._running = False
@@ -999,8 +1057,8 @@ class ReactiveExecutor(DependencyAwareExecutor):
                         self._tg = tg
                         for node in initial:
                             if self.on_progress:
-                                _name = node.metadata.get("reference_id", str(node.id)[:8])
-                                self.on_progress(str(node.id), _name, "queued", 0.0)
+                                _name, _fallback = self._display_name(node)
+                                self._emit_progress(str(node.id), _name, "queued", 0.0, _fallback)
                             tg.start_soon(self._run_tracked, node)
                 except get_cancelled_exc_class():
                     raise  # let driver_cancel_scope absorb our own cancellation
@@ -1273,8 +1331,8 @@ class ReactiveExecutor(DependencyAwareExecutor):
             self._assign_injected_branch(child, emitter_id, independent)
             self._emit_node_spawned(child, emitter_id, independent)
             if self.on_progress:
-                _name = child.metadata.get("reference_id", str(child.id)[:8])
-                self.on_progress(str(child.id), _name, "queued", 0.0)
+                _name, _fallback = self._display_name(child)
+                self._emit_progress(str(child.id), _name, "queued", 0.0, _fallback)
         return True
 
     def _emit_node_spawned(self, child: Operation, emitter_id: Any, independent: bool) -> None:

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -123,7 +123,9 @@ class _FakeBuilder:
         self._nodes: dict[str, _FakeNode] = {}
         self._counter = 0
 
-    def add_operation(self, op_type, *, branch=None, depends_on=None, instruction="", context=None):
+    def add_operation(
+        self, op_type, *, branch=None, depends_on=None, instruction="", context=None, node_id=None
+    ):
         node_id = f"node-{self._counter}"
         self._counter += 1
         self._nodes[node_id] = _FakeNode(node_id)

--- a/tests/operations/test_flow_lifecycle_terminal.py
+++ b/tests/operations/test_flow_lifecycle_terminal.py
@@ -252,6 +252,81 @@ async def test_reactive_spawn_shares_one_name_when_spawn_branch_setup_names_the_
 
 
 @pytest.mark.asyncio
+async def test_branch_name_colliding_with_op_id_prefix_stays_pinned_through_later_rename():
+    """A branch's real ``.name`` is an unrestricted str, assignable via the
+    branch setup seam (spawn_branch_setup / on_branch_created) -- it can
+    coincidentally equal the op_id's own 8-char prefix. flow_signals used to
+    infer "this is the queued-time fallback placeholder" from string equality
+    with ``op_id[:8]``, so a genuine branch name that happened to collide
+    with the prefix was misclassified as a fallback and left unpinned; a
+    later rename (e.g. the cancellation/abandoned-terminal safety net
+    re-reading branch.name after started already fired) then split the
+    operation across two names on the Studio-facing signal bus. Structural
+    provenance (name_is_fallback, computed by the producer) replaces the
+    string comparison."""
+    from lionagi.engines.flow_signals import flow_progress_signals
+    from lionagi.operations.flow import DependencyAwareExecutor
+    from lionagi.session.branch import Branch
+    from lionagi.session.session import Session
+    from lionagi.session.signal import NodeCompleted, NodeFailed, NodeQueued, NodeStarted
+
+    op = Operation(operation="work", parameters={})
+    collision_name = str(op.id)[:8]  # no reference_id -> queued's own fallback too
+
+    session = Session()
+    branch = Branch(name=collision_name)
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    graph = Graph()
+    graph.add_node(op)
+
+    signal_log: list[tuple[str, str, str]] = []
+    for sig_cls, kind in (
+        (NodeQueued, "queued"),
+        (NodeStarted, "started"),
+        (NodeCompleted, "completed"),
+        (NodeFailed, "failed"),
+    ):
+        session.observe(
+            sig_cls,
+            handler=lambda s, _, kind=kind: signal_log.append((kind, s.op_id, s.name)),
+        )
+
+    async with flow_progress_signals(session, graph) as on_progress:
+        executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
+        executor.on_progress = on_progress
+
+        # queued: no reference_id -> falls back to op_id[:8], which happens
+        # to equal the branch's genuine name (pure coincidence).
+        name, is_fallback = executor._display_name(op)
+        executor._emit_progress(str(op.id), name, "queued", 0.0, is_fallback)
+
+        # started: resolves the branch's OWN name -- genuine, not a
+        # fallback, even though it coincides with op_id[:8].
+        executor._started_ops.add(op.id)
+        name, is_fallback = executor._branch_display_name(op, branch)
+        executor._emit_progress(str(op.id), name, "started", 0.0, is_fallback)
+        assert name == collision_name
+        assert is_fallback is False
+
+        # A later rename (a workspace-retargeting hook, or the cancellation
+        # safety net re-reading branch.name after started already fired)
+        # must not split the correlation.
+        branch.name = "renamed-later"
+        executor._emit_abandoned_terminal(op)
+
+    op_id = str(op.id)
+    names = {kind: name for kind, oid, name in signal_log if oid == op_id}
+    assert names["queued"] == names["started"] == collision_name
+    terminal_name = names.get("completed") or names.get("failed")
+    assert terminal_name == collision_name, (
+        "a branch name colliding with op_id[:8] must stay pinned through a "
+        f"later rename, got {signal_log}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_executor_raw_callback_diverges_without_reference_id_pre_fix_symptom():
     """Pins the pre-fix symptom at its source, one layer below the signal bus:
     the raw ``DependencyAwareExecutor.on_progress`` callback itself falls back
@@ -433,8 +508,8 @@ async def test_emit_terminal_once_is_idempotent_across_call_sites():
     executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
     executor.on_progress = log
 
-    executor._emit_terminal_once(op, "analyst", "completed", 1.0)
-    executor._emit_terminal_once(op, "analyst", "failed", 2.0)
+    executor._emit_terminal_once(op, "analyst", "completed", 1.0, False)
+    executor._emit_terminal_once(op, "analyst", "failed", 2.0, False)
 
     op_id = str(op.id)
     assert log.statuses_for(op_id) == ["completed"]

--- a/tests/operations/test_flow_lifecycle_terminal.py
+++ b/tests/operations/test_flow_lifecycle_terminal.py
@@ -327,6 +327,42 @@ async def test_branch_name_colliding_with_op_id_prefix_stays_pinned_through_late
 
 
 @pytest.mark.asyncio
+async def test_on_progress_seam_requires_provenance_instead_of_defaulting():
+    """r5 found that ``flow_signals._on_progress`` defaulted
+    ``name_is_fallback=True``, so an untagged caller supplying an authored
+    name at queued and the UUID prefix at started rendered a split identity:
+    a direct probe fed ``on_progress(op_id, "authored-name", "queued", 0.0)``
+    then ``on_progress(op_id, op_id[:8], "started", 0.0)`` and the bus showed
+    ``queued=authored-name``, ``started=109b2103`` -- two names for one op.
+
+    The seam's only callers are the four lifecycle producers in
+    ``operations/flow.py``, and all four already pass the bit explicitly, so
+    there is no real "unknown provenance" case to default for. This test
+    pins the seam shut: reproducing the exact untagged call shape from the
+    probe above must now fail loudly (TypeError) rather than silently
+    guessing fallback=True and risking the split-identity render.
+    """
+    from lionagi.engines.flow_signals import flow_progress_signals
+    from lionagi.session.branch import Branch
+
+    op = Operation(operation="work", parameters={})
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+
+    graph = Graph()
+    graph.add_node(op)
+
+    async with flow_progress_signals(session, graph) as on_progress:
+        op_id = str(op.id)
+        with pytest.raises(TypeError):
+            on_progress(op_id, "authored-name", "queued", 0.0)
+        with pytest.raises(TypeError):
+            on_progress(op_id, op_id[:8], "started", 0.0)
+
+
+@pytest.mark.asyncio
 async def test_executor_raw_callback_diverges_without_reference_id_pre_fix_symptom():
     """Pins the pre-fix symptom at its source, one layer below the signal bus:
     the raw ``DependencyAwareExecutor.on_progress`` callback itself falls back

--- a/tests/operations/test_flow_lifecycle_terminal.py
+++ b/tests/operations/test_flow_lifecycle_terminal.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lifecycle telemetry corrections: one stable identity across queued/started/
+terminal signals, and exactly one terminal on_progress emission after every
+"started" across success, failure, cancellation, and abandonment.
+
+Regression guards for the root cause traced in signal_root_cause.md: a node
+built without ``reference_id`` was announced under the UUID prefix at queued
+time and under the branch name at started time, and a cancelled or otherwise
+abandoned operation never reached a terminal on_progress call at all — the
+graph rendered it as running forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi.ln.concurrency import CapacityLimiter
+from lionagi.operations.flow import DependencyAwareExecutor
+from lionagi.operations.node import Operation
+from lionagi.protocols.graph.graph import Graph
+from lionagi.session.session import Session
+
+
+def _session_with_ops(**ops):
+    """A Session whose default branch resolves the given named operations."""
+    from lionagi.session.branch import Branch
+
+    session = Session()
+    branch = Branch(name="root")
+    session.include_branches(branch)
+    session.default_branch = branch
+    for name, fn in ops.items():
+        session.register_operation(name, fn)
+    return session
+
+
+class _ProgressLog:
+    """Captures on_progress(op_id, name, status, elapsed) calls in order."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, str, str, float]] = []
+
+    def __call__(self, op_id: str, name: str, status: str, elapsed: float) -> None:
+        self.calls.append((op_id, name, status, elapsed))
+
+    def statuses_for(self, op_id: str) -> list[str]:
+        return [c[2] for c in self.calls if c[0] == op_id]
+
+    def names_for(self, op_id: str) -> list[str]:
+        return [c[1] for c in self.calls if c[0] == op_id]
+
+
+# ---------------------------------------------------------------------------
+# queued/started identity agreement (reference_id fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_queued_and_started_share_the_same_name_when_reference_id_set():
+    """A node built with a reference_id (the CLI-flow fix: ``node_id=agent_ids[i]``
+    threaded through ``_build_worker_operate_node`` -> ``add_operation``) must be
+    announced under the SAME name at queued and started time on the actual
+    Studio-facing signal bus (``Engine.run_dag`` -> ``flow_progress_signals``).
+
+    The identity agreement happens in ``flow_signals._on_progress``, which
+    prefers the authored ``reference_id`` snapshot over whatever name the raw
+    executor callback passed — this is what makes queued and started resolve
+    to one name regardless of the executor's own (still divergent) internal
+    fallback chain, exercised directly by the next test below."""
+    from lionagi.engines import Engine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.signal import NodeQueued, NodeStarted
+
+    async def work(**kw):
+        return "ok"
+
+    session = _session_with_ops(work=work)
+
+    signal_log: list[tuple[str, str, str]] = []
+    session.observe(NodeQueued, handler=lambda s, _: signal_log.append(("queued", s.op_id, s.name)))
+    session.observe(
+        NodeStarted, handler=lambda s, _: signal_log.append(("started", s.op_id, s.name))
+    )
+
+    builder = OperationGraphBuilder()
+    builder.add_operation("work", node_id="analyst")
+    graph = builder.get_graph()
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(graph)
+    assert len(result["completed_operations"]) == 1
+
+    op_id = str(result["completed_operations"][0])
+    names = {kind: name for kind, oid, name in signal_log if oid == op_id}
+    assert names == {"queued": "analyst", "started": "analyst"}, (
+        f"queued/started must share one identity, got {signal_log}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_executor_raw_callback_diverges_without_reference_id_pre_fix_symptom():
+    """Pins the pre-fix symptom at its source, one layer below the signal bus:
+    the raw ``DependencyAwareExecutor.on_progress`` callback itself falls back
+    to the UUID prefix at queued time and the branch name at started time when
+    no ``reference_id`` is set on the node. This is exactly why an unfixed CLI
+    call site (no ``node_id=``) produced two different names — the bus-level
+    override in ``flow_signals`` only works because the CLI fix populates
+    ``reference_id`` in the first place."""
+
+    async def work(**kw):
+        return "ok"
+
+    session = _session_with_ops(work=work)
+    graph = Graph()
+    op = Operation(operation="work", parameters={})
+    graph.add_node(op)
+
+    log = _ProgressLog()
+    executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
+    executor.on_progress = log
+    await executor.execute()
+
+    op_id = str(op.id)
+    names = log.names_for(op_id)
+    assert names[0] == op_id[:8], "queued falls back to the UUID prefix without reference_id"
+    assert names[1] == "root", "started falls back to branch.name without reference_id"
+    assert names[0] != names[1]
+
+
+# ---------------------------------------------------------------------------
+# exactly one terminal signal after every start
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_path_emits_exactly_one_terminal_signal():
+    async def work(**kw):
+        return "ok"
+
+    session = _session_with_ops(work=work)
+    graph = Graph()
+    op = Operation(operation="work", parameters={})
+    graph.add_node(op)
+
+    log = _ProgressLog()
+    executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
+    executor.on_progress = log
+    await executor.execute()
+
+    op_id = str(op.id)
+    terminal = [s for s in log.statuses_for(op_id) if s in ("completed", "failed")]
+    assert terminal == ["completed"]
+
+
+@pytest.mark.asyncio
+async def test_failure_path_emits_exactly_one_terminal_signal():
+    async def work(**kw):
+        raise RuntimeError("operation-level failure")
+
+    session = _session_with_ops(work=work)
+    graph = Graph()
+    op = Operation(operation="work", parameters={})
+    graph.add_node(op)
+
+    log = _ProgressLog()
+    executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
+    executor.on_progress = log
+    await executor.execute()
+
+    op_id = str(op.id)
+    terminal = [s for s in log.statuses_for(op_id) if s in ("completed", "failed")]
+    assert terminal == ["failed"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_after_start_emits_exactly_one_terminal_signal():
+    """CancelledError during invoke() must still close the started identity
+    with a terminal "failed" (there is no separate cancelled signal kind) —
+    the pre-fix behaviour swallowed the terminal signal in this path
+    entirely, leaving the node rendered as running forever."""
+
+    async def work(**kw):
+        return "unused"
+
+    session = _session_with_ops(work=work)
+    graph = Graph()
+    op = Operation(operation="work", parameters={})
+    graph.add_node(op)
+
+    log = _ProgressLog()
+    executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
+    executor.on_progress = log
+    executor.operation_branches[op.id] = session.default_branch
+
+    object.__setattr__(op, "invoke", AsyncMock(side_effect=asyncio.CancelledError()))
+    limiter = CapacityLimiter(10)
+
+    with pytest.raises(asyncio.CancelledError):
+        await executor._execute_operation(op, limiter)
+
+    op_id = str(op.id)
+    assert log.statuses_for(op_id) == ["started", "failed"]
+    assert executor.completion_events[op.id].is_set()
+
+
+@pytest.mark.asyncio
+async def test_abandonment_unexpected_flow_error_after_start_emits_one_terminal():
+    """An unexpected flow-level error after "started" (not an operation-level
+    failure — those are caught inside Event.invoke() and become the normal
+    FAILED path) must still close the started identity with exactly one
+    terminal "failed" signal, and must not propagate out of
+    _execute_operation (matching the existing defensive-net contract)."""
+
+    async def work(**kw):
+        return "unused"
+
+    session = _session_with_ops(work=work)
+    graph = Graph()
+    op = Operation(operation="work", parameters={})
+    graph.add_node(op)
+
+    log = _ProgressLog()
+    executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
+    executor.on_progress = log
+    executor.operation_branches[op.id] = session.default_branch
+
+    object.__setattr__(
+        op, "invoke", AsyncMock(side_effect=RuntimeError("unexpected flow-level bug"))
+    )
+    limiter = CapacityLimiter(10)
+
+    await executor._execute_operation(op, limiter)  # must not raise
+
+    op_id = str(op.id)
+    assert log.statuses_for(op_id) == ["started", "failed"]
+    assert executor.completion_events[op.id].is_set()
+    assert op.id in executor.results
+
+
+@pytest.mark.asyncio
+async def test_never_started_op_gets_no_terminal_from_safety_net():
+    """The abandonment safety net must be a no-op for an operation that never
+    reached "started" — e.g. a sibling still queued when a group cancels —
+    so it never fabricates a terminal signal for work that never began."""
+
+    async def work(**kw):
+        return "ok"
+
+    session = _session_with_ops(work=work)
+    graph = Graph()
+    op = Operation(operation="work", parameters={})
+    graph.add_node(op)
+
+    log = _ProgressLog()
+    executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
+    executor.on_progress = log
+
+    assert op.id not in executor._started_ops
+    executor._emit_abandoned_terminal(op)
+
+    assert log.calls == []
+
+
+@pytest.mark.asyncio
+async def test_emit_terminal_once_is_idempotent_across_call_sites():
+    """Two independent exit paths racing to close out the same operation
+    (e.g. the normal FAILED branch and a safety net) must produce exactly
+    one terminal on_progress call — the first one wins."""
+
+    async def work(**kw):
+        return "ok"
+
+    session = _session_with_ops(work=work)
+    graph = Graph()
+    op = Operation(operation="work", parameters={})
+    graph.add_node(op)
+
+    log = _ProgressLog()
+    executor = DependencyAwareExecutor(session=session, graph=graph, max_concurrent=10)
+    executor.on_progress = log
+
+    executor._emit_terminal_once(op, "analyst", "completed", 1.0)
+    executor._emit_terminal_once(op, "analyst", "failed", 2.0)
+
+    op_id = str(op.id)
+    assert log.statuses_for(op_id) == ["completed"]

--- a/tests/operations/test_flow_lifecycle_terminal.py
+++ b/tests/operations/test_flow_lifecycle_terminal.py
@@ -175,6 +175,83 @@ async def test_reactive_spawn_shares_one_name_across_queued_started_terminal():
 
 
 @pytest.mark.asyncio
+async def test_reactive_spawn_shares_one_name_when_spawn_branch_setup_names_the_clone():
+    """Same reactive-spawn setup as the test above, but the caller's
+    ``spawn_branch_setup`` hook (the public callback ``_assign_injected_branch``
+    invokes right after cloning) assigns the cloned branch a display name.
+    ``started``/``completed`` used to resolve their on_progress ``name`` from
+    ``getattr(branch, "name", None) or ref_id`` (flow.py), which then preferred
+    the hook-assigned branch name over the ``reference_id`` the ``queued``
+    signal already used -- splitting one spawned child across two identities
+    (queued=spawn-1, started/completed=<branch name>). A branch-naming hook
+    must not change which identity a reactive child's lifecycle signals
+    correlate under."""
+    import json
+
+    from lionagi.operations.node import create_operation
+    from lionagi.orchestration.patterns import grant_spawn, role_node_builder
+    from lionagi.protocols.graph.graph import Graph
+    from lionagi.session.signal import NodeCompleted, NodeFailed, NodeQueued, NodeStarted
+    from lionagi.testing import TestBranch
+
+    def _capability_chunk(**spawn_fields) -> dict:
+        payload = json.dumps({"spawn_request": spawn_fields})
+        return {"type": "stream", "chunks": [{"type": "text", "content": payload}]}
+
+    spawner = TestBranch.from_responses(
+        [_capability_chunk(instruction="do the follow-up", assignee="follower", independent=True)],
+        name="spawner",
+    )
+    follower = TestBranch.from_text("follow-up complete", name="follower")
+
+    session = _session_with_ops()
+    session.include_branches(spawner)
+    session.include_branches(follower)
+    session.default_branch = spawner
+    grant_spawn(spawner, prompt=False)
+
+    signal_log: list[tuple[str, str, str]] = []
+    for sig_cls, kind in (
+        (NodeQueued, "queued"),
+        (NodeStarted, "started"),
+        (NodeCompleted, "completed"),
+        (NodeFailed, "failed"),
+    ):
+        session.observe(
+            sig_cls,
+            handler=lambda s, _, kind=kind: signal_log.append((kind, s.op_id, s.name)),
+        )
+
+    graph = Graph()
+    root = create_operation("operate", parameters={"instruction": "start"})
+    root.branch_id = spawner.id
+    graph.add_node(root)
+
+    from lionagi.engines import Engine
+
+    def _name_the_clone(_op, clone) -> None:
+        clone.name = "explicit-child-name"
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(
+        graph,
+        reactive=True,
+        node_builder=role_node_builder({"follower": follower}),
+        spawn_branch_setup=_name_the_clone,
+    )
+
+    assert result["spawned_operations"] == 1
+    spawned_op_id = next(oid for oid in result["completed_operations"] if str(oid) != str(root.id))
+    names = {kind: name for kind, oid, name in signal_log if oid == str(spawned_op_id)}
+    assert "started" in names, f"no started signal recorded for spawned child, got {signal_log}"
+    terminal_name = names.get("completed") or names.get("failed")
+    assert names["queued"] == names["started"] == terminal_name == "spawn-1", (
+        "a branch-naming hook must not split a reactive child's lifecycle "
+        f"identity, got {signal_log}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_executor_raw_callback_diverges_without_reference_id_pre_fix_symptom():
     """Pins the pre-fix symptom at its source, one layer below the signal bus:
     the raw ``DependencyAwareExecutor.on_progress`` callback itself falls back

--- a/tests/operations/test_flow_lifecycle_terminal.py
+++ b/tests/operations/test_flow_lifecycle_terminal.py
@@ -103,6 +103,78 @@ async def test_queued_and_started_share_the_same_name_when_reference_id_set():
 
 
 @pytest.mark.asyncio
+async def test_reactive_spawn_shares_one_name_across_queued_started_terminal():
+    """The static case above threads node_id through the CLI builder; a
+    REACTIVE spawn takes a different path — role_node_builder stamps
+    spawn_id/reference_id on the child node (orchestration/patterns.py), but
+    flow_signals._on_spawned's NodeSpawned handler used to overwrite that
+    child's node_edge_meta entry with only parent_id/depends_on, dropping the
+    name. queued (which reads reference_id straight off the node) and
+    started (which falls back to the cloned branch's own name) then resolved
+    to two different names for the same op_id — buildNodeStatusesByName
+    (operationGraph.ts) split the same reactive child into a phantom
+    queued-forever node plus a separately-named started node."""
+    import json
+
+    from lionagi.operations.node import create_operation
+    from lionagi.orchestration.patterns import grant_spawn, role_node_builder
+    from lionagi.protocols.graph.graph import Graph
+    from lionagi.session.signal import NodeCompleted, NodeFailed, NodeQueued, NodeStarted
+    from lionagi.testing import TestBranch
+
+    def _capability_chunk(**spawn_fields) -> dict:
+        payload = json.dumps({"spawn_request": spawn_fields})
+        return {"type": "stream", "chunks": [{"type": "text", "content": payload}]}
+
+    spawner = TestBranch.from_responses(
+        [_capability_chunk(instruction="do the follow-up", assignee="follower", independent=True)],
+        name="spawner",
+    )
+    follower = TestBranch.from_text("follow-up complete", name="follower")
+
+    session = _session_with_ops()
+    session.include_branches(spawner)
+    session.include_branches(follower)
+    session.default_branch = spawner
+    grant_spawn(spawner, prompt=False)
+
+    signal_log: list[tuple[str, str, str]] = []
+    for sig_cls, kind in (
+        (NodeQueued, "queued"),
+        (NodeStarted, "started"),
+        (NodeCompleted, "completed"),
+        (NodeFailed, "failed"),
+    ):
+        session.observe(
+            sig_cls,
+            handler=lambda s, _, kind=kind: signal_log.append((kind, s.op_id, s.name)),
+        )
+
+    graph = Graph()
+    root = create_operation("operate", parameters={"instruction": "start"})
+    root.branch_id = spawner.id
+    graph.add_node(root)
+
+    from lionagi.engines import Engine
+
+    run = Engine().new_run(session=session)
+    result = await run.run_dag(
+        graph,
+        reactive=True,
+        node_builder=role_node_builder({"follower": follower}),
+    )
+
+    assert result["spawned_operations"] == 1
+    spawned_op_id = next(oid for oid in result["completed_operations"] if str(oid) != str(root.id))
+    names = {kind: name for kind, oid, name in signal_log if oid == str(spawned_op_id)}
+    assert "started" in names, f"no started signal recorded for spawned child, got {signal_log}"
+    terminal_name = names.get("completed") or names.get("failed")
+    assert names["queued"] == names["started"] == terminal_name == "spawn-1", (
+        f"reactive spawn must keep ONE name across queued/started/terminal, got {signal_log}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_executor_raw_callback_diverges_without_reference_id_pre_fix_symptom():
     """Pins the pre-fix symptom at its source, one layer below the signal bus:
     the raw ``DependencyAwareExecutor.on_progress`` callback itself falls back


### PR DESCRIPTION
Makes execution-graph progress readable at a glance and keeps node identity stable while a run is live.

- Stabilize node identity across execution lifecycle signals: graph nodes no longer detach from their branch rows when lifecycle events rename or re-key an in-flight node; matching is by durable identity, so statuses land on the node the viewer is already watching.
- Progress at a glance: a compact progress summary (done/running/failed counts and elapsed time) on the run detail view, follow-mode that keeps the active node in view, and clearer per-node progress states on the canvas.
- Translate the new progress strings across all 16 locales, with the locale test pinning full key parity.

Frontend: typecheck, lint, and 1462 tests green. Backend: ruff and the flow lifecycle/checkpoint suites green.
