### PR TITLE
feat(studio): one Operator conversation is one branch, and add rename_session

### DIFF
--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 
 from .cancel_run import CANCEL_RUN_DESCRIPTION, CancelRunInput, cancel_run
 from .redact import scrub_text
+from .rename_session import RENAME_SESSION_DESCRIPTION, RenameSessionInput, rename_session
 from .resume_run import RESUME_RUN_DESCRIPTION, ResumeRunInput, resume_run
 from .run_findings import RunFindingsInput, run_findings
 from .run_progress import RunProgressInput, run_progress
@@ -132,6 +133,7 @@ _TOOL_MODELS: dict[str, type[BaseModel]] = {
     "run_findings": RunFindingsInput,
     "cancel_run": CancelRunInput,
     "resume_run": ResumeRunInput,
+    "rename_session": RenameSessionInput,
 }
 
 _TOOL_DESCRIPTIONS = {
@@ -196,6 +198,7 @@ _TOOL_DESCRIPTIONS = {
     ),
     "cancel_run": CANCEL_RUN_DESCRIPTION,
     "resume_run": RESUME_RUN_DESCRIPTION,
+    "rename_session": RENAME_SESSION_DESCRIPTION,
 }
 
 _TOOL_SCHEMAS = [
@@ -506,6 +509,7 @@ _TOOL_HANDLERS = {
     "run_findings": run_findings,
     "cancel_run": cancel_run,
     "resume_run": resume_run,
+    "rename_session": rename_session,
 }
 
 

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -323,6 +323,10 @@ class OperatorCoordinator:
             selected_provider = conversation_row.get("provider")
             selected_model = conversation_row.get("providerModel")
             selected_effort = turn_row.get("effort")
+            # The conversation's own durable branch identity, claimed once and
+            # reused by every turn so the log groups them as one branch instead
+            # of a fresh one per turn (see OperatorStore.claim_branch_id).
+            branch_id = await self.store.claim_branch_id(conversation_id)
             engine_turn = OperatorEngineTurn(
                 conversation_id=conversation_id,
                 request_id=request_id,
@@ -334,6 +338,7 @@ class OperatorCoordinator:
                 # Filled in below, once the store has said whether the session
                 # still belongs to what this turn is about to run on.
                 provider_session_id=None,
+                branch_id=branch_id,
                 provider=selected_provider if isinstance(selected_provider, str) else None,
                 model=selected_model if isinstance(selected_model, str) else None,
                 effort=selected_effort if isinstance(selected_effort, str) else None,

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -88,6 +88,10 @@ async def _execute_application_command(
         from .resume_run import execute_resume_command
 
         return await execute_resume_command(command)
+    if command_type == "rename_session":
+        from .rename_session import execute_rename_session_command
+
+        return await execute_rename_session_command(command)
     if command_type != "launch":
         raise ValueError(f"Unsupported Operator application command: {command_type!r}")
     from lionagi.studio.services.launches import launch

--- a/lionagi/studio/operator/engine.py
+++ b/lionagi/studio/operator/engine.py
@@ -75,6 +75,7 @@ _OPERATOR_MCP_TOOLS = [
     "mcp__studio_operator__run_findings",
     "mcp__studio_operator__cancel_run",
     "mcp__studio_operator__resume_run",
+    "mcp__studio_operator__rename_session",
 ]
 _MODEL_CONTEXT_FRAME_LIMIT = 64
 _MODEL_CONTEXT_BYTE_LIMIT = 128 * 1024

--- a/lionagi/studio/operator/engine.py
+++ b/lionagi/studio/operator/engine.py
@@ -615,4 +615,11 @@ def build_operator_branch(turn: OperatorEngineTurn):
         }
     model_name = _apply_operator_effort(provider, model_name, turn.effort, model_kwargs)
     chat_model = iModel(provider=provider, model=model_name, **model_kwargs)
-    return Branch(system=_SYSTEM_PROMPT, chat_model=chat_model)
+    # The conversation's own durable identity, so this turn's branch/session
+    # persists as the same log entry every other turn of this conversation
+    # uses instead of a fresh, unrelated one (see OperatorStore.claim_branch_id).
+    # No live Branch is ever cached across turns -- only this id is reused.
+    branch_kwargs: dict[str, Any] = {"system": _SYSTEM_PROMPT, "chat_model": chat_model}
+    if turn.branch_id:
+        branch_kwargs["id"] = turn.branch_id
+    return Branch(**branch_kwargs)

--- a/lionagi/studio/operator/rename_session.py
+++ b/lionagi/studio/operator/rename_session.py
@@ -20,13 +20,23 @@ from __future__ import annotations
 
 import asyncio
 import time
+import unicodedata
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .redact import public_project
 from .run_progress import resolve_run
 from .store import OperatorStore
+
+# Cc/Cf: C0/C1 controls (incl. NUL, DEL) and Unicode formatting chars (incl.
+# bidi overrides) -- not printable characters a human ever intends to type
+# into a name. Zl/Zp: line/paragraph separators -- structurally the same
+# problem as an embedded newline. Deliberately category-based rather than an
+# enumerated blocklist so it does not need updating as new control code
+# points are assigned. Zs (ordinary space) is NOT included -- an internal
+# space is a normal, expected part of a name.
+_REJECTED_NAME_CATEGORIES = frozenset({"Cc", "Cf", "Zl", "Zp"})
 
 RENAME_SESSION_COMMAND_TYPE = "rename_session"
 
@@ -49,6 +59,18 @@ class _StrictInput(BaseModel):
 class RenameSessionInput(_StrictInput):
     run: str = Field(min_length=1, max_length=200)
     name: str = Field(min_length=1, max_length=160)
+
+    @field_validator("name")
+    @classmethod
+    def _reject_control_characters(cls, value: str) -> str:
+        for char in value:
+            category = unicodedata.category(char)
+            if category in _REJECTED_NAME_CATEGORIES:
+                raise ValueError(
+                    f"name must not contain control or line/paragraph-separator "
+                    f"characters (found {char!r}, category {category})"
+                )
+        return value
 
 
 def _identity() -> tuple[OperatorStore, str, str]:

--- a/lionagi/studio/operator/rename_session.py
+++ b/lionagi/studio/operator/rename_session.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Studio Operator lifecycle service/adapter: ``rename_session``.
+
+Gives one Studio run (a `sessions` row) a human name through the Operator,
+gated on the same durable human allow/deny proposal flow `cancel_run` and
+`resume_run` use (`application_mcp.py::launch_playbook`'s shape). This is
+deliberately distinct from renaming the Operator's own *conversation*
+(`store.py::update_conversation`, shipped separately as a direct human
+UI/REST action): a conversation can talk about many runs over its life, and
+this tool names the run the conversation is currently discussing, not the
+conversation thread itself.
+
+Reuses `run_progress.py::resolve_run` for reference resolution -- the same
+id/prefix/name/"current" vocabulary and project-scoping `resume_run` already
+uses -- rather than a third private copy of that logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .redact import public_project
+from .run_progress import resolve_run
+from .store import OperatorStore
+
+RENAME_SESSION_COMMAND_TYPE = "rename_session"
+
+RENAME_SESSION_DESCRIPTION = (
+    "Give one Studio run a human name. This renames the run's own record "
+    "only -- it is not the Operator conversation's own name, which has a "
+    "separate rename path outside this tool. Goes through a human approval "
+    "flow; it is never automatic, and a denied proposal leaves the run's "
+    "name untouched. Accepts a run UUID, an 8+ hex id prefix, a name "
+    "substring (minimum 3 characters), or 'current' for the run open when "
+    "this instruction was sent. Ambiguous references return candidates "
+    "rather than guessing."
+)
+
+
+class _StrictInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class RenameSessionInput(_StrictInput):
+    run: str = Field(min_length=1, max_length=200)
+    name: str = Field(min_length=1, max_length=160)
+
+
+def _identity() -> tuple[OperatorStore, str, str]:
+    import os
+
+    db_path = os.environ.get("LIONAGI_OPERATOR_DB_PATH")
+    conversation_id = os.environ.get("LIONAGI_OPERATOR_CONVERSATION_ID")
+    request_id = os.environ.get("LIONAGI_OPERATOR_REQUEST_ID")
+    if not db_path or not conversation_id or not request_id:
+        raise RuntimeError("Studio application bridge is missing its durable turn identity")
+    return OperatorStore(db_path), conversation_id, request_id
+
+
+def _rename_summary(row: dict[str, Any], new_name: str) -> str:
+    """A human deciding whether to approve a rename needs more than a bare
+    id -- the project, the run's current name (if any), and the proposed one."""
+    run_id = row["id"]
+    parts = [f"Rename run {run_id[:12]}"]
+    project_label = public_project(row.get("project"))
+    if project_label:
+        parts.append(f"project {project_label}")
+    old_name = row.get("name")
+    if old_name:
+        parts.append(f"from '{old_name}'")
+    parts.append(f"to '{new_name}'")
+    return " -- ".join(parts)
+
+
+def _redacted_rename_result(proposal: dict[str, Any], run_id: str) -> dict[str, Any]:
+    if proposal["status"] != "succeeded":
+        reason = "denied" if proposal["status"] == "cancelled" else proposal["status"]
+        return {"renamed": False, "reason": reason, "id": run_id}
+    raw = proposal.get("result")
+    result = raw if isinstance(raw, dict) else {}
+    # A "succeeded" proposal only means the executor ran without raising --
+    # it says nothing about whether the row was actually renamed. Only
+    # `status == "renamed"` means the database write happened; every other
+    # outcome (not_found) leaves the run exactly as it was.
+    status = result.get("status", "unknown")
+    return {
+        "renamed": status == "renamed",
+        "status": status,
+        "id": run_id,
+        "name": result.get("name"),
+    }
+
+
+async def rename_session(arguments: dict[str, Any]) -> dict[str, Any]:
+    """MCP tool handler: resolve -> durable proposal -> poll -> result.
+
+    Mirrors `cancel_run.py::cancel_run` / `resume_run.py::resume_run`'s
+    shape exactly: this function only creates the proposal and waits for it
+    to leave "pending". The actual rename happens in
+    `execute_rename_session_command`, invoked by the coordinator once a
+    human allows the proposal.
+    """
+    args = RenameSessionInput.model_validate(arguments)
+    store, conversation_id, request_id = _identity()
+
+    resolution = await resolve_run(args.run)
+    if not resolution["found"]:
+        return {"renamed": False, "reason": "not_found"}
+    if resolution.get("ambiguous"):
+        return {
+            "renamed": False,
+            "reason": "ambiguous_reference",
+            "candidates": resolution["candidates"],
+            "truncated": resolution.get("truncated", False),
+        }
+
+    run_id = resolution["session_id"]
+    from lionagi.state.db import StateDB
+
+    async with StateDB() as db:
+        row = await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (run_id,))
+        row_dict = db._row_to_dict(row) if row is not None else None
+    if row_dict is None:
+        # resolve_run() already scoped the match to this turn's project, so
+        # this row disappearing between resolution and this re-read is a
+        # genuine race (the run was deleted), not an ownership question.
+        return {"renamed": False, "reason": "not_found"}
+
+    # Carried through to `execute_rename_session_command` so ownership is
+    # checked again immediately before the row is written, not only once at
+    # resolution time -- the human's approval window is a gap a run's
+    # project could change across, the same reasoning `cancel_run` documents.
+    command = {"session_id": run_id, "name": args.name, "project": row_dict.get("project")}
+    stable = store.canonical_hash(
+        {"requestId": request_id, "tool": "rename_session", "command": command}
+    )
+    proposal = await store.create_proposal(
+        conversation_id,
+        request_id,
+        command_type=RENAME_SESSION_COMMAND_TYPE,
+        command=command,
+        risk="mutate",
+        summary=_rename_summary(row_dict, args.name),
+        idempotency_key=f"operator-app:{stable}",
+    )
+    while True:
+        proposal = await store.get_proposal(proposal["id"])
+        status = proposal["status"]
+        if status == "pending" and proposal["expiresAt"] <= time.time():
+            proposal = await store.expire_proposal(proposal["id"])
+            status = proposal["status"]
+        if status in {"succeeded", "failed", "cancelled", "expired", "conflict"}:
+            return _redacted_rename_result(proposal, run_id)
+        await asyncio.sleep(0.1)
+
+
+async def execute_rename_session_command(command: dict[str, Any]) -> dict[str, Any]:
+    """The real state-changing act -- the adapter's other half.
+
+    Wire this into `OperatorCoordinator`'s ``command_executor`` for
+    ``command_type == "rename_session"`` (see `coordinator.py`'s
+    ``_execute_application_command``). Re-resolves the session by exact id
+    and re-checks ownership at execute time rather than trusting the
+    resolution captured in the command -- mirrors
+    `cancel_run.py::execute_cancel_command`'s same guard for the same
+    reason: the human's approval window is a gap the run's project could
+    change across.
+    """
+    from lionagi.state.db import StateDB
+
+    run_id = command.get("session_id")
+    if not isinstance(run_id, str) or not run_id:
+        raise ValueError("rename command is missing session_id")
+    name = command.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("rename command is missing name")
+    project = command.get("project")
+
+    async with StateDB() as db:
+        row = await db.fetch_one("SELECT * FROM sessions WHERE id = ?", (run_id,))
+        if row is None:
+            return {"status": "not_found", "id": run_id}
+        row_dict = db._row_to_dict(row)
+        # A command built by rename_session() above always carries the
+        # caller's own (non-empty) project -- a missing or empty project
+        # here is itself an ownership failure, not a value meaning
+        # "unscoped, allow any row" -- it fails exactly like a project
+        # mismatch and exactly like a nonexistent id, the same reasoning
+        # `execute_cancel_command` documents.
+        if not isinstance(project, str) or not project or row_dict.get("project") != project:
+            return {"status": "not_found", "id": run_id}
+        await db.update_session(run_id, name=name)
+
+    return {"status": "renamed", "id": run_id, "name": name}

--- a/lionagi/studio/operator/resume_run.py
+++ b/lionagi/studio/operator/resume_run.py
@@ -3,17 +3,21 @@
 """Studio Operator lifecycle service/adapter: ``resume_run``.
 
 Delegates to the real, supported ``POST /runs/{run_id}/resume`` surface
-(`lionagi/studio/services/run_resume.py::resume_run`) for every dispatch
-decision -- this adapter does not re-derive which invocation kinds are
-resumable or what inputs they accept; it forwards the caller's arguments and
-reports back whatever the service decides. For an ``agent`` run that means
-the same ``li agent -r`` path a human resuming from the CLI or Studio UI
-uses, continuing the branch with a new instruction. For a ``play``/``flow``/
-``show-play`` run it means replaying the run's persisted checkpoint via
-``li o flow --resume`` -- the checkpoint owns the plan, so no instruction is
-accepted for those kinds. Gated on the same durable human allow/deny
-proposal flow ``cancel_run``/``launch_playbook`` use, since it starts a new
-process.
+(`lionagi/studio/services/run_resume.py::resume_run`) for the actual launch
+decision -- this adapter never picks an argv or a resume path itself. It
+does read the run's recorded ``invocation_kind`` before creating a proposal,
+though: that is what lets the proposal's summary say the true thing the
+dispatcher is about to do, and lets an argument combination the dispatcher
+would always reject (e.g. an instruction for a checkpoint-replay kind) be
+refused before a human ever sees an approvable proposal for it, instead of
+after they approve one that was always going to fail. For an ``agent`` run
+that means the same ``li agent -r`` path a human resuming from the CLI or
+Studio UI uses, continuing the branch with a new instruction. For a
+``play``/``flow``/``show-play`` run it means replaying the run's persisted
+checkpoint via ``li o flow --resume`` -- the checkpoint owns the plan, so no
+instruction is accepted for those kinds. Gated on the same durable human
+allow/deny proposal flow ``cancel_run``/``launch_playbook`` use, since it
+starts a new process.
 
 This is a distinct operation from "un-pausing a paused run": the session
 lifecycle policy has no edge back out of a terminal state such as
@@ -74,6 +78,49 @@ class ResumeRunInput(_StrictInput):
     # Only meaningful for a checkpoint-replay run; never defaulted to true
     # automatically. See run_resume.py::_resume_flow_run.
     allow_degraded_context: bool = False
+
+
+def _kind_argument_mismatch(
+    run_id: str, kind: str | None, args: ResumeRunInput
+) -> tuple[str, str] | None:
+    """Mirror ``run_resume.py::_dispatch_resume_by_kind``'s argument-vs-kind
+    rules so a combination the dispatcher would refuse never gets far enough
+    to become a proposal. Returns ``None`` when the combination is fine, or
+    an ``(reason, message)`` pair matching the ``error``/``message`` shape
+    ``execute_resume_command`` would have produced for the same rejection --
+    the only thing this changes is when the caller learns it, not what they
+    are told.
+    """
+    from lionagi.studio.services.run_resume import FLOW_RESUME_KINDS
+
+    if kind == "agent":
+        if args.instruction is None:
+            return "invalid_input", "instruction is required to resume an agent run"
+        return None
+    if kind in FLOW_RESUME_KINDS:
+        if args.instruction is not None:
+            return (
+                "invalid_input",
+                f"invocation_kind {kind!r} replays the persisted checkpoint plan; "
+                "instruction is not accepted",
+            )
+        if args.branch is not None:
+            return (
+                "invalid_input",
+                f"invocation_kind {kind!r} replays the persisted checkpoint plan; "
+                "branch_id is not accepted",
+            )
+        if args.model is not None:
+            return (
+                "invalid_input",
+                f"invocation_kind {kind!r} replays the persisted checkpoint plan; "
+                "model is not accepted",
+            )
+        return None
+    return (
+        "conflict",
+        f"Run {run_id!r} has invocation_kind {kind!r}, which does not support resume.",
+    )
 
 
 def _identity() -> tuple[OperatorStore, str, str]:
@@ -141,6 +188,18 @@ async def resume_run(arguments: dict[str, Any]) -> dict[str, Any]:
         }
 
     run_id = resolution["session_id"]
+
+    from lionagi.state.db import StateDB, read_only_open_supported
+
+    async with StateDB(readonly=read_only_open_supported()) as db:
+        session = await db.get_session(run_id)
+    kind = session.get("invocation_kind") if session is not None else None
+
+    mismatch = _kind_argument_mismatch(run_id, kind, args)
+    if mismatch is not None:
+        reason, message = mismatch
+        return {"resumed": False, "reason": reason, "id": run_id, "message": message}
+
     command = {
         "run_id": run_id,
         "instruction": args.instruction,
@@ -151,13 +210,13 @@ async def resume_run(arguments: dict[str, Any]) -> dict[str, Any]:
     stable = store.canonical_hash(
         {"requestId": request_id, "tool": "resume_run", "command": command}
     )
-    # instruction is required for an 'agent' resume and rejected for a
-    # checkpoint-replay one (play/flow/show-play) -- its presence here is
-    # already the kind split the service itself enforces, so the summary
-    # can say which resume this actually is without a second lookup.
+    # The mismatch check above already confirmed kind matches the argument
+    # shape (agent+instruction, or a flow kind with none), so the summary
+    # can be phrased from the run's own recorded kind rather than from
+    # argument presence -- the two can no longer disagree.
     summary = (
         f"Resume run {run_id[:12]} with a new instruction"
-        if args.instruction is not None
+        if kind == "agent"
         else f"Resume run {run_id[:12]} by replaying its checkpoint"
     )
     proposal = await store.create_proposal(

--- a/lionagi/studio/operator/resume_run.py
+++ b/lionagi/studio/operator/resume_run.py
@@ -151,7 +151,15 @@ async def resume_run(arguments: dict[str, Any]) -> dict[str, Any]:
     stable = store.canonical_hash(
         {"requestId": request_id, "tool": "resume_run", "command": command}
     )
-    summary = f"Resume run {run_id[:12]} with a new instruction"
+    # instruction is required for an 'agent' resume and rejected for a
+    # checkpoint-replay one (play/flow/show-play) -- its presence here is
+    # already the kind split the service itself enforces, so the summary
+    # can say which resume this actually is without a second lookup.
+    summary = (
+        f"Resume run {run_id[:12]} with a new instruction"
+        if args.instruction is not None
+        else f"Resume run {run_id[:12]} by replaying its checkpoint"
+    )
     proposal = await store.create_proposal(
         conversation_id,
         request_id,

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -54,6 +54,12 @@ CREATE TABLE IF NOT EXISTS studio_operator_conversations (
   -- recorded a resolution yet, which is not the same as "it changed".
   resolved_provider   TEXT,
   resolved_model      TEXT,
+  -- The identity every turn's Branch is constructed with, so N turns of one
+  -- conversation persist as one branch/session instead of N unrelated ones.
+  -- NULL until the first turn claims it (see claim_branch_id) -- a
+  -- conversation created before this column existed adopts one lazily on its
+  -- next turn rather than through a history-rewriting migration.
+  branch_id          TEXT,
   pinned             INTEGER NOT NULL DEFAULT 0,
   created_at         REAL NOT NULL,
   updated_at         REAL NOT NULL,
@@ -251,6 +257,7 @@ class OperatorStore:
                         "resolved_provider": "TEXT",
                         "resolved_model": "TEXT",
                         "pinned": "INTEGER NOT NULL DEFAULT 0",
+                        "branch_id": "TEXT",
                     },
                 )
                 await self._add_missing_columns(
@@ -338,6 +345,7 @@ class OperatorStore:
             "providerSessionId": row["provider_session_id"],
             "providerModel": row["provider_model"],
             "provider": row["provider"],
+            "branchId": row["branch_id"],
             # Served beside the pin because a session that resets has to be
             # explainable: without these, "my conversation started over" has no
             # visible cause anywhere in the UI or the API.
@@ -846,6 +854,71 @@ class OperatorStore:
                 )
             await db.commit()
         return None if moved else session_id
+
+    async def claim_branch_id(self, conversation_id: str) -> str:
+        """Return the identity every turn of this conversation builds its
+        Branch with, minting and persisting one on the first call.
+
+        This is the fix for the Operator's own log showing N unrelated
+        branches for one N-turn conversation: previously every turn built a
+        brand-new ``Branch()`` with a fresh random id, so
+        ``setup_agent_persist`` (``lionagi/cli/_runs.py``) saw a never-before-
+        seen branch id on every turn and created a new ``sessions`` row for
+        each one. Feeding the SAME id back in lets that existing machinery's
+        own "resume" arm run instead: it looks up ``branch_id`` in the
+        ``branches`` table, and when found, reopens that branch's existing
+        session and appends to it rather than inserting a new row --
+        `setup_agent_persist` already contains this append path (used for CLI
+        resume); nothing about that machinery is changed here. This method
+        only decides what id every turn hands it.
+
+        A brand-new Branch object is still constructed in-process on every
+        turn -- this stores an IDENTITY (a UUID), never a live Branch, since
+        turns arrive as separate HTTP requests, the daemon restarts between
+        them, and two browser tabs can drive one conversation concurrently.
+        None of those can be assumed to share a Python object.
+
+        Idempotent and race-safe: wrapped in the store's usual
+        ``BEGIN IMMEDIATE`` transaction (the same pattern
+        ``claim_resolved_pair`` uses), which SQLite serializes against any
+        other write transaction on this file. Two turns racing to claim the
+        first id for one conversation therefore never see a NULL row at the
+        same time -- the second transaction blocks until the first commits,
+        then reads back the id the first one just wrote and returns that
+        instead of minting its own. The conversation never ends up with two
+        candidate ids to disagree about.
+
+        A conversation created before this column existed reads NULL here on
+        its first post-upgrade turn and adopts an id at that point --
+        deliberately, rather than backfilling one via migration. Its turns
+        already on record stay exactly as they were recorded; only turns from
+        here forward group under the newly-claimed id. No history is
+        rewritten.
+        """
+        await self.ensure_schema()
+        async with open_db(str(self.path())) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            row = await (
+                await db.execute(
+                    "SELECT branch_id FROM studio_operator_conversations WHERE id = ?",
+                    (conversation_id,),
+                )
+            ).fetchone()
+            if row is None:
+                await db.rollback()
+                raise OperatorNotFoundError(f"Operator conversation '{conversation_id}' not found")
+            existing = row["branch_id"]
+            if isinstance(existing, str) and existing:
+                await db.rollback()
+                return existing
+            new_branch_id = str(uuid.uuid4())
+            await db.execute(
+                "UPDATE studio_operator_conversations SET branch_id = ?, updated_at = ? "
+                "WHERE id = ?",
+                (new_branch_id, time.time(), conversation_id),
+            )
+            await db.commit()
+        return new_branch_id
 
     @staticmethod
     async def _write_selection(

--- a/lionagi/studio/operator/types.py
+++ b/lionagi/studio/operator/types.py
@@ -222,6 +222,11 @@ class OperatorEngineTurn:
     store_path: str | None = None
     run_dir: Any | None = None
     provider_session_id: str | None = None
+    # The conversation's durable branch identity (see
+    # OperatorStore.claim_branch_id). None only for a caller that never
+    # claimed one (e.g. a bare unit test) -- build_operator_branch falls back
+    # to a fresh random id in that case, the same default Branch() always had.
+    branch_id: str | None = None
     model: str | None = None
     provider: str | None = None
     effort: str | None = None

--- a/lionagi/studio/services/run_resume.py
+++ b/lionagi/studio/services/run_resume.py
@@ -96,7 +96,7 @@ class RunResumeRequest(BaseModel):
 # that misdescribes why. Treating it as unsupported instead is the honest,
 # structurally-correct answer, decided by what the kind can ever produce, not
 # by kind membership in a set built for a different execution shape.
-_FLOW_RESUME_KINDS = frozenset({"play", "flow", "show-play"})
+FLOW_RESUME_KINDS = frozenset({"play", "flow", "show-play"})
 
 
 _resume_admission_lock = asyncio.Lock()
@@ -575,7 +575,7 @@ async def _dispatch_resume_by_kind(
             run_id, instruction=instruction, branch_id=branch_id, model=model
         )
 
-    if kind in _FLOW_RESUME_KINDS:
+    if kind in FLOW_RESUME_KINDS:
         if instruction is not None:
             raise ValueError(
                 f"invocation_kind {kind!r} replays the persisted checkpoint plan; "
@@ -651,7 +651,7 @@ async def resume_availability(run_id: str) -> dict[str, Any]:
             "branch_id": branch_id,
         }
 
-    if kind in _FLOW_RESUME_KINDS:
+    if kind in FLOW_RESUME_KINDS:
         try:
             run_dir, _checkpoint = await _resolve_flow_checkpoint(run_id)
         except RunResumeCheckpointError as exc:

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -3121,6 +3121,11 @@ async def test_concurrent_claim_branch_id_converges_on_one_id(tmp_path):
 
 # -- Part 2: the rename_session Operator tool -----------------------------
 
+# Neutral, non-host-shaped project label for the rename_session tests below
+# -- unlike `_seed_running_session`'s own default, this deliberately avoids
+# looking like a machine path.
+_RENAME_TEST_PROJECT = "studio-test-project"
+
 
 @pytest.mark.asyncio
 async def test_application_mcp_rename_session_allow_executes_via_the_real_default_coordinator(
@@ -3138,7 +3143,7 @@ async def test_application_mcp_rename_session_allow_executes_via_the_real_defaul
     path = tmp_path / "state.db"
     _patch_state_db(monkeypatch, path)
     async with StateDB() as db:
-        run_id = await _seed_running_session(db)
+        run_id = await _seed_running_session(db, project=_RENAME_TEST_PROJECT)
 
     store = OperatorStore(path)
     coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
@@ -3151,7 +3156,7 @@ async def test_application_mcp_rename_session_allow_executes_via_the_real_defaul
             "space": "mission",
             "route": "/",
             "filters": {},
-            "project": "/Users/admin/test-project",
+            "project": _RENAME_TEST_PROJECT,
         },
         expected_last_sequence=0,
     )
@@ -3167,7 +3172,7 @@ async def test_application_mcp_rename_session_allow_executes_via_the_real_defaul
     assert proposal["command"] == {
         "session_id": run_id,
         "name": "nightly backfill",
-        "project": "/Users/admin/test-project",
+        "project": _RENAME_TEST_PROJECT,
     }
     assert proposal["risk"] == "mutate"
 
@@ -3209,7 +3214,7 @@ async def test_application_mcp_rename_session_deny_leaves_run_untouched_via_real
     path = tmp_path / "state.db"
     _patch_state_db(monkeypatch, path)
     async with StateDB() as db:
-        run_id = await _seed_running_session(db)
+        run_id = await _seed_running_session(db, project=_RENAME_TEST_PROJECT)
 
     store = OperatorStore(path)
     coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
@@ -3222,7 +3227,7 @@ async def test_application_mcp_rename_session_deny_leaves_run_untouched_via_real
             "space": "mission",
             "route": "/",
             "filters": {},
-            "project": "/Users/admin/test-project",
+            "project": _RENAME_TEST_PROJECT,
         },
         expected_last_sequence=0,
     )
@@ -3280,7 +3285,7 @@ async def test_rename_session_not_found_reports_reason_without_creating_a_propos
             "space": "mission",
             "route": "/",
             "filters": {},
-            "project": "/Users/admin/test-project",
+            "project": _RENAME_TEST_PROJECT,
         },
         expected_last_sequence=0,
     )
@@ -3295,3 +3300,68 @@ async def test_rename_session_not_found_reports_reason_without_creating_a_propos
 
     await store.finish_turn(accepted["requestId"], outcome="completed")
     await coordinator.shutdown()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("bad\nname", id="embedded-newline"),
+        pytest.param("bad\x00name", id="embedded-nul"),
+        pytest.param("bad‮name", id="bidi-control-rlo"),
+        pytest.param("bad name", id="line-separator"),
+        pytest.param("bad name", id="paragraph-separator"),
+        pytest.param("bad\x7fname", id="delete-control"),
+    ],
+)
+def test_rename_session_input_rejects_unicode_control_characters(name):
+    """`RenameSessionInput.name` must refuse Unicode `Cc`/`Cf`/`Zl`/`Zp`
+    characters before a proposal is ever created -- the value is copied
+    verbatim into the proposal command and reaches `db.update_session`,
+    which validates column names, not values. Category-based, not an
+    enumerated blocklist, so this covers control characters the author
+    never explicitly thought of."""
+    from pydantic import ValidationError
+
+    from lionagi.studio.operator.rename_session import RenameSessionInput
+
+    with pytest.raises(ValidationError):
+        RenameSessionInput.model_validate({"run": "some-run", "name": name})
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("café", id="accented-latin"),
+        pytest.param("日本語のセッション", id="cjk"),
+        pytest.param("nightly backfill 🎉", id="emoji"),
+        pytest.param("nightly backfill", id="internal-space"),
+    ],
+)
+def test_rename_session_input_keeps_non_ascii_names(name):
+    """The control-character check must not overshoot into rejecting
+    ordinary non-ASCII text: accented Latin, CJK, emoji, and an internal
+    space all name a run just as validly as plain ASCII does."""
+    from lionagi.studio.operator.rename_session import RenameSessionInput
+
+    args = RenameSessionInput.model_validate({"run": "some-run", "name": name})
+    assert args.name == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace-only"),
+        pytest.param("x" * 161, id="over-length"),
+    ],
+)
+def test_rename_session_input_still_rejects_empty_whitespace_and_over_length(name):
+    """The pre-existing length/whitespace rejections must keep working
+    alongside the new control-character check, not be silently dropped by
+    it."""
+    from pydantic import ValidationError
+
+    from lionagi.studio.operator.rename_session import RenameSessionInput
+
+    with pytest.raises(ValidationError):
+        RenameSessionInput.model_validate({"run": "some-run", "name": name})

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -39,6 +39,29 @@ class ScriptedEngine:
         return self._stream(turn)
 
 
+class MessageWritingEngine:
+    """Adds real messages to the turn's branch through the same hooked
+    async add-path `Branch.chat_and_record` uses, so persistence-layer
+    append/dedup behavior is actually exercised. `ScriptedEngine` never
+    touches the branch's messages at all, so it cannot stand in for a real
+    engine when a test cares about what got persisted."""
+
+    async def _stream(self, turn):
+        branch = turn.runtime_branch
+        await branch.msgs.a_add_message(
+            instruction=turn.instruction, sender=branch.user, recipient=branch.id
+        )
+        await branch.msgs.a_add_message(
+            assistant_response=f"ack: {turn.instruction}",
+            sender=branch.id,
+            recipient=branch.user,
+        )
+        yield OperatorEngineEvent("text", {"content": "ok", "format": "plain", "role": "assistant"})
+
+    def stream(self, turn):
+        return self._stream(turn)
+
+
 class FailingEngine:
     async def _stream(self, _turn):
         raise RuntimeError("engine exploded mid-turn")
@@ -157,6 +180,7 @@ def test_real_operator_branch_exposes_only_strict_request_scoped_mcp_tools(tmp_p
         "mcp__studio_operator__run_findings",
         "mcp__studio_operator__cancel_run",
         "mcp__studio_operator__resume_run",
+        "mcp__studio_operator__rename_session",
     }
     # The first turn of a conversation has nothing to resume.
     assert "resume" not in kwargs
@@ -183,6 +207,7 @@ _REQUIRED_OPERATOR_TOOLS = frozenset(
         "run_findings",
         "cancel_run",
         "resume_run",
+        "rename_session",
     }
 )
 
@@ -1018,6 +1043,21 @@ async def _wait_done(
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         frames = await store.list_frames(conversation_id)
+        if any(frame["type"] == "done" for frame in frames):
+            return frames
+        await asyncio.sleep(0.01)
+    raise TimeoutError("Operator turn did not finish")
+
+
+async def _wait_done_since(
+    store: OperatorStore, conversation_id: str, after_sequence: int, *, timeout: float = 5
+) -> list[dict]:
+    """Like `_wait_done`, scoped to frames after *after_sequence* -- needed
+    once a conversation has more than one turn, since `_wait_done` would
+    otherwise match the earlier turn's own "done" frame."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        frames = await store.list_frames(conversation_id, after_sequence=after_sequence)
         if any(frame["type"] == "done" for frame in frames):
             return frames
         await asyncio.sleep(0.01)
@@ -2873,3 +2913,316 @@ async def test_a_repeated_observation_timestamp_is_not_applied_twice(tmp_path):
 
     view, _ = await store.get_view(cid, "page-a")
     assert view["space"] == "library"
+
+
+# -- Part 1: one conversation is one branch -----------------------------
+
+
+def _run_link(frames: list[dict]) -> dict:
+    frame = next(
+        f
+        for f in frames
+        if f["type"] == "tool_result"
+        and isinstance(f["payload"].get("result"), dict)
+        and f["payload"]["result"].get("runId")
+    )
+    return frame["payload"]["result"]
+
+
+@pytest.mark.asyncio
+async def test_second_turn_on_a_conversation_reuses_the_same_branch_and_appends(
+    tmp_path, monkeypatch
+):
+    """A conversation of N turns must be ONE branch/session in the log
+    (asserted end to end, from the store through the actual sessions/
+    branches reader), and the second turn's messages must be appended to
+    the first turn's progression, never overwrite it."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.services.runs import list_runs
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(store=store, engine_factory=MessageWritingEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="Multi-turn"))["conversation"]["id"]
+
+    await coordinator.submit(
+        cid,
+        instruction="first turn",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    frames1 = await _wait_done(store, cid)
+    link1 = _run_link(frames1)
+    run_id1, branch_id1 = link1["runId"], link1["branchId"]
+
+    conv_after_turn1 = await store.get_conversation(cid)
+    assert conv_after_turn1["branchId"] == branch_id1
+
+    async with StateDB() as db:
+        branch_row = await db.get_branch(branch_id1)
+        msg_ids_after_turn1 = set(await db.get_progression(branch_row["progression_id"]))
+    assert msg_ids_after_turn1, "turn 1 must have written at least one message"
+
+    last_seq = frames1[-1]["sequence"]
+    await coordinator.submit(
+        cid,
+        instruction="second turn",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=last_seq,
+    )
+    frames2 = await _wait_done_since(store, cid, last_seq)
+    link2 = _run_link(frames2)
+    run_id2, branch_id2 = link2["runId"], link2["branchId"]
+
+    # The identity itself: both turns constructed their Branch against the
+    # same conversation-level id, and the CLI persistence layer's existing
+    # resume path folded the second turn into the same DB session row.
+    assert branch_id2 == branch_id1
+    assert run_id2 == run_id1
+
+    # From the store through to what the sessions/messages reader serves --
+    # not just that the id was written, but that the log actually shows one
+    # branch and one run for this conversation.
+    async with StateDB() as db:
+        db_branches = await db.list_branches(run_id1)
+        branch_row_after = await db.get_branch(branch_id1)
+        msg_ids_after_turn2 = set(await db.get_progression(branch_row_after["progression_id"]))
+    assert [row["id"] for row in db_branches] == [branch_id1]
+
+    runs = await list_runs(limit=50, offset=0)
+    matching_runs = [item for item in runs if item["id"] == run_id1]
+    assert len(matching_runs) == 1
+
+    # Append, not clobber: every message turn 1 wrote is still there, and
+    # turn 2 added strictly more.
+    assert msg_ids_after_turn1 <= msg_ids_after_turn2
+    assert len(msg_ids_after_turn2) > len(msg_ids_after_turn1)
+
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_conversation_with_no_stored_branch_id_adopts_one_lazily_on_first_turn(
+    tmp_path, monkeypatch
+):
+    """A conversation created before `branch_id` existed (or simply before
+    its first turn) has no stored identity. It must keep working: the rule
+    is adopt-on-next-turn, never a migration that rewrites history."""
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation(title="Legacy"))["conversation"]["id"]
+
+    assert (await store.get_conversation(cid))["branchId"] is None
+
+    await coordinator.submit(
+        cid,
+        instruction="first turn ever",
+        context={"space": "mission", "route": "/", "filters": {}},
+        expected_last_sequence=0,
+    )
+    frames = await _wait_done(store, cid)
+    link = _run_link(frames)
+
+    conv_after = await store.get_conversation(cid)
+    assert conv_after["branchId"] == link["branchId"]
+    assert conv_after["branchId"] is not None
+
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_claim_branch_id_converges_on_one_id(tmp_path):
+    """Two turns racing to claim the first branch id for one conversation
+    must never leave it with two candidate ids to disagree about."""
+    path = tmp_path / "state.db"
+    store = OperatorStore(path)
+    cid = (await store.create_conversation(title="Race"))["id"]
+    assert (await store.get_conversation(cid))["branchId"] is None
+
+    claimed = await asyncio.gather(*(store.claim_branch_id(cid) for _ in range(8)))
+
+    assert len(set(claimed)) == 1
+    assert (await store.get_conversation(cid))["branchId"] == claimed[0]
+
+
+# -- Part 2: the rename_session Operator tool -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_application_mcp_rename_session_allow_executes_via_the_real_default_coordinator(
+    tmp_path, monkeypatch
+):
+    """Same real default `OperatorCoordinator` wiring as the cancel_run/
+    resume_run integration tests above: proves
+    `coordinator.py::_execute_application_command`'s `rename_session` branch
+    really dispatches to `rename_session.execute_rename_session_command`
+    end to end, and that the run's name is actually changed once a human
+    allows the proposal."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.operator.rename_session import rename_session
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    async with StateDB() as db:
+        run_id = await _seed_running_session(db)
+
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="call that run 'nightly backfill'",
+        context={
+            "space": "mission",
+            "route": "/",
+            "filters": {},
+            "project": "/Users/admin/test-project",
+        },
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    task = asyncio.create_task(rename_session({"run": run_id, "name": "nightly backfill"}))
+    proposal = await _wait_proposal(store, accepted["requestId"])
+    assert not task.done()
+    assert proposal["commandType"] == "rename_session"
+    assert proposal["command"] == {
+        "session_id": run_id,
+        "name": "nightly backfill",
+        "project": "/Users/admin/test-project",
+    }
+    assert proposal["risk"] == "mutate"
+
+    decision = await coordinator.decide(
+        cid,
+        proposal["id"],
+        allow=True,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=proposal["targetVersion"],
+    )
+    result = await asyncio.wait_for(task, timeout=2)
+
+    assert decision["status"] == "succeeded"
+    assert result == {
+        "renamed": True,
+        "status": "renamed",
+        "id": run_id,
+        "name": "nightly backfill",
+    }
+
+    async with StateDB() as db:
+        row = await db.fetch_one("SELECT name FROM sessions WHERE id = ?", (run_id,))
+        assert row["name"] == "nightly backfill"
+    await store.finish_turn(accepted["requestId"], outcome="completed")
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_application_mcp_rename_session_deny_leaves_run_untouched_via_real_coordinator(
+    tmp_path, monkeypatch
+):
+    """Same real default wiring as the allow-path test above, but denied:
+    the run's name must be left exactly as it was and
+    `execute_rename_session_command` must never run, regardless of which
+    command type a proposal names."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.operator.rename_session import rename_session
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    async with StateDB() as db:
+        run_id = await _seed_running_session(db)
+
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="rename that run",
+        context={
+            "space": "mission",
+            "route": "/",
+            "filters": {},
+            "project": "/Users/admin/test-project",
+        },
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    task = asyncio.create_task(rename_session({"run": run_id, "name": "should not land"}))
+    proposal = await _wait_proposal(store, accepted["requestId"])
+
+    decision = await coordinator.decide(
+        cid,
+        proposal["id"],
+        allow=False,
+        expected_command_hash=proposal["commandHash"],
+        expected_target_version=proposal["targetVersion"],
+    )
+    result = await asyncio.wait_for(task, timeout=2)
+
+    assert decision["status"] == "failed"
+    assert decision["error"]["code"] == "denied"
+    assert result == {"renamed": False, "reason": "denied", "id": run_id}
+
+    async with StateDB() as db:
+        row = await db.fetch_one("SELECT name FROM sessions WHERE id = ?", (run_id,))
+        assert row["name"] is None
+    await store.finish_turn(accepted["requestId"], outcome="completed")
+    await coordinator.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_rename_session_not_found_reports_reason_without_creating_a_proposal(
+    tmp_path, monkeypatch
+):
+    """An unresolvable run reference is a distinct reported outcome, not a
+    generic failure -- and critically, never reaches the proposal flow at
+    all, so nothing is ever offered to a human for approval."""
+    from lionagi.state.db import StateDB
+    from lionagi.studio.operator.rename_session import rename_session
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    async with StateDB() as db:
+        # Only to force the schema into existence; this run is never named.
+        await _seed_running_session(db)
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="rename a run that doesn't exist",
+        context={
+            "space": "mission",
+            "route": "/",
+            "filters": {},
+            "project": "/Users/admin/test-project",
+        },
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    result = await rename_session({"run": "not-a-real-run-id", "name": "ghost"})
+    assert result == {"renamed": False, "reason": "not_found"}
+    assert await store.list_proposals_for_request(accepted["requestId"]) == []
+
+    await store.finish_turn(accepted["requestId"], outcome="completed")
+    await coordinator.shutdown()

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -1033,6 +1033,75 @@ async def test_application_mcp_resume_run_delegates_flow_kind_to_checkpoint_repl
     await coordinator.shutdown()
 
 
+async def test_application_mcp_resume_run_rejects_instruction_for_flow_kind_before_proposal(
+    tmp_path, monkeypatch
+):
+    """A flow-kind run supplied an instruction must never produce an
+    approvable proposal describing a replay-with-instruction: the real
+    dispatcher (`run_resume.py::_dispatch_resume_by_kind`) rejects an
+    instruction for a checkpoint-replay kind, so offering that as an
+    approvable action would let a human approve something the executor was
+    always going to refuse. No proposal may be created at all -- the
+    mismatch must be caught before `store.create_proposal`, not surfaced as
+    a later execution failure."""
+    import uuid
+
+    from lionagi.state.db import StateDB
+    from lionagi.studio.operator.resume_run import resume_run
+
+    path = tmp_path / "state.db"
+    _patch_state_db(monkeypatch, path)
+    run_id = str(uuid.uuid4())
+    async with StateDB() as db:
+        progression_id = str(uuid.uuid4())
+        await db.create_progression(progression_id)
+        await db.create_session(
+            {
+                "id": run_id,
+                "progression_id": progression_id,
+                "status": "completed",
+                "started_at": time.time(),
+                "invocation_kind": "flow",
+                "project": "studio-test-project",
+            }
+        )
+
+    store = OperatorStore(path)
+    coordinator = OperatorCoordinator(store=store, engine_factory=ScriptedEngine)
+    await coordinator.startup()
+    cid = (await coordinator.create_conversation())["conversation"]["id"]
+    accepted = await store.submit_turn(
+        cid,
+        instruction="continue that run",
+        context={
+            "space": "mission",
+            "route": "/",
+            "filters": {},
+            "project": "studio-test-project",
+        },
+        expected_last_sequence=0,
+    )
+    assert await store.mark_running(accepted["requestId"])
+    monkeypatch.setenv("LIONAGI_OPERATOR_DB_PATH", str(path))
+    monkeypatch.setenv("LIONAGI_OPERATOR_CONVERSATION_ID", cid)
+    monkeypatch.setenv("LIONAGI_OPERATOR_REQUEST_ID", accepted["requestId"])
+
+    result = await asyncio.wait_for(
+        resume_run({"run": run_id, "instruction": "keep going with step two"}), timeout=2
+    )
+
+    assert result["resumed"] is False
+    assert result["reason"] == "invalid_input"
+    assert result["id"] == run_id
+    assert "instruction" in result["message"]
+
+    proposals = await store.list_proposals_for_request(accepted["requestId"])
+    assert proposals == []
+
+    await store.finish_turn(accepted["requestId"], outcome="completed")
+    await coordinator.shutdown()
+
+
 async def _noop() -> None:
     return None
 


### PR DESCRIPTION
## What changed

Two Operator capabilities, plus the wiring that makes the first one actually reachable.

### One conversation is one branch

An Operator conversation now carries a durable branch identity, so every turn in
a conversation appends to the same branch instead of minting a fresh one. The log
groups a conversation as a single branch, and the existing resume path reuses the
same session and progression.

- `studio_operator_conversations` gains a nullable `branch_id`, claimed once per
  conversation by `OperatorStore.claim_branch_id`.
- Only the identity crosses turn boundaries, never a live `Branch` object.
- Concurrency: the claim runs under `BEGIN IMMEDIATE`, so racing turns serialize
  and the loser reads back the winner's id. Covered by a test that fires eight
  concurrent claims and asserts they converge on one id.
- Pre-existing conversations adopt on their next turn. `branch_id` stays NULL
  until then; no migration, no rewrite of historical turns.

### `rename_session` on the Operator surface

The Operator could rename a conversation but had no way to rename the underlying
session or run. `rename_session` closes that, following the same proposal flow and
tool-allowlist rules as the other application commands.

### Fix

`resume_run` described every resume as continuing "with a new instruction", which is
wrong for the replay kinds. The proposal summary is now accurate per invocation kind.

## Why the coordinator change matters

The branch-identity plumbing (store column, claim method, turn field) existed but
`OperatorCoordinator` — the only site that constructs an `OperatorEngineTurn` — never
called the claim or passed the id, so every turn still received a fresh random branch
id and the feature was inert end to end. The coordinator now claims the id once per
turn and threads it through.

## Tests

New coverage in `tests/apps_studio_server/test_operator_protocol.py`:

- a second turn on a conversation reuses the same branch and **appends** — same
  branch and run id across turns, exactly one `branches` row, and the message-id
  set strictly grows and stays a superset of the first turn's
- eight concurrent claims converge on a single id
- `rename_session` is present in both directions of the Operator tool-registry
  agreement check

Gate: 184 tests across the operator-scoped suites pass.

