### PR TITLE
refactor: auto-registration seam and V0 public-surface contract gate

### DIFF
--- a/lionagi/_auto.py
+++ b/lionagi/_auto.py
@@ -1,0 +1,482 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Private declaration compiler for Studio HTTP routes and CLI commands."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Literal, Protocol, TypeVar, overload
+
+Handler = TypeVar("Handler", bound=Callable[..., Any])
+HttpMethod = Literal["GET", "POST", "PUT", "PATCH", "DELETE"]
+CliParserResult = argparse.ArgumentParser | Mapping[str, argparse.ArgumentParser] | None
+
+_HTTP_METHODS: tuple[HttpMethod, ...] = ("GET", "POST", "PUT", "PATCH", "DELETE")
+
+
+class CliParserFactory(Protocol):
+    """Callable that installs a command's subparser and returns its parser(s)."""
+
+    def __call__(self, subparsers: argparse._SubParsersAction) -> CliParserResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class HttpDeclaration:
+    """Transport-neutral metadata for one auto-registered HTTP route."""
+
+    path: str
+    method: HttpMethod
+    response_model: Any | None = None
+    dependencies: tuple[Any, ...] = ()
+    status_code: int | None = None
+    tags: tuple[str, ...] | None = None
+    name: str | None = None
+    summary: str | None = None
+    description: str | None = None
+    response_class: type[Any] | None = None
+    responses: Mapping[int | str, Mapping[str, Any]] | None = None
+    include_in_schema: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class CliDeclaration:
+    """Marks a handler as the parser factory for a given CLI seed."""
+
+    seed: str
+    parser_factory: CliParserFactory
+
+
+@dataclass(frozen=True, slots=True)
+class CliSeed:
+    """Discovery metadata for one canonical CLI command."""
+
+    name: str
+    help: str
+    module: str
+    aliases: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class Registration:
+    """One compiled auto-registration: the declaration plus the original handler."""
+
+    order: int
+    area: str
+    module: str
+    qualname: str
+    handler: Callable[..., Any]
+    http: HttpDeclaration | None = None
+    cli: CliDeclaration | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CliBuild:
+    """Result of building the root CLI parser for a selected (or no) seed."""
+
+    parser: argparse.ArgumentParser
+    seed: CliSeed | None
+    registration: Registration | None
+    selected_parser: CliParserResult
+
+
+class RegistrationError(ValueError):
+    """Base error for invalid or conflicting auto-registration declarations."""
+
+
+class InvalidRegistrationError(RegistrationError):
+    """Raised when a declaration itself is malformed."""
+
+
+class DuplicateRegistrationError(RegistrationError):
+    """Raised when two distinct handlers claim the same registration identity."""
+
+
+class RegistrationContractError(RegistrationError):
+    """Raised when compiled markers violate the one-marker-per-seed contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class _Marker:
+    """Private immutable marker attached to a decorated handler."""
+
+    area: str
+    http: HttpDeclaration | None
+    cli: CliDeclaration | None
+
+
+_MARKER_ATTR = "_lionagi_auto_marker"
+
+# Fixed HTTP module import order, mirroring lionagi/studio/registry.py's
+# current _STUDIO_ROUTE_MODULES exactly; no consumer is wired to this
+# compiler yet (C2 is deferred), so it must import what actually exists today.
+_HTTP_MODULES: tuple[str, ...] = (
+    "lionagi.studio.services.casts",
+    "lionagi.studio.services.runs",
+    "lionagi.studio.services.run_resume",
+    "lionagi.studio.services.engine_runs",
+    "lionagi.studio.services.definitions",
+    "lionagi.studio.services.agents",
+    "lionagi.studio.services.playbooks",
+    "lionagi.studio.services.shows",
+    "lionagi.studio.services.skills",
+    "lionagi.studio.services.plugins",
+    "lionagi.studio.services.mcp_servers",
+    "lionagi.studio.services.teams",
+    "lionagi.studio.services.invocations",
+    "lionagi.studio.services.launches",
+    "lionagi.studio.services.projects",
+    "lionagi.studio.services.engine_defs",
+    "lionagi.studio.services.workflow_defs",
+    "lionagi.studio.services.sessions",
+    "lionagi.studio.services.run_tags",
+    "lionagi.studio.services.operator",
+    "lionagi.studio.services.approvals",
+    "lionagi.studio.services.admin",
+    "lionagi.studio.services.schedules",
+    "lionagi.studio.services.stats",
+)
+
+# Fixed CLI seed tuple: the 21 canonical commands in their existing order,
+# copied byte-for-byte from lionagi/cli/main.py's _COMMAND_REGISTRY.
+_CLI_SEEDS: tuple[CliSeed, ...] = (
+    CliSeed(
+        name="orchestrate",
+        help="Multi-agent orchestration patterns.",
+        module="lionagi.cli.orchestrate",
+        aliases=("o",),
+    ),
+    CliSeed(
+        name="agent",
+        help="Spawn one-shot subagent (blocking); prints final response.",
+        module="lionagi.cli.agent",
+    ),
+    CliSeed(
+        name="casts",
+        help="inspect built-in roles and modes",
+        module="lionagi.casts.surfaces",
+    ),
+    CliSeed(
+        name="engine",
+        help="Run domain-specific multi-agent engine pipelines.",
+        module="lionagi.cli.engine",
+    ),
+    CliSeed(
+        name="team",
+        help="Team messaging — send/receive between named agents.",
+        module="lionagi.cli.team",
+    ),
+    CliSeed(
+        name="studio",
+        help="Lion Studio server",
+        module="lionagi.studio.cli",
+    ),
+    CliSeed(
+        name="schedule",
+        help="Manage lionagi Studio schedules.",
+        module="lionagi.studio.cli",
+    ),
+    CliSeed(
+        name="state",
+        help="Inspect and migrate lionagi state.db.",
+        module="lionagi.cli.state",
+    ),
+    CliSeed(
+        name="invoke",
+        help="Track a skill-level orchestration.",
+        module="lionagi.cli.invoke",
+    ),
+    CliSeed(
+        name="kill",
+        help="Terminate a running entity (run/session/play/show).",
+        module="lionagi.cli.kill",
+    ),
+    CliSeed(
+        name="mirror",
+        help="Mirror Claude Code sessions into studio (live).",
+        module="lionagi.cli.mirror",
+    ),
+    CliSeed(
+        name="monitor",
+        help="Observe play/agent/run progress in real-time.",
+        module="lionagi.cli.monitor",
+        aliases=("mon",),
+    ),
+    CliSeed(
+        name="dispatch",
+        help="Inspect and acknowledge durable dispatch_outbox rows.",
+        module="lionagi.cli.dispatch",
+    ),
+    CliSeed(
+        name="doctor",
+        help="Check the lionagi CLI environment/install for common failure modes.",
+        module="lionagi.cli.doctor",
+    ),
+    CliSeed(
+        name="stats",
+        help="Read-only aggregate reporting over lionagi's StateDB.",
+        module="lionagi.cli.stats",
+    ),
+    CliSeed(
+        name="plugin",
+        help="Inspect, trust, and enable/disable LionAGI plugin bundles.",
+        module="lionagi.cli.plugin",
+    ),
+    CliSeed(
+        name="hooks",
+        help="Import Claude Code / Codex hook configs; trust imported hook commands.",
+        module="lionagi.cli.hooks",
+    ),
+    CliSeed(
+        name="handshake",
+        help="Report the machine-result contract version this build speaks.",
+        module="lionagi.cli.machine",
+    ),
+    CliSeed(
+        name="runs",
+        help="List recorded runs and what each one wrote.",
+        module="lionagi.cli.machine",
+    ),
+    CliSeed(
+        name="lifecycle",
+        help="Report the recorded lifecycle state of a run.",
+        module="lionagi.cli.machine",
+    ),
+    CliSeed(
+        name="mcp",
+        help="Serve the lionagi MCP server (background job submit/query) over stdio.",
+        module="lionagi.cli.mcp",
+    ),
+)
+
+
+def _build_seed_by_token(seeds: tuple[CliSeed, ...]) -> dict[str, CliSeed]:
+    by_token: dict[str, CliSeed] = {}
+    for seed in seeds:
+        for token in (seed.name, *seed.aliases):
+            existing = by_token.get(token)
+            if existing is not None:
+                raise DuplicateRegistrationError(
+                    f"Duplicate CLI seed token {token!r}: claimed by both "
+                    f"{existing.name!r} and {seed.name!r}"
+                )
+            by_token[token] = seed
+    return by_token
+
+
+# Module-level registry state.
+_http: list[Registration] = []
+_http_keys: dict[tuple[str, HttpMethod, str, str], Callable[..., Any]] = {}
+_cli_seeds: tuple[CliSeed, ...] = _CLI_SEEDS
+_cli_seed_by_token: dict[str, CliSeed] = _build_seed_by_token(_cli_seeds)
+_cli_realized: dict[str, Registration] = {}
+
+
+@overload
+def auto_register(
+    *, area: str, http: HttpDeclaration, cli: None = None
+) -> Callable[[Handler], Handler]: ...
+
+
+@overload
+def auto_register(
+    *, area: str, http: None = None, cli: CliDeclaration
+) -> Callable[[Handler], Handler]: ...
+
+
+def auto_register(
+    *,
+    area: str,
+    http: HttpDeclaration | None = None,
+    cli: CliDeclaration | None = None,
+) -> Callable[[Handler], Handler]:
+    """Attach one immutable auto-registration marker and return the handler unchanged."""
+    if not area:
+        raise InvalidRegistrationError("auto_register requires a non-empty area")
+    if (http is None) == (cli is None):
+        raise InvalidRegistrationError("auto_register requires exactly one of http or cli")
+    if http is not None:
+        if not http.path:
+            raise InvalidRegistrationError(
+                "auto_register http declaration requires a non-empty path"
+            )
+        if http.method not in _HTTP_METHODS:
+            raise InvalidRegistrationError(
+                f"auto_register http declaration has an invalid method: {http.method!r}"
+            )
+    if cli is not None and not cli.seed:
+        raise InvalidRegistrationError("auto_register cli declaration requires a non-empty seed")
+    marker = _Marker(area=area, http=http, cli=cli)
+
+    def decorator(fn: Handler) -> Handler:
+        setattr(fn, _MARKER_ATTR, marker)
+        return fn
+
+    return decorator
+
+
+def _iter_local_http_markers(module: Any) -> Iterator[tuple[Callable[..., Any], _Marker]]:
+    for obj in vars(module).values():
+        marker = getattr(obj, _MARKER_ATTR, None)
+        if marker is None or marker.http is None:
+            continue
+        if getattr(obj, "__module__", None) != module.__name__:
+            continue
+        yield obj, marker
+
+
+def _compile_http(fn: Callable[..., Any], area: str, http: HttpDeclaration) -> None:
+    key = (http.path, http.method, fn.__module__, fn.__qualname__)
+    existing = _http_keys.get(key)
+    if existing is not None:
+        if existing is fn:
+            return
+        raise DuplicateRegistrationError(
+            f"Duplicate auto_register http registration: {http.method} {http.path} "
+            f"({fn.__module__}.{fn.__qualname__})"
+        )
+    resolved = http if http.tags is not None else dataclasses.replace(http, tags=(area,))
+    registration = Registration(
+        order=len(_http),
+        area=area,
+        module=fn.__module__,
+        qualname=fn.__qualname__,
+        handler=fn,
+        http=resolved,
+        cli=None,
+    )
+    _http.append(registration)
+    _http_keys[key] = fn
+
+
+def load_http_modules() -> None:
+    """Import each HTTP module in fixed order and compile its http markers."""
+    for module_path in _HTTP_MODULES:
+        module = import_module(module_path)
+        for fn, marker in _iter_local_http_markers(module):
+            assert marker.http is not None
+            _compile_http(fn, marker.area, marker.http)
+
+
+def iter_http(*, area: str | None = None) -> tuple[Registration, ...]:
+    """Return compiled HTTP registrations sorted by order, optionally filtered by area."""
+    registrations = sorted(_http, key=lambda r: r.order)
+    if area is not None:
+        registrations = [r for r in registrations if r.area == area]
+    return tuple(registrations)
+
+
+def iter_cli_seeds() -> tuple[CliSeed, ...]:
+    """Return the fixed CLI seed tuple in canonical order."""
+    return _cli_seeds
+
+
+def seed_for(command_name_or_alias: str) -> CliSeed | None:
+    """Resolve a canonical command name or alias to its seed, or None if unknown."""
+    return _cli_seed_by_token.get(command_name_or_alias)
+
+
+def command_exists(command_name_or_alias: str) -> bool:
+    """Report whether a token is a known canonical CLI command name or alias."""
+    return command_name_or_alias in _cli_seed_by_token
+
+
+def load_cli_command(seed: CliSeed) -> Registration:
+    """Import a seed's module and compile its single matching CLI marker."""
+    cached = _cli_realized.get(seed.name)
+    if cached is not None:
+        return cached
+    module = import_module(seed.module)
+    matches: list[tuple[Callable[..., Any], _Marker]] = []
+    for obj in vars(module).values():
+        marker = getattr(obj, _MARKER_ATTR, None)
+        if marker is None or marker.cli is None or marker.cli.seed != seed.name:
+            continue
+        matches.append((obj, marker))
+    if len(matches) != 1:
+        raise RegistrationContractError(
+            f"expected exactly one auto_register cli marker for seed {seed.name!r} "
+            f"in {seed.module!r}, found {len(matches)}"
+        )
+    fn, marker = matches[0]
+    if fn.__module__ != seed.module:
+        raise RegistrationContractError(
+            f"auto_register cli marker for seed {seed.name!r} is defined by "
+            f"{fn.__module__!r}, not its seed module {seed.module!r}"
+        )
+    registration = Registration(
+        order=_cli_seeds.index(seed),
+        area=marker.area,
+        module=fn.__module__,
+        qualname=fn.__qualname__,
+        handler=fn,
+        http=None,
+        cli=marker.cli,
+    )
+    _cli_realized[seed.name] = registration
+    return registration
+
+
+def _cli_version() -> str:
+    from lionagi.version import __version__
+
+    return __version__
+
+
+def build_cli_parser(selected: CliSeed | None) -> CliBuild:
+    """Build the root CLI parser, realizing only the selected seed's real parser."""
+    parser = argparse.ArgumentParser(
+        prog="li",
+        description="lionagi command line — spawn subagents via any CLI-backed provider.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_cli_version()}",
+        help="Print the installed lionagi version and exit.",
+    )
+    parser.add_argument(
+        "--machine",
+        action="store_true",
+        help=(
+            "Emit one machine-result JSON object on stdout and send every "
+            "human-facing line to stderr."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    registration: Registration | None = None
+    selected_parser: CliParserResult = None
+    for seed in _cli_seeds:
+        if selected is not None and seed.name == selected.name:
+            registration = load_cli_command(seed)
+            assert registration.cli is not None
+            selected_parser = registration.cli.parser_factory(subparsers)
+        else:
+            subparsers.add_parser(seed.name, aliases=list(seed.aliases), help=seed.help)
+    return CliBuild(
+        parser=parser, seed=selected, registration=registration, selected_parser=selected_parser
+    )
+
+
+@contextmanager
+def _isolated_registry_for_tests() -> Iterator[None]:
+    """Snapshot both compiled surfaces, clear them, and restore on exit."""
+    http_snapshot = list(_http)
+    http_keys_snapshot = dict(_http_keys)
+    cli_realized_snapshot = dict(_cli_realized)
+    _http.clear()
+    _http_keys.clear()
+    _cli_realized.clear()
+    try:
+        yield
+    finally:
+        _http.clear()
+        _http.extend(http_snapshot)
+        _http_keys.clear()
+        _http_keys.update(http_keys_snapshot)
+        _cli_realized.clear()
+        _cli_realized.update(cli_realized_snapshot)

--- a/lionagi/casts/__init__.py
+++ b/lionagi/casts/__init__.py
@@ -3,38 +3,52 @@
 
 """casts — composable agent configuration: patterns, profiles, packs, and emission contracts."""
 
-from .catalog import build_catalog
-from .emission import (
-    SPAWN_ALLOWED_OPERATIONS,
-    AnalysisResult,
-    ArtifactProduced,
-    ComplexityScore,
-    ComplianceVerdict,
-    Conflict,
-    DesignSpec,
-    Diagnosis,
-    Document,
-    EscalationRequest,
-    ExecutionPlan,
-    Finding,
-    Gap,
-    Objection,
-    OperationOutcome,
-    Postmortem,
-    Proposal,
-    Recommendation,
-    RiskAssessment,
-    SpawnRequest,
-    Synthesis,
-    TaskAssignment,
-    Verdict,
-    VerificationResult,
-    build_emission_operable,
-    field_name_for,
-)
-from .pack import Pack, RoleConfig, RolePolicy
-from .pattern import Mode, Pattern, PatternKind, Role, list_modes, list_roles
-from .profile import Profile
+from ..ln._lazy_init import lazy_import
+
+_LAZY_MAP: dict[str, tuple[str, str | None]] = {
+    "build_catalog": ("catalog", None),
+    "SPAWN_ALLOWED_OPERATIONS": ("emission", None),
+    "AnalysisResult": ("emission", None),
+    "ArtifactProduced": ("emission", None),
+    "ComplexityScore": ("emission", None),
+    "ComplianceVerdict": ("emission", None),
+    "Conflict": ("emission", None),
+    "DesignSpec": ("emission", None),
+    "Diagnosis": ("emission", None),
+    "Document": ("emission", None),
+    "EscalationRequest": ("emission", None),
+    "ExecutionPlan": ("emission", None),
+    "Finding": ("emission", None),
+    "Gap": ("emission", None),
+    "Objection": ("emission", None),
+    "OperationOutcome": ("emission", None),
+    "Postmortem": ("emission", None),
+    "Proposal": ("emission", None),
+    "Recommendation": ("emission", None),
+    "RiskAssessment": ("emission", None),
+    "SpawnRequest": ("emission", None),
+    "Synthesis": ("emission", None),
+    "TaskAssignment": ("emission", None),
+    "Verdict": ("emission", None),
+    "VerificationResult": ("emission", None),
+    "build_emission_operable": ("emission", None),
+    "field_name_for": ("emission", None),
+    "Pack": ("pack", None),
+    "RoleConfig": ("pack", None),
+    "RolePolicy": ("pack", None),
+    "Mode": ("pattern", None),
+    "Pattern": ("pattern", None),
+    "PatternKind": ("pattern", None),
+    "Role": ("pattern", None),
+    "list_modes": ("pattern", None),
+    "list_roles": ("pattern", None),
+    "Profile": ("profile", None),
+}
+
+
+def __getattr__(name: str):
+    return lazy_import(name, _LAZY_MAP, __name__, globals())
+
 
 __all__ = (
     # catalog (read-only metadata seam)

--- a/lionagi/casts/surfaces.py
+++ b/lionagi/casts/surfaces.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""`casts` area surfaces: CLI (`li casts`) and HTTP (`GET /api/casts/`)."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from lionagi._auto import CliDeclaration, HttpDeclaration, auto_register
+
+
+def add_casts_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("casts", help="inspect built-in roles and modes")
+    p.add_argument(
+        "name",
+        nargs="?",
+        default=None,
+        help=(
+            "Role or mode to print in full, including its prompt body. Looked up in both "
+            "catalogs, so you need not know which it is. Omit it to list names only."
+        ),
+    )
+    p.add_argument(
+        "--modes",
+        action="store_true",
+        default=False,
+        help=(
+            "List the behavior overlays (modes) instead of the personas (roles). "
+            "Only affects the bare listing; ignored when a name is given."
+        ),
+    )
+
+
+@auto_register(area="casts", cli=CliDeclaration(seed="casts", parser_factory=add_casts_subparser))
+def run_casts(args: argparse.Namespace) -> int:
+    from lionagi.casts.catalog import build_catalog
+    from lionagi.cli._logging import log_error
+
+    catalog = build_catalog()
+
+    if args.name is None:
+        if args.modes:
+            _print_table(catalog["modes"], kind="mode")
+        else:
+            _print_table(catalog["roles"], kind="role")
+        return 0
+
+    name = args.name
+    role = next((r for r in catalog["roles"] if r["name"] == name), None)
+    mode = next((m for m in catalog["modes"] if m["name"] == name), None)
+
+    if role is not None:
+        _print_role_detail(role)
+        return 0
+    if mode is not None:
+        _print_mode_detail(mode)
+        return 0
+
+    log_error(f"unknown role or mode: {name!r}")
+    return 1
+
+
+def _print_table(entries: list[dict], *, kind: str) -> None:
+    if not entries:
+        print(f"(no {kind}s)")
+        return
+    col = max(len(e["name"]) for e in entries) + 2
+    print(f"{'NAME':<{col}}  DESCRIPTION")
+    print("-" * (col + 2) + "  " + "-" * 40)
+    for e in entries:
+        desc = e["description"]
+        if len(desc) > 72:
+            desc = desc[:69] + "..."
+        print(f"{e['name']:<{col}}  {desc}")
+
+
+def _print_role_detail(role: dict) -> None:
+    print(f"Role: {role['name']}")
+    print()
+    print(role["description"])
+    if role["emits"]:
+        print()
+        print("Emits: " + ", ".join(e["model"] for e in role["emits"]))
+    if role["body"]:
+        print()
+        print(role["body"].rstrip())
+
+
+def _print_mode_detail(mode: dict) -> None:
+    print(f"Mode: {mode['name']}")
+    print()
+    print(mode["description"])
+    if mode["conflicts_with"]:
+        print()
+        print("Conflicts with: " + ", ".join(mode["conflicts_with"]))
+    if mode["behaviors"]:
+        print()
+        print(mode["behaviors"].rstrip())
+
+
+@auto_register(area="casts", http=HttpDeclaration(path="/casts/", method="GET"))
+async def get_casts() -> dict[str, Any]:
+    from lionagi.casts.catalog import build_catalog
+
+    return build_catalog()

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 
 from lionagi import Branch
+from lionagi._auto import CliDeclaration, auto_register
 from lionagi._errors import ConfigurationError
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.ln.concurrency import (
@@ -1589,6 +1590,7 @@ def _resolve_model_and_prompt(args: argparse.Namespace) -> tuple[str | None, str
     return None
 
 
+@auto_register(area="agent", cli=CliDeclaration(seed="agent", parser_factory=add_agent_subparser))
 def run_agent(args: argparse.Namespace) -> int:
     """Dispatch agent command."""
     if getattr(args, "list_profiles", False):

--- a/lionagi/cli/dispatch.py
+++ b/lionagi/cli/dispatch.py
@@ -13,6 +13,8 @@ from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
+
 __all__ = (
     "add_dispatch_subparser",
     "run_dispatch",
@@ -306,6 +308,9 @@ def add_dispatch_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+@auto_register(
+    area="dispatch", cli=CliDeclaration(seed="dispatch", parser_factory=add_dispatch_subparser)
+)
 def run_dispatch(args: argparse.Namespace) -> int:
     from lionagi.ln.concurrency import run_async
 

--- a/lionagi/cli/doctor.py
+++ b/lionagi/cli/doctor.py
@@ -10,6 +10,8 @@ import json
 import sys
 from pathlib import Path
 
+from lionagi._auto import CliDeclaration, auto_register
+
 __all__ = (
     "add_doctor_subparser",
     "run_doctor",
@@ -229,6 +231,9 @@ def add_doctor_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+@auto_register(
+    area="doctor", cli=CliDeclaration(seed="doctor", parser_factory=add_doctor_subparser)
+)
 def run_doctor(args: argparse.Namespace) -> int:
     checks = collect_checks()
     if getattr(args, "json", False):

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -10,6 +10,8 @@ import time
 import uuid
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
+
 from ._logging import log_error, progress, warn
 
 # ── Engine kind registry ───────────────────────────────────────────────────
@@ -196,6 +198,9 @@ def add_engine_subparser(subparsers: argparse._SubParsersAction) -> None:
 # ── Main dispatch ──────────────────────────────────────────────────────────
 
 
+@auto_register(
+    area="engine", cli=CliDeclaration(seed="engine", parser_factory=add_engine_subparser)
+)
 def run_engine(args: argparse.Namespace) -> int:
     """Entry point called from main() when args.command == 'engine'."""
     from lionagi.ln.concurrency import run_async

--- a/lionagi/cli/hooks.py
+++ b/lionagi/cli/hooks.py
@@ -30,6 +30,8 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
+
 from ._logging import log_error
 
 __all__ = ("add_hooks_subparser", "run_hooks")
@@ -473,6 +475,7 @@ def _run_trust(cwd: str | None, *, assume_yes: bool) -> int:
     return 0
 
 
+@auto_register(area="hooks", cli=CliDeclaration(seed="hooks", parser_factory=add_hooks_subparser))
 def run_hooks(args: argparse.Namespace) -> int:
     if args.hooks_command == "import":
         return _run_import(args.source, args.path, args.cwd)

--- a/lionagi/cli/invoke.py
+++ b/lionagi/cli/invoke.py
@@ -10,6 +10,8 @@ import time
 import uuid
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
+
 from ._logging import hint, log_error
 
 # ── async helpers ─────────────────────────────────────────────────────────────
@@ -203,6 +205,9 @@ def _parse_metadata(raw: str | None) -> dict | None:
     return parsed
 
 
+@auto_register(
+    area="invoke", cli=CliDeclaration(seed="invoke", parser_factory=add_invoke_subparser)
+)
 def run_invoke(args: argparse.Namespace) -> int:
     from lionagi.ln.concurrency import run_async
 

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 
 import psutil
 
+from lionagi._auto import CliDeclaration, auto_register
 from lionagi.state.db import PLAY_ACTIVE_STATUSES as _PLAY_ACTIVE_STATUSES
 
 from ._logging import log_error, warn
@@ -950,6 +951,7 @@ def add_kill_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+@auto_register(area="kill", cli=CliDeclaration(seed="kill", parser_factory=add_kill_subparser))
 def run_kill(args: argparse.Namespace) -> int:
     from lionagi.ln.concurrency import run_async
 

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -20,6 +20,8 @@ from importlib import import_module
 from pathlib import Path
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
+
 __all__ = (
     "CONTRACT_VERSION",
     "MIN_SUPPORTED_CONTRACT_VERSION",
@@ -817,6 +819,10 @@ def add_handshake_subparser(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--machine", action="store_true", help="Emit the machine-result envelope.")
 
 
+@auto_register(
+    area="handshake",
+    cli=CliDeclaration(seed="handshake", parser_factory=add_handshake_subparser),
+)
 def run_handshake(args: argparse.Namespace) -> int:
     data = handshake_data()
     for key, value in data.items():
@@ -834,6 +840,7 @@ def add_runs_subparser(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--machine", action="store_true", help="Emit the machine-result envelope.")
 
 
+@auto_register(area="runs", cli=CliDeclaration(seed="runs", parser_factory=add_runs_subparser))
 def run_runs(args: argparse.Namespace) -> int:
     data = runs_data(getattr(args, "limit", _DEFAULT_RUNS_LIMIT))
     listing = data["runs"]
@@ -869,6 +876,9 @@ def add_lifecycle_subparser(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--machine", action="store_true", help="Emit the machine-result envelope.")
 
 
+@auto_register(
+    area="lifecycle", cli=CliDeclaration(seed="lifecycle", parser_factory=add_lifecycle_subparser)
+)
 def run_lifecycle(args: argparse.Namespace) -> int:
     from ._logging import log_error
 

--- a/lionagi/cli/machine.py
+++ b/lionagi/cli/machine.py
@@ -793,9 +793,9 @@ def _run_machine_command(argv: list[str]) -> dict[str, Any]:
     if module_name is not None:
         return import_module(module_name, __package__).machine_result(rest)
 
-    from .main import _COMMAND_BY_NAME
+    from lionagi._auto import command_exists
 
-    if name in _COMMAND_BY_NAME or name in ("play", "skill", "wait"):
+    if command_exists(name) or name in ("play", "skill", "wait"):
         raise MachineError(
             "unavailable",
             f"li {name} has no machine-mode result in contract version "

--- a/lionagi/cli/main.py
+++ b/lionagi/cli/main.py
@@ -8,10 +8,9 @@ import argparse
 import signal
 import sys
 import traceback
-from collections.abc import Callable
-from dataclasses import dataclass
 from importlib import import_module
-from types import ModuleType
+
+from lionagi._auto import build_cli_parser, seed_for
 
 from ._logging import configure_cli_logging, log_error
 from ._util import (
@@ -22,360 +21,16 @@ from ._util import (
 )
 
 
-def _load_agent() -> ModuleType:
-    return import_module(".agent", __package__)
-
-
-def _load_casts() -> ModuleType:
-    return import_module(".casts", __package__)
-
-
-def _load_dispatch() -> ModuleType:
-    return import_module(".dispatch", __package__)
-
-
-def _load_doctor() -> ModuleType:
-    return import_module(".doctor", __package__)
-
-
-def _load_engine() -> ModuleType:
-    return import_module(".engine", __package__)
-
-
-def _load_hooks() -> ModuleType:
-    return import_module(".hooks", __package__)
-
-
-def _load_invoke() -> ModuleType:
-    return import_module(".invoke", __package__)
-
-
-def _load_kill() -> ModuleType:
-    return import_module(".kill", __package__)
-
-
-def _load_machine() -> ModuleType:
-    return import_module(".machine", __package__)
-
-
-def _load_mcp() -> ModuleType:
-    return import_module(".mcp", __package__)
-
-
-def _load_mirror() -> ModuleType:
-    return import_module(".mirror", __package__)
-
-
-def _load_monitor() -> ModuleType:
-    return import_module(".monitor", __package__)
-
-
-def _load_orchestrate() -> ModuleType:
+def _load_orchestrate():
     return import_module(".orchestrate", __package__)
 
 
-def _load_plugin() -> ModuleType:
-    return import_module(".plugin", __package__)
+def _load_machine():
+    return import_module(".machine", __package__)
 
 
-def _load_state() -> ModuleType:
-    return import_module(".state", __package__)
-
-
-def _load_stats() -> ModuleType:
-    return import_module(".stats", __package__)
-
-
-def _load_team() -> ModuleType:
-    return import_module(".team", __package__)
-
-
-def _load_studio() -> ModuleType:
+def _load_studio():
     return import_module("lionagi.studio.cli")
-
-
-@dataclass(frozen=True)
-class _CommandSpec:
-    name: str
-    help: str
-    loader: Callable[[], ModuleType]
-    parser_factory: str
-    handler: str
-    aliases: tuple[str, ...] = ()
-
-
-_COMMAND_REGISTRY = (
-    _CommandSpec(
-        "orchestrate",
-        "Multi-agent orchestration patterns.",
-        _load_orchestrate,
-        "add_orchestrate_subparser",
-        "run_orchestrate",
-        ("o",),
-    ),
-    _CommandSpec(
-        "agent",
-        "Spawn one-shot subagent (blocking); prints final response.",
-        _load_agent,
-        "add_agent_subparser",
-        "run_agent",
-    ),
-    _CommandSpec(
-        "casts",
-        "inspect built-in roles and modes",
-        _load_casts,
-        "add_casts_subparser",
-        "run_casts",
-    ),
-    _CommandSpec(
-        "engine",
-        "Run domain-specific multi-agent engine pipelines.",
-        _load_engine,
-        "add_engine_subparser",
-        "run_engine",
-    ),
-    _CommandSpec(
-        "team",
-        "Team messaging — send/receive between named agents.",
-        _load_team,
-        "add_team_subparser",
-        "run_team",
-    ),
-    _CommandSpec(
-        "studio",
-        "Lion Studio server",
-        _load_studio,
-        "add_studio_subparser",
-        "run_studio",
-    ),
-    _CommandSpec(
-        "schedule",
-        "Manage lionagi Studio schedules.",
-        _load_studio,
-        "add_schedule_subparser",
-        "run_schedule",
-    ),
-    _CommandSpec(
-        "state",
-        "Inspect and migrate lionagi state.db.",
-        _load_state,
-        "add_state_subparser",
-        "run_state",
-    ),
-    _CommandSpec(
-        "invoke",
-        "Track a skill-level orchestration.",
-        _load_invoke,
-        "add_invoke_subparser",
-        "run_invoke",
-    ),
-    _CommandSpec(
-        "kill",
-        "Terminate a running entity (run/session/play/show).",
-        _load_kill,
-        "add_kill_subparser",
-        "run_kill",
-    ),
-    _CommandSpec(
-        "mirror",
-        "Mirror Claude Code sessions into studio (live).",
-        _load_mirror,
-        "add_mirror_subparser",
-        "run_mirror",
-    ),
-    _CommandSpec(
-        "monitor",
-        "Observe play/agent/run progress in real-time.",
-        _load_monitor,
-        "add_monitor_subparser",
-        "run_monitor",
-        ("mon",),
-    ),
-    _CommandSpec(
-        "dispatch",
-        "Inspect and acknowledge durable dispatch_outbox rows.",
-        _load_dispatch,
-        "add_dispatch_subparser",
-        "run_dispatch",
-    ),
-    _CommandSpec(
-        "doctor",
-        "Check the lionagi CLI environment/install for common failure modes.",
-        _load_doctor,
-        "add_doctor_subparser",
-        "run_doctor",
-    ),
-    _CommandSpec(
-        "stats",
-        "Read-only aggregate reporting over lionagi's StateDB.",
-        _load_stats,
-        "add_stats_subparser",
-        "run_stats",
-    ),
-    _CommandSpec(
-        "plugin",
-        "Inspect, trust, and enable/disable LionAGI plugin bundles.",
-        _load_plugin,
-        "add_plugin_subparser",
-        "run_plugin",
-    ),
-    _CommandSpec(
-        "hooks",
-        "Import Claude Code / Codex hook configs; trust imported hook commands.",
-        _load_hooks,
-        "add_hooks_subparser",
-        "run_hooks",
-    ),
-    _CommandSpec(
-        "handshake",
-        "Report the machine-result contract version this build speaks.",
-        _load_machine,
-        "add_handshake_subparser",
-        "run_handshake",
-    ),
-    _CommandSpec(
-        "runs",
-        "List recorded runs and what each one wrote.",
-        _load_machine,
-        "add_runs_subparser",
-        "run_runs",
-    ),
-    _CommandSpec(
-        "lifecycle",
-        "Report the recorded lifecycle state of a run.",
-        _load_machine,
-        "add_lifecycle_subparser",
-        "run_lifecycle",
-    ),
-    _CommandSpec(
-        "mcp",
-        "Serve the lionagi MCP server (background job submit/query) over stdio.",
-        _load_mcp,
-        "add_mcp_subparser",
-        "run_mcp",
-    ),
-)
-_COMMAND_BY_NAME = {
-    command_name: spec for spec in _COMMAND_REGISTRY for command_name in (spec.name, *spec.aliases)
-}
-
-
-def _build_parser(selected: _CommandSpec | None) -> tuple[argparse.ArgumentParser, object | None]:
-    parser = argparse.ArgumentParser(
-        prog="li",
-        description="lionagi command line — spawn subagents via any CLI-backed provider.",
-    )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"%(prog)s {_get_version()}",
-        help="Print the installed lionagi version and exit.",
-    )
-    parser.add_argument(
-        "--machine",
-        action="store_true",
-        help=(
-            "Emit one machine-result JSON object on stdout and send every "
-            "human-facing line to stderr."
-        ),
-    )
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    # Every command is registered for usage/error listing; only the selected
-    # one loads its real parser module, the rest stay metadata-only stubs.
-    selected_parser = None
-    for spec in _COMMAND_REGISTRY:
-        if selected is not None and spec.name == selected.name:
-            factory = getattr(selected.loader(), selected.parser_factory)
-            selected_parser = factory(subparsers)
-        else:
-            subparsers.add_parser(spec.name, aliases=list(spec.aliases), help=spec.help)
-    return parser, selected_parser
-
-
-# These forwarding functions preserve the main module's existing patch points
-# without importing a command implementation until that command is dispatched.
-def run_agent(args: argparse.Namespace) -> int:
-    return _load_agent().run_agent(args)
-
-
-def run_casts(args: argparse.Namespace) -> int:
-    return _load_casts().run_casts(args)
-
-
-def run_dispatch(args: argparse.Namespace) -> int:
-    return _load_dispatch().run_dispatch(args)
-
-
-def run_doctor(args: argparse.Namespace) -> int:
-    return _load_doctor().run_doctor(args)
-
-
-def run_engine(args: argparse.Namespace) -> int:
-    return _load_engine().run_engine(args)
-
-
-def run_invoke(args: argparse.Namespace) -> int:
-    return _load_invoke().run_invoke(args)
-
-
-def run_kill(args: argparse.Namespace) -> int:
-    return _load_kill().run_kill(args)
-
-
-def run_mcp(args: argparse.Namespace) -> int:
-    return _load_mcp().run_mcp(args)
-
-
-def run_mirror(args: argparse.Namespace) -> int:
-    return _load_mirror().run_mirror(args)
-
-
-def run_monitor(args: argparse.Namespace) -> int:
-    return _load_monitor().run_monitor(args)
-
-
-def run_orchestrate(args: argparse.Namespace) -> int:
-    return _load_orchestrate().run_orchestrate(args)
-
-
-def run_handshake(args: argparse.Namespace) -> int:
-    return _load_machine().run_handshake(args)
-
-
-def run_runs(args: argparse.Namespace) -> int:
-    return _load_machine().run_runs(args)
-
-
-def run_lifecycle(args: argparse.Namespace) -> int:
-    return _load_machine().run_lifecycle(args)
-
-
-def run_hooks(args: argparse.Namespace) -> int:
-    return _load_hooks().run_hooks(args)
-
-
-def run_plugin(args: argparse.Namespace) -> int:
-    return _load_plugin().run_plugin(args)
-
-
-def run_schedule(args: argparse.Namespace) -> int:
-    return _load_studio().run_schedule(args)
-
-
-def run_state(args: argparse.Namespace) -> int:
-    return _load_state().run_state(args)
-
-
-def run_stats(args: argparse.Namespace) -> int:
-    return _load_stats().run_stats(args)
-
-
-def run_studio(args: argparse.Namespace) -> int:
-    return _load_studio().run_studio(args)
-
-
-def run_team(args: argparse.Namespace) -> int:
-    return _load_team().run_team(args)
 
 
 def run_skill(argv: list[str]) -> int:
@@ -695,9 +350,9 @@ def _run(argv: list[str] | None = None) -> int:
 
         return run_wait(_argv[1:])
 
-    selected = _COMMAND_BY_NAME.get(_argv[0]) if _argv else None
+    selected = seed_for(_argv[0]) if _argv else None
     try:
-        parser, selected_parser = _build_parser(selected)
+        build = build_cli_parser(selected)
     except ModuleNotFoundError as exc:
         # An environment fault, not a command-scoped one — nothing ran, so
         # exit 78 rather than the 1 a started-and-failed run would return.
@@ -713,11 +368,12 @@ def _run(argv: list[str] | None = None) -> int:
         # dispatch; report it as a command-scoped error, not a traceback.
         log_error(f"command {_argv[0]!r} failed to load: {type(exc).__name__}: {exc}")
         return 1
+    parser, selected_parser = build.parser, build.selected_parser
 
     # `li o flow -p NAME`: inject the playbook's declared args as flags on
     # the flow sub-parser before argparse runs, so prompts don't swallow them.
     orch_parsers: dict[str, argparse.ArgumentParser] | None = None
-    if selected is _COMMAND_BY_NAME["orchestrate"]:
+    if selected is not None and selected.name == "orchestrate":
         orch_parsers = selected_parser
         _load_orchestrate().inject_playbook_schema_into_parser(orch_parsers["flow"], _argv)
 
@@ -725,7 +381,7 @@ def _run(argv: list[str] | None = None) -> int:
     # [MODEL] PROMPT. parse_intermixed_args is unusable: it drops the `--`
     # sentinel between passes, letting a prompt like "--bypass" after `--`
     # toggle real flags on re-parse. Split at the sentinel ourselves instead.
-    if selected is _COMMAND_BY_NAME["agent"]:
+    if selected is not None and selected.name == "agent":
         agent_parser = selected_parser
         tail = _argv[1:]
         if "--" in tail:
@@ -738,14 +394,15 @@ def _run(argv: list[str] | None = None) -> int:
         if unknown:
             agent_parser.error(f"unrecognized arguments: {' '.join(unknown)}")
         args.query = [*(args.query or []), *extras, *post]
-        return run_agent(args)
+        return build.registration.handler(args)
 
     # `li o flow` / `li o fanout` parse standalone for the same reason as
     # `agent` above (nested subparser dispatch can't intermix flags with
     # the [MODEL] PROMPT positionals). See docs/internals/cli.md.
     if (
         _argv
-        and selected is _COMMAND_BY_NAME["orchestrate"]
+        and selected is not None
+        and selected.name == "orchestrate"
         and len(_argv) > 1
         and _argv[1] in ("fanout", "flow")
     ):
@@ -765,12 +422,12 @@ def _run(argv: list[str] | None = None) -> int:
         args.query = [*(args.query or []), *extras, *post]
         args.command = "orchestrate"
         args.orch_command = sub_name
-        return run_orchestrate(args)
+        return build.registration.handler(args)
 
     # `li schedule ...` parses its own subparser directly (mirroring the
     # `agent` special-case above) so an unrecognized flag gets a one-line
     # "did you mean --X?" suggestion instead of argparse's generic usage dump.
-    if selected is _COMMAND_BY_NAME["schedule"]:
+    if selected is not None and selected.name == "schedule":
         schedule_parser = selected_parser
         # `li schedule create <kind> <name> ...` — a typed quick-create form
         # additive to the legacy flat `li schedule create NAME ...`. The kind
@@ -797,12 +454,13 @@ def _run(argv: list[str] | None = None) -> int:
                         continue
                 log_error(f"unrecognized argument: {tok}")
             return 2
-        return run_schedule(ns)
+        return build.registration.handler(ns)
 
     args = parser.parse_args(_argv)
 
     if selected is not None:
-        return globals()[selected.handler](args)
+        assert build.registration is not None
+        return build.registration.handler(args)
 
     parser.print_help()
     return 1

--- a/lionagi/cli/mcp.py
+++ b/lionagi/cli/mcp.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import argparse
 
+from lionagi._auto import CliDeclaration, auto_register
+
 from ._logging import log_error
 from ._util import EXIT_CODE_ENVIRONMENT_ERROR
 
@@ -45,6 +47,7 @@ def add_mcp_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+@auto_register(area="mcp", cli=CliDeclaration(seed="mcp", parser_factory=add_mcp_subparser))
 def run_mcp(args: argparse.Namespace) -> int:
     if getattr(args, "action", "serve") != "serve":
         log_error(f"unknown mcp action: {args.action}")

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -24,6 +24,21 @@ from ._logging import hint, log_error, progress, warn
 
 CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
+
+
+def _display_path(path: Path) -> str:
+    """Render a path under the home directory as ~/... for display.
+
+    Help text is the same on every machine this way. Printing the expanded
+    absolute path puts the running user's home directory into --help output,
+    which differs per machine and ends up in anything that captures it.
+    """
+    try:
+        return f"~/{path.relative_to(Path.home())}"
+    except ValueError:
+        return str(path)
+
+
 _OFFSETS_PATH = LIONAGI_HOME / "mirror" / "offsets.json"
 
 # A session whose newest message is within this window counts as live (running);
@@ -70,13 +85,13 @@ def add_mirror_subparser(subparsers: argparse._SubParsersAction) -> None:
         "--root",
         default=None,
         metavar="DIR",
-        help=f"Claude projects directory (default {CLAUDE_PROJECTS_DIR}).",
+        help=f"Claude projects directory (default {_display_path(CLAUDE_PROJECTS_DIR)}).",
     )
     p.add_argument(
         "--codex-root",
         default=None,
         metavar="DIR",
-        help=f"Codex sessions directory (default {CODEX_SESSIONS_DIR}).",
+        help=f"Codex sessions directory (default {_display_path(CODEX_SESSIONS_DIR)}).",
     )
     p.add_argument(
         "--source",

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
 from lionagi.ln._json_dump import raise_if_non_finite
 from lionagi.state.session_naming import sanitize_prompt_name
@@ -901,6 +902,9 @@ async def _run(args: argparse.Namespace) -> int:
     return 0
 
 
+@auto_register(
+    area="mirror", cli=CliDeclaration(seed="mirror", parser_factory=add_mirror_subparser)
+)
 def run_mirror(args: argparse.Namespace) -> int:
     from lionagi.ln.concurrency import run_async
 

--- a/lionagi/cli/monitor.py
+++ b/lionagi/cli/monitor.py
@@ -15,6 +15,7 @@ from functools import cache
 from pathlib import Path
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
 from lionagi.state.engine import mask_credentials
 
 from ._project import detect_project
@@ -1716,6 +1717,9 @@ def add_monitor_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+@auto_register(
+    area="monitor", cli=CliDeclaration(seed="monitor", parser_factory=add_monitor_subparser)
+)
 def run_monitor(args: argparse.Namespace) -> int:
     """Dispatch `li monitor` subcommand."""
     from lionagi.ln.concurrency import run_async

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -8,6 +8,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from lionagi._auto import CliDeclaration, auto_register
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.libs.path_safety import validate_path_component as validate_path_component
@@ -1068,6 +1069,10 @@ def _run_orch_command(coro, *, verbose: bool, extra_handlers: tuple = ()) -> tup
     return result, 0
 
 
+@auto_register(
+    area="orchestrate",
+    cli=CliDeclaration(seed="orchestrate", parser_factory=add_orchestrate_subparser),
+)
 def run_orchestrate(args: argparse.Namespace) -> int:
     if args.orch_command == "fanout":
         resolved = _resolve_model_and_prompt(getattr(args, "query", None) or [])

--- a/lionagi/cli/plugin.py
+++ b/lionagi/cli/plugin.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
+
 from ._logging import log_error
 
 
@@ -237,6 +239,9 @@ def _run_set_enabled(name: str, *, enabled: bool) -> int:
     return 0
 
 
+@auto_register(
+    area="plugin", cli=CliDeclaration(seed="plugin", parser_factory=add_plugin_subparser)
+)
 def run_plugin(args: argparse.Namespace) -> int:
     if args.plugin_command == "list":
         return _run_list()

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -10,6 +10,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
 from lionagi.state.content_pruned import CONTENT_PRUNED_KEY, pruned_content_sql
 from lionagi.state.session_naming import resolve_display_name
 
@@ -1648,6 +1649,7 @@ def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+@auto_register(area="state", cli=CliDeclaration(seed="state", parser_factory=add_state_subparser))
 def run_state(args: argparse.Namespace) -> int:
     from lionagi.ln.concurrency import run_async
 

--- a/lionagi/cli/stats.py
+++ b/lionagi/cli/stats.py
@@ -9,6 +9,8 @@ import json
 from datetime import datetime, timezone
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
+
 from .monitor import _since_timestamp
 
 __all__ = (
@@ -186,6 +188,7 @@ def add_stats_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+@auto_register(area="stats", cli=CliDeclaration(seed="stats", parser_factory=add_stats_subparser))
 def run_stats(args: argparse.Namespace) -> int:
     """Dispatch `li stats` subcommand."""
     from lionagi.ln.concurrency import run_async

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from lionagi._auto import CliDeclaration, auto_register
 from lionagi._paths import ensure_lionagi_dir
 from lionagi.cli._util import AmbiguousIdError
 from lionagi.ln._json_dump import raise_if_non_finite
@@ -624,6 +625,7 @@ def add_team_subparser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+@auto_register(area="team", cli=CliDeclaration(seed="team", parser_factory=add_team_subparser))
 def run_team(args: argparse.Namespace) -> int:
     cmd = args.team_command
     if cmd == "create":

--- a/lionagi/mcp/projection.py
+++ b/lionagi/mcp/projection.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
+from lionagi._auto import CliSeed, build_cli_parser, iter_cli_seeds, seed_for
 from lionagi.cli._argtypes import JsonArgument
 
 __all__ = (
@@ -59,16 +60,6 @@ class PlaybookResolutionError(SchemaProjectionError):
 
 
 # ── the CLI seam ─────────────────────────────────────────────────────────────
-
-
-def _cli_main() -> ModuleType:
-    """The ``lionagi.cli.main`` module object.
-
-    Plain imports of it resolve to the ``main()`` function instead (the
-    package `__init__` shadows the submodule), so this goes through
-    ``import_module`` to reach ``_COMMAND_REGISTRY``/``_build_parser``.
-    """
-    return import_module("lionagi.cli.main")
 
 
 def _subparser_actions(parser: argparse.ArgumentParser) -> list[argparse._SubParsersAction]:
@@ -106,7 +97,7 @@ def _walk(parser: argparse.ArgumentParser, prefix: tuple[str, ...], canonical: b
     return found
 
 
-def _command_tree(spec: Any) -> _Tree:
+def _command_tree(spec: CliSeed) -> _Tree:
     """Every parser path under one top-level command, freshly built.
 
     Each entry says whether the path spells every level with its canonical
@@ -115,8 +106,7 @@ def _command_tree(spec: Any) -> _Tree:
     factory's own return value, since ``orchestrate`` returns a dict of
     sub-parsers where the others return a single parser.
     """
-    main = _cli_main()
-    root, _selected = main._build_parser(spec)
+    root = build_cli_parser(spec).parser
     tree: _Tree = {}
     for sub_action in _subparser_actions(root):
         for name, aliases, sub in _canonical_choices(sub_action):
@@ -135,9 +125,8 @@ def _split(path: str) -> tuple[str, ...]:
     return parts
 
 
-def _spec_for(head: str) -> Any:
-    main = _cli_main()
-    spec = main._COMMAND_BY_NAME.get(head)
+def _spec_for(head: str) -> CliSeed:
+    spec = seed_for(head)
     if spec is None:
         raise SchemaProjectionError(head, "no such command")
     return spec
@@ -149,9 +138,8 @@ def available_paths() -> tuple[str, ...]:
     Reachability here is not authorization — what the projector can read is
     strictly wider than what the dispatch surface allows.
     """
-    main = _cli_main()
     paths: list[str] = []
-    for spec in main._COMMAND_REGISTRY:
+    for spec in iter_cli_seeds():
         for parts, (_parser, canonical) in _command_tree(spec).items():
             if canonical:
                 paths.append(" ".join(parts))

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -22,6 +22,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from lionagi._auto import CliDeclaration, auto_register
 from lionagi._paths import ensure_lionagi_dir
 from lionagi.cli._argtypes import JsonArgument
 from lionagi.cli._logging import log_error, warn
@@ -156,6 +157,9 @@ def _validate_mode_flags(args: argparse.Namespace) -> None:
         raise SystemExit(2)
 
 
+@auto_register(
+    area="studio", cli=CliDeclaration(seed="studio", parser_factory=add_studio_subparser)
+)
 def run_studio(args: argparse.Namespace) -> int:
     if not getattr(args, "studio_action", None):
         args.studio_action = "start"
@@ -2351,6 +2355,9 @@ _ACTION_MAP = {
 }
 
 
+@auto_register(
+    area="schedule", cli=CliDeclaration(seed="schedule", parser_factory=add_schedule_subparser)
+)
 def run_schedule(args: argparse.Namespace) -> int:
     action = getattr(args, "schedule_action", None)
     fn = _ACTION_MAP.get(action)

--- a/tests/cli/orchestrate/test_fanout_worker_pool.py
+++ b/tests/cli/orchestrate/test_fanout_worker_pool.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 import argparse
 
-import lionagi.cli.main as cli_main
+from lionagi._auto import build_cli_parser, seed_for
 from lionagi.cli.orchestrate.fanout import _parse_worker_pool
 
 
 def _fanout_parser() -> argparse.ArgumentParser:
-    parser, _ = cli_main._build_parser(cli_main._COMMAND_BY_NAME["orchestrate"])
+    parser = build_cli_parser(seed_for("orchestrate")).parser
     top_subparsers = next(
         action for action in parser._actions if isinstance(action, argparse._SubParsersAction)
     )

--- a/tests/cli/test_broken_environment_exit_code.py
+++ b/tests/cli/test_broken_environment_exit_code.py
@@ -152,7 +152,7 @@ def test_the_loader_boundary_does_not_absorb_a_missing_dependency(monkeypatch, r
     def _boom(selected):
         raise ModuleNotFoundError("No module named 'somedep'", name="somedep")
 
-    monkeypatch.setattr(cli_main, "_build_parser", _boom)
+    monkeypatch.setattr(cli_main, "build_cli_parser", _boom)
 
     assert cli_main.main(["doctor"]) == EXIT_CODE_ENVIRONMENT_ERROR
     assert "somedep" in "\n".join(reported)

--- a/tests/cli/test_cli_contracts.py
+++ b/tests/cli/test_cli_contracts.py
@@ -42,8 +42,6 @@ import tempfile
 
 import pytest
 
-import lionagi.cli.main as cli_main
-
 _CLI = [sys.executable, "-m", "lionagi.cli.main"]
 
 
@@ -68,8 +66,10 @@ def _command_parser(command: str, *subs: str) -> argparse.ArgumentParser:
     contract. Private argparse attributes are used deliberately — they are
     the stable introspection surface for this.
     """
-    spec = cli_main._COMMAND_BY_NAME[command]
-    parser, _ = cli_main._build_parser(spec)
+    from lionagi._auto import build_cli_parser, seed_for
+
+    seed = seed_for(command)
+    parser = build_cli_parser(seed).parser
     for name in (command, *subs):
         sub_action = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
         parser = sub_action.choices[name]

--- a/tests/cli/test_cli_help_coverage.py
+++ b/tests/cli/test_cli_help_coverage.py
@@ -65,7 +65,9 @@ def _built_parsers() -> list[argparse.ArgumentParser]:
     selected one for real; the rest stay metadata-only stubs. Selecting each in
     turn is therefore the only way to reach the whole surface.
     """
-    return [cli_main._build_parser(spec)[0] for spec in cli_main._COMMAND_REGISTRY]
+    from lionagi._auto import build_cli_parser, iter_cli_seeds
+
+    return [build_cli_parser(seed).parser for seed in iter_cli_seeds()]
 
 
 def test_built_parsers_describe_every_argument():

--- a/tests/cli/test_cli_surface_goldens.py
+++ b/tests/cli/test_cli_surface_goldens.py
@@ -78,8 +78,10 @@ def _command_parser(command: str, *subs: str) -> argparse.ArgumentParser:
     ``option_strings``/``_actions`` off the live parser is immune to
     argparse's rendered-help formatting changing across Python versions.
     """
-    spec = cli_main._COMMAND_BY_NAME[command]
-    parser, _ = cli_main._build_parser(spec)
+    from lionagi._auto import build_cli_parser, seed_for
+
+    seed = seed_for(command)
+    parser = build_cli_parser(seed).parser
     for name in (command, *subs):
         sub_action = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
         parser = sub_action.choices[name]
@@ -104,7 +106,9 @@ def _positional_dests(command: str, *subs: str) -> list[str]:
 
 
 def _top_level_subcommand_set() -> list[str]:
-    parser, _ = cli_main._build_parser(None)
+    from lionagi._auto import build_cli_parser
+
+    parser = build_cli_parser(None).parser
     sub_action = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
     return sorted(sub_action.choices.keys())
 
@@ -264,8 +268,8 @@ SCHEDULE_OBSERVABILITY_SUBCOMMAND_SHAPES = {
 class TestTopLevelCommandRegistryGolden:
     def test_top_level_command_set_is_pinned(self):
         """A command (or alias) silently added to or removed from
-        `_COMMAND_REGISTRY` must fail this golden until the change to the
-        set of things `li` accepts as a first argument is deliberate."""
+        the typed CLI seed registry must fail this golden until the change to
+        the set of things `li` accepts as a first argument is deliberate."""
         assert _top_level_subcommand_set() == sorted(TOP_LEVEL_COMMANDS)
 
 

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -803,6 +803,9 @@ def test_main_routes_engine_command(monkeypatch):
 
     # Get the actual main.py module (not the main() function exported via __init__)
     main_module = importlib.import_module("lionagi.cli.main")
+    engine_mod = importlib.import_module("lionagi.cli.engine")
+
+    from lionagi._auto import _MARKER_ATTR, _isolated_registry_for_tests
 
     run_engine_calls = []
 
@@ -810,10 +813,19 @@ def test_main_routes_engine_command(monkeypatch):
         run_engine_calls.append(args)
         return 0
 
-    monkeypatch.setattr(main_module, "run_engine", _mock_run_engine)
+    # The real `run_engine` carries the auto-registration marker as a property
+    # of the function object itself (not the module attribute); copy it onto
+    # the mock, and claim the seed module's `__module__` too, so the typed CLI
+    # seam still finds exactly one matching `engine` marker.
+    setattr(_mock_run_engine, _MARKER_ATTR, getattr(engine_mod.run_engine, _MARKER_ATTR))
+    _mock_run_engine.__module__ = engine_mod.__name__
+    monkeypatch.setattr(engine_mod, "run_engine", _mock_run_engine)
 
-    # 'engine run research <spec>' — must be routed to run_engine.
-    rc = main_module.main(["engine", "run", "research", "test topic"])
+    # 'engine run research <spec>' — must be routed to run_engine. The seed
+    # registry is isolated so this test's monkeypatch is what gets discovered,
+    # regardless of whether another test already realized the "engine" seed.
+    with _isolated_registry_for_tests():
+        rc = main_module.main(["engine", "run", "research", "test topic"])
     assert rc == 0
     assert len(run_engine_calls) == 1
     assert run_engine_calls[0].command == "engine"

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -431,12 +431,13 @@ def test_cli_package_getattr_raises_for_unknown_attr():
 
 def test_command_registry_loaders_expose_parser_and_handler():
     """Every registry entry resolves before a command-specific parse needs it."""
-    import lionagi.cli.main as main_module
+    from lionagi._auto import build_cli_parser, iter_cli_seeds
 
-    for spec in main_module._COMMAND_REGISTRY:
-        module = spec.loader()
-        assert callable(getattr(module, spec.parser_factory))
-        assert callable(getattr(module, spec.handler))
+    for seed in iter_cli_seeds():
+        build = build_cli_parser(seed)
+        assert build.registration is not None
+        assert callable(build.registration.cli.parser_factory)
+        assert callable(build.registration.handler)
 
 
 def test_version_and_root_help_work_in_fresh_cli_processes():
@@ -467,17 +468,13 @@ def test_leaf_command_parse_error_preserves_full_root_usage():
 def test_broken_command_loader_reports_error_without_traceback(capsys, monkeypatch):
     import lionagi.cli.main as main_module
 
-    monkeypatch.setitem(
-        main_module._COMMAND_BY_NAME,
-        "agent",
-        main_module._CommandSpec(
-            "agent",
-            "broken",
-            lambda: __import__("missing_lionagi_command_module"),
-            "add_agent_subparser",
-            "run_agent",
-        ),
-    )
+    def _boom(selected):
+        raise ModuleNotFoundError(
+            "No module named 'missing_lionagi_command_module'",
+            name="missing_lionagi_command_module",
+        )
+
+    monkeypatch.setattr(main_module, "build_cli_parser", _boom)
     rc = main_module.main(["agent", "--help"])
     # A module missing from the environment is reported as an unusable
     # environment, not as a failed run: exit 1 here is what a run that started
@@ -500,20 +497,10 @@ def test_a_command_loader_failing_for_another_reason_is_an_ordinary_failure(caps
     """
     import lionagi.cli.main as main_module
 
-    def _explode():
+    def _explode(selected):
         raise RuntimeError("bad module")
 
-    monkeypatch.setitem(
-        main_module._COMMAND_BY_NAME,
-        "agent",
-        main_module._CommandSpec(
-            "agent",
-            "broken",
-            _explode,
-            "add_agent_subparser",
-            "run_agent",
-        ),
-    )
+    monkeypatch.setattr(main_module, "build_cli_parser", _explode)
     rc = main_module.main(["agent", "--help"])
     assert rc == 1
     err = capsys.readouterr().err

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -415,6 +415,41 @@ def capture_specialized() -> list[dict[str, Any]]:
     return [_run_cli(list(argv)) for argv in SPECIALIZED_CASES]
 
 
+# A handful of the committable specialized-CLI cases capture argparse's own
+# rendered usage/help/error text verbatim (see _COMMITTABLE_SPECIALIZED_ARGV
+# in test_public_surfaces.py). That text depends on the interpreter's
+# HelpFormatter, which CPython changed twice across this project's CI matrix:
+# invalid-choice error text dropped quoting around each choice in 3.12
+# (e.g. "choose from 'a', 'b'" -> "choose from a, b"), and 3.13 collapsed a
+# repeated-per-option-string metavar into one shared metavar
+# (e.g. "-f PATH, --file PATH" -> "-f, --file PATH"), which also reflows the
+# surrounding wrapped usage lines. This is a real, declared difference in the
+# interpreter -- not an accident of import order or machine state, and not
+# something regex normalization should paper over, since that risks masking
+# an actual change in this CLI's own text. Each CI-tested minor version gets
+# its own pinned literal baseline instead.
+_SPECIALIZED_BASELINE_BY_PYVER: dict[tuple[int, int], str] = {
+    (3, 10): "specialized",
+    (3, 14): "specialized_py314",
+}
+
+
+def specialized_baseline_name() -> str:
+    """Name (without ``.json``) of the ``tests/contracts/data/`` fixture
+    holding the specialized-CLI baseline for the running interpreter."""
+    key = sys.version_info[:2]
+    try:
+        return _SPECIALIZED_BASELINE_BY_PYVER[key]
+    except KeyError:
+        raise RuntimeError(
+            f"no pinned specialized-CLI baseline for Python {key[0]}.{key[1]} -- "
+            "this interpreter isn't in the CI matrix "
+            f"({sorted(_SPECIALIZED_BASELINE_BY_PYVER)}); capture a new "
+            "tests/contracts/data/specialized_pyXY.json baseline (see "
+            "capture_specialized()) and add it to _SPECIALIZED_BASELINE_BY_PYVER"
+        ) from None
+
+
 # ── MCP available paths / catalog / projections / errors ────────────────────
 
 # Negative cases spanning every distinct SchemaProjectionError class this

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -628,6 +628,53 @@ def _run_import_trace(seed_name: str, timeout: float = 20.0) -> dict[str, Any]:
         }
 
 
+_COMPAT_TRACE_SCRIPT = (
+    "import sys, json, importlib, warnings\n"
+    "name = sys.argv[1]\n"
+    "try:\n"
+    "    with warnings.catch_warnings(record=True) as w:\n"
+    "        warnings.simplefilter('always')\n"
+    "        mod = importlib.import_module(name)\n"
+    "        result = {\n"
+    "            'ok': True,\n"
+    "            'dir': sorted(n for n in dir(mod) if not n.startswith('_')),\n"
+    "            'warning_categories': sorted({wi.category.__name__ for wi in w}),\n"
+    "        }\n"
+    "except Exception as e:\n"
+    "    result = {'ok': False, 'error': f'{type(e).__name__}: {e}'}\n"
+    "print(json.dumps(result))\n"
+)
+
+
+def _run_compat_trace(module_name: str, timeout: float = 20.0) -> dict[str, Any]:
+    """Import *module_name* alone in a fresh subprocess and report its public
+    ``dir()``. A compat module's own ``__init__.py`` declares its intended
+    re-exports, but Python also binds any submodule onto its parent package's
+    namespace the moment *anything* imports that submodule dotted-path --
+    including unrelated code elsewhere in the process (e.g. a lazy import
+    inside a different module). In-process capture would pick up whichever of
+    those happened to run first in this pytest worker, making the result
+    depend on suite composition rather than the compat module's own surface.
+    A fresh subprocess with a declared import set (only *module_name* itself)
+    removes that dependency."""
+    proc = subprocess.run(
+        [sys.executable, "-c", _COMPAT_TRACE_SCRIPT, module_name],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        return {"ok": False, "error": f"exit {proc.returncode}: {proc.stderr.strip()[-2000:]}"}
+    try:
+        return json.loads(proc.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError) as e:
+        return {
+            "ok": False,
+            "error": f"unparseable output: {e}: stdout={proc.stdout!r} stderr={proc.stderr!r}",
+        }
+
+
 def capture_import_laziness() -> dict[str, Any]:
     """Fresh-process ``sys.modules`` traces proving selected-only CLI loading.
 
@@ -661,9 +708,6 @@ COMPAT_MODULES: tuple[str, ...] = (
 
 
 def capture_imports() -> dict[str, Any]:
-    import importlib
-    import warnings
-
     import lionagi
 
     root_all = list(lionagi.__all__)
@@ -682,19 +726,7 @@ def capture_imports() -> dict[str, Any]:
     lazy_map = getattr(lionagi, "_LAZY_MAP", None) or {}
     lazy_map_keys = sorted(lazy_map.keys())
 
-    compat: dict[str, Any] = {}
-    for m in COMPAT_MODULES:
-        try:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                mod = importlib.import_module(m)
-                compat[m] = {
-                    "ok": True,
-                    "dir": sorted(n for n in dir(mod) if not n.startswith("_")),
-                    "warning_categories": sorted({wi.category.__name__ for wi in w}),
-                }
-        except Exception as e:  # noqa: BLE001
-            compat[m] = {"ok": False, "error": f"{type(e).__name__}: {e}"}
+    compat: dict[str, Any] = {m: _run_compat_trace(m) for m in COMPAT_MODULES}
 
     return {
         "root_all": sorted(root_all),

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -13,10 +13,14 @@ calls them again and diffs the live result against the frozen one.
 from __future__ import annotations
 
 import argparse
+import getpass
 import json
+import os
 import re
+import socket
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -262,6 +266,89 @@ def _run_cli(argv: list[str], timeout: float = 20.0) -> dict[str, Any]:
         "stderr": proc.stderr,
         "exit_code": proc.returncode,
     }
+
+
+def _run_cli_env(
+    argv: list[str],
+    env_overrides: dict[str, str] | None = None,
+    cwd: Path | None = None,
+    timeout: float = 20.0,
+) -> dict[str, Any]:
+    """Same as :func:`_run_cli`, but lets the caller vary the subprocess's
+    environment and working directory -- used by the differential-capture
+    check below to prove a committable case's output does not depend on
+    either."""
+    env = {**os.environ, **(env_overrides or {})}
+    proc = subprocess.run(
+        [sys.executable, "-m", "lionagi.cli.main", *argv],
+        cwd=cwd or REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+    return {
+        "argv": argv,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "exit_code": proc.returncode,
+    }
+
+
+_DIFFERENTIAL_FAKE_HOME = "/tmp/lionagi-differential-fake-home"
+_DIFFERENTIAL_FAKE_TMPDIR = "/tmp/lionagi-differential-fake-tmp"
+_DIFFERENTIAL_FAKE_USER = "lionagi-differential-fake-user"
+
+
+def differential_capture(argv: list[str], timeout: float = 20.0) -> list[dict[str, Any]]:
+    """Capture *argv* three times: once under the ambient environment and
+    working directory, once under a deliberately different HOME / TMPDIR /
+    USER and a different working directory, and once more after a wall-clock
+    gap crossing a one-second boundary. A stream that reads anything from
+    the environment, the current directory, or the clock necessarily differs
+    across these runs; genuinely static argparse usage/error text does not.
+    This replaces guessing at what a leaked value looks like (a pattern list,
+    a vocabulary of "known-safe" words) with a check on the property that
+    actually matters: does the output depend on the machine at all."""
+    fake_cwd = Path(_DIFFERENTIAL_FAKE_TMPDIR)
+    fake_cwd.mkdir(parents=True, exist_ok=True)
+    runs = [
+        _run_cli_env(argv, timeout=timeout),
+        _run_cli_env(
+            argv,
+            env_overrides={
+                "HOME": _DIFFERENTIAL_FAKE_HOME,
+                "TMPDIR": _DIFFERENTIAL_FAKE_TMPDIR,
+                "USER": _DIFFERENTIAL_FAKE_USER,
+                "LOGNAME": _DIFFERENTIAL_FAKE_USER,
+                "USERNAME": _DIFFERENTIAL_FAKE_USER,
+            },
+            cwd=fake_cwd,
+            timeout=timeout,
+        ),
+    ]
+    time.sleep(1.05)
+    runs.append(_run_cli_env(argv, timeout=timeout))
+    return runs
+
+
+def known_machine_identity() -> frozenset[str]:
+    """Literal values that identify *this* machine or checkout: hostname,
+    real username, home directory, and this repo's own checkout path.
+
+    ``differential_capture`` above cannot catch a value that is constant on
+    this machine but still identifying -- a hostname baked into a banner
+    line does not vary between two runs on the same box. This closes that
+    gap by redacting known values rather than guessing at shapes: it is
+    redaction of an identified secret, not a pattern or vocabulary guess.
+    """
+    values = {
+        socket.gethostname(),
+        getpass.getuser(),
+        str(Path.home()),
+        str(REPO_ROOT),
+    }
+    return frozenset(v for v in values if v)
 
 
 SPECIALIZED_CASES: tuple[tuple[str, ...], ...] = (

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -418,22 +418,33 @@ def capture_specialized() -> list[dict[str, Any]]:
 # A handful of the committable specialized-CLI cases capture argparse's own
 # rendered usage/help/error text verbatim (see _COMMITTABLE_SPECIALIZED_ARGV
 # in test_public_surfaces.py). That text depends on the interpreter's
-# HelpFormatter, which CPython changed twice across this project's CI matrix:
-# invalid-choice error text dropped quoting around each choice in 3.12
-# (e.g. "choose from 'a', 'b'" -> "choose from a, b"), and 3.13 collapsed a
-# repeated-per-option-string metavar into one shared metavar
-# (e.g. "-f PATH, --file PATH" -> "-f, --file PATH"), which also reflows the
-# surrounding wrapped usage lines. This is a real, declared difference in the
-# interpreter -- not an accident of import order or machine state, and not
-# something regex normalization should paper over, since that risks masking
-# an actual change in this CLI's own text. Each CI-tested minor version gets
-# its own pinned literal baseline instead.
+# HelpFormatter, which CPython has changed more than once across this
+# project's CI matrix. Two distinct changes are in play here, and only one of
+# them is stable enough to pin per minor version:
+#
+# - Invalid-choice quoting (e.g. "choose from 'a', 'b'" vs "choose from a,
+#   b") is NOT a stable per-minor-version property: it was dropped in 3.12,
+#   and CPython has since flipped it again *within* the 3.14 series (a local
+#   3.14.3 interpreter renders unquoted; CI's 3.14.6 renders quoted, for the
+#   same argparse call). A per-minor-version baseline key cannot represent a
+#   property that changes between patch releases of the same minor. This is
+#   handled by narrow, named normalization -- see
+#   ``normalize_argparse_choice_quoting`` below -- applied only to the
+#   "(choose from ...)" fragment, so the choice names themselves (this
+#   project's own subcommand list) still fail the comparison if they change.
+# - The 3.13 metavar collapse (a repeated per-option-string metavar folded
+#   into one shared metavar, e.g. "-f PATH, --file PATH" -> "-f, --file
+#   PATH") is a real, stable rendering change that also reflows the
+#   surrounding wrapped usage lines. It has not been observed to vary within
+#   a minor version, so it keeps its own pinned baseline rather than being
+#   normalized away -- normalizing it would risk masking an actual change in
+#   this CLI's own usage/help text.
 _SPECIALIZED_BASELINE_BY_PYVER: dict[tuple[int, int], str] = {
     (3, 10): "specialized",
-    (3, 11): "specialized",  # measured byte-identical to 3.10's capture
-    (3, 12): "specialized_py312",
-    (3, 13): "specialized_py314",  # measured byte-identical to 3.14's capture
-    (3, 14): "specialized_py314",
+    (3, 11): "specialized",  # measured byte-identical to 3.10's capture (mod. choice quoting)
+    (3, 12): "specialized",  # measured byte-identical to 3.10's capture (mod. choice quoting)
+    (3, 13): "specialized_py314",  # metavar collapse; measured byte-identical to 3.14's capture
+    (3, 14): "specialized_py314",  # metavar collapse
 }
 
 # Every Python minor CI actually runs, mirroring the full-matrix branch of
@@ -463,6 +474,33 @@ def specialized_baseline_name() -> str:
             "tests/contracts/data/specialized_pyXY.json baseline (see "
             "capture_specialized()) and add it to _SPECIALIZED_BASELINE_BY_PYVER"
         ) from None
+
+
+# Matches argparse's "(choose from ...)" fragment inside an invalid-choice
+# error, whether each choice name is quoted (e.g. "'a', 'b'") or bare (e.g.
+# "a, b") -- the one rendering detail this fixture's baseline comparison
+# tolerates. See ``normalize_argparse_choice_quoting`` below.
+_CHOOSE_FROM_RE = re.compile(r"\(choose from ((?:'[^']*'|[^,)]+)(?:, (?:'[^']*'|[^,)]+))*)\)")
+
+
+def normalize_argparse_choice_quoting(text: str) -> str:
+    """Strip the quote characters CPython's argparse ``HelpFormatter`` wraps
+    each choice name in inside a "(choose from ...)" invalid-choice error.
+
+    This targets exactly that fragment, not the surrounding text: the choice
+    *names* are this project's own subcommand list and remain fully
+    compared by the caller (a renamed, added, or removed choice still
+    produces a different normalized fragment and fails); only the
+    quote-or-not rendering argparse wraps them in -- which CPython has
+    flipped more than once within a single Python 3.14 patch series -- is
+    discarded.
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        choices = [c.strip().strip("'\"") for c in match.group(1).split(", ")]
+        return "(choose from " + ", ".join(choices) + ")"
+
+    return _CHOOSE_FROM_RE.sub(_sub, text)
 
 
 # ── MCP available paths / catalog / projections / errors ────────────────────

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -187,11 +187,26 @@ def capture_http() -> dict[str, Any]:
 # ── CLI registry + parser tree ───────────────────────────────────────────────
 
 
+def _required_flag(a: argparse.Action) -> Any:
+    """``a.required`` for a ``nargs='*'`` positional -- CPython's own
+    internal bookkeeping value on the Action object, not an enforced
+    constraint: parsing zero arguments into it has always succeeded on every
+    supported Python version. That attribute's default value changed from
+    ``True`` (3.10/3.11) to ``False`` (3.12+) with no parsing-behavior change
+    at all, so trusting it raw makes the contract flag an interpreter upgrade
+    as a CLI surface change. Normalize to the value every version actually
+    enforces (never required) rather than whatever the raw attribute reports.
+    """
+    if not a.option_strings and a.nargs == "*":
+        return False
+    return getattr(a, "required", None)
+
+
 def _action_to_dict(a: argparse.Action) -> dict[str, Any]:
     return {
         "option_strings": list(a.option_strings),
         "dest": a.dest,
-        "required": getattr(a, "required", None),
+        "required": _required_flag(a),
         "nargs": a.nargs if isinstance(a.nargs, (int, str, type(None))) else str(a.nargs),
         "default": a.default
         if isinstance(a.default, (int, str, float, bool, type(None)))

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -1,0 +1,616 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Shared capture functions for the V0 public-surface contract.
+
+Every function here returns a JSON-serializable structure describing one
+observable public surface (HTTP routes, OpenAPI, CLI parser tree, MCP
+projections, machine-mode classification, or public imports). The frozen
+snapshots under ``tests/contracts/data/`` were produced by calling these
+functions once, before any consolidation edit; ``test_public_surfaces.py``
+calls them again and diffs the live result against the frozen one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+def _stable(value: Any) -> Any:
+    """A JSON-safe, deterministic representation of an arbitrary runtime value."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_stable(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _stable(v) for k, v in value.items()}
+    if isinstance(value, type):
+        return f"{value.__module__}.{value.__qualname__}"
+    if type(value).__name__ == "DefaultPlaceholder":
+        return {"default_placeholder": _stable(value.value)}
+    if type(value).__name__ == "Depends":
+        dep = value.dependency
+        return {"depends": _stable(dep), "use_cache": getattr(value, "use_cache", None)}
+    module = getattr(value, "__module__", None)
+    qualname = getattr(value, "__qualname__", None)
+    if qualname is not None:
+        return f"{module}.{qualname}" if module else qualname
+    return type(value).__name__
+
+
+# ── HTTP routes + OpenAPI ────────────────────────────────────────────────────
+
+# FastAPI strips a Starlette path-converter suffix (e.g. "{tag:path}") down to
+# "{tag}" when it renders the OpenAPI document, so a route's raw `.path` must
+# be normalized the same way before it is used as an `openapi["paths"]` key.
+_PATH_CONVERTER_RE = re.compile(r"\{(\w+):[^}]*\}")
+
+_OPENAPI_HTTP_METHODS = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+
+
+def _openapi_path_key(path: str) -> str:
+    return _PATH_CONVERTER_RE.sub(r"{\1}", path)
+
+
+def _route_responses(
+    path: str | None, methods: list[str] | None, openapi_paths: dict[str, Any]
+) -> dict[str, Any]:
+    """Per-status-code ``responses`` for one route, read from the live OpenAPI
+    document — ``APIRoute.responses`` itself is always empty in this codebase
+    (the ``responses=`` kwarg only reaches FastAPI's OpenAPI generation, not
+    the route object), so this is the only place the data actually lives."""
+    if not path or not methods:
+        return {}
+    path_item = openapi_paths.get(_openapi_path_key(path), {})
+    for method in methods:
+        op = path_item.get(method.lower())
+        if op is not None:
+            return _stable(op.get("responses", {}))
+    return {}
+
+
+def _normalize_operation(op: Any) -> dict[str, Any] | None:
+    """Stable projection of one OpenAPI operation object.
+
+    ``operationId`` is deliberately excluded: it derives from the handler's
+    Python qualified name and changes whenever a handler is absorbed into a
+    new module, which the design explicitly treats as an internal detail, not
+    an external route field. Every other field is preserved verbatim.
+    """
+    if not isinstance(op, dict):
+        return None
+    result: dict[str, Any] = {}
+    tags = op.get("tags")
+    if tags is not None:
+        result["tags"] = sorted(tags)
+    summary = op.get("summary")
+    if summary is not None:
+        result["summary"] = summary
+    description = op.get("description")
+    if description is not None:
+        result["description"] = description
+    parameters = op.get("parameters")
+    if parameters is not None:
+        result["parameters"] = [
+            _stable(p) for p in sorted(parameters, key=lambda p: p.get("name", ""))
+        ]
+    request_body = op.get("requestBody")
+    if request_body is not None:
+        result["requestBody"] = _stable(request_body)
+    responses = op.get("responses")
+    if responses is not None:
+        result["responses"] = _stable(responses)
+    if op.get("deprecated"):
+        result["deprecated"] = True
+    security = op.get("security")
+    if security is not None:
+        result["security"] = _stable(security)
+    return result
+
+
+def _normalize_openapi(openapi: dict[str, Any]) -> dict[str, Any]:
+    """Full, stable, JSON-serializable projection of the OpenAPI document:
+    every path's operations (parameters, request/response schemas) and every
+    named component schema in full, not just path/schema name lists."""
+    paths: dict[str, Any] = {}
+    for path_name in sorted(openapi.get("paths", {})):
+        path_item = openapi["paths"][path_name]
+        operations: dict[str, Any] = {}
+        for method in sorted(k for k in path_item if k in _OPENAPI_HTTP_METHODS):
+            normalized = _normalize_operation(path_item[method])
+            if normalized is not None:
+                operations[method] = normalized
+        if operations:
+            paths[path_name] = operations
+    schemas = openapi.get("components", {}).get("schemas", {})
+    return {
+        "openapi": openapi.get("openapi"),
+        "info": _stable(openapi.get("info")),
+        "paths": paths,
+        "path_count": len(paths),
+        "schemas": _stable(schemas),
+        "schema_count": len(schemas),
+    }
+
+
+def capture_http() -> dict[str, Any]:
+    from lionagi.studio.app import create_app
+
+    app = create_app()
+    openapi = app.openapi()
+    openapi_paths = openapi.get("paths", {})
+
+    routes: list[dict[str, Any]] = []
+    for ordinal, r in enumerate(app.routes):
+        path = getattr(r, "path", None)
+        methods = sorted(getattr(r, "methods", None) or []) if getattr(r, "methods", None) else None
+        routes.append(
+            {
+                "ordinal": ordinal,
+                "path": path,
+                "methods": methods,
+                "name": getattr(r, "name", None),
+                "response_model": _stable(getattr(r, "response_model", None)),
+                "dependencies": _stable(getattr(r, "dependencies", None) or []),
+                "response_class": _stable(getattr(r, "response_class", None)),
+                "responses": _route_responses(path, methods, openapi_paths),
+                "status_code": getattr(r, "status_code", None),
+                "tags": sorted(getattr(r, "tags", None) or []) if getattr(r, "tags", None) else [],
+                "summary": getattr(r, "summary", None),
+                "description": getattr(r, "description", None) or None,
+                "include_in_schema": getattr(r, "include_in_schema", None),
+                "handler_identity": {
+                    "module": getattr(getattr(r, "endpoint", None), "__module__", None),
+                    "qualname": getattr(getattr(r, "endpoint", None), "__qualname__", None),
+                },
+            }
+        )
+    return {
+        "count": len(routes),
+        "routes": routes,
+        "openapi": _normalize_openapi(openapi),
+    }
+
+
+# ── CLI registry + parser tree ───────────────────────────────────────────────
+
+
+def _action_to_dict(a: argparse.Action) -> dict[str, Any]:
+    return {
+        "option_strings": list(a.option_strings),
+        "dest": a.dest,
+        "required": getattr(a, "required", None),
+        "nargs": a.nargs if isinstance(a.nargs, (int, str, type(None))) else str(a.nargs),
+        "default": a.default
+        if isinstance(a.default, (int, str, float, bool, type(None)))
+        else str(a.default),
+        "choices": sorted(a.choices) if a.choices else None,
+        "help": a.help,
+    }
+
+
+def _parser_to_dict(p: argparse.ArgumentParser) -> dict[str, Any]:
+    actions = [_action_to_dict(a) for a in p._actions]
+    subparsers: dict[str, Any] = {}
+    for a in p._actions:
+        if hasattr(a, "choices") and a.choices and hasattr(a, "_name_parser_map"):
+            for name, sub in a.choices.items():
+                subparsers[name] = _parser_to_dict(sub)
+    return {"prog": p.prog, "actions": actions, "subparsers": subparsers}
+
+
+def capture_cli() -> dict[str, Any]:
+    from lionagi._auto import build_cli_parser, iter_cli_seeds
+
+    seeds = iter_cli_seeds()
+    top_level = [
+        {
+            "name": seed.name,
+            "help": seed.help,
+            "aliases": sorted(seed.aliases),
+        }
+        for seed in seeds
+    ]
+    name_map: dict[str, str] = {}
+    for seed in seeds:
+        for token in (seed.name, *seed.aliases):
+            name_map[token] = seed.name
+    per_command: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+    for seed in seeds:
+        try:
+            build = build_cli_parser(seed)
+            selected_parser = build.selected_parser
+            if selected_parser is None:
+                per_command[seed.name] = _parser_to_dict(build.parser)
+            elif isinstance(selected_parser, dict):
+                per_command[seed.name] = {k: _parser_to_dict(v) for k, v in selected_parser.items()}
+            else:
+                per_command[seed.name] = _parser_to_dict(selected_parser)
+        except Exception as e:  # noqa: BLE001 — one unbuildable parser must not hide the rest
+            errors[seed.name] = f"{type(e).__name__}: {e}"
+    return {
+        "registry_order": [s.name for s in seeds],
+        "registry_count": len(seeds),
+        "name_map": dict(sorted(name_map.items())),
+        "name_map_count": len(name_map),
+        "top_level": top_level,
+        "per_command_detail": per_command,
+        "build_errors": errors,
+    }
+
+
+def _run_cli(argv: list[str], timeout: float = 20.0) -> dict[str, Any]:
+    proc = subprocess.run(
+        [sys.executable, "-m", "lionagi.cli.main", *argv],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return {
+        "argv": argv,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "exit_code": proc.returncode,
+    }
+
+
+SPECIALIZED_CASES: tuple[tuple[str, ...], ...] = (
+    ("--help",),
+    ("wait",),
+    ("skill", "list"),
+    ("agent", "status"),
+    ("monitor", "run"),
+    ("doctor", "--machine"),
+    ("bogus-unknown-command",),
+    # ── play: pre-parser sugar for `li o flow -p NAME` (main.py:189-269) ────
+    ("play",),  # no NAME: usage printed, exit 1
+    ("play", "list"),  # lists playbooks read from disk; volatile content
+    ("play", "nonexistent"),  # unresolvable playbook; volatile (lists available names)
+    ("play", "--help"),  # no NAME before the flag: "NAME is required", exit 1
+    # ── orchestrate flow / fanout: standalone intermixed-arg parse
+    #    (main.py:396-425) ────────────────────────────────────────────────
+    ("o", "flow", "--help"),
+    ("o", "fanout", "--help"),
+    ("o", "flow"),  # no prompt/file/playbook: exit 1
+    ("o", "fanout"),  # no prompt: exit 1
+    # ── schedule: standalone parse + quick-create + did-you-mean
+    #    (main.py:427-457) ───────────────────────────────────────────────
+    ("schedule", "--help"),
+    ("schedule",),  # no subcommand: argparse required-subparser error, exit 2
+    ("schedule", "list", "--bogus"),  # unrecognized flag, no synonym match, exit 2
+    (
+        "schedule",
+        "create",
+        "capture-test",
+        "--every",
+        "15m",
+    ),  # legacy create + did-you-mean synonym (--every -> --interval), exit 2
+    ("schedule", "create", "agent", "capture-test"),  # typed quick-create, missing
+    # --profile/trigger: its own argparse subparser rejects before any network
+    # call, exit 2
+    (
+        "schedule",
+        "create",
+        "command",
+        "capture-test",
+        "--every",
+        "15m",
+    ),  # quick-create validation error (missing trailing --), exit 1
+)
+
+
+def capture_specialized() -> list[dict[str, Any]]:
+    return [_run_cli(list(argv)) for argv in SPECIALIZED_CASES]
+
+
+# ── MCP available paths / catalog / projections / errors ────────────────────
+
+# Negative cases spanning every distinct SchemaProjectionError class this
+# codebase currently raises: empty path, unknown top-level command, an
+# unresolved-subcommand path one level deep, an unresolved-subcommand path at
+# the root, and the one unsupported-argparse-type case (`mirror --since` uses
+# a custom `_since_window` type with no scalar JSON counterpart).
+_MCP_NEGATIVE_CASES: tuple[str, ...] = (
+    "",
+    "nonexistent-command",
+    "dispatch nonexistent-subcommand",
+    "state",
+    "mirror",
+)
+
+
+def _classify_projection_error(exc: Exception) -> str:
+    """Bucket a SchemaProjectionError by its ``.reason`` text so the fixture
+    records *why* a path failed, not just that it did."""
+    reason = getattr(exc, "reason", None)
+    if reason is None:
+        return "other"
+    if reason.startswith("path stops at an unresolved subcommand"):
+        return "unresolved_subcommand"
+    if "has no scalar JSON counterpart" in reason:
+        return "unsupported_argparse_type"
+    if reason == "empty command path":
+        return "empty_command_path"
+    if reason == "no such command":
+        return "no_such_command"
+    if reason == "no such command path":
+        return "no_such_command_path"
+    return "other"
+
+
+def _seed_alias_map() -> dict[str, tuple[str, ...]]:
+    from lionagi._auto import iter_cli_seeds
+
+    return {seed.name: seed.aliases for seed in iter_cli_seeds() if seed.aliases}
+
+
+def _aliases_for_path(path: str, alias_by_head: dict[str, tuple[str, ...]]) -> list[str]:
+    """Alternative spellings of *path* reachable through a top-level CLI
+    alias (e.g. ``o`` for ``orchestrate``), derived from the live seed table
+    rather than a hardcoded name list."""
+    parts = path.split()
+    if not parts:
+        return []
+    head_aliases = alias_by_head.get(parts[0])
+    if not head_aliases:
+        return []
+    return sorted(" ".join([alias, *parts[1:]]) for alias in head_aliases)
+
+
+def capture_mcp() -> dict[str, Any]:
+    from lionagi.mcp import dispatch as mcp_dispatch
+    from lionagi.mcp import projection as mcp_projection
+    from lionagi.mcp.verbs import ABSENT
+
+    available = list(mcp_projection.available_paths())
+    catalog = mcp_dispatch.catalog()
+    alias_by_head = _seed_alias_map()
+
+    # Every available path, not a 7-path sample: each entry carries its full
+    # projected schema plus any alias spellings; each failure carries the
+    # exception type, its classified reason, and the message.
+    projections: dict[str, Any] = {}
+    proj_errors: dict[str, dict[str, str]] = {}
+    for path in available:
+        try:
+            result = mcp_projection.project(path)
+            entry = result.to_dict()
+            aliases = _aliases_for_path(path, alias_by_head)
+            if aliases:
+                entry["aliases"] = aliases
+            projections[path] = entry
+        except Exception as e:  # noqa: BLE001 — one unprojectable path must not hide the rest
+            proj_errors[path] = {
+                "kind": type(e).__name__,
+                "class": _classify_projection_error(e),
+                "message": str(e),
+            }
+
+    errors: list[dict[str, Any]] = []
+    for bad_path in _MCP_NEGATIVE_CASES:
+        try:
+            mcp_projection.project(bad_path)
+            errors.append({"input": bad_path, "kind": None, "class": None, "message": None})
+        except Exception as e:  # noqa: BLE001
+            errors.append(
+                {
+                    "input": bad_path,
+                    "kind": type(e).__name__,
+                    "class": _classify_projection_error(e),
+                    "message": str(e),
+                }
+            )
+
+    # The catalog's ABSENT verbs, in full (name, summary, reason, cli_path) —
+    # not just folded into a verb_count delta.
+    absent_verbs = [
+        {"name": a.name, "summary": a.summary, "reason": a.reason, "cli_path": a.cli_path}
+        for a in sorted(ABSENT, key=lambda a: a.name)
+    ]
+
+    return {
+        "available_paths": available,
+        "available_path_count": len(available),
+        "catalog": {
+            "verb_count": catalog["verb_count"],
+            "available_count": catalog["available_count"],
+            "max_ops": catalog["max_ops"],
+            "verb_names": sorted(v["verb"] for v in catalog["verbs"]),
+            "available_verb_names": sorted(v["verb"] for v in catalog["verbs"] if v["available"]),
+        },
+        "projections": projections,
+        "projection_count": len(projections),
+        "projection_errors": proj_errors,
+        "projection_error_count": len(proj_errors),
+        "absent_verbs": absent_verbs,
+        "absent_verb_count": len(absent_verbs),
+        "errors": errors,
+    }
+
+
+# ── Machine classification ──────────────────────────────────────────────────
+
+MACHINE_CASES: tuple[tuple[str, ...], ...] = (
+    ("handshake", "--machine"),
+    ("doctor", "--machine"),
+    ("runs", "--machine"),
+    ("lifecycle", "--machine"),
+    ("monitor", "--machine"),
+    ("agent", "--machine"),
+    ("bogus-unknown-command", "--machine"),
+    ("--machine",),
+)
+
+
+def capture_machine() -> list[dict[str, Any]]:
+    cases = []
+    for argv in MACHINE_CASES:
+        result = _run_cli(list(argv))
+        parsed_ok = None
+        try:
+            parsed_ok = (
+                json.loads(result["stdout"].strip()).get("ok") if result["stdout"].strip() else None
+            )
+        except Exception:  # noqa: BLE001
+            parsed_ok = "unparseable"
+        cases.append({**result, "envelope_ok": parsed_ok})
+    return cases
+
+
+# ── Fresh-process import-laziness trace ──────────────────────────────────────
+
+# Self-contained subprocess payload: import only the named seed via the
+# registry's own `load_cli_command`, then report which *other* seeds' modules
+# leaked in, whether the HTTP registry got realized as a side effect, and
+# which seed(s) ended up in `_cli_realized`. Comparing against
+# `{s.module for s in iter_cli_seeds() if s.module != seed.module}` handles
+# shared modules (studio/schedule -> lionagi.studio.cli;
+# handshake/runs/lifecycle -> lionagi.cli.machine) for free: a shared
+# module's string is removed from the "other" set together with the selected
+# seed's own module, so loading `studio` never flags `lionagi.studio.cli`
+# even though `schedule` also maps to it.
+_IMPORT_TRACE_SCRIPT = (
+    "import sys, json\n"
+    "from lionagi._auto import load_cli_command, seed_for, iter_cli_seeds, _http, _cli_realized\n"
+    "name = sys.argv[1]\n"
+    "seed = seed_for(name)\n"
+    "other_modules = {s.module for s in iter_cli_seeds() if s.module != seed.module}\n"
+    "before = set(sys.modules)\n"
+    "load_cli_command(seed)\n"
+    "after = set(sys.modules)\n"
+    "new_lionagi = sorted(m for m in (after - before) if m.startswith('lionagi.'))\n"
+    "leaked = sorted(other_modules & set(new_lionagi))\n"
+    "result = {\n"
+    "    'seed': name,\n"
+    "    'module': seed.module,\n"
+    "    'new_lionagi_module_count': len(new_lionagi),\n"
+    "    'other_seed_modules_imported': leaked,\n"
+    "    'other_seed_modules_imported_count': len(leaked),\n"
+    "    'http_registry_realized': len(_http) > 0,\n"
+    "    'http_registry_count': len(_http),\n"
+    "    'cli_realized_names': sorted(_cli_realized.keys()),\n"
+    "}\n"
+    "print(json.dumps(result))\n"
+)
+
+
+def _run_import_trace(seed_name: str, timeout: float = 20.0) -> dict[str, Any]:
+    proc = subprocess.run(
+        [sys.executable, "-c", _IMPORT_TRACE_SCRIPT, seed_name],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        return {
+            "seed": seed_name,
+            "_error": f"exit {proc.returncode}: {proc.stderr.strip()[-2000:]}",
+        }
+    try:
+        return json.loads(proc.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError) as e:
+        return {
+            "seed": seed_name,
+            "_error": f"unparseable output: {e}: stdout={proc.stdout!r} stderr={proc.stderr!r}",
+        }
+
+
+def capture_import_laziness() -> dict[str, Any]:
+    """Fresh-process ``sys.modules`` traces proving selected-only CLI loading.
+
+    For each of the 21 canonical CLI seeds, launches a fresh subprocess that
+    imports only that seed through the registry (``load_cli_command``), never
+    the whole CLI. In-process checks (``capture_imports`` below) cannot prove
+    this: pytest itself has already imported most of the tree by the time a
+    test runs, so only a fresh interpreter can show what one seed selection
+    actually pulls in.
+    """
+    from lionagi._auto import iter_cli_seeds
+
+    seeds = [s.name for s in iter_cli_seeds()]
+    traces = {name: _run_import_trace(name) for name in seeds}
+    return {
+        "seed_count": len(seeds),
+        "seed_names": seeds,
+        "traces": traces,
+    }
+
+
+# ── Import surfaces ──────────────────────────────────────────────────────────
+
+COMPAT_MODULES: tuple[str, ...] = (
+    "lionagi.protocols.types",
+    "lionagi.tools.types",
+    "lionagi.operations.parse",
+    "lionagi.service.connections.cli_endpoint",
+    "lionagi.dispatch.revival",
+)
+
+
+def capture_imports() -> dict[str, Any]:
+    import importlib
+    import warnings
+
+    import lionagi
+
+    root_all = list(lionagi.__all__)
+    symbols: dict[str, Any] = {}
+    for name in root_all:
+        try:
+            val = getattr(lionagi, name)
+            symbols[name] = {
+                "type": type(val).__name__,
+                "module": getattr(val, "__module__", None),
+                "qualname": getattr(val, "__qualname__", None),
+            }
+        except Exception as e:  # noqa: BLE001
+            symbols[name] = {"error": f"{type(e).__name__}: {e}"}
+
+    lazy_map = getattr(lionagi, "_LAZY_MAP", None) or {}
+    lazy_map_keys = sorted(lazy_map.keys())
+
+    compat: dict[str, Any] = {}
+    for m in COMPAT_MODULES:
+        try:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                mod = importlib.import_module(m)
+                compat[m] = {
+                    "ok": True,
+                    "dir": sorted(n for n in dir(mod) if not n.startswith("_")),
+                    "warning_categories": sorted({wi.category.__name__ for wi in w}),
+                }
+        except Exception as e:  # noqa: BLE001
+            compat[m] = {"ok": False, "error": f"{type(e).__name__}: {e}"}
+
+    return {
+        "root_all": sorted(root_all),
+        "root_all_count": len(root_all),
+        "symbols": symbols,
+        "lazy_map_keys": lazy_map_keys,
+        "lazy_map_key_count": len(lazy_map_keys),
+        "compat_modules": compat,
+        "import_laziness": capture_import_laziness(),
+    }
+
+
+def capture_all() -> dict[str, Any]:
+    return {
+        "http": capture_http(),
+        "cli": capture_cli(),
+        "specialized": capture_specialized(),
+        "mcp": capture_mcp(),
+        "machine": capture_machine(),
+        "imports": capture_imports(),
+    }

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -430,8 +430,23 @@ def capture_specialized() -> list[dict[str, Any]]:
 # its own pinned literal baseline instead.
 _SPECIALIZED_BASELINE_BY_PYVER: dict[tuple[int, int], str] = {
     (3, 10): "specialized",
+    (3, 11): "specialized",  # measured byte-identical to 3.10's capture
+    (3, 12): "specialized_py312",
+    (3, 13): "specialized_py314",  # measured byte-identical to 3.14's capture
     (3, 14): "specialized_py314",
 }
+
+# Every Python minor CI actually runs, mirroring the full-matrix branch of
+# .github/workflows/ci.yml:174 (`test.strategy.matrix.python-version`). PRs
+# only run the oldest+newest of these, so a PR's own green does not prove
+# the other three still resolve -- see test_specialized_baseline_covers_ci_matrix.
+_CI_MATRIX_PYVERS: tuple[tuple[int, int], ...] = (
+    (3, 10),
+    (3, 11),
+    (3, 12),
+    (3, 13),
+    (3, 14),
+)
 
 
 def specialized_baseline_name() -> str:

--- a/tests/contracts/data/cli.json
+++ b/tests/contracts/data/cli.json
@@ -1,0 +1,13242 @@
+{
+  "registry_order": [
+    "orchestrate",
+    "agent",
+    "casts",
+    "engine",
+    "team",
+    "studio",
+    "schedule",
+    "state",
+    "invoke",
+    "kill",
+    "mirror",
+    "monitor",
+    "dispatch",
+    "doctor",
+    "stats",
+    "plugin",
+    "hooks",
+    "handshake",
+    "runs",
+    "lifecycle",
+    "mcp"
+  ],
+  "registry_count": 21,
+  "name_map": {
+    "agent": "agent",
+    "casts": "casts",
+    "dispatch": "dispatch",
+    "doctor": "doctor",
+    "engine": "engine",
+    "handshake": "handshake",
+    "hooks": "hooks",
+    "invoke": "invoke",
+    "kill": "kill",
+    "lifecycle": "lifecycle",
+    "mcp": "mcp",
+    "mirror": "mirror",
+    "mon": "monitor",
+    "monitor": "monitor",
+    "o": "orchestrate",
+    "orchestrate": "orchestrate",
+    "plugin": "plugin",
+    "runs": "runs",
+    "schedule": "schedule",
+    "state": "state",
+    "stats": "stats",
+    "studio": "studio",
+    "team": "team"
+  },
+  "name_map_count": 23,
+  "top_level": [
+    {
+      "name": "orchestrate",
+      "help": "Multi-agent orchestration patterns.",
+      "aliases": [
+        "o"
+      ]
+    },
+    {
+      "name": "agent",
+      "help": "Spawn one-shot subagent (blocking); prints final response.",
+      "aliases": []
+    },
+    {
+      "name": "casts",
+      "help": "inspect built-in roles and modes",
+      "aliases": []
+    },
+    {
+      "name": "engine",
+      "help": "Run domain-specific multi-agent engine pipelines.",
+      "aliases": []
+    },
+    {
+      "name": "team",
+      "help": "Team messaging \u2014 send/receive between named agents.",
+      "aliases": []
+    },
+    {
+      "name": "studio",
+      "help": "Lion Studio server",
+      "aliases": []
+    },
+    {
+      "name": "schedule",
+      "help": "Manage lionagi Studio schedules.",
+      "aliases": []
+    },
+    {
+      "name": "state",
+      "help": "Inspect and migrate lionagi state.db.",
+      "aliases": []
+    },
+    {
+      "name": "invoke",
+      "help": "Track a skill-level orchestration.",
+      "aliases": []
+    },
+    {
+      "name": "kill",
+      "help": "Terminate a running entity (run/session/play/show).",
+      "aliases": []
+    },
+    {
+      "name": "mirror",
+      "help": "Mirror Claude Code sessions into studio (live).",
+      "aliases": []
+    },
+    {
+      "name": "monitor",
+      "help": "Observe play/agent/run progress in real-time.",
+      "aliases": [
+        "mon"
+      ]
+    },
+    {
+      "name": "dispatch",
+      "help": "Inspect and acknowledge durable dispatch_outbox rows.",
+      "aliases": []
+    },
+    {
+      "name": "doctor",
+      "help": "Check the lionagi CLI environment/install for common failure modes.",
+      "aliases": []
+    },
+    {
+      "name": "stats",
+      "help": "Read-only aggregate reporting over lionagi's StateDB.",
+      "aliases": []
+    },
+    {
+      "name": "plugin",
+      "help": "Inspect, trust, and enable/disable LionAGI plugin bundles.",
+      "aliases": []
+    },
+    {
+      "name": "hooks",
+      "help": "Import Claude Code / Codex hook configs; trust imported hook commands.",
+      "aliases": []
+    },
+    {
+      "name": "handshake",
+      "help": "Report the machine-result contract version this build speaks.",
+      "aliases": []
+    },
+    {
+      "name": "runs",
+      "help": "List recorded runs and what each one wrote.",
+      "aliases": []
+    },
+    {
+      "name": "lifecycle",
+      "help": "Report the recorded lifecycle state of a run.",
+      "aliases": []
+    },
+    {
+      "name": "mcp",
+      "help": "Serve the lionagi MCP server (background job submit/query) over stdio.",
+      "aliases": []
+    }
+  ],
+  "per_command_detail": {
+    "orchestrate": {
+      "fanout": {
+        "prog": "li orchestrate fanout",
+        "actions": [
+          {
+            "option_strings": [
+              "-h",
+              "--help"
+            ],
+            "dest": "help",
+            "required": false,
+            "nargs": 0,
+            "default": "==SUPPRESS==",
+            "choices": null,
+            "help": "show this help message and exit"
+          },
+          {
+            "option_strings": [],
+            "dest": "query",
+            "required": true,
+            "nargs": "*",
+            "default": null,
+            "choices": null,
+            "help": "Orchestrator model spec (provider/model-effort) followed by the task prompt. Model is also used as the default worker model unless --workers is set; omit it when -a/--agent provides one. A single positional is treated as the prompt."
+          },
+          {
+            "option_strings": [
+              "-a",
+              "--agent"
+            ],
+            "dest": "agent",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Load orchestrator profile by name. Resolves .lionagi/agents/<NAME>/<NAME>.md first, then .lionagi/agents/<NAME>.md. Profile provides system prompt, default model, effort, yolo. CLI flags and positional model override profile settings."
+          },
+          {
+            "option_strings": [
+              "-n",
+              "--num-workers"
+            ],
+            "dest": "num_workers",
+            "required": false,
+            "nargs": null,
+            "default": 3,
+            "choices": null,
+            "help": "Maximum assignments the orchestrator generates (default 3). It may generate fewer if the task does not divide that far, and --workers specs beyond this cap go unused."
+          },
+          {
+            "option_strings": [
+              "--workers"
+            ],
+            "dest": "workers",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Comma-separated worker model specs, assigned round-robin (each may carry an effort suffix). This is how one fanout mixes cheap and expensive models across workers."
+          },
+          {
+            "option_strings": [
+              "--pack"
+            ],
+            "dest": "pack",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Path to a YAML routing pack. Provides per-role model/effort when --workers is absent. --workers overrides pack routing."
+          },
+          {
+            "option_strings": [
+              "--max-concurrent"
+            ],
+            "dest": "max_concurrent",
+            "required": false,
+            "nargs": null,
+            "default": 0,
+            "choices": null,
+            "help": "Cap on workers running at the same time. 0, the default, runs them all at once \u2014 lower it to stay under a provider's rate limit."
+          },
+          {
+            "option_strings": [
+              "--with-synthesis"
+            ],
+            "dest": "with_synthesis",
+            "required": false,
+            "nargs": "?",
+            "default": false,
+            "choices": null,
+            "help": "Run a final pass merging the workers' results into one answer. Bare flag uses the orchestrator model; with an argument, that model instead."
+          },
+          {
+            "option_strings": [
+              "--synthesis-prompt"
+            ],
+            "dest": "synthesis_prompt",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "What the merged answer should be \u2014 a ranked list, a decision, a single patch. Implies synthesis."
+          },
+          {
+            "option_strings": [
+              "--output"
+            ],
+            "dest": "output",
+            "required": false,
+            "nargs": null,
+            "default": "text",
+            "choices": [
+              "json",
+              "text"
+            ],
+            "help": "Result format: 'text' (default) for reading, 'json' for a machine-readable run."
+          },
+          {
+            "option_strings": [
+              "--save"
+            ],
+            "dest": "save",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Directory to write each worker's output and the run's artifacts into. Without it they land in the run's own artifacts directory."
+          },
+          {
+            "option_strings": [
+              "--team-mode"
+            ],
+            "dest": "team_mode",
+            "required": false,
+            "nargs": "?",
+            "default": null,
+            "choices": null,
+            "help": "Create a persistent team for this fanout. Workers get team context and results are posted as team messages. Bare flag uses 'fanout' as team name; with arg uses that name."
+          },
+          {
+            "option_strings": [
+              "--mcp-config"
+            ],
+            "dest": "mcp_config",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Read this MCP config and hand its servers to every worker this run builds. By default the nearest .mcp.json at or above the directory this command was run in is used, so the workers' tools come from the submission rather than from --cwd. The file is read once, at startup."
+          },
+          {
+            "option_strings": [
+              "--no-mcp-config"
+            ],
+            "dest": "no_mcp_config",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Hand the workers no MCP servers, and say so deliberately instead of arriving there by an empty search."
+          },
+          {
+            "option_strings": [
+              "--yolo"
+            ],
+            "dest": "yolo",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Auto-approve the agent's tool calls, so an unattended run is never left waiting."
+          },
+          {
+            "option_strings": [
+              "--bypass"
+            ],
+            "dest": "bypass",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Bypass all codex approvals and sandbox (for cloud/codespace environments)."
+          },
+          {
+            "option_strings": [
+              "--fast"
+            ],
+            "dest": "fast",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Route codex requests through OpenAI's priority service tier (lower latency; requires account eligibility). Does not change model or reasoning effort."
+          },
+          {
+            "option_strings": [
+              "-v",
+              "--verbose"
+            ],
+            "dest": "verbose",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Stream the agent's output as it is produced instead of printing only the final result, and silence the progress lines that would interleave with it."
+          },
+          {
+            "option_strings": [
+              "--theme"
+            ],
+            "dest": "theme",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": [
+              "dark",
+              "light"
+            ],
+            "help": "Pick the colour scheme printed output is tuned for: 'light' or 'dark' terminal."
+          },
+          {
+            "option_strings": [
+              "--effort"
+            ],
+            "dest": "effort",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Override effort (overrides spec suffix). claude: low|medium|high|xhigh|max. codex: none|minimal|low|medium|high|xhigh|max|ultra (max/ultra clamp per model support). gemini-code/gemini-cli: folded into --model as Low|Medium|High (Gemini 3.1 Pro has no Medium)."
+          },
+          {
+            "option_strings": [
+              "--cwd"
+            ],
+            "dest": "cwd",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Directory the agent's process runs in \u2014 the repo or worktree it acts on. Defaults to the current directory."
+          },
+          {
+            "option_strings": [
+              "--timeout"
+            ],
+            "dest": "timeout",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Hard wall-clock timeout in seconds. When set, a [DEADLINE] preamble is injected into the agent's prompt so the agent knows its time budget and can pace reasoning accordingly."
+          },
+          {
+            "option_strings": [
+              "--invocation"
+            ],
+            "dest": "invocation",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Parent invocation id (from `li invoke start`). Groups this session under a skill orchestration record. Optional."
+          },
+          {
+            "option_strings": [
+              "--project"
+            ],
+            "dest": "project",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Explicit project name for this session. Overrides auto-detection from .lionagi/config.toml or git remote."
+          },
+          {
+            "option_strings": [
+              "--resume-on-timeout"
+            ],
+            "dest": "resume_on_timeout",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "If the run terminates on --timeout, automatically fire one resume of the same session with 'continue and conclude the task' and report the combined result. Bounded to a single auto-resume; a timeout on the resumed leg terminates normally. Same effect as an agent profile's 'resume_on_timeout: once'."
+          },
+          {
+            "option_strings": [
+              "--notify"
+            ],
+            "dest": "notify",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Shell command template run once this run reaches its terminal status. Overrides .lionagi/settings.yaml notify.on_terminal. Substitutes {payload} (full JSON), {status}, {invocation_id}."
+          }
+        ],
+        "subparsers": {}
+      },
+      "flow": {
+        "prog": "li orchestrate flow",
+        "actions": [
+          {
+            "option_strings": [
+              "-h",
+              "--help"
+            ],
+            "dest": "help",
+            "required": false,
+            "nargs": 0,
+            "default": "==SUPPRESS==",
+            "choices": null,
+            "help": "show this help message and exit"
+          },
+          {
+            "option_strings": [],
+            "dest": "query",
+            "required": true,
+            "nargs": "*",
+            "default": null,
+            "choices": null,
+            "help": "Orchestrator model spec followed by the task prompt. Model is optional when -a/--agent provides one; a single positional is treated as the prompt. The prompt itself may instead come from -f/--file or -p/--playbook."
+          },
+          {
+            "option_strings": [
+              "-f",
+              "--file"
+            ],
+            "dest": "file",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Load flow spec from YAML or JSON file. File values serve as defaults; CLI flags override them. Prompt can come from the file (prompt: key) or as a positional argument."
+          },
+          {
+            "option_strings": [
+              "-p",
+              "--playbook"
+            ],
+            "dest": "playbook",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Load playbook from ~/.lionagi/playbooks/<NAME>.playbook.yaml. Playbooks may declare args: schema, artifacts: contracts, or argument-hint: placeholders for prompt template values."
+          },
+          {
+            "option_strings": [
+              "-a",
+              "--agent"
+            ],
+            "dest": "agent",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Load orchestrator profile by name \u2014 resolves .lionagi/agents/<NAME>/<NAME>.md first, then .lionagi/agents/<NAME>.md."
+          },
+          {
+            "option_strings": [
+              "--with-synthesis"
+            ],
+            "dest": "with_synthesis",
+            "required": false,
+            "nargs": "?",
+            "default": false,
+            "choices": null,
+            "help": "Run a final pass merging the DAG's results into one answer. Bare flag uses the orchestrator model; with an argument, that model instead."
+          },
+          {
+            "option_strings": [
+              "--max-concurrent"
+            ],
+            "dest": "max_concurrent",
+            "required": false,
+            "nargs": null,
+            "default": 0,
+            "choices": null,
+            "help": "Cap on agents running at the same time within one phase. 0, the default, runs the whole phase at once \u2014 lower it to stay under a provider's rate limit."
+          },
+          {
+            "option_strings": [
+              "--output"
+            ],
+            "dest": "output",
+            "required": false,
+            "nargs": null,
+            "default": "text",
+            "choices": [
+              "json",
+              "text"
+            ],
+            "help": "Result format: 'text' (default) for reading, 'json' for a machine-readable run."
+          },
+          {
+            "option_strings": [
+              "--save"
+            ],
+            "dest": "save",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Directory to write each agent's output and the run's artifacts into. Required by --background, which has nowhere else to report."
+          },
+          {
+            "option_strings": [
+              "--team-mode"
+            ],
+            "dest": "team_mode",
+            "required": false,
+            "nargs": "?",
+            "default": null,
+            "choices": null,
+            "help": "Create a FRESH team for this flow (new UUID every invocation). Bare flag uses 'flow' as the name."
+          },
+          {
+            "option_strings": [
+              "--team-attach"
+            ],
+            "dest": "team_attach",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Attach to a team by NAME \u2014 upsert semantics: load existing team if found (preserving message history), else create fresh. Mutually exclusive with --team-mode."
+          },
+          {
+            "option_strings": [
+              "--team-max-rounds"
+            ],
+            "dest": "team_max_rounds",
+            "required": false,
+            "nargs": null,
+            "default": 2,
+            "choices": null,
+            "help": "In team mode (reactive), how many extra wakeup rounds the coordinator may run after all currently-running workers signal done, to deliver unread teammate messages before the run wraps up (default: 2)."
+          },
+          {
+            "option_strings": [
+              "--dry-run"
+            ],
+            "dest": "dry_run",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Plan the DAG but don't execute. Shows agents, deps, and model resolution."
+          },
+          {
+            "option_strings": [
+              "--show-graph"
+            ],
+            "dest": "show_graph",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Render DAG as matplotlib visualization. With --save, saves PNG to save dir."
+          },
+          {
+            "option_strings": [
+              "--background"
+            ],
+            "dest": "background",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Run flow in background. Requires --save. Check output in save dir."
+          },
+          {
+            "option_strings": [
+              "--bare"
+            ],
+            "dest": "bare",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Ignore agent profiles \u2014 all workers use the CLI model spec. Roles define behavioral focus only, no profile system prompts."
+          },
+          {
+            "option_strings": [
+              "--workers"
+            ],
+            "dest": "workers",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Comma-separated worker model specs (assignment i uses pool[i %% len]). Overrides the per-role model while KEEPING each role's profile/system prompt \u2014 unlike --bare, which also drops profiles. Enables mixed-model flows (cheap roles + expensive roles)."
+          },
+          {
+            "option_strings": [
+              "--pack"
+            ],
+            "dest": "pack",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Path to a YAML routing pack. Provides per-role model/effort when --workers is absent. --workers overrides pack routing."
+          },
+          {
+            "option_strings": [
+              "--max-ops",
+              "--max-agents"
+            ],
+            "dest": "max_ops",
+            "required": false,
+            "nargs": null,
+            "default": 0,
+            "choices": null,
+            "help": "Cap total ops (nodes in the planned DAG). 0 = unlimited. `--max-agents` is a deprecated alias \u2014 prefer `--max-ops`."
+          },
+          {
+            "option_strings": [
+              "--reactive"
+            ],
+            "dest": "reactive",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Who may grow the live DAG by emitting a SpawnRequest: 'all' (default \u2014 every worker), 'off' (flat batch DAG, no spawning), or a comma-separated list of roles (e.g. 'critic,evaluator') that alone may spawn. Caps still apply via --max-ops."
+          },
+          {
+            "option_strings": [
+              "--resume"
+            ],
+            "dest": "resume",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Resume a checkpointed flow from a prior process (by run id, or any session/invocation/play id backed by one). Replays the persisted plan verbatim \u2014 no planner call, no other flow flags read (model/prompt/playbook/etc. all come from the checkpoint). Distinct from `li o ctl resume`, which un-pauses a still-running session."
+          },
+          {
+            "option_strings": [
+              "--allow-degraded-context"
+            ],
+            "dest": "allow_degraded_context",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "With --resume: proceed even when a pending op declared inherit_context \u2014 it runs against an empty branch instead of its predecessor's conversation history, which resume does not restore. Without this flag such ops refuse loudly, naming them."
+          },
+          {
+            "option_strings": [
+              "--mcp-config"
+            ],
+            "dest": "mcp_config",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Read this MCP config and hand its servers to every worker this run builds. By default the nearest .mcp.json at or above the directory this command was run in is used, so the workers' tools come from the submission rather than from --cwd. The file is read once, at startup."
+          },
+          {
+            "option_strings": [
+              "--no-mcp-config"
+            ],
+            "dest": "no_mcp_config",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Hand the workers no MCP servers, and say so deliberately instead of arriving there by an empty search."
+          },
+          {
+            "option_strings": [
+              "--yolo"
+            ],
+            "dest": "yolo",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Auto-approve the agent's tool calls, so an unattended run is never left waiting."
+          },
+          {
+            "option_strings": [
+              "--bypass"
+            ],
+            "dest": "bypass",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Bypass all codex approvals and sandbox (for cloud/codespace environments)."
+          },
+          {
+            "option_strings": [
+              "--fast"
+            ],
+            "dest": "fast",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Route codex requests through OpenAI's priority service tier (lower latency; requires account eligibility). Does not change model or reasoning effort."
+          },
+          {
+            "option_strings": [
+              "-v",
+              "--verbose"
+            ],
+            "dest": "verbose",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "Stream the agent's output as it is produced instead of printing only the final result, and silence the progress lines that would interleave with it."
+          },
+          {
+            "option_strings": [
+              "--theme"
+            ],
+            "dest": "theme",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": [
+              "dark",
+              "light"
+            ],
+            "help": "Pick the colour scheme printed output is tuned for: 'light' or 'dark' terminal."
+          },
+          {
+            "option_strings": [
+              "--effort"
+            ],
+            "dest": "effort",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Override effort (overrides spec suffix). claude: low|medium|high|xhigh|max. codex: none|minimal|low|medium|high|xhigh|max|ultra (max/ultra clamp per model support). gemini-code/gemini-cli: folded into --model as Low|Medium|High (Gemini 3.1 Pro has no Medium)."
+          },
+          {
+            "option_strings": [
+              "--cwd"
+            ],
+            "dest": "cwd",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Directory the agent's process runs in \u2014 the repo or worktree it acts on. Defaults to the current directory."
+          },
+          {
+            "option_strings": [
+              "--timeout"
+            ],
+            "dest": "timeout",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Hard wall-clock timeout in seconds. When set, a [DEADLINE] preamble is injected into the agent's prompt so the agent knows its time budget and can pace reasoning accordingly."
+          },
+          {
+            "option_strings": [
+              "--invocation"
+            ],
+            "dest": "invocation",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Parent invocation id (from `li invoke start`). Groups this session under a skill orchestration record. Optional."
+          },
+          {
+            "option_strings": [
+              "--project"
+            ],
+            "dest": "project",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Explicit project name for this session. Overrides auto-detection from .lionagi/config.toml or git remote."
+          },
+          {
+            "option_strings": [
+              "--resume-on-timeout"
+            ],
+            "dest": "resume_on_timeout",
+            "required": false,
+            "nargs": 0,
+            "default": false,
+            "choices": null,
+            "help": "If the run terminates on --timeout, automatically fire one resume of the same session with 'continue and conclude the task' and report the combined result. Bounded to a single auto-resume; a timeout on the resumed leg terminates normally. Same effect as an agent profile's 'resume_on_timeout: once'."
+          },
+          {
+            "option_strings": [
+              "--notify"
+            ],
+            "dest": "notify",
+            "required": false,
+            "nargs": null,
+            "default": null,
+            "choices": null,
+            "help": "Shell command template run once this run reaches its terminal status. Overrides .lionagi/settings.yaml notify.on_terminal. Substitutes {payload} (full JSON), {status}, {invocation_id}."
+          }
+        ],
+        "subparsers": {}
+      },
+      "ctl": {
+        "prog": "li orchestrate ctl",
+        "actions": [
+          {
+            "option_strings": [
+              "-h",
+              "--help"
+            ],
+            "dest": "help",
+            "required": false,
+            "nargs": 0,
+            "default": "==SUPPRESS==",
+            "choices": null,
+            "help": "show this help message and exit"
+          },
+          {
+            "option_strings": [],
+            "dest": "ctl_command",
+            "required": true,
+            "nargs": "A...",
+            "default": null,
+            "choices": [
+              "msg",
+              "pause",
+              "resolve",
+              "resume",
+              "status"
+            ],
+            "help": null
+          }
+        ],
+        "subparsers": {
+          "status": {
+            "prog": "li orchestrate ctl status",
+            "actions": [
+              {
+                "option_strings": [
+                  "-h",
+                  "--help"
+                ],
+                "dest": "help",
+                "required": false,
+                "nargs": 0,
+                "default": "==SUPPRESS==",
+                "choices": null,
+                "help": "show this help message and exit"
+              },
+              {
+                "option_strings": [],
+                "dest": "id",
+                "required": true,
+                "nargs": null,
+                "default": null,
+                "choices": null,
+                "help": "Session, invocation, play, or run id to report on \u2014 full, or an unambiguous prefix. Required here: this command has no 'latest run' default."
+              },
+              {
+                "option_strings": [
+                  "--json"
+                ],
+                "dest": "as_json",
+                "required": false,
+                "nargs": 0,
+                "default": false,
+                "choices": null,
+                "help": "Print one JSON object with stable keys instead of the human table, for scripting."
+              }
+            ],
+            "subparsers": {}
+          },
+          "pause": {
+            "prog": "li orchestrate ctl pause",
+            "actions": [
+              {
+                "option_strings": [
+                  "-h",
+                  "--help"
+                ],
+                "dest": "help",
+                "required": false,
+                "nargs": 0,
+                "default": "==SUPPRESS==",
+                "choices": null,
+                "help": "show this help message and exit"
+              },
+              {
+                "option_strings": [],
+                "dest": "id",
+                "required": true,
+                "nargs": null,
+                "default": null,
+                "choices": null,
+                "help": "Running flow to pause, by session, invocation, play, or run id (full, or an unambiguous prefix). The pause lands at the next op boundary, not mid-op."
+              }
+            ],
+            "subparsers": {}
+          },
+          "resume": {
+            "prog": "li orchestrate ctl resume",
+            "actions": [
+              {
+                "option_strings": [
+                  "-h",
+                  "--help"
+                ],
+                "dest": "help",
+                "required": false,
+                "nargs": 0,
+                "default": "==SUPPRESS==",
+                "choices": null,
+                "help": "show this help message and exit"
+              },
+              {
+                "option_strings": [],
+                "dest": "id",
+                "required": true,
+                "nargs": null,
+                "default": null,
+                "choices": null,
+                "help": "Paused flow to release, by session, invocation, play, or run id (full, or an unambiguous prefix)."
+              }
+            ],
+            "subparsers": {}
+          },
+          "msg": {
+            "prog": "li orchestrate ctl msg",
+            "actions": [
+              {
+                "option_strings": [
+                  "-h",
+                  "--help"
+                ],
+                "dest": "help",
+                "required": false,
+                "nargs": 0,
+                "default": "==SUPPRESS==",
+                "choices": null,
+                "help": "show this help message and exit"
+              },
+              {
+                "option_strings": [],
+                "dest": "id",
+                "required": true,
+                "nargs": null,
+                "default": null,
+                "choices": null,
+                "help": "Running flow, playbook run, or agent leg to message, by session, invocation, play, or run id (full, or an unambiguous prefix)."
+              },
+              {
+                "option_strings": [],
+                "dest": "text",
+                "required": true,
+                "nargs": null,
+                "default": null,
+                "choices": null,
+                "help": "Message merged into the flow's workspace context. Ops already started will not see it; every op that has not started yet will."
+              }
+            ],
+            "subparsers": {}
+          },
+          "resolve": {
+            "prog": "li orchestrate ctl resolve",
+            "actions": [
+              {
+                "option_strings": [
+                  "-h",
+                  "--help"
+                ],
+                "dest": "help",
+                "required": false,
+                "nargs": 0,
+                "default": "==SUPPRESS==",
+                "choices": null,
+                "help": "show this help message and exit"
+              },
+              {
+                "option_strings": [],
+                "dest": "control_id",
+                "required": true,
+                "nargs": null,
+                "default": null,
+                "choices": null,
+                "help": "The control id shown by `li o ctl status` (full, no prefix matching)."
+              },
+              {
+                "option_strings": [
+                  "--as"
+                ],
+                "dest": "outcome",
+                "required": true,
+                "nargs": null,
+                "default": null,
+                "choices": [
+                  "abandoned",
+                  "applied"
+                ],
+                "help": "What you established actually happened: 'applied' if the message reached the run, 'abandoned' if it did not and will not."
+              },
+              {
+                "option_strings": [
+                  "--by"
+                ],
+                "dest": "actor",
+                "required": false,
+                "nargs": null,
+                "default": null,
+                "choices": null,
+                "help": "Who resolved it, recorded beside the claim. Defaults to the OS account running the command; pass this when that is not the person who found out."
+              }
+            ],
+            "subparsers": {}
+          }
+        }
+      }
+    },
+    "agent": {
+      "prog": "li agent",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [],
+          "dest": "query",
+          "required": true,
+          "nargs": "*",
+          "default": null,
+          "choices": null,
+          "help": "Optional model spec followed by the prompt. Model is one of 'claude', 'codex', 'gemini-code' (defaults), or a full spec like 'claude/opus'; omit it when -a / --resume / -c provides one. The prompt may instead be passed via --prompt or --prompt-file."
+        },
+        {
+          "option_strings": [
+            "--prompt"
+          ],
+          "dest": "prompt_flag",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "The instruction, as a flag instead of the positional PROMPT. Give it one way or the other, never both."
+        },
+        {
+          "option_strings": [
+            "--prompt-file"
+          ],
+          "dest": "prompt_file",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Read the instruction from a file; '-' reads stdin, which is heredoc-friendly. The file is read once at spawn, so editing it afterwards cannot change the run."
+        },
+        {
+          "option_strings": [
+            "-a",
+            "--agent"
+          ],
+          "dest": "agent",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Load agent profile by name. Resolves .lionagi/agents/<NAME>/<NAME>.md first, then .lionagi/agents/<NAME>.md, then a trusted+enabled plugin's declared profile ('<plugin>/<NAME>', or a bare NAME when only one plugin declares it). Profile provides system prompt, default model, effort, yolo, timeout, resume_on_timeout. CLI flags override profile settings."
+        },
+        {
+          "option_strings": [
+            "--list-profiles"
+          ],
+          "dest": "list_profiles",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Print every agent profile -a would resolve, as JSON, and exit without running anything. Use it to find out what names are available here."
+        },
+        {
+          "option_strings": [
+            "-r",
+            "--resume"
+          ],
+          "dest": "resume",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Continue a previous run by its branch id, keeping that conversation's history. Cannot be combined with --context-from, which is for starting fresh."
+        },
+        {
+          "option_strings": [
+            "-c",
+            "--continue-last"
+          ],
+          "dest": "continue_last",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Continue the most recently used branch, keeping its history, without having to look up its id."
+        },
+        {
+          "option_strings": [
+            "--preset"
+          ],
+          "dest": "preset",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": [
+            "coding"
+          ],
+          "help": "Apply a built-in agent configuration preset. Supported values: coding. 'coding' wires CodingToolkit with path-guard hooks and a coding system prompt; cwd defaults to the invocation directory."
+        },
+        {
+          "option_strings": [
+            "--form"
+          ],
+          "dest": "form",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Path to a YAML or JSON work-form spec file. The spec declares typed fields and values; validation runs BEFORE any LLM call. Exits rc=1 on validation error. Validated values are injected into the prompt as structured context."
+        },
+        {
+          "option_strings": [
+            "--image"
+          ],
+          "dest": "image",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Attach an image file to the prompt (repeatable, e.g. --image a.png --image b.jpg). Supported extensions: .gif, .jpeg, .jpg, .png, .webp. Each file is read, base64-encoded, and attached as an image content part on the user message."
+        },
+        {
+          "option_strings": [
+            "--context-from"
+          ],
+          "dest": "context_from",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Inject distilled context from a prior session id, branch id, run id, or file path into this new branch's first instruction, above the prompt. Repeatable (concatenated in argv order); the total budget (see --context-budget) is shared across all refs. Rejected in combination with -r / --resume or -c / --continue-last."
+        },
+        {
+          "option_strings": [
+            "--context-budget"
+          ],
+          "dest": "context_budget",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Total token budget for --context-from content (default 8000; ~4 chars/token)."
+        },
+        {
+          "option_strings": [
+            "--mcp-config"
+          ],
+          "dest": "mcp_config",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Read this MCP config and hand its servers to the leg explicitly. By default the nearest .mcp.json at or above the directory this command was run in is used, so the leg's tools come from the submission rather than from --cwd. The file is read once at spawn."
+        },
+        {
+          "option_strings": [
+            "--no-mcp-config"
+          ],
+          "dest": "no_mcp_config",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Hand the leg no MCP servers, and say so deliberately instead of arriving there by an empty search."
+        },
+        {
+          "option_strings": [
+            "--yolo"
+          ],
+          "dest": "yolo",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Auto-approve the agent's tool calls, so an unattended run is never left waiting."
+        },
+        {
+          "option_strings": [
+            "--bypass"
+          ],
+          "dest": "bypass",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Bypass all codex approvals and sandbox (for cloud/codespace environments)."
+        },
+        {
+          "option_strings": [
+            "--fast"
+          ],
+          "dest": "fast",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Route codex requests through OpenAI's priority service tier (lower latency; requires account eligibility). Does not change model or reasoning effort."
+        },
+        {
+          "option_strings": [
+            "-v",
+            "--verbose"
+          ],
+          "dest": "verbose",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Stream the agent's output as it is produced instead of printing only the final result, and silence the progress lines that would interleave with it."
+        },
+        {
+          "option_strings": [
+            "--theme"
+          ],
+          "dest": "theme",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": [
+            "dark",
+            "light"
+          ],
+          "help": "Pick the colour scheme printed output is tuned for: 'light' or 'dark' terminal."
+        },
+        {
+          "option_strings": [
+            "--effort"
+          ],
+          "dest": "effort",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Override effort (overrides spec suffix). claude: low|medium|high|xhigh|max. codex: none|minimal|low|medium|high|xhigh|max|ultra (max/ultra clamp per model support). gemini-code/gemini-cli: folded into --model as Low|Medium|High (Gemini 3.1 Pro has no Medium)."
+        },
+        {
+          "option_strings": [
+            "--cwd"
+          ],
+          "dest": "cwd",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Directory the agent's process runs in \u2014 the repo or worktree it acts on. Defaults to the current directory."
+        },
+        {
+          "option_strings": [
+            "--timeout"
+          ],
+          "dest": "timeout",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Hard wall-clock timeout in seconds. When set, a [DEADLINE] preamble is injected into the agent's prompt so the agent knows its time budget and can pace reasoning accordingly."
+        },
+        {
+          "option_strings": [
+            "--invocation"
+          ],
+          "dest": "invocation",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Parent invocation id (from `li invoke start`). Groups this session under a skill orchestration record. Optional."
+        },
+        {
+          "option_strings": [
+            "--project"
+          ],
+          "dest": "project",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Explicit project name for this session. Overrides auto-detection from .lionagi/config.toml or git remote."
+        },
+        {
+          "option_strings": [
+            "--resume-on-timeout"
+          ],
+          "dest": "resume_on_timeout",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "If the run terminates on --timeout, automatically fire one resume of the same session with 'continue and conclude the task' and report the combined result. Bounded to a single auto-resume; a timeout on the resumed leg terminates normally. Same effect as an agent profile's 'resume_on_timeout: once'."
+        },
+        {
+          "option_strings": [
+            "--notify"
+          ],
+          "dest": "notify",
+          "required": false,
+          "nargs": null,
+          "default": null,
+          "choices": null,
+          "help": "Shell command template run once this run reaches its terminal status. Overrides .lionagi/settings.yaml notify.on_terminal. Substitutes {payload} (full JSON), {status}, {invocation_id}."
+        }
+      ],
+      "subparsers": {}
+    },
+    "casts": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "name",
+              "required": false,
+              "nargs": "?",
+              "default": null,
+              "choices": null,
+              "help": "Role or mode to print in full, including its prompt body. Looked up in both catalogs, so you need not know which it is. Omit it to list names only."
+            },
+            {
+              "option_strings": [
+                "--modes"
+              ],
+              "dest": "modes",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "List the behavior overlays (modes) instead of the personas (roles). Only affects the bare listing; ignored when a name is given."
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "engine": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "engine_command",
+              "required": true,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "run"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "run": {
+              "prog": "li engine run",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "kind",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": [
+                    "coding",
+                    "hypothesis",
+                    "planning",
+                    "research",
+                    "review"
+                  ],
+                  "help": "Engine kind to run. One of: coding, hypothesis, planning, research, review."
+                },
+                {
+                  "option_strings": [],
+                  "dest": "spec",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Main input for the engine (topic / artifact / spec / findings / prompt)."
+                },
+                {
+                  "option_strings": [
+                    "--test-cmd"
+                  ],
+                  "dest": "test_cmd",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Test command to validate generated code (required for 'coding' kind). May be a shell string or a quoted list."
+                },
+                {
+                  "option_strings": [
+                    "--export-dir"
+                  ],
+                  "dest": "export_dir",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Directory to save engine outputs to (optional; supported by 'coding' and 'hypothesis' kinds)."
+                },
+                {
+                  "option_strings": [
+                    "--dedup-repo"
+                  ],
+                  "dest": "dedup_repo",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "GitHub repo to check findings against before extraction ('hypothesis' kind only). Findings whose mechanism an existing open or closed issue already covers are recorded and not expanded; certified-new findings land in the export's filing queue. The engine never files issues itself."
+                },
+                {
+                  "option_strings": [
+                    "--dedup-cwd"
+                  ],
+                  "dest": "dedup_cwd",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Checkout of the dedup repo so the novelty check can source-confirm a finding's cite ('hypothesis' kind only; optional)."
+                },
+                {
+                  "option_strings": [
+                    "--model"
+                  ],
+                  "dest": "model",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Model to use (provider/name, e.g. claude/sonnet; an effort suffix like codex/gpt-5.6-luna-high is honored). Overrides per-stage defaults. Uses engine defaults if omitted."
+                },
+                {
+                  "option_strings": [
+                    "--effort"
+                  ],
+                  "dest": "effort",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Reasoning effort for all stages (e.g. low, medium, high, xhigh). Overrides per-stage defaults; a per-stage default applies otherwise."
+                },
+                {
+                  "option_strings": [
+                    "--max-depth"
+                  ],
+                  "dest": "max_depth",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Maximum recursion/expansion depth for the engine (kind-specific default)."
+                },
+                {
+                  "option_strings": [
+                    "--max-agents"
+                  ],
+                  "dest": "max_agents",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Maximum number of sub-agents the engine may spawn."
+                },
+                {
+                  "option_strings": [
+                    "--session-id"
+                  ],
+                  "dest": "session_id",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Associate this engine run with an existing session in StateDB (written to engine_runs.session_id)."
+                },
+                {
+                  "option_strings": [
+                    "--no-persist"
+                  ],
+                  "dest": "no_persist",
+                  "required": false,
+                  "nargs": 0,
+                  "default": false,
+                  "choices": null,
+                  "help": "Skip writing the engine run record to StateDB."
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "team": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "team_command",
+              "required": true,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "create",
+                "list",
+                "ls",
+                "receive",
+                "recv",
+                "send",
+                "show"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "create": {
+              "prog": "li team create",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "name",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Name for the new team. Every other team command accepts it in place of the team id."
+                },
+                {
+                  "option_strings": [
+                    "-m",
+                    "--members"
+                  ],
+                  "dest": "members",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Comma-separated member names. Only these names can send or receive as themselves; a message from or to anyone else still goes through, with a warning."
+                }
+              ],
+              "subparsers": {}
+            },
+            "list": {
+              "prog": "li team list",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                }
+              ],
+              "subparsers": {}
+            },
+            "ls": {
+              "prog": "li team list",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                }
+              ],
+              "subparsers": {}
+            },
+            "show": {
+              "prog": "li team show",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "team",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Team to show \u2014 its id, its name, or an unambiguous id prefix."
+                }
+              ],
+              "subparsers": {}
+            },
+            "send": {
+              "prog": "li team send",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "content",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Message body, as the recipients will read it."
+                },
+                {
+                  "option_strings": [
+                    "--team",
+                    "-t"
+                  ],
+                  "dest": "team",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Team to send into \u2014 its id, its name, or an unambiguous id prefix."
+                },
+                {
+                  "option_strings": [
+                    "--to"
+                  ],
+                  "dest": "to",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Recipients: 'all' to broadcast to the whole team, or comma-separated member names."
+                },
+                {
+                  "option_strings": [
+                    "--from"
+                  ],
+                  "dest": "sender",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Name to send as, so recipients know who is asking (defaults to '_cli'). A name that is not a member still sends, and is reported as a warning."
+                },
+                {
+                  "option_strings": [
+                    "--from-op"
+                  ],
+                  "dest": "from_op",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "The op id this message belongs to (e.g. 'o3'). Ties a coord signal to a specific invocation when the sender agent runs multiple ops on the same branch."
+                },
+                {
+                  "option_strings": [
+                    "--kind"
+                  ],
+                  "dest": "kind",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": [
+                    "done",
+                    "finished",
+                    "message",
+                    "wakeup"
+                  ],
+                  "help": "Message kind (default: 'message'). Use 'done' when you've finished your part and may be revived later, 'finished' when you're permanently done \u2014 quiescence detection reads this."
+                },
+                {
+                  "option_strings": [
+                    "--artifacts"
+                  ],
+                  "dest": "artifacts",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Comma-separated artifact paths to attach (used with --kind done)."
+                }
+              ],
+              "subparsers": {}
+            },
+            "receive": {
+              "prog": "li team receive",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--team",
+                    "-t"
+                  ],
+                  "dest": "team",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Team to read from \u2014 its id, its name, or an unambiguous id prefix."
+                },
+                {
+                  "option_strings": [
+                    "--as"
+                  ],
+                  "dest": "member",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Read as this member: returns only their unread mail and marks it read. Omit it to dump every message and mark nothing read."
+                }
+              ],
+              "subparsers": {}
+            },
+            "recv": {
+              "prog": "li team receive",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--team",
+                    "-t"
+                  ],
+                  "dest": "team",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Team to read from \u2014 its id, its name, or an unambiguous id prefix."
+                },
+                {
+                  "option_strings": [
+                    "--as"
+                  ],
+                  "dest": "member",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Read as this member: returns only their unread mail and marks it read. Omit it to dump every message and mark nothing read."
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "studio": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [
+                "--port"
+              ],
+              "dest": "port",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Backend API port (default: LIONAGI_STUDIO_PORT env or 8765)"
+            },
+            {
+              "option_strings": [
+                "--host"
+              ],
+              "dest": "host",
+              "required": false,
+              "nargs": null,
+              "default": "127.0.0.1",
+              "choices": null,
+              "help": "Host to bind (default: 127.0.0.1)"
+            },
+            {
+              "option_strings": [
+                "--frontend-port"
+              ],
+              "dest": "frontend_port",
+              "required": false,
+              "nargs": null,
+              "default": 3000,
+              "choices": null,
+              "help": "Frontend port (default: 3000)"
+            },
+            {
+              "option_strings": [
+                "--no-open"
+              ],
+              "dest": "no_open",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Don't open the hosted UI in a browser (--web only)"
+            },
+            {
+              "option_strings": [
+                "--no-docker"
+              ],
+              "dest": "no_docker",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "==SUPPRESS=="
+            },
+            {
+              "option_strings": [
+                "--web"
+              ],
+              "dest": "web",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Start the backend only; frontend is the hosted UI (default)"
+            },
+            {
+              "option_strings": [
+                "--docker"
+              ],
+              "dest": "docker",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Run the bundled frontend + backend via Docker"
+            },
+            {
+              "option_strings": [
+                "--no-frontend"
+              ],
+              "dest": "no_frontend",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Only start the backend API server"
+            },
+            {
+              "option_strings": [
+                "--dev"
+              ],
+              "dest": "dev",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Run the in-repo frontend in dev mode (hot-reload, no build step)"
+            },
+            {
+              "option_strings": [],
+              "dest": "studio_action",
+              "required": false,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "start"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "start": {
+              "prog": "li studio start",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--port"
+                  ],
+                  "dest": "port",
+                  "required": false,
+                  "nargs": null,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "Backend API port (default: LIONAGI_STUDIO_PORT env or 8765)"
+                },
+                {
+                  "option_strings": [
+                    "--host"
+                  ],
+                  "dest": "host",
+                  "required": false,
+                  "nargs": null,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "Host to bind (default: 127.0.0.1)"
+                },
+                {
+                  "option_strings": [
+                    "--frontend-port"
+                  ],
+                  "dest": "frontend_port",
+                  "required": false,
+                  "nargs": null,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "Frontend port (default: 3000)"
+                },
+                {
+                  "option_strings": [
+                    "--no-open"
+                  ],
+                  "dest": "no_open",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "Don't open the hosted UI in a browser (--web only)"
+                },
+                {
+                  "option_strings": [
+                    "--no-docker"
+                  ],
+                  "dest": "no_docker",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "==SUPPRESS=="
+                },
+                {
+                  "option_strings": [
+                    "--web"
+                  ],
+                  "dest": "web",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "Start the backend only; frontend is the hosted UI (default)"
+                },
+                {
+                  "option_strings": [
+                    "--docker"
+                  ],
+                  "dest": "docker",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "Run the bundled frontend + backend via Docker"
+                },
+                {
+                  "option_strings": [
+                    "--no-frontend"
+                  ],
+                  "dest": "no_frontend",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "Only start the backend API server"
+                },
+                {
+                  "option_strings": [
+                    "--dev"
+                  ],
+                  "dest": "dev",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "Run the in-repo frontend in dev mode (hot-reload, no build step)"
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "schedule": {
+      "prog": "li schedule",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [],
+          "dest": "schedule_action",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "apply",
+            "create",
+            "delete",
+            "disable",
+            "enable",
+            "export",
+            "get",
+            "limits",
+            "list",
+            "run",
+            "runs",
+            "status",
+            "trigger",
+            "validate"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "list": {
+          "prog": "li schedule list",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "get": {
+          "prog": "li schedule get",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Id of the schedule, as returned by `li schedule list` in its `id` field."
+            }
+          ],
+          "subparsers": {}
+        },
+        "limits": {
+          "prog": "li schedule limits",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "create": {
+          "prog": "li schedule create",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "name",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Unique name identifying this schedule. Reused as the display label in listings; a name already in use is rejected rather than overwritten."
+            },
+            {
+              "option_strings": [
+                "--trigger-type"
+              ],
+              "dest": "trigger_type",
+              "required": false,
+              "nargs": null,
+              "default": "cron",
+              "choices": [
+                "cron",
+                "github",
+                "github_poll",
+                "interval"
+              ],
+              "help": "Trigger type (default: cron). 'github' is an alias for 'github_poll'."
+            },
+            {
+              "option_strings": [
+                "--cron"
+              ],
+              "dest": "cron",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Cron expression, e.g. \"0 * * * *\". Required when --trigger-type is cron, which is the default; ignored for other trigger types."
+            },
+            {
+              "option_strings": [
+                "--interval"
+              ],
+              "dest": "interval",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Seconds between fires. Required when --trigger-type is interval; ignored for other trigger types."
+            },
+            {
+              "option_strings": [
+                "--github-repo"
+              ],
+              "dest": "github_repo",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "GitHub repository to poll (required for --trigger-type github/github_poll)."
+            },
+            {
+              "option_strings": [
+                "--github-filter"
+              ],
+              "dest": "github_filter",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "JSON object filtering which PRs fire the trigger, e.g. '{\"state\": \"open\", \"base\": \"main\"}'."
+            },
+            {
+              "option_strings": [
+                "--threshold-config"
+              ],
+              "dest": "threshold_config",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Metric threshold alert config as a JSON object: {\"metric\": \"failed_sessions|total_cost_usd|p95_latency_ms|github_poll_healthy_age_minutes|github_poll_consecutive_401\", \"op\": \"gt|gte\", \"value\": N, \"window_minutes\": N}. When set, this schedule's own cron/interval cadence only evaluates the metric on each tick and fires the action only when the threshold is breached (cooldown = window_minutes). Full validation happens server-side, e.g. '{\"metric\": \"failed_sessions\", \"op\": \"gt\", \"value\": 5, \"window_minutes\": 60}'."
+            },
+            {
+              "option_strings": [
+                "--poll-interval"
+              ],
+              "dest": "poll_interval",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "How often to poll GitHub, in seconds (github_poll only)."
+            },
+            {
+              "option_strings": [
+                "--action-kind"
+              ],
+              "dest": "action_kind",
+              "required": false,
+              "nargs": null,
+              "default": "agent",
+              "choices": [
+                "agent",
+                "command",
+                "engine",
+                "fanout",
+                "flow",
+                "flow_yaml",
+                "play",
+                "playbook"
+              ],
+              "help": "Stored action kind or accepted alias (default: agent)."
+            },
+            {
+              "option_strings": [
+                "--prompt"
+              ],
+              "dest": "prompt",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Instruction the scheduled agent runs at each fire. Required when --action-kind is agent, which is the default. A profile named by --agent supplies the model and settings, never this instruction, so a schedule created without it fires and fails."
+            },
+            {
+              "option_strings": [
+                "--model"
+              ],
+              "dest": "model",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Model spec for agent action."
+            },
+            {
+              "option_strings": [
+                "--agent"
+              ],
+              "dest": "agent",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Agent profile to run, resolved the same way `li agent --agent` resolves it. Supplies the system prompt, model and effort the fire runs with."
+            },
+            {
+              "option_strings": [
+                "--playbook"
+              ],
+              "dest": "playbook",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Playbook name (for action-kind=play/playbook)."
+            },
+            {
+              "option_strings": [
+                "--flow-yaml"
+              ],
+              "dest": "flow_yaml",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Path to a YAML flow spec file (for action-kind=flow_yaml)."
+            },
+            {
+              "option_strings": [
+                "--action-command"
+              ],
+              "dest": "action_command",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Executable name to spawn directly, bypassing `li` (for action-kind=command). Must be a bare name (no path separators) and be a member of LIONAGI_SCHEDULER_COMMAND_ALLOWLIST; refused loudly at create time and re-checked at fire time."
+            },
+            {
+              "option_strings": [
+                "--action-command-args"
+              ],
+              "dest": "action_command_args",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "action-kind=command argv, as a JSON array of {{var}} templates rendered from trigger_context at fire time, e.g. '[\"review-pr\", \"--pr\", \"{{pr_number}}\"]'."
+            },
+            {
+              "option_strings": [
+                "--project"
+              ],
+              "dest": "project",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Project this schedule's runs are recorded under. Defaults to the project detected from the execution root."
+            },
+            {
+              "option_strings": [
+                "--cwd"
+              ],
+              "dest": "cwd",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Explicit execution root for this schedule's spawned process (must be an existing directory). Persisted at creation time so the schedule's spawn cwd never depends on where the Studio daemon is running from (default: --project's registered path, or this CLI's own working directory)."
+            },
+            {
+              "option_strings": [
+                "--description"
+              ],
+              "dest": "description",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Human-readable description."
+            },
+            {
+              "option_strings": [
+                "--max-runs"
+              ],
+              "dest": "max_runs",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Auto-disable this schedule once N total runs have fired (default: unlimited). Chained on_success/on_fail fires do not count toward N. Mutually exclusive with --once."
+            },
+            {
+              "option_strings": [
+                "--once"
+              ],
+              "dest": "once",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Sugar for --max-runs 1 \u2014 fire once, then auto-disable."
+            },
+            {
+              "option_strings": [
+                "--max-cost-usd"
+              ],
+              "dest": "max_cost_usd",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Auto-disable this schedule once its cumulative session spend reaches USD (default: unlimited). Pre-fire cumulative gate: an in-flight run is not interrupted, so the schedule may overshoot by up to one run's cost before the next fire is refused."
+            },
+            {
+              "option_strings": [
+                "--max-tokens"
+              ],
+              "dest": "max_tokens",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Auto-disable this schedule once its cumulative session token usage (input+output) reaches N (default: unlimited). Same pre-fire cumulative semantics as --max-cost-usd."
+            },
+            {
+              "option_strings": [
+                "--on-success"
+              ],
+              "dest": "on_success",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Chain action to fire when this run exits 0, as a JSON object (allowed keys: kind/action_kind, model, prompt, agent, playbook, on_success, on_fail). WARNING \u2014 shallow merge: the chain child is built as {**this_schedule, **on_success}, so any key you omit is INHERITED from this schedule, including on_success/on_fail themselves. A 2-level chain must set the inner level's own \"on_success\": null explicitly, or the chain keeps re-firing at each depth (capped, but rarely what you want). Example: --on-success '{\"prompt\": \"notify done\", \"on_success\": null}'."
+            },
+            {
+              "option_strings": [
+                "--on-fail"
+              ],
+              "dest": "on_fail",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Chain action to fire when this run exits non-zero, as a JSON object (same allowed keys and shallow-merge caveat as --on-success \u2014 see above). Example: --on-fail '{\"prompt\": \"alert on-call\", \"on_fail\": null}'."
+            }
+          ],
+          "subparsers": {}
+        },
+        "validate": {
+          "prog": "li schedule validate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "file",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Path to a ScheduleSet YAML file."
+            },
+            {
+              "option_strings": [
+                "--json"
+              ],
+              "dest": "as_json",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit JSON."
+            }
+          ],
+          "subparsers": {}
+        },
+        "apply": {
+          "prog": "li schedule apply",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "file",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Path to a ScheduleSet YAML file."
+            },
+            {
+              "option_strings": [
+                "--dry-run"
+              ],
+              "dest": "dry_run",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Show the reconciliation plan with resolved values; no database writes."
+            },
+            {
+              "option_strings": [
+                "--adopt"
+              ],
+              "dest": "adopt",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Migrate a same-named row owned by another set/quick-create into this set. Not yet supported."
+            },
+            {
+              "option_strings": [
+                "--json"
+              ],
+              "dest": "as_json",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit JSON."
+            }
+          ],
+          "subparsers": {}
+        },
+        "export": {
+          "prog": "li schedule export",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [
+                "--legacy"
+              ],
+              "dest": "legacy",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Convert chain-free legacy rows (managed_by is null, i.e. rows predating the declaration layer) instead of declaration/cli-managed rows. A row with on_success/on_fail is reported BLOCKED and omitted."
+            },
+            {
+              "option_strings": [
+                "--output"
+              ],
+              "dest": "output",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Write the ScheduleSet YAML here (default: stdout)."
+            },
+            {
+              "option_strings": [
+                "--report"
+              ],
+              "dest": "report",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Write the human-readable conversion report here (default: stderr)."
+            }
+          ],
+          "subparsers": {}
+        },
+        "enable": {
+          "prog": "li schedule enable",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Id of the schedule, as returned by `li schedule list` in its `id` field."
+            }
+          ],
+          "subparsers": {}
+        },
+        "disable": {
+          "prog": "li schedule disable",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Id of the schedule, as returned by `li schedule list` in its `id` field."
+            }
+          ],
+          "subparsers": {}
+        },
+        "delete": {
+          "prog": "li schedule delete",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Id of the schedule, as returned by `li schedule list` in its `id` field."
+            }
+          ],
+          "subparsers": {}
+        },
+        "trigger": {
+          "prog": "li schedule trigger",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Id of the schedule, as returned by `li schedule list` in its `id` field."
+            },
+            {
+              "option_strings": [
+                "--wait"
+              ],
+              "dest": "wait",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Block until the fired occurrence reaches a terminal status (retries a short grace period first, since the occurrence row isn't durably written until just after this returns a run id), then print its outcome and exit non-zero on failure."
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li schedule runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Id of the schedule, as returned by `li schedule list` in its `id` field."
+            },
+            {
+              "option_strings": [
+                "--limit"
+              ],
+              "dest": "limit",
+              "required": false,
+              "nargs": null,
+              "default": 20,
+              "choices": null,
+              "help": "Max runs to return, 1-200 (default: 20)."
+            },
+            {
+              "option_strings": [
+                "--status"
+              ],
+              "dest": "status",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Filter by run status; repeatable (e.g. --status failed --status timed_out)."
+            },
+            {
+              "option_strings": [
+                "--json"
+              ],
+              "dest": "as_json",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit JSON."
+            }
+          ],
+          "subparsers": {}
+        },
+        "run": {
+          "prog": "li schedule run",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Schedule run ID."
+            },
+            {
+              "option_strings": [
+                "--json"
+              ],
+              "dest": "as_json",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit JSON."
+            }
+          ],
+          "subparsers": {}
+        },
+        "status": {
+          "prog": "li schedule status",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Id of the schedule, as returned by `li schedule list` in its `id` field."
+            },
+            {
+              "option_strings": [
+                "--wait"
+              ],
+              "dest": "wait",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Wait for the latest in-flight run to finish first."
+            },
+            {
+              "option_strings": [
+                "--json"
+              ],
+              "dest": "as_json",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit JSON."
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "state": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "state_command",
+              "required": true,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "checkpoint",
+                "doctor",
+                "import",
+                "import-teams",
+                "ls",
+                "null-content",
+                "prune",
+                "stats",
+                "vacuum"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "import": {
+              "prog": "li state import",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                }
+              ],
+              "subparsers": {}
+            },
+            "import-teams": {
+              "prog": "li state import-teams",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                }
+              ],
+              "subparsers": {}
+            },
+            "ls": {
+              "prog": "li state ls",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--limit"
+                  ],
+                  "dest": "limit",
+                  "required": false,
+                  "nargs": null,
+                  "default": 50,
+                  "choices": null,
+                  "help": "Maximum sessions to print, newest first (default 50)."
+                },
+                {
+                  "option_strings": [
+                    "--status"
+                  ],
+                  "dest": "status",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Show only sessions in this status: running, completed, failed or aborted. Omit to list every status."
+                }
+              ],
+              "subparsers": {}
+            },
+            "stats": {
+              "prog": "li state stats",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                }
+              ],
+              "subparsers": {}
+            },
+            "checkpoint": {
+              "prog": "li state checkpoint",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--mode"
+                  ],
+                  "dest": "mode",
+                  "required": false,
+                  "nargs": null,
+                  "default": "TRUNCATE",
+                  "choices": [
+                    "FULL",
+                    "PASSIVE",
+                    "RESTART",
+                    "TRUNCATE"
+                  ],
+                  "help": "How hard to push the WAL back into the database. TRUNCATE (default) frees the WAL file outright but needs no active readers; PASSIVE, FULL and RESTART give up completeness to avoid blocking. No run data is lost in any mode."
+                }
+              ],
+              "subparsers": {}
+            },
+            "vacuum": {
+              "prog": "li state vacuum",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                }
+              ],
+              "subparsers": {}
+            },
+            "prune": {
+              "prog": "li state prune",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--keep-days"
+                  ],
+                  "dest": "keep_days",
+                  "required": false,
+                  "nargs": null,
+                  "default": 30,
+                  "choices": null,
+                  "help": "Keep sessions updated within the last N days (default 30)."
+                },
+                {
+                  "option_strings": [
+                    "--keep-n"
+                  ],
+                  "dest": "keep_n",
+                  "required": false,
+                  "nargs": null,
+                  "default": 100,
+                  "choices": null,
+                  "help": "Always keep the N most recent sessions (default 100)."
+                },
+                {
+                  "option_strings": [
+                    "--dry-run"
+                  ],
+                  "dest": "dry_run",
+                  "required": false,
+                  "nargs": 0,
+                  "default": false,
+                  "choices": null,
+                  "help": "Print what WOULD be deleted, but don't actually delete."
+                }
+              ],
+              "subparsers": {}
+            },
+            "null-content": {
+              "prog": "li state null-content",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--older-than"
+                  ],
+                  "dest": "older_than",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Reclaim bodies older than N days. Required and deliberately has no default: there is no age that is safe to assume for an irreversible operation."
+                },
+                {
+                  "option_strings": [
+                    "--role"
+                  ],
+                  "dest": "role",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Limit to messages with this role; repeatable. Omitted means every role. Check `li state stats` first \u2014 the roles are not evenly sized, and one of them usually holds most of the bytes."
+                },
+                {
+                  "option_strings": [
+                    "--dry-run"
+                  ],
+                  "dest": "dry_run",
+                  "required": false,
+                  "nargs": 0,
+                  "default": false,
+                  "choices": null,
+                  "help": "Perform the reclaim and roll it back, reporting what it measured."
+                }
+              ],
+              "subparsers": {}
+            },
+            "doctor": {
+              "prog": "li state doctor",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--stale-hours"
+                  ],
+                  "dest": "stale_hours",
+                  "required": false,
+                  "nargs": null,
+                  "default": 24,
+                  "choices": null,
+                  "help": "Threshold in hours since started_at (default 24)."
+                },
+                {
+                  "option_strings": [
+                    "--new-status"
+                  ],
+                  "dest": "new_status",
+                  "required": false,
+                  "nargs": null,
+                  "default": "aborted",
+                  "choices": [
+                    "aborted",
+                    "failed"
+                  ],
+                  "help": "Status to assign swept sessions (default 'aborted')."
+                },
+                {
+                  "option_strings": [
+                    "--dry-run"
+                  ],
+                  "dest": "dry_run",
+                  "required": false,
+                  "nargs": 0,
+                  "default": false,
+                  "choices": null,
+                  "help": "Print what WOULD be swept, but don't update rows."
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "invoke": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "invoke_command",
+              "required": true,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "end",
+                "list",
+                "start"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "start": {
+              "prog": "li invoke start",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--skill"
+                  ],
+                  "dest": "skill",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Name of the orchestration being recorded, e.g. 'show', 'codex-pr-review' or 'reprompt'. Every session spawned under this id groups by it."
+                },
+                {
+                  "option_strings": [
+                    "--plugin"
+                  ],
+                  "dest": "plugin",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Marketplace plugin packaging that skill, when the skill came from one."
+                },
+                {
+                  "option_strings": [
+                    "--prompt"
+                  ],
+                  "dest": "prompt",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "The request that triggered this work, stored as free text for later reading."
+                },
+                {
+                  "option_strings": [
+                    "--metadata"
+                  ],
+                  "dest": "metadata",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Skill-specific JSON to attach (e.g. show plan, review rounds). Stored verbatim; rendered as-is on the invocation detail page."
+                }
+              ],
+              "subparsers": {}
+            },
+            "end": {
+              "prog": "li invoke end",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "invocation_id",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "The id printed by `li invoke start`. An invocation never closed stays 'running' forever."
+                },
+                {
+                  "option_strings": [
+                    "--status"
+                  ],
+                  "dest": "status",
+                  "required": false,
+                  "nargs": null,
+                  "default": "completed",
+                  "choices": [
+                    "aborted",
+                    "cancelled",
+                    "completed",
+                    "failed",
+                    "timed_out"
+                  ],
+                  "help": "How the work ended, which also fixes the reason stored with it: 'completed' for success, 'failed' for an exception, 'timed_out' for a deadline, 'aborted' for a user interrupt, 'cancelled' for a system cancellation. Later listings and dashboards filter on this, so leaving the default on work that did not succeed records it as a success."
+                },
+                {
+                  "option_strings": [
+                    "--metadata"
+                  ],
+                  "dest": "metadata",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "JSON merged key-by-key into the invocation's existing metadata, so anything written during the run survives unless this overwrites that key."
+                }
+              ],
+              "subparsers": {}
+            },
+            "list": {
+              "prog": "li invoke list",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--skill"
+                  ],
+                  "dest": "skill",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Show only invocations of this skill name, matched exactly."
+                },
+                {
+                  "option_strings": [
+                    "--status"
+                  ],
+                  "dest": "status",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Show only invocations in this status: running, completed, failed, timed_out, aborted or cancelled."
+                },
+                {
+                  "option_strings": [
+                    "--limit"
+                  ],
+                  "dest": "limit",
+                  "required": false,
+                  "nargs": null,
+                  "default": 20,
+                  "choices": null,
+                  "help": "Maximum rows to print, newest first (default 20)."
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "kill": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": false,
+              "nargs": "?",
+              "default": null,
+              "choices": null,
+              "help": "Entity id to kill: run_id / session_id / invocation_id / play_id / show_id. Accepts a full UUID, or an id prefix (resolved to the first matching row)."
+            },
+            {
+              "option_strings": [
+                "--reason"
+              ],
+              "dest": "reason",
+              "required": false,
+              "nargs": null,
+              "default": "",
+              "choices": null,
+              "help": "Optional human-readable reason recorded in status_transitions."
+            },
+            {
+              "option_strings": [
+                "--recursive"
+              ],
+              "dest": "recursive",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Also kill direct child entities (e.g. invocations spawned by a session). Has no effect on a play kill, which already reaps whatever worker chain the row records, or on a show kill, which cannot reach one -- kill the session ids directly to stop a show's workers."
+            },
+            {
+              "option_strings": [
+                "--all-stale"
+              ],
+              "dest": "all_stale",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Sweep stale sessions and invocations with dead PIDs older than --threshold. A play older than --threshold whose recorded worker session has gone terminal is marked 'blocked'; a play that records no worker session is left running, because age alone cannot tell it apart from one still working. A show is marked 'aborted' only once it is older than --threshold and ALL of its plays are terminal."
+            },
+            {
+              "option_strings": [
+                "--threshold"
+              ],
+              "dest": "threshold",
+              "required": false,
+              "nargs": null,
+              "default": 3600,
+              "choices": null,
+              "help": "Stale threshold in seconds (default 3600 = 1h). Only entities started more than this many seconds ago are swept."
+            },
+            {
+              "option_strings": [
+                "--dry-run"
+              ],
+              "dest": "dry_run",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Print what would be killed/cancelled without making any changes."
+            },
+            {
+              "option_strings": [
+                "--grace"
+              ],
+              "dest": "grace",
+              "required": false,
+              "nargs": null,
+              "default": 5.0,
+              "choices": null,
+              "help": "Seconds to wait after SIGTERM before escalating to SIGKILL (default 5)."
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "mirror": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [
+                "--once"
+              ],
+              "dest": "once",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Do a single catch-up pass over existing transcripts and exit, instead of tailing for new ones. Use it to backfill history without leaving a process running."
+            },
+            {
+              "option_strings": [
+                "--interval"
+              ],
+              "dest": "interval",
+              "required": false,
+              "nargs": null,
+              "default": 3.0,
+              "choices": null,
+              "help": "Seconds between passes over the transcript directory while tailing (default 3)."
+            },
+            {
+              "option_strings": [
+                "--since"
+              ],
+              "dest": "since",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Only mirror transcripts modified within this window (e.g. 12h, 7d). Default: all."
+            },
+            {
+              "option_strings": [
+                "--root"
+              ],
+              "dest": "root",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Claude projects directory (default ~/.claude/projects)."
+            },
+            {
+              "option_strings": [
+                "--codex-root"
+              ],
+              "dest": "codex_root",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Codex sessions directory (default ~/.codex/sessions)."
+            },
+            {
+              "option_strings": [
+                "--source"
+              ],
+              "dest": "source",
+              "required": false,
+              "nargs": null,
+              "default": "both",
+              "choices": [
+                "both",
+                "claude",
+                "codex"
+              ],
+              "help": "Which transcripts to mirror (default both). A full codex backfill is large; pair 'codex' with --since to bound it."
+            },
+            {
+              "option_strings": [
+                "--live-window"
+              ],
+              "dest": "live_window",
+              "required": false,
+              "nargs": null,
+              "default": 300.0,
+              "choices": null,
+              "help": "Idle gap since the last message after which a session is marked completed (default 300)."
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "monitor": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": false,
+              "nargs": "?",
+              "default": null,
+              "choices": null,
+              "help": "Run, session, play or show to open in the detail view \u2014 full id, or an unambiguous prefix. Omit it for the table of everything in flight."
+            },
+            {
+              "option_strings": [
+                "--watch",
+                "-w"
+              ],
+              "dest": "watch",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Redraw the view every --refresh seconds until interrupted, instead of printing one snapshot and exiting."
+            },
+            {
+              "option_strings": [
+                "--refresh"
+              ],
+              "dest": "refresh",
+              "required": false,
+              "nargs": null,
+              "default": 2,
+              "choices": null,
+              "help": "Seconds between redraws under --watch (default 2). Ignored without it."
+            },
+            {
+              "option_strings": [
+                "--since"
+              ],
+              "dest": "since",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Only show entities updated within this time window. Format: 30m, 1h, 2d (minutes/hours/days). Default: all running."
+            },
+            {
+              "option_strings": [
+                "--type",
+                "-t"
+              ],
+              "dest": "entity_type",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": [
+                "invocation",
+                "play",
+                "session",
+                "show"
+              ],
+              "help": "Narrow the table to one kind of entity: session, invocation, show or play."
+            },
+            {
+              "option_strings": [
+                "--project",
+                "-p"
+              ],
+              "dest": "project",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Filter sessions and plays to one project name, matched exactly \u2014 the same name the table's project column shows."
+            },
+            {
+              "option_strings": [
+                "--run"
+              ],
+              "dest": "run_ids",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Wait for one or more schedule_run IDs to reach a terminal state, then exit (scripting primitive; see `li monitor run --help` for the positional form). Follows scheduler on_success/on_fail chain children by default (see --no-chain). Ignores id/--watch/--since/--type/--project."
+            },
+            {
+              "option_strings": [
+                "--interval"
+              ],
+              "dest": "interval",
+              "required": false,
+              "nargs": null,
+              "default": 3.0,
+              "choices": null,
+              "help": "Seconds between state.db polls in --run mode (default 3). Independent of --refresh, which paces the table redraw."
+            },
+            {
+              "option_strings": [
+                "--follow"
+              ],
+              "dest": "follow",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "With --run: keep discovering schedule_runs created after the initial set drains, instead of exiting once it is empty. Never ends on its own \u2014 pair with --max-wait."
+            },
+            {
+              "option_strings": [
+                "--no-chain"
+              ],
+              "dest": "chain",
+              "required": false,
+              "nargs": 0,
+              "default": true,
+              "choices": null,
+              "help": "With --run: watch only the literal id(s) given, instead of following scheduler on_success/on_fail chain children by default."
+            },
+            {
+              "option_strings": [
+                "--max-wait"
+              ],
+              "dest": "max_wait",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "With --run: give up waiting after this many seconds and exit EXIT_RUNNING for whatever is still pending, instead of blocking forever on a stuck session or run. Default: 900s. Pass 0 for unlimited."
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "id",
+              "required": false,
+              "nargs": "?",
+              "default": null,
+              "choices": null,
+              "help": "Run, session, play or show to open in the detail view \u2014 full id, or an unambiguous prefix. Omit it for the table of everything in flight."
+            },
+            {
+              "option_strings": [
+                "--watch",
+                "-w"
+              ],
+              "dest": "watch",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Redraw the view every --refresh seconds until interrupted, instead of printing one snapshot and exiting."
+            },
+            {
+              "option_strings": [
+                "--refresh"
+              ],
+              "dest": "refresh",
+              "required": false,
+              "nargs": null,
+              "default": 2,
+              "choices": null,
+              "help": "Seconds between redraws under --watch (default 2). Ignored without it."
+            },
+            {
+              "option_strings": [
+                "--since"
+              ],
+              "dest": "since",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Only show entities updated within this time window. Format: 30m, 1h, 2d (minutes/hours/days). Default: all running."
+            },
+            {
+              "option_strings": [
+                "--type",
+                "-t"
+              ],
+              "dest": "entity_type",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": [
+                "invocation",
+                "play",
+                "session",
+                "show"
+              ],
+              "help": "Narrow the table to one kind of entity: session, invocation, show or play."
+            },
+            {
+              "option_strings": [
+                "--project",
+                "-p"
+              ],
+              "dest": "project",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Filter sessions and plays to one project name, matched exactly \u2014 the same name the table's project column shows."
+            },
+            {
+              "option_strings": [
+                "--run"
+              ],
+              "dest": "run_ids",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "Wait for one or more schedule_run IDs to reach a terminal state, then exit (scripting primitive; see `li monitor run --help` for the positional form). Follows scheduler on_success/on_fail chain children by default (see --no-chain). Ignores id/--watch/--since/--type/--project."
+            },
+            {
+              "option_strings": [
+                "--interval"
+              ],
+              "dest": "interval",
+              "required": false,
+              "nargs": null,
+              "default": 3.0,
+              "choices": null,
+              "help": "Seconds between state.db polls in --run mode (default 3). Independent of --refresh, which paces the table redraw."
+            },
+            {
+              "option_strings": [
+                "--follow"
+              ],
+              "dest": "follow",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "With --run: keep discovering schedule_runs created after the initial set drains, instead of exiting once it is empty. Never ends on its own \u2014 pair with --max-wait."
+            },
+            {
+              "option_strings": [
+                "--no-chain"
+              ],
+              "dest": "chain",
+              "required": false,
+              "nargs": 0,
+              "default": true,
+              "choices": null,
+              "help": "With --run: watch only the literal id(s) given, instead of following scheduler on_success/on_fail chain children by default."
+            },
+            {
+              "option_strings": [
+                "--max-wait"
+              ],
+              "dest": "max_wait",
+              "required": false,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "With --run: give up waiting after this many seconds and exit EXIT_RUNNING for whatever is still pending, instead of blocking forever on a stuck session or run. Default: 900s. Pass 0 for unlimited."
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "dispatch": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "dispatch_command",
+              "required": true,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "ack",
+                "ls",
+                "purge",
+                "retry",
+                "show"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "ls": {
+              "prog": "li dispatch ls",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--status"
+                  ],
+                  "dest": "status",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Show only rows in this status: pending, delivering, delivered, acked, dead_letter or expired. Omit to list every status."
+                },
+                {
+                  "option_strings": [
+                    "--limit"
+                  ],
+                  "dest": "limit",
+                  "required": false,
+                  "nargs": null,
+                  "default": 50,
+                  "choices": null,
+                  "help": "Maximum rows to print, newest first (default 50)."
+                }
+              ],
+              "subparsers": {}
+            },
+            "show": {
+              "prog": "li dispatch show",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "id",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Id of the dispatch row to show, as listed by `li dispatch ls`."
+                }
+              ],
+              "subparsers": {}
+            },
+            "ack": {
+              "prog": "li dispatch ack",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "id",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Id of the dispatch to acknowledge, as listed by `li dispatch ls`."
+                },
+                {
+                  "option_strings": [],
+                  "dest": "token",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "The ack_token this dispatch was delivered with, reported by `li dispatch show`. A mismatched token is refused, so an acknowledgement cannot be guessed."
+                }
+              ],
+              "subparsers": {}
+            },
+            "retry": {
+              "prog": "li dispatch retry",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "id",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Id of the dispatch to re-queue for delivery."
+                }
+              ],
+              "subparsers": {}
+            },
+            "purge": {
+              "prog": "li dispatch purge",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "id",
+                  "required": false,
+                  "nargs": "?",
+                  "default": null,
+                  "choices": null,
+                  "help": "Id of a single dispatch to delete, whatever its status. Omit it to bulk-delete by --status/--before instead; one of the two is then required."
+                },
+                {
+                  "option_strings": [
+                    "--status"
+                  ],
+                  "dest": "status",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Bulk purge: match this status exactly, including pending/delivering (explicit status is deliberate operator intent)."
+                },
+                {
+                  "option_strings": [
+                    "--before"
+                  ],
+                  "dest": "before",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Bulk purge: match rows with updated_at <= this epoch-seconds value. Without --status, this is scoped to terminal statuses only (delivered/acked/dead_letter/expired) and never sweeps pending/delivering rows."
+                },
+                {
+                  "option_strings": [
+                    "--dry-run"
+                  ],
+                  "dest": "dry_run",
+                  "required": false,
+                  "nargs": 0,
+                  "default": false,
+                  "choices": null,
+                  "help": "Report what would be deleted without deleting (single-row and bulk)."
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "doctor": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [
+                "--json"
+              ],
+              "dest": "json",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit a JSON object of check name -> {status, detail} instead of plain text."
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "stats": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "stats_command",
+              "required": true,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "runs"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "runs": {
+              "prog": "li stats runs",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--since"
+                  ],
+                  "dest": "since",
+                  "required": false,
+                  "nargs": null,
+                  "default": "7d",
+                  "choices": null,
+                  "help": "Only include runs updated within this window. Format: 30m, 1h, 7d. Default: 7d."
+                },
+                {
+                  "option_strings": [
+                    "--group-by"
+                  ],
+                  "dest": "group_by",
+                  "required": false,
+                  "nargs": null,
+                  "default": "project,kind",
+                  "choices": null,
+                  "help": "Comma-separated group keys from {project, kind, agent, model, status}. Default: project,kind."
+                },
+                {
+                  "option_strings": [
+                    "--json"
+                  ],
+                  "dest": "json",
+                  "required": false,
+                  "nargs": 0,
+                  "default": false,
+                  "choices": null,
+                  "help": "Emit a JSON array of row objects instead of an aligned table."
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "plugin": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "plugin_command",
+              "required": true,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "disable",
+                "enable",
+                "info",
+                "list",
+                "trust"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "list": {
+              "prog": "li plugin list",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                }
+              ],
+              "subparsers": {}
+            },
+            "info": {
+              "prog": "li plugin info",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "name",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Plugin to describe \u2014 its manifest `name:`, as listed by `li plugin list`."
+                }
+              ],
+              "subparsers": {}
+            },
+            "trust": {
+              "prog": "li plugin trust",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "name",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Plugin to trust, as named by `li plugin list`."
+                },
+                {
+                  "option_strings": [
+                    "--yes"
+                  ],
+                  "dest": "yes",
+                  "required": false,
+                  "nargs": 0,
+                  "default": false,
+                  "choices": null,
+                  "help": "Record trust without an interactive confirmation prompt."
+                }
+              ],
+              "subparsers": {}
+            },
+            "enable": {
+              "prog": "li plugin enable",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "name",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Plugin to load again, as named by `li plugin list`. It must already be trusted."
+                }
+              ],
+              "subparsers": {}
+            },
+            "disable": {
+              "prog": "li plugin disable",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "name",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Plugin to leave installed and trusted but inert, as named by `li plugin list`. Re-enable it with `li plugin enable`."
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "hooks": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "hooks_command",
+              "required": true,
+              "nargs": "A...",
+              "default": null,
+              "choices": [
+                "import",
+                "trust"
+              ],
+              "help": null
+            }
+          ],
+          "subparsers": {
+            "import": {
+              "prog": "li hooks import",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [],
+                  "dest": "source",
+                  "required": true,
+                  "nargs": null,
+                  "default": null,
+                  "choices": [
+                    "claude",
+                    "codex"
+                  ],
+                  "help": "Which harness wrote the config being imported: 'claude' for Claude Code's settings.json shape, 'codex' for the Codex hooks.json shape."
+                },
+                {
+                  "option_strings": [],
+                  "dest": "path",
+                  "required": false,
+                  "nargs": "?",
+                  "default": null,
+                  "choices": null,
+                  "help": "Config file to read. Defaults to .claude/settings.json or .codex/hooks.json under the project directory, matching the source given."
+                },
+                {
+                  "option_strings": [
+                    "--cwd"
+                  ],
+                  "dest": "cwd",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Project whose .lionagi/settings.yaml receives the imported hooks, and where the default config path is looked up (defaults to the current directory)."
+                }
+              ],
+              "subparsers": {}
+            },
+            "trust": {
+              "prog": "li hooks trust",
+              "actions": [
+                {
+                  "option_strings": [
+                    "-h",
+                    "--help"
+                  ],
+                  "dest": "help",
+                  "required": false,
+                  "nargs": 0,
+                  "default": "==SUPPRESS==",
+                  "choices": null,
+                  "help": "show this help message and exit"
+                },
+                {
+                  "option_strings": [
+                    "--cwd"
+                  ],
+                  "dest": "cwd",
+                  "required": false,
+                  "nargs": null,
+                  "default": null,
+                  "choices": null,
+                  "help": "Project whose imported hook commands are listed and approved (defaults to the current directory)."
+                },
+                {
+                  "option_strings": [
+                    "--yes"
+                  ],
+                  "dest": "yes",
+                  "required": false,
+                  "nargs": 0,
+                  "default": false,
+                  "choices": null,
+                  "help": "Record trust without an interactive confirmation prompt."
+                }
+              ],
+              "subparsers": {}
+            }
+          }
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "handshake": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [
+                "--machine"
+              ],
+              "dest": "machine",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit the machine-result envelope."
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "runs": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [
+                "--limit"
+              ],
+              "dest": "limit",
+              "required": false,
+              "nargs": null,
+              "default": 20,
+              "choices": null,
+              "help": "How many runs to list."
+            },
+            {
+              "option_strings": [
+                "--machine"
+              ],
+              "dest": "machine",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit the machine-result envelope."
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "lifecycle": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "run_id",
+              "required": true,
+              "nargs": null,
+              "default": null,
+              "choices": null,
+              "help": "The run id to report on."
+            },
+            {
+              "option_strings": [
+                "--machine"
+              ],
+              "dest": "machine",
+              "required": false,
+              "nargs": 0,
+              "default": false,
+              "choices": null,
+              "help": "Emit the machine-result envelope."
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    },
+    "mcp": {
+      "prog": "li",
+      "actions": [
+        {
+          "option_strings": [
+            "-h",
+            "--help"
+          ],
+          "dest": "help",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "show this help message and exit"
+        },
+        {
+          "option_strings": [
+            "--version"
+          ],
+          "dest": "version",
+          "required": false,
+          "nargs": 0,
+          "default": "==SUPPRESS==",
+          "choices": null,
+          "help": "Print the installed lionagi version and exit."
+        },
+        {
+          "option_strings": [
+            "--machine"
+          ],
+          "dest": "machine",
+          "required": false,
+          "nargs": 0,
+          "default": false,
+          "choices": null,
+          "help": "Emit one machine-result JSON object on stdout and send every human-facing line to stderr."
+        },
+        {
+          "option_strings": [],
+          "dest": "command",
+          "required": true,
+          "nargs": "A...",
+          "default": null,
+          "choices": [
+            "agent",
+            "casts",
+            "dispatch",
+            "doctor",
+            "engine",
+            "handshake",
+            "hooks",
+            "invoke",
+            "kill",
+            "lifecycle",
+            "mcp",
+            "mirror",
+            "mon",
+            "monitor",
+            "o",
+            "orchestrate",
+            "plugin",
+            "runs",
+            "schedule",
+            "state",
+            "stats",
+            "studio",
+            "team"
+          ],
+          "help": null
+        }
+      ],
+      "subparsers": {
+        "orchestrate": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "o": {
+          "prog": "li orchestrate",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "agent": {
+          "prog": "li agent",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "casts": {
+          "prog": "li casts",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "engine": {
+          "prog": "li engine",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "team": {
+          "prog": "li team",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "studio": {
+          "prog": "li studio",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "schedule": {
+          "prog": "li schedule",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "state": {
+          "prog": "li state",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "invoke": {
+          "prog": "li invoke",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "kill": {
+          "prog": "li kill",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mirror": {
+          "prog": "li mirror",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "monitor": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mon": {
+          "prog": "li monitor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "dispatch": {
+          "prog": "li dispatch",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "doctor": {
+          "prog": "li doctor",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "stats": {
+          "prog": "li stats",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "plugin": {
+          "prog": "li plugin",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "hooks": {
+          "prog": "li hooks",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "handshake": {
+          "prog": "li handshake",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "runs": {
+          "prog": "li runs",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "lifecycle": {
+          "prog": "li lifecycle",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            }
+          ],
+          "subparsers": {}
+        },
+        "mcp": {
+          "prog": "li mcp",
+          "actions": [
+            {
+              "option_strings": [
+                "-h",
+                "--help"
+              ],
+              "dest": "help",
+              "required": false,
+              "nargs": 0,
+              "default": "==SUPPRESS==",
+              "choices": null,
+              "help": "show this help message and exit"
+            },
+            {
+              "option_strings": [],
+              "dest": "action",
+              "required": false,
+              "nargs": "?",
+              "default": "serve",
+              "choices": [
+                "serve"
+              ],
+              "help": "What to do: 'serve' (the default and only value) runs the server on stdin/stdout until the client disconnects."
+            }
+          ],
+          "subparsers": {}
+        }
+      }
+    }
+  },
+  "build_errors": {}
+}

--- a/tests/contracts/data/cli.json
+++ b/tests/contracts/data/cli.json
@@ -180,7 +180,7 @@
           {
             "option_strings": [],
             "dest": "query",
-            "required": true,
+            "required": false,
             "nargs": "*",
             "default": null,
             "choices": null,
@@ -480,7 +480,7 @@
           {
             "option_strings": [],
             "dest": "query",
-            "required": true,
+            "required": false,
             "nargs": "*",
             "default": null,
             "choices": null,
@@ -1107,7 +1107,7 @@
         {
           "option_strings": [],
           "dest": "query",
-          "required": true,
+          "required": false,
           "nargs": "*",
           "default": null,
           "choices": null,

--- a/tests/contracts/data/http.json
+++ b/tests/contracts/data/http.json
@@ -1,5 +1,5 @@
 {
-  "count": 133,
+  "count": 134,
   "routes": [
     {
       "ordinal": 0,
@@ -2641,6 +2641,54 @@
     },
     {
       "ordinal": 59,
+      "path": "/api/skills/{name}/validate",
+      "methods": [
+        "POST"
+      ],
+      "name": "validate_skill",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Validate Skill Api Skills  Name  Validate Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "skills"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.skills",
+        "qualname": "validate_skill_route"
+      }
+    },
+    {
+      "ordinal": 60,
       "path": "/api/plugins",
       "methods": [
         "GET"
@@ -2678,7 +2726,7 @@
       }
     },
     {
-      "ordinal": 60,
+      "ordinal": 61,
       "path": "/api/plugins/{name}",
       "methods": [
         "GET"
@@ -2726,7 +2774,7 @@
       }
     },
     {
-      "ordinal": 61,
+      "ordinal": 62,
       "path": "/api/plugins/{plugin_name}/skills/{skill_name}",
       "methods": [
         "GET"
@@ -2774,7 +2822,7 @@
       }
     },
     {
-      "ordinal": 62,
+      "ordinal": 63,
       "path": "/api/plugins/{plugin_name}/agents/{agent_name}",
       "methods": [
         "GET"
@@ -2822,7 +2870,7 @@
       }
     },
     {
-      "ordinal": 63,
+      "ordinal": 64,
       "path": "/api/mcp/servers/",
       "methods": [
         "GET"
@@ -2860,7 +2908,7 @@
       }
     },
     {
-      "ordinal": 64,
+      "ordinal": 65,
       "path": "/api/mcp/servers/{name}",
       "methods": [
         "GET"
@@ -2908,7 +2956,7 @@
       }
     },
     {
-      "ordinal": 65,
+      "ordinal": 66,
       "path": "/api/mcp/servers/",
       "methods": [
         "POST"
@@ -2956,7 +3004,7 @@
       }
     },
     {
-      "ordinal": 66,
+      "ordinal": 67,
       "path": "/api/mcp/servers/{name}",
       "methods": [
         "PUT"
@@ -3004,7 +3052,7 @@
       }
     },
     {
-      "ordinal": 67,
+      "ordinal": 68,
       "path": "/api/mcp/servers/{name}/enable",
       "methods": [
         "POST"
@@ -3052,7 +3100,7 @@
       }
     },
     {
-      "ordinal": 68,
+      "ordinal": 69,
       "path": "/api/mcp/servers/{name}/disable",
       "methods": [
         "POST"
@@ -3100,7 +3148,7 @@
       }
     },
     {
-      "ordinal": 69,
+      "ordinal": 70,
       "path": "/api/mcp/servers/{name}",
       "methods": [
         "DELETE"
@@ -3148,7 +3196,7 @@
       }
     },
     {
-      "ordinal": 70,
+      "ordinal": 71,
       "path": "/api/mcp/servers/{name}/check",
       "methods": [
         "POST"
@@ -3196,7 +3244,7 @@
       }
     },
     {
-      "ordinal": 71,
+      "ordinal": 72,
       "path": "/api/mcp/servers/{name}/validate",
       "methods": [
         "POST"
@@ -3244,7 +3292,7 @@
       }
     },
     {
-      "ordinal": 72,
+      "ordinal": 73,
       "path": "/api/teams/",
       "methods": [
         "GET"
@@ -3292,7 +3340,7 @@
       }
     },
     {
-      "ordinal": 73,
+      "ordinal": 74,
       "path": "/api/teams/{team_id}",
       "methods": [
         "GET"
@@ -3340,7 +3388,7 @@
       }
     },
     {
-      "ordinal": 74,
+      "ordinal": 75,
       "path": "/api/invocations/",
       "methods": [
         "GET"
@@ -3388,7 +3436,7 @@
       }
     },
     {
-      "ordinal": 75,
+      "ordinal": 76,
       "path": "/api/invocations/{invocation_id}",
       "methods": [
         "GET"
@@ -3436,7 +3484,7 @@
       }
     },
     {
-      "ordinal": 76,
+      "ordinal": 77,
       "path": "/api/artifacts/{artifact_id}",
       "methods": [
         "GET"
@@ -3484,7 +3532,7 @@
       }
     },
     {
-      "ordinal": 77,
+      "ordinal": 78,
       "path": "/api/artifacts/by-session/{session_id}",
       "methods": [
         "GET"
@@ -3532,7 +3580,7 @@
       }
     },
     {
-      "ordinal": 78,
+      "ordinal": 79,
       "path": "/api/projects/",
       "methods": [
         "GET"
@@ -3570,7 +3618,7 @@
       }
     },
     {
-      "ordinal": 79,
+      "ordinal": 80,
       "path": "/api/projects/{name}",
       "methods": [
         "GET"
@@ -3618,7 +3666,7 @@
       }
     },
     {
-      "ordinal": 80,
+      "ordinal": 81,
       "path": "/api/projects/",
       "methods": [
         "POST"
@@ -3666,7 +3714,7 @@
       }
     },
     {
-      "ordinal": 81,
+      "ordinal": 82,
       "path": "/api/projects/{name}",
       "methods": [
         "PUT"
@@ -3714,7 +3762,7 @@
       }
     },
     {
-      "ordinal": 82,
+      "ordinal": 83,
       "path": "/api/projects/{name}/assign",
       "methods": [
         "POST"
@@ -3762,7 +3810,7 @@
       }
     },
     {
-      "ordinal": 83,
+      "ordinal": 84,
       "path": "/api/projects/{name}",
       "methods": [
         "DELETE"
@@ -3810,7 +3858,7 @@
       }
     },
     {
-      "ordinal": 84,
+      "ordinal": 85,
       "path": "/api/engine-defs/",
       "methods": [
         "GET"
@@ -3861,7 +3909,7 @@
       }
     },
     {
-      "ordinal": 85,
+      "ordinal": 86,
       "path": "/api/engine-defs/",
       "methods": [
         "POST"
@@ -3909,7 +3957,7 @@
       }
     },
     {
-      "ordinal": 86,
+      "ordinal": 87,
       "path": "/api/engine-defs/{def_id}",
       "methods": [
         "GET"
@@ -3957,7 +4005,7 @@
       }
     },
     {
-      "ordinal": 87,
+      "ordinal": 88,
       "path": "/api/engine-defs/{def_id}",
       "methods": [
         "PUT"
@@ -4005,7 +4053,7 @@
       }
     },
     {
-      "ordinal": 88,
+      "ordinal": 89,
       "path": "/api/engine-defs/{def_id}",
       "methods": [
         "DELETE"
@@ -4053,7 +4101,7 @@
       }
     },
     {
-      "ordinal": 89,
+      "ordinal": 90,
       "path": "/api/workflow-defs/",
       "methods": [
         "GET"
@@ -4104,7 +4152,7 @@
       }
     },
     {
-      "ordinal": 90,
+      "ordinal": 91,
       "path": "/api/workflow-defs/",
       "methods": [
         "POST"
@@ -4152,7 +4200,7 @@
       }
     },
     {
-      "ordinal": 91,
+      "ordinal": 92,
       "path": "/api/workflow-defs/{def_id}",
       "methods": [
         "GET"
@@ -4200,7 +4248,7 @@
       }
     },
     {
-      "ordinal": 92,
+      "ordinal": 93,
       "path": "/api/workflow-defs/{def_id}",
       "methods": [
         "PUT"
@@ -4248,7 +4296,7 @@
       }
     },
     {
-      "ordinal": 93,
+      "ordinal": 94,
       "path": "/api/workflow-defs/{def_id}",
       "methods": [
         "DELETE"
@@ -4296,7 +4344,7 @@
       }
     },
     {
-      "ordinal": 94,
+      "ordinal": 95,
       "path": "/api/workflow-defs/{def_id}/run",
       "methods": [
         "POST"
@@ -4344,7 +4392,7 @@
       }
     },
     {
-      "ordinal": 95,
+      "ordinal": 96,
       "path": "/api/sessions/{session_id}/tags",
       "methods": [
         "POST"
@@ -4392,7 +4440,7 @@
       }
     },
     {
-      "ordinal": 96,
+      "ordinal": 97,
       "path": "/api/sessions/{session_id}/tags/{tag:path}",
       "methods": [
         "DELETE"
@@ -4440,7 +4488,7 @@
       }
     },
     {
-      "ordinal": 97,
+      "ordinal": 98,
       "path": "/api/operator/conversations",
       "methods": [
         "GET"
@@ -4488,7 +4536,7 @@
       }
     },
     {
-      "ordinal": 98,
+      "ordinal": 99,
       "path": "/api/operator/conversations",
       "methods": [
         "POST"
@@ -4536,7 +4584,7 @@
       }
     },
     {
-      "ordinal": 99,
+      "ordinal": 100,
       "path": "/api/operator/conversations/{conversation_id}",
       "methods": [
         "PATCH"
@@ -4584,7 +4632,7 @@
       }
     },
     {
-      "ordinal": 100,
+      "ordinal": 101,
       "path": "/api/operator/conversations/{conversation_id}/fork",
       "methods": [
         "POST"
@@ -4632,7 +4680,7 @@
       }
     },
     {
-      "ordinal": 101,
+      "ordinal": 102,
       "path": "/api/operator/conversations/{conversation_id}",
       "methods": [
         "GET"
@@ -4680,7 +4728,7 @@
       }
     },
     {
-      "ordinal": 102,
+      "ordinal": 103,
       "path": "/api/operator/conversations/{conversation_id}",
       "methods": [
         "DELETE"
@@ -4728,7 +4776,7 @@
       }
     },
     {
-      "ordinal": 103,
+      "ordinal": 104,
       "path": "/api/operator/conversations/{conversation_id}/turns",
       "methods": [
         "POST"
@@ -4776,7 +4824,7 @@
       }
     },
     {
-      "ordinal": 104,
+      "ordinal": 105,
       "path": "/api/operator/models",
       "methods": [
         "GET"
@@ -4814,7 +4862,7 @@
       }
     },
     {
-      "ordinal": 105,
+      "ordinal": 106,
       "path": "/api/operator/conversations/{conversation_id}/view",
       "methods": [
         "POST"
@@ -4862,7 +4910,7 @@
       }
     },
     {
-      "ordinal": 106,
+      "ordinal": 107,
       "path": "/api/operator/conversations/{conversation_id}/requests/{request_id}/cancel",
       "methods": [
         "POST"
@@ -4910,7 +4958,7 @@
       }
     },
     {
-      "ordinal": 107,
+      "ordinal": 108,
       "path": "/api/operator/conversations/{conversation_id}/stream",
       "methods": [
         "GET"
@@ -4954,7 +5002,7 @@
       }
     },
     {
-      "ordinal": 108,
+      "ordinal": 109,
       "path": "/api/operator/conversations/{conversation_id}/proposals/{proposal_id}/confirm",
       "methods": [
         "POST"
@@ -5002,7 +5050,7 @@
       }
     },
     {
-      "ordinal": 109,
+      "ordinal": 110,
       "path": "/api/operator/conversations/{conversation_id}/proposals/{proposal_id}/decision",
       "methods": [
         "POST"
@@ -5050,7 +5098,7 @@
       }
     },
     {
-      "ordinal": 110,
+      "ordinal": 111,
       "path": "/api/operator/conversations/{conversation_id}/effects/{effect_id}/ack",
       "methods": [
         "POST"
@@ -5098,7 +5146,7 @@
       }
     },
     {
-      "ordinal": 111,
+      "ordinal": 112,
       "path": "/api/approvals/",
       "methods": [
         "POST"
@@ -5146,7 +5194,7 @@
       }
     },
     {
-      "ordinal": 112,
+      "ordinal": 113,
       "path": "/api/approvals/evidence/verify",
       "methods": [
         "GET"
@@ -5184,7 +5232,7 @@
       }
     },
     {
-      "ordinal": 113,
+      "ordinal": 114,
       "path": "/api/approvals/{approval_id}",
       "methods": [
         "GET"
@@ -5232,7 +5280,7 @@
       }
     },
     {
-      "ordinal": 114,
+      "ordinal": 115,
       "path": "/api/approvals/{approval_id}/grant",
       "methods": [
         "POST"
@@ -5280,7 +5328,7 @@
       }
     },
     {
-      "ordinal": 115,
+      "ordinal": 116,
       "path": "/api/approvals/{approval_id}/deny",
       "methods": [
         "POST"
@@ -5328,7 +5376,7 @@
       }
     },
     {
-      "ordinal": 116,
+      "ordinal": 117,
       "path": "/api/admin/doctor",
       "methods": [
         "GET"
@@ -5376,7 +5424,7 @@
       }
     },
     {
-      "ordinal": 117,
+      "ordinal": 118,
       "path": "/api/admin/health",
       "methods": [
         "GET"
@@ -5414,7 +5462,7 @@
       }
     },
     {
-      "ordinal": 118,
+      "ordinal": 119,
       "path": "/api/admin/readiness",
       "methods": [
         "GET"
@@ -5462,7 +5510,7 @@
       }
     },
     {
-      "ordinal": 119,
+      "ordinal": 120,
       "path": "/api/admin/transition",
       "methods": [
         "POST"
@@ -5510,7 +5558,7 @@
       }
     },
     {
-      "ordinal": 120,
+      "ordinal": 121,
       "path": "/api/admin/events",
       "methods": [
         "GET"
@@ -5558,7 +5606,7 @@
       }
     },
     {
-      "ordinal": 121,
+      "ordinal": 122,
       "path": "/api/admin/prune-old-data",
       "methods": [
         "POST"
@@ -5608,7 +5656,7 @@
       }
     },
     {
-      "ordinal": 122,
+      "ordinal": 123,
       "path": "/api/admin/maintenance",
       "methods": [
         "POST"
@@ -5656,7 +5704,7 @@
       }
     },
     {
-      "ordinal": 123,
+      "ordinal": 124,
       "path": "/api/admin/prune",
       "methods": [
         "POST"
@@ -5706,7 +5754,7 @@
       }
     },
     {
-      "ordinal": 124,
+      "ordinal": 125,
       "path": "/api/stats/activity",
       "methods": [
         "GET"
@@ -5752,7 +5800,7 @@
       }
     },
     {
-      "ordinal": 125,
+      "ordinal": 126,
       "path": "/api/stats/spend",
       "methods": [
         "GET"
@@ -5798,7 +5846,7 @@
       }
     },
     {
-      "ordinal": 126,
+      "ordinal": 127,
       "path": "/api/stats/spend/rollup",
       "methods": [
         "GET"
@@ -5844,7 +5892,7 @@
       }
     },
     {
-      "ordinal": 127,
+      "ordinal": 128,
       "path": "/api/stats",
       "methods": [
         "GET"
@@ -5880,7 +5928,7 @@
       }
     },
     {
-      "ordinal": 128,
+      "ordinal": 129,
       "path": "/api/attention/dispositions/",
       "methods": [
         "GET"
@@ -5918,7 +5966,7 @@
       }
     },
     {
-      "ordinal": 129,
+      "ordinal": 130,
       "path": "/api/attention/dispositions/{item_id}",
       "methods": [
         "PUT"
@@ -5966,7 +6014,7 @@
       }
     },
     {
-      "ordinal": 130,
+      "ordinal": 131,
       "path": "/api/attention/dispositions/{item_id}",
       "methods": [
         "DELETE"
@@ -6014,7 +6062,7 @@
       }
     },
     {
-      "ordinal": 131,
+      "ordinal": 132,
       "path": "/api/attention/dispositions/{item_id}/history",
       "methods": [
         "GET"
@@ -6062,7 +6110,7 @@
       }
     },
     {
-      "ordinal": 132,
+      "ordinal": 133,
       "path": "/health",
       "methods": [
         "GET"
@@ -7994,6 +8042,22 @@
                 "minimum": 0,
                 "default": 0,
                 "title": "Offset"
+              }
+            },
+            {
+              "name": "plugin",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Plugin"
               }
             },
             {
@@ -11689,6 +11753,59 @@
           }
         }
       },
+      "/api/skills/{name}/validate": {
+        "post": {
+          "tags": [
+            "skills"
+          ],
+          "summary": "Validate Skill",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillValidateBody"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Validate Skill Api Skills  Name  Validate Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "/api/stats": {
         "get": {
           "summary": "Get Stats",
@@ -12246,7 +12363,7 @@
         }
       }
     },
-    "path_count": 102,
+    "path_count": 103,
     "schemas": {
       "AcknowledgeEffectRequest": {
         "properties": {
@@ -13462,6 +13579,19 @@
         ],
         "title": "SaveBody"
       },
+      "SkillValidateBody": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "title": "SkillValidateBody"
+      },
       "TagBody": {
         "properties": {
           "tag": {
@@ -14259,6 +14389,6 @@
         "title": "_DispositionBody"
       }
     },
-    "schema_count": 32
+    "schema_count": 33
   }
 }

--- a/tests/contracts/data/http.json
+++ b/tests/contracts/data/http.json
@@ -1,0 +1,14264 @@
+{
+  "count": 133,
+  "routes": [
+    {
+      "ordinal": 0,
+      "path": "/openapi.json",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "openapi",
+      "response_model": null,
+      "dependencies": [],
+      "response_class": null,
+      "responses": {},
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": false,
+      "handler_identity": {
+        "module": "fastapi.applications",
+        "qualname": "FastAPI.setup.<locals>.openapi"
+      }
+    },
+    {
+      "ordinal": 1,
+      "path": "/docs",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "swagger_ui_html",
+      "response_model": null,
+      "dependencies": [],
+      "response_class": null,
+      "responses": {},
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": false,
+      "handler_identity": {
+        "module": "fastapi.applications",
+        "qualname": "FastAPI.setup.<locals>.swagger_ui_html"
+      }
+    },
+    {
+      "ordinal": 2,
+      "path": "/docs/oauth2-redirect",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "swagger_ui_redirect",
+      "response_model": null,
+      "dependencies": [],
+      "response_class": null,
+      "responses": {},
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": false,
+      "handler_identity": {
+        "module": "fastapi.applications",
+        "qualname": "FastAPI.setup.<locals>.swagger_ui_redirect"
+      }
+    },
+    {
+      "ordinal": 3,
+      "path": "/redoc",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "redoc_html",
+      "response_model": null,
+      "dependencies": [],
+      "response_class": null,
+      "responses": {},
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": false,
+      "handler_identity": {
+        "module": "fastapi.applications",
+        "qualname": "FastAPI.setup.<locals>.redoc_html"
+      }
+    },
+    {
+      "ordinal": 4,
+      "path": "/api/casts/",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_casts",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Get Casts Api Casts  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "casts"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.casts",
+        "qualname": "get_casts"
+      }
+    },
+    {
+      "ordinal": 5,
+      "path": "/api/sessions/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_sessions",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List Sessions Api Sessions  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "sessions"
+      ],
+      "summary": null,
+      "description": "One page of sessions. The response always reports `total` and\n`truncated` so a bounded answer can never be mistaken for a complete one.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.sessions",
+        "qualname": "list_sessions_route"
+      }
+    },
+    {
+      "ordinal": 6,
+      "path": "/api/sessions/{session_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_session",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Session Api Sessions  Session Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "sessions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.sessions",
+        "qualname": "get_session_route"
+      }
+    },
+    {
+      "ordinal": 7,
+      "path": "/api/sessions/{session_id}/stream",
+      "methods": [
+        "GET"
+      ],
+      "name": "stream_session",
+      "response_model": null,
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "sessions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.sessions",
+        "qualname": "stream_session_route"
+      }
+    },
+    {
+      "ordinal": 8,
+      "path": "/api/sessions/{session_id}/signals",
+      "methods": [
+        "GET"
+      ],
+      "name": "stream_signals",
+      "response_model": "typing.Any",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "Response Stream Signals Api Sessions  Session Id  Signals Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "sessions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.sessions",
+        "qualname": "stream_signals"
+      }
+    },
+    {
+      "ordinal": 9,
+      "path": "/api/runs/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_runs",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List Runs Api Runs  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "runs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.runs",
+        "qualname": "list_runs_route"
+      }
+    },
+    {
+      "ordinal": 10,
+      "path": "/api/runs/projects",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_run_projects",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Run Projects Api Runs Projects Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "runs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.runs",
+        "qualname": "list_run_projects_route"
+      }
+    },
+    {
+      "ordinal": 11,
+      "path": "/api/runs/{run_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_run",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Run Api Runs  Run Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "runs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.runs",
+        "qualname": "get_run_route"
+      }
+    },
+    {
+      "ordinal": 12,
+      "path": "/api/runs/{run_id}/file",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_run_file",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Run File Api Runs  Run Id  File Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "runs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.runs",
+        "qualname": "get_run_file_route"
+      }
+    },
+    {
+      "ordinal": 13,
+      "path": "/api/schedules/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_schedules",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List Schedules Api Schedules  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "list_schedules_route"
+      }
+    },
+    {
+      "ordinal": 14,
+      "path": "/api/schedules/limits",
+      "methods": [
+        "GET"
+      ],
+      "name": "schedule_limits",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Schedule Limits Api Schedules Limits Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "schedule_limits_route"
+      }
+    },
+    {
+      "ordinal": 15,
+      "path": "/api/schedules/{schedule_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_schedule",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Schedule Api Schedules  Schedule Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "get_schedule_route"
+      }
+    },
+    {
+      "ordinal": 16,
+      "path": "/api/schedules/",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_schedule",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "201": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Create Schedule Api Schedules  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 201,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "create_schedule_route"
+      }
+    },
+    {
+      "ordinal": 17,
+      "path": "/api/schedules/{schedule_id}",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "update_schedule",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Update Schedule Api Schedules  Schedule Id  Patch"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "update_schedule_route"
+      }
+    },
+    {
+      "ordinal": 18,
+      "path": "/api/schedules/{schedule_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_schedule",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Schedule Api Schedules  Schedule Id  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "delete_schedule_route"
+      }
+    },
+    {
+      "ordinal": 19,
+      "path": "/api/schedules/{schedule_id}/enable",
+      "methods": [
+        "POST"
+      ],
+      "name": "enable_schedule",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Enable Schedule Api Schedules  Schedule Id  Enable Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "enable_schedule_route"
+      }
+    },
+    {
+      "ordinal": 20,
+      "path": "/api/schedules/{schedule_id}/disable",
+      "methods": [
+        "POST"
+      ],
+      "name": "disable_schedule",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Disable Schedule Api Schedules  Schedule Id  Disable Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "disable_schedule_route"
+      }
+    },
+    {
+      "ordinal": 21,
+      "path": "/api/schedules/{schedule_id}/trigger",
+      "methods": [
+        "POST"
+      ],
+      "name": "trigger_schedule",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Trigger Schedule Api Schedules  Schedule Id  Trigger Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "trigger_schedule_route"
+      }
+    },
+    {
+      "ordinal": 22,
+      "path": "/api/schedules/{schedule_id}/runs",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_schedule_runs",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List Schedule Runs Api Schedules  Schedule Id  Runs Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "list_schedule_runs_route"
+      }
+    },
+    {
+      "ordinal": 23,
+      "path": "/api/schedules/runs/{run_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_schedule_run",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Schedule Run Api Schedules Runs  Run Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedule-runs",
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "get_schedule_run_route"
+      }
+    },
+    {
+      "ordinal": 24,
+      "path": "/api/schedules/{schedule_id}/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_schedule_status",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Schedule Status Api Schedules  Schedule Id  Status Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "schedules"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.schedules",
+        "qualname": "get_schedule_status_route"
+      }
+    },
+    {
+      "ordinal": 25,
+      "path": "/api/launches/",
+      "methods": [
+        "POST"
+      ],
+      "name": "launch_run",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "202": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Launch Run Api Launches  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 202,
+      "tags": [
+        "launches"
+      ],
+      "summary": null,
+      "description": "Fire an orchestration run immediately; process runs detached.\n\nReturns invocation_id; monitor via GET /api/invocations/{id} and GET /api/sessions/{id}/signals.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.launches",
+        "qualname": "launch_run"
+      }
+    },
+    {
+      "ordinal": 26,
+      "path": "/api/invocations/{invocation_id}/cancel",
+      "methods": [
+        "POST"
+      ],
+      "name": "cancel_launch",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "202": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Cancel Launch Api Invocations  Invocation Id  Cancel Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 202,
+      "tags": [
+        "launches"
+      ],
+      "summary": null,
+      "description": "Cancel an in-flight launch: terminate its detached process; the task records a cancelled invocation row.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.launches",
+        "qualname": "cancel_launch"
+      }
+    },
+    {
+      "ordinal": 27,
+      "path": "/api/runs/{run_id}/resume",
+      "methods": [
+        "GET"
+      ],
+      "name": "resume_availability",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Resume Availability Api Runs  Run Id  Resume Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "runs"
+      ],
+      "summary": null,
+      "description": "Read-only precheck: can this run be resumed, and why/why not.\n\nThe UI calls this before rendering the resume action so a run with no\ncheckpoint reads as an explicit, explained state rather than a dead or\nguessed-at control.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.run_resume",
+        "qualname": "resume_availability_route"
+      }
+    },
+    {
+      "ordinal": 28,
+      "path": "/api/runs/{run_id}/resume",
+      "methods": [
+        "POST"
+      ],
+      "name": "resume_run",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "202": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Resume Run Api Runs  Run Id  Resume Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 202,
+      "tags": [
+        "runs"
+      ],
+      "summary": null,
+      "description": "Resume any run that has an underlying branch or checkpoint, dispatched by invocation_kind.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.run_resume",
+        "qualname": "resume_run_route"
+      }
+    },
+    {
+      "ordinal": 29,
+      "path": "/api/engine-runs/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_engine_runs",
+      "response_model": "builtins.list",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "title": "Response List Engine Runs Api Engine Runs  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "engine-runs"
+      ],
+      "summary": null,
+      "description": "List engine runs, newest-first.  All query params are optional filters.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.engine_runs",
+        "qualname": "list_engine_runs_route"
+      }
+    },
+    {
+      "ordinal": 30,
+      "path": "/api/engine-runs/{run_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_engine_run",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Engine Run Api Engine Runs  Run Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "engine-runs"
+      ],
+      "summary": null,
+      "description": "Return a single engine run row by id.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.engine_runs",
+        "qualname": "get_engine_run_route"
+      }
+    },
+    {
+      "ordinal": 31,
+      "path": "/api/agents/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_agents",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Agents Api Agents  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "agents"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.agents",
+        "qualname": "list_agents_route"
+      }
+    },
+    {
+      "ordinal": 32,
+      "path": "/api/agents/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_agent",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Agent Api Agents  Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "agents"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.agents",
+        "qualname": "get_agent_route"
+      }
+    },
+    {
+      "ordinal": 33,
+      "path": "/api/agents/{name}",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_agent",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Create Agent Api Agents  Name  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "agents"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.agents",
+        "qualname": "create_agent_route"
+      }
+    },
+    {
+      "ordinal": 34,
+      "path": "/api/agents/{name}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_agent",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Update Agent Api Agents  Name  Put"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "agents"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.agents",
+        "qualname": "update_agent_route"
+      }
+    },
+    {
+      "ordinal": 35,
+      "path": "/api/agents/{name}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_agent",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Agent Api Agents  Name  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "agents"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.agents",
+        "qualname": "delete_agent_route"
+      }
+    },
+    {
+      "ordinal": 36,
+      "path": "/api/agents/{name}/validate",
+      "methods": [
+        "POST"
+      ],
+      "name": "validate_agent",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Validate Agent Api Agents  Name  Validate Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "agents"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.agents",
+        "qualname": "validate_agent"
+      }
+    },
+    {
+      "ordinal": 37,
+      "path": "/api/definitions/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_definitions",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List Definitions Api Definitions  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "definitions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.definitions",
+        "qualname": "list_definitions_route"
+      }
+    },
+    {
+      "ordinal": 38,
+      "path": "/api/definitions/{kind}/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_definition",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Definition Api Definitions  Kind   Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "definitions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.definitions",
+        "qualname": "get_definition_route"
+      }
+    },
+    {
+      "ordinal": 39,
+      "path": "/api/definitions/{kind}/{name}/versions/{version}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_version",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Version Api Definitions  Kind   Name  Versions  Version  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "definitions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.definitions",
+        "qualname": "get_version_route"
+      }
+    },
+    {
+      "ordinal": 40,
+      "path": "/api/definitions/{kind}/{name}",
+      "methods": [
+        "POST"
+      ],
+      "name": "save_definition",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Save Definition Api Definitions  Kind   Name  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "definitions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.definitions",
+        "qualname": "save_definition_route"
+      }
+    },
+    {
+      "ordinal": 41,
+      "path": "/api/definitions/{kind}/{name}/rollback",
+      "methods": [
+        "POST"
+      ],
+      "name": "rollback_definition",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Rollback Definition Api Definitions  Kind   Name  Rollback Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "definitions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.definitions",
+        "qualname": "rollback_definition_route"
+      }
+    },
+    {
+      "ordinal": 42,
+      "path": "/api/definitions/snapshot",
+      "methods": [
+        "POST"
+      ],
+      "name": "snapshot_current",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Snapshot Current Api Definitions Snapshot Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "definitions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.definitions",
+        "qualname": "snapshot_current_route"
+      }
+    },
+    {
+      "ordinal": 43,
+      "path": "/api/playbooks/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_playbooks",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Playbooks Api Playbooks  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "list_playbooks_route"
+      }
+    },
+    {
+      "ordinal": 44,
+      "path": "/api/playbooks/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_playbook",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Playbook Api Playbooks  Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "get_playbook_route"
+      }
+    },
+    {
+      "ordinal": 45,
+      "path": "/api/playbooks/{name}",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_playbook",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Create Playbook Api Playbooks  Name  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "create_playbook_route"
+      }
+    },
+    {
+      "ordinal": 46,
+      "path": "/api/playbooks/{name}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_playbook",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Update Playbook Api Playbooks  Name  Put"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "update_playbook_route"
+      }
+    },
+    {
+      "ordinal": 47,
+      "path": "/api/playbooks/{name}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_playbook",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Playbook Api Playbooks  Name  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "delete_playbook"
+      }
+    },
+    {
+      "ordinal": 48,
+      "path": "/api/playbooks/{name}/validate",
+      "methods": [
+        "POST"
+      ],
+      "name": "validate_playbook",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Validate Playbook Api Playbooks  Name  Validate Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "validate_playbook_route"
+      }
+    },
+    {
+      "ordinal": 49,
+      "path": "/api/playbooks/{name}/run",
+      "methods": [
+        "POST"
+      ],
+      "name": "run_playbook",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Run Playbook Api Playbooks  Name  Run Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "run_playbook"
+      }
+    },
+    {
+      "ordinal": 50,
+      "path": "/api/playbook-templates/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_builtin_playbooks",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Builtin Playbooks Api Playbook Templates  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "list_builtin_playbooks_route"
+      }
+    },
+    {
+      "ordinal": 51,
+      "path": "/api/playbook-templates/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_builtin_playbook",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Builtin Playbook Api Playbook Templates  Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "get_builtin_playbook_route"
+      }
+    },
+    {
+      "ordinal": 52,
+      "path": "/api/playbook-templates/{name}/install",
+      "methods": [
+        "POST"
+      ],
+      "name": "install_builtin_playbook",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Install Builtin Playbook Api Playbook Templates  Name  Install Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "playbooks"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.playbooks",
+        "qualname": "install_builtin_playbook_route"
+      }
+    },
+    {
+      "ordinal": 53,
+      "path": "/api/shows/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_shows",
+      "response_model": "builtins.list",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array",
+                "title": "Response List Shows Api Shows  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "shows"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.shows",
+        "qualname": "list_shows_route"
+      }
+    },
+    {
+      "ordinal": 54,
+      "path": "/api/shows/import",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_shows",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "type": "object",
+                "title": "Response Import Shows Api Shows Import Post"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "shows",
+        "shows"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.shows",
+        "qualname": "import_shows_route"
+      }
+    },
+    {
+      "ordinal": 55,
+      "path": "/api/shows/{topic}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_show",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Show Api Shows  Topic  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "shows"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.shows",
+        "qualname": "get_show_route"
+      }
+    },
+    {
+      "ordinal": 56,
+      "path": "/api/shows/{topic}/stream",
+      "methods": [
+        "GET"
+      ],
+      "name": "stream_show",
+      "response_model": null,
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "shows"
+      ],
+      "summary": null,
+      "description": "SSE stream of file changes under one show directory.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.shows",
+        "qualname": "stream_show"
+      }
+    },
+    {
+      "ordinal": 57,
+      "path": "/api/skills/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_skills",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Skills Api Skills  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "skills"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.skills",
+        "qualname": "list_skills_route"
+      }
+    },
+    {
+      "ordinal": 58,
+      "path": "/api/skills/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_skill",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Skill Api Skills  Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "skills"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.skills",
+        "qualname": "get_skill_route"
+      }
+    },
+    {
+      "ordinal": 59,
+      "path": "/api/plugins",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_plugins_endpoint",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Plugins Endpoint Api Plugins Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "plugins"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.plugins",
+        "qualname": "list_plugins_endpoint"
+      }
+    },
+    {
+      "ordinal": 60,
+      "path": "/api/plugins/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_endpoint",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Plugin Endpoint Api Plugins  Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "plugins"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.plugins",
+        "qualname": "get_plugin_endpoint"
+      }
+    },
+    {
+      "ordinal": 61,
+      "path": "/api/plugins/{plugin_name}/skills/{skill_name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_skill_endpoint",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Plugin Skill Endpoint Api Plugins  Plugin Name  Skills  Skill Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "plugins"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.plugins",
+        "qualname": "get_plugin_skill_endpoint"
+      }
+    },
+    {
+      "ordinal": 62,
+      "path": "/api/plugins/{plugin_name}/agents/{agent_name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_agent_endpoint",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Plugin Agent Endpoint Api Plugins  Plugin Name  Agents  Agent Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "plugins"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.plugins",
+        "qualname": "get_plugin_agent_endpoint"
+      }
+    },
+    {
+      "ordinal": 63,
+      "path": "/api/mcp/servers/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_mcp_servers",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Mcp Servers Api Mcp Servers  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "list_mcp_servers_route"
+      }
+    },
+    {
+      "ordinal": 64,
+      "path": "/api/mcp/servers/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_mcp_server",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Mcp Server Api Mcp Servers  Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "get_mcp_server_route"
+      }
+    },
+    {
+      "ordinal": 65,
+      "path": "/api/mcp/servers/",
+      "methods": [
+        "POST"
+      ],
+      "name": "register_mcp_server",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "201": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Register Mcp Server Api Mcp Servers  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 201,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "register_mcp_server_route"
+      }
+    },
+    {
+      "ordinal": 66,
+      "path": "/api/mcp/servers/{name}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_mcp_server",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Update Mcp Server Api Mcp Servers  Name  Put"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "update_mcp_server_route"
+      }
+    },
+    {
+      "ordinal": 67,
+      "path": "/api/mcp/servers/{name}/enable",
+      "methods": [
+        "POST"
+      ],
+      "name": "enable_mcp_server",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Enable Mcp Server Api Mcp Servers  Name  Enable Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "enable_mcp_server_route"
+      }
+    },
+    {
+      "ordinal": 68,
+      "path": "/api/mcp/servers/{name}/disable",
+      "methods": [
+        "POST"
+      ],
+      "name": "disable_mcp_server",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Disable Mcp Server Api Mcp Servers  Name  Disable Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "disable_mcp_server_route"
+      }
+    },
+    {
+      "ordinal": 69,
+      "path": "/api/mcp/servers/{name}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_mcp_server",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Mcp Server Api Mcp Servers  Name  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "delete_mcp_server_route"
+      }
+    },
+    {
+      "ordinal": 70,
+      "path": "/api/mcp/servers/{name}/check",
+      "methods": [
+        "POST"
+      ],
+      "name": "check_mcp_server",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Check Mcp Server Api Mcp Servers  Name  Check Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "check_mcp_server_route"
+      }
+    },
+    {
+      "ordinal": 71,
+      "path": "/api/mcp/servers/{name}/validate",
+      "methods": [
+        "POST"
+      ],
+      "name": "validate_mcp_server",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Validate Mcp Server Api Mcp Servers  Name  Validate Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "mcp"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.mcp_servers",
+        "qualname": "validate_mcp_server_route"
+      }
+    },
+    {
+      "ordinal": 72,
+      "path": "/api/teams/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_teams",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List Teams Api Teams  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "teams"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.teams",
+        "qualname": "list_teams_route"
+      }
+    },
+    {
+      "ordinal": 73,
+      "path": "/api/teams/{team_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_team",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Team Api Teams  Team Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "teams"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.teams",
+        "qualname": "get_team_route"
+      }
+    },
+    {
+      "ordinal": 74,
+      "path": "/api/invocations/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_invocations",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List Invocations Api Invocations  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "invocations"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.invocations",
+        "qualname": "list_invocations_route"
+      }
+    },
+    {
+      "ordinal": 75,
+      "path": "/api/invocations/{invocation_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_invocation",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Invocation Api Invocations  Invocation Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "invocations"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.invocations",
+        "qualname": "get_invocation_route"
+      }
+    },
+    {
+      "ordinal": 76,
+      "path": "/api/artifacts/{artifact_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_artifact",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Artifact Api Artifacts  Artifact Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "artifacts"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.invocations",
+        "qualname": "get_artifact_route"
+      }
+    },
+    {
+      "ordinal": 77,
+      "path": "/api/artifacts/by-session/{session_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_for_session",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List For Session Api Artifacts By Session  Session Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "artifacts"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.invocations",
+        "qualname": "list_for_session"
+      }
+    },
+    {
+      "ordinal": 78,
+      "path": "/api/projects/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_projects",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Projects Api Projects  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "projects"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.projects",
+        "qualname": "list_projects_route"
+      }
+    },
+    {
+      "ordinal": 79,
+      "path": "/api/projects/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_project",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Project Api Projects  Name  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "projects"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.projects",
+        "qualname": "get_project_route"
+      }
+    },
+    {
+      "ordinal": 80,
+      "path": "/api/projects/",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_project",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "201": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Create Project Api Projects  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 201,
+      "tags": [
+        "projects"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.projects",
+        "qualname": "create_project_route"
+      }
+    },
+    {
+      "ordinal": 81,
+      "path": "/api/projects/{name}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_project",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Update Project Api Projects  Name  Put"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "projects"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.projects",
+        "qualname": "update_project_route"
+      }
+    },
+    {
+      "ordinal": 82,
+      "path": "/api/projects/{name}/assign",
+      "methods": [
+        "POST"
+      ],
+      "name": "assign_project",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Assign Project Api Projects  Name  Assign Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "projects"
+      ],
+      "summary": null,
+      "description": "Assign sessions to a project. Use session_ids for specific ones, or all_unassigned=true.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.projects",
+        "qualname": "assign_project"
+      }
+    },
+    {
+      "ordinal": 83,
+      "path": "/api/projects/{name}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_project",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Project Api Projects  Name  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "projects"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.projects",
+        "qualname": "delete_project_route"
+      }
+    },
+    {
+      "ordinal": 84,
+      "path": "/api/engine-defs/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_engine_defs",
+      "response_model": "builtins.list",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "title": "Response List Engine Defs Api Engine Defs  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "engine-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.engine_defs",
+        "qualname": "list_engine_defs_route"
+      }
+    },
+    {
+      "ordinal": 85,
+      "path": "/api/engine-defs/",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_engine_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "201": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Create Engine Def Api Engine Defs  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 201,
+      "tags": [
+        "engine-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.engine_defs",
+        "qualname": "create_engine_def_route"
+      }
+    },
+    {
+      "ordinal": 86,
+      "path": "/api/engine-defs/{def_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_engine_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Engine Def Api Engine Defs  Def Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "engine-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.engine_defs",
+        "qualname": "get_engine_def_route"
+      }
+    },
+    {
+      "ordinal": 87,
+      "path": "/api/engine-defs/{def_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_engine_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Update Engine Def Api Engine Defs  Def Id  Put"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "engine-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.engine_defs",
+        "qualname": "update_engine_def_route"
+      }
+    },
+    {
+      "ordinal": 88,
+      "path": "/api/engine-defs/{def_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_engine_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Engine Def Api Engine Defs  Def Id  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "engine-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.engine_defs",
+        "qualname": "delete_engine_def_route"
+      }
+    },
+    {
+      "ordinal": 89,
+      "path": "/api/workflow-defs/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_workflow_defs",
+      "response_model": "builtins.list",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "title": "Response List Workflow Defs Api Workflow Defs  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "workflow-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.workflow_defs",
+        "qualname": "list_workflow_defs_route"
+      }
+    },
+    {
+      "ordinal": 90,
+      "path": "/api/workflow-defs/",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_workflow_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "201": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Create Workflow Def Api Workflow Defs  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 201,
+      "tags": [
+        "workflow-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.workflow_defs",
+        "qualname": "create_workflow_def_route"
+      }
+    },
+    {
+      "ordinal": 91,
+      "path": "/api/workflow-defs/{def_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_workflow_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Workflow Def Api Workflow Defs  Def Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "workflow-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.workflow_defs",
+        "qualname": "get_workflow_def_route"
+      }
+    },
+    {
+      "ordinal": 92,
+      "path": "/api/workflow-defs/{def_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_workflow_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Update Workflow Def Api Workflow Defs  Def Id  Put"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "workflow-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.workflow_defs",
+        "qualname": "update_workflow_def_route"
+      }
+    },
+    {
+      "ordinal": 93,
+      "path": "/api/workflow-defs/{def_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_workflow_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Workflow Def Api Workflow Defs  Def Id  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "workflow-defs"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.workflow_defs",
+        "qualname": "delete_workflow_def_route"
+      }
+    },
+    {
+      "ordinal": 94,
+      "path": "/api/workflow-defs/{def_id}/run",
+      "methods": [
+        "POST"
+      ],
+      "name": "run_workflow_def",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "202": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Run Workflow Def Api Workflow Defs  Def Id  Run Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 202,
+      "tags": [
+        "workflow-defs"
+      ],
+      "summary": null,
+      "description": "Compile *def_id* and execute it via Session.flow; returns {run_id, status}.\n\nrun_id is the same id GET /api/sessions/{id} already reads \u2014 no new telemetry surface.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.workflow_defs",
+        "qualname": "run_workflow_def_route"
+      }
+    },
+    {
+      "ordinal": 95,
+      "path": "/api/sessions/{session_id}/tags",
+      "methods": [
+        "POST"
+      ],
+      "name": "add_run_tag",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Add Run Tag Api Sessions  Session Id  Tags Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "sessions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.run_tags",
+        "qualname": "add_run_tag"
+      }
+    },
+    {
+      "ordinal": 96,
+      "path": "/api/sessions/{session_id}/tags/{tag:path}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "remove_run_tag",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Remove Run Tag Api Sessions  Session Id  Tags  Tag  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "sessions"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.run_tags",
+        "qualname": "remove_run_tag"
+      }
+    },
+    {
+      "ordinal": 97,
+      "path": "/api/operator/conversations",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_operator_conversations",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response List Operator Conversations Api Operator Conversations Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "list_operator_conversations"
+      }
+    },
+    {
+      "ordinal": 98,
+      "path": "/api/operator/conversations",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_operator_conversation",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Create Operator Conversation Api Operator Conversations Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "create_operator_conversation"
+      }
+    },
+    {
+      "ordinal": 99,
+      "path": "/api/operator/conversations/{conversation_id}",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "update_operator_conversation",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Update Operator Conversation Api Operator Conversations  Conversation Id  Patch"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "update_operator_conversation"
+      }
+    },
+    {
+      "ordinal": 100,
+      "path": "/api/operator/conversations/{conversation_id}/fork",
+      "methods": [
+        "POST"
+      ],
+      "name": "fork_operator_conversation",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "201": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Fork Operator Conversation Api Operator Conversations  Conversation Id  Fork Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 201,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "fork_operator_conversation"
+      }
+    },
+    {
+      "ordinal": 101,
+      "path": "/api/operator/conversations/{conversation_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_operator_conversation",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Operator Conversation Api Operator Conversations  Conversation Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "get_operator_conversation"
+      }
+    },
+    {
+      "ordinal": 102,
+      "path": "/api/operator/conversations/{conversation_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_operator_conversation",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Operator Conversation Api Operator Conversations  Conversation Id  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "delete_operator_conversation"
+      }
+    },
+    {
+      "ordinal": 103,
+      "path": "/api/operator/conversations/{conversation_id}/turns",
+      "methods": [
+        "POST"
+      ],
+      "name": "submit_operator_turn",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "202": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Submit Operator Turn Api Operator Conversations  Conversation Id  Turns Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 202,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "submit_operator_turn"
+      }
+    },
+    {
+      "ordinal": 104,
+      "path": "/api/operator/models",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_operator_models",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Operator Models Api Operator Models Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": "The Operator's model catalog: every model the daemon can actually drive,\ngrouped by provider, with the reasoning-effort levels each accepts.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "list_operator_models"
+      }
+    },
+    {
+      "ordinal": 105,
+      "path": "/api/operator/conversations/{conversation_id}/view",
+      "methods": [
+        "POST"
+      ],
+      "name": "report_operator_view",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Report Operator View Api Operator Conversations  Conversation Id  View Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": "Record where the human is now, so the Operator can read it mid-turn.\n\nA turn's context is frozen at submit. Without this the Operator answers\n\"where am I\" with wherever the human was when they hit send, which is\nwrong precisely when they have moved since.\n\nA report that does not count higher than the one already stored by the same\npage is discarded, since reports race and the loser of that race is the\nstale view.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "report_operator_view"
+      }
+    },
+    {
+      "ordinal": 106,
+      "path": "/api/operator/conversations/{conversation_id}/requests/{request_id}/cancel",
+      "methods": [
+        "POST"
+      ],
+      "name": "cancel_operator_turn",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "202": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Cancel Operator Turn Api Operator Conversations  Conversation Id  Requests  Request Id  Cancel Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": 202,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "cancel_operator_turn"
+      }
+    },
+    {
+      "ordinal": 107,
+      "path": "/api/operator/conversations/{conversation_id}/stream",
+      "methods": [
+        "GET"
+      ],
+      "name": "stream_operator_conversation",
+      "response_model": null,
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "stream_operator_conversation"
+      }
+    },
+    {
+      "ordinal": 108,
+      "path": "/api/operator/conversations/{conversation_id}/proposals/{proposal_id}/confirm",
+      "methods": [
+        "POST"
+      ],
+      "name": "confirm_operator_proposal",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Confirm Operator Proposal Api Operator Conversations  Conversation Id  Proposals  Proposal Id  Confirm Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "confirm_operator_proposal"
+      }
+    },
+    {
+      "ordinal": 109,
+      "path": "/api/operator/conversations/{conversation_id}/proposals/{proposal_id}/decision",
+      "methods": [
+        "POST"
+      ],
+      "name": "decide_operator_proposal",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Decide Operator Proposal Api Operator Conversations  Conversation Id  Proposals  Proposal Id  Decision Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "decide_operator_proposal"
+      }
+    },
+    {
+      "ordinal": 110,
+      "path": "/api/operator/conversations/{conversation_id}/effects/{effect_id}/ack",
+      "methods": [
+        "POST"
+      ],
+      "name": "acknowledge_operator_effect",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Acknowledge Operator Effect Api Operator Conversations  Conversation Id  Effects  Effect Id  Ack Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "operator"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.operator",
+        "qualname": "acknowledge_operator_effect"
+      }
+    },
+    {
+      "ordinal": 111,
+      "path": "/api/approvals/",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_approval",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Create Approval Api Approvals  Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "approvals"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.approvals",
+        "qualname": "create_approval_route"
+      }
+    },
+    {
+      "ordinal": 112,
+      "path": "/api/approvals/evidence/verify",
+      "methods": [
+        "GET"
+      ],
+      "name": "verify_approval_evidence",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Verify Approval Evidence Api Approvals Evidence Verify Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "approvals"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.approvals",
+        "qualname": "verify_approval_evidence_route"
+      }
+    },
+    {
+      "ordinal": 113,
+      "path": "/api/approvals/{approval_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_approval",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Approval Api Approvals  Approval Id  Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "approvals"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.approvals",
+        "qualname": "get_approval_route"
+      }
+    },
+    {
+      "ordinal": 114,
+      "path": "/api/approvals/{approval_id}/grant",
+      "methods": [
+        "POST"
+      ],
+      "name": "grant_approval",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Grant Approval Api Approvals  Approval Id  Grant Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "approvals"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.approvals",
+        "qualname": "grant_approval_route"
+      }
+    },
+    {
+      "ordinal": 115,
+      "path": "/api/approvals/{approval_id}/deny",
+      "methods": [
+        "POST"
+      ],
+      "name": "deny_approval",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Deny Approval Api Approvals  Approval Id  Deny Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "approvals"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.approvals",
+        "qualname": "deny_approval_route"
+      }
+    },
+    {
+      "ordinal": 116,
+      "path": "/api/admin/doctor",
+      "methods": [
+        "GET"
+      ],
+      "name": "doctor",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Doctor Api Admin Doctor Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "admin"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.admin",
+        "qualname": "doctor_route"
+      }
+    },
+    {
+      "ordinal": 117,
+      "path": "/api/admin/health",
+      "methods": [
+        "GET"
+      ],
+      "name": "health",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Health Api Admin Health Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "admin"
+      ],
+      "summary": null,
+      "description": "ADR-0057 D6: composite session health report.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.admin",
+        "qualname": "health_route"
+      }
+    },
+    {
+      "ordinal": 118,
+      "path": "/api/admin/readiness",
+      "methods": [
+        "GET"
+      ],
+      "name": "readiness",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Readiness Api Admin Readiness Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "admin"
+      ],
+      "summary": null,
+      "description": "Whether a query against the store will actually return.\n\nDistinct from ``/health``, which answers only whether the process is up:\nthat stays true while every database-backed endpoint is unresponsive, which\nis exactly the failure this reports. Never 5xx -- the verdict is in the\nbody, so a caller can tell \"store unreachable\" from \"store slow\" from\n\"healthy\" instead of getting one boolean for all three.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.admin",
+        "qualname": "readiness_route"
+      }
+    },
+    {
+      "ordinal": 119,
+      "path": "/api/admin/transition",
+      "methods": [
+        "POST"
+      ],
+      "name": "transition",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Transition Api Admin Transition Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "admin"
+      ],
+      "summary": null,
+      "description": "Mark running sessions terminal with a reason code.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.admin",
+        "qualname": "transition_route"
+      }
+    },
+    {
+      "ordinal": 120,
+      "path": "/api/admin/events",
+      "methods": [
+        "GET"
+      ],
+      "name": "admin_events",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Admin Events Api Admin Events Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "admin"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.admin",
+        "qualname": "admin_events_route"
+      }
+    },
+    {
+      "ordinal": 121,
+      "path": "/api/admin/prune-old-data",
+      "methods": [
+        "POST"
+      ],
+      "name": "prune_old_data",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "type": "object",
+                "title": "Response Prune Old Data Api Admin Prune Old Data Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "admin"
+      ],
+      "summary": null,
+      "description": "Remove terminal sessions/runs older than keep_days (default from config).",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.admin",
+        "qualname": "prune_old_data_route"
+      }
+    },
+    {
+      "ordinal": 122,
+      "path": "/api/admin/maintenance",
+      "methods": [
+        "POST"
+      ],
+      "name": "run_maintenance",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Run Maintenance Api Admin Maintenance Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "admin"
+      ],
+      "summary": null,
+      "description": "Run a DB maintenance action (vacuum | checkpoint | prune). Returns 409,\nnot 500, when SQLite can't acquire the write lock \u2014 a retryable signal.",
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.admin",
+        "qualname": "run_maintenance_route"
+      }
+    },
+    {
+      "ordinal": 123,
+      "path": "/api/admin/prune",
+      "methods": [
+        "POST"
+      ],
+      "name": "prune",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": {
+                  "type": "integer"
+                },
+                "type": "object",
+                "title": "Response Prune Api Admin Prune Post"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "admin"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.admin",
+        "qualname": "prune_route"
+      }
+    },
+    {
+      "ordinal": 124,
+      "path": "/api/stats/activity",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_activity_stats",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Activity Stats Api Stats Activity Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.stats",
+        "qualname": "get_activity_stats_route"
+      }
+    },
+    {
+      "ordinal": 125,
+      "path": "/api/stats/spend",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_spend_stats",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Spend Stats Api Stats Spend Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.stats",
+        "qualname": "get_spend_stats_route"
+      }
+    },
+    {
+      "ordinal": 126,
+      "path": "/api/stats/spend/rollup",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_spend_rollup",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Spend Rollup Api Stats Spend Rollup Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.stats",
+        "qualname": "get_spend_rollup_route"
+      }
+    },
+    {
+      "ordinal": 127,
+      "path": "/api/stats",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_stats",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Get Stats Api Stats Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.stats",
+        "qualname": "get_stats_route"
+      }
+    },
+    {
+      "ordinal": 128,
+      "path": "/api/attention/dispositions/",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_attention_dispositions",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response List Attention Dispositions Api Attention Dispositions  Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "attention"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.attention",
+        "qualname": "list_attention_dispositions_route"
+      }
+    },
+    {
+      "ordinal": 129,
+      "path": "/api/attention/dispositions/{item_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "put_attention_disposition",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Put Attention Disposition Api Attention Dispositions  Item Id  Put"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "attention"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.attention",
+        "qualname": "put_attention_disposition_route"
+      }
+    },
+    {
+      "ordinal": 130,
+      "path": "/api/attention/dispositions/{item_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_attention_disposition",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Delete Attention Disposition Api Attention Dispositions  Item Id  Delete"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "attention"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.attention",
+        "qualname": "delete_attention_disposition_route"
+      }
+    },
+    {
+      "ordinal": 131,
+      "path": "/api/attention/dispositions/{item_id}/history",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_attention_disposition_history",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "title": "Response Get Attention Disposition History Api Attention Dispositions  Item Id  History Get"
+              }
+            }
+          }
+        },
+        "422": {
+          "description": "Validation Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HTTPValidationError"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [
+        "attention"
+      ],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.services.attention",
+        "qualname": "get_attention_disposition_history_route"
+      }
+    },
+    {
+      "ordinal": 132,
+      "path": "/health",
+      "methods": [
+        "GET"
+      ],
+      "name": "health",
+      "response_model": "builtins.dict",
+      "dependencies": [],
+      "response_class": {
+        "default_placeholder": "starlette.responses.JSONResponse"
+      },
+      "responses": {
+        "200": {
+          "description": "Successful Response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Response Health Health Get"
+              }
+            }
+          }
+        }
+      },
+      "status_code": null,
+      "tags": [],
+      "summary": null,
+      "description": null,
+      "include_in_schema": true,
+      "handler_identity": {
+        "module": "lionagi.studio.app",
+        "qualname": "create_app.<locals>.health"
+      }
+    }
+  ],
+  "openapi": {
+    "openapi": "3.1.0",
+    "info": {
+      "title": "Lion Studio Server",
+      "version": "0.33.0"
+    },
+    "paths": {
+      "/api/admin/doctor": {
+        "get": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Doctor",
+          "parameters": [
+            {
+              "name": "stale_hours",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "default": 1.0,
+                "title": "Stale Hours"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Doctor Api Admin Doctor Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/admin/events": {
+        "get": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Admin Events",
+          "parameters": [
+            {
+              "name": "action",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Action"
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 1000,
+                "minimum": 1,
+                "default": 100,
+                "title": "Limit"
+              }
+            },
+            {
+              "name": "target_id",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Target Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Admin Events Api Admin Events Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/admin/health": {
+        "get": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Health",
+          "description": "ADR-0057 D6: composite session health report.",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Health Api Admin Health Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/admin/maintenance": {
+        "post": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Run Maintenance",
+          "description": "Run a DB maintenance action (vacuum | checkpoint | prune). Returns 409,\nnot 500, when SQLite can't acquire the write lock \u2014 a retryable signal.",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceBody"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Run Maintenance Api Admin Maintenance Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/admin/prune": {
+        "post": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Prune",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PruneBody"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": {
+                      "type": "integer"
+                    },
+                    "type": "object",
+                    "title": "Response Prune Api Admin Prune Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/admin/prune-old-data": {
+        "post": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Prune Old Data",
+          "description": "Remove terminal sessions/runs older than keep_days (default from config).",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PruneOldDataBody"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": {
+                      "type": "integer"
+                    },
+                    "type": "object",
+                    "title": "Response Prune Old Data Api Admin Prune Old Data Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/admin/readiness": {
+        "get": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Readiness",
+          "description": "Whether a query against the store will actually return.\n\nDistinct from ``/health``, which answers only whether the process is up:\nthat stays true while every database-backed endpoint is unresponsive, which\nis exactly the failure this reports. Never 5xx -- the verdict is in the\nbody, so a caller can tell \"store unreachable\" from \"store slow\" from\n\"healthy\" instead of getting one boolean for all three.",
+          "parameters": [
+            {
+              "name": "timeout_ms",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 10000,
+                "minimum": 50,
+                "description": "How long the probe waits for the store before reporting slow",
+                "default": 1000,
+                "title": "Timeout Ms"
+              },
+              "description": "How long the probe waits for the store before reporting slow"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Readiness Api Admin Readiness Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/admin/transition": {
+        "post": {
+          "tags": [
+            "admin"
+          ],
+          "summary": "Transition",
+          "description": "Mark running sessions terminal with a reason code.",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransitionBody"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Transition Api Admin Transition Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/agents/": {
+        "get": {
+          "tags": [
+            "agents"
+          ],
+          "summary": "List Agents",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Agents Api Agents  Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/agents/{name}": {
+        "delete": {
+          "tags": [
+            "agents"
+          ],
+          "summary": "Delete Agent",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Agent Api Agents  Name  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "tags": [
+            "agents"
+          ],
+          "summary": "Get Agent",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Agent Api Agents  Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "agents"
+          ],
+          "summary": "Create Agent",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Create Agent Api Agents  Name  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "agents"
+          ],
+          "summary": "Update Agent",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Update Agent Api Agents  Name  Put"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/agents/{name}/validate": {
+        "post": {
+          "tags": [
+            "agents"
+          ],
+          "summary": "Validate Agent",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Validate Agent Api Agents  Name  Validate Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/approvals/": {
+        "post": {
+          "tags": [
+            "approvals"
+          ],
+          "summary": "Create Approval",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_CreateApprovalBody"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Create Approval Api Approvals  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/approvals/evidence/verify": {
+        "get": {
+          "tags": [
+            "approvals"
+          ],
+          "summary": "Verify Approval Evidence",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Verify Approval Evidence Api Approvals Evidence Verify Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/approvals/{approval_id}": {
+        "get": {
+          "tags": [
+            "approvals"
+          ],
+          "summary": "Get Approval",
+          "parameters": [
+            {
+              "name": "approval_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Approval Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Approval Api Approvals  Approval Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/approvals/{approval_id}/deny": {
+        "post": {
+          "tags": [
+            "approvals"
+          ],
+          "summary": "Deny Approval",
+          "parameters": [
+            {
+              "name": "approval_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Approval Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/_DenyBody"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Deny Approval Api Approvals  Approval Id  Deny Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/approvals/{approval_id}/grant": {
+        "post": {
+          "tags": [
+            "approvals"
+          ],
+          "summary": "Grant Approval",
+          "parameters": [
+            {
+              "name": "approval_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Approval Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Grant Approval Api Approvals  Approval Id  Grant Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/artifacts/by-session/{session_id}": {
+        "get": {
+          "tags": [
+            "artifacts"
+          ],
+          "summary": "List For Session",
+          "parameters": [
+            {
+              "name": "session_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Session Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List For Session Api Artifacts By Session  Session Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/artifacts/{artifact_id}": {
+        "get": {
+          "tags": [
+            "artifacts"
+          ],
+          "summary": "Get Artifact",
+          "parameters": [
+            {
+              "name": "artifact_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Artifact Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Artifact Api Artifacts  Artifact Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/attention/dispositions/": {
+        "get": {
+          "tags": [
+            "attention"
+          ],
+          "summary": "List Attention Dispositions",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Attention Dispositions Api Attention Dispositions  Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/attention/dispositions/{item_id}": {
+        "delete": {
+          "tags": [
+            "attention"
+          ],
+          "summary": "Delete Attention Disposition",
+          "parameters": [
+            {
+              "name": "item_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Item Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Attention Disposition Api Attention Dispositions  Item Id  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "attention"
+          ],
+          "summary": "Put Attention Disposition",
+          "parameters": [
+            {
+              "name": "item_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Item Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_DispositionBody"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Put Attention Disposition Api Attention Dispositions  Item Id  Put"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/attention/dispositions/{item_id}/history": {
+        "get": {
+          "tags": [
+            "attention"
+          ],
+          "summary": "Get Attention Disposition History",
+          "parameters": [
+            {
+              "name": "item_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Item Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Attention Disposition History Api Attention Dispositions  Item Id  History Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/casts/": {
+        "get": {
+          "tags": [
+            "casts"
+          ],
+          "summary": "Get Casts",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Get Casts Api Casts  Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/definitions/": {
+        "get": {
+          "tags": [
+            "definitions"
+          ],
+          "summary": "List Definitions",
+          "parameters": [
+            {
+              "name": "kind",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Filter by kind: agent, playbook",
+                "title": "Kind"
+              },
+              "description": "Filter by kind: agent, playbook"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List Definitions Api Definitions  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/definitions/snapshot": {
+        "post": {
+          "tags": [
+            "definitions"
+          ],
+          "summary": "Snapshot Current",
+          "parameters": [
+            {
+              "name": "kind",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Kind"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Snapshot Current Api Definitions Snapshot Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/definitions/{kind}/{name}": {
+        "get": {
+          "tags": [
+            "definitions"
+          ],
+          "summary": "Get Definition",
+          "parameters": [
+            {
+              "name": "kind",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Kind"
+              }
+            },
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Definition Api Definitions  Kind   Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "definitions"
+          ],
+          "summary": "Save Definition",
+          "parameters": [
+            {
+              "name": "kind",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Kind"
+              }
+            },
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SaveBody"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Save Definition Api Definitions  Kind   Name  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/definitions/{kind}/{name}/rollback": {
+        "post": {
+          "tags": [
+            "definitions"
+          ],
+          "summary": "Rollback Definition",
+          "parameters": [
+            {
+              "name": "kind",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Kind"
+              }
+            },
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            },
+            {
+              "name": "version",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "integer",
+                "description": "Target version to restore",
+                "title": "Version"
+              },
+              "description": "Target version to restore"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Rollback Definition Api Definitions  Kind   Name  Rollback Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/definitions/{kind}/{name}/versions/{version}": {
+        "get": {
+          "tags": [
+            "definitions"
+          ],
+          "summary": "Get Version",
+          "parameters": [
+            {
+              "name": "kind",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Kind"
+              }
+            },
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            },
+            {
+              "name": "version",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "integer",
+                "title": "Version"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Version Api Definitions  Kind   Name  Versions  Version  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/engine-defs/": {
+        "get": {
+          "tags": [
+            "engine-defs"
+          ],
+          "summary": "List Engine Defs",
+          "parameters": [
+            {
+              "name": "kind",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Kind"
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 200,
+                "minimum": 1,
+                "default": 100,
+                "title": "Limit"
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "title": "Offset"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "title": "Response List Engine Defs Api Engine Defs  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "engine-defs"
+          ],
+          "summary": "Create Engine Def",
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateEngineDefRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "201": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Create Engine Def Api Engine Defs  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/engine-defs/{def_id}": {
+        "delete": {
+          "tags": [
+            "engine-defs"
+          ],
+          "summary": "Delete Engine Def",
+          "parameters": [
+            {
+              "name": "def_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Def Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Engine Def Api Engine Defs  Def Id  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "tags": [
+            "engine-defs"
+          ],
+          "summary": "Get Engine Def",
+          "parameters": [
+            {
+              "name": "def_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Def Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Engine Def Api Engine Defs  Def Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "engine-defs"
+          ],
+          "summary": "Update Engine Def",
+          "parameters": [
+            {
+              "name": "def_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Def Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateEngineDefRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Update Engine Def Api Engine Defs  Def Id  Put"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/engine-runs/": {
+        "get": {
+          "tags": [
+            "engine-runs"
+          ],
+          "summary": "List Engine Runs",
+          "description": "List engine runs, newest-first.  All query params are optional filters.",
+          "parameters": [
+            {
+              "name": "kind",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Filter by engine kind.",
+                "title": "Kind"
+              },
+              "description": "Filter by engine kind."
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 500,
+                "minimum": 1,
+                "default": 100,
+                "title": "Limit"
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "title": "Offset"
+              }
+            },
+            {
+              "name": "session_id",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Filter by associated session id.",
+                "title": "Session Id"
+              },
+              "description": "Filter by associated session id."
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Filter by status.",
+                "title": "Status"
+              },
+              "description": "Filter by status."
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "title": "Response List Engine Runs Api Engine Runs  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/engine-runs/{run_id}": {
+        "get": {
+          "tags": [
+            "engine-runs"
+          ],
+          "summary": "Get Engine Run",
+          "description": "Return a single engine run row by id.",
+          "parameters": [
+            {
+              "name": "run_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Run Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Engine Run Api Engine Runs  Run Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/invocations/": {
+        "get": {
+          "tags": [
+            "invocations"
+          ],
+          "summary": "List Invocations",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 200,
+                "minimum": 1,
+                "default": 50,
+                "title": "Limit"
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "title": "Offset"
+              }
+            },
+            {
+              "name": "skill",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Skill"
+              }
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Status"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List Invocations Api Invocations  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/invocations/{invocation_id}": {
+        "get": {
+          "tags": [
+            "invocations"
+          ],
+          "summary": "Get Invocation",
+          "parameters": [
+            {
+              "name": "invocation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Invocation Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Invocation Api Invocations  Invocation Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/invocations/{invocation_id}/cancel": {
+        "post": {
+          "tags": [
+            "launches"
+          ],
+          "summary": "Cancel Launch",
+          "description": "Cancel an in-flight launch: terminate its detached process; the task records a cancelled invocation row.",
+          "parameters": [
+            {
+              "name": "invocation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Invocation Id"
+              }
+            }
+          ],
+          "responses": {
+            "202": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Cancel Launch Api Invocations  Invocation Id  Cancel Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/launches/": {
+        "post": {
+          "tags": [
+            "launches"
+          ],
+          "summary": "Launch Run",
+          "description": "Fire an orchestration run immediately; process runs detached.\n\nReturns invocation_id; monitor via GET /api/invocations/{id} and GET /api/sessions/{id}/signals.",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchRequest"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "202": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Launch Run Api Launches  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/mcp/servers/": {
+        "get": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "List Mcp Servers",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Mcp Servers Api Mcp Servers  Get"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "Register Mcp Server",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Body"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Register Mcp Server Api Mcp Servers  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/mcp/servers/{name}": {
+        "delete": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "Delete Mcp Server",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Mcp Server Api Mcp Servers  Name  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "Get Mcp Server",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Mcp Server Api Mcp Servers  Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "Update Mcp Server",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Update Mcp Server Api Mcp Servers  Name  Put"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/mcp/servers/{name}/check": {
+        "post": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "Check Mcp Server",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Check Mcp Server Api Mcp Servers  Name  Check Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/mcp/servers/{name}/disable": {
+        "post": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "Disable Mcp Server",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Disable Mcp Server Api Mcp Servers  Name  Disable Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/mcp/servers/{name}/enable": {
+        "post": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "Enable Mcp Server",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Enable Mcp Server Api Mcp Servers  Name  Enable Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/mcp/servers/{name}/validate": {
+        "post": {
+          "tags": [
+            "mcp"
+          ],
+          "summary": "Validate Mcp Server",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Validate Mcp Server Api Mcp Servers  Name  Validate Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations": {
+        "get": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "List Operator Conversations",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 500,
+                "minimum": 1,
+                "default": 100,
+                "title": "Limit"
+              }
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "enum": [
+                  "active",
+                  "archived",
+                  "all"
+                ],
+                "type": "string",
+                "default": "active",
+                "title": "Status"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List Operator Conversations Api Operator Conversations Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Create Operator Conversation",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/CreateConversationRequest"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Create Operator Conversation Api Operator Conversations Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}": {
+        "delete": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Delete Operator Conversation",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Operator Conversation Api Operator Conversations  Conversation Id  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Get Operator Conversation",
+          "parameters": [
+            {
+              "name": "after_sequence",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "title": "After Sequence"
+              }
+            },
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            },
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 1000,
+                "minimum": 1,
+                "default": 1000,
+                "title": "Limit"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Operator Conversation Api Operator Conversations  Conversation Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Update Operator Conversation",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateConversationRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Update Operator Conversation Api Operator Conversations  Conversation Id  Patch"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}/effects/{effect_id}/ack": {
+        "post": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Acknowledge Operator Effect",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            },
+            {
+              "name": "effect_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Effect Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcknowledgeEffectRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Acknowledge Operator Effect Api Operator Conversations  Conversation Id  Effects  Effect Id  Ack Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}/fork": {
+        "post": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Fork Operator Conversation",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ForkConversationRequest"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "201": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Fork Operator Conversation Api Operator Conversations  Conversation Id  Fork Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}/proposals/{proposal_id}/confirm": {
+        "post": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Confirm Operator Proposal",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            },
+            {
+              "name": "proposal_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Proposal Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfirmProposalRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Confirm Operator Proposal Api Operator Conversations  Conversation Id  Proposals  Proposal Id  Confirm Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}/proposals/{proposal_id}/decision": {
+        "post": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Decide Operator Proposal",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            },
+            {
+              "name": "proposal_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Proposal Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DecideProposalRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Decide Operator Proposal Api Operator Conversations  Conversation Id  Proposals  Proposal Id  Decision Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}/requests/{request_id}/cancel": {
+        "post": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Cancel Operator Turn",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            },
+            {
+              "name": "request_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Request Id"
+              }
+            }
+          ],
+          "responses": {
+            "202": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Cancel Operator Turn Api Operator Conversations  Conversation Id  Requests  Request Id  Cancel Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}/stream": {
+        "get": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Stream Operator Conversation",
+          "parameters": [
+            {
+              "name": "after_sequence",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "title": "After Sequence"
+              }
+            },
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}/turns": {
+        "post": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Submit Operator Turn",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorTurnRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "202": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Submit Operator Turn Api Operator Conversations  Conversation Id  Turns Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/conversations/{conversation_id}/view": {
+        "post": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "Report Operator View",
+          "description": "Record where the human is now, so the Operator can read it mid-turn.\n\nA turn's context is frozen at submit. Without this the Operator answers\n\"where am I\" with wherever the human was when they hit send, which is\nwrong precisely when they have moved since.\n\nA report that does not count higher than the one already stored by the same\npage is discarded, since reports race and the loser of that race is the\nstale view.",
+          "parameters": [
+            {
+              "name": "conversation_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Conversation Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorViewReport"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Report Operator View Api Operator Conversations  Conversation Id  View Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/operator/models": {
+        "get": {
+          "tags": [
+            "operator"
+          ],
+          "summary": "List Operator Models",
+          "description": "The Operator's model catalog: every model the daemon can actually drive,\ngrouped by provider, with the reasoning-effort levels each accepts.",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Operator Models Api Operator Models Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/playbook-templates/": {
+        "get": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "List Builtin Playbooks",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Builtin Playbooks Api Playbook Templates  Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/playbook-templates/{name}": {
+        "get": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "Get Builtin Playbook",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Builtin Playbook Api Playbook Templates  Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/playbook-templates/{name}/install": {
+        "post": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "Install Builtin Playbook",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Install Builtin Playbook Api Playbook Templates  Name  Install Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/playbooks/": {
+        "get": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "List Playbooks",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Playbooks Api Playbooks  Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/playbooks/{name}": {
+        "delete": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "Delete Playbook",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Playbook Api Playbooks  Name  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "Get Playbook",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Playbook Api Playbooks  Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "Create Playbook",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Create Playbook Api Playbooks  Name  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "Update Playbook",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Update Playbook Api Playbooks  Name  Put"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/playbooks/{name}/run": {
+        "post": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "Run Playbook",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Run Playbook Api Playbooks  Name  Run Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/playbooks/{name}/validate": {
+        "post": {
+          "tags": [
+            "playbooks"
+          ],
+          "summary": "Validate Playbook",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Body"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Validate Playbook Api Playbooks  Name  Validate Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/plugins": {
+        "get": {
+          "tags": [
+            "plugins"
+          ],
+          "summary": "List Plugins Endpoint",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Plugins Endpoint Api Plugins Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/plugins/{name}": {
+        "get": {
+          "tags": [
+            "plugins"
+          ],
+          "summary": "Get Plugin Endpoint",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Plugin Endpoint Api Plugins  Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/plugins/{plugin_name}/agents/{agent_name}": {
+        "get": {
+          "tags": [
+            "plugins"
+          ],
+          "summary": "Get Plugin Agent Endpoint",
+          "parameters": [
+            {
+              "name": "agent_name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Agent Name"
+              }
+            },
+            {
+              "name": "plugin_name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Plugin Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Plugin Agent Endpoint Api Plugins  Plugin Name  Agents  Agent Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/plugins/{plugin_name}/skills/{skill_name}": {
+        "get": {
+          "tags": [
+            "plugins"
+          ],
+          "summary": "Get Plugin Skill Endpoint",
+          "parameters": [
+            {
+              "name": "plugin_name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Plugin Name"
+              }
+            },
+            {
+              "name": "skill_name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Skill Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Plugin Skill Endpoint Api Plugins  Plugin Name  Skills  Skill Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/projects/": {
+        "get": {
+          "tags": [
+            "projects"
+          ],
+          "summary": "List Projects",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Projects Api Projects  Get"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "projects"
+          ],
+          "summary": "Create Project",
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateProjectRequest"
+                }
+              }
+            },
+            "required": true
+          },
+          "responses": {
+            "201": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Create Project Api Projects  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/projects/{name}": {
+        "delete": {
+          "tags": [
+            "projects"
+          ],
+          "summary": "Delete Project",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Project Api Projects  Name  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "tags": [
+            "projects"
+          ],
+          "summary": "Get Project",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Project Api Projects  Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "projects"
+          ],
+          "summary": "Update Project",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateProjectRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Update Project Api Projects  Name  Put"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/projects/{name}/assign": {
+        "post": {
+          "tags": [
+            "projects"
+          ],
+          "summary": "Assign Project",
+          "description": "Assign sessions to a project. Use session_ids for specific ones, or all_unassigned=true.",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignProjectRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Assign Project Api Projects  Name  Assign Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/runs/": {
+        "get": {
+          "tags": [
+            "runs"
+          ],
+          "summary": "List Runs",
+          "parameters": [
+            {
+              "name": "page",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "1-based page number",
+                "default": 1,
+                "title": "Page"
+              },
+              "description": "1-based page number"
+            },
+            {
+              "name": "per_page",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 500,
+                "minimum": 1,
+                "description": "Rows per page (max 500)",
+                "default": 20,
+                "title": "Per Page"
+              },
+              "description": "Rows per page (max 500)"
+            },
+            {
+              "name": "playbook",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Case-insensitive playbook contains filter",
+                "title": "Playbook"
+              },
+              "description": "Case-insensitive playbook contains filter"
+            },
+            {
+              "name": "project",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Exact project name filter (ADR-0063)",
+                "title": "Project"
+              },
+              "description": "Exact project name filter (ADR-0063)"
+            },
+            {
+              "name": "project_null",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "boolean",
+                "description": "Filter to runs with no project",
+                "default": false,
+                "title": "Project Null"
+              },
+              "description": "Filter to runs with no project"
+            },
+            {
+              "name": "search",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Case-insensitive contains match on session name or agent name",
+                "title": "Search"
+              },
+              "description": "Case-insensitive contains match on session name or agent name"
+            },
+            {
+              "name": "sort",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "description": "Sort order: 'recent' (default) or 'cost' (highest reported spend first)",
+                "default": "recent",
+                "title": "Sort"
+              },
+              "description": "Sort order: 'recent' (default) or 'cost' (highest reported spend first)"
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Repeated status filter",
+                "title": "Status"
+              },
+              "description": "Repeated status filter"
+            },
+            {
+              "name": "tag",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Repeated tag filter (AND-composed)",
+                "title": "Tag"
+              },
+              "description": "Repeated tag filter (AND-composed)"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List Runs Api Runs  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/runs/projects": {
+        "get": {
+          "tags": [
+            "runs"
+          ],
+          "summary": "List Run Projects",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Run Projects Api Runs Projects Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/runs/{run_id}": {
+        "get": {
+          "tags": [
+            "runs"
+          ],
+          "summary": "Get Run",
+          "parameters": [
+            {
+              "name": "message_cursor",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Message Cursor"
+              }
+            },
+            {
+              "name": "message_limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 1000,
+                "minimum": 1,
+                "default": 200,
+                "title": "Message Limit"
+              }
+            },
+            {
+              "name": "run_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Run Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Run Api Runs  Run Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/runs/{run_id}/file": {
+        "get": {
+          "tags": [
+            "runs"
+          ],
+          "summary": "Get Run File",
+          "parameters": [
+            {
+              "name": "path",
+              "in": "query",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Path"
+              }
+            },
+            {
+              "name": "run_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Run Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Run File Api Runs  Run Id  File Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/runs/{run_id}/resume": {
+        "get": {
+          "tags": [
+            "runs"
+          ],
+          "summary": "Resume Availability",
+          "description": "Read-only precheck: can this run be resumed, and why/why not.\n\nThe UI calls this before rendering the resume action so a run with no\ncheckpoint reads as an explicit, explained state rather than a dead or\nguessed-at control.",
+          "parameters": [
+            {
+              "name": "run_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Run Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Resume Availability Api Runs  Run Id  Resume Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "runs"
+          ],
+          "summary": "Resume Run",
+          "description": "Resume any run that has an underlying branch or checkpoint, dispatched by invocation_kind.",
+          "parameters": [
+            {
+              "name": "run_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Run Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunResumeRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "202": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Resume Run Api Runs  Run Id  Resume Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/": {
+        "get": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "List Schedules",
+          "parameters": [
+            {
+              "name": "enabled",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Enabled"
+              }
+            },
+            {
+              "name": "project",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Project"
+              }
+            },
+            {
+              "name": "trigger_type",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Trigger Type"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List Schedules Api Schedules  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Create Schedule",
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateScheduleRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "201": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Create Schedule Api Schedules  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/limits": {
+        "get": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Schedule Limits",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Schedule Limits Api Schedules Limits Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/runs/{run_id}": {
+        "get": {
+          "tags": [
+            "schedule-runs",
+            "schedules"
+          ],
+          "summary": "Get Schedule Run",
+          "parameters": [
+            {
+              "name": "run_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Run Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Schedule Run Api Schedules Runs  Run Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/{schedule_id}": {
+        "delete": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Delete Schedule",
+          "parameters": [
+            {
+              "name": "schedule_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Schedule Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Schedule Api Schedules  Schedule Id  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Get Schedule",
+          "parameters": [
+            {
+              "name": "schedule_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Schedule Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Schedule Api Schedules  Schedule Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "patch": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Update Schedule",
+          "parameters": [
+            {
+              "name": "schedule_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Schedule Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateScheduleRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Update Schedule Api Schedules  Schedule Id  Patch"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/{schedule_id}/disable": {
+        "post": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Disable Schedule",
+          "parameters": [
+            {
+              "name": "schedule_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Schedule Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Disable Schedule Api Schedules  Schedule Id  Disable Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/{schedule_id}/enable": {
+        "post": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Enable Schedule",
+          "parameters": [
+            {
+              "name": "schedule_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Schedule Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Enable Schedule Api Schedules  Schedule Id  Enable Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/{schedule_id}/runs": {
+        "get": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "List Schedule Runs",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 200,
+                "minimum": 1,
+                "default": 50,
+                "title": "Limit"
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "title": "Offset"
+              }
+            },
+            {
+              "name": "schedule_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Schedule Id"
+              }
+            },
+            {
+              "name": "status",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Status"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List Schedule Runs Api Schedules  Schedule Id  Runs Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/{schedule_id}/status": {
+        "get": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Get Schedule Status",
+          "parameters": [
+            {
+              "name": "schedule_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Schedule Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Schedule Status Api Schedules  Schedule Id  Status Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/schedules/{schedule_id}/trigger": {
+        "post": {
+          "tags": [
+            "schedules"
+          ],
+          "summary": "Trigger Schedule",
+          "parameters": [
+            {
+              "name": "schedule_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Schedule Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Trigger Schedule Api Schedules  Schedule Id  Trigger Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/sessions/": {
+        "get": {
+          "tags": [
+            "sessions"
+          ],
+          "summary": "List Sessions",
+          "description": "One page of sessions. The response always reports `total` and\n`truncated` so a bounded answer can never be mistaken for a complete one.",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 500,
+                "minimum": 1,
+                "description": "Rows to return, newest first (max 500)",
+                "default": 500,
+                "title": "Limit"
+              },
+              "description": "Rows to return, newest first (max 500)"
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Rows to skip, newest first",
+                "default": 0,
+                "title": "Offset"
+              },
+              "description": "Rows to skip, newest first"
+            },
+            {
+              "name": "sort",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "description": "Sort order: 'recent' (default) or 'cost' (highest reported spend first)",
+                "default": "recent",
+                "title": "Sort"
+              },
+              "description": "Sort order: 'recent' (default) or 'cost' (highest reported spend first)"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List Sessions Api Sessions  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/sessions/{session_id}": {
+        "get": {
+          "tags": [
+            "sessions"
+          ],
+          "summary": "Get Session",
+          "parameters": [
+            {
+              "name": "message_cursor",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Message Cursor"
+              }
+            },
+            {
+              "name": "message_limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "default": 200,
+                "title": "Message Limit"
+              }
+            },
+            {
+              "name": "message_offset",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "default": 0,
+                "title": "Message Offset"
+              }
+            },
+            {
+              "name": "session_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Session Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Session Api Sessions  Session Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/sessions/{session_id}/signals": {
+        "get": {
+          "tags": [
+            "sessions"
+          ],
+          "summary": "Stream Signals",
+          "parameters": [
+            {
+              "name": "session_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Session Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "title": "Response Stream Signals Api Sessions  Session Id  Signals Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/sessions/{session_id}/stream": {
+        "get": {
+          "tags": [
+            "sessions"
+          ],
+          "summary": "Stream Session",
+          "parameters": [
+            {
+              "name": "session_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Session Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/sessions/{session_id}/tags": {
+        "post": {
+          "tags": [
+            "sessions"
+          ],
+          "summary": "Add Run Tag",
+          "parameters": [
+            {
+              "name": "session_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Session Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagBody"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Add Run Tag Api Sessions  Session Id  Tags Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/sessions/{session_id}/tags/{tag}": {
+        "delete": {
+          "tags": [
+            "sessions"
+          ],
+          "summary": "Remove Run Tag",
+          "parameters": [
+            {
+              "name": "session_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Session Id"
+              }
+            },
+            {
+              "name": "tag",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Tag"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Remove Run Tag Api Sessions  Session Id  Tags  Tag  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/shows/": {
+        "get": {
+          "tags": [
+            "shows"
+          ],
+          "summary": "List Shows",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "items": {
+                      "additionalProperties": true,
+                      "type": "object"
+                    },
+                    "type": "array",
+                    "title": "Response List Shows Api Shows  Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/shows/import": {
+        "post": {
+          "tags": [
+            "shows",
+            "shows"
+          ],
+          "summary": "Import Shows",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": {
+                      "type": "integer"
+                    },
+                    "type": "object",
+                    "title": "Response Import Shows Api Shows Import Post"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/shows/{topic}": {
+        "get": {
+          "tags": [
+            "shows"
+          ],
+          "summary": "Get Show",
+          "parameters": [
+            {
+              "name": "topic",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Topic"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Show Api Shows  Topic  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/shows/{topic}/stream": {
+        "get": {
+          "tags": [
+            "shows"
+          ],
+          "summary": "Stream Show",
+          "description": "SSE stream of file changes under one show directory.",
+          "parameters": [
+            {
+              "name": "topic",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Topic"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/skills/": {
+        "get": {
+          "tags": [
+            "skills"
+          ],
+          "summary": "List Skills",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response List Skills Api Skills  Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/skills/{name}": {
+        "get": {
+          "tags": [
+            "skills"
+          ],
+          "summary": "Get Skill",
+          "parameters": [
+            {
+              "name": "name",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Name"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Skill Api Skills  Name  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/stats": {
+        "get": {
+          "summary": "Get Stats",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Get Stats Api Stats Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/stats/activity": {
+        "get": {
+          "summary": "Get Activity Stats",
+          "parameters": [
+            {
+              "name": "window",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "description": "Activity window: 24h or 7d",
+                "default": "24h",
+                "title": "Window"
+              },
+              "description": "Activity window: 24h or 7d"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Activity Stats Api Stats Activity Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/stats/spend": {
+        "get": {
+          "summary": "Get Spend Stats",
+          "parameters": [
+            {
+              "name": "window",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "description": "Spend window: 24h or 7d",
+                "default": "24h",
+                "title": "Window"
+              },
+              "description": "Spend window: 24h or 7d"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Spend Stats Api Stats Spend Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/stats/spend/rollup": {
+        "get": {
+          "summary": "Get Spend Rollup",
+          "parameters": [
+            {
+              "name": "window",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "string",
+                "description": "Spend window: 24h or 7d",
+                "default": "24h",
+                "title": "Window"
+              },
+              "description": "Spend window: 24h or 7d"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Spend Rollup Api Stats Spend Rollup Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/teams/": {
+        "get": {
+          "tags": [
+            "teams"
+          ],
+          "summary": "List Teams",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 100,
+                "minimum": 1,
+                "default": 20,
+                "title": "Limit"
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "title": "Offset"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response List Teams Api Teams  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/teams/{team_id}": {
+        "get": {
+          "tags": [
+            "teams"
+          ],
+          "summary": "Get Team",
+          "parameters": [
+            {
+              "name": "team_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Team Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Team Api Teams  Team Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/workflow-defs/": {
+        "get": {
+          "tags": [
+            "workflow-defs"
+          ],
+          "summary": "List Workflow Defs",
+          "parameters": [
+            {
+              "name": "limit",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "maximum": 200,
+                "minimum": 1,
+                "default": 100,
+                "title": "Limit"
+              }
+            },
+            {
+              "name": "offset",
+              "in": "query",
+              "required": false,
+              "schema": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "title": "Offset"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "title": "Response List Workflow Defs Api Workflow Defs  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "post": {
+          "tags": [
+            "workflow-defs"
+          ],
+          "summary": "Create Workflow Def",
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateWorkflowDefRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "201": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Create Workflow Def Api Workflow Defs  Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/workflow-defs/{def_id}": {
+        "delete": {
+          "tags": [
+            "workflow-defs"
+          ],
+          "summary": "Delete Workflow Def",
+          "parameters": [
+            {
+              "name": "def_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Def Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Delete Workflow Def Api Workflow Defs  Def Id  Delete"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get": {
+          "tags": [
+            "workflow-defs"
+          ],
+          "summary": "Get Workflow Def",
+          "parameters": [
+            {
+              "name": "def_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Def Id"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Get Workflow Def Api Workflow Defs  Def Id  Get"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "put": {
+          "tags": [
+            "workflow-defs"
+          ],
+          "summary": "Update Workflow Def",
+          "parameters": [
+            {
+              "name": "def_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Def Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateWorkflowDefRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Update Workflow Def Api Workflow Defs  Def Id  Put"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/workflow-defs/{def_id}/run": {
+        "post": {
+          "tags": [
+            "workflow-defs"
+          ],
+          "summary": "Run Workflow Def",
+          "description": "Compile *def_id* and execute it via Session.flow; returns {run_id, status}.\n\nrun_id is the same id GET /api/sessions/{id} already reads \u2014 no new telemetry surface.",
+          "parameters": [
+            {
+              "name": "def_id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "title": "Def Id"
+              }
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunWorkflowDefRequest"
+                }
+              }
+            }
+          },
+          "responses": {
+            "202": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "title": "Response Run Workflow Def Api Workflow Defs  Def Id  Run Post"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Validation Error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/health": {
+        "get": {
+          "summary": "Health",
+          "responses": {
+            "200": {
+              "description": "Successful Response",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "title": "Response Health Health Get"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "path_count": 102,
+    "schemas": {
+      "AcknowledgeEffectRequest": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "applied",
+              "rejected"
+            ],
+            "title": "Status"
+          },
+          "clientRoute": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clientroute"
+          },
+          "rejectionCode": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "unsupported",
+                  "invalid_params",
+                  "stale_context",
+                  "not_visible",
+                  "client_error"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rejectioncode"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "AcknowledgeEffectRequest"
+      },
+      "AssignProjectRequest": {
+        "properties": {
+          "session_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Ids"
+          },
+          "all_unassigned": {
+            "type": "boolean",
+            "title": "All Unassigned",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "AssignProjectRequest"
+      },
+      "ConfirmProposalRequest": {
+        "properties": {
+          "expectedCommandHash": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 64,
+            "title": "Expectedcommandhash"
+          },
+          "expectedTargetVersion": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expectedtargetversion"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "expectedCommandHash"
+        ],
+        "title": "ConfirmProposalRequest"
+      },
+      "CreateConversationRequest": {
+        "properties": {
+          "project": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "CreateConversationRequest"
+      },
+      "CreateEngineDefRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "max_depth": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Depth"
+          },
+          "max_agents": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Agents"
+          },
+          "options": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Options"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "kind"
+        ],
+        "title": "CreateEngineDefRequest"
+      },
+      "CreateProjectRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "github": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Path"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CreateProjectRequest"
+      },
+      "CreateScheduleRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "trigger_type": {
+            "type": "string",
+            "title": "Trigger Type"
+          },
+          "cron_expr": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cron Expr"
+          },
+          "interval_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interval Sec"
+          },
+          "github_repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github Repo"
+          },
+          "github_filter": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github Filter"
+          },
+          "poll_interval_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poll Interval Sec"
+          },
+          "action_kind": {
+            "type": "string",
+            "title": "Action Kind"
+          },
+          "action_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Model"
+          },
+          "action_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Prompt"
+          },
+          "action_agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Agent"
+          },
+          "action_playbook": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Playbook"
+          },
+          "action_flow_yaml": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Flow Yaml"
+          },
+          "action_project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Project"
+          },
+          "action_cwd": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Cwd"
+          },
+          "action_extra_args": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Extra Args"
+          },
+          "action_command": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Command"
+          },
+          "action_command_args": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Command Args"
+          },
+          "on_success": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Success"
+          },
+          "on_fail": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Fail"
+          },
+          "missed_fire_policy": {
+            "type": "string",
+            "title": "Missed Fire Policy",
+            "default": "skip"
+          },
+          "overlap_policy": {
+            "type": "string",
+            "title": "Overlap Policy",
+            "default": "skip"
+          },
+          "max_runs": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Runs"
+          },
+          "budget_usd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Usd"
+          },
+          "budget_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Tokens"
+          },
+          "rate_limit": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Limit"
+          },
+          "project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project"
+          },
+          "threshold_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Threshold Config"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "name",
+          "trigger_type",
+          "action_kind"
+        ],
+        "title": "CreateScheduleRequest"
+      },
+      "CreateWorkflowDefRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "spec_json": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec Json"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CreateWorkflowDefRequest"
+      },
+      "DecideProposalRequest": {
+        "properties": {
+          "decision": {
+            "type": "string",
+            "enum": [
+              "allow",
+              "deny"
+            ],
+            "title": "Decision"
+          },
+          "expectedCommandHash": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64,
+                "minLength": 64
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expectedcommandhash"
+          },
+          "expectedTargetVersion": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expectedtargetversion"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "decision"
+        ],
+        "title": "DecideProposalRequest"
+      },
+      "ForkConversationRequest": {
+        "properties": {
+          "upToSequence": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uptosequence"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "ForkConversationRequest"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "LaunchRequest": {
+        "properties": {
+          "action_kind": {
+            "type": "string",
+            "title": "Action Kind"
+          },
+          "action_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Model"
+          },
+          "action_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Prompt"
+          },
+          "action_agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Agent"
+          },
+          "action_playbook": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Playbook"
+          },
+          "action_project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Project"
+          },
+          "action_flow_yaml": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Flow Yaml"
+          },
+          "action_engine_def": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Engine Def"
+          },
+          "action_extra_args": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Extra Args"
+          },
+          "action_command": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Command"
+          },
+          "action_command_args": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Command Args"
+          }
+        },
+        "type": "object",
+        "required": [
+          "action_kind"
+        ],
+        "title": "LaunchRequest"
+      },
+      "MaintenanceBody": {
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "vacuum",
+              "checkpoint",
+              "prune"
+            ],
+            "title": "Action",
+            "description": "DB maintenance action: 'vacuum', 'checkpoint', or 'prune'."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "action"
+        ],
+        "title": "MaintenanceBody",
+        "description": "Request body for POST /api/admin/maintenance."
+      },
+      "OperatorContextSnapshot": {
+        "properties": {
+          "project": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project"
+          },
+          "space": {
+            "type": "string",
+            "enum": [
+              "mission",
+              "designer",
+              "library",
+              "history",
+              "schedules",
+              "system"
+            ],
+            "title": "Space"
+          },
+          "route": {
+            "type": "string",
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Route"
+          },
+          "selection": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection"
+          },
+          "filters": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Filters"
+          },
+          "observationSeq": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observationseq"
+          },
+          "observerId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observerid"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "space",
+          "route"
+        ],
+        "title": "OperatorContextSnapshot"
+      },
+      "OperatorTurnRequest": {
+        "properties": {
+          "instruction": {
+            "type": "string",
+            "maxLength": 32768,
+            "minLength": 1,
+            "title": "Instruction"
+          },
+          "context": {
+            "$ref": "#/components/schemas/OperatorContextSnapshot"
+          },
+          "expectedLastSequence": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Expectedlastsequence"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "claude_code",
+                  "codex",
+                  "gemini_code"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "effort": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "ultra"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effort"
+          },
+          "clearSelection": {
+            "type": "boolean",
+            "title": "Clearselection",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "instruction",
+          "context",
+          "expectedLastSequence"
+        ],
+        "title": "OperatorTurnRequest"
+      },
+      "OperatorViewReport": {
+        "properties": {
+          "project": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project"
+          },
+          "space": {
+            "type": "string",
+            "enum": [
+              "mission",
+              "designer",
+              "library",
+              "history",
+              "schedules",
+              "system"
+            ],
+            "title": "Space"
+          },
+          "route": {
+            "type": "string",
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Route"
+          },
+          "selection": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection"
+          },
+          "filters": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Filters"
+          },
+          "observationSeq": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Observationseq"
+          },
+          "observerId": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Observerid"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "space",
+          "route",
+          "observationSeq",
+          "observerId"
+        ],
+        "title": "OperatorViewReport",
+        "description": "A view the browser reports outside of any turn.\n\nBoth fields are required here, unlike on a turn's snapshot: a report exists\nonly to answer \"where is the human now\", and one that cannot say who saw it\nor where it fell in their sequence cannot be ordered against anything, so\naccepting it would mean storing a view that can only ever be reported with\nthe wrong freshness label."
+      },
+      "PruneBody": {
+        "properties": {
+          "session_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Ids"
+          },
+          "all_phantom": {
+            "type": "boolean",
+            "title": "All Phantom",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "PruneBody"
+      },
+      "PruneOldDataBody": {
+        "properties": {
+          "keep_days": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Keep Days",
+            "description": "Retain sessions newer than this many days"
+          }
+        },
+        "type": "object",
+        "title": "PruneOldDataBody"
+      },
+      "RunResumeRequest": {
+        "properties": {
+          "instruction": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 262144
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instruction"
+          },
+          "branch_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch Id"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "allow_degraded_context": {
+            "type": "boolean",
+            "title": "Allow Degraded Context",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "RunResumeRequest"
+      },
+      "RunWorkflowDefRequest": {
+        "properties": {
+          "inputs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inputs"
+          },
+          "base_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Dir"
+          }
+        },
+        "type": "object",
+        "title": "RunWorkflowDefRequest"
+      },
+      "SaveBody": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "title": "SaveBody"
+      },
+      "TagBody": {
+        "properties": {
+          "tag": {
+            "type": "string",
+            "title": "Tag"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tag"
+        ],
+        "title": "TagBody"
+      },
+      "TransitionBody": {
+        "properties": {
+          "session_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Session Ids"
+          },
+          "target_status": {
+            "type": "string",
+            "enum": [
+              "failed",
+              "aborted",
+              "cancelled"
+            ],
+            "title": "Target Status"
+          },
+          "reason_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason Code"
+          },
+          "reason_summary": {
+            "type": "string",
+            "title": "Reason Summary",
+            "default": ""
+          },
+          "evidence_refs": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Evidence Refs"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "actor": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Actor",
+            "default": "admin"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_ids",
+          "target_status"
+        ],
+        "title": "TransitionBody",
+        "description": "Admin session transition; reason_code is preferred over deprecated reason."
+      },
+      "UpdateConversationRequest": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "pinned": {
+            "type": "boolean",
+            "title": "Pinned",
+            "default": false
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "archived"
+            ],
+            "title": "Status",
+            "default": "active"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "UpdateConversationRequest",
+        "description": "Partial update: only fields present in the request body are applied.\n\n``status`` only accepts ``active``/``archived`` here -- deletion stays on\nthe dedicated DELETE route so it keeps its own, more final, semantics."
+      },
+      "UpdateEngineDefRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "max_depth": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Depth"
+          },
+          "max_agents": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Agents"
+          },
+          "options": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Options"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "type": "object",
+        "title": "UpdateEngineDefRequest"
+      },
+      "UpdateProjectRequest": {
+        "properties": {
+          "github": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Path"
+          }
+        },
+        "type": "object",
+        "title": "UpdateProjectRequest"
+      },
+      "UpdateScheduleRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "trigger_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger Type"
+          },
+          "cron_expr": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cron Expr"
+          },
+          "interval_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interval Sec"
+          },
+          "github_repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github Repo"
+          },
+          "github_filter": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github Filter"
+          },
+          "github_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Github Cursor"
+          },
+          "poll_interval_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Poll Interval Sec"
+          },
+          "action_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Kind"
+          },
+          "action_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Model"
+          },
+          "action_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Prompt"
+          },
+          "action_agent": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Agent"
+          },
+          "action_playbook": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Playbook"
+          },
+          "action_flow_yaml": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Flow Yaml"
+          },
+          "action_project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Project"
+          },
+          "action_cwd": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Cwd"
+          },
+          "action_extra_args": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Extra Args"
+          },
+          "action_command": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Command"
+          },
+          "action_command_args": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Command Args"
+          },
+          "on_success": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Success"
+          },
+          "on_fail": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "On Fail"
+          },
+          "missed_fire_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Missed Fire Policy"
+          },
+          "overlap_policy": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Overlap Policy"
+          },
+          "max_runs": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Runs"
+          },
+          "budget_usd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Usd"
+          },
+          "budget_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Tokens"
+          },
+          "rate_limit": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rate Limit"
+          },
+          "project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project"
+          },
+          "threshold_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Threshold Config"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "UpdateScheduleRequest"
+      },
+      "UpdateWorkflowDefRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "spec_json": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spec Json"
+          }
+        },
+        "type": "object",
+        "title": "UpdateWorkflowDefRequest"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "_CreateApprovalBody": {
+        "properties": {
+          "action_kind": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Action Kind"
+          },
+          "params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Params"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "action_kind"
+        ],
+        "title": "_CreateApprovalBody"
+      },
+      "_DenyBody": {
+        "properties": {
+          "reason_class": {
+            "type": "string",
+            "enum": [
+              "security",
+              "policy",
+              "mistake",
+              "other"
+            ],
+            "title": "Reason Class"
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "reason_class",
+          "reason"
+        ],
+        "title": "_DenyBody",
+        "description": "Typed justification for a deny. Optional at the route: a body-less\ndeny is still valid (the human clicked \"deny\", no reason required), but\na body that IS sent must carry a real reason -- empty/whitespace-only\ntext is rejected."
+      },
+      "_DispositionBody": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "acknowledged",
+              "resolved",
+              "expected",
+              "snoozed"
+            ],
+            "title": "State"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "source_status": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Source Status"
+          },
+          "actor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor"
+          },
+          "revision": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state",
+          "source_status"
+        ],
+        "title": "_DispositionBody"
+      }
+    },
+    "schema_count": 32
+  }
+}

--- a/tests/contracts/data/imports.json
+++ b/tests/contracts/data/imports.json
@@ -1,0 +1,806 @@
+{
+  "root_all": [
+    "Adaptable",
+    "AdapterError",
+    "AdapterRegistry",
+    "AsyncAdaptable",
+    "AsyncAdapterRegistry",
+    "BaseModel",
+    "Branch",
+    "Broadcaster",
+    "Builder",
+    "ContextProvider",
+    "ContextProviderRegistry",
+    "CsvAdapter",
+    "DataClass",
+    "Edge",
+    "Element",
+    "Event",
+    "Field",
+    "FieldModel",
+    "Graph",
+    "HookRegistry",
+    "HookedEvent",
+    "InMemoryStore",
+    "InvalidConstructorError",
+    "JsonAdapter",
+    "LNDLError",
+    "LNDLOutput",
+    "MemoryItem",
+    "MemoryQuery",
+    "MemoryStore",
+    "Message",
+    "MissingFieldError",
+    "MissingLvarError",
+    "Node",
+    "Operable",
+    "OperableModel",
+    "Operation",
+    "Params",
+    "Pile",
+    "Progression",
+    "ProviderReport",
+    "Session",
+    "Spec",
+    "TomlAdapter",
+    "TypeMismatchError",
+    "Undefined",
+    "Unset",
+    "__version__",
+    "alcall",
+    "create_message",
+    "extract_lndl_blocks",
+    "get_lndl_system_prompt",
+    "iModel",
+    "json_dumps",
+    "lcall",
+    "ln",
+    "load_mcp_tools",
+    "logger",
+    "normalize_lndl_text",
+    "to_dict",
+    "to_list",
+    "types"
+  ],
+  "root_all_count": 61,
+  "symbols": {
+    "__version__": {
+      "type": "str",
+      "module": null,
+      "qualname": null
+    },
+    "Adaptable": {
+      "type": "type",
+      "module": "lionagi.adapters._base",
+      "qualname": "Adaptable"
+    },
+    "AdapterError": {
+      "type": "type",
+      "module": "lionagi.adapters._base",
+      "qualname": "AdapterError"
+    },
+    "AdapterRegistry": {
+      "type": "type",
+      "module": "lionagi.adapters._base",
+      "qualname": "AdapterRegistry"
+    },
+    "AsyncAdaptable": {
+      "type": "type",
+      "module": "lionagi.adapters._base",
+      "qualname": "AsyncAdaptable"
+    },
+    "AsyncAdapterRegistry": {
+      "type": "type",
+      "module": "lionagi.adapters._base",
+      "qualname": "AsyncAdapterRegistry"
+    },
+    "BaseModel": {
+      "type": "ModelMetaclass",
+      "module": "pydantic.main",
+      "qualname": "BaseModel"
+    },
+    "Branch": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.session.branch",
+      "qualname": "Branch"
+    },
+    "Broadcaster": {
+      "type": "type",
+      "module": "lionagi.service.broadcaster",
+      "qualname": "Broadcaster"
+    },
+    "Builder": {
+      "type": "type",
+      "module": "lionagi.operations.builder",
+      "qualname": "OperationGraphBuilder"
+    },
+    "ContextProvider": {
+      "type": "_ProtocolMeta",
+      "module": "lionagi.protocols.context_providers",
+      "qualname": "ContextProvider"
+    },
+    "ContextProviderRegistry": {
+      "type": "type",
+      "module": "lionagi.protocols.context_providers",
+      "qualname": "ContextProviderRegistry"
+    },
+    "CsvAdapter": {
+      "type": "_ProtocolMeta",
+      "module": "lionagi.adapters.csv_",
+      "qualname": "CsvAdapter"
+    },
+    "DataClass": {
+      "type": "type",
+      "module": "lionagi.ln.types.base",
+      "qualname": "DataClass"
+    },
+    "Edge": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.graph.edge",
+      "qualname": "Edge"
+    },
+    "Element": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.generic.element",
+      "qualname": "Element"
+    },
+    "Event": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.generic.event",
+      "qualname": "Event"
+    },
+    "Field": {
+      "type": "function",
+      "module": "pydantic.fields",
+      "qualname": "Field"
+    },
+    "FieldModel": {
+      "type": "type",
+      "module": "lionagi.models.field_model",
+      "qualname": "FieldModel"
+    },
+    "Graph": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.graph.graph",
+      "qualname": "Graph"
+    },
+    "HookRegistry": {
+      "type": "type",
+      "module": "lionagi.service.hooks.hook_registry",
+      "qualname": "HookRegistry"
+    },
+    "HookedEvent": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.service.hooks.hooked_event",
+      "qualname": "HookedEvent"
+    },
+    "InMemoryStore": {
+      "type": "type",
+      "module": "lionagi.protocols.memory",
+      "qualname": "InMemoryStore"
+    },
+    "InvalidConstructorError": {
+      "type": "type",
+      "module": "lionagi.lndl.errors",
+      "qualname": "InvalidConstructorError"
+    },
+    "JsonAdapter": {
+      "type": "_ProtocolMeta",
+      "module": "lionagi.adapters.json_",
+      "qualname": "JsonAdapter"
+    },
+    "LNDLError": {
+      "type": "type",
+      "module": "lionagi.lndl.errors",
+      "qualname": "LNDLError"
+    },
+    "LNDLOutput": {
+      "type": "type",
+      "module": "lionagi.lndl.types",
+      "qualname": "LNDLOutput"
+    },
+    "MemoryItem": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.memory",
+      "qualname": "MemoryItem"
+    },
+    "MemoryQuery": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.memory",
+      "qualname": "MemoryQuery"
+    },
+    "MemoryStore": {
+      "type": "_ProtocolMeta",
+      "module": "lionagi.protocols.memory",
+      "qualname": "MemoryStore"
+    },
+    "Message": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.messages.message",
+      "qualname": "Message"
+    },
+    "MissingFieldError": {
+      "type": "type",
+      "module": "lionagi.lndl.errors",
+      "qualname": "MissingFieldError"
+    },
+    "MissingLvarError": {
+      "type": "type",
+      "module": "lionagi.lndl.errors",
+      "qualname": "MissingLvarError"
+    },
+    "Node": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.graph.node",
+      "qualname": "Node"
+    },
+    "Operable": {
+      "type": "type",
+      "module": "lionagi.ln.types.operable",
+      "qualname": "Operable"
+    },
+    "OperableModel": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.models.operable_model",
+      "qualname": "OperableModel"
+    },
+    "Operation": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.operations.node",
+      "qualname": "Operation"
+    },
+    "Params": {
+      "type": "type",
+      "module": "lionagi.ln.types.base",
+      "qualname": "Params"
+    },
+    "Pile": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.generic.pile",
+      "qualname": "Pile"
+    },
+    "Progression": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.protocols.generic.progression",
+      "qualname": "Progression"
+    },
+    "ProviderReport": {
+      "type": "type",
+      "module": "lionagi.protocols.context_providers",
+      "qualname": "ProviderReport"
+    },
+    "Session": {
+      "type": "ModelMetaclass",
+      "module": "lionagi.session.session",
+      "qualname": "Session"
+    },
+    "Spec": {
+      "type": "type",
+      "module": "lionagi.ln.types.spec",
+      "qualname": "Spec"
+    },
+    "TomlAdapter": {
+      "type": "_ProtocolMeta",
+      "module": "lionagi.adapters.toml_",
+      "qualname": "TomlAdapter"
+    },
+    "TypeMismatchError": {
+      "type": "type",
+      "module": "lionagi.lndl.errors",
+      "qualname": "TypeMismatchError"
+    },
+    "Undefined": {
+      "type": "UndefinedType",
+      "module": "lionagi.ln.types._sentinel",
+      "qualname": null
+    },
+    "Unset": {
+      "type": "UnsetType",
+      "module": "lionagi.ln.types._sentinel",
+      "qualname": null
+    },
+    "alcall": {
+      "type": "function",
+      "module": "lionagi.ln._async_call",
+      "qualname": "alcall"
+    },
+    "create_message": {
+      "type": "function",
+      "module": "lionagi.protocols.messages.manager",
+      "qualname": "create_message"
+    },
+    "extract_lndl_blocks": {
+      "type": "function",
+      "module": "lionagi.lndl.extract",
+      "qualname": "extract_lndl_blocks"
+    },
+    "get_lndl_system_prompt": {
+      "type": "function",
+      "module": "lionagi.lndl.prompt",
+      "qualname": "get_lndl_system_prompt"
+    },
+    "iModel": {
+      "type": "type",
+      "module": "lionagi.service.imodel",
+      "qualname": "iModel"
+    },
+    "json_dumps": {
+      "type": "function",
+      "module": "lionagi.ln._json_dump",
+      "qualname": "json_dumps"
+    },
+    "lcall": {
+      "type": "function",
+      "module": "lionagi.ln._list_call",
+      "qualname": "lcall"
+    },
+    "ln": {
+      "type": "module",
+      "module": null,
+      "qualname": null
+    },
+    "load_mcp_tools": {
+      "type": "function",
+      "module": "lionagi.protocols.action.manager",
+      "qualname": "load_mcp_tools"
+    },
+    "logger": {
+      "type": "Logger",
+      "module": "logging",
+      "qualname": null
+    },
+    "normalize_lndl_text": {
+      "type": "function",
+      "module": "lionagi.lndl.normalize",
+      "qualname": "normalize_lndl_text"
+    },
+    "to_dict": {
+      "type": "function",
+      "module": "lionagi.ln.fuzzy._to_dict",
+      "qualname": "to_dict"
+    },
+    "to_list": {
+      "type": "function",
+      "module": "lionagi.ln._to_list",
+      "qualname": "to_list"
+    },
+    "types": {
+      "type": "module",
+      "module": null,
+      "qualname": null
+    }
+  },
+  "lazy_map_keys": [
+    "Adaptable",
+    "AdapterError",
+    "AdapterRegistry",
+    "AsyncAdaptable",
+    "AsyncAdapterRegistry",
+    "Branch",
+    "Broadcaster",
+    "Builder",
+    "ContextProvider",
+    "ContextProviderRegistry",
+    "CsvAdapter",
+    "Edge",
+    "Element",
+    "Event",
+    "FieldModel",
+    "Graph",
+    "HookRegistry",
+    "HookedEvent",
+    "InMemoryStore",
+    "InvalidConstructorError",
+    "JsonAdapter",
+    "LNDLError",
+    "LNDLOutput",
+    "MemoryItem",
+    "MemoryQuery",
+    "MemoryStore",
+    "Message",
+    "MissingFieldError",
+    "MissingLvarError",
+    "Node",
+    "OperableModel",
+    "Operation",
+    "Pile",
+    "Progression",
+    "ProviderReport",
+    "Session",
+    "TomlAdapter",
+    "TypeMismatchError",
+    "alcall",
+    "create_message",
+    "extract_lndl_blocks",
+    "get_lndl_system_prompt",
+    "iModel",
+    "json_dumps",
+    "lcall",
+    "load_mcp_tools",
+    "normalize_lndl_text",
+    "to_dict",
+    "to_list"
+  ],
+  "lazy_map_key_count": 49,
+  "compat_modules": {
+    "lionagi.protocols.types": {
+      "ok": true,
+      "dir": [
+        "ActionRequest",
+        "ActionResponse",
+        "AssistantResponse",
+        "Collective",
+        "Communicatable",
+        "Condition",
+        "DataLogger",
+        "DataLoggerConfig",
+        "Edge",
+        "EdgeCondition",
+        "Element",
+        "Event",
+        "EventStatus",
+        "Execution",
+        "Executor",
+        "Graph",
+        "ID",
+        "InMemoryStore",
+        "Instruction",
+        "Log",
+        "MESSAGE_FIELDS",
+        "Manager",
+        "MemoryItem",
+        "MemoryQuery",
+        "MemoryStore",
+        "Message",
+        "MessageField",
+        "MessageManager",
+        "MessageRole",
+        "Node",
+        "Observable",
+        "Observer",
+        "Ordering",
+        "Pile",
+        "Processor",
+        "Progression",
+        "Relational",
+        "RoledMessage",
+        "Sendable",
+        "SenderRecipient",
+        "System",
+        "canonical_id",
+        "prog",
+        "to_uuid",
+        "validate_order",
+        "validate_sender_recipient"
+      ],
+      "warning_categories": []
+    },
+    "lionagi.tools.types": {
+      "ok": true,
+      "dir": [
+        "BashTool",
+        "CodingToolkit",
+        "ContextTool",
+        "EditorTool",
+        "ReaderTool",
+        "SearchTool",
+        "chunk"
+      ],
+      "warning_categories": []
+    },
+    "lionagi.operations.parse": {
+      "ok": true,
+      "dir": [
+        "ExtractionError",
+        "ParseError",
+        "ParseFailureKind",
+        "SchemaRejectedError",
+        "UnparsedResponse"
+      ],
+      "warning_categories": []
+    },
+    "lionagi.service.connections.cli_endpoint": {
+      "ok": true,
+      "dir": [
+        "AgenticEndpoint",
+        "warnings"
+      ],
+      "warning_categories": []
+    },
+    "lionagi.dispatch.revival": {
+      "ok": true,
+      "dir": [
+        "Any",
+        "DEFAULT_MAX_ATTEMPTS",
+        "annotations",
+        "enqueue_dispatch",
+        "enqueue_revival_heartbeat"
+      ],
+      "warning_categories": []
+    }
+  },
+  "import_laziness": {
+    "seed_count": 21,
+    "seed_names": [
+      "orchestrate",
+      "agent",
+      "casts",
+      "engine",
+      "team",
+      "studio",
+      "schedule",
+      "state",
+      "invoke",
+      "kill",
+      "mirror",
+      "monitor",
+      "dispatch",
+      "doctor",
+      "stats",
+      "plugin",
+      "hooks",
+      "handshake",
+      "runs",
+      "lifecycle",
+      "mcp"
+    ],
+    "traces": {
+      "orchestrate": {
+        "seed": "orchestrate",
+        "module": "lionagi.cli.orchestrate",
+        "new_lionagi_module_count": 156,
+        "other_seed_modules_imported": [
+          "lionagi.cli.team"
+        ],
+        "other_seed_modules_imported_count": 1,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "orchestrate"
+        ]
+      },
+      "agent": {
+        "seed": "agent",
+        "module": "lionagi.cli.agent",
+        "new_lionagi_module_count": 126,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "agent"
+        ]
+      },
+      "casts": {
+        "seed": "casts",
+        "module": "lionagi.casts.surfaces",
+        "new_lionagi_module_count": 2,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "casts"
+        ]
+      },
+      "engine": {
+        "seed": "engine",
+        "module": "lionagi.cli.engine",
+        "new_lionagi_module_count": 3,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "engine"
+        ]
+      },
+      "team": {
+        "seed": "team",
+        "module": "lionagi.cli.team",
+        "new_lionagi_module_count": 17,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "team"
+        ]
+      },
+      "studio": {
+        "seed": "studio",
+        "module": "lionagi.studio.cli",
+        "new_lionagi_module_count": 31,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "studio"
+        ]
+      },
+      "schedule": {
+        "seed": "schedule",
+        "module": "lionagi.studio.cli",
+        "new_lionagi_module_count": 31,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "schedule"
+        ]
+      },
+      "state": {
+        "seed": "state",
+        "module": "lionagi.cli.state",
+        "new_lionagi_module_count": 25,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "state"
+        ]
+      },
+      "invoke": {
+        "seed": "invoke",
+        "module": "lionagi.cli.invoke",
+        "new_lionagi_module_count": 3,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "invoke"
+        ]
+      },
+      "kill": {
+        "seed": "kill",
+        "module": "lionagi.cli.kill",
+        "new_lionagi_module_count": 30,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "kill"
+        ]
+      },
+      "mirror": {
+        "seed": "mirror",
+        "module": "lionagi.cli.mirror",
+        "new_lionagi_module_count": 8,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "mirror"
+        ]
+      },
+      "monitor": {
+        "seed": "monitor",
+        "module": "lionagi.cli.monitor",
+        "new_lionagi_module_count": 25,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "monitor"
+        ]
+      },
+      "dispatch": {
+        "seed": "dispatch",
+        "module": "lionagi.cli.dispatch",
+        "new_lionagi_module_count": 2,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "dispatch"
+        ]
+      },
+      "doctor": {
+        "seed": "doctor",
+        "module": "lionagi.cli.doctor",
+        "new_lionagi_module_count": 2,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "doctor"
+        ]
+      },
+      "stats": {
+        "seed": "stats",
+        "module": "lionagi.cli.stats",
+        "new_lionagi_module_count": 26,
+        "other_seed_modules_imported": [
+          "lionagi.cli.monitor"
+        ],
+        "other_seed_modules_imported_count": 1,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "stats"
+        ]
+      },
+      "plugin": {
+        "seed": "plugin",
+        "module": "lionagi.cli.plugin",
+        "new_lionagi_module_count": 3,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "plugin"
+        ]
+      },
+      "hooks": {
+        "seed": "hooks",
+        "module": "lionagi.cli.hooks",
+        "new_lionagi_module_count": 3,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "hooks"
+        ]
+      },
+      "handshake": {
+        "seed": "handshake",
+        "module": "lionagi.cli.machine",
+        "new_lionagi_module_count": 2,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "handshake"
+        ]
+      },
+      "runs": {
+        "seed": "runs",
+        "module": "lionagi.cli.machine",
+        "new_lionagi_module_count": 2,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "runs"
+        ]
+      },
+      "lifecycle": {
+        "seed": "lifecycle",
+        "module": "lionagi.cli.machine",
+        "new_lionagi_module_count": 2,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "lifecycle"
+        ]
+      },
+      "mcp": {
+        "seed": "mcp",
+        "module": "lionagi.cli.mcp",
+        "new_lionagi_module_count": 4,
+        "other_seed_modules_imported": [],
+        "other_seed_modules_imported_count": 0,
+        "http_registry_realized": false,
+        "http_registry_count": 0,
+        "cli_realized_names": [
+          "mcp"
+        ]
+      }
+    }
+  }
+}

--- a/tests/contracts/data/machine.json
+++ b/tests/contracts/data/machine.json
@@ -1,0 +1,81 @@
+[
+  {
+    "argv": [
+      "handshake",
+      "--machine"
+    ],
+    "stdout": "[redacted: this case's stdout reports live host state (home paths, run ids, artifact directories, host-installed skill names). It is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0,
+    "envelope_ok": true
+  },
+  {
+    "argv": [
+      "doctor",
+      "--machine"
+    ],
+    "stdout": "[redacted: this case's stdout reports live host state (home paths, run ids, artifact directories, host-installed skill names). It is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0,
+    "envelope_ok": true
+  },
+  {
+    "argv": [
+      "runs",
+      "--machine"
+    ],
+    "stdout": "[redacted: this case's stdout reports live host state (home paths, run ids, artifact directories, host-installed skill names). It is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0,
+    "envelope_ok": true
+  },
+  {
+    "argv": [
+      "lifecycle",
+      "--machine"
+    ],
+    "stdout": "{\"ok\": false, \"contract_version\": 1, \"data\": null, \"error\": {\"kind\": \"invalid_input\", \"message\": \"li lifecycle needs a run id\", \"detail\": null}}\n",
+    "stderr": "",
+    "exit_code": 0,
+    "envelope_ok": false
+  },
+  {
+    "argv": [
+      "monitor",
+      "--machine"
+    ],
+    "stdout": "[redacted: this case's stdout reports live host state (home paths, run ids, artifact directories, host-installed skill names). It is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0,
+    "envelope_ok": true
+  },
+  {
+    "argv": [
+      "agent",
+      "--machine"
+    ],
+    "stdout": "{\"ok\": false, \"contract_version\": 1, \"data\": null, \"error\": {\"kind\": \"unavailable\", \"message\": \"li agent has no machine-mode result in contract version 1; it is a human-facing command\", \"detail\": null}}\n",
+    "stderr": "",
+    "exit_code": 0,
+    "envelope_ok": false
+  },
+  {
+    "argv": [
+      "bogus-unknown-command",
+      "--machine"
+    ],
+    "stdout": "{\"ok\": false, \"contract_version\": 1, \"data\": null, \"error\": {\"kind\": \"invalid_input\", \"message\": \"no such command: bogus-unknown-command\", \"detail\": null}}\n",
+    "stderr": "",
+    "exit_code": 0,
+    "envelope_ok": false
+  },
+  {
+    "argv": [
+      "--machine"
+    ],
+    "stdout": "{\"ok\": false, \"contract_version\": 1, \"data\": null, \"error\": {\"kind\": \"invalid_input\", \"message\": \"no command given\", \"detail\": null}}\n",
+    "stderr": "",
+    "exit_code": 0,
+    "envelope_ok": false
+  }
+]

--- a/tests/contracts/data/machine.json
+++ b/tests/contracts/data/machine.json
@@ -54,7 +54,7 @@
       "agent",
       "--machine"
     ],
-    "stdout": "{\"ok\": false, \"contract_version\": 1, \"data\": null, \"error\": {\"kind\": \"unavailable\", \"message\": \"li agent has no machine-mode result in contract version 1; it is a human-facing command\", \"detail\": null}}\n",
+    "stdout": "[redacted: this case is classified as reporting live agent run state and is excluded from byte-for-byte stdout comparison. Pinning today's literal text would carry no oracle value and risks silently committing live state if the implementation starts reporting it, so it is not committed.]",
     "stderr": "",
     "exit_code": 0,
     "envelope_ok": false

--- a/tests/contracts/data/mcp.json
+++ b/tests/contracts/data/mcp.json
@@ -1,0 +1,2987 @@
+{
+  "available_paths": [
+    "agent",
+    "casts",
+    "dispatch",
+    "dispatch ack",
+    "dispatch ls",
+    "dispatch purge",
+    "dispatch retry",
+    "dispatch show",
+    "doctor",
+    "engine",
+    "engine run",
+    "handshake",
+    "hooks",
+    "hooks import",
+    "hooks trust",
+    "invoke",
+    "invoke end",
+    "invoke list",
+    "invoke start",
+    "kill",
+    "lifecycle",
+    "mcp",
+    "mirror",
+    "monitor",
+    "orchestrate",
+    "orchestrate ctl",
+    "orchestrate ctl msg",
+    "orchestrate ctl pause",
+    "orchestrate ctl resolve",
+    "orchestrate ctl resume",
+    "orchestrate ctl status",
+    "orchestrate fanout",
+    "orchestrate flow",
+    "plugin",
+    "plugin disable",
+    "plugin enable",
+    "plugin info",
+    "plugin list",
+    "plugin trust",
+    "runs",
+    "schedule",
+    "schedule apply",
+    "schedule create",
+    "schedule delete",
+    "schedule disable",
+    "schedule enable",
+    "schedule export",
+    "schedule get",
+    "schedule limits",
+    "schedule list",
+    "schedule run",
+    "schedule runs",
+    "schedule status",
+    "schedule trigger",
+    "schedule validate",
+    "state",
+    "state checkpoint",
+    "state doctor",
+    "state import",
+    "state import-teams",
+    "state ls",
+    "state null-content",
+    "state prune",
+    "state stats",
+    "state vacuum",
+    "stats",
+    "stats runs",
+    "studio",
+    "studio start",
+    "team",
+    "team create",
+    "team list",
+    "team receive",
+    "team send",
+    "team show"
+  ],
+  "available_path_count": 75,
+  "catalog": {
+    "verb_count": 70,
+    "available_count": 40,
+    "max_ops": 8,
+    "verb_names": [
+      "agent.submit",
+      "casts",
+      "dispatch.ack",
+      "dispatch.ls",
+      "dispatch.purge",
+      "dispatch.retry",
+      "dispatch.show",
+      "doctor",
+      "engine.run",
+      "fanout.submit",
+      "flow.submit",
+      "handshake",
+      "hooks.import",
+      "invoke.end",
+      "invoke.list",
+      "invoke.start",
+      "job.kill",
+      "job.list",
+      "job.output",
+      "job.status",
+      "job.wait",
+      "kill",
+      "lifecycle",
+      "mcp",
+      "mirror",
+      "monitor",
+      "orchestrate.ctl.msg",
+      "orchestrate.ctl.pause",
+      "orchestrate.ctl.resolve",
+      "orchestrate.ctl.resume",
+      "orchestrate.ctl.status",
+      "play.submit",
+      "plugin.disable",
+      "plugin.enable",
+      "plugin.info",
+      "plugin.list",
+      "profile.list",
+      "profile.show",
+      "runs",
+      "schedule.apply",
+      "schedule.create",
+      "schedule.delete",
+      "schedule.disable",
+      "schedule.enable",
+      "schedule.export",
+      "schedule.get",
+      "schedule.limits",
+      "schedule.list",
+      "schedule.run",
+      "schedule.runs",
+      "schedule.status",
+      "schedule.trigger",
+      "schedule.validate",
+      "server.info",
+      "state.checkpoint",
+      "state.doctor",
+      "state.import",
+      "state.import-teams",
+      "state.ls",
+      "state.null-content",
+      "state.prune",
+      "state.stats",
+      "state.vacuum",
+      "stats.runs",
+      "studio.start",
+      "team.create",
+      "team.list",
+      "team.receive",
+      "team.send",
+      "team.show"
+    ],
+    "available_verb_names": [
+      "agent.submit",
+      "dispatch.ack",
+      "dispatch.ls",
+      "dispatch.purge",
+      "dispatch.retry",
+      "dispatch.show",
+      "doctor",
+      "fanout.submit",
+      "flow.submit",
+      "handshake",
+      "invoke.list",
+      "job.kill",
+      "job.list",
+      "job.output",
+      "job.status",
+      "job.wait",
+      "lifecycle",
+      "monitor",
+      "play.submit",
+      "plugin.info",
+      "profile.list",
+      "profile.show",
+      "runs",
+      "schedule.create",
+      "schedule.delete",
+      "schedule.disable",
+      "schedule.enable",
+      "schedule.export",
+      "schedule.get",
+      "schedule.limits",
+      "schedule.list",
+      "schedule.runs",
+      "schedule.status",
+      "schedule.trigger",
+      "schedule.validate",
+      "server.info",
+      "state.ls",
+      "state.stats",
+      "stats.runs",
+      "team.list"
+    ]
+  },
+  "projections": {
+    "agent": {
+      "path": "agent",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "agent",
+        "properties": {
+          "query": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional model spec followed by the prompt. Model is one of 'claude', 'codex', 'gemini-code' (defaults), or a full spec like 'claude/opus'; omit it when -a / --resume / -c provides one. The prompt may instead be passed via --prompt or --prompt-file.",
+            "x-positional": true
+          },
+          "prompt_flag": {
+            "type": "string",
+            "description": "The instruction, as a flag instead of the positional PROMPT. Give it one way or the other, never both.",
+            "x-flag": "--prompt"
+          },
+          "prompt_file": {
+            "type": "string",
+            "description": "Read the instruction from a file; '-' reads stdin, which is heredoc-friendly. The file is read once at spawn, so editing it afterwards cannot change the run.",
+            "x-flag": "--prompt-file"
+          },
+          "agent": {
+            "type": "string",
+            "description": "Load agent profile by name. Resolves .lionagi/agents/<NAME>/<NAME>.md first, then .lionagi/agents/<NAME>.md, then a trusted+enabled plugin's declared profile ('<plugin>/<NAME>', or a bare NAME when only one plugin declares it). Profile provides system prompt, default model, effort, yolo, timeout, resume_on_timeout. CLI flags override profile settings.",
+            "x-flag": "--agent",
+            "x-aliases": [
+              "-a"
+            ]
+          },
+          "list_profiles": {
+            "type": "boolean",
+            "description": "Print every agent profile -a would resolve, as JSON, and exit without running anything. Use it to find out what names are available here.",
+            "default": false,
+            "x-flag": "--list-profiles"
+          },
+          "resume": {
+            "type": "string",
+            "description": "Continue a previous run by its branch id, keeping that conversation's history. Cannot be combined with --context-from, which is for starting fresh.",
+            "x-flag": "--resume",
+            "x-aliases": [
+              "-r"
+            ]
+          },
+          "continue_last": {
+            "type": "boolean",
+            "description": "Continue the most recently used branch, keeping its history, without having to look up its id.",
+            "default": false,
+            "x-flag": "--continue-last",
+            "x-aliases": [
+              "-c"
+            ]
+          },
+          "preset": {
+            "type": "string",
+            "enum": [
+              "coding"
+            ],
+            "description": "Apply a built-in agent configuration preset. Supported values: coding. 'coding' wires CodingToolkit with path-guard hooks and a coding system prompt; cwd defaults to the invocation directory.",
+            "x-flag": "--preset"
+          },
+          "form": {
+            "type": "string",
+            "description": "Path to a YAML or JSON work-form spec file. The spec declares typed fields and values; validation runs BEFORE any LLM call. Exits rc=1 on validation error. Validated values are injected into the prompt as structured context.",
+            "x-flag": "--form"
+          },
+          "image": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Attach an image file to the prompt (repeatable, e.g. --image a.png --image b.jpg). Supported extensions: .gif, .jpeg, .jpg, .png, .webp. Each file is read, base64-encoded, and attached as an image content part on the user message.",
+            "x-flag": "--image"
+          },
+          "context_from": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Inject distilled context from a prior session id, branch id, run id, or file path into this new branch's first instruction, above the prompt. Repeatable (concatenated in argv order); the total budget (see --context-budget) is shared across all refs. Rejected in combination with -r / --resume or -c / --continue-last.",
+            "x-flag": "--context-from"
+          },
+          "context_budget": {
+            "type": "integer",
+            "description": "Total token budget for --context-from content (default 8000; ~4 chars/token).",
+            "x-flag": "--context-budget"
+          },
+          "mcp_config": {
+            "type": "string",
+            "description": "Read this MCP config and hand its servers to the leg explicitly. By default the nearest .mcp.json at or above the directory this command was run in is used, so the leg's tools come from the submission rather than from --cwd. The file is read once at spawn.",
+            "x-flag": "--mcp-config"
+          },
+          "no_mcp_config": {
+            "type": "boolean",
+            "description": "Hand the leg no MCP servers, and say so deliberately instead of arriving there by an empty search.",
+            "default": false,
+            "x-flag": "--no-mcp-config"
+          },
+          "yolo": {
+            "type": "boolean",
+            "description": "Auto-approve the agent's tool calls, so an unattended run is never left waiting.",
+            "default": false,
+            "x-flag": "--yolo"
+          },
+          "bypass": {
+            "type": "boolean",
+            "description": "Bypass all codex approvals and sandbox (for cloud/codespace environments).",
+            "default": false,
+            "x-flag": "--bypass"
+          },
+          "fast": {
+            "type": "boolean",
+            "description": "Route codex requests through OpenAI's priority service tier (lower latency; requires account eligibility). Does not change model or reasoning effort.",
+            "default": false,
+            "x-flag": "--fast"
+          },
+          "verbose": {
+            "type": "boolean",
+            "description": "Stream the agent's output as it is produced instead of printing only the final result, and silence the progress lines that would interleave with it.",
+            "default": false,
+            "x-flag": "--verbose",
+            "x-aliases": [
+              "-v"
+            ]
+          },
+          "theme": {
+            "type": "string",
+            "enum": [
+              "light",
+              "dark"
+            ],
+            "description": "Pick the colour scheme printed output is tuned for: 'light' or 'dark' terminal.",
+            "x-flag": "--theme"
+          },
+          "effort": {
+            "type": "string",
+            "description": "Override effort (overrides spec suffix). claude: low|medium|high|xhigh|max. codex: none|minimal|low|medium|high|xhigh|max|ultra (max/ultra clamp per model support). gemini-code/gemini-cli: folded into --model as Low|Medium|High (Gemini 3.1 Pro has no Medium).",
+            "x-flag": "--effort"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Directory the agent's process runs in \u2014 the repo or worktree it acts on. Defaults to the current directory.",
+            "x-flag": "--cwd"
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Hard wall-clock timeout in seconds. When set, a [DEADLINE] preamble is injected into the agent's prompt so the agent knows its time budget and can pace reasoning accordingly.",
+            "x-flag": "--timeout"
+          },
+          "invocation": {
+            "type": "string",
+            "description": "Parent invocation id (from `li invoke start`). Groups this session under a skill orchestration record. Optional.",
+            "x-flag": "--invocation"
+          },
+          "project": {
+            "type": "string",
+            "description": "Explicit project name for this session. Overrides auto-detection from .lionagi/config.toml or git remote.",
+            "x-flag": "--project"
+          },
+          "resume_on_timeout": {
+            "type": "boolean",
+            "description": "If the run terminates on --timeout, automatically fire one resume of the same session with 'continue and conclude the task' and report the combined result. Bounded to a single auto-resume; a timeout on the resumed leg terminates normally. Same effect as an agent profile's 'resume_on_timeout: once'.",
+            "default": false,
+            "x-flag": "--resume-on-timeout"
+          },
+          "notify": {
+            "type": "string",
+            "description": "Shell command template run once this run reaches its terminal status. Overrides .lionagi/settings.yaml notify.on_terminal. Substitutes {payload} (full JSON), {status}, {invocation_id}.",
+            "x-flag": "--notify"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Spawn a single subagent and wait for its final response. Flags may appear anywhere relative to the positionals. Use -r / -c to continue a previous conversation. Use -a to load a profile from .lionagi/agents/. Use --preset to apply a built-in agent configuration. Use --form to load and validate structured inputs before invoking. Use --context-from to hand a new agent distilled context from a prior session/branch/run/file.",
+        "x-required-unenforced": [
+          "query"
+        ],
+        "x-positional-order": [
+          "query"
+        ]
+      }
+    },
+    "casts": {
+      "path": "casts",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "casts",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Role or mode to print in full, including its prompt body. Looked up in both catalogs, so you need not know which it is. Omit it to list names only.",
+            "x-positional": true
+          },
+          "modes": {
+            "type": "boolean",
+            "description": "List the behavior overlays (modes) instead of the personas (roles). Only affects the bare listing; ignored when a name is given.",
+            "default": false,
+            "x-flag": "--modes"
+          }
+        },
+        "additionalProperties": false,
+        "x-positional-order": [
+          "name"
+        ]
+      }
+    },
+    "dispatch ack": {
+      "path": "dispatch ack",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "dispatch ack",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the dispatch to acknowledge, as listed by `li dispatch ls`.",
+            "x-positional": true
+          },
+          "token": {
+            "type": "string",
+            "description": "The ack_token this dispatch was delivered with, reported by `li dispatch show`. A mismatched token is refused, so an acknowledgement cannot be guessed.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "token"
+        ],
+        "x-positional-order": [
+          "id",
+          "token"
+        ]
+      }
+    },
+    "dispatch ls": {
+      "path": "dispatch ls",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "dispatch ls",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Show only rows in this status: pending, delivering, delivered, acked, dead_letter or expired. Omit to list every status.",
+            "x-flag": "--status"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum rows to print, newest first (default 50).",
+            "default": 50,
+            "x-flag": "--limit"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "dispatch purge": {
+      "path": "dispatch purge",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "dispatch purge",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of a single dispatch to delete, whatever its status. Omit it to bulk-delete by --status/--before instead; one of the two is then required.",
+            "x-positional": true
+          },
+          "status": {
+            "type": "string",
+            "description": "Bulk purge: match this status exactly, including pending/delivering (explicit status is deliberate operator intent).",
+            "x-flag": "--status"
+          },
+          "before": {
+            "type": "number",
+            "description": "Bulk purge: match rows with updated_at <= this epoch-seconds value. Without --status, this is scoped to terminal statuses only (delivered/acked/dead_letter/expired) and never sweeps pending/delivering rows.",
+            "x-flag": "--before"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "description": "Report what would be deleted without deleting (single-row and bulk).",
+            "default": false,
+            "x-flag": "--dry-run"
+          }
+        },
+        "additionalProperties": false,
+        "description": "With ID: delete that one row (any status), auditable via admin_events action=dispatch_purge. Without ID: bulk-delete by --status/--before (at least one required, so a bare `purge` cannot mass-delete); --dry-run reports counts without deleting. An explicit --status is honored exactly as given, including pending/delivering (naming an in-flight status is deliberate operator intent). A bare --before with no --status is scoped to terminal statuses only (delivered/acked/dead_letter/expired) and never touches pending/delivering rows.",
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "dispatch retry": {
+      "path": "dispatch retry",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "dispatch retry",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the dispatch to re-queue for delivery.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "dispatch show": {
+      "path": "dispatch show",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "dispatch show",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the dispatch row to show, as listed by `li dispatch ls`.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "doctor": {
+      "path": "doctor",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "doctor",
+        "properties": {
+          "json": {
+            "type": "boolean",
+            "description": "Emit a JSON object of check name -> {status, detail} instead of plain text.",
+            "default": false,
+            "x-flag": "--json"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Environment preflight: install location + editability, Python/venv, the import chain `li --version` traverses, core dependency importability, Studio daemon reachability, and ~/.lionagi writability."
+      }
+    },
+    "engine run": {
+      "path": "engine run",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "engine run",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "research",
+              "review",
+              "coding",
+              "hypothesis",
+              "planning"
+            ],
+            "description": "Engine kind to run. One of: coding, hypothesis, planning, research, review.",
+            "x-positional": true
+          },
+          "spec": {
+            "type": "string",
+            "description": "Main input for the engine (topic / artifact / spec / findings / prompt).",
+            "x-positional": true
+          },
+          "test_cmd": {
+            "type": "string",
+            "description": "Test command to validate generated code (required for 'coding' kind). May be a shell string or a quoted list.",
+            "x-flag": "--test-cmd"
+          },
+          "export_dir": {
+            "type": "string",
+            "description": "Directory to save engine outputs to (optional; supported by 'coding' and 'hypothesis' kinds).",
+            "x-flag": "--export-dir"
+          },
+          "dedup_repo": {
+            "type": "string",
+            "description": "GitHub repo to check findings against before extraction ('hypothesis' kind only). Findings whose mechanism an existing open or closed issue already covers are recorded and not expanded; certified-new findings land in the export's filing queue. The engine never files issues itself.",
+            "x-flag": "--dedup-repo"
+          },
+          "dedup_cwd": {
+            "type": "string",
+            "description": "Checkout of the dedup repo so the novelty check can source-confirm a finding's cite ('hypothesis' kind only; optional).",
+            "x-flag": "--dedup-cwd"
+          },
+          "model": {
+            "type": "string",
+            "description": "Model to use (provider/name, e.g. claude/sonnet; an effort suffix like codex/gpt-5.6-luna-high is honored). Overrides per-stage defaults. Uses engine defaults if omitted.",
+            "x-flag": "--model"
+          },
+          "effort": {
+            "type": "string",
+            "description": "Reasoning effort for all stages (e.g. low, medium, high, xhigh). Overrides per-stage defaults; a per-stage default applies otherwise.",
+            "x-flag": "--effort"
+          },
+          "max_depth": {
+            "type": "integer",
+            "description": "Maximum recursion/expansion depth for the engine (kind-specific default).",
+            "x-flag": "--max-depth"
+          },
+          "max_agents": {
+            "type": "integer",
+            "description": "Maximum number of sub-agents the engine may spawn.",
+            "x-flag": "--max-agents"
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Associate this engine run with an existing session in StateDB (written to engine_runs.session_id).",
+            "x-flag": "--session-id"
+          },
+          "no_persist": {
+            "type": "boolean",
+            "description": "Skip writing the engine run record to StateDB.",
+            "default": false,
+            "x-flag": "--no-persist"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Run a lionagi engine of a specific kind.\n\nAvailable kinds: coding, hypothesis, planning, research, review\n\nProgress events are written to stderr as human-readable lines.\nThe final result is written as JSON to stdout.",
+        "required": [
+          "kind",
+          "spec"
+        ],
+        "x-positional-order": [
+          "kind",
+          "spec"
+        ]
+      }
+    },
+    "handshake": {
+      "path": "handshake",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "handshake",
+        "properties": {
+          "machine": {
+            "type": "boolean",
+            "description": "Emit the machine-result envelope.",
+            "default": false,
+            "x-flag": "--machine"
+          }
+        },
+        "additionalProperties": false,
+        "description": "The version a machine consumer negotiates against at registration. Add --machine for the contract envelope on stdout."
+      }
+    },
+    "hooks import": {
+      "path": "hooks import",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "hooks import",
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": [
+              "claude",
+              "codex"
+            ],
+            "description": "Which harness wrote the config being imported: 'claude' for Claude Code's settings.json shape, 'codex' for the Codex hooks.json shape.",
+            "x-positional": true
+          },
+          "path": {
+            "type": "string",
+            "description": "Config file to read. Defaults to .claude/settings.json or .codex/hooks.json under the project directory, matching the source given.",
+            "x-positional": true
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Project whose .lionagi/settings.yaml receives the imported hooks, and where the default config path is looked up (defaults to the current directory).",
+            "x-flag": "--cwd"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "source"
+        ],
+        "x-positional-order": [
+          "source",
+          "path"
+        ]
+      }
+    },
+    "hooks trust": {
+      "path": "hooks trust",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "hooks trust",
+        "properties": {
+          "cwd": {
+            "type": "string",
+            "description": "Project whose imported hook commands are listed and approved (defaults to the current directory).",
+            "x-flag": "--cwd"
+          },
+          "yes": {
+            "type": "boolean",
+            "description": "Record trust without an interactive confirmation prompt.",
+            "default": false,
+            "x-flag": "--yes"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "invoke end": {
+      "path": "invoke end",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "invoke end",
+        "properties": {
+          "invocation_id": {
+            "type": "string",
+            "description": "The id printed by `li invoke start`. An invocation never closed stays 'running' forever.",
+            "x-positional": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "failed",
+              "timed_out",
+              "aborted",
+              "cancelled"
+            ],
+            "description": "How the work ended, which also fixes the reason stored with it: 'completed' for success, 'failed' for an exception, 'timed_out' for a deadline, 'aborted' for a user interrupt, 'cancelled' for a system cancellation. Later listings and dashboards filter on this, so leaving the default on work that did not succeed records it as a success.",
+            "default": "completed",
+            "x-flag": "--status"
+          },
+          "metadata": {
+            "type": "string",
+            "description": "JSON merged key-by-key into the invocation's existing metadata, so anything written during the run survives unless this overwrites that key.",
+            "x-flag": "--metadata"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "invocation_id"
+        ],
+        "x-positional-order": [
+          "invocation_id"
+        ]
+      }
+    },
+    "invoke list": {
+      "path": "invoke list",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "invoke list",
+        "properties": {
+          "skill": {
+            "type": "string",
+            "description": "Show only invocations of this skill name, matched exactly.",
+            "x-flag": "--skill"
+          },
+          "status": {
+            "type": "string",
+            "description": "Show only invocations in this status: running, completed, failed, timed_out, aborted or cancelled.",
+            "x-flag": "--status"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum rows to print, newest first (default 20).",
+            "default": 20,
+            "x-flag": "--limit"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "invoke start": {
+      "path": "invoke start",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "invoke start",
+        "properties": {
+          "skill": {
+            "type": "string",
+            "description": "Name of the orchestration being recorded, e.g. 'show', 'codex-pr-review' or 'reprompt'. Every session spawned under this id groups by it.",
+            "x-flag": "--skill"
+          },
+          "plugin": {
+            "type": "string",
+            "description": "Marketplace plugin packaging that skill, when the skill came from one.",
+            "x-flag": "--plugin"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "The request that triggered this work, stored as free text for later reading.",
+            "x-flag": "--prompt"
+          },
+          "metadata": {
+            "type": "string",
+            "description": "Skill-specific JSON to attach (e.g. show plan, review rounds). Stored verbatim; rendered as-is on the invocation detail page.",
+            "x-flag": "--metadata"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "skill"
+        ]
+      }
+    },
+    "kill": {
+      "path": "kill",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "kill",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Entity id to kill: run_id / session_id / invocation_id / play_id / show_id. Accepts a full UUID, or an id prefix (resolved to the first matching row).",
+            "x-positional": true
+          },
+          "reason": {
+            "type": "string",
+            "description": "Optional human-readable reason recorded in status_transitions.",
+            "default": "",
+            "x-flag": "--reason"
+          },
+          "recursive": {
+            "type": "boolean",
+            "description": "Also kill direct child entities (e.g. invocations spawned by a session). Has no effect on a play kill, which already reaps whatever worker chain the row records, or on a show kill, which cannot reach one -- kill the session ids directly to stop a show's workers.",
+            "default": false,
+            "x-flag": "--recursive"
+          },
+          "all_stale": {
+            "type": "boolean",
+            "description": "Sweep stale sessions and invocations with dead PIDs older than --threshold. A play older than --threshold whose recorded worker session has gone terminal is marked 'blocked'; a play that records no worker session is left running, because age alone cannot tell it apart from one still working. A show is marked 'aborted' only once it is older than --threshold and ALL of its plays are terminal.",
+            "default": false,
+            "x-flag": "--all-stale"
+          },
+          "threshold": {
+            "type": "integer",
+            "description": "Stale threshold in seconds (default 3600 = 1h). Only entities started more than this many seconds ago are swept.",
+            "default": 3600,
+            "x-flag": "--threshold"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "description": "Print what would be killed/cancelled without making any changes.",
+            "default": false,
+            "x-flag": "--dry-run"
+          },
+          "grace": {
+            "type": "number",
+            "description": "Seconds to wait after SIGTERM before escalating to SIGKILL (default 5).",
+            "default": 5.0,
+            "x-flag": "--grace"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Kill a running lionagi entity by id, or sweep all stale running entities whose underlying OS process is dead.\n\nThe entity's status is set to 'cancelled' (sessions/invocations), 'blocked' (plays), or 'aborted' (shows) with reason tracking per ADR-0028.\n\nRecursion boundary: --recursive kills a session's or invocation's direct children, which are the PID-bearing workers. A PLAY kill reaches the play's worker chain only when the row records the session it started; a play created by a live run does not, so that kill marks the row terminal and exits non-zero to say no worker was stopped. A SHOW kill only marks the show row terminal. To stop work either one cannot reach, kill the session ids directly; --all-stale marks a play 'blocked' only when the row records a worker session that has gone terminal, and leaves an unlinked play running.\n\nExamples:\n  li kill abc123                        # kill by id prefix\n  li kill <session-id>                  # stop a worker process\n  li kill abc123 --reason 'stuck'\n  li kill abc123 --recursive            # kill + direct children\n  li kill --all-stale                   # sweep dead-PID rows\n  li kill --all-stale --threshold 3600  # only rows older than 1h\n  li kill --all-stale --dry-run",
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "lifecycle": {
+      "path": "lifecycle",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "lifecycle",
+        "properties": {
+          "run_id": {
+            "type": "string",
+            "description": "The run id to report on.",
+            "x-positional": true
+          },
+          "machine": {
+            "type": "boolean",
+            "description": "Emit the machine-result envelope.",
+            "default": false,
+            "x-flag": "--machine"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Read-only: what the lifecycle store records about one run id \u2014 whether a session was ever recorded for it, whether every one of them has ended, and with what outcome. A run stopped by `li kill` reads as cancelled here. Add --machine for the contract envelope on stdout.",
+        "required": [
+          "run_id"
+        ],
+        "x-positional-order": [
+          "run_id"
+        ]
+      }
+    },
+    "mcp": {
+      "path": "mcp",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "mcp",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "serve"
+            ],
+            "description": "What to do: 'serve' (the default and only value) runs the server on stdin/stdout until the client disconnects.",
+            "default": "serve",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Serve the lionagi MCP server over stdio. It advertises one tool, request(ops=[{op, args}], help?), with every operation behind it as a namespaced verb: agent.submit, flow.submit, fanout.submit and play.submit start detached background runs, job.status, job.output, job.list, job.wait and job.kill follow them. Call request(help=true) for the verb catalog and request(help=\"<verb>\") for one verb's parameters, generated from this CLI's own parsers. Requires the 'mcp' extra: pip install 'lionagi[mcp]'.",
+        "x-positional-order": [
+          "action"
+        ]
+      }
+    },
+    "monitor": {
+      "path": "monitor",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "monitor",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Run, session, play or show to open in the detail view \u2014 full id, or an unambiguous prefix. Omit it for the table of everything in flight.",
+            "x-positional": true
+          },
+          "watch": {
+            "type": "boolean",
+            "description": "Redraw the view every --refresh seconds until interrupted, instead of printing one snapshot and exiting.",
+            "default": false,
+            "x-flag": "--watch",
+            "x-aliases": [
+              "-w"
+            ]
+          },
+          "refresh": {
+            "type": "integer",
+            "description": "Seconds between redraws under --watch (default 2). Ignored without it.",
+            "default": 2,
+            "x-flag": "--refresh"
+          },
+          "since": {
+            "type": "string",
+            "description": "Only show entities updated within this time window. Format: 30m, 1h, 2d (minutes/hours/days). Default: all running.",
+            "x-flag": "--since"
+          },
+          "entity_type": {
+            "type": "string",
+            "enum": [
+              "session",
+              "invocation",
+              "show",
+              "play"
+            ],
+            "description": "Narrow the table to one kind of entity: session, invocation, show or play.",
+            "x-flag": "--type",
+            "x-aliases": [
+              "-t"
+            ]
+          },
+          "project": {
+            "type": "string",
+            "description": "Filter sessions and plays to one project name, matched exactly \u2014 the same name the table's project column shows.",
+            "x-flag": "--project",
+            "x-aliases": [
+              "-p"
+            ]
+          },
+          "run_ids": {
+            "type": "string",
+            "description": "Wait for one or more schedule_run IDs to reach a terminal state, then exit (scripting primitive; see `li monitor run --help` for the positional form). Follows scheduler on_success/on_fail chain children by default (see --no-chain). Ignores id/--watch/--since/--type/--project.",
+            "x-flag": "--run"
+          },
+          "interval": {
+            "type": "number",
+            "description": "Seconds between state.db polls in --run mode (default 3). Independent of --refresh, which paces the table redraw.",
+            "default": 3.0,
+            "x-flag": "--interval"
+          },
+          "follow": {
+            "type": "boolean",
+            "description": "With --run: keep discovering schedule_runs created after the initial set drains, instead of exiting once it is empty. Never ends on its own \u2014 pair with --max-wait.",
+            "default": false,
+            "x-flag": "--follow"
+          },
+          "chain": {
+            "type": "boolean",
+            "description": "With --run: watch only the literal id(s) given, instead of following scheduler on_success/on_fail chain children by default.",
+            "default": true,
+            "x-flag": "--no-chain"
+          },
+          "max_wait": {
+            "type": "number",
+            "description": "With --run: give up waiting after this many seconds and exit EXIT_RUNNING for whatever is still pending, instead of blocking forever on a stuck session or run. Default: 900s. Pass 0 for unlimited.",
+            "x-flag": "--max-wait"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Show all running entities (sessions, invocations, shows, plays) in a compact table, or drill into one entity by ID. Use --watch for live refresh.",
+        "x-positional-order": [
+          "id"
+        ]
+      },
+      "aliases": [
+        "mon"
+      ]
+    },
+    "orchestrate ctl msg": {
+      "path": "orchestrate ctl msg",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "orchestrate ctl msg",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Running flow, playbook run, or agent leg to message, by session, invocation, play, or run id (full, or an unambiguous prefix).",
+            "x-positional": true
+          },
+          "text": {
+            "type": "string",
+            "description": "Message merged into the flow's workspace context. Ops already started will not see it; every op that has not started yet will.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Queues a message control row. A flow or playbook run's control poller deep-merges it into the workspace context, visible to any op not yet started (context mode only; --as-op is not supported by this command yet). A running `li agent` leg instead drains it at its next turn boundary, landing as a warm continuation turn rather than a context merge \u2014 check `li o ctl status` for which happened.",
+        "required": [
+          "id",
+          "text"
+        ],
+        "x-positional-order": [
+          "id",
+          "text"
+        ]
+      },
+      "aliases": [
+        "o ctl msg"
+      ]
+    },
+    "orchestrate ctl pause": {
+      "path": "orchestrate ctl pause",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "orchestrate ctl pause",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Running flow to pause, by session, invocation, play, or run id (full, or an unambiguous prefix). The pause lands at the next op boundary, not mid-op.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Queues a pause control row; the target flow's control poller applies it at the next op boundary (idempotent \u2014 safe to queue more than once).",
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      },
+      "aliases": [
+        "o ctl pause"
+      ]
+    },
+    "orchestrate ctl resolve": {
+      "path": "orchestrate ctl resolve",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "orchestrate ctl resolve",
+        "properties": {
+          "control_id": {
+            "type": "string",
+            "description": "The control id shown by `li o ctl status` (full, no prefix matching).",
+            "x-positional": true
+          },
+          "outcome": {
+            "type": "string",
+            "enum": [
+              "applied",
+              "abandoned"
+            ],
+            "description": "What you established actually happened: 'applied' if the message reached the run, 'abandoned' if it did not and will not.",
+            "x-flag": "--as"
+          },
+          "actor": {
+            "type": "string",
+            "description": "Who resolved it, recorded beside the claim. Defaults to the OS account running the command; pass this when that is not the person who found out.",
+            "x-flag": "--by"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A `msg` control is delivered at most once, so a consumer claims it before attempting the delivery. If that consumer dies in between, nothing left behind can say whether the message reached the model, and the row is deliberately left standing rather than guessed at. `li o ctl status` shows who claimed it and when. Use this once you have found out which it was; the claim is preserved in the record.",
+        "required": [
+          "control_id",
+          "outcome"
+        ],
+        "x-positional-order": [
+          "control_id"
+        ]
+      },
+      "aliases": [
+        "o ctl resolve"
+      ]
+    },
+    "orchestrate ctl resume": {
+      "path": "orchestrate ctl resume",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "orchestrate ctl resume",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Paused flow to release, by session, invocation, play, or run id (full, or an unambiguous prefix).",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Queues a resume control row, releasing a pending pause gate.",
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      },
+      "aliases": [
+        "o ctl resume"
+      ]
+    },
+    "orchestrate ctl status": {
+      "path": "orchestrate ctl status",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "orchestrate ctl status",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Session, invocation, play, or run id to report on \u2014 full, or an unambiguous prefix. Required here: this command has no 'latest run' default.",
+            "x-positional": true
+          },
+          "as_json": {
+            "type": "boolean",
+            "description": "Print one JSON object with stable keys instead of the human table, for scripting.",
+            "default": false,
+            "x-flag": "--json"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Generic id-addressed status lookup \u2014 no agent/play kind scoping, so <id> is required (no 'latest run' default). Prefer `li agent status` / `li play status` when the kind is known.",
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      },
+      "aliases": [
+        "o ctl status"
+      ]
+    },
+    "orchestrate fanout": {
+      "path": "orchestrate fanout",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "orchestrate fanout",
+        "properties": {
+          "query": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Orchestrator model spec (provider/model-effort) followed by the task prompt. Model is also used as the default worker model unless --workers is set; omit it when -a/--agent provides one. A single positional is treated as the prompt.",
+            "x-positional": true
+          },
+          "agent": {
+            "type": "string",
+            "description": "Load orchestrator profile by name. Resolves .lionagi/agents/<NAME>/<NAME>.md first, then .lionagi/agents/<NAME>.md. Profile provides system prompt, default model, effort, yolo. CLI flags and positional model override profile settings.",
+            "x-flag": "--agent",
+            "x-aliases": [
+              "-a"
+            ]
+          },
+          "num_workers": {
+            "type": "integer",
+            "description": "Maximum assignments the orchestrator generates (default 3). It may generate fewer if the task does not divide that far, and --workers specs beyond this cap go unused.",
+            "default": 3,
+            "x-flag": "--num-workers",
+            "x-aliases": [
+              "-n"
+            ]
+          },
+          "workers": {
+            "type": "string",
+            "description": "Comma-separated worker model specs, assigned round-robin (each may carry an effort suffix). This is how one fanout mixes cheap and expensive models across workers.",
+            "x-flag": "--workers"
+          },
+          "pack": {
+            "type": "string",
+            "description": "Path to a YAML routing pack. Provides per-role model/effort when --workers is absent. --workers overrides pack routing.",
+            "x-flag": "--pack"
+          },
+          "max_concurrent": {
+            "type": "integer",
+            "description": "Cap on workers running at the same time. 0, the default, runs them all at once \u2014 lower it to stay under a provider's rate limit.",
+            "default": 0,
+            "x-flag": "--max-concurrent"
+          },
+          "with_synthesis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "const": true
+              }
+            ],
+            "x-bare-value": true,
+            "description": "Run a final pass merging the workers' results into one answer. Bare flag uses the orchestrator model; with an argument, that model instead.",
+            "default": false,
+            "x-flag": "--with-synthesis"
+          },
+          "synthesis_prompt": {
+            "type": "string",
+            "description": "What the merged answer should be \u2014 a ranked list, a decision, a single patch. Implies synthesis.",
+            "x-flag": "--synthesis-prompt"
+          },
+          "output": {
+            "type": "string",
+            "enum": [
+              "text",
+              "json"
+            ],
+            "description": "Result format: 'text' (default) for reading, 'json' for a machine-readable run.",
+            "default": "text",
+            "x-flag": "--output"
+          },
+          "save": {
+            "type": "string",
+            "description": "Directory to write each worker's output and the run's artifacts into. Without it they land in the run's own artifacts directory.",
+            "x-flag": "--save"
+          },
+          "team_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "const": true
+              }
+            ],
+            "x-bare-value": "fanout",
+            "description": "Create a persistent team for this fanout. Workers get team context and results are posted as team messages. Bare flag uses 'fanout' as team name; with arg uses that name.",
+            "x-flag": "--team-mode"
+          },
+          "mcp_config": {
+            "type": "string",
+            "description": "Read this MCP config and hand its servers to every worker this run builds. By default the nearest .mcp.json at or above the directory this command was run in is used, so the workers' tools come from the submission rather than from --cwd. The file is read once, at startup.",
+            "x-flag": "--mcp-config"
+          },
+          "no_mcp_config": {
+            "type": "boolean",
+            "description": "Hand the workers no MCP servers, and say so deliberately instead of arriving there by an empty search.",
+            "default": false,
+            "x-flag": "--no-mcp-config"
+          },
+          "yolo": {
+            "type": "boolean",
+            "description": "Auto-approve the agent's tool calls, so an unattended run is never left waiting.",
+            "default": false,
+            "x-flag": "--yolo"
+          },
+          "bypass": {
+            "type": "boolean",
+            "description": "Bypass all codex approvals and sandbox (for cloud/codespace environments).",
+            "default": false,
+            "x-flag": "--bypass"
+          },
+          "fast": {
+            "type": "boolean",
+            "description": "Route codex requests through OpenAI's priority service tier (lower latency; requires account eligibility). Does not change model or reasoning effort.",
+            "default": false,
+            "x-flag": "--fast"
+          },
+          "verbose": {
+            "type": "boolean",
+            "description": "Stream the agent's output as it is produced instead of printing only the final result, and silence the progress lines that would interleave with it.",
+            "default": false,
+            "x-flag": "--verbose",
+            "x-aliases": [
+              "-v"
+            ]
+          },
+          "theme": {
+            "type": "string",
+            "enum": [
+              "light",
+              "dark"
+            ],
+            "description": "Pick the colour scheme printed output is tuned for: 'light' or 'dark' terminal.",
+            "x-flag": "--theme"
+          },
+          "effort": {
+            "type": "string",
+            "description": "Override effort (overrides spec suffix). claude: low|medium|high|xhigh|max. codex: none|minimal|low|medium|high|xhigh|max|ultra (max/ultra clamp per model support). gemini-code/gemini-cli: folded into --model as Low|Medium|High (Gemini 3.1 Pro has no Medium).",
+            "x-flag": "--effort"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Directory the agent's process runs in \u2014 the repo or worktree it acts on. Defaults to the current directory.",
+            "x-flag": "--cwd"
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Hard wall-clock timeout in seconds. When set, a [DEADLINE] preamble is injected into the agent's prompt so the agent knows its time budget and can pace reasoning accordingly.",
+            "x-flag": "--timeout"
+          },
+          "invocation": {
+            "type": "string",
+            "description": "Parent invocation id (from `li invoke start`). Groups this session under a skill orchestration record. Optional.",
+            "x-flag": "--invocation"
+          },
+          "project": {
+            "type": "string",
+            "description": "Explicit project name for this session. Overrides auto-detection from .lionagi/config.toml or git remote.",
+            "x-flag": "--project"
+          },
+          "resume_on_timeout": {
+            "type": "boolean",
+            "description": "If the run terminates on --timeout, automatically fire one resume of the same session with 'continue and conclude the task' and report the combined result. Bounded to a single auto-resume; a timeout on the resumed leg terminates normally. Same effect as an agent profile's 'resume_on_timeout: once'.",
+            "default": false,
+            "x-flag": "--resume-on-timeout"
+          },
+          "notify": {
+            "type": "string",
+            "description": "Shell command template run once this run reaches its terminal status. Overrides .lionagi/settings.yaml notify.on_terminal. Substitutes {payload} (full JSON), {status}, {invocation_id}.",
+            "x-flag": "--notify"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Orchestrator decomposes task into N agent requests, fans out to workers, optionally synthesizes. Effort can be embedded in model spec: claude/opus-4-7-high. Flags may appear anywhere relative to the positionals.",
+        "x-required-unenforced": [
+          "query"
+        ],
+        "x-positional-order": [
+          "query"
+        ]
+      },
+      "aliases": [
+        "o fanout"
+      ]
+    },
+    "orchestrate flow": {
+      "path": "orchestrate flow",
+      "stage": "base",
+      "schema": {
+        "type": "object",
+        "title": "orchestrate flow",
+        "properties": {
+          "query": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Orchestrator model spec followed by the task prompt. Model is optional when -a/--agent provides one; a single positional is treated as the prompt. The prompt itself may instead come from -f/--file or -p/--playbook.",
+            "x-positional": true
+          },
+          "file": {
+            "type": "string",
+            "description": "Load flow spec from YAML or JSON file. File values serve as defaults; CLI flags override them. Prompt can come from the file (prompt: key) or as a positional argument.",
+            "x-flag": "--file",
+            "x-aliases": [
+              "-f"
+            ]
+          },
+          "playbook": {
+            "type": "string",
+            "description": "Load playbook from ~/.lionagi/playbooks/<NAME>.playbook.yaml. Playbooks may declare args: schema, artifacts: contracts, or argument-hint: placeholders for prompt template values.",
+            "x-flag": "--playbook",
+            "x-aliases": [
+              "-p"
+            ]
+          },
+          "agent": {
+            "type": "string",
+            "description": "Load orchestrator profile by name \u2014 resolves .lionagi/agents/<NAME>/<NAME>.md first, then .lionagi/agents/<NAME>.md.",
+            "x-flag": "--agent",
+            "x-aliases": [
+              "-a"
+            ]
+          },
+          "with_synthesis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "const": true
+              }
+            ],
+            "x-bare-value": true,
+            "description": "Run a final pass merging the DAG's results into one answer. Bare flag uses the orchestrator model; with an argument, that model instead.",
+            "default": false,
+            "x-flag": "--with-synthesis"
+          },
+          "max_concurrent": {
+            "type": "integer",
+            "description": "Cap on agents running at the same time within one phase. 0, the default, runs the whole phase at once \u2014 lower it to stay under a provider's rate limit.",
+            "default": 0,
+            "x-flag": "--max-concurrent"
+          },
+          "output": {
+            "type": "string",
+            "enum": [
+              "text",
+              "json"
+            ],
+            "description": "Result format: 'text' (default) for reading, 'json' for a machine-readable run.",
+            "default": "text",
+            "x-flag": "--output"
+          },
+          "save": {
+            "type": "string",
+            "description": "Directory to write each agent's output and the run's artifacts into. Required by --background, which has nowhere else to report.",
+            "x-flag": "--save"
+          },
+          "team_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "const": true
+              }
+            ],
+            "x-bare-value": "flow",
+            "description": "Create a FRESH team for this flow (new UUID every invocation). Bare flag uses 'flow' as the name.",
+            "x-flag": "--team-mode"
+          },
+          "team_attach": {
+            "type": "string",
+            "description": "Attach to a team by NAME \u2014 upsert semantics: load existing team if found (preserving message history), else create fresh. Mutually exclusive with --team-mode.",
+            "x-flag": "--team-attach"
+          },
+          "team_max_rounds": {
+            "type": "integer",
+            "description": "In team mode (reactive), how many extra wakeup rounds the coordinator may run after all currently-running workers signal done, to deliver unread teammate messages before the run wraps up (default: 2).",
+            "default": 2,
+            "x-flag": "--team-max-rounds"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "description": "Plan the DAG but don't execute. Shows agents, deps, and model resolution.",
+            "default": false,
+            "x-flag": "--dry-run"
+          },
+          "show_graph": {
+            "type": "boolean",
+            "description": "Render DAG as matplotlib visualization. With --save, saves PNG to save dir.",
+            "default": false,
+            "x-flag": "--show-graph"
+          },
+          "background": {
+            "type": "boolean",
+            "description": "Run flow in background. Requires --save. Check output in save dir.",
+            "default": false,
+            "x-flag": "--background"
+          },
+          "bare": {
+            "type": "boolean",
+            "description": "Ignore agent profiles \u2014 all workers use the CLI model spec. Roles define behavioral focus only, no profile system prompts.",
+            "default": false,
+            "x-flag": "--bare"
+          },
+          "workers": {
+            "type": "string",
+            "description": "Comma-separated worker model specs (assignment i uses pool[i % len]). Overrides the per-role model while KEEPING each role's profile/system prompt \u2014 unlike --bare, which also drops profiles. Enables mixed-model flows (cheap roles + expensive roles).",
+            "x-flag": "--workers"
+          },
+          "pack": {
+            "type": "string",
+            "description": "Path to a YAML routing pack. Provides per-role model/effort when --workers is absent. --workers overrides pack routing.",
+            "x-flag": "--pack"
+          },
+          "max_ops": {
+            "type": "integer",
+            "description": "Cap total ops (nodes in the planned DAG). 0 = unlimited. `--max-agents` is a deprecated alias \u2014 prefer `--max-ops`.",
+            "default": 0,
+            "x-flag": "--max-ops",
+            "x-aliases": [
+              "--max-agents"
+            ]
+          },
+          "reactive": {
+            "type": "string",
+            "description": "Who may grow the live DAG by emitting a SpawnRequest: 'all' (default \u2014 every worker), 'off' (flat batch DAG, no spawning), or a comma-separated list of roles (e.g. 'critic,evaluator') that alone may spawn. Caps still apply via --max-ops.",
+            "x-flag": "--reactive"
+          },
+          "resume": {
+            "type": "string",
+            "description": "Resume a checkpointed flow from a prior process (by run id, or any session/invocation/play id backed by one). Replays the persisted plan verbatim \u2014 no planner call, no other flow flags read (model/prompt/playbook/etc. all come from the checkpoint). Distinct from `li o ctl resume`, which un-pauses a still-running session.",
+            "x-flag": "--resume"
+          },
+          "allow_degraded_context": {
+            "type": "boolean",
+            "description": "With --resume: proceed even when a pending op declared inherit_context \u2014 it runs against an empty branch instead of its predecessor's conversation history, which resume does not restore. Without this flag such ops refuse loudly, naming them.",
+            "default": false,
+            "x-flag": "--allow-degraded-context"
+          },
+          "mcp_config": {
+            "type": "string",
+            "description": "Read this MCP config and hand its servers to every worker this run builds. By default the nearest .mcp.json at or above the directory this command was run in is used, so the workers' tools come from the submission rather than from --cwd. The file is read once, at startup.",
+            "x-flag": "--mcp-config"
+          },
+          "no_mcp_config": {
+            "type": "boolean",
+            "description": "Hand the workers no MCP servers, and say so deliberately instead of arriving there by an empty search.",
+            "default": false,
+            "x-flag": "--no-mcp-config"
+          },
+          "yolo": {
+            "type": "boolean",
+            "description": "Auto-approve the agent's tool calls, so an unattended run is never left waiting.",
+            "default": false,
+            "x-flag": "--yolo"
+          },
+          "bypass": {
+            "type": "boolean",
+            "description": "Bypass all codex approvals and sandbox (for cloud/codespace environments).",
+            "default": false,
+            "x-flag": "--bypass"
+          },
+          "fast": {
+            "type": "boolean",
+            "description": "Route codex requests through OpenAI's priority service tier (lower latency; requires account eligibility). Does not change model or reasoning effort.",
+            "default": false,
+            "x-flag": "--fast"
+          },
+          "verbose": {
+            "type": "boolean",
+            "description": "Stream the agent's output as it is produced instead of printing only the final result, and silence the progress lines that would interleave with it.",
+            "default": false,
+            "x-flag": "--verbose",
+            "x-aliases": [
+              "-v"
+            ]
+          },
+          "theme": {
+            "type": "string",
+            "enum": [
+              "light",
+              "dark"
+            ],
+            "description": "Pick the colour scheme printed output is tuned for: 'light' or 'dark' terminal.",
+            "x-flag": "--theme"
+          },
+          "effort": {
+            "type": "string",
+            "description": "Override effort (overrides spec suffix). claude: low|medium|high|xhigh|max. codex: none|minimal|low|medium|high|xhigh|max|ultra (max/ultra clamp per model support). gemini-code/gemini-cli: folded into --model as Low|Medium|High (Gemini 3.1 Pro has no Medium).",
+            "x-flag": "--effort"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Directory the agent's process runs in \u2014 the repo or worktree it acts on. Defaults to the current directory.",
+            "x-flag": "--cwd"
+          },
+          "timeout": {
+            "type": "integer",
+            "description": "Hard wall-clock timeout in seconds. When set, a [DEADLINE] preamble is injected into the agent's prompt so the agent knows its time budget and can pace reasoning accordingly.",
+            "x-flag": "--timeout"
+          },
+          "invocation": {
+            "type": "string",
+            "description": "Parent invocation id (from `li invoke start`). Groups this session under a skill orchestration record. Optional.",
+            "x-flag": "--invocation"
+          },
+          "project": {
+            "type": "string",
+            "description": "Explicit project name for this session. Overrides auto-detection from .lionagi/config.toml or git remote.",
+            "x-flag": "--project"
+          },
+          "resume_on_timeout": {
+            "type": "boolean",
+            "description": "If the run terminates on --timeout, automatically fire one resume of the same session with 'continue and conclude the task' and report the combined result. Bounded to a single auto-resume; a timeout on the resumed leg terminates normally. Same effect as an agent profile's 'resume_on_timeout: once'.",
+            "default": false,
+            "x-flag": "--resume-on-timeout"
+          },
+          "notify": {
+            "type": "string",
+            "description": "Shell command template run once this run reaches its terminal status. Overrides .lionagi/settings.yaml notify.on_terminal. Substitutes {payload} (full JSON), {status}, {invocation_id}.",
+            "x-flag": "--notify"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Orchestrator analyzes the task, composes a DAG of agents with dependency edges, and executes with automatic parallelism where dependencies allow. Flags may appear anywhere relative to the positionals.",
+        "x-required-unenforced": [
+          "query"
+        ],
+        "x-positional-order": [
+          "query"
+        ],
+        "x-playbook-arguments": "This command accepts arguments declared by the playbook named in 'playbook'. Ask for this schema again with that playbook named to see them."
+      },
+      "aliases": [
+        "o flow"
+      ]
+    },
+    "plugin disable": {
+      "path": "plugin disable",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "plugin disable",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Plugin to leave installed and trusted but inert, as named by `li plugin list`. Re-enable it with `li plugin enable`.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A settings flag, not a file mutation \u2014 the bundle stays pristine.",
+        "required": [
+          "name"
+        ],
+        "x-positional-order": [
+          "name"
+        ]
+      }
+    },
+    "plugin enable": {
+      "path": "plugin enable",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "plugin enable",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Plugin to load again, as named by `li plugin list`. It must already be trusted.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "x-positional-order": [
+          "name"
+        ]
+      }
+    },
+    "plugin info": {
+      "path": "plugin info",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "plugin info",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Plugin to describe \u2014 its manifest `name:`, as listed by `li plugin list`.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "x-positional-order": [
+          "name"
+        ]
+      }
+    },
+    "plugin list": {
+      "path": "plugin list",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "plugin list",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "State is one of: active, disabled, untrusted, changed, incompatible, collision, invalid. Also garbage-collects trust records whose bundle directory no longer exists, printing which ones were pruned and why."
+      }
+    },
+    "plugin trust": {
+      "path": "plugin trust",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "plugin trust",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Plugin to trust, as named by `li plugin list`.",
+            "x-positional": true
+          },
+          "yes": {
+            "type": "boolean",
+            "description": "Record trust without an interactive confirmation prompt.",
+            "default": false,
+            "x-flag": "--yes"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Renders the plugin's full inventory \u2014 every tool target, hook command argv, agent/playbook/pack file, and provider module \u2014 then records a sha256 of each in ~/.lionagi/settings.yaml. Any later change to any of these reverts the plugin to 'changed' until re-trusted. Use --yes to skip the confirmation prompt.",
+        "required": [
+          "name"
+        ],
+        "x-positional-order": [
+          "name"
+        ]
+      }
+    },
+    "runs": {
+      "path": "runs",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "runs",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "description": "How many runs to list.",
+            "default": 20,
+            "x-flag": "--limit"
+          },
+          "machine": {
+            "type": "boolean",
+            "description": "Emit the machine-result envelope.",
+            "default": false,
+            "x-flag": "--machine"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Read-only listing of ~/.lionagi/runs, newest first."
+      }
+    },
+    "schedule apply": {
+      "path": "schedule apply",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule apply",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "Path to a ScheduleSet YAML file.",
+            "x-positional": true
+          },
+          "dry_run": {
+            "type": "boolean",
+            "description": "Show the reconciliation plan with resolved values; no database writes.",
+            "default": false,
+            "x-flag": "--dry-run"
+          },
+          "adopt": {
+            "type": "boolean",
+            "description": "Migrate a same-named row owned by another set/quick-create into this set. Not yet supported.",
+            "default": false,
+            "x-flag": "--adopt"
+          },
+          "as_json": {
+            "type": "boolean",
+            "description": "Emit JSON.",
+            "default": false,
+            "x-flag": "--json"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "file"
+        ],
+        "x-positional-order": [
+          "file"
+        ]
+      }
+    },
+    "schedule create": {
+      "path": "schedule create",
+      "stage": "base",
+      "schema": {
+        "type": "object",
+        "title": "schedule create",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Unique name identifying this schedule. Reused as the display label in listings; a name already in use is rejected rather than overwritten.",
+            "x-positional": true
+          },
+          "trigger_type": {
+            "type": "string",
+            "enum": [
+              "cron",
+              "interval",
+              "github",
+              "github_poll"
+            ],
+            "description": "Trigger type (default: cron). 'github' is an alias for 'github_poll'.",
+            "default": "cron",
+            "x-flag": "--trigger-type"
+          },
+          "cron": {
+            "type": "string",
+            "description": "Cron expression, e.g. \"0 * * * *\". Required when --trigger-type is cron, which is the default; ignored for other trigger types.",
+            "x-flag": "--cron"
+          },
+          "interval": {
+            "type": "integer",
+            "description": "Seconds between fires. Required when --trigger-type is interval; ignored for other trigger types.",
+            "x-flag": "--interval"
+          },
+          "github_repo": {
+            "type": "string",
+            "description": "GitHub repository to poll (required for --trigger-type github/github_poll).",
+            "x-flag": "--github-repo"
+          },
+          "github_filter": {
+            "type": "string",
+            "description": "JSON object filtering which PRs fire the trigger, e.g. '{\"state\": \"open\", \"base\": \"main\"}'.",
+            "x-flag": "--github-filter"
+          },
+          "threshold_config": {
+            "type": "string",
+            "description": "Metric threshold alert config as a JSON object: {\"metric\": \"failed_sessions|total_cost_usd|p95_latency_ms|github_poll_healthy_age_minutes|github_poll_consecutive_401\", \"op\": \"gt|gte\", \"value\": N, \"window_minutes\": N}. When set, this schedule's own cron/interval cadence only evaluates the metric on each tick and fires the action only when the threshold is breached (cooldown = window_minutes). Full validation happens server-side, e.g. '{\"metric\": \"failed_sessions\", \"op\": \"gt\", \"value\": 5, \"window_minutes\": 60}'.",
+            "x-flag": "--threshold-config"
+          },
+          "poll_interval": {
+            "type": "integer",
+            "description": "How often to poll GitHub, in seconds (github_poll only).",
+            "x-flag": "--poll-interval"
+          },
+          "action_kind": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "command",
+              "engine",
+              "fanout",
+              "flow",
+              "flow_yaml",
+              "play",
+              "playbook"
+            ],
+            "description": "Stored action kind or accepted alias (default: agent).",
+            "default": "agent",
+            "x-flag": "--action-kind"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Instruction the scheduled agent runs at each fire. Required when --action-kind is agent, which is the default. A profile named by --agent supplies the model and settings, never this instruction, so a schedule created without it fires and fails.",
+            "x-flag": "--prompt"
+          },
+          "model": {
+            "type": "string",
+            "description": "Model spec for agent action.",
+            "x-flag": "--model"
+          },
+          "agent": {
+            "type": "string",
+            "description": "Agent profile to run, resolved the same way `li agent --agent` resolves it. Supplies the system prompt, model and effort the fire runs with.",
+            "x-flag": "--agent"
+          },
+          "playbook": {
+            "type": "string",
+            "description": "Playbook name (for action-kind=play/playbook).",
+            "x-flag": "--playbook"
+          },
+          "flow_yaml": {
+            "type": "string",
+            "description": "Path to a YAML flow spec file (for action-kind=flow_yaml).",
+            "x-flag": "--flow-yaml"
+          },
+          "action_command": {
+            "type": "string",
+            "description": "Executable name to spawn directly, bypassing `li` (for action-kind=command). Must be a bare name (no path separators) and be a member of LIONAGI_SCHEDULER_COMMAND_ALLOWLIST; refused loudly at create time and re-checked at fire time.",
+            "x-flag": "--action-command"
+          },
+          "action_command_args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "x-json-encoded": true,
+            "description": "action-kind=command argv, as a JSON array of {{var}} templates rendered from trigger_context at fire time, e.g. '[\"review-pr\", \"--pr\", \"{{pr_number}}\"]'.",
+            "x-flag": "--action-command-args"
+          },
+          "project": {
+            "type": "string",
+            "description": "Project this schedule's runs are recorded under. Defaults to the project detected from the execution root.",
+            "x-flag": "--project"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Explicit execution root for this schedule's spawned process (must be an existing directory). Persisted at creation time so the schedule's spawn cwd never depends on where the Studio daemon is running from (default: --project's registered path, or this CLI's own working directory).",
+            "x-flag": "--cwd"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description.",
+            "x-flag": "--description"
+          },
+          "max_runs": {
+            "type": "integer",
+            "description": "Auto-disable this schedule once N total runs have fired (default: unlimited). Chained on_success/on_fail fires do not count toward N. Mutually exclusive with --once.",
+            "x-flag": "--max-runs"
+          },
+          "once": {
+            "type": "boolean",
+            "description": "Sugar for --max-runs 1 \u2014 fire once, then auto-disable.",
+            "default": false,
+            "x-flag": "--once"
+          },
+          "max_cost_usd": {
+            "type": "number",
+            "description": "Auto-disable this schedule once its cumulative session spend reaches USD (default: unlimited). Pre-fire cumulative gate: an in-flight run is not interrupted, so the schedule may overshoot by up to one run's cost before the next fire is refused.",
+            "x-flag": "--max-cost-usd"
+          },
+          "max_tokens": {
+            "type": "integer",
+            "description": "Auto-disable this schedule once its cumulative session token usage (input+output) reaches N (default: unlimited). Same pre-fire cumulative semantics as --max-cost-usd.",
+            "x-flag": "--max-tokens"
+          },
+          "on_success": {
+            "type": "string",
+            "description": "Chain action to fire when this run exits 0, as a JSON object (allowed keys: kind/action_kind, model, prompt, agent, playbook, on_success, on_fail). WARNING \u2014 shallow merge: the chain child is built as {**this_schedule, **on_success}, so any key you omit is INHERITED from this schedule, including on_success/on_fail themselves. A 2-level chain must set the inner level's own \"on_success\": null explicitly, or the chain keeps re-firing at each depth (capped, but rarely what you want). Example: --on-success '{\"prompt\": \"notify done\", \"on_success\": null}'.",
+            "x-flag": "--on-success"
+          },
+          "on_fail": {
+            "type": "string",
+            "description": "Chain action to fire when this run exits non-zero, as a JSON object (same allowed keys and shallow-merge caveat as --on-success \u2014 see above). Example: --on-fail '{\"prompt\": \"alert on-call\", \"on_fail\": null}'.",
+            "x-flag": "--on-fail"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "x-positional-order": [
+          "name"
+        ],
+        "x-playbook-arguments": "This command accepts arguments declared by the playbook named in 'playbook'. Ask for this schema again with that playbook named to see them."
+      }
+    },
+    "schedule delete": {
+      "path": "schedule delete",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule delete",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "schedule disable": {
+      "path": "schedule disable",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule disable",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "schedule enable": {
+      "path": "schedule enable",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule enable",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "schedule export": {
+      "path": "schedule export",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule export",
+        "properties": {
+          "legacy": {
+            "type": "boolean",
+            "description": "Convert chain-free legacy rows (managed_by is null, i.e. rows predating the declaration layer) instead of declaration/cli-managed rows. A row with on_success/on_fail is reported BLOCKED and omitted.",
+            "default": false,
+            "x-flag": "--legacy"
+          },
+          "output": {
+            "type": "string",
+            "description": "Write the ScheduleSet YAML here (default: stdout).",
+            "x-flag": "--output"
+          },
+          "report": {
+            "type": "string",
+            "description": "Write the human-readable conversion report here (default: stderr).",
+            "x-flag": "--report"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "schedule get": {
+      "path": "schedule get",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule get",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "schedule limits": {
+      "path": "schedule limits",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule limits",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    "schedule list": {
+      "path": "schedule list",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule list",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    "schedule run": {
+      "path": "schedule run",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule run",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Schedule run ID.",
+            "x-positional": true
+          },
+          "as_json": {
+            "type": "boolean",
+            "description": "Emit JSON.",
+            "default": false,
+            "x-flag": "--json"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "schedule runs": {
+      "path": "schedule runs",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule runs",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+            "x-positional": true
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Max runs to return, 1-200 (default: 20).",
+            "default": 20,
+            "x-flag": "--limit"
+          },
+          "status": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Filter by run status; repeatable (e.g. --status failed --status timed_out).",
+            "x-flag": "--status"
+          },
+          "as_json": {
+            "type": "boolean",
+            "description": "Emit JSON.",
+            "default": false,
+            "x-flag": "--json"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "schedule status": {
+      "path": "schedule status",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule status",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+            "x-positional": true
+          },
+          "wait": {
+            "type": "boolean",
+            "description": "Wait for the latest in-flight run to finish first.",
+            "default": false,
+            "x-flag": "--wait"
+          },
+          "as_json": {
+            "type": "boolean",
+            "description": "Emit JSON.",
+            "default": false,
+            "x-flag": "--json"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "schedule trigger": {
+      "path": "schedule trigger",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule trigger",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the schedule, as returned by `li schedule list` in its `id` field.",
+            "x-positional": true
+          },
+          "wait": {
+            "type": "boolean",
+            "description": "Block until the fired occurrence reaches a terminal status (retries a short grace period first, since the occurrence row isn't durably written until just after this returns a run id), then print its outcome and exit non-zero on failure.",
+            "default": false,
+            "x-flag": "--wait"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ],
+        "x-positional-order": [
+          "id"
+        ]
+      }
+    },
+    "schedule validate": {
+      "path": "schedule validate",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "schedule validate",
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "Path to a ScheduleSet YAML file.",
+            "x-positional": true
+          },
+          "as_json": {
+            "type": "boolean",
+            "description": "Emit JSON.",
+            "default": false,
+            "x-flag": "--json"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "file"
+        ],
+        "x-positional-order": [
+          "file"
+        ]
+      }
+    },
+    "state checkpoint": {
+      "path": "state checkpoint",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state checkpoint",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "PASSIVE",
+              "FULL",
+              "RESTART",
+              "TRUNCATE"
+            ],
+            "description": "How hard to push the WAL back into the database. TRUNCATE (default) frees the WAL file outright but needs no active readers; PASSIVE, FULL and RESTART give up completeness to avoid blocking. No run data is lost in any mode.",
+            "default": "TRUNCATE",
+            "x-flag": "--mode"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Run PRAGMA wal_checkpoint(TRUNCATE|PASSIVE|RESTART|FULL). Default is TRUNCATE \u2014 most aggressive, frees the WAL file if no readers are active."
+      }
+    },
+    "state doctor": {
+      "path": "state doctor",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state doctor",
+        "properties": {
+          "stale_hours": {
+            "type": "integer",
+            "description": "Threshold in hours since started_at (default 24).",
+            "default": 24,
+            "x-flag": "--stale-hours"
+          },
+          "new_status": {
+            "type": "string",
+            "enum": [
+              "aborted",
+              "failed"
+            ],
+            "description": "Status to assign swept sessions (default 'aborted').",
+            "default": "aborted",
+            "x-flag": "--new-status"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "description": "Print what WOULD be swept, but don't update rows.",
+            "default": false,
+            "x-flag": "--dry-run"
+          }
+        },
+        "additionalProperties": false,
+        "description": "A SIGKILL or unclean exit between session-open and teardown leaves the session row at status='running' forever. This command resets such rows (older than --stale-hours, default 24) to --new-status (default 'aborted'). Conservative: a session is swept only if its started_at is older than the threshold AND its recorded process is not running, so an actively-running CLI process is left alone even when the session it resumed started long ago. Use --dry-run first."
+      }
+    },
+    "state import": {
+      "path": "state import",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state import",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "Scan ~/.lionagi/runs/ for run directories with run.json manifests and load their sessions, branches, and messages into state.db. Already-imported sessions are skipped (idempotent)."
+      }
+    },
+    "state import-teams": {
+      "path": "state import-teams",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state import-teams",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "Scan ~/.lionagi/teams/*.json and INSERT each team + its messages into the `teams` and `team_messages` tables. Idempotent: existing rows (matched by team id) are left alone. Run once after upgrading; the runtime can keep using JSON until the dual-write path ships."
+      }
+    },
+    "state ls": {
+      "path": "state ls",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state ls",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "description": "Maximum sessions to print, newest first (default 50).",
+            "default": 50,
+            "x-flag": "--limit"
+          },
+          "status": {
+            "type": "string",
+            "description": "Show only sessions in this status: running, completed, failed or aborted. Omit to list every status.",
+            "x-flag": "--status"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Print a table of sessions stored in state.db."
+      }
+    },
+    "state null-content": {
+      "path": "state null-content",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state null-content",
+        "properties": {
+          "older_than": {
+            "type": "integer",
+            "description": "Reclaim bodies older than N days. Required and deliberately has no default: there is no age that is safe to assume for an irreversible operation.",
+            "x-flag": "--older-than"
+          },
+          "role": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Limit to messages with this role; repeatable. Omitted means every role. Check `li state stats` first \u2014 the roles are not evenly sized, and one of them usually holds most of the bytes.",
+            "x-flag": "--role"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "description": "Perform the reclaim and roll it back, reporting what it measured.",
+            "default": false,
+            "x-flag": "--dry-run"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Reclaim the space held by message bodies older than --older-than days, keeping every row, id, role, timestamp and progression reference. THIS IS WHERE THE BYTES ARE, and prune cannot reach them: prune selects SESSIONS, and a message any surviving progression still names is kept whatever its age. A store can therefore be almost entirely message content, have every message inside a keep-window, and give a prune nothing to delete.\n\nA reclaimed body is not emptied. It is replaced with a marker recording that a body was there and how large it was, so it stays distinguishable from a turn that genuinely produced nothing. Reclaiming is not reversible: the text is gone.\n\nThe file does not shrink. Freed pages return to the database's own free list and the bytes on disk stay where they are until `li state vacuum` rebuilds the file.\n\n--dry-run is not a read. It performs the update and rolls it back, so its numbers measure the operation instead of estimating it, and it takes the same write lock for the same duration.",
+        "required": [
+          "older_than"
+        ]
+      }
+    },
+    "state prune": {
+      "path": "state prune",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state prune",
+        "properties": {
+          "keep_days": {
+            "type": "integer",
+            "description": "Keep sessions updated within the last N days (default 30).",
+            "default": 30,
+            "x-flag": "--keep-days"
+          },
+          "keep_n": {
+            "type": "integer",
+            "description": "Always keep the N most recent sessions (default 100).",
+            "default": 100,
+            "x-flag": "--keep-n"
+          },
+          "dry_run": {
+            "type": "boolean",
+            "description": "Print what WOULD be deleted, but don't actually delete.",
+            "default": false,
+            "x-flag": "--dry-run"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Delete sessions older than --keep-days (default 30), keeping the most recent --keep-n (default 100). Foreign key cascades drop branches; messages are dropped if no other session references them via progression. Use --dry-run to preview.\n\nSESSIONS ARE THE AXIS, AND MESSAGES HOLD THE BYTES. A message a surviving progression still names is kept whatever its age, so a run can delete thousands of sessions and free no message rows. Read the message counts, not the session count, to judge whether this reclaimed space; `li state stats` shows both distributions.\n\n--dry-run is not a read. It runs the real deletes and rolls the transaction back, which is what makes its counts exact rather than estimated, and which means it takes the same write lock for the same duration as the real thing."
+      }
+    },
+    "state stats": {
+      "path": "state stats",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state stats",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "Report state.db + state.db-wal sizes, per-table row counts, messages broken down by role and by age, session status distribution, and SQLite PRAGMAs (journal_mode, wal_autocheckpoint, busy_timeout). Use to spot growth and lock contention, and to check before pruning whether the keep-window can reach anything at all."
+      }
+    },
+    "state vacuum": {
+      "path": "state vacuum",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "state vacuum",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "Run VACUUM \u2014 rebuilds the entire DB file, reclaiming pages freed by previous deletes. Holds an exclusive lock for the duration. Run after `li state prune`."
+      }
+    },
+    "stats runs": {
+      "path": "stats runs",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "stats runs",
+        "properties": {
+          "since": {
+            "type": "string",
+            "description": "Only include runs updated within this window. Format: 30m, 1h, 7d. Default: 7d.",
+            "default": "7d",
+            "x-flag": "--since"
+          },
+          "group_by": {
+            "type": "string",
+            "description": "Comma-separated group keys from {project, kind, agent, model, status}. Default: project,kind.",
+            "default": "project,kind",
+            "x-flag": "--group-by"
+          },
+          "json": {
+            "type": "boolean",
+            "description": "Emit a JSON array of row objects instead of an aligned table.",
+            "default": false,
+            "x-flag": "--json"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Aggregate sessions rows updated within --since into run_count, completed, and failed counts per group. Read-only: no writes, no schema changes, no PRAGMA mutations."
+      }
+    },
+    "studio start": {
+      "path": "studio start",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "studio start",
+        "properties": {
+          "port": {
+            "type": "integer",
+            "description": "Backend API port (default: LIONAGI_STUDIO_PORT env or 8765)",
+            "x-flag": "--port"
+          },
+          "host": {
+            "type": "string",
+            "description": "Host to bind (default: 127.0.0.1)",
+            "x-flag": "--host"
+          },
+          "frontend_port": {
+            "type": "integer",
+            "description": "Frontend port (default: 3000)",
+            "x-flag": "--frontend-port"
+          },
+          "no_open": {
+            "type": "boolean",
+            "description": "Don't open the hosted UI in a browser (--web only)",
+            "x-flag": "--no-open"
+          },
+          "no_docker": {
+            "type": "boolean",
+            "description": "==SUPPRESS==",
+            "x-flag": "--no-docker"
+          },
+          "web": {
+            "type": "boolean",
+            "description": "Start the backend only; frontend is the hosted UI (default)",
+            "x-flag": "--web"
+          },
+          "docker": {
+            "type": "boolean",
+            "description": "Run the bundled frontend + backend via Docker",
+            "x-flag": "--docker"
+          },
+          "no_frontend": {
+            "type": "boolean",
+            "description": "Only start the backend API server",
+            "x-flag": "--no-frontend"
+          },
+          "dev": {
+            "type": "boolean",
+            "description": "Run the in-repo frontend in dev mode (hot-reload, no build step)",
+            "x-flag": "--dev"
+          }
+        },
+        "additionalProperties": false,
+        "x-mutually-exclusive": [
+          {
+            "parameters": [
+              "web",
+              "docker",
+              "no_frontend",
+              "dev"
+            ],
+            "required": false
+          }
+        ]
+      }
+    },
+    "team create": {
+      "path": "team create",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "team create",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name for the new team. Every other team command accepts it in place of the team id.",
+            "x-positional": true
+          },
+          "members": {
+            "type": "string",
+            "description": "Comma-separated member names. Only these names can send or receive as themselves; a message from or to anyone else still goes through, with a warning.",
+            "x-flag": "--members",
+            "x-aliases": [
+              "-m"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "members"
+        ],
+        "x-positional-order": [
+          "name"
+        ]
+      }
+    },
+    "team list": {
+      "path": "team list",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "team list",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    "team receive": {
+      "path": "team receive",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "team receive",
+        "properties": {
+          "team": {
+            "type": "string",
+            "description": "Team to read from \u2014 its id, its name, or an unambiguous id prefix.",
+            "x-flag": "--team",
+            "x-aliases": [
+              "-t"
+            ]
+          },
+          "member": {
+            "type": "string",
+            "description": "Read as this member: returns only their unread mail and marks it read. Omit it to dump every message and mark nothing read.",
+            "x-flag": "--as"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "team"
+        ]
+      }
+    },
+    "team send": {
+      "path": "team send",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "team send",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Message body, as the recipients will read it.",
+            "x-positional": true
+          },
+          "team": {
+            "type": "string",
+            "description": "Team to send into \u2014 its id, its name, or an unambiguous id prefix.",
+            "x-flag": "--team",
+            "x-aliases": [
+              "-t"
+            ]
+          },
+          "to": {
+            "type": "string",
+            "description": "Recipients: 'all' to broadcast to the whole team, or comma-separated member names.",
+            "x-flag": "--to"
+          },
+          "sender": {
+            "type": "string",
+            "description": "Name to send as, so recipients know who is asking (defaults to '_cli'). A name that is not a member still sends, and is reported as a warning.",
+            "x-flag": "--from"
+          },
+          "from_op": {
+            "type": "string",
+            "description": "The op id this message belongs to (e.g. 'o3'). Ties a coord signal to a specific invocation when the sender agent runs multiple ops on the same branch.",
+            "x-flag": "--from-op"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "message",
+              "done",
+              "finished",
+              "wakeup"
+            ],
+            "description": "Message kind (default: 'message'). Use 'done' when you've finished your part and may be revived later, 'finished' when you're permanently done \u2014 quiescence detection reads this.",
+            "x-flag": "--kind"
+          },
+          "artifacts": {
+            "type": "string",
+            "description": "Comma-separated artifact paths to attach (used with --kind done).",
+            "x-flag": "--artifacts"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "content",
+          "team",
+          "to"
+        ],
+        "x-positional-order": [
+          "content"
+        ]
+      }
+    },
+    "team show": {
+      "path": "team show",
+      "stage": "static",
+      "schema": {
+        "type": "object",
+        "title": "team show",
+        "properties": {
+          "team": {
+            "type": "string",
+            "description": "Team to show \u2014 its id, its name, or an unambiguous id prefix.",
+            "x-positional": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "team"
+        ],
+        "x-positional-order": [
+          "team"
+        ]
+      }
+    }
+  },
+  "projection_count": 62,
+  "projection_errors": {
+    "dispatch": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'dispatch' action 'dispatch_command': path stops at an unresolved subcommand; name one of ['ack', 'ls', 'purge', 'retry', 'show']"
+    },
+    "engine": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'engine' action 'engine_command': path stops at an unresolved subcommand; name one of ['run']"
+    },
+    "hooks": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'hooks' action 'hooks_command': path stops at an unresolved subcommand; name one of ['import', 'trust']"
+    },
+    "invoke": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'invoke' action 'invoke_command': path stops at an unresolved subcommand; name one of ['end', 'list', 'start']"
+    },
+    "mirror": {
+      "kind": "SchemaProjectionError",
+      "class": "unsupported_argparse_type",
+      "message": "cannot project 'mirror' action '--since': type=_since_window has no scalar JSON counterpart"
+    },
+    "orchestrate": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'orchestrate' action 'orch_command': path stops at an unresolved subcommand; name one of ['ctl', 'fanout', 'flow']"
+    },
+    "orchestrate ctl": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'orchestrate ctl' action 'ctl_command': path stops at an unresolved subcommand; name one of ['msg', 'pause', 'resolve', 'resume', 'status']"
+    },
+    "plugin": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'plugin' action 'plugin_command': path stops at an unresolved subcommand; name one of ['disable', 'enable', 'info', 'list', 'trust']"
+    },
+    "schedule": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'schedule' action 'schedule_action': path stops at an unresolved subcommand; name one of ['apply', 'create', 'delete', 'disable', 'enable', 'export', 'get', 'limits', 'list', 'run', 'runs', 'status', 'trigger', 'validate']"
+    },
+    "state": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'state' action 'state_command': path stops at an unresolved subcommand; name one of ['checkpoint', 'doctor', 'import', 'import-teams', 'ls', 'null-content', 'prune', 'stats', 'vacuum']"
+    },
+    "stats": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'stats' action 'stats_command': path stops at an unresolved subcommand; name one of ['runs']"
+    },
+    "studio": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'studio' action 'studio_action': path stops at an unresolved subcommand; name one of ['start']"
+    },
+    "team": {
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'team' action 'team_command': path stops at an unresolved subcommand; name one of ['create', 'list', 'ls', 'receive', 'recv', 'send', 'show']"
+    }
+  },
+  "projection_error_count": 13,
+  "absent_verbs": [
+    {
+      "name": "casts",
+      "summary": "The built-in roles and modes an agent can be composed from.",
+      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
+      "cli_path": "casts"
+    },
+    {
+      "name": "engine.run",
+      "summary": "Run a domain-specific multi-agent pipeline.",
+      "reason": "the spawn verbs return a job id because they go through this server's job records; this path spawns without one, so a caller would get a result it could not later ask about",
+      "cli_path": "engine run"
+    },
+    {
+      "name": "hooks.import",
+      "summary": "Importing hook commands from another tool's config.",
+      "reason": "it widens what this caller can reach \u2014 trusting a bundle, enabling a plugin or importing a hook command grants a right to the agent asking for it, so no machine seam would make it available here",
+      "cli_path": "hooks import"
+    },
+    {
+      "name": "invoke.end",
+      "summary": "Opening and closing a skill-level orchestration record.",
+      "reason": "the pair brackets a caller's own work, and this surface has no way to tell that the caller who opened a record is the one closing it; invoke.list reads what they wrote",
+      "cli_path": "invoke end"
+    },
+    {
+      "name": "invoke.start",
+      "summary": "Opening and closing a skill-level orchestration record.",
+      "reason": "the pair brackets a caller's own work, and this surface has no way to tell that the caller who opened a record is the one closing it; invoke.list reads what they wrote",
+      "cli_path": "invoke start"
+    },
+    {
+      "name": "kill",
+      "summary": "Terminate a run, session, play or show by id.",
+      "reason": "job.kill covers the jobs this server spawned, where the record carries the pid to correlate against; this path reaches entities this server never spawned and holds no identity for",
+      "cli_path": "kill"
+    },
+    {
+      "name": "mcp",
+      "summary": "Serve this surface over stdio.",
+      "reason": "it is this server: a call to it from here would serve a second copy of the surface the call arrived on",
+      "cli_path": "mcp"
+    },
+    {
+      "name": "mirror",
+      "summary": "Mirror Claude Code sessions into Studio, live.",
+      "reason": "it runs for as long as the process lives rather than returning a result, so it is a process to start, not a call to make",
+      "cli_path": "mirror"
+    },
+    {
+      "name": "orchestrate.ctl.msg",
+      "summary": "The running-flow control plane.",
+      "reason": "it steers a flow that is already running, and the effect lands on the flow rather than in a result; whether the flow honoured it is read from the flow's own state, not returned here",
+      "cli_path": "orchestrate ctl msg"
+    },
+    {
+      "name": "orchestrate.ctl.pause",
+      "summary": "The running-flow control plane.",
+      "reason": "it steers a flow that is already running, and the effect lands on the flow rather than in a result; whether the flow honoured it is read from the flow's own state, not returned here",
+      "cli_path": "orchestrate ctl pause"
+    },
+    {
+      "name": "orchestrate.ctl.resolve",
+      "summary": "Close a control whose consumer claimed it and never reported back.",
+      "reason": "it records what a human established about a delivery the system cannot determine; a machine caller would be asserting the fact the row is waiting for rather than reporting one",
+      "cli_path": "orchestrate ctl resolve"
+    },
+    {
+      "name": "orchestrate.ctl.resume",
+      "summary": "The running-flow control plane.",
+      "reason": "it steers a flow that is already running, and the effect lands on the flow rather than in a result; whether the flow honoured it is read from the flow's own state, not returned here",
+      "cli_path": "orchestrate ctl resume"
+    },
+    {
+      "name": "orchestrate.ctl.status",
+      "summary": "What a running flow's control plane reports about it.",
+      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
+      "cli_path": "orchestrate ctl status"
+    },
+    {
+      "name": "plugin.disable",
+      "summary": "Plugin bundle enablement.",
+      "reason": "it widens what this caller can reach \u2014 trusting a bundle, enabling a plugin or importing a hook command grants a right to the agent asking for it, so no machine seam would make it available here",
+      "cli_path": "plugin disable"
+    },
+    {
+      "name": "plugin.enable",
+      "summary": "Plugin bundle enablement.",
+      "reason": "it widens what this caller can reach \u2014 trusting a bundle, enabling a plugin or importing a hook command grants a right to the agent asking for it, so no machine seam would make it available here",
+      "cli_path": "plugin enable"
+    },
+    {
+      "name": "plugin.list",
+      "summary": "Installed plugin bundles and their trust state.",
+      "reason": "listing prunes trust records for plugins whose bundle directory is gone, so it writes to user settings on the trust surface; a listing that skipped the prune would not be this command",
+      "cli_path": "plugin list"
+    },
+    {
+      "name": "schedule.apply",
+      "summary": "Reconcile a whole ScheduleSet file into the store, atomically.",
+      "reason": "it writes a whole ScheduleSet atomically and reports a per-row plan; the plan's shape has not been decided as a machine result yet",
+      "cli_path": "schedule apply"
+    },
+    {
+      "name": "schedule.run",
+      "summary": "One schedule run.",
+      "reason": "it reports one schedule run, which schedule.runs already returns in a machine result",
+      "cli_path": "schedule run"
+    },
+    {
+      "name": "state.checkpoint",
+      "summary": "Writes against the lifecycle store.",
+      "reason": "it rewrites or removes rows in the lifecycle store that every read verb reports on, and nothing in a machine result tells a caller which of its own earlier answers the write invalidated",
+      "cli_path": "state checkpoint"
+    },
+    {
+      "name": "state.doctor",
+      "summary": "Read-only inspection of the lifecycle store.",
+      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
+      "cli_path": "state doctor"
+    },
+    {
+      "name": "state.import",
+      "summary": "Writes against the lifecycle store.",
+      "reason": "it rewrites or removes rows in the lifecycle store that every read verb reports on, and nothing in a machine result tells a caller which of its own earlier answers the write invalidated",
+      "cli_path": "state import"
+    },
+    {
+      "name": "state.import-teams",
+      "summary": "Writes against the lifecycle store.",
+      "reason": "it rewrites or removes rows in the lifecycle store that every read verb reports on, and nothing in a machine result tells a caller which of its own earlier answers the write invalidated",
+      "cli_path": "state import-teams"
+    },
+    {
+      "name": "state.null-content",
+      "summary": "Reclaiming the space held by old message bodies.",
+      "reason": "it destroys message content permanently \u2014 the rows and their references survive but the bodies do not, and nothing a machine result could say would give a caller back what its own call removed",
+      "cli_path": "state null-content"
+    },
+    {
+      "name": "state.prune",
+      "summary": "Writes against the lifecycle store.",
+      "reason": "it rewrites or removes rows in the lifecycle store that every read verb reports on, and nothing in a machine result tells a caller which of its own earlier answers the write invalidated",
+      "cli_path": "state prune"
+    },
+    {
+      "name": "state.vacuum",
+      "summary": "Writes against the lifecycle store.",
+      "reason": "it rewrites or removes rows in the lifecycle store that every read verb reports on, and nothing in a machine result tells a caller which of its own earlier answers the write invalidated",
+      "cli_path": "state vacuum"
+    },
+    {
+      "name": "studio.start",
+      "summary": "The Studio server.",
+      "reason": "it runs for as long as the process lives rather than returning a result, so it is a process to start, not a call to make",
+      "cli_path": "studio start"
+    },
+    {
+      "name": "team.create",
+      "summary": "Messaging between agents working as a team.",
+      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
+      "cli_path": "team create"
+    },
+    {
+      "name": "team.receive",
+      "summary": "Messaging between agents working as a team.",
+      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
+      "cli_path": "team receive"
+    },
+    {
+      "name": "team.send",
+      "summary": "Messaging between agents working as a team.",
+      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
+      "cli_path": "team send"
+    },
+    {
+      "name": "team.show",
+      "summary": "Messaging between agents working as a team.",
+      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
+      "cli_path": "team show"
+    }
+  ],
+  "absent_verb_count": 30,
+  "errors": [
+    {
+      "input": "",
+      "kind": "SchemaProjectionError",
+      "class": "empty_command_path",
+      "message": "cannot project '': empty command path"
+    },
+    {
+      "input": "nonexistent-command",
+      "kind": "SchemaProjectionError",
+      "class": "no_such_command",
+      "message": "cannot project 'nonexistent-command': no such command"
+    },
+    {
+      "input": "dispatch nonexistent-subcommand",
+      "kind": "SchemaProjectionError",
+      "class": "no_such_command_path",
+      "message": "cannot project 'dispatch nonexistent-subcommand': no such command path"
+    },
+    {
+      "input": "state",
+      "kind": "SchemaProjectionError",
+      "class": "unresolved_subcommand",
+      "message": "cannot project 'state' action 'state_command': path stops at an unresolved subcommand; name one of ['checkpoint', 'doctor', 'import', 'import-teams', 'ls', 'null-content', 'prune', 'stats', 'vacuum']"
+    },
+    {
+      "input": "mirror",
+      "kind": "SchemaProjectionError",
+      "class": "unsupported_argparse_type",
+      "message": "cannot project 'mirror' action '--since': type=_since_window has no scalar JSON counterpart"
+    }
+  ]
+}

--- a/tests/contracts/data/specialized.json
+++ b/tests/contracts/data/specialized.json
@@ -1,0 +1,198 @@
+[
+  {
+    "argv": [
+      "--help"
+    ],
+    "stdout": "usage: li [-h] [--version] [--machine]\n          {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp}\n          ...\n\nlionagi command line \u2014 spawn subagents via any CLI-backed provider.\n\npositional arguments:\n  {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp}\n    orchestrate (o)     Multi-agent orchestration patterns.\n    agent               Spawn one-shot subagent (blocking); prints final\n                        response.\n    casts               inspect built-in roles and modes\n    engine              Run domain-specific multi-agent engine pipelines.\n    team                Team messaging \u2014 send/receive between named agents.\n    studio              Lion Studio server\n    schedule            Manage lionagi Studio schedules.\n    state               Inspect and migrate lionagi state.db.\n    invoke              Track a skill-level orchestration.\n    kill                Terminate a running entity (run/session/play/show).\n    mirror              Mirror Claude Code sessions into studio (live).\n    monitor (mon)       Observe play/agent/run progress in real-time.\n    dispatch            Inspect and acknowledge durable dispatch_outbox rows.\n    doctor              Check the lionagi CLI environment/install for common\n                        failure modes.\n    stats               Read-only aggregate reporting over lionagi's StateDB.\n    plugin              Inspect, trust, and enable/disable LionAGI plugin\n                        bundles.\n    hooks               Import Claude Code / Codex hook configs; trust\n                        imported hook commands.\n    handshake           Report the machine-result contract version this build\n                        speaks.\n    runs                List recorded runs and what each one wrote.\n    lifecycle           Report the recorded lifecycle state of a run.\n    mcp                 Serve the lionagi MCP server (background job\n                        submit/query) over stdio.\n\noptions:\n  -h, --help            show this help message and exit\n  --version             Print the installed lionagi version and exit.\n  --machine             Emit one machine-result JSON object on stdout and send\n                        every human-facing line to stderr.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "wait"
+    ],
+    "stdout": "",
+    "stderr": "usage: li wait [-h] [--interval SECS] ids [ids ...]\nli wait: error: the following arguments are required: ids\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "skill",
+      "list"
+    ],
+    "stdout": "[redacted: this case's stdout lists the skills installed in the host's ~/.lionagi/skills, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal list serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "agent",
+      "status"
+    ],
+    "stdout": "SESSION  1fe58be6-1b2a-41a8-8a9c-870f308968fd\n  status:      running\n  label:       implementer\n  model:       claude/claude-sonnet-5\n  provider:    claude\n  project:     ohdearquant/lionagi\n  last active: 2026-08-07 05:39:54\n  resume:      li agent -r 5ca320f1-16ab-474e-9b22-1930df903919 \"...\"\n",
+    "stderr": "Linked SQLite 3.46.0 predates the fix for the WAL-reset corruption race (fixed in 3.51.3; backported to 3.44.6 and 3.50.7). WAL is still enabled because concurrent readers and writers depend on it; upgrade the SQLite library to remove the exposure.\n",
+    "exit_code": 3
+  },
+  {
+    "argv": [
+      "monitor",
+      "run"
+    ],
+    "stdout": "",
+    "stderr": "usage: li monitor run [-h] [--interval SECS] [--follow] [--no-chain]\n                      [--max-wait SECS]\n                      ids [ids ...]\nli monitor run: error: the following arguments are required: ids\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "doctor",
+      "--machine"
+    ],
+    "stdout": "[redacted: this case's stdout reports live host state (home paths, run ids, artifact directories, host-installed skill names). It is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "bogus-unknown-command"
+    ],
+    "stdout": "",
+    "stderr": "usage: li [-h] [--version] [--machine]\n          {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp}\n          ...\nli: error: argument command: invalid choice: 'bogus-unknown-command' (choose from 'orchestrate', 'o', 'agent', 'casts', 'engine', 'team', 'studio', 'schedule', 'state', 'invoke', 'kill', 'mirror', 'monitor', 'mon', 'dispatch', 'doctor', 'stats', 'plugin', 'hooks', 'handshake', 'runs', 'lifecycle', 'mcp')\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "play"
+    ],
+    "stdout": "Usage: li play <name> [args...]  |  li play list\n",
+    "stderr": "",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "play",
+      "list"
+    ],
+    "stdout": "arch-discovery\natlas-calibrate\natlas-place\naudit\nbackend-wire\nci-gate-systematization\ndoc-alignment\nfeature\nfirm-audit\nkhive\nkhive-issue-triage\nkhive-kg-curation\nlionagi-consolidate\nlionagi-feature\nlionagi-issue-triage\nlionagi-rearchitect\nlndl-symbolic-design\nperf-loop\nplay-plan\npr-review\nproduct-polish\nprogress-research\nresearch\nresolve-issues\nrust-ui\nshowcase-alpha\nshowcase-beta\nshowcase-break\nshowcase-discovery\nshowcase-polish\nshowcase-tool\nstyx-emitter\ntest-coverage\nui\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "play",
+      "nonexistent"
+    ],
+    "stdout": "",
+    "stderr": "error: playbook not found: 'nonexistent'. Available: arch-discovery, atlas-calibrate, atlas-place, audit, backend-wire, ci-gate-systematization, doc-alignment, feature, firm-audit, khive\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "play",
+      "--help"
+    ],
+    "stdout": "",
+    "stderr": "error: playbook NAME is required\nUsage: li play <name> \"<prompt>\" [--bypass --team-mode TEAM --timeout N ...]\nFlags may appear anywhere relative to NAME and the prompt.\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "o",
+      "flow",
+      "--help"
+    ],
+    "stdout": "usage: li orchestrate flow [-h] [-f PATH] [-p NAME] [-a NAME]\n                           [--with-synthesis [MODEL]]\n                           [--max-concurrent MAX_CONCURRENT]\n                           [--output {text,json}] [--save DIR]\n                           [--team-mode [NAME]] [--team-attach NAME]\n                           [--team-max-rounds N] [--dry-run] [--show-graph]\n                           [--background] [--bare] [--workers M1,M2,...]\n                           [--pack PATH] [--max-ops N] [--reactive MODE]\n                           [--resume RUN_OR_SESSION_ID]\n                           [--allow-degraded-context] [--mcp-config PATH]\n                           [--no-mcp-config] [--yolo] [--bypass] [--fast] [-v]\n                           [--theme {light,dark}] [--effort LEVEL] [--cwd DIR]\n                           [--timeout SECONDS] [--invocation ID]\n                           [--project NAME] [--resume-on-timeout]\n                           [--notify CMD]\n                           [[MODEL] PROMPT ...]\n\nOrchestrator analyzes the task, composes a DAG of agents with dependency\nedges, and executes with automatic parallelism where dependencies allow. Flags\nmay appear anywhere relative to the positionals.\n\npositional arguments:\n  [MODEL] PROMPT        Orchestrator model spec followed by the task prompt.\n                        Model is optional when -a/--agent provides one; a\n                        single positional is treated as the prompt. The prompt\n                        itself may instead come from -f/--file or\n                        -p/--playbook.\n\noptions:\n  -h, --help            show this help message and exit\n  -f PATH, --file PATH  Load flow spec from YAML or JSON file. File values\n                        serve as defaults; CLI flags override them. Prompt can\n                        come from the file (prompt: key) or as a positional\n                        argument.\n  -p NAME, --playbook NAME\n                        Load playbook from\n                        ~/.lionagi/playbooks/<NAME>.playbook.yaml. Playbooks\n                        may declare args: schema, artifacts: contracts, or\n                        argument-hint: placeholders for prompt template\n                        values.\n  -a NAME, --agent NAME\n                        Load orchestrator profile by name \u2014 resolves\n                        .lionagi/agents/<NAME>/<NAME>.md first, then\n                        .lionagi/agents/<NAME>.md.\n  --with-synthesis [MODEL]\n                        Run a final pass merging the DAG's results into one\n                        answer. Bare flag uses the orchestrator model; with an\n                        argument, that model instead.\n  --max-concurrent MAX_CONCURRENT\n                        Cap on agents running at the same time within one\n                        phase. 0, the default, runs the whole phase at once \u2014\n                        lower it to stay under a provider's rate limit.\n  --output {text,json}  Result format: 'text' (default) for reading, 'json'\n                        for a machine-readable run.\n  --save DIR            Directory to write each agent's output and the run's\n                        artifacts into. Required by --background, which has\n                        nowhere else to report.\n  --team-mode [NAME]    Create a FRESH team for this flow (new UUID every\n                        invocation). Bare flag uses 'flow' as the name.\n  --team-attach NAME    Attach to a team by NAME \u2014 upsert semantics: load\n                        existing team if found (preserving message history),\n                        else create fresh. Mutually exclusive with --team-\n                        mode.\n  --team-max-rounds N   In team mode (reactive), how many extra wakeup rounds\n                        the coordinator may run after all currently-running\n                        workers signal done, to deliver unread teammate\n                        messages before the run wraps up (default: 2).\n  --dry-run             Plan the DAG but don't execute. Shows agents, deps,\n                        and model resolution.\n  --show-graph          Render DAG as matplotlib visualization. With --save,\n                        saves PNG to save dir.\n  --background          Run flow in background. Requires --save. Check output\n                        in save dir.\n  --bare                Ignore agent profiles \u2014 all workers use the CLI model\n                        spec. Roles define behavioral focus only, no profile\n                        system prompts.\n  --workers M1,M2,...   Comma-separated worker model specs (assignment i uses\n                        pool[i % len]). Overrides the per-role model while\n                        KEEPING each role's profile/system prompt \u2014 unlike\n                        --bare, which also drops profiles. Enables mixed-model\n                        flows (cheap roles + expensive roles).\n  --pack PATH           Path to a YAML routing pack. Provides per-role\n                        model/effort when --workers is absent. --workers\n                        overrides pack routing.\n  --max-ops N, --max-agents N\n                        Cap total ops (nodes in the planned DAG). 0 =\n                        unlimited. `--max-agents` is a deprecated alias \u2014\n                        prefer `--max-ops`.\n  --reactive MODE       Who may grow the live DAG by emitting a SpawnRequest:\n                        'all' (default \u2014 every worker), 'off' (flat batch DAG,\n                        no spawning), or a comma-separated list of roles (e.g.\n                        'critic,evaluator') that alone may spawn. Caps still\n                        apply via --max-ops.\n  --resume RUN_OR_SESSION_ID\n                        Resume a checkpointed flow from a prior process (by\n                        run id, or any session/invocation/play id backed by\n                        one). Replays the persisted plan verbatim \u2014 no planner\n                        call, no other flow flags read\n                        (model/prompt/playbook/etc. all come from the\n                        checkpoint). Distinct from `li o ctl resume`, which\n                        un-pauses a still-running session.\n  --allow-degraded-context\n                        With --resume: proceed even when a pending op declared\n                        inherit_context \u2014 it runs against an empty branch\n                        instead of its predecessor's conversation history,\n                        which resume does not restore. Without this flag such\n                        ops refuse loudly, naming them.\n  --mcp-config PATH     Read this MCP config and hand its servers to every\n                        worker this run builds. By default the nearest\n                        .mcp.json at or above the directory this command was\n                        run in is used, so the workers' tools come from the\n                        submission rather than from --cwd. The file is read\n                        once, at startup.\n  --no-mcp-config       Hand the workers no MCP servers, and say so\n                        deliberately instead of arriving there by an empty\n                        search.\n  --yolo                Auto-approve the agent's tool calls, so an unattended\n                        run is never left waiting.\n  --bypass              Bypass all codex approvals and sandbox (for\n                        cloud/codespace environments).\n  --fast                Route codex requests through OpenAI's priority service\n                        tier (lower latency; requires account eligibility).\n                        Does not change model or reasoning effort.\n  -v, --verbose         Stream the agent's output as it is produced instead of\n                        printing only the final result, and silence the\n                        progress lines that would interleave with it.\n  --theme {light,dark}  Pick the colour scheme printed output is tuned for:\n                        'light' or 'dark' terminal.\n  --effort LEVEL        Override effort (overrides spec suffix). claude:\n                        low|medium|high|xhigh|max. codex:\n                        none|minimal|low|medium|high|xhigh|max|ultra\n                        (max/ultra clamp per model support). gemini-\n                        code/gemini-cli: folded into --model as\n                        Low|Medium|High (Gemini 3.1 Pro has no Medium).\n  --cwd DIR             Directory the agent's process runs in \u2014 the repo or\n                        worktree it acts on. Defaults to the current\n                        directory.\n  --timeout SECONDS     Hard wall-clock timeout in seconds. When set, a\n                        [DEADLINE] preamble is injected into the agent's\n                        prompt so the agent knows its time budget and can pace\n                        reasoning accordingly.\n  --invocation ID       Parent invocation id (from `li invoke start`). Groups\n                        this session under a skill orchestration record.\n                        Optional.\n  --project NAME        Explicit project name for this session. Overrides\n                        auto-detection from .lionagi/config.toml or git\n                        remote.\n  --resume-on-timeout   If the run terminates on --timeout, automatically fire\n                        one resume of the same session with 'continue and\n                        conclude the task' and report the combined result.\n                        Bounded to a single auto-resume; a timeout on the\n                        resumed leg terminates normally. Same effect as an\n                        agent profile's 'resume_on_timeout: once'.\n  --notify CMD          Shell command template run once this run reaches its\n                        terminal status. Overrides .lionagi/settings.yaml\n                        notify.on_terminal. Substitutes {payload} (full JSON),\n                        {status}, {invocation_id}.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "o",
+      "fanout",
+      "--help"
+    ],
+    "stdout": "usage: li orchestrate fanout [-h] [-a NAME] [-n NUM_WORKERS]\n                             [--workers M1,M2,...] [--pack PATH]\n                             [--max-concurrent MAX_CONCURRENT]\n                             [--with-synthesis [MODEL]]\n                             [--synthesis-prompt SYNTHESIS_PROMPT]\n                             [--output {text,json}] [--save DIR]\n                             [--team-mode [NAME]] [--mcp-config PATH]\n                             [--no-mcp-config] [--yolo] [--bypass] [--fast]\n                             [-v] [--theme {light,dark}] [--effort LEVEL]\n                             [--cwd DIR] [--timeout SECONDS] [--invocation ID]\n                             [--project NAME] [--resume-on-timeout]\n                             [--notify CMD]\n                             [[MODEL] PROMPT ...]\n\nOrchestrator decomposes task into N agent requests, fans out to workers,\noptionally synthesizes. Effort can be embedded in model spec:\nclaude/opus-4-7-high. Flags may appear anywhere relative to the positionals.\n\npositional arguments:\n  [MODEL] PROMPT        Orchestrator model spec (provider/model-effort)\n                        followed by the task prompt. Model is also used as the\n                        default worker model unless --workers is set; omit it\n                        when -a/--agent provides one. A single positional is\n                        treated as the prompt.\n\noptions:\n  -h, --help            show this help message and exit\n  -a NAME, --agent NAME\n                        Load orchestrator profile by name. Resolves\n                        .lionagi/agents/<NAME>/<NAME>.md first, then\n                        .lionagi/agents/<NAME>.md. Profile provides system\n                        prompt, default model, effort, yolo. CLI flags and\n                        positional model override profile settings.\n  -n NUM_WORKERS, --num-workers NUM_WORKERS\n                        Maximum assignments the orchestrator generates\n                        (default 3). It may generate fewer if the task does\n                        not divide that far, and --workers specs beyond this\n                        cap go unused.\n  --workers M1,M2,...   Comma-separated worker model specs, assigned round-\n                        robin (each may carry an effort suffix). This is how\n                        one fanout mixes cheap and expensive models across\n                        workers.\n  --pack PATH           Path to a YAML routing pack. Provides per-role\n                        model/effort when --workers is absent. --workers\n                        overrides pack routing.\n  --max-concurrent MAX_CONCURRENT\n                        Cap on workers running at the same time. 0, the\n                        default, runs them all at once \u2014 lower it to stay\n                        under a provider's rate limit.\n  --with-synthesis [MODEL]\n                        Run a final pass merging the workers' results into one\n                        answer. Bare flag uses the orchestrator model; with an\n                        argument, that model instead.\n  --synthesis-prompt SYNTHESIS_PROMPT\n                        What the merged answer should be \u2014 a ranked list, a\n                        decision, a single patch. Implies synthesis.\n  --output {text,json}  Result format: 'text' (default) for reading, 'json'\n                        for a machine-readable run.\n  --save DIR            Directory to write each worker's output and the run's\n                        artifacts into. Without it they land in the run's own\n                        artifacts directory.\n  --team-mode [NAME]    Create a persistent team for this fanout. Workers get\n                        team context and results are posted as team messages.\n                        Bare flag uses 'fanout' as team name; with arg uses\n                        that name.\n  --mcp-config PATH     Read this MCP config and hand its servers to every\n                        worker this run builds. By default the nearest\n                        .mcp.json at or above the directory this command was\n                        run in is used, so the workers' tools come from the\n                        submission rather than from --cwd. The file is read\n                        once, at startup.\n  --no-mcp-config       Hand the workers no MCP servers, and say so\n                        deliberately instead of arriving there by an empty\n                        search.\n  --yolo                Auto-approve the agent's tool calls, so an unattended\n                        run is never left waiting.\n  --bypass              Bypass all codex approvals and sandbox (for\n                        cloud/codespace environments).\n  --fast                Route codex requests through OpenAI's priority service\n                        tier (lower latency; requires account eligibility).\n                        Does not change model or reasoning effort.\n  -v, --verbose         Stream the agent's output as it is produced instead of\n                        printing only the final result, and silence the\n                        progress lines that would interleave with it.\n  --theme {light,dark}  Pick the colour scheme printed output is tuned for:\n                        'light' or 'dark' terminal.\n  --effort LEVEL        Override effort (overrides spec suffix). claude:\n                        low|medium|high|xhigh|max. codex:\n                        none|minimal|low|medium|high|xhigh|max|ultra\n                        (max/ultra clamp per model support). gemini-\n                        code/gemini-cli: folded into --model as\n                        Low|Medium|High (Gemini 3.1 Pro has no Medium).\n  --cwd DIR             Directory the agent's process runs in \u2014 the repo or\n                        worktree it acts on. Defaults to the current\n                        directory.\n  --timeout SECONDS     Hard wall-clock timeout in seconds. When set, a\n                        [DEADLINE] preamble is injected into the agent's\n                        prompt so the agent knows its time budget and can pace\n                        reasoning accordingly.\n  --invocation ID       Parent invocation id (from `li invoke start`). Groups\n                        this session under a skill orchestration record.\n                        Optional.\n  --project NAME        Explicit project name for this session. Overrides\n                        auto-detection from .lionagi/config.toml or git\n                        remote.\n  --resume-on-timeout   If the run terminates on --timeout, automatically fire\n                        one resume of the same session with 'continue and\n                        conclude the task' and report the combined result.\n                        Bounded to a single auto-resume; a timeout on the\n                        resumed leg terminates normally. Same effect as an\n                        agent profile's 'resume_on_timeout: once'.\n  --notify CMD          Shell command template run once this run reaches its\n                        terminal status. Overrides .lionagi/settings.yaml\n                        notify.on_terminal. Substitutes {payload} (full JSON),\n                        {status}, {invocation_id}.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "o",
+      "flow"
+    ],
+    "stdout": "",
+    "stderr": "error: prompt is required (positional or via -f spec file)\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "o",
+      "fanout"
+    ],
+    "stdout": "",
+    "stderr": "error: prompt is required\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "schedule",
+      "--help"
+    ],
+    "stdout": "usage: li schedule [-h]\n                   {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status}\n                   ...\n\nCreate, list, enable, disable, trigger, and delete schedules via the Studio\nAPI (default http://127.0.0.1:8765). Set LIONAGI_STUDIO_URL to use a different\nbase URL.\n\npositional arguments:\n  {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status}\n    list                List all schedules.\n    get                 Show schedule details.\n    limits              Show the global concurrent-fire cap and current in-\n                        flight count.\n    create              Create a new schedule.\n    validate            Validate + statically resolve a ScheduleSet file (no\n                        database writes).\n    apply               Reconcile a ScheduleSet file into the database,\n                        atomically.\n    export              Convert schedules into a ScheduleSet document (never\n                        writes the database).\n    enable              Enable a schedule.\n    disable             Disable a schedule.\n    delete              Delete a schedule.\n    trigger             Fire a schedule immediately.\n    runs                List runs for a schedule.\n    run                 Show one schedule run.\n    status              \"Did it work?\" summary for a schedule.\n\noptions:\n  -h, --help            show this help message and exit\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "schedule"
+    ],
+    "stdout": "",
+    "stderr": "usage: li schedule [-h]\n                   {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status}\n                   ...\nli schedule: error: the following arguments are required: schedule_action\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "list",
+      "--bogus"
+    ],
+    "stdout": "",
+    "stderr": "error: unrecognized argument: --bogus\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "capture-test",
+      "--every",
+      "15m"
+    ],
+    "stdout": "",
+    "stderr": "error: unrecognized argument '--every' \u2014 did you mean '--interval'?\nerror: unrecognized argument: 15m\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "agent",
+      "capture-test"
+    ],
+    "stdout": "",
+    "stderr": "usage: li schedule create agent [-h] --profile PROFILE [--prompt PROMPT]\n                                [--prompt-file PATH] [--model MODEL]\n                                (--at RFC3339 | --cron EXPR | --every DURATION | --github OWNER/NAME)\n                                [--timezone IANA_TZ] [--github-filter JSON]\n                                [--cwd PATH] [--once] [--max-runs N]\n                                [--overlap {skip,allow}]\n                                [--missed-fire {skip,run_once}]\n                                [--budget-usd USD] [--budget-tokens N]\n                                [--rate-limit JSON]\n                                [--description DESCRIPTION] [--disabled]\n                                name\nli schedule create agent: error: the following arguments are required: --profile\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "command",
+      "capture-test",
+      "--every",
+      "15m"
+    ],
+    "stdout": "",
+    "stderr": "Error: command target requires a trailing '--' before the executable, e.g. `li schedule create command NAME --every 15m -- refresh-index --incremental`.\n",
+    "exit_code": 1
+  }
+]

--- a/tests/contracts/data/specialized.json
+++ b/tests/contracts/data/specialized.json
@@ -29,8 +29,8 @@
       "agent",
       "status"
     ],
-    "stdout": "SESSION  1fe58be6-1b2a-41a8-8a9c-870f308968fd\n  status:      running\n  label:       implementer\n  model:       claude/claude-sonnet-5\n  provider:    claude\n  project:     ohdearquant/lionagi\n  last active: 2026-08-07 05:39:54\n  resume:      li agent -r 5ca320f1-16ab-474e-9b22-1930df903919 \"...\"\n",
-    "stderr": "Linked SQLite 3.46.0 predates the fix for the WAL-reset corruption race (fixed in 3.51.3; backported to 3.44.6 and 3.50.7). WAL is still enabled because concurrent readers and writers depend on it; upgrade the SQLite library to remove the exposure.\n",
+    "stdout": "[redacted: this case's stdout reports live session state (session id, status, timestamps, project label, and a resume command carrying a fresh session id) that varies per run and host. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "[redacted: this case's stderr reports the host's linked SQLite library version and its CVE posture, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
     "exit_code": 3
   },
   {
@@ -72,7 +72,7 @@
       "play",
       "list"
     ],
-    "stdout": "arch-discovery\natlas-calibrate\natlas-place\naudit\nbackend-wire\nci-gate-systematization\ndoc-alignment\nfeature\nfirm-audit\nkhive\nkhive-issue-triage\nkhive-kg-curation\nlionagi-consolidate\nlionagi-feature\nlionagi-issue-triage\nlionagi-rearchitect\nlndl-symbolic-design\nperf-loop\nplay-plan\npr-review\nproduct-polish\nprogress-research\nresearch\nresolve-issues\nrust-ui\nshowcase-alpha\nshowcase-beta\nshowcase-break\nshowcase-discovery\nshowcase-polish\nshowcase-tool\nstyx-emitter\ntest-coverage\nui\n",
+    "stdout": "[redacted: this case's stdout lists the playbooks installed in the host's ~/.lionagi/playbooks, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal list serves no oracle purpose and is not committed.]",
     "stderr": "",
     "exit_code": 0
   },
@@ -82,7 +82,7 @@
       "nonexistent"
     ],
     "stdout": "",
-    "stderr": "error: playbook not found: 'nonexistent'. Available: arch-discovery, atlas-calibrate, atlas-place, audit, backend-wire, ci-gate-systematization, doc-alignment, feature, firm-audit, khive\n",
+    "stderr": "[redacted: this case's stderr embeds the same host-specific playbook name list as the 'play list' case (read from ~/.lionagi/playbooks), which varies per machine. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
     "exit_code": 1
   },
   {

--- a/tests/contracts/data/specialized_py312.json
+++ b/tests/contracts/data/specialized_py312.json
@@ -1,0 +1,198 @@
+[
+  {
+    "argv": [
+      "--help"
+    ],
+    "stdout": "usage: li [-h] [--version] [--machine]\n          {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp}\n          ...\n\nlionagi command line \u2014 spawn subagents via any CLI-backed provider.\n\npositional arguments:\n  {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp}\n    orchestrate (o)     Multi-agent orchestration patterns.\n    agent               Spawn one-shot subagent (blocking); prints final\n                        response.\n    casts               inspect built-in roles and modes\n    engine              Run domain-specific multi-agent engine pipelines.\n    team                Team messaging \u2014 send/receive between named agents.\n    studio              Lion Studio server\n    schedule            Manage lionagi Studio schedules.\n    state               Inspect and migrate lionagi state.db.\n    invoke              Track a skill-level orchestration.\n    kill                Terminate a running entity (run/session/play/show).\n    mirror              Mirror Claude Code sessions into studio (live).\n    monitor (mon)       Observe play/agent/run progress in real-time.\n    dispatch            Inspect and acknowledge durable dispatch_outbox rows.\n    doctor              Check the lionagi CLI environment/install for common\n                        failure modes.\n    stats               Read-only aggregate reporting over lionagi's StateDB.\n    plugin              Inspect, trust, and enable/disable LionAGI plugin\n                        bundles.\n    hooks               Import Claude Code / Codex hook configs; trust\n                        imported hook commands.\n    handshake           Report the machine-result contract version this build\n                        speaks.\n    runs                List recorded runs and what each one wrote.\n    lifecycle           Report the recorded lifecycle state of a run.\n    mcp                 Serve the lionagi MCP server (background job\n                        submit/query) over stdio.\n\noptions:\n  -h, --help            show this help message and exit\n  --version             Print the installed lionagi version and exit.\n  --machine             Emit one machine-result JSON object on stdout and send\n                        every human-facing line to stderr.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "wait"
+    ],
+    "stdout": "",
+    "stderr": "usage: li wait [-h] [--interval SECS] ids [ids ...]\nli wait: error: the following arguments are required: ids\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "skill",
+      "list"
+    ],
+    "stdout": "[redacted: this case's stdout lists the skills installed in the host's ~/.lionagi/skills, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal list serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "agent",
+      "status"
+    ],
+    "stdout": "[redacted: this case's stdout reports live session state (session id, status, timestamps, project label, and a resume command carrying a fresh session id) that varies per run and host. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "[redacted: this case's stderr reports the host's linked SQLite library version and its CVE posture, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "exit_code": 3
+  },
+  {
+    "argv": [
+      "monitor",
+      "run"
+    ],
+    "stdout": "",
+    "stderr": "usage: li monitor run [-h] [--interval SECS] [--follow] [--no-chain]\n                      [--max-wait SECS]\n                      ids [ids ...]\nli monitor run: error: the following arguments are required: ids\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "doctor",
+      "--machine"
+    ],
+    "stdout": "[redacted: this case's stdout reports live host state (home paths, run ids, artifact directories, host-installed skill names). It is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "bogus-unknown-command"
+    ],
+    "stdout": "",
+    "stderr": "usage: li [-h] [--version] [--machine]\n          {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp}\n          ...\nli: error: argument command: invalid choice: 'bogus-unknown-command' (choose from orchestrate, o, agent, casts, engine, team, studio, schedule, state, invoke, kill, mirror, monitor, mon, dispatch, doctor, stats, plugin, hooks, handshake, runs, lifecycle, mcp)\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "play"
+    ],
+    "stdout": "Usage: li play <name> [args...]  |  li play list\n",
+    "stderr": "",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "play",
+      "list"
+    ],
+    "stdout": "[redacted: this case's stdout lists the playbooks installed in the host's ~/.lionagi/playbooks, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal list serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "play",
+      "nonexistent"
+    ],
+    "stdout": "",
+    "stderr": "[redacted: this case's stderr embeds the same host-specific playbook name list as the 'play list' case (read from ~/.lionagi/playbooks), which varies per machine. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "play",
+      "--help"
+    ],
+    "stdout": "",
+    "stderr": "error: playbook NAME is required\nUsage: li play <name> \"<prompt>\" [--bypass --team-mode TEAM --timeout N ...]\nFlags may appear anywhere relative to NAME and the prompt.\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "o",
+      "flow",
+      "--help"
+    ],
+    "stdout": "usage: li orchestrate flow [-h] [-f PATH] [-p NAME] [-a NAME]\n                           [--with-synthesis [MODEL]]\n                           [--max-concurrent MAX_CONCURRENT]\n                           [--output {text,json}] [--save DIR]\n                           [--team-mode [NAME]] [--team-attach NAME]\n                           [--team-max-rounds N] [--dry-run] [--show-graph]\n                           [--background] [--bare] [--workers M1,M2,...]\n                           [--pack PATH] [--max-ops N] [--reactive MODE]\n                           [--resume RUN_OR_SESSION_ID]\n                           [--allow-degraded-context] [--mcp-config PATH]\n                           [--no-mcp-config] [--yolo] [--bypass] [--fast] [-v]\n                           [--theme {light,dark}] [--effort LEVEL] [--cwd DIR]\n                           [--timeout SECONDS] [--invocation ID]\n                           [--project NAME] [--resume-on-timeout]\n                           [--notify CMD]\n                           [[MODEL] PROMPT ...]\n\nOrchestrator analyzes the task, composes a DAG of agents with dependency\nedges, and executes with automatic parallelism where dependencies allow. Flags\nmay appear anywhere relative to the positionals.\n\npositional arguments:\n  [MODEL] PROMPT        Orchestrator model spec followed by the task prompt.\n                        Model is optional when -a/--agent provides one; a\n                        single positional is treated as the prompt. The prompt\n                        itself may instead come from -f/--file or\n                        -p/--playbook.\n\noptions:\n  -h, --help            show this help message and exit\n  -f PATH, --file PATH  Load flow spec from YAML or JSON file. File values\n                        serve as defaults; CLI flags override them. Prompt can\n                        come from the file (prompt: key) or as a positional\n                        argument.\n  -p NAME, --playbook NAME\n                        Load playbook from\n                        ~/.lionagi/playbooks/<NAME>.playbook.yaml. Playbooks\n                        may declare args: schema, artifacts: contracts, or\n                        argument-hint: placeholders for prompt template\n                        values.\n  -a NAME, --agent NAME\n                        Load orchestrator profile by name \u2014 resolves\n                        .lionagi/agents/<NAME>/<NAME>.md first, then\n                        .lionagi/agents/<NAME>.md.\n  --with-synthesis [MODEL]\n                        Run a final pass merging the DAG's results into one\n                        answer. Bare flag uses the orchestrator model; with an\n                        argument, that model instead.\n  --max-concurrent MAX_CONCURRENT\n                        Cap on agents running at the same time within one\n                        phase. 0, the default, runs the whole phase at once \u2014\n                        lower it to stay under a provider's rate limit.\n  --output {text,json}  Result format: 'text' (default) for reading, 'json'\n                        for a machine-readable run.\n  --save DIR            Directory to write each agent's output and the run's\n                        artifacts into. Required by --background, which has\n                        nowhere else to report.\n  --team-mode [NAME]    Create a FRESH team for this flow (new UUID every\n                        invocation). Bare flag uses 'flow' as the name.\n  --team-attach NAME    Attach to a team by NAME \u2014 upsert semantics: load\n                        existing team if found (preserving message history),\n                        else create fresh. Mutually exclusive with --team-\n                        mode.\n  --team-max-rounds N   In team mode (reactive), how many extra wakeup rounds\n                        the coordinator may run after all currently-running\n                        workers signal done, to deliver unread teammate\n                        messages before the run wraps up (default: 2).\n  --dry-run             Plan the DAG but don't execute. Shows agents, deps,\n                        and model resolution.\n  --show-graph          Render DAG as matplotlib visualization. With --save,\n                        saves PNG to save dir.\n  --background          Run flow in background. Requires --save. Check output\n                        in save dir.\n  --bare                Ignore agent profiles \u2014 all workers use the CLI model\n                        spec. Roles define behavioral focus only, no profile\n                        system prompts.\n  --workers M1,M2,...   Comma-separated worker model specs (assignment i uses\n                        pool[i % len]). Overrides the per-role model while\n                        KEEPING each role's profile/system prompt \u2014 unlike\n                        --bare, which also drops profiles. Enables mixed-model\n                        flows (cheap roles + expensive roles).\n  --pack PATH           Path to a YAML routing pack. Provides per-role\n                        model/effort when --workers is absent. --workers\n                        overrides pack routing.\n  --max-ops N, --max-agents N\n                        Cap total ops (nodes in the planned DAG). 0 =\n                        unlimited. `--max-agents` is a deprecated alias \u2014\n                        prefer `--max-ops`.\n  --reactive MODE       Who may grow the live DAG by emitting a SpawnRequest:\n                        'all' (default \u2014 every worker), 'off' (flat batch DAG,\n                        no spawning), or a comma-separated list of roles (e.g.\n                        'critic,evaluator') that alone may spawn. Caps still\n                        apply via --max-ops.\n  --resume RUN_OR_SESSION_ID\n                        Resume a checkpointed flow from a prior process (by\n                        run id, or any session/invocation/play id backed by\n                        one). Replays the persisted plan verbatim \u2014 no planner\n                        call, no other flow flags read\n                        (model/prompt/playbook/etc. all come from the\n                        checkpoint). Distinct from `li o ctl resume`, which\n                        un-pauses a still-running session.\n  --allow-degraded-context\n                        With --resume: proceed even when a pending op declared\n                        inherit_context \u2014 it runs against an empty branch\n                        instead of its predecessor's conversation history,\n                        which resume does not restore. Without this flag such\n                        ops refuse loudly, naming them.\n  --mcp-config PATH     Read this MCP config and hand its servers to every\n                        worker this run builds. By default the nearest\n                        .mcp.json at or above the directory this command was\n                        run in is used, so the workers' tools come from the\n                        submission rather than from --cwd. The file is read\n                        once, at startup.\n  --no-mcp-config       Hand the workers no MCP servers, and say so\n                        deliberately instead of arriving there by an empty\n                        search.\n  --yolo                Auto-approve the agent's tool calls, so an unattended\n                        run is never left waiting.\n  --bypass              Bypass all codex approvals and sandbox (for\n                        cloud/codespace environments).\n  --fast                Route codex requests through OpenAI's priority service\n                        tier (lower latency; requires account eligibility).\n                        Does not change model or reasoning effort.\n  -v, --verbose         Stream the agent's output as it is produced instead of\n                        printing only the final result, and silence the\n                        progress lines that would interleave with it.\n  --theme {light,dark}  Pick the colour scheme printed output is tuned for:\n                        'light' or 'dark' terminal.\n  --effort LEVEL        Override effort (overrides spec suffix). claude:\n                        low|medium|high|xhigh|max. codex:\n                        none|minimal|low|medium|high|xhigh|max|ultra\n                        (max/ultra clamp per model support). gemini-\n                        code/gemini-cli: folded into --model as\n                        Low|Medium|High (Gemini 3.1 Pro has no Medium).\n  --cwd DIR             Directory the agent's process runs in \u2014 the repo or\n                        worktree it acts on. Defaults to the current\n                        directory.\n  --timeout SECONDS     Hard wall-clock timeout in seconds. When set, a\n                        [DEADLINE] preamble is injected into the agent's\n                        prompt so the agent knows its time budget and can pace\n                        reasoning accordingly.\n  --invocation ID       Parent invocation id (from `li invoke start`). Groups\n                        this session under a skill orchestration record.\n                        Optional.\n  --project NAME        Explicit project name for this session. Overrides\n                        auto-detection from .lionagi/config.toml or git\n                        remote.\n  --resume-on-timeout   If the run terminates on --timeout, automatically fire\n                        one resume of the same session with 'continue and\n                        conclude the task' and report the combined result.\n                        Bounded to a single auto-resume; a timeout on the\n                        resumed leg terminates normally. Same effect as an\n                        agent profile's 'resume_on_timeout: once'.\n  --notify CMD          Shell command template run once this run reaches its\n                        terminal status. Overrides .lionagi/settings.yaml\n                        notify.on_terminal. Substitutes {payload} (full JSON),\n                        {status}, {invocation_id}.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "o",
+      "fanout",
+      "--help"
+    ],
+    "stdout": "usage: li orchestrate fanout [-h] [-a NAME] [-n NUM_WORKERS]\n                             [--workers M1,M2,...] [--pack PATH]\n                             [--max-concurrent MAX_CONCURRENT]\n                             [--with-synthesis [MODEL]]\n                             [--synthesis-prompt SYNTHESIS_PROMPT]\n                             [--output {text,json}] [--save DIR]\n                             [--team-mode [NAME]] [--mcp-config PATH]\n                             [--no-mcp-config] [--yolo] [--bypass] [--fast]\n                             [-v] [--theme {light,dark}] [--effort LEVEL]\n                             [--cwd DIR] [--timeout SECONDS] [--invocation ID]\n                             [--project NAME] [--resume-on-timeout]\n                             [--notify CMD]\n                             [[MODEL] PROMPT ...]\n\nOrchestrator decomposes task into N agent requests, fans out to workers,\noptionally synthesizes. Effort can be embedded in model spec:\nclaude/opus-4-7-high. Flags may appear anywhere relative to the positionals.\n\npositional arguments:\n  [MODEL] PROMPT        Orchestrator model spec (provider/model-effort)\n                        followed by the task prompt. Model is also used as the\n                        default worker model unless --workers is set; omit it\n                        when -a/--agent provides one. A single positional is\n                        treated as the prompt.\n\noptions:\n  -h, --help            show this help message and exit\n  -a NAME, --agent NAME\n                        Load orchestrator profile by name. Resolves\n                        .lionagi/agents/<NAME>/<NAME>.md first, then\n                        .lionagi/agents/<NAME>.md. Profile provides system\n                        prompt, default model, effort, yolo. CLI flags and\n                        positional model override profile settings.\n  -n NUM_WORKERS, --num-workers NUM_WORKERS\n                        Maximum assignments the orchestrator generates\n                        (default 3). It may generate fewer if the task does\n                        not divide that far, and --workers specs beyond this\n                        cap go unused.\n  --workers M1,M2,...   Comma-separated worker model specs, assigned round-\n                        robin (each may carry an effort suffix). This is how\n                        one fanout mixes cheap and expensive models across\n                        workers.\n  --pack PATH           Path to a YAML routing pack. Provides per-role\n                        model/effort when --workers is absent. --workers\n                        overrides pack routing.\n  --max-concurrent MAX_CONCURRENT\n                        Cap on workers running at the same time. 0, the\n                        default, runs them all at once \u2014 lower it to stay\n                        under a provider's rate limit.\n  --with-synthesis [MODEL]\n                        Run a final pass merging the workers' results into one\n                        answer. Bare flag uses the orchestrator model; with an\n                        argument, that model instead.\n  --synthesis-prompt SYNTHESIS_PROMPT\n                        What the merged answer should be \u2014 a ranked list, a\n                        decision, a single patch. Implies synthesis.\n  --output {text,json}  Result format: 'text' (default) for reading, 'json'\n                        for a machine-readable run.\n  --save DIR            Directory to write each worker's output and the run's\n                        artifacts into. Without it they land in the run's own\n                        artifacts directory.\n  --team-mode [NAME]    Create a persistent team for this fanout. Workers get\n                        team context and results are posted as team messages.\n                        Bare flag uses 'fanout' as team name; with arg uses\n                        that name.\n  --mcp-config PATH     Read this MCP config and hand its servers to every\n                        worker this run builds. By default the nearest\n                        .mcp.json at or above the directory this command was\n                        run in is used, so the workers' tools come from the\n                        submission rather than from --cwd. The file is read\n                        once, at startup.\n  --no-mcp-config       Hand the workers no MCP servers, and say so\n                        deliberately instead of arriving there by an empty\n                        search.\n  --yolo                Auto-approve the agent's tool calls, so an unattended\n                        run is never left waiting.\n  --bypass              Bypass all codex approvals and sandbox (for\n                        cloud/codespace environments).\n  --fast                Route codex requests through OpenAI's priority service\n                        tier (lower latency; requires account eligibility).\n                        Does not change model or reasoning effort.\n  -v, --verbose         Stream the agent's output as it is produced instead of\n                        printing only the final result, and silence the\n                        progress lines that would interleave with it.\n  --theme {light,dark}  Pick the colour scheme printed output is tuned for:\n                        'light' or 'dark' terminal.\n  --effort LEVEL        Override effort (overrides spec suffix). claude:\n                        low|medium|high|xhigh|max. codex:\n                        none|minimal|low|medium|high|xhigh|max|ultra\n                        (max/ultra clamp per model support). gemini-\n                        code/gemini-cli: folded into --model as\n                        Low|Medium|High (Gemini 3.1 Pro has no Medium).\n  --cwd DIR             Directory the agent's process runs in \u2014 the repo or\n                        worktree it acts on. Defaults to the current\n                        directory.\n  --timeout SECONDS     Hard wall-clock timeout in seconds. When set, a\n                        [DEADLINE] preamble is injected into the agent's\n                        prompt so the agent knows its time budget and can pace\n                        reasoning accordingly.\n  --invocation ID       Parent invocation id (from `li invoke start`). Groups\n                        this session under a skill orchestration record.\n                        Optional.\n  --project NAME        Explicit project name for this session. Overrides\n                        auto-detection from .lionagi/config.toml or git\n                        remote.\n  --resume-on-timeout   If the run terminates on --timeout, automatically fire\n                        one resume of the same session with 'continue and\n                        conclude the task' and report the combined result.\n                        Bounded to a single auto-resume; a timeout on the\n                        resumed leg terminates normally. Same effect as an\n                        agent profile's 'resume_on_timeout: once'.\n  --notify CMD          Shell command template run once this run reaches its\n                        terminal status. Overrides .lionagi/settings.yaml\n                        notify.on_terminal. Substitutes {payload} (full JSON),\n                        {status}, {invocation_id}.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "o",
+      "flow"
+    ],
+    "stdout": "",
+    "stderr": "error: prompt is required (positional or via -f spec file)\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "o",
+      "fanout"
+    ],
+    "stdout": "",
+    "stderr": "error: prompt is required\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "schedule",
+      "--help"
+    ],
+    "stdout": "usage: li schedule [-h]\n                   {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status}\n                   ...\n\nCreate, list, enable, disable, trigger, and delete schedules via the Studio\nAPI (default http://127.0.0.1:8765). Set LIONAGI_STUDIO_URL to use a different\nbase URL.\n\npositional arguments:\n  {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status}\n    list                List all schedules.\n    get                 Show schedule details.\n    limits              Show the global concurrent-fire cap and current in-\n                        flight count.\n    create              Create a new schedule.\n    validate            Validate + statically resolve a ScheduleSet file (no\n                        database writes).\n    apply               Reconcile a ScheduleSet file into the database,\n                        atomically.\n    export              Convert schedules into a ScheduleSet document (never\n                        writes the database).\n    enable              Enable a schedule.\n    disable             Disable a schedule.\n    delete              Delete a schedule.\n    trigger             Fire a schedule immediately.\n    runs                List runs for a schedule.\n    run                 Show one schedule run.\n    status              \"Did it work?\" summary for a schedule.\n\noptions:\n  -h, --help            show this help message and exit\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "schedule"
+    ],
+    "stdout": "",
+    "stderr": "usage: li schedule [-h]\n                   {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status}\n                   ...\nli schedule: error: the following arguments are required: schedule_action\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "list",
+      "--bogus"
+    ],
+    "stdout": "",
+    "stderr": "error: unrecognized argument: --bogus\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "capture-test",
+      "--every",
+      "15m"
+    ],
+    "stdout": "",
+    "stderr": "error: unrecognized argument '--every' \u2014 did you mean '--interval'?\nerror: unrecognized argument: 15m\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "agent",
+      "capture-test"
+    ],
+    "stdout": "",
+    "stderr": "usage: li schedule create agent [-h] --profile PROFILE [--prompt PROMPT]\n                                [--prompt-file PATH] [--model MODEL]\n                                (--at RFC3339 | --cron EXPR | --every DURATION | --github OWNER/NAME)\n                                [--timezone IANA_TZ] [--github-filter JSON]\n                                [--cwd PATH] [--once] [--max-runs N]\n                                [--overlap {skip,allow}]\n                                [--missed-fire {skip,run_once}]\n                                [--budget-usd USD] [--budget-tokens N]\n                                [--rate-limit JSON]\n                                [--description DESCRIPTION] [--disabled]\n                                name\nli schedule create agent: error: the following arguments are required: --profile\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "command",
+      "capture-test",
+      "--every",
+      "15m"
+    ],
+    "stdout": "",
+    "stderr": "Error: command target requires a trailing '--' before the executable, e.g. `li schedule create command NAME --every 15m -- refresh-index --incremental`.\n",
+    "exit_code": 1
+  }
+]

--- a/tests/contracts/data/specialized_py314.json
+++ b/tests/contracts/data/specialized_py314.json
@@ -1,0 +1,198 @@
+[
+  {
+    "argv": [
+      "--help"
+    ],
+    "stdout": "usage: li [-h] [--version] [--machine]\n          {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp} ...\n\nlionagi command line \u2014 spawn subagents via any CLI-backed provider.\n\npositional arguments:\n  {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp}\n    orchestrate (o)     Multi-agent orchestration patterns.\n    agent               Spawn one-shot subagent (blocking); prints final\n                        response.\n    casts               inspect built-in roles and modes\n    engine              Run domain-specific multi-agent engine pipelines.\n    team                Team messaging \u2014 send/receive between named agents.\n    studio              Lion Studio server\n    schedule            Manage lionagi Studio schedules.\n    state               Inspect and migrate lionagi state.db.\n    invoke              Track a skill-level orchestration.\n    kill                Terminate a running entity (run/session/play/show).\n    mirror              Mirror Claude Code sessions into studio (live).\n    monitor (mon)       Observe play/agent/run progress in real-time.\n    dispatch            Inspect and acknowledge durable dispatch_outbox rows.\n    doctor              Check the lionagi CLI environment/install for common\n                        failure modes.\n    stats               Read-only aggregate reporting over lionagi's StateDB.\n    plugin              Inspect, trust, and enable/disable LionAGI plugin\n                        bundles.\n    hooks               Import Claude Code / Codex hook configs; trust\n                        imported hook commands.\n    handshake           Report the machine-result contract version this build\n                        speaks.\n    runs                List recorded runs and what each one wrote.\n    lifecycle           Report the recorded lifecycle state of a run.\n    mcp                 Serve the lionagi MCP server (background job\n                        submit/query) over stdio.\n\noptions:\n  -h, --help            show this help message and exit\n  --version             Print the installed lionagi version and exit.\n  --machine             Emit one machine-result JSON object on stdout and send\n                        every human-facing line to stderr.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "wait"
+    ],
+    "stdout": "",
+    "stderr": "usage: li wait [-h] [--interval SECS] ids [ids ...]\nli wait: error: the following arguments are required: ids\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "skill",
+      "list"
+    ],
+    "stdout": "[redacted: this case's stdout lists the skills installed in the host's ~/.lionagi/skills, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal list serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "agent",
+      "status"
+    ],
+    "stdout": "[redacted: this case's stdout reports live session state (session id, status, timestamps, project label, and a resume command carrying a fresh session id) that varies per run and host. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "[redacted: this case's stderr reports the host's linked SQLite library version and its CVE posture, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "exit_code": 3
+  },
+  {
+    "argv": [
+      "monitor",
+      "run"
+    ],
+    "stdout": "",
+    "stderr": "usage: li monitor run [-h] [--interval SECS] [--follow] [--no-chain]\n                      [--max-wait SECS]\n                      ids [ids ...]\nli monitor run: error: the following arguments are required: ids\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "doctor",
+      "--machine"
+    ],
+    "stdout": "[redacted: this case's stdout reports live host state (home paths, run ids, artifact directories, host-installed skill names). It is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "bogus-unknown-command"
+    ],
+    "stdout": "",
+    "stderr": "usage: li [-h] [--version] [--machine]\n          {orchestrate,o,agent,casts,engine,team,studio,schedule,state,invoke,kill,mirror,monitor,mon,dispatch,doctor,stats,plugin,hooks,handshake,runs,lifecycle,mcp} ...\nli: error: argument command: invalid choice: 'bogus-unknown-command' (choose from orchestrate, o, agent, casts, engine, team, studio, schedule, state, invoke, kill, mirror, monitor, mon, dispatch, doctor, stats, plugin, hooks, handshake, runs, lifecycle, mcp)\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "play"
+    ],
+    "stdout": "Usage: li play <name> [args...]  |  li play list\n",
+    "stderr": "",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "play",
+      "list"
+    ],
+    "stdout": "[redacted: this case's stdout lists the playbooks installed in the host's ~/.lionagi/playbooks, which varies per machine. The case is excluded from byte-for-byte comparison, so the literal list serves no oracle purpose and is not committed.]",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "play",
+      "nonexistent"
+    ],
+    "stdout": "",
+    "stderr": "[redacted: this case's stderr embeds the same host-specific playbook name list as the 'play list' case (read from ~/.lionagi/playbooks), which varies per machine. The case is excluded from byte-for-byte comparison, so the literal text serves no oracle purpose and is not committed.]",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "play",
+      "--help"
+    ],
+    "stdout": "",
+    "stderr": "error: playbook NAME is required\nUsage: li play <name> \"<prompt>\" [--bypass --team-mode TEAM --timeout N ...]\nFlags may appear anywhere relative to NAME and the prompt.\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "o",
+      "flow",
+      "--help"
+    ],
+    "stdout": "usage: li orchestrate flow [-h] [-f PATH] [-p NAME] [-a NAME]\n                           [--with-synthesis [MODEL]]\n                           [--max-concurrent MAX_CONCURRENT]\n                           [--output {text,json}] [--save DIR]\n                           [--team-mode [NAME]] [--team-attach NAME]\n                           [--team-max-rounds N] [--dry-run] [--show-graph]\n                           [--background] [--bare] [--workers M1,M2,...]\n                           [--pack PATH] [--max-ops N] [--reactive MODE]\n                           [--resume RUN_OR_SESSION_ID]\n                           [--allow-degraded-context] [--mcp-config PATH]\n                           [--no-mcp-config] [--yolo] [--bypass] [--fast] [-v]\n                           [--theme {light,dark}] [--effort LEVEL] [--cwd DIR]\n                           [--timeout SECONDS] [--invocation ID]\n                           [--project NAME] [--resume-on-timeout]\n                           [--notify CMD]\n                           [[MODEL] PROMPT ...]\n\nOrchestrator analyzes the task, composes a DAG of agents with dependency\nedges, and executes with automatic parallelism where dependencies allow. Flags\nmay appear anywhere relative to the positionals.\n\npositional arguments:\n  [MODEL] PROMPT        Orchestrator model spec followed by the task prompt.\n                        Model is optional when -a/--agent provides one; a\n                        single positional is treated as the prompt. The prompt\n                        itself may instead come from -f/--file or\n                        -p/--playbook.\n\noptions:\n  -h, --help            show this help message and exit\n  -f, --file PATH       Load flow spec from YAML or JSON file. File values\n                        serve as defaults; CLI flags override them. Prompt can\n                        come from the file (prompt: key) or as a positional\n                        argument.\n  -p, --playbook NAME   Load playbook from\n                        ~/.lionagi/playbooks/<NAME>.playbook.yaml. Playbooks\n                        may declare args: schema, artifacts: contracts, or\n                        argument-hint: placeholders for prompt template\n                        values.\n  -a, --agent NAME      Load orchestrator profile by name \u2014 resolves\n                        .lionagi/agents/<NAME>/<NAME>.md first, then\n                        .lionagi/agents/<NAME>.md.\n  --with-synthesis [MODEL]\n                        Run a final pass merging the DAG's results into one\n                        answer. Bare flag uses the orchestrator model; with an\n                        argument, that model instead.\n  --max-concurrent MAX_CONCURRENT\n                        Cap on agents running at the same time within one\n                        phase. 0, the default, runs the whole phase at once \u2014\n                        lower it to stay under a provider's rate limit.\n  --output {text,json}  Result format: 'text' (default) for reading, 'json'\n                        for a machine-readable run.\n  --save DIR            Directory to write each agent's output and the run's\n                        artifacts into. Required by --background, which has\n                        nowhere else to report.\n  --team-mode [NAME]    Create a FRESH team for this flow (new UUID every\n                        invocation). Bare flag uses 'flow' as the name.\n  --team-attach NAME    Attach to a team by NAME \u2014 upsert semantics: load\n                        existing team if found (preserving message history),\n                        else create fresh. Mutually exclusive with --team-\n                        mode.\n  --team-max-rounds N   In team mode (reactive), how many extra wakeup rounds\n                        the coordinator may run after all currently-running\n                        workers signal done, to deliver unread teammate\n                        messages before the run wraps up (default: 2).\n  --dry-run             Plan the DAG but don't execute. Shows agents, deps,\n                        and model resolution.\n  --show-graph          Render DAG as matplotlib visualization. With --save,\n                        saves PNG to save dir.\n  --background          Run flow in background. Requires --save. Check output\n                        in save dir.\n  --bare                Ignore agent profiles \u2014 all workers use the CLI model\n                        spec. Roles define behavioral focus only, no profile\n                        system prompts.\n  --workers M1,M2,...   Comma-separated worker model specs (assignment i uses\n                        pool[i % len]). Overrides the per-role model while\n                        KEEPING each role's profile/system prompt \u2014 unlike\n                        --bare, which also drops profiles. Enables mixed-model\n                        flows (cheap roles + expensive roles).\n  --pack PATH           Path to a YAML routing pack. Provides per-role\n                        model/effort when --workers is absent. --workers\n                        overrides pack routing.\n  --max-ops, --max-agents N\n                        Cap total ops (nodes in the planned DAG). 0 =\n                        unlimited. `--max-agents` is a deprecated alias \u2014\n                        prefer `--max-ops`.\n  --reactive MODE       Who may grow the live DAG by emitting a SpawnRequest:\n                        'all' (default \u2014 every worker), 'off' (flat batch DAG,\n                        no spawning), or a comma-separated list of roles (e.g.\n                        'critic,evaluator') that alone may spawn. Caps still\n                        apply via --max-ops.\n  --resume RUN_OR_SESSION_ID\n                        Resume a checkpointed flow from a prior process (by\n                        run id, or any session/invocation/play id backed by\n                        one). Replays the persisted plan verbatim \u2014 no planner\n                        call, no other flow flags read\n                        (model/prompt/playbook/etc. all come from the\n                        checkpoint). Distinct from `li o ctl resume`, which\n                        un-pauses a still-running session.\n  --allow-degraded-context\n                        With --resume: proceed even when a pending op declared\n                        inherit_context \u2014 it runs against an empty branch\n                        instead of its predecessor's conversation history,\n                        which resume does not restore. Without this flag such\n                        ops refuse loudly, naming them.\n  --mcp-config PATH     Read this MCP config and hand its servers to every\n                        worker this run builds. By default the nearest\n                        .mcp.json at or above the directory this command was\n                        run in is used, so the workers' tools come from the\n                        submission rather than from --cwd. The file is read\n                        once, at startup.\n  --no-mcp-config       Hand the workers no MCP servers, and say so\n                        deliberately instead of arriving there by an empty\n                        search.\n  --yolo                Auto-approve the agent's tool calls, so an unattended\n                        run is never left waiting.\n  --bypass              Bypass all codex approvals and sandbox (for\n                        cloud/codespace environments).\n  --fast                Route codex requests through OpenAI's priority service\n                        tier (lower latency; requires account eligibility).\n                        Does not change model or reasoning effort.\n  -v, --verbose         Stream the agent's output as it is produced instead of\n                        printing only the final result, and silence the\n                        progress lines that would interleave with it.\n  --theme {light,dark}  Pick the colour scheme printed output is tuned for:\n                        'light' or 'dark' terminal.\n  --effort LEVEL        Override effort (overrides spec suffix). claude:\n                        low|medium|high|xhigh|max. codex:\n                        none|minimal|low|medium|high|xhigh|max|ultra\n                        (max/ultra clamp per model support). gemini-\n                        code/gemini-cli: folded into --model as\n                        Low|Medium|High (Gemini 3.1 Pro has no Medium).\n  --cwd DIR             Directory the agent's process runs in \u2014 the repo or\n                        worktree it acts on. Defaults to the current\n                        directory.\n  --timeout SECONDS     Hard wall-clock timeout in seconds. When set, a\n                        [DEADLINE] preamble is injected into the agent's\n                        prompt so the agent knows its time budget and can pace\n                        reasoning accordingly.\n  --invocation ID       Parent invocation id (from `li invoke start`). Groups\n                        this session under a skill orchestration record.\n                        Optional.\n  --project NAME        Explicit project name for this session. Overrides\n                        auto-detection from .lionagi/config.toml or git\n                        remote.\n  --resume-on-timeout   If the run terminates on --timeout, automatically fire\n                        one resume of the same session with 'continue and\n                        conclude the task' and report the combined result.\n                        Bounded to a single auto-resume; a timeout on the\n                        resumed leg terminates normally. Same effect as an\n                        agent profile's 'resume_on_timeout: once'.\n  --notify CMD          Shell command template run once this run reaches its\n                        terminal status. Overrides .lionagi/settings.yaml\n                        notify.on_terminal. Substitutes {payload} (full JSON),\n                        {status}, {invocation_id}.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "o",
+      "fanout",
+      "--help"
+    ],
+    "stdout": "usage: li orchestrate fanout [-h] [-a NAME] [-n NUM_WORKERS]\n                             [--workers M1,M2,...] [--pack PATH]\n                             [--max-concurrent MAX_CONCURRENT]\n                             [--with-synthesis [MODEL]]\n                             [--synthesis-prompt SYNTHESIS_PROMPT]\n                             [--output {text,json}] [--save DIR]\n                             [--team-mode [NAME]] [--mcp-config PATH]\n                             [--no-mcp-config] [--yolo] [--bypass] [--fast]\n                             [-v] [--theme {light,dark}] [--effort LEVEL]\n                             [--cwd DIR] [--timeout SECONDS] [--invocation ID]\n                             [--project NAME] [--resume-on-timeout]\n                             [--notify CMD]\n                             [[MODEL] PROMPT ...]\n\nOrchestrator decomposes task into N agent requests, fans out to workers,\noptionally synthesizes. Effort can be embedded in model spec:\nclaude/opus-4-7-high. Flags may appear anywhere relative to the positionals.\n\npositional arguments:\n  [MODEL] PROMPT        Orchestrator model spec (provider/model-effort)\n                        followed by the task prompt. Model is also used as the\n                        default worker model unless --workers is set; omit it\n                        when -a/--agent provides one. A single positional is\n                        treated as the prompt.\n\noptions:\n  -h, --help            show this help message and exit\n  -a, --agent NAME      Load orchestrator profile by name. Resolves\n                        .lionagi/agents/<NAME>/<NAME>.md first, then\n                        .lionagi/agents/<NAME>.md. Profile provides system\n                        prompt, default model, effort, yolo. CLI flags and\n                        positional model override profile settings.\n  -n, --num-workers NUM_WORKERS\n                        Maximum assignments the orchestrator generates\n                        (default 3). It may generate fewer if the task does\n                        not divide that far, and --workers specs beyond this\n                        cap go unused.\n  --workers M1,M2,...   Comma-separated worker model specs, assigned round-\n                        robin (each may carry an effort suffix). This is how\n                        one fanout mixes cheap and expensive models across\n                        workers.\n  --pack PATH           Path to a YAML routing pack. Provides per-role\n                        model/effort when --workers is absent. --workers\n                        overrides pack routing.\n  --max-concurrent MAX_CONCURRENT\n                        Cap on workers running at the same time. 0, the\n                        default, runs them all at once \u2014 lower it to stay\n                        under a provider's rate limit.\n  --with-synthesis [MODEL]\n                        Run a final pass merging the workers' results into one\n                        answer. Bare flag uses the orchestrator model; with an\n                        argument, that model instead.\n  --synthesis-prompt SYNTHESIS_PROMPT\n                        What the merged answer should be \u2014 a ranked list, a\n                        decision, a single patch. Implies synthesis.\n  --output {text,json}  Result format: 'text' (default) for reading, 'json'\n                        for a machine-readable run.\n  --save DIR            Directory to write each worker's output and the run's\n                        artifacts into. Without it they land in the run's own\n                        artifacts directory.\n  --team-mode [NAME]    Create a persistent team for this fanout. Workers get\n                        team context and results are posted as team messages.\n                        Bare flag uses 'fanout' as team name; with arg uses\n                        that name.\n  --mcp-config PATH     Read this MCP config and hand its servers to every\n                        worker this run builds. By default the nearest\n                        .mcp.json at or above the directory this command was\n                        run in is used, so the workers' tools come from the\n                        submission rather than from --cwd. The file is read\n                        once, at startup.\n  --no-mcp-config       Hand the workers no MCP servers, and say so\n                        deliberately instead of arriving there by an empty\n                        search.\n  --yolo                Auto-approve the agent's tool calls, so an unattended\n                        run is never left waiting.\n  --bypass              Bypass all codex approvals and sandbox (for\n                        cloud/codespace environments).\n  --fast                Route codex requests through OpenAI's priority service\n                        tier (lower latency; requires account eligibility).\n                        Does not change model or reasoning effort.\n  -v, --verbose         Stream the agent's output as it is produced instead of\n                        printing only the final result, and silence the\n                        progress lines that would interleave with it.\n  --theme {light,dark}  Pick the colour scheme printed output is tuned for:\n                        'light' or 'dark' terminal.\n  --effort LEVEL        Override effort (overrides spec suffix). claude:\n                        low|medium|high|xhigh|max. codex:\n                        none|minimal|low|medium|high|xhigh|max|ultra\n                        (max/ultra clamp per model support). gemini-\n                        code/gemini-cli: folded into --model as\n                        Low|Medium|High (Gemini 3.1 Pro has no Medium).\n  --cwd DIR             Directory the agent's process runs in \u2014 the repo or\n                        worktree it acts on. Defaults to the current\n                        directory.\n  --timeout SECONDS     Hard wall-clock timeout in seconds. When set, a\n                        [DEADLINE] preamble is injected into the agent's\n                        prompt so the agent knows its time budget and can pace\n                        reasoning accordingly.\n  --invocation ID       Parent invocation id (from `li invoke start`). Groups\n                        this session under a skill orchestration record.\n                        Optional.\n  --project NAME        Explicit project name for this session. Overrides\n                        auto-detection from .lionagi/config.toml or git\n                        remote.\n  --resume-on-timeout   If the run terminates on --timeout, automatically fire\n                        one resume of the same session with 'continue and\n                        conclude the task' and report the combined result.\n                        Bounded to a single auto-resume; a timeout on the\n                        resumed leg terminates normally. Same effect as an\n                        agent profile's 'resume_on_timeout: once'.\n  --notify CMD          Shell command template run once this run reaches its\n                        terminal status. Overrides .lionagi/settings.yaml\n                        notify.on_terminal. Substitutes {payload} (full JSON),\n                        {status}, {invocation_id}.\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "o",
+      "flow"
+    ],
+    "stdout": "",
+    "stderr": "error: prompt is required (positional or via -f spec file)\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "o",
+      "fanout"
+    ],
+    "stdout": "",
+    "stderr": "error: prompt is required\n",
+    "exit_code": 1
+  },
+  {
+    "argv": [
+      "schedule",
+      "--help"
+    ],
+    "stdout": "usage: li schedule [-h]\n                   {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status} ...\n\nCreate, list, enable, disable, trigger, and delete schedules via the Studio\nAPI (default http://127.0.0.1:8765). Set LIONAGI_STUDIO_URL to use a different\nbase URL.\n\npositional arguments:\n  {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status}\n    list                List all schedules.\n    get                 Show schedule details.\n    limits              Show the global concurrent-fire cap and current in-\n                        flight count.\n    create              Create a new schedule.\n    validate            Validate + statically resolve a ScheduleSet file (no\n                        database writes).\n    apply               Reconcile a ScheduleSet file into the database,\n                        atomically.\n    export              Convert schedules into a ScheduleSet document (never\n                        writes the database).\n    enable              Enable a schedule.\n    disable             Disable a schedule.\n    delete              Delete a schedule.\n    trigger             Fire a schedule immediately.\n    runs                List runs for a schedule.\n    run                 Show one schedule run.\n    status              \"Did it work?\" summary for a schedule.\n\noptions:\n  -h, --help            show this help message and exit\n",
+    "stderr": "",
+    "exit_code": 0
+  },
+  {
+    "argv": [
+      "schedule"
+    ],
+    "stdout": "",
+    "stderr": "usage: li schedule [-h]\n                   {list,get,limits,create,validate,apply,export,enable,disable,delete,trigger,runs,run,status} ...\nli schedule: error: the following arguments are required: schedule_action\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "list",
+      "--bogus"
+    ],
+    "stdout": "",
+    "stderr": "error: unrecognized argument: --bogus\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "capture-test",
+      "--every",
+      "15m"
+    ],
+    "stdout": "",
+    "stderr": "error: unrecognized argument '--every' \u2014 did you mean '--interval'?\nerror: unrecognized argument: 15m\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "agent",
+      "capture-test"
+    ],
+    "stdout": "",
+    "stderr": "usage: li schedule create agent [-h] --profile PROFILE [--prompt PROMPT]\n                                [--prompt-file PATH] [--model MODEL]\n                                (--at RFC3339 | --cron EXPR |\n                                --every DURATION | --github OWNER/NAME)\n                                [--timezone IANA_TZ] [--github-filter JSON]\n                                [--cwd PATH] [--once] [--max-runs N]\n                                [--overlap {skip,allow}]\n                                [--missed-fire {skip,run_once}]\n                                [--budget-usd USD] [--budget-tokens N]\n                                [--rate-limit JSON]\n                                [--description DESCRIPTION] [--disabled]\n                                name\nli schedule create agent: error: the following arguments are required: --profile\n",
+    "exit_code": 2
+  },
+  {
+    "argv": [
+      "schedule",
+      "create",
+      "command",
+      "capture-test",
+      "--every",
+      "15m"
+    ],
+    "stdout": "",
+    "stderr": "Error: command target requires a trailing '--' before the executable, e.g. `li schedule create command NAME --every 15m -- refresh-index --incremental`.\n",
+    "exit_code": 1
+  }
+]

--- a/tests/contracts/test_auto_registry.py
+++ b/tests/contracts/test_auto_registry.py
@@ -1,0 +1,417 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Focused contract tests for lionagi/_auto.py's declaration compiler."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+import types
+
+import pytest
+
+from lionagi import _auto
+
+_EXPECTED_CLI_SEEDS: tuple[tuple[str, tuple[str, ...], str], ...] = (
+    ("orchestrate", ("o",), "lionagi.cli.orchestrate"),
+    ("agent", (), "lionagi.cli.agent"),
+    ("casts", (), "lionagi.casts.surfaces"),
+    ("engine", (), "lionagi.cli.engine"),
+    ("team", (), "lionagi.cli.team"),
+    ("studio", (), "lionagi.studio.cli"),
+    ("schedule", (), "lionagi.studio.cli"),
+    ("state", (), "lionagi.cli.state"),
+    ("invoke", (), "lionagi.cli.invoke"),
+    ("kill", (), "lionagi.cli.kill"),
+    ("mirror", (), "lionagi.cli.mirror"),
+    ("monitor", ("mon",), "lionagi.cli.monitor"),
+    ("dispatch", (), "lionagi.cli.dispatch"),
+    ("doctor", (), "lionagi.cli.doctor"),
+    ("stats", (), "lionagi.cli.stats"),
+    ("plugin", (), "lionagi.cli.plugin"),
+    ("hooks", (), "lionagi.cli.hooks"),
+    ("handshake", (), "lionagi.cli.machine"),
+    ("runs", (), "lionagi.cli.machine"),
+    ("lifecycle", (), "lionagi.cli.machine"),
+    ("mcp", (), "lionagi.cli.mcp"),
+)
+
+
+def _make_module(name: str, source: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    exec(compile(source, name, "exec"), module.__dict__)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_fake_modules():
+    before = set(sys.modules)
+    yield
+    for name in set(sys.modules) - before:
+        del sys.modules[name]
+
+
+# --- value objects ----------------------------------------------------------
+
+
+def test_value_objects_are_frozen_and_slotted():
+    http = _auto.HttpDeclaration(path="/x", method="GET")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        http.path = "/y"  # type: ignore[misc]
+    assert not hasattr(http, "__dict__")
+
+    seed = _auto.CliSeed(name="x", help="h", module="m")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        seed.name = "y"  # type: ignore[misc]
+    assert not hasattr(seed, "__dict__")
+
+
+def test_http_declaration_defaults():
+    http = _auto.HttpDeclaration(path="/x", method="GET")
+    assert http.tags is None
+    assert http.dependencies == ()
+    assert http.include_in_schema is True
+
+
+# --- auto_register validation ------------------------------------------------
+
+
+def test_auto_register_returns_handler_unchanged_and_attaches_marker():
+    http = _auto.HttpDeclaration(path="/x", method="GET")
+
+    def handler():
+        return 1
+
+    decorated = _auto.auto_register(area="widgets", http=http)(handler)
+    assert decorated is handler
+    marker = getattr(decorated, _auto._MARKER_ATTR)
+    assert marker.area == "widgets"
+    assert marker.http is http
+    assert marker.cli is None
+
+
+def test_auto_register_requires_exactly_one_surface():
+    with pytest.raises(_auto.InvalidRegistrationError):
+        _auto.auto_register(area="widgets")
+
+    http = _auto.HttpDeclaration(path="/x", method="GET")
+    cli = _auto.CliDeclaration(seed="widgets", parser_factory=lambda subparsers: None)
+    with pytest.raises(_auto.InvalidRegistrationError):
+        _auto.auto_register(area="widgets", http=http, cli=cli)
+
+
+def test_auto_register_rejects_empty_area():
+    http = _auto.HttpDeclaration(path="/x", method="GET")
+    with pytest.raises(_auto.InvalidRegistrationError):
+        _auto.auto_register(area="", http=http)
+
+
+def test_auto_register_rejects_invalid_method_and_empty_path():
+    with pytest.raises(_auto.InvalidRegistrationError):
+        _auto.auto_register(
+            area="widgets",
+            http=_auto.HttpDeclaration(path="/x", method="TRACE"),  # type: ignore[arg-type]
+        )
+    with pytest.raises(_auto.InvalidRegistrationError):
+        _auto.auto_register(area="widgets", http=_auto.HttpDeclaration(path="", method="GET"))
+
+
+def test_auto_register_rejects_empty_cli_seed():
+    cli = _auto.CliDeclaration(seed="", parser_factory=lambda subparsers: None)
+    with pytest.raises(_auto.InvalidRegistrationError):
+        _auto.auto_register(area="widgets", cli=cli)
+
+
+# --- CLI seed contract --------------------------------------------------------
+
+
+def test_cli_seeds_are_fixed_21_in_order():
+    seeds = _auto.iter_cli_seeds()
+    assert len(seeds) == 21
+    actual = tuple((s.name, s.aliases, s.module) for s in seeds)
+    assert actual == _EXPECTED_CLI_SEEDS
+
+
+def test_seed_for_and_command_exists_resolve_canonical_names_and_aliases():
+    assert _auto.seed_for("orchestrate").name == "orchestrate"
+    assert _auto.seed_for("o").name == "orchestrate"
+    assert _auto.seed_for("mon").name == "monitor"
+    assert _auto.seed_for("does-not-exist") is None
+    assert _auto.command_exists("mcp") is True
+    assert _auto.command_exists("does-not-exist") is False
+
+
+def test_duplicate_seed_token_raises_duplicate_registration_error():
+    a = _auto.CliSeed(name="alpha", help="a", module="m.a")
+    b = _auto.CliSeed(name="beta", help="b", module="m.b", aliases=("alpha",))
+    with pytest.raises(_auto.DuplicateRegistrationError):
+        _auto._build_seed_by_token((a, b))
+
+
+def test_duplicate_canonical_seed_name_raises_duplicate_registration_error():
+    a = _auto.CliSeed(name="same", help="a", module="m.a")
+    b = _auto.CliSeed(name="same", help="b", module="m.b")
+    with pytest.raises(_auto.DuplicateRegistrationError):
+        _auto._build_seed_by_token((a, b))
+
+
+# --- HTTP compilation ---------------------------------------------------------
+
+
+def test_http_load_compiles_in_fixed_module_and_definition_order(monkeypatch):
+    mod_a = _make_module(
+        "tests.contracts._fake_http_a",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='a', http=_auto.HttpDeclaration(path='/a1', method='GET'))\n"
+        "def a1():\n    return 1\n"
+        "@_auto.auto_register(area='a', http=_auto.HttpDeclaration(path='/a2', method='GET'))\n"
+        "def a2():\n    return 2\n",
+    )
+    mod_b = _make_module(
+        "tests.contracts._fake_http_b",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='b', http=_auto.HttpDeclaration(path='/b1', method='POST'))\n"
+        "def b1():\n    return 3\n",
+    )
+    monkeypatch.setattr(_auto, "_HTTP_MODULES", (mod_a.__name__, mod_b.__name__))
+    with _auto._isolated_registry_for_tests():
+        _auto.load_http_modules()
+        registrations = _auto.iter_http()
+        assert [r.qualname for r in registrations] == ["a1", "a2", "b1"]
+        assert [r.order for r in registrations] == [0, 1, 2]
+
+
+def test_http_tags_default_to_area_when_unset_and_preserved_when_set(monkeypatch):
+    mod = _make_module(
+        "tests.contracts._fake_http_tags",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='widgets', http=_auto.HttpDeclaration(path='/w', method='GET'))\n"
+        "def untagged():\n    return 1\n"
+        "@_auto.auto_register(area='widgets', http=_auto.HttpDeclaration(path='/w2', method='GET', tags=('custom',)))\n"
+        "def tagged():\n    return 2\n",
+    )
+    monkeypatch.setattr(_auto, "_HTTP_MODULES", (mod.__name__,))
+    with _auto._isolated_registry_for_tests():
+        _auto.load_http_modules()
+        by_name = {r.qualname: r for r in _auto.iter_http()}
+        assert by_name["untagged"].http.tags == ("widgets",)
+        assert by_name["tagged"].http.tags == ("custom",)
+
+
+def test_http_rescan_of_cached_module_is_idempotent(monkeypatch):
+    mod = _make_module(
+        "tests.contracts._fake_http_idempotent",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='a', http=_auto.HttpDeclaration(path='/a', method='GET'))\n"
+        "def handler():\n    return 1\n",
+    )
+    monkeypatch.setattr(_auto, "_HTTP_MODULES", (mod.__name__,))
+    with _auto._isolated_registry_for_tests():
+        _auto.load_http_modules()
+        _auto.load_http_modules()
+        assert len(_auto.iter_http()) == 1
+
+
+def test_http_duplicate_identity_with_different_callable_raises(monkeypatch):
+    mod = _make_module(
+        "tests.contracts._fake_http_dup",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='a', http=_auto.HttpDeclaration(path='/a', method='GET'))\n"
+        "def handler():\n    return 1\n"
+        "@_auto.auto_register(area='a', http=_auto.HttpDeclaration(path='/a', method='GET'))\n"
+        "def handler2():\n    return 2\n",
+    )
+    # Force a colliding identity: same module/qualname/path/method, distinct objects.
+    mod.handler2.__qualname__ = mod.handler.__qualname__
+    monkeypatch.setattr(_auto, "_HTTP_MODULES", (mod.__name__,))
+    with _auto._isolated_registry_for_tests():
+        with pytest.raises(_auto.DuplicateRegistrationError):
+            _auto.load_http_modules()
+
+
+def test_http_scan_ignores_imported_callables_and_cli_only_markers(monkeypatch):
+    source_mod = _make_module(
+        "tests.contracts._fake_http_source",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='a', http=_auto.HttpDeclaration(path='/a', method='GET'))\n"
+        "def local_http():\n    return 1\n"
+        "@_auto.auto_register(area='a', cli=_auto.CliDeclaration(seed='x', parser_factory=lambda s: None))\n"
+        "def local_cli():\n    return 2\n",
+    )
+    importer_mod = _make_module(
+        "tests.contracts._fake_http_importer",
+        "from tests.contracts._fake_http_source import local_http, local_cli\n",
+    )
+    monkeypatch.setattr(_auto, "_HTTP_MODULES", (importer_mod.__name__,))
+    with _auto._isolated_registry_for_tests():
+        _auto.load_http_modules()
+        assert _auto.iter_http() == ()
+
+
+# --- CLI compilation -----------------------------------------------------------
+
+
+def test_cli_load_command_imports_only_the_selected_module(monkeypatch):
+    mod_a = _make_module(
+        "tests.contracts._fake_cli_a",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='a', cli=_auto.CliDeclaration(seed='alpha', parser_factory=lambda s: None))\n"
+        "def add_alpha_subparser():\n    return 1\n",
+    )
+    seed_a = _auto.CliSeed(name="alpha", help="h", module=mod_a.__name__)
+    seed_b = _auto.CliSeed(
+        name="beta", help="h", module="tests.contracts._nonexistent_should_not_import"
+    )
+    monkeypatch.setattr(_auto, "_cli_seeds", (seed_a, seed_b))
+    monkeypatch.setattr(_auto, "_cli_seed_by_token", {"alpha": seed_a, "beta": seed_b})
+    with _auto._isolated_registry_for_tests():
+        registration = _auto.load_cli_command(seed_a)
+        assert registration.handler is mod_a.add_alpha_subparser
+        assert "tests.contracts._nonexistent_should_not_import" not in sys.modules
+
+
+def test_cli_load_command_is_cached(monkeypatch):
+    mod_a = _make_module(
+        "tests.contracts._fake_cli_cache",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='a', cli=_auto.CliDeclaration(seed='alpha', parser_factory=lambda s: None))\n"
+        "def handler():\n    return 1\n",
+    )
+    seed_a = _auto.CliSeed(name="alpha", help="h", module=mod_a.__name__)
+    monkeypatch.setattr(_auto, "_cli_seeds", (seed_a,))
+    with _auto._isolated_registry_for_tests():
+        first = _auto.load_cli_command(seed_a)
+        second = _auto.load_cli_command(seed_a)
+        assert first is second
+
+
+def test_cli_zero_matching_markers_raises_contract_error(monkeypatch):
+    mod_a = _make_module("tests.contracts._fake_cli_zero", "x = 1\n")
+    seed_a = _auto.CliSeed(name="alpha", help="h", module=mod_a.__name__)
+    with _auto._isolated_registry_for_tests():
+        with pytest.raises(_auto.RegistrationContractError):
+            _auto.load_cli_command(seed_a)
+
+
+def test_cli_multiple_matching_markers_raises_contract_error(monkeypatch):
+    mod_a = _make_module(
+        "tests.contracts._fake_cli_multi",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='a', cli=_auto.CliDeclaration(seed='alpha', parser_factory=lambda s: None))\n"
+        "def one():\n    return 1\n"
+        "@_auto.auto_register(area='a', cli=_auto.CliDeclaration(seed='alpha', parser_factory=lambda s: None))\n"
+        "def two():\n    return 2\n",
+    )
+    seed_a = _auto.CliSeed(name="alpha", help="h", module=mod_a.__name__)
+    with _auto._isolated_registry_for_tests():
+        with pytest.raises(_auto.RegistrationContractError):
+            _auto.load_cli_command(seed_a)
+
+
+def test_cli_marker_module_mismatch_raises_contract_error(monkeypatch):
+    _make_module(
+        "tests.contracts._fake_cli_origin",
+        "from lionagi import _auto\n"
+        "@_auto.auto_register(area='a', cli=_auto.CliDeclaration(seed='alpha', parser_factory=lambda s: None))\n"
+        "def handler():\n    return 1\n",
+    )
+    reexport_mod = _make_module(
+        "tests.contracts._fake_cli_reexport",
+        "from tests.contracts._fake_cli_origin import handler\n",
+    )
+    seed_a = _auto.CliSeed(name="alpha", help="h", module=reexport_mod.__name__)
+    with _auto._isolated_registry_for_tests():
+        with pytest.raises(_auto.RegistrationContractError):
+            _auto.load_cli_command(seed_a)
+
+
+# --- build_cli_parser ------------------------------------------------------------
+
+
+def test_build_cli_parser_with_no_selection_registers_every_seed_as_stub():
+    build = _auto.build_cli_parser(None)
+    assert build.parser.prog == "li"
+    assert build.seed is None
+    assert build.registration is None
+    assert build.selected_parser is None
+    action_dests = {a.dest for a in build.parser._actions}
+    assert "machine" in action_dests
+    choices = build.parser._subparsers._group_actions[0].choices  # type: ignore[union-attr]
+    assert "orchestrate" in choices
+    assert "o" in choices  # alias registered
+    assert len(_auto.iter_cli_seeds()) == 21
+
+
+def test_build_cli_parser_with_selection_uses_its_parser_factory(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def factory(subparsers: argparse._SubParsersAction):
+        p = subparsers.add_parser("alpha")
+        captured["subparsers"] = subparsers
+        return p
+
+    mod_a = _make_module("tests.contracts._fake_cli_build", "")
+    mod_a.factory = factory
+    mod_a.handler = lambda args: 0
+    marker_source = (
+        "from lionagi import _auto\n"
+        "from tests.contracts._fake_cli_build import factory\n"
+        "@_auto.auto_register(area='a', cli=_auto.CliDeclaration(seed='alpha', parser_factory=factory))\n"
+        "def add_alpha_subparser():\n    return 1\n"
+    )
+    marker_mod = _make_module("tests.contracts._fake_cli_build_marker", marker_source)
+    seed_a = _auto.CliSeed(name="alpha", help="h", module=marker_mod.__name__)
+    monkeypatch.setattr(_auto, "_cli_seeds", (seed_a,))
+    monkeypatch.setattr(_auto, "_cli_seed_by_token", {"alpha": seed_a})
+    with _auto._isolated_registry_for_tests():
+        build = _auto.build_cli_parser(seed_a)
+        assert build.seed is seed_a
+        assert build.registration.handler is marker_mod.add_alpha_subparser
+        assert isinstance(build.selected_parser, argparse.ArgumentParser)
+        assert "subparsers" in captured
+
+
+# --- isolation context manager ----------------------------------------------------
+
+
+def test_isolated_registry_for_tests_restores_previous_state():
+    # Start from a known-clean slate: an earlier test in this worker may have
+    # dispatched a real `li <command>` invocation outside any isolation
+    # context (C1 wires `lionagi.cli.main` to this module-global registry),
+    # leaving compiled entries this test does not own. Only the "pre" entry
+    # set below belongs to this test's own before/after assertions.
+    _auto._http.clear()
+    _auto._http_keys.clear()
+    _auto._cli_realized.clear()
+    sentinel_reg = _auto.Registration(
+        order=0, area="pre", module="m", qualname="q", handler=lambda: None
+    )
+    _auto._http.append(sentinel_reg)
+    _auto._cli_realized["pre"] = sentinel_reg
+    try:
+        with _auto._isolated_registry_for_tests():
+            assert _auto.iter_http() == ()
+            assert _auto._cli_realized == {}
+            _auto._http.append(
+                _auto.Registration(
+                    order=0, area="inside", module="m", qualname="q2", handler=lambda: None
+                )
+            )
+        assert _auto.iter_http() == (sentinel_reg,)
+        assert _auto._cli_realized == {"pre": sentinel_reg}
+    finally:
+        _auto._http.clear()
+        _auto._http_keys.clear()
+        _auto._cli_realized.clear()
+
+
+# --- import isolation boundary -------------------------------------------------
+
+
+def test_auto_module_is_not_exported_from_root():
+    import lionagi
+
+    assert "_auto" not in lionagi.__all__
+    assert all(target[0] != "_auto" for target in lionagi._LAZY_MAP.values())

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -113,16 +113,42 @@ def test_http_route_count_is_133():
     assert live["count"] == 133
 
 
+def _routes_by_key(payload: dict) -> dict[str, dict]:
+    """Project a ``capture_http()`` payload's routes into a dict keyed by
+    their actual identity, ``(methods, path)`` -- with the
+    registration-order-derived ``ordinal`` field dropped.
+
+    ``ordinal`` reflects the position a route's decorator happened to run at
+    in *this* process, not a fact about the route: ``load_studio_route_modules``
+    imports each area module in a fixed order, but ``import_module`` on an
+    already-imported module is a no-op, so a route's real position depends on
+    whichever test in the same worker imported its owning service module
+    first (many tests import a single ``lionagi.studio.services.*`` module
+    directly to unit-test a handler, without going through ``create_app()``).
+    Comparing ``ordinal`` positionally turns one such incidental reordering
+    into a whole-file diff, since every route after the moved one shifts too.
+    Keying by identity instead means an actual added/removed/changed route
+    diffs as one entry.
+    """
+    by_key: dict[str, dict] = {}
+    for route in payload["routes"]:
+        key = json.dumps([route["methods"], route["path"]], sort_keys=True)
+        by_key[key] = {k: v for k, v in route.items() if k != "ordinal"}
+    return by_key
+
+
 def test_http_routes_match_baseline():
     """http.json is generated from this branch's own base commit and is
-    byte-for-byte identical to the live capture — the strongest available
-    behavior-preservation proof. Regenerate it (and this test's expected
-    count above) only when an intentional route change lands, never to
-    paper over an unreviewed drift.
+    identical (per route, keyed by (methods, path) -- see _routes_by_key) to
+    the live capture — the strongest available behavior-preservation proof.
+    Regenerate it (and this test's expected count above) only when an
+    intentional route change lands, never to paper over an unreviewed drift.
     """
     expected = _load("http")
     live = _capture.capture_http()
-    assert _sorted_json(live) == _sorted_json(expected)
+    assert live["count"] == expected["count"]
+    assert _sorted_json(_routes_by_key(live)) == _sorted_json(_routes_by_key(expected))
+    assert _sorted_json(live["openapi"]) == _sorted_json(expected["openapi"])
 
 
 def test_http_all_routes_have_responses_field():

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -1,0 +1,384 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""V0 behavior-preservation gate for the consolidation manifest.
+
+Each test loads the frozen baseline captured before any consolidation edit
+(``tests/contracts/data/*.json``, generated once by running the functions in
+``_capture.py`` against the pre-consolidation worktree) and compares it,
+field for field, against a fresh capture of the live code. A delta here means
+an observable public surface changed; the manifest requires behavior
+preservation, so these baselines must never be refreshed to match a change —
+only to correct a capture bug.
+
+Two fields carry inherent host-state volatility and are excluded from the
+byte-for-byte comparison: the "agent status" specialized-CLI case includes a
+live session UUID and elapsed timers, and machine-mode "monitor"/"agent"
+cases report live run state. Their exit codes and envelope shape are still
+compared; their literal stdout is not.
+
+Waiver:
+  W-02: the "agent status" / "doctor --machine" / "handshake --machine" /
+    "runs --machine" cases carry live session, git-identity, and daemon
+    state that is non-deterministic across checkouts and wall clocks --
+    excluded below via _VOLATILE_ARGV / _VOLATILE_MACHINE_ARGV. Cases whose
+    captured stdout is itself host-specific (machine paths, run ids,
+    installed skill names) carry a redaction marker in the fixture instead
+    of the literal text -- see test_fixtures_carry_no_host_specific_state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.contracts import _capture
+
+DATA_DIR = Path(__file__).parent / "data"
+
+# W-02 waiver (see delta_resolution.md): every argv below carries live
+# session/git/daemon state that varies across checkouts and wall clocks by
+# design, not because of a consolidation code change.
+_VOLATILE_ARGV = {
+    ("agent", "status"),
+    ("monitor", "--machine"),
+    ("agent", "--machine"),
+    ("doctor", "--machine"),  # reports a live timestamp and working-tree cleanliness
+    ("play", "list"),  # playbook names read from ~/.lionagi/playbooks/, host-specific
+    ("play", "nonexistent"),  # error text lists the same host-specific playbook names
+    ("skill", "list"),  # skill names read from ~/.lionagi/skills/, host-specific
+}
+_VOLATILE_MACHINE_ARGV = {
+    ("handshake", "--machine"),  # data.comparison_ref reads live git state
+    ("doctor", "--machine"),  # reports a live timestamp and working-tree cleanliness
+    ("runs", "--machine"),  # lists live run/artifact state on disk
+}
+
+
+def _load(name: str):
+    with open(DATA_DIR / f"{name}.json") as f:
+        return json.load(f)
+
+
+def _sorted_json(value):
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+def test_http_route_count_is_133():
+    live = _capture.capture_http()
+    assert live["count"] == 133
+
+
+def test_http_routes_match_baseline():
+    """http.json is generated from this branch's own base commit and is
+    byte-for-byte identical to the live capture — the strongest available
+    behavior-preservation proof. Regenerate it (and this test's expected
+    count above) only when an intentional route change lands, never to
+    paper over an unreviewed drift.
+    """
+    expected = _load("http")
+    live = _capture.capture_http()
+    assert _sorted_json(live) == _sorted_json(expected)
+
+
+def test_http_all_routes_have_responses_field():
+    live = _capture.capture_http()
+    for route in live["routes"]:
+        assert "responses" in route, f"route {route['ordinal']} {route['path']} missing responses"
+
+
+def test_http_api_routes_have_nonempty_responses():
+    live = _capture.capture_http()
+    api_routes = [r for r in live["routes"] if r["path"] and r["path"].startswith("/api/")]
+    assert api_routes, "expected at least one /api/ business route"
+    missing = [r["path"] for r in api_routes if not r["responses"]]
+    assert not missing, f"business routes missing responses: {missing[:5]}"
+
+
+def test_http_openapi_has_full_operations_and_schemas():
+    live = _capture.capture_http()
+    openapi = live["openapi"]
+    assert openapi["path_count"] > 0
+    assert openapi["schema_count"] > 0
+    _, sample_ops = next(iter(openapi["paths"].items()))
+    sample_op = next(iter(sample_ops.values()))
+    # Full operation content, not just a path-name list.
+    assert "responses" in sample_op
+    # operationId is deliberately excluded: derives from the handler's
+    # Python qualname, which moves when a handler is absorbed into a new
+    # module — an internal migration detail, not an external route field.
+    assert "operationId" not in sample_op
+    sample_schema = next(iter(openapi["schemas"].values()))
+    assert isinstance(sample_schema, dict) and sample_schema, "expected full schema definitions"
+
+
+def test_cli_registry_has_21_commands():
+    live = _capture.capture_cli()
+    assert live["registry_count"] == 21
+    assert live["name_map_count"] == 23
+
+
+def test_cli_surface_matches_baseline():
+    expected = _load("cli")
+    live = _capture.capture_cli()
+    assert _sorted_json(live) == _sorted_json(expected)
+
+
+def test_cli_specialized_paths_match_baseline():
+    expected = {tuple(c["argv"]): c for c in _load("specialized")}
+    live = {tuple(c["argv"]): c for c in _capture.capture_specialized()}
+    # Every frozen case must still be present and, modulo known volatility
+    # (W-02, below), unchanged.
+    assert set(expected) <= set(live), f"missing from live: {set(expected) - set(live)}"
+    for argv, exp in expected.items():
+        got = live[argv]
+        if argv in _VOLATILE_ARGV:
+            continue
+        assert got["exit_code"] == exp["exit_code"], f"exit code changed for {argv}"
+        assert got["stdout"] == exp["stdout"], f"stdout changed for {argv}"
+        assert got["stderr"] == exp["stderr"], f"stderr changed for {argv}"
+
+
+def test_mcp_available_paths_match_baseline():
+    expected = _load("mcp")
+    live = _capture.capture_mcp()
+    assert live["available_paths"] == expected["available_paths"]
+    assert live["available_path_count"] == expected["available_path_count"]
+
+
+def test_mcp_catalog_matches_baseline():
+    expected = _load("mcp")
+    live = _capture.capture_mcp()
+    assert live["catalog"] == expected["catalog"]
+
+
+def test_mcp_projections_match_baseline():
+    expected = _load("mcp")
+    live = _capture.capture_mcp()
+    assert live["projections"] == expected["projections"]
+    assert live["projection_errors"] == expected["projection_errors"]
+    assert live["errors"] == expected["errors"]
+
+
+def test_mcp_projects_every_available_path():
+    live = _capture.capture_mcp()
+    assert live["projection_count"] + live["projection_error_count"] == live["available_path_count"]
+    assert live["available_path_count"] == 75
+    assert live["projection_count"] == 62
+    assert live["projection_error_count"] == 13
+
+
+def test_mcp_projection_errors_are_classified():
+    live = _capture.capture_mcp()
+    valid_classes = {
+        "unresolved_subcommand",
+        "unsupported_argparse_type",
+        "empty_command_path",
+        "no_such_command",
+        "no_such_command_path",
+        "other",
+    }
+    for path, err in live["projection_errors"].items():
+        assert err["class"] in valid_classes, f"{path}: unclassified error {err}"
+        assert err["class"] != "other", f"{path}: fell through to 'other' — {err}"
+    classes = {err["class"] for err in live["projection_errors"].values()}
+    assert "unresolved_subcommand" in classes
+    # The one known unsupported-argparse-type case (`mirror --since`).
+    assert "unsupported_argparse_type" in classes
+    assert live["projection_errors"]["mirror"]["class"] == "unsupported_argparse_type"
+
+
+def test_mcp_aliases_derived_from_live_seed_table():
+    live = _capture.capture_mcp()
+    assert live["projections"]["orchestrate flow"]["aliases"] == ["o flow"]
+    assert live["projections"]["monitor"]["aliases"] == ["mon"]
+    # A path with no aliased head carries no aliases key at all.
+    assert "aliases" not in live["projections"]["agent"]
+
+
+def test_mcp_absent_verbs_are_captured_in_full():
+    live = _capture.capture_mcp()
+    assert live["absent_verb_count"] == 30
+    by_name = {v["name"]: v for v in live["absent_verbs"]}
+    assert "mirror" in by_name
+    assert "casts" in by_name
+    for entry in live["absent_verbs"]:
+        assert entry["summary"]
+        assert entry["reason"]
+        assert entry["cli_path"]
+
+
+def test_mcp_negative_cases_cover_every_error_class():
+    live = _capture.capture_mcp()
+    classes = {e["class"] for e in live["errors"]}
+    assert {
+        "empty_command_path",
+        "no_such_command",
+        "no_such_command_path",
+        "unresolved_subcommand",
+        "unsupported_argparse_type",
+    } <= classes
+
+
+def test_machine_classification_matches_baseline():
+    expected = {tuple(c["argv"]): c for c in _load("machine")}
+    live = {tuple(c["argv"]): c for c in _capture.capture_machine()}
+    assert set(live) == set(expected)
+    for argv, exp in expected.items():
+        got = live[argv]
+        assert got["exit_code"] == exp["exit_code"], f"exit code changed for {argv}"
+        assert got["envelope_ok"] == exp["envelope_ok"], f"envelope ok changed for {argv}"
+        if argv in _VOLATILE_ARGV or argv in _VOLATILE_MACHINE_ARGV:
+            continue
+        assert got["stdout"] == exp["stdout"], f"stdout changed for {argv}"
+
+
+def test_public_imports_match_baseline():
+    expected = _load("imports")
+    live = _capture.capture_imports()
+    assert live["root_all"] == expected["root_all"]
+    assert live["root_all_count"] == expected["root_all_count"] == 61
+    assert live["symbols"] == expected["symbols"]
+    assert live["lazy_map_keys"] == expected["lazy_map_keys"]
+    assert live["compat_modules"] == expected["compat_modules"]
+    # `import_laziness` is new this round (see test_import_laziness_* below);
+    # imports.json's four existing keys above are unaffected by its addition.
+
+
+# Exit codes for the play / orchestrate-flow / orchestrate-fanout / schedule
+# quick-create and did-you-mean specialized-CLI cases, asserted directly as a
+# structural check independent of the byte-for-byte fixture comparison above.
+_NEW_SPECIALIZED_EXPECTED_EXIT: dict[tuple[str, ...], int] = {
+    ("play",): 1,
+    ("play", "list"): 0,
+    ("play", "nonexistent"): 1,
+    ("play", "--help"): 1,
+    ("o", "flow", "--help"): 0,
+    ("o", "fanout", "--help"): 0,
+    ("o", "flow"): 1,
+    ("o", "fanout"): 1,
+    ("schedule", "--help"): 0,
+    ("schedule",): 2,
+    ("schedule", "list", "--bogus"): 2,
+    ("schedule", "create", "capture-test", "--every", "15m"): 2,
+    ("schedule", "create", "agent", "capture-test"): 2,
+    ("schedule", "create", "command", "capture-test", "--every", "15m"): 1,
+}
+
+
+def test_specialized_new_branches_have_expected_exit_codes():
+    live = {tuple(c["argv"]): c for c in _capture.capture_specialized()}
+    for argv, expected_exit in _NEW_SPECIALIZED_EXPECTED_EXIT.items():
+        assert argv in live, f"{argv} missing from capture_specialized() output"
+        got_exit = live[argv]["exit_code"]
+        assert got_exit == expected_exit, (
+            f"{argv} exit code {got_exit} != expected {expected_exit}\n"
+            f"stdout={live[argv]['stdout']!r}\nstderr={live[argv]['stderr']!r}"
+        )
+
+
+def test_schedule_did_you_mean_suggests_synonym():
+    live = {tuple(c["argv"]): c for c in _capture.capture_specialized()}
+    case = live[("schedule", "create", "capture-test", "--every", "15m")]
+    assert "did you mean '--interval'?" in case["stderr"]
+
+
+def test_schedule_quick_create_validates_before_any_network_call():
+    """Both quick-create negative cases must fail through argparse/local
+    validation alone — no DB or HTTP state may be created by this contract
+    test. Asserted implicitly: both stderr messages name the missing
+    argument/flag rather than any connection or server error."""
+    live = {tuple(c["argv"]): c for c in _capture.capture_specialized()}
+    agent_case = live[("schedule", "create", "agent", "capture-test")]
+    assert "--profile" in agent_case["stderr"]
+    command_case = live[("schedule", "create", "command", "capture-test", "--every", "15m")]
+    assert "trailing" in command_case["stderr"]
+
+
+# Cross-seed imports that are known, source-grounded, and pre-existing —
+# neither introduced by nor related to A0/C1D/C1X/C1's registry/dispatch
+# work, so the import-laziness oracle allowlists exactly these two instead of
+# asserting a blanket zero that would misreport them as regressions:
+#   - orchestrate: lionagi/cli/orchestrate/_common.py:14 does a *module-level*
+#     `from .. import team as _team_module` (team-mode support), so importing
+#     lionagi.cli.orchestrate always pulls in lionagi.cli.team.
+#   - stats: lionagi/cli/stats.py:14 does a *module-level*
+#     `from .monitor import _since_timestamp`, reusing a helper function.
+_KNOWN_CROSS_SEED_IMPORTS: dict[str, tuple[str, ...]] = {
+    "orchestrate": ("lionagi.cli.team",),
+    "stats": ("lionagi.cli.monitor",),
+}
+
+
+def test_import_laziness_traces_all_21_seeds_cleanly():
+    live = _capture.capture_imports()
+    trace = live["import_laziness"]
+    assert trace["seed_count"] == 21
+    assert len(trace["seed_names"]) == 21
+    for name, result in trace["traces"].items():
+        assert not result.get("_error"), f"{name}: subprocess trace failed: {result.get('_error')}"
+        assert not result["http_registry_realized"], (
+            f"{name}: loading this CLI seed realized the HTTP registry "
+            f"(count={result['http_registry_count']})"
+        )
+        assert result["cli_realized_names"] == [name], (
+            f"{name}: expected only itself in _cli_realized, got {result['cli_realized_names']}"
+        )
+        allowed = set(_KNOWN_CROSS_SEED_IMPORTS.get(name, ()))
+        leaked = set(result["other_seed_modules_imported"])
+        unexpected = leaked - allowed
+        assert not unexpected, f"{name}: unexpected cross-seed imports {sorted(unexpected)}"
+
+
+def test_import_laziness_casts_seed_stays_cli_only():
+    """The one seed whose module declares both a CLI and an HTTP marker
+    (lionagi/casts/surfaces.py) — the exact boundary C1X's own result flagged
+    as the eager-import risk to watch (implementer-4/c1x_result.md:71-76)."""
+    live = _capture.capture_imports()
+    casts = live["import_laziness"]["traces"]["casts"]
+    assert not casts.get("_error")
+    assert casts["cli_realized_names"] == ["casts"]
+    assert not casts["http_registry_realized"]
+    assert casts["other_seed_modules_imported"] == []
+
+
+@pytest.mark.parametrize("case", _capture.MACHINE_CASES, ids=lambda c: " ".join(c))
+def test_machine_envelope_shape_is_well_formed(case):
+    result = _capture._run_cli(list(case))
+    stdout = result["stdout"].strip()
+    if not stdout:
+        return
+    envelope = json.loads(stdout)
+    assert "ok" in envelope
+    assert "contract_version" in envelope
+
+
+# Contract fixtures are committed to a public repository and are compared
+# byte-for-byte, so a captured value that varies per machine breaks both at
+# once: it publishes whatever the capturing developer's home directory held,
+# and it makes the suite pass only on that machine. Cases whose output is
+# genuinely host-dependent are excluded from comparison above and their stdout
+# is redacted rather than committed. This guards both properties at once.
+_HOST_STATE_PATTERNS = (
+    "/Users/",
+    "/home/",
+    "khive-work",
+)
+
+
+def test_fixtures_carry_no_host_specific_state():
+    offenders = []
+    for path in sorted(DATA_DIR.glob("*.json")):
+        text = path.read_text()
+        for pattern in _HOST_STATE_PATTERNS:
+            if pattern in text:
+                line = next((i for i, ln in enumerate(text.splitlines(), 1) if pattern in ln), None)
+                offenders.append(f"{path.name}:{line} contains {pattern!r}")
+    # Positive control: the check can see a planted value, so an empty result
+    # means "no host state" rather than "the search was broken".
+    assert any(p in "/Users/someone/x" for p in _HOST_STATE_PATTERNS)
+    assert not offenders, (
+        "contract fixtures must not carry host-specific state (see the note above): "
+        + "; ".join(offenders)
+    )

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -195,7 +195,11 @@ def test_cli_surface_matches_baseline():
 
 
 def test_cli_specialized_paths_match_baseline():
-    expected = {tuple(c["argv"]): c for c in _load("specialized")}
+    """Committable cases capture argparse's own rendered text verbatim, which
+    CPython's HelpFormatter changed across this project's CI-tested Python
+    versions (see _capture.specialized_baseline_name); the baseline loaded
+    here is pinned to the running interpreter rather than a single file."""
+    expected = {tuple(c["argv"]): c for c in _load(_capture.specialized_baseline_name())}
     live = {tuple(c["argv"]): c for c in _capture.capture_specialized()}
     # Every frozen case must still be present and, modulo known volatility
     # (W-02, below), unchanged.
@@ -472,11 +476,15 @@ def test_fixtures_carry_no_host_specific_state():
 _REDACTION_MARKER_RE = re.compile(r"^\[redacted: .+\]$", re.DOTALL)
 
 
-def _unredacted_fields(file_name: str, cases: list) -> list[str]:
+def _unredacted_fields(file_name: str, cases: list, *, label: str | None = None) -> list[str]:
     """(file, argv, field) labels for every case classified volatile for
     *file_name* whose captured stream is neither empty nor the redaction
-    marker -- i.e. still carries literal captured output."""
+    marker -- i.e. still carries literal captured output. *file_name* selects
+    the volatile-case population (SPECIALIZED_CASES / MACHINE_CASES); *label*
+    overrides the fixture name in the offender message when *cases* came from
+    a differently-named file (e.g. a per-Python-version pinned baseline)."""
     volatile = _volatile_argv_for(file_name)
+    label = label or file_name
     offenders = []
     for case in cases:
         argv = tuple(case["argv"])
@@ -485,14 +493,15 @@ def _unredacted_fields(file_name: str, cases: list) -> list[str]:
         for field in ("stdout", "stderr"):
             value = case.get(field, "")
             if value and not _REDACTION_MARKER_RE.match(value):
-                offenders.append(f"{file_name}.json {argv} {field}")
+                offenders.append(f"{label}.json {argv} {field}")
     return offenders
 
 
 def test_volatile_fixture_cases_are_fully_redacted():
     offenders = []
-    for file_name in ("specialized", "machine"):
-        offenders += _unredacted_fields(file_name, _load(file_name))
+    for name in _capture._SPECIALIZED_BASELINE_BY_PYVER.values():
+        offenders += _unredacted_fields("specialized", _load(name), label=name)
+    offenders += _unredacted_fields("machine", _load("machine"))
     assert not offenders, (
         "volatile fixture cases still carry literal captured output instead of the "
         "redaction marker: " + "; ".join(offenders)

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -34,6 +34,7 @@ import json
 import re
 import socket
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
@@ -194,6 +195,34 @@ def test_cli_surface_matches_baseline():
     assert _sorted_json(live) == _sorted_json(expected)
 
 
+def _assert_stderr_matches_baseline(
+    argv: tuple[str, ...], got_stderr: str, exp_stderr: str
+) -> None:
+    """Compare one case's live stderr against its frozen baseline, tolerating
+    only the argparse choice-quoting rendering difference (see
+    ``_capture.normalize_argparse_choice_quoting``) -- everything else,
+    including a changed/added/removed/renamed choice name, must still match
+    byte-for-byte.
+
+    A normalization that silently accepts a difference reads identically to
+    a byte-for-byte match that never needed it, so any case where
+    normalization was load-bearing announces itself via a pytest warning
+    (visible in the run's warnings summary even when the test passes)
+    instead of passing silently.
+    """
+    if got_stderr == exp_stderr:
+        return
+    norm_got = _capture.normalize_argparse_choice_quoting(got_stderr)
+    norm_exp = _capture.normalize_argparse_choice_quoting(exp_stderr)
+    assert norm_got == norm_exp, f"stderr changed for {argv}"
+    warnings.warn(
+        f"{argv}: stderr differed from the frozen baseline only in argparse "
+        "choice-name quoting -- normalized before comparing.\n"
+        f"  baseline: {exp_stderr!r}\n  live:     {got_stderr!r}",
+        stacklevel=2,
+    )
+
+
 def test_cli_specialized_paths_match_baseline():
     """Committable cases capture argparse's own rendered text verbatim, which
     CPython's HelpFormatter changed across this project's CI-tested Python
@@ -211,7 +240,68 @@ def test_cli_specialized_paths_match_baseline():
             continue
         assert got["exit_code"] == exp["exit_code"], f"exit code changed for {argv}"
         assert got["stdout"] == exp["stdout"], f"stdout changed for {argv}"
-        assert got["stderr"] == exp["stderr"], f"stderr changed for {argv}"
+        _assert_stderr_matches_baseline(argv, got["stderr"], exp["stderr"])
+
+
+def test_normalize_argparse_choice_quoting_is_quoting_agnostic():
+    """Property 1: the same choice list, quoted or bare, normalizes to the
+    same fragment. Uses this project's own frozen baselines rather than a
+    synthetic example: ``specialized.json`` (captured on 3.10, quoted) and
+    ``specialized_py312.json`` (captured on 3.12, bare) are, for
+    ``bogus-unknown-command``, identical in every other respect (both
+    predate the 3.13 usage-line-wrap/metavar-collapse change -- unlike
+    specialized_py314.json, which also differs in wrapping and would make
+    this comparison conflate two unrelated rendering changes) -- so this
+    pair isolates exactly the quoting difference the normalizer targets.
+    This is also why the version map collapses (3, 10)-(3, 12) onto one
+    baseline file above."""
+    quoted = {tuple(c["argv"]): c for c in _load("specialized")}[("bogus-unknown-command",)][
+        "stderr"
+    ]
+    bare = {tuple(c["argv"]): c for c in _load("specialized_py312")}[("bogus-unknown-command",)][
+        "stderr"
+    ]
+    assert quoted != bare, "fixture no longer exercises the quoting difference"
+    assert _capture.normalize_argparse_choice_quoting(
+        quoted
+    ) == _capture.normalize_argparse_choice_quoting(bare)
+
+
+def test_normalize_argparse_choice_quoting_still_flags_a_renamed_choice():
+    """Property 2 (mutation): renaming one choice name inside the baseline's
+    own "(choose from ...)" fragment must still fail after normalization --
+    proving the normalizer discards only quoting, never the choice list
+    itself. Expected red declared up front: the normalized mutant must NOT
+    equal the normalized original."""
+    original = {tuple(c["argv"]): c for c in _load("specialized")}[("bogus-unknown-command",)][
+        "stderr"
+    ]
+    assert "'orchestrate'" in original and "'orchestrated'" not in original
+    mutant = original.replace("'orchestrate'", "'orchestrated'", 1)
+    # Verify the mutation actually applied before trusting anything downstream.
+    assert mutant != original
+    assert "'orchestrated'" in mutant
+    assert _capture.normalize_argparse_choice_quoting(
+        original
+    ) != _capture.normalize_argparse_choice_quoting(mutant), (
+        "normalization swallowed a renamed subcommand choice -- this must fail"
+    )
+
+
+def test_stderr_baseline_comparison_still_fails_on_a_renamed_choice():
+    """Same mutation as above, run through the actual comparison helper
+    (``_assert_stderr_matches_baseline``) that
+    test_cli_specialized_paths_match_baseline uses -- not just the
+    normalizer in isolation -- so a normalizer wired in slightly wrong (e.g.
+    bypassing the choice-name check) cannot pass silently. Expected red
+    declared up front via ``pytest.raises``."""
+    original = {tuple(c["argv"]): c for c in _load("specialized")}[("bogus-unknown-command",)][
+        "stderr"
+    ]
+    mutant = original.replace("'orchestrate'", "'orchestrated'", 1)
+    assert mutant != original and "'orchestrated'" in mutant
+    with pytest.raises(AssertionError, match="stderr changed"):
+        _assert_stderr_matches_baseline(("bogus-unknown-command",), mutant, original)
 
 
 def test_specialized_baseline_covers_ci_matrix():
@@ -400,9 +490,9 @@ def test_schedule_quick_create_validates_before_any_network_call():
 
 
 # Cross-seed imports that are known, source-grounded, and pre-existing —
-# neither introduced by nor related to A0/C1D/C1X/C1's registry/dispatch
-# work, so the import-laziness oracle allowlists exactly these two instead of
-# asserting a blanket zero that would misreport them as regressions:
+# unrelated to this module's own registry/dispatch consolidation, so the
+# import-laziness oracle allowlists exactly these two instead of asserting a
+# blanket zero that would misreport them as regressions:
 #   - orchestrate: lionagi/cli/orchestrate/_common.py:14 does a *module-level*
 #     `from .. import team as _team_module` (team-mode support), so importing
 #     lionagi.cli.orchestrate always pulls in lionagi.cli.team.
@@ -436,8 +526,9 @@ def test_import_laziness_traces_all_21_seeds_cleanly():
 
 def test_import_laziness_casts_seed_stays_cli_only():
     """The one seed whose module declares both a CLI and an HTTP marker
-    (lionagi/casts/surfaces.py) — the exact boundary C1X's own result flagged
-    as the eager-import risk to watch (implementer-4/c1x_result.md:71-76)."""
+    (lionagi/casts/surfaces.py) — loading it as a CLI seed must not eagerly
+    realize the HTTP registry as a side effect, the risk a single module
+    serving both surfaces creates."""
     live = _capture.capture_imports()
     casts = live["import_laziness"]["traces"]["casts"]
     assert not casts.get("_error")
@@ -629,13 +720,20 @@ def _offending_fields(runs: list[dict]) -> list[str]:
 
 def _identity_hits(text: str, identity: frozenset[str]) -> list[str]:
     """Whole-word/whole-path occurrences of a known machine-identity value in
-    *text*. Word-bounded rather than a raw substring test: a short real
+    *text*, INCLUDING a path root appearing as a prefix of a longer path
+    (e.g. identity value ``/Users/lion`` must hit inside
+    ``/Users/lion/some/deeper/path``, not just an exact standalone
+    occurrence) -- a value under a redacted root is exactly as identifying as
+    the root itself. Only the trailing boundary allows a `/` continuation;
+    a following word character still must not match, so a same-prefixed but
+    distinct name (``/Users/lionx``) is not misreported as a hit. The
+    leading boundary is unchanged and still word-bounded: a short real
     username can legitimately be a substring of an unrelated CLI word (this
     repo's own real capture hit this -- the checkout's username is a
     substring of "lionagi", which appears throughout genuinely static help
     text), and a raw substring match would misreport that collision as a
     leak."""
-    return [v for v in identity if v and re.search(rf"(?<![\w/]){re.escape(v)}(?![\w/])", text)]
+    return [v for v in identity if v and re.search(rf"(?<![\w/]){re.escape(v)}(?!\w)", text)]
 
 
 def test_offending_fields_accepts_identical_runs():
@@ -650,12 +748,12 @@ def test_offending_fields_accepts_identical_runs():
 
 
 def test_offending_fields_flags_env_derived_variance():
-    """Mutation arm: reproduces Finding 1 (a username/hostname pair that a
-    vocabulary check would accept because both words are independently
-    public in this repo's own source) at the level that actually matters --
-    the value differs across two runs made under different simulated
-    identities, exactly what a real env-derived "Connected to
-    {user}@{host}" banner would do."""
+    """Mutation arm: reproduces a username/hostname pair that a vocabulary
+    check would accept because both words are independently public in this
+    repo's own source, at the level that actually matters -- the value
+    differs across two runs made under different simulated identities,
+    exactly what a real env-derived "Connected to {user}@{host}" banner
+    would do."""
     runs = [
         {"stdout": "Connected to admin@runner-1", "stderr": ""},
         {"stdout": "Connected to admin@runner-2", "stderr": ""},
@@ -664,11 +762,11 @@ def test_offending_fields_flags_env_derived_variance():
 
 
 def test_offending_fields_flags_clock_derived_variance():
-    """Mutation arm: reproduces Finding 2 (a timestamp / tmp-path shape the
-    old token check was structurally blind to, since it only scanned
-    alphabetic runs and three literal path prefixes). A clock- or
-    tmpdir-derived value necessarily differs between two wall-clock-
-    separated runs; this check needs no shape enumeration to catch it."""
+    """Mutation arm: reproduces a timestamp / tmp-path shape the old token
+    check was structurally blind to, since it only scanned alphabetic runs
+    and three literal path prefixes. A clock- or tmpdir-derived value
+    necessarily differs between two wall-clock-separated runs; this check
+    needs no shape enumeration to catch it."""
     runs = [
         {
             "stdout": "session 2026-08-07T12:34:56.123456 /private/tmp/run-0123456789",
@@ -704,12 +802,41 @@ def test_known_identity_check_flags_a_planted_hostname():
     """Mutation arm for the constant-identity gap: a hostname cannot vary
     between two runs on the same machine, so differential capture alone
     cannot catch it. Splice this machine's own real hostname into an
-    "admin@{host}"-shaped banner -- exactly Finding 1's scenario -- and
-    confirm the known-value check names it."""
+    "admin@{host}"-shaped banner -- the same env-derived-banner shape as
+    ``test_offending_fields_flags_env_derived_variance`` above, but constant
+    rather than varying -- and confirm the known-value check names it."""
     identity = _capture.known_machine_identity()
     hostname = socket.gethostname()
     text = f"Connected to admin@{hostname}"
     assert hostname in _identity_hits(text, identity)
+
+
+def test_identity_hits_matches_a_path_roots_descendant():
+    """Fix for a redaction-gap regression: a value found *underneath* a
+    redacted path root -- not just the root occurring verbatim -- must also
+    be caught. Before this fix, ``_identity_hits`` treated a trailing `/` as
+    disqualifying (the same boundary that rejects a mid-word continuation),
+    so a value like ``/Users/lion/some/deeper/path`` produced
+    ``predicate_hits=[]`` for identity value ``/Users/lion`` while
+    ``/Users/lion`` alone was caught -- the gate stayed green on exactly the
+    kind of leak it exists to catch."""
+    identity = frozenset({"/Users/lion"})
+    descendant = "wrote output to /Users/lion/some/deeper/path"
+    assert _identity_hits(descendant, identity) == ["/Users/lion"]
+    # A same-prefixed but distinct name must still not be misreported.
+    sibling = "wrote output to /Users/lionx/unrelated"
+    assert _identity_hits(sibling, identity) == []
+
+    # Point the control at the fix: no-op it (restore the pre-fix trailing
+    # boundary, which excluded a following `/`) and require this exact
+    # descendant case to go red.
+    def _pre_fix_identity_hits(text: str, identity: frozenset[str]) -> list[str]:
+        return [v for v in identity if v and re.search(rf"(?<![\w/]){re.escape(v)}(?![\w/])", text)]
+
+    assert _pre_fix_identity_hits(descendant, identity) == [], (
+        "control is not sensitive to the fix -- the pre-fix pattern should "
+        "have missed this descendant path"
+    )
 
 
 def test_committable_case_output_has_no_known_machine_identity():

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -19,11 +19,13 @@ compared; their literal stdout is not.
 Waiver:
   W-02: the "agent status" / "doctor --machine" / "handshake --machine" /
     "runs --machine" cases carry live session, git-identity, and daemon
-    state that is non-deterministic across checkouts and wall clocks --
-    excluded below via _VOLATILE_ARGV / _VOLATILE_MACHINE_ARGV. Cases whose
-    captured stdout is itself host-specific (machine paths, run ids,
-    installed skill names) carry a redaction marker in the fixture instead
-    of the literal text -- see test_fixtures_carry_no_host_specific_state.
+    state that is non-deterministic across checkouts and wall clocks. These
+    -- and every other case captured by SPECIALIZED_CASES / MACHINE_CASES --
+    are redacted by default: only an argv listed in
+    _COMMITTABLE_SPECIALIZED_ARGV / _COMMITTABLE_MACHINE_ARGV, with a stated
+    reason, is compared byte-for-byte or committed as literal text below.
+    See test_new_case_defaults_closed_without_declaration for why this is a
+    population rule, not a list someone has to remember to grow.
 """
 
 from __future__ import annotations
@@ -39,23 +41,61 @@ from tests.contracts import _capture
 
 DATA_DIR = Path(__file__).parent / "data"
 
-# W-02 waiver (see delta_resolution.md): every argv below carries live
-# session/git/daemon state that varies across checkouts and wall clocks by
-# design, not because of a consolidation code change.
-_VOLATILE_ARGV = {
-    ("agent", "status"),
-    ("monitor", "--machine"),
-    ("agent", "--machine"),
-    ("doctor", "--machine"),  # reports a live timestamp and working-tree cleanliness
-    ("play", "list"),  # playbook names read from ~/.lionagi/playbooks/, host-specific
-    ("play", "nonexistent"),  # error text lists the same host-specific playbook names
-    ("skill", "list"),  # skill names read from ~/.lionagi/skills/, host-specific
+# Case-level allowlist: the ONLY way a case's literal captured stdout/stderr
+# may be committed to this public repository. Each entry states why that
+# argv's output is safe -- static argparse usage/help/error text, derived
+# from this repo's own source, carrying no session/host/run state. A case
+# captured by SPECIALIZED_CASES / MACHINE_CASES (tests/contracts/_capture.py)
+# with no entry here is untrusted BY DEFAULT: excluded from the byte-for-byte
+# comparison below, and its committed fixture entry must carry the
+# redaction marker (test_volatile_fixture_cases_are_fully_redacted enforces
+# this against the live population, not a fixed list -- see
+# test_new_case_defaults_closed_without_declaration). Making a new case's
+# output committable requires adding a reasoned entry here: a deliberate,
+# reviewable diff, not something that happens by omission.
+_COMMITTABLE_SPECIALIZED_ARGV: dict[tuple[str, ...], str] = {
+    ("--help",): "top-level argparse usage/help text",
+    ("wait",): "argparse usage + required-argument error",
+    ("monitor", "run"): "argparse usage + required-argument error",
+    ("bogus-unknown-command",): "argparse invalid-choice error, static command list",
+    ("play",): "static usage line, no NAME resolved yet",
+    ("play", "--help"): "static usage/flag text, no NAME resolved yet",
+    ("o", "flow", "--help"): "argparse usage/help text",
+    ("o", "fanout", "--help"): "argparse usage/help text",
+    ("o", "flow"): "static required-prompt error",
+    ("o", "fanout"): "static required-prompt error",
+    ("schedule", "--help"): "argparse usage/help text",
+    ("schedule",): "argparse required-subparser error",
+    ("schedule", "list", "--bogus"): "argparse unrecognized-argument error",
+    ("schedule", "create", "capture-test", "--every", "15m"): (
+        "argparse did-you-mean error, static synonym text"
+    ),
+    ("schedule", "create", "agent", "capture-test"): ("argparse usage + required-argument error"),
+    ("schedule", "create", "command", "capture-test", "--every", "15m"): (
+        "static validation error, no host state"
+    ),
 }
-_VOLATILE_MACHINE_ARGV = {
-    ("handshake", "--machine"),  # data.comparison_ref reads live git state
-    ("doctor", "--machine"),  # reports a live timestamp and working-tree cleanliness
-    ("runs", "--machine"),  # lists live run/artifact state on disk
+_COMMITTABLE_MACHINE_ARGV: dict[tuple[str, ...], str] = {
+    ("lifecycle", "--machine"): "static machine-envelope error, no live run/host state",
+    ("bogus-unknown-command", "--machine"): (
+        "argparse invalid-choice error inside the machine envelope"
+    ),
+    ("--machine",): "top-level machine-mode usage error",
 }
+
+
+def _volatile_argv_for(file_name: str) -> set[tuple[str, ...]]:
+    """Every argv captured for *file_name* that is NOT declared committable
+    above -- derived from the live capture-case population in _capture.py,
+    not a hand-maintained denylist. A case appended to SPECIALIZED_CASES /
+    MACHINE_CASES with no matching committable-allowlist entry is
+    automatically volatile: excluded from byte-for-byte comparison and
+    required to be redacted in the committed fixture."""
+    if file_name == "specialized":
+        return set(_capture.SPECIALIZED_CASES) - set(_COMMITTABLE_SPECIALIZED_ARGV)
+    if file_name == "machine":
+        return set(_capture.MACHINE_CASES) - set(_COMMITTABLE_MACHINE_ARGV)
+    return set()
 
 
 def _load(name: str):
@@ -133,9 +173,10 @@ def test_cli_specialized_paths_match_baseline():
     # Every frozen case must still be present and, modulo known volatility
     # (W-02, below), unchanged.
     assert set(expected) <= set(live), f"missing from live: {set(expected) - set(live)}"
+    volatile = _volatile_argv_for("specialized")
     for argv, exp in expected.items():
         got = live[argv]
-        if argv in _VOLATILE_ARGV:
+        if argv in volatile:
             continue
         assert got["exit_code"] == exp["exit_code"], f"exit code changed for {argv}"
         assert got["stdout"] == exp["stdout"], f"stdout changed for {argv}"
@@ -227,11 +268,12 @@ def test_machine_classification_matches_baseline():
     expected = {tuple(c["argv"]): c for c in _load("machine")}
     live = {tuple(c["argv"]): c for c in _capture.capture_machine()}
     assert set(live) == set(expected)
+    volatile = _volatile_argv_for("machine")
     for argv, exp in expected.items():
         got = live[argv]
         assert got["exit_code"] == exp["exit_code"], f"exit code changed for {argv}"
         assert got["envelope_ok"] == exp["envelope_ok"], f"envelope ok changed for {argv}"
-        if argv in _VOLATILE_ARGV or argv in _VOLATILE_MACHINE_ARGV:
+        if argv in volatile:
             continue
         assert got["stdout"] == exp["stdout"], f"stdout changed for {argv}"
 
@@ -391,24 +433,16 @@ def test_fixtures_carry_no_host_specific_state():
 # it says nothing about a captured field that leaks host state through some
 # other shape (a session id, a library version, a CVE posture, a directory
 # listing). The check below instead enumerates the *population* every
-# byte-for-byte comparison already excludes as volatile (the same
-# _VOLATILE_ARGV / _VOLATILE_MACHINE_ARGV sets test_cli_specialized_paths_
-# match_baseline and test_machine_classification_matches_baseline read) and
-# requires every captured stream of every case in that population to be
-# either empty or carry the redaction marker -- never literal captured text.
-# A case's content having no *currently visible* host-specific value is not
-# an exemption: if it is excluded from comparison, pinning its literal bytes
-# has no oracle value and is pure downside if the command ever starts
-# reporting live state through that field.
+# byte-for-byte comparison already excludes as volatile (_volatile_argv_for,
+# above -- derived from _COMMITTABLE_SPECIALIZED_ARGV / _COMMITTABLE_MACHINE_
+# ARGV, not a hand-written denylist) and requires every captured stream of
+# every case in that population to be either empty or carry the redaction
+# marker -- never literal captured text. A case's content having no
+# *currently visible* host-specific value is not an exemption: if it is
+# excluded from comparison, pinning its literal bytes has no oracle value
+# and is pure downside if the command ever starts reporting live state
+# through that field.
 _REDACTION_MARKER_RE = re.compile(r"^\[redacted: .+\]$", re.DOTALL)
-
-
-def _volatile_argv_for(file_name: str) -> set[tuple[str, ...]]:
-    if file_name == "specialized":
-        return set(_VOLATILE_ARGV)
-    if file_name == "machine":
-        return set(_VOLATILE_ARGV) | set(_VOLATILE_MACHINE_ARGV)
-    return set()
 
 
 def _unredacted_fields(file_name: str, cases: list) -> list[str]:
@@ -455,13 +489,39 @@ def test_redaction_check_flags_unredacted_volatile_stderr():
     assert _unredacted_fields("specialized", cases) == [f"specialized.json {argv} stderr"]
 
 
-def test_redaction_check_flags_a_newly_classified_volatile_case(monkeypatch):
-    """Mutation arm (c): growing the volatile classification with an
-    unredacted case turns the check red without any edit to this test file --
-    proving the check is derived from the live classification, not a
-    hand-written list of cases."""
+def test_new_case_defaults_closed_without_declaration(monkeypatch):
+    """Mutation arm (a): a brand-new case appended to the LIVE capture set
+    (_capture.SPECIALIZED_CASES) -- with no entry added to
+    _COMMITTABLE_SPECIALIZED_ARGV -- must be classified volatile purely
+    because it is absent from the allowlist, and a literal fixture entry for
+    it must turn the redaction check red. No edit to _VOLATILE_ARGV, to
+    _unredacted_fields, or to any other test is needed: the population is
+    read live from _capture.py, so this is a rule over the whole capture
+    set, not a list someone has to remember to extend."""
     new_argv = ("totally", "new", "specialized", "case")
-    assert new_argv not in _VOLATILE_ARGV
-    monkeypatch.setattr(sys.modules[__name__], "_VOLATILE_ARGV", _VOLATILE_ARGV | {new_argv})
+    assert new_argv not in _COMMITTABLE_SPECIALIZED_ARGV
+    monkeypatch.setattr(_capture, "SPECIALIZED_CASES", (*_capture.SPECIALIZED_CASES, new_argv))
+    assert new_argv in _volatile_argv_for("specialized")
     cases = [{"argv": list(new_argv), "stdout": "literal unredacted output", "stderr": ""}]
     assert _unredacted_fields("specialized", cases) == [f"specialized.json {new_argv} stdout"]
+
+
+def test_new_case_becomes_committable_only_via_declaration(monkeypatch):
+    """The complement of arm (a): the same new case, once given a reasoned
+    entry in _COMMITTABLE_SPECIALIZED_ARGV, drops out of the volatile
+    population and its literal fixture text is accepted -- proving
+    committing literal text is available, but only through the deliberate,
+    reviewable act of adding a reason, not by silence."""
+    new_argv = ("totally", "new", "specialized", "case")
+    monkeypatch.setattr(_capture, "SPECIALIZED_CASES", (*_capture.SPECIALIZED_CASES, new_argv))
+    monkeypatch.setattr(
+        sys.modules[__name__],
+        "_COMMITTABLE_SPECIALIZED_ARGV",
+        {
+            **_COMMITTABLE_SPECIALIZED_ARGV,
+            new_argv: "test fixture: reviewed, static, no host state",
+        },
+    )
+    assert new_argv not in _volatile_argv_for("specialized")
+    cases = [{"argv": list(new_argv), "stdout": "literal reviewed output", "stderr": ""}]
+    assert _unredacted_fields("specialized", cases) == []

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -108,9 +108,9 @@ def _sorted_json(value):
     return json.dumps(value, indent=2, sort_keys=True)
 
 
-def test_http_route_count_is_133():
+def test_http_route_count_is_134():
     live = _capture.capture_http()
-    assert live["count"] == 133
+    assert live["count"] == 134
 
 
 def _routes_by_key(payload: dict) -> dict[str, dict]:

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -30,10 +30,9 @@ Waiver:
 
 from __future__ import annotations
 
-import argparse
-import ast
 import json
 import re
+import socket
 import sys
 from pathlib import Path
 
@@ -529,112 +528,134 @@ def test_new_case_becomes_committable_only_via_declaration(monkeypatch):
     assert _unredacted_fields("specialized", cases) == []
 
 
-# ── Token-level check on committable streams ─────────────────────────────
+# ── Differential check on committable streams ────────────────────────────
 #
 # A case-level committable declaration means a human read that command's
 # output once and judged it safe. That judgment decays: the SAME command can
-# grow a host-shaped token in its output later (a new flag whose default
-# reads an env var, a dependency bump that changes an error message) without
-# ever leaving the allowlist, so nothing above would catch it. This check
-# re-verifies every committable case's CURRENT captured content, token by
-# token, against a vocabulary derived from the repo's own CLI/MCP source
-# (plus the Python argparse stdlib, whose boilerplate -- "usage:", "show
-# this help message and exit" -- these commands' output is partly built
-# from) and a small closed-class set of English function words. A token
-# that cannot be traced to either source is rejected: that is exactly the
-# shape a leaked identifier, hostname, or internal label would take.
-_WORD_RE = re.compile(r"[A-Za-z]+(?:'[A-Za-z]+)?")
-
-# Closed-class grammar words: articles, prepositions, conjunctions. This is
-# the only hand-typed piece of the token rule, deliberately small and
-# closed -- it does not grow with the CLI surface the way command/option
-# vocabulary does, so (unlike a hand-typed noun list) it does not rot.
-_ENGLISH_FUNCTION_WORDS = frozenset(
-    """
-    a an the this that these those is are was were be been being to of in
-    on at for and or nor not no if then else than as by from into onto
-    with without via before after above below over under between
-    """.split()
-)
+# grow env-, cwd-, or clock-derived content later (a new flag whose default
+# reads an env var, a banner that prints the working directory, a dependency
+# bump that starts stamping a timestamp) without ever leaving the allowlist.
+# A vocabulary/pattern check only catches shapes someone thought to list; it
+# also produces false accepts, since a real username or hostname can just
+# happen to collide with an ordinary CLI word already public in this repo's
+# own source (e.g. "admin", "runner").
+#
+# The property that actually matters: committable output must not depend on
+# the machine, the environment, or the clock at all. `differential_capture`
+# runs each committable case more than once under deliberately different
+# HOME/TMPDIR/USER/cwd and at two different wall-clock moments; anything
+# derived from any of those necessarily differs across the runs, and
+# genuinely static argparse usage/error text does not. A hostname is the one
+# thing that is identifying but constant on a given machine, so it cannot
+# show up as cross-run variance -- that gap is closed separately by
+# `known_machine_identity`, which redacts by known value rather than shape.
 
 
-def _repo_cli_vocabulary() -> frozenset[str]:
-    """Lowercased word-tokens from every string literal in: the Python
-    argparse stdlib module (the source of the "usage:" / "positional
-    arguments:" / "show this help message and exit" boilerplate every
-    argparse-backed case's output is partly made of), this repo's own
-    CLI/MCP/studio source tree, and this suite's own capture harness
-    (tests/contracts/_capture.py -- the source of literal argv values like
-    "bogus-unknown-command" and "capture-test" that get echoed back into
-    some error messages). Derived at test time from the current tree, not
-    pinned to a snapshot, so it tracks the CLI surface instead of rotting
-    against it -- this is the "repo's own tracked CLI vocabulary" the round
-    3 brief asks for, not a hand-typed word list.
-    """
-    roots = [
-        Path(argparse.__file__),
-        _capture.REPO_ROOT / "lionagi" / "cli",
-        _capture.REPO_ROOT / "lionagi" / "studio",
-        _capture.REPO_ROOT / "lionagi" / "mcp",
-        _capture.REPO_ROOT / "lionagi" / "casts" / "surfaces.py",
-        _capture.REPO_ROOT / "lionagi" / "_auto.py",
-        Path(__file__).resolve().parent / "_capture.py",
-    ]
-    files: set[Path] = set()
-    for root in roots:
-        if root.is_file():
-            files.add(root)
-        elif root.is_dir():
-            files.update(root.rglob("*.py"))
-
-    words: set[str] = set()
-    for path in files:
-        tree = ast.parse(path.read_text(), filename=str(path))
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                words.update(m.group(0).lower() for m in _WORD_RE.finditer(node.value))
-    return frozenset(words)
-
-
-def _unrecognized_tokens(text: str, vocabulary: frozenset[str]) -> list[str]:
-    """Word-tokens (length >= 2) in *text* that are neither repo-tracked CLI
-    vocabulary nor a closed-class English function word. Tokens of length 1
-    (single option-letter fragments, duration-unit suffixes like the "m" in
-    "15m") and non-alphabetic runs (numbers, version strings, UUIDs, paths --
-    already covered by test_fixtures_carry_no_host_specific_state and the
-    _VOLATILE_ARGV redaction requirement) are out of scope for this check by
-    construction: _WORD_RE only matches letter runs."""
-    allowed = vocabulary | _ENGLISH_FUNCTION_WORDS
+def _offending_fields(runs: list[dict]) -> list[str]:
+    """Field names ("stdout"/"stderr") whose captured content is not
+    byte-identical across *runs* -- i.e. varies with environment, working
+    directory, or wall clock and therefore cannot be committed as literal
+    fixture text."""
     offenders = []
-    for match in _WORD_RE.finditer(text):
-        token = match.group(0).lower()
-        if len(token) < 2:
-            continue
-        if token not in allowed:
-            offenders.append(token)
+    for field in ("stdout", "stderr"):
+        values = {r.get(field, "") for r in runs}
+        if len(values) > 1:
+            offenders.append(field)
     return offenders
 
 
-def test_repo_cli_vocabulary_is_not_vacuous():
-    """Positive control: the vocabulary derivation actually finds words, and
-    finds ones we know must be there (both argparse-stdlib boilerplate and
-    this repo's own CLI vocabulary) -- so an empty offenders list from the
-    checks below means "nothing unrecognized", not "the scan is broken"."""
-    vocabulary = _repo_cli_vocabulary()
-    assert len(vocabulary) > 500
-    assert "usage" in vocabulary  # argparse stdlib boilerplate
-    assert "schedule" in vocabulary  # this repo's own CLI vocabulary
+def _identity_hits(text: str, identity: frozenset[str]) -> list[str]:
+    """Whole-word/whole-path occurrences of a known machine-identity value in
+    *text*. Word-bounded rather than a raw substring test: a short real
+    username can legitimately be a substring of an unrelated CLI word (this
+    repo's own real capture hit this -- the checkout's username is a
+    substring of "lionagi", which appears throughout genuinely static help
+    text), and a raw substring match would misreport that collision as a
+    leak."""
+    return [v for v in identity if v and re.search(rf"(?<![\w/]){re.escape(v)}(?![\w/])", text)]
 
 
-def test_committable_case_tokens_are_recognized_vocabulary():
-    """Every committable case's LIVE captured stdout/stderr -- checked fresh
-    each run, not just the frozen fixture -- must be built entirely from
-    tokens the repo's own CLI source (plus argparse's stdlib boilerplate and
-    a small closed-class grammar list) can account for. This is what catches
-    a declared-safe command's output growing a host-shaped token later: the
-    case-level declaration only asserts the command was safe when it was
+def test_offending_fields_accepts_identical_runs():
+    """Positive control: byte-identical runs (the shape every genuinely
+    static committable case must produce) report no offending fields."""
+    runs = [
+        {"stdout": "usage: li [-h]\n", "stderr": ""},
+        {"stdout": "usage: li [-h]\n", "stderr": ""},
+        {"stdout": "usage: li [-h]\n", "stderr": ""},
+    ]
+    assert _offending_fields(runs) == []
+
+
+def test_offending_fields_flags_env_derived_variance():
+    """Mutation arm: reproduces Finding 1 (a username/hostname pair that a
+    vocabulary check would accept because both words are independently
+    public in this repo's own source) at the level that actually matters --
+    the value differs across two runs made under different simulated
+    identities, exactly what a real env-derived "Connected to
+    {user}@{host}" banner would do."""
+    runs = [
+        {"stdout": "Connected to admin@runner-1", "stderr": ""},
+        {"stdout": "Connected to admin@runner-2", "stderr": ""},
+    ]
+    assert _offending_fields(runs) == ["stdout"]
+
+
+def test_offending_fields_flags_clock_derived_variance():
+    """Mutation arm: reproduces Finding 2 (a timestamp / tmp-path shape the
+    old token check was structurally blind to, since it only scanned
+    alphabetic runs and three literal path prefixes). A clock- or
+    tmpdir-derived value necessarily differs between two wall-clock-
+    separated runs; this check needs no shape enumeration to catch it."""
+    runs = [
+        {
+            "stdout": "session 2026-08-07T12:34:56.123456 /private/tmp/run-0123456789",
+            "stderr": "",
+        },
+        {
+            "stdout": "session 2026-08-07T12:34:57.654321 /private/tmp/run-9876543210",
+            "stderr": "",
+        },
+    ]
+    assert _offending_fields(runs) == ["stdout"]
+
+
+def test_committable_case_output_is_env_and_clock_invariant():
+    """Every committable case's LIVE output -- captured fresh under
+    deliberately varied HOME/TMPDIR/USER/cwd and across a wall-clock gap --
+    must be byte-identical across all runs. This is what catches a
+    declared-safe command's output starting to depend on the machine later:
+    the case-level declaration only asserts the command was safe when it was
     reviewed, not that it stays safe forever."""
-    vocabulary = _repo_cli_vocabulary()
+    offenders: dict[str, list[str]] = {}
+    for argv in (*_COMMITTABLE_SPECIALIZED_ARGV, *_COMMITTABLE_MACHINE_ARGV):
+        bad = _offending_fields(_capture.differential_capture(list(argv)))
+        if bad:
+            offenders[str(argv)] = bad
+    assert not offenders, (
+        "committable case output varies across environment/cwd/wall-clock "
+        f"runs -- carries machine-, env-, or clock-derived state: {offenders}"
+    )
+
+
+def test_known_identity_check_flags_a_planted_hostname():
+    """Mutation arm for the constant-identity gap: a hostname cannot vary
+    between two runs on the same machine, so differential capture alone
+    cannot catch it. Splice this machine's own real hostname into an
+    "admin@{host}"-shaped banner -- exactly Finding 1's scenario -- and
+    confirm the known-value check names it."""
+    identity = _capture.known_machine_identity()
+    hostname = socket.gethostname()
+    text = f"Connected to admin@{hostname}"
+    assert hostname in _identity_hits(text, identity)
+
+
+def test_committable_case_output_has_no_known_machine_identity():
+    """Every committable case's LIVE stdout/stderr must not contain this
+    machine's own hostname, real username, home directory, or repo checkout
+    path -- the one class of identifying value that is constant rather than
+    cross-run variant, and so invisible to
+    test_committable_case_output_is_env_and_clock_invariant above."""
+    identity = _capture.known_machine_identity()
     live_specialized = {tuple(c["argv"]): c for c in _capture.capture_specialized()}
     live_machine = {tuple(c["argv"]): c for c in _capture.capture_machine()}
 
@@ -642,30 +663,17 @@ def test_committable_case_tokens_are_recognized_vocabulary():
     for argv in _COMMITTABLE_SPECIALIZED_ARGV:
         case = live_specialized[argv]
         for field in ("stdout", "stderr"):
-            bad = _unrecognized_tokens(case.get(field, ""), vocabulary)
-            if bad:
-                offenders[f"specialized {argv} {field}"] = bad
+            hit = _identity_hits(case.get(field, ""), identity)
+            if hit:
+                offenders[f"specialized {argv} {field}"] = hit
     for argv in _COMMITTABLE_MACHINE_ARGV:
         case = live_machine[argv]
         for field in ("stdout", "stderr"):
-            bad = _unrecognized_tokens(case.get(field, ""), vocabulary)
-            if bad:
-                offenders[f"machine {argv} {field}"] = bad
+            hit = _identity_hits(case.get(field, ""), identity)
+            if hit:
+                offenders[f"machine {argv} {field}"] = hit
 
     assert not offenders, (
-        "committable case output contains tokens absent from the repo's own "
-        "tracked CLI vocabulary -- either a genuine leak, or the source root "
-        f"list in _repo_cli_vocabulary() needs to grow: {offenders}"
+        "committable case output contains this machine's own hostname, "
+        f"username, home directory, or checkout path: {offenders}"
     )
-
-
-def test_token_check_flags_a_host_shaped_token_in_a_committable_stream():
-    """Mutation arm (b): a committable case's declaration only vouches for
-    the text a human actually read. Splice a host-shaped token -- not a
-    UUID or a path, since test_fixtures_carry_no_host_specific_state already
-    catches those shapes; the point of this check is what that one does not
-    catch -- into an otherwise-real committable stream and confirm it goes
-    red, naming exactly the injected words."""
-    vocabulary = _repo_cli_vocabulary()
-    stream = "usage: li [-h] quixotic-fizzbuzz-workstation\n"
-    assert _unrecognized_tokens(stream, vocabulary) == ["quixotic", "fizzbuzz", "workstation"]

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -30,6 +30,8 @@ Waiver:
 
 from __future__ import annotations
 
+import argparse
+import ast
 import json
 import re
 import sys
@@ -525,3 +527,145 @@ def test_new_case_becomes_committable_only_via_declaration(monkeypatch):
     assert new_argv not in _volatile_argv_for("specialized")
     cases = [{"argv": list(new_argv), "stdout": "literal reviewed output", "stderr": ""}]
     assert _unredacted_fields("specialized", cases) == []
+
+
+# ── Token-level check on committable streams ─────────────────────────────
+#
+# A case-level committable declaration means a human read that command's
+# output once and judged it safe. That judgment decays: the SAME command can
+# grow a host-shaped token in its output later (a new flag whose default
+# reads an env var, a dependency bump that changes an error message) without
+# ever leaving the allowlist, so nothing above would catch it. This check
+# re-verifies every committable case's CURRENT captured content, token by
+# token, against a vocabulary derived from the repo's own CLI/MCP source
+# (plus the Python argparse stdlib, whose boilerplate -- "usage:", "show
+# this help message and exit" -- these commands' output is partly built
+# from) and a small closed-class set of English function words. A token
+# that cannot be traced to either source is rejected: that is exactly the
+# shape a leaked identifier, hostname, or internal label would take.
+_WORD_RE = re.compile(r"[A-Za-z]+(?:'[A-Za-z]+)?")
+
+# Closed-class grammar words: articles, prepositions, conjunctions. This is
+# the only hand-typed piece of the token rule, deliberately small and
+# closed -- it does not grow with the CLI surface the way command/option
+# vocabulary does, so (unlike a hand-typed noun list) it does not rot.
+_ENGLISH_FUNCTION_WORDS = frozenset(
+    """
+    a an the this that these those is are was were be been being to of in
+    on at for and or nor not no if then else than as by from into onto
+    with without via before after above below over under between
+    """.split()
+)
+
+
+def _repo_cli_vocabulary() -> frozenset[str]:
+    """Lowercased word-tokens from every string literal in: the Python
+    argparse stdlib module (the source of the "usage:" / "positional
+    arguments:" / "show this help message and exit" boilerplate every
+    argparse-backed case's output is partly made of), this repo's own
+    CLI/MCP/studio source tree, and this suite's own capture harness
+    (tests/contracts/_capture.py -- the source of literal argv values like
+    "bogus-unknown-command" and "capture-test" that get echoed back into
+    some error messages). Derived at test time from the current tree, not
+    pinned to a snapshot, so it tracks the CLI surface instead of rotting
+    against it -- this is the "repo's own tracked CLI vocabulary" the round
+    3 brief asks for, not a hand-typed word list.
+    """
+    roots = [
+        Path(argparse.__file__),
+        _capture.REPO_ROOT / "lionagi" / "cli",
+        _capture.REPO_ROOT / "lionagi" / "studio",
+        _capture.REPO_ROOT / "lionagi" / "mcp",
+        _capture.REPO_ROOT / "lionagi" / "casts" / "surfaces.py",
+        _capture.REPO_ROOT / "lionagi" / "_auto.py",
+        Path(__file__).resolve().parent / "_capture.py",
+    ]
+    files: set[Path] = set()
+    for root in roots:
+        if root.is_file():
+            files.add(root)
+        elif root.is_dir():
+            files.update(root.rglob("*.py"))
+
+    words: set[str] = set()
+    for path in files:
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                words.update(m.group(0).lower() for m in _WORD_RE.finditer(node.value))
+    return frozenset(words)
+
+
+def _unrecognized_tokens(text: str, vocabulary: frozenset[str]) -> list[str]:
+    """Word-tokens (length >= 2) in *text* that are neither repo-tracked CLI
+    vocabulary nor a closed-class English function word. Tokens of length 1
+    (single option-letter fragments, duration-unit suffixes like the "m" in
+    "15m") and non-alphabetic runs (numbers, version strings, UUIDs, paths --
+    already covered by test_fixtures_carry_no_host_specific_state and the
+    _VOLATILE_ARGV redaction requirement) are out of scope for this check by
+    construction: _WORD_RE only matches letter runs."""
+    allowed = vocabulary | _ENGLISH_FUNCTION_WORDS
+    offenders = []
+    for match in _WORD_RE.finditer(text):
+        token = match.group(0).lower()
+        if len(token) < 2:
+            continue
+        if token not in allowed:
+            offenders.append(token)
+    return offenders
+
+
+def test_repo_cli_vocabulary_is_not_vacuous():
+    """Positive control: the vocabulary derivation actually finds words, and
+    finds ones we know must be there (both argparse-stdlib boilerplate and
+    this repo's own CLI vocabulary) -- so an empty offenders list from the
+    checks below means "nothing unrecognized", not "the scan is broken"."""
+    vocabulary = _repo_cli_vocabulary()
+    assert len(vocabulary) > 500
+    assert "usage" in vocabulary  # argparse stdlib boilerplate
+    assert "schedule" in vocabulary  # this repo's own CLI vocabulary
+
+
+def test_committable_case_tokens_are_recognized_vocabulary():
+    """Every committable case's LIVE captured stdout/stderr -- checked fresh
+    each run, not just the frozen fixture -- must be built entirely from
+    tokens the repo's own CLI source (plus argparse's stdlib boilerplate and
+    a small closed-class grammar list) can account for. This is what catches
+    a declared-safe command's output growing a host-shaped token later: the
+    case-level declaration only asserts the command was safe when it was
+    reviewed, not that it stays safe forever."""
+    vocabulary = _repo_cli_vocabulary()
+    live_specialized = {tuple(c["argv"]): c for c in _capture.capture_specialized()}
+    live_machine = {tuple(c["argv"]): c for c in _capture.capture_machine()}
+
+    offenders: dict[str, list[str]] = {}
+    for argv in _COMMITTABLE_SPECIALIZED_ARGV:
+        case = live_specialized[argv]
+        for field in ("stdout", "stderr"):
+            bad = _unrecognized_tokens(case.get(field, ""), vocabulary)
+            if bad:
+                offenders[f"specialized {argv} {field}"] = bad
+    for argv in _COMMITTABLE_MACHINE_ARGV:
+        case = live_machine[argv]
+        for field in ("stdout", "stderr"):
+            bad = _unrecognized_tokens(case.get(field, ""), vocabulary)
+            if bad:
+                offenders[f"machine {argv} {field}"] = bad
+
+    assert not offenders, (
+        "committable case output contains tokens absent from the repo's own "
+        "tracked CLI vocabulary -- either a genuine leak, or the source root "
+        f"list in _repo_cli_vocabulary() needs to grow: {offenders}"
+    )
+
+
+def test_token_check_flags_a_host_shaped_token_in_a_committable_stream():
+    """Mutation arm (b): a committable case's declaration only vouches for
+    the text a human actually read. Splice a host-shaped token -- not a
+    UUID or a path, since test_fixtures_carry_no_host_specific_state already
+    catches those shapes; the point of this check is what that one does not
+    catch -- into an otherwise-real committable stream and confirm it goes
+    red, naming exactly the injected words."""
+    vocabulary = _repo_cli_vocabulary()
+    stream = "usage: li [-h] quixotic-fizzbuzz-workstation\n"
+    assert _unrecognized_tokens(stream, vocabulary) == ["quixotic", "fizzbuzz", "workstation"]

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -214,6 +214,34 @@ def test_cli_specialized_paths_match_baseline():
         assert got["stderr"] == exp["stderr"], f"stderr changed for {argv}"
 
 
+def test_specialized_baseline_covers_ci_matrix():
+    """Every Python minor the full-matrix CI job runs (_capture._CI_MATRIX_PYVERS,
+    mirroring .github/workflows/ci.yml:174) must have a pinned specialized-CLI
+    baseline entry. PRs only exercise the oldest+newest of that matrix, so a
+    missing entry for any interpreter in between is invisible to every check
+    a PR can run and only breaks main once a push runs the full matrix."""
+    missing = [
+        v for v in _capture._CI_MATRIX_PYVERS if v not in _capture._SPECIALIZED_BASELINE_BY_PYVER
+    ]
+    assert not missing, f"no pinned specialized-CLI baseline for CI-matrix Python(s): {missing}"
+
+
+def test_specialized_baseline_name_resolves_for_known_interpreter(monkeypatch):
+    """Mutation arm (a): a Python minor present in the mapping resolves to
+    its pinned baseline name instead of raising."""
+    monkeypatch.setattr(_capture.sys, "version_info", (3, 10, 99, "final", 0))
+    assert _capture.specialized_baseline_name() == "specialized"
+
+
+def test_specialized_baseline_name_raises_for_unknown_interpreter(monkeypatch):
+    """Mutation arm (b): a Python minor absent from the mapping raises
+    RuntimeError rather than silently falling back -- this is what makes a
+    matrix gap a guaranteed failure instead of a silent breakage on main."""
+    monkeypatch.setattr(_capture.sys, "version_info", (3, 99, 0, "final", 0))
+    with pytest.raises(RuntimeError, match="no pinned specialized-CLI baseline"):
+        _capture.specialized_baseline_name()
+
+
 def test_mcp_available_paths_match_baseline():
     expected = _load("mcp")
     live = _capture.capture_mcp()

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -29,6 +29,8 @@ Waiver:
 from __future__ import annotations
 
 import json
+import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -382,3 +384,84 @@ def test_fixtures_carry_no_host_specific_state():
         "contract fixtures must not carry host-specific state (see the note above): "
         + "; ".join(offenders)
     )
+
+
+# `test_fixtures_carry_no_host_specific_state` above only catches leaks that
+# happen to match one of a few path patterns. That is a pattern-shaped check:
+# it says nothing about a captured field that leaks host state through some
+# other shape (a session id, a library version, a CVE posture, a directory
+# listing). The check below instead enumerates the *population* every
+# byte-for-byte comparison already excludes as volatile (the same
+# _VOLATILE_ARGV / _VOLATILE_MACHINE_ARGV sets test_cli_specialized_paths_
+# match_baseline and test_machine_classification_matches_baseline read) and
+# requires every captured stream of every case in that population to be
+# either empty or carry the redaction marker -- never literal captured text.
+# A case's content having no *currently visible* host-specific value is not
+# an exemption: if it is excluded from comparison, pinning its literal bytes
+# has no oracle value and is pure downside if the command ever starts
+# reporting live state through that field.
+_REDACTION_MARKER_RE = re.compile(r"^\[redacted: .+\]$", re.DOTALL)
+
+
+def _volatile_argv_for(file_name: str) -> set[tuple[str, ...]]:
+    if file_name == "specialized":
+        return set(_VOLATILE_ARGV)
+    if file_name == "machine":
+        return set(_VOLATILE_ARGV) | set(_VOLATILE_MACHINE_ARGV)
+    return set()
+
+
+def _unredacted_fields(file_name: str, cases: list) -> list[str]:
+    """(file, argv, field) labels for every case classified volatile for
+    *file_name* whose captured stream is neither empty nor the redaction
+    marker -- i.e. still carries literal captured output."""
+    volatile = _volatile_argv_for(file_name)
+    offenders = []
+    for case in cases:
+        argv = tuple(case["argv"])
+        if argv not in volatile:
+            continue
+        for field in ("stdout", "stderr"):
+            value = case.get(field, "")
+            if value and not _REDACTION_MARKER_RE.match(value):
+                offenders.append(f"{file_name}.json {argv} {field}")
+    return offenders
+
+
+def test_volatile_fixture_cases_are_fully_redacted():
+    offenders = []
+    for file_name in ("specialized", "machine"):
+        offenders += _unredacted_fields(file_name, _load(file_name))
+    assert not offenders, (
+        "volatile fixture cases still carry literal captured output instead of the "
+        "redaction marker: " + "; ".join(offenders)
+    )
+
+
+def test_redaction_check_flags_unredacted_volatile_stdout():
+    """Mutation arm (a): a disposable copy with a volatile case's stdout put
+    back to literal text must turn the population check red, naming the case."""
+    argv = ("agent", "status")
+    cases = [{"argv": list(argv), "stdout": "SESSION deadbeef-...", "stderr": "[redacted: ok]"}]
+    assert _unredacted_fields("specialized", cases) == [f"specialized.json {argv} stdout"]
+
+
+def test_redaction_check_flags_unredacted_volatile_stderr():
+    """Mutation arm (b): same as (a) but for stderr -- this is the arm that
+    matters, since the original defect was a stderr leak the stdout-only
+    remedy would not have caught."""
+    argv = ("agent", "status")
+    cases = [{"argv": list(argv), "stdout": "[redacted: ok]", "stderr": "Linked SQLite 3.46.0 ..."}]
+    assert _unredacted_fields("specialized", cases) == [f"specialized.json {argv} stderr"]
+
+
+def test_redaction_check_flags_a_newly_classified_volatile_case(monkeypatch):
+    """Mutation arm (c): growing the volatile classification with an
+    unredacted case turns the check red without any edit to this test file --
+    proving the check is derived from the live classification, not a
+    hand-written list of cases."""
+    new_argv = ("totally", "new", "specialized", "case")
+    assert new_argv not in _VOLATILE_ARGV
+    monkeypatch.setattr(sys.modules[__name__], "_VOLATILE_ARGV", _VOLATILE_ARGV | {new_argv})
+    cases = [{"argv": list(new_argv), "stdout": "literal unredacted output", "stderr": ""}]
+    assert _unredacted_fields("specialized", cases) == [f"specialized.json {new_argv} stdout"]

--- a/tests/docs/test_site_contract.py
+++ b/tests/docs/test_site_contract.py
@@ -60,16 +60,16 @@ def test_stale_pages_are_excluded_from_the_published_site() -> None:
 
 
 def test_cli_reference_covers_every_shipped_surface() -> None:
-    from lionagi.cli.main import _COMMAND_REGISTRY
+    from lionagi._auto import iter_cli_seeds
 
     reference = (DOCS / "cli-reference.md").read_text().lower()
     aliases = {
         "orchestrate": ("li orchestrate", "li o "),
     }
-    for spec in _COMMAND_REGISTRY:
-        needles = aliases.get(spec.name, (f"li {spec.name}",))
+    for seed in iter_cli_seeds():
+        needles = aliases.get(seed.name, (f"li {seed.name}",))
         assert any(needle in reference for needle in needles), (
-            f"cli-reference.md does not make `li {spec.name}` discoverable"
+            f"cli-reference.md does not make `li {seed.name}` discoverable"
         )
 
     for hidden_surface in ("li play", "li skill", "li wait"):

--- a/tests/marketplace_lint.py
+++ b/tests/marketplace_lint.py
@@ -128,7 +128,7 @@ _KNOWN_MCP_SERVERS: frozenset[str] = frozenset(
 #
 # The shims below cannot be derived the same way. Each is dispatched by an
 # `_argv[0] == "..."` branch in main() ahead of argparse, so all three are
-# absent from `li --help` and from _COMMAND_BY_NAME while being real commands
+# absent from `li --help` and from the typed CLI seed registry while being real commands
 # with their own usage output. Deriving alone would reject them.
 #
 # This list is still hand-maintained, and it was short by `wait` on its first
@@ -141,9 +141,13 @@ _PRE_PARSE_SHIMS: frozenset[str] = frozenset({"play", "skill", "wait"})
 
 
 def _known_li_subcommands() -> frozenset[str]:
-    from lionagi.cli.main import _COMMAND_BY_NAME
+    from lionagi._auto import iter_cli_seeds
 
-    return frozenset(_COMMAND_BY_NAME) | _PRE_PARSE_SHIMS
+    names: set[str] = set()
+    for seed in iter_cli_seeds():
+        names.add(seed.name)
+        names.update(seed.aliases)
+    return frozenset(names) | _PRE_PARSE_SHIMS
 
 
 _KNOWN_LI_SUBCOMMANDS: frozenset[str] = _known_li_subcommands()
@@ -292,17 +296,29 @@ def test_pre_parse_shims_are_all_declared() -> None:
     introduced to stop producing. This is the drift detector for the part that
     still has to be written by hand.
     """
-    from lionagi.cli import main as cli_main
-    from lionagi.cli.main import _COMMAND_BY_NAME
+    from importlib import import_module
+
+    from lionagi._auto import iter_cli_seeds
+
+    # `import_module` reaches the module unambiguously; `from lionagi.cli
+    # import main` can resolve to the lazily-exported callable instead,
+    # depending on which spelling a prior import in this process used first
+    # (see tests/mcp/test_projection.py's attribute-vs-dotted-import probe).
+    cli_main = import_module("lionagi.cli.main")
 
     source = Path(cli_main.__file__).read_text(encoding="utf-8")
     candidates = _shim_candidates_in(source)
     assert candidates, "extractor found no argv[0] comparisons in main.py at all"
 
+    known_names: set[str] = set()
+    for seed in iter_cli_seeds():
+        known_names.add(seed.name)
+        known_names.update(seed.aliases)
+
     # Names already in the registry are dispatched normally; an argv[0] check on
     # one of those is an interception of a SUBcommand (`li agent status`,
     # `li monitor run`), not a top-level shim.
-    undeclared = candidates - frozenset(_COMMAND_BY_NAME) - _PRE_PARSE_SHIMS
+    undeclared = candidates - frozenset(known_names) - _PRE_PARSE_SHIMS
     assert not undeclared, (
         "main() dispatches these on argv[0] but they are in neither the CLI "
         f"registry nor _PRE_PARSE_SHIMS: {sorted(undeclared)}. A skill "

--- a/tests/mcp/test_catalog_coverage.py
+++ b/tests/mcp/test_catalog_coverage.py
@@ -20,7 +20,7 @@ import argparse
 
 import pytest
 
-from lionagi.cli.main import _COMMAND_REGISTRY
+from lionagi._auto import iter_cli_seeds, load_cli_command
 from lionagi.mcp.verbs import ABSENT, FENCED_PATHS, VERBS
 
 
@@ -62,19 +62,20 @@ def _cli_leaves() -> tuple[dict[str, str], dict[str, str]]:
     """
     leaves: dict[str, str] = {}
     unbuildable: dict[str, str] = {}
-    for spec in _COMMAND_REGISTRY:
+    for seed in iter_cli_seeds():
         root = argparse.ArgumentParser(prog="li")
         subparsers = root.add_subparsers(dest="command")
         try:
-            getattr(spec.loader(), spec.parser_factory)(subparsers)
+            registration = load_cli_command(seed)
+            registration.cli.parser_factory(subparsers)
         except Exception as exc:  # noqa: BLE001 — recorded, and failed on by the caller
-            unbuildable[spec.name] = f"{type(exc).__name__}: {exc}"
+            unbuildable[seed.name] = f"{type(exc).__name__}: {exc}"
             continue
         for name, sub in subparsers.choices.items():
-            if name not in (spec.name, *spec.aliases):
+            if name not in (seed.name, *seed.aliases):
                 continue
             for spelling, canonical in _leaves(sub, name).items():
-                leaves[spelling] = canonical.replace(name, spec.name, 1)
+                leaves[spelling] = canonical.replace(name, seed.name, 1)
     return leaves, unbuildable
 
 

--- a/tests/mcp/test_projection.py
+++ b/tests/mcp/test_projection.py
@@ -129,7 +129,7 @@ from importlib import import_module
 print(type(attribute_import).__name__)
 print(type(dotted_import).__name__)
 print(type(import_module("lionagi.cli.main")).__name__)
-print(getattr(import_module("lionagi.cli.main"), "_COMMAND_REGISTRY", None) is not None)
+print(getattr(import_module("lionagi.cli.main"), "build_cli_parser", None) is not None)
 """
 
 
@@ -155,8 +155,8 @@ def test_attribute_style_import_of_cli_main_yields_the_function(tmp_path) -> Non
 
 def test_command_registry_is_reached_through_the_module() -> None:
     module = import_module("lionagi.cli.main")
-    assert module._COMMAND_REGISTRY
-    assert callable(module._build_parser)
+    assert callable(module.build_cli_parser)
+    assert callable(module.seed_for)
 
 
 # ── unrepresentable means unavailable ────────────────────────────────────────

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -527,15 +527,15 @@ async def test_spawned_cli_session_is_included_in_schedule_spend(tmp_path, monke
             import argparse
             import asyncio
 
-            import lionagi.cli.main as cli_main
+            from lionagi._auto import build_cli_parser, seed_for
             from lionagi.cli._runs import setup_agent_persist, teardown_agent_persist
             from lionagi.session.branch import Branch
             from lionagi.state.db import StateDB
 
 
             def agent_options():
-                spec = cli_main._COMMAND_BY_NAME["agent"]
-                parser, _ = cli_main._build_parser(spec)
+                seed = seed_for("agent")
+                parser = build_cli_parser(seed).parser
                 subcommands = next(
                     action
                     for action in parser._actions


### PR DESCRIPTION
## What

A contract gate for the public surface, and the registration architecture that makes it enforceable:

- **V0 public-surface contract suite** (`tests/contracts/`): oracles that capture the CLI command tree, HTTP route table, and MCP tool surface as committed JSON fixtures, so any surface change shows up as a reviewable fixture diff instead of an accident. Fixtures are generated from this codebase and carry no host-specific state; a dedicated test enforces that rule on the fixtures themselves.
- **Auto-registration seam** (`lionagi/_auto.py`): a declaration marker + compiler that lets command modules declare their CLI surface at definition site. Seventeen command modules now carry `@auto_register` declarations.
- **Casts surface consolidation** (`lionagi/casts/surfaces.py`): the casts CLI and HTTP surfaces move behind one module so the two stay in sync by construction.
- **Dispatch migration**: CLI/MCP/machine dispatch resolves through the auto-registry instead of hand-maintained tables.

## Why

Surface drift has been caught late, at review or after merge. With committed oracles, adding/removing/renaming a command, route, or tool fails a test until the fixture is regenerated deliberately — the diff is the review artifact.

## Verification

- `tests/contracts/` suite green (57 tests).
- `tests/cli/` green; one pre-existing failure on machines with a configured secrets lookup (`test_ndjson_from_cli_inherits_stamped_depth` asserts `env is None`; unrelated to this change, fails identically on main there, green in CI).
- Full studio server suite green.
- `tests/ln/` green (import machinery untouched in behavior; cold import verified).
- `ruff check` clean.
