### PR TITLE
fix: four correctness gaps in Progression membership, graph conformance, marketplace validation, and reservation rollback

### DIFF
--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -234,6 +234,11 @@ _RUN_ID_ATTEMPTS = 8
 _PROMPT_FILENAME = "prompt.txt"
 _MCP_SNAPSHOT_FILENAME = "mcp-servers.json"
 _RESERVATION_CONTENTS = (_PROMPT_FILENAME, _MCP_SNAPSHOT_FILENAME)
+# Written into a reservation directory only when its giveback could not remove
+# it, never as part of a submission's own state — kept out of
+# _RESERVATION_CONTENTS so a later giveback attempt doesn't try to unlink it
+# before the directory itself is gone.
+_RESERVATION_STRANDED_MARKER = "RESERVATION_ROLLBACK_INCOMPLETE"
 
 
 def _reserve_run_dir() -> tuple[str, Path]:
@@ -257,7 +262,7 @@ def _reserve_run_dir() -> tuple[str, Path]:
     )
 
 
-def _discard_reservation(d: Path) -> None:
+def _discard_reservation(d: Path) -> bool:
     """Give a reserved directory back, along with what a submission put in it.
 
     A submission that fails partway through writing has already left files
@@ -275,6 +280,13 @@ def _discard_reservation(d: Path) -> None:
     on the short list above stops the removal. A removal that fails for any other
     reason leaves a directory nobody claimed, which is worth less than the error
     that sent us here.
+
+    Returns whether the directory is actually gone afterward. When it is not —
+    the one case this function suppresses rather than raises for — a marker is
+    left in what remains of it, so a directory found later under the jobs root
+    with no job record reads as a giveback that could not run rather than as one
+    that succeeded; both leave the same absence of a job otherwise, and nothing
+    else here tells them apart.
     """
     for name in _RESERVATION_CONTENTS:
         try:
@@ -285,6 +297,15 @@ def _discard_reservation(d: Path) -> None:
         d.rmdir()
     except OSError:
         pass
+    given_back = not d.exists()
+    if not given_back:
+        with contextlib.suppress(OSError):
+            (d / _RESERVATION_STRANDED_MARKER).write_text(
+                "this reservation's giveback could not fully run: the "
+                "directory below the jobs root was left behind rather than "
+                "removed or claimed by a job.\n"
+            )
+    return given_back
 
 
 # --- record I/O ----------------------------------------------------------------

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import copy
 import json
+import logging
 import math
 import os
 import shlex
@@ -36,6 +37,8 @@ from lionagi.ln._proc import (
 )
 
 from . import config
+
+_log = logging.getLogger(__name__)
 
 # Per-run mutation lock: platform's own advisory file lock.
 if sys.platform == "win32":  # pragma: no cover - POSIX is what CI runs
@@ -306,6 +309,24 @@ def _discard_reservation(d: Path) -> bool:
                 "removed or claimed by a job.\n"
             )
     return given_back
+
+
+def _discard_reservation_and_warn(d: Path, run_id: str) -> None:
+    """Give a reservation back, and say so when the giveback itself fails.
+
+    ``_discard_reservation``'s own marker only helps an operator who later
+    goes looking under the jobs root. The boolean it returns is the only
+    signal available at the moment the failure actually happens, so every
+    caller that discards a reservation on an error path must act on it here
+    rather than let a `False` disappear along with the exception it rode in on.
+    """
+    if not _discard_reservation(d):
+        _log.warning(
+            "reservation rollback for run %s could not remove %s; marked %s",
+            run_id,
+            d,
+            d / _RESERVATION_STRANDED_MARKER,
+        )
 
 
 # --- record I/O ----------------------------------------------------------------
@@ -1136,7 +1157,7 @@ def submit(
         if mcp_servers is not None and mcp_config_path is not None:
             _write_mcp_server_snapshot(Path(mcp_config_path), mcp_servers)
     except BaseException:
-        _discard_reservation(d)
+        _discard_reservation_and_warn(d, run_id)
         raise
 
     # Persist the record BEFORE spawning, so the child's terminal --notify hook
@@ -1194,7 +1215,7 @@ def submit(
         # back, reached one step later. This is the last point where giving it
         # back is the right answer: past this line the run exists, and a failure
         # is marked on the record rather than erased along with it.
-        _discard_reservation(d)
+        _discard_reservation_and_warn(d, run_id)
         raise
 
     try:

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -319,13 +319,29 @@ def _discard_reservation_and_warn(d: Path, run_id: str) -> None:
     signal available at the moment the failure actually happens, so every
     caller that discards a reservation on an error path must act on it here
     rather than let a `False` disappear along with the exception it rode in on.
+
+    The boolean says nothing about whether the marker write itself landed —
+    that write is best-effort and suppresses its own ``OSError`` — so this
+    checks the marker's actual presence afterward rather than assuming it from
+    the directory surviving. An operator reading the warning must not be sent
+    looking for a file that was never written.
     """
-    if not _discard_reservation(d):
+    if _discard_reservation(d):
+        return
+    marker = d / _RESERVATION_STRANDED_MARKER
+    if marker.exists():
         _log.warning(
             "reservation rollback for run %s could not remove %s; marked %s",
             run_id,
             d,
-            d / _RESERVATION_STRANDED_MARKER,
+            marker,
+        )
+    else:
+        _log.warning(
+            "reservation rollback for run %s could not remove %s; the "
+            "stranding marker could not be written either",
+            run_id,
+            d,
         )
 
 

--- a/lionagi/protocols/generic/progression.py
+++ b/lionagi/protocols/generic/progression.py
@@ -248,15 +248,15 @@ class Progression(Element, Ordering[T], Generic[T]):
         else:
             self._ensure_synced()
             try:
-                old = self.order[key]
+                # `self.order` is a bound `_MembersDeque` here (guaranteed by
+                # `_ensure_synced()` above), so its own `__setitem__` already
+                # applies the same duplicate-aware discard/add to `_members`
+                # — updating it again here would be a second, independently
+                # maintained copy of that rule, free to drift from the first.
                 self.order[key] = refs[0]
-                if old not in self.order:
-                    self._members.discard(old)
-                self._members.add(refs[0])
                 self._order_len = len(self.order)
             except IndexError:
                 self.order.insert(key, refs[0])
-                self._members.add(refs[0])
                 self._order_len = len(self.order)
 
     def __delitem__(self, key: int | slice) -> None:
@@ -316,15 +316,17 @@ class Progression(Element, Ordering[T], Generic[T]):
         return len(self.order) < before
 
     def append(self, item: Any, /) -> None:
+        # `self.order` is a bound `_MembersDeque` after `_ensure_synced()`, so
+        # `.append`/`.extend` already add to `_members` themselves — see the
+        # note in `__setitem__` above; the same applies to every method below
+        # that mutates `self.order` through it rather than replacing it.
         self._ensure_synced()
         if isinstance(item, Element):
             self.order.append(item.id)
-            self._members.add(item.id)
             self._order_len = len(self.order)
             return
         refs = validate_order(item)
         self.order.extend(refs)
-        self._members.update(refs)
         self._order_len = len(self.order)
 
     def pop(self, index: int = -1) -> UUID:
@@ -337,8 +339,6 @@ class Progression(Element, Ordering[T], Generic[T]):
             else:
                 uid = self.order[index]
                 del self.order[index]
-            if uid not in self.order:
-                self._members.discard(uid)
             self._order_len = len(self.order)
             return uid
         except Exception as e:
@@ -349,8 +349,6 @@ class Progression(Element, Ordering[T], Generic[T]):
             raise ItemNotFoundError("No items in progression.")
         self._ensure_synced()
         uid = self.order.popleft()
-        if uid not in self.order:
-            self._members.discard(uid)
         self._order_len = len(self.order)
         return uid
 
@@ -384,7 +382,6 @@ class Progression(Element, Ordering[T], Generic[T]):
             raise ValueError("Can only extend with another Progression.")
         self._ensure_synced()
         self.order.extend(other.order)
-        self._members.update(other.order)
         self._order_len = len(self.order)
 
     def __add__(self, other: Any) -> Progression[T]:
@@ -414,7 +411,6 @@ class Progression(Element, Ordering[T], Generic[T]):
         for i in reversed(item_):
             uid = ID.get_id(i)
             self.order.insert(index, uid)
-            self._members.add(uid)
         self._order_len = len(self.order)
 
     def _validate_index(self, index: int, allow_end: bool = False) -> int:

--- a/marketplace/scripts/testdata/claude_plugin_validate_empty_mcp_server.txt
+++ b/marketplace/scripts/testdata/claude_plugin_validate_empty_mcp_server.txt
@@ -1,0 +1,21 @@
+Captured output of the upstream `claude plugin validate` tool (Claude Code
+2.1.224), run against a plugin.json whose "mcpServers" block contains a
+single entry with an empty object value:
+
+  {"mcpServers": {"empty": {}}}
+
+Command: claude plugin validate <plugin-dir>
+
+Validating plugin manifest: <plugin-dir>/.claude-plugin/plugin.json
+
+✘ Found 1 error:
+
+  ❯ mcpServers: Invalid input
+
+✘ Validation failed
+exit code: 1
+
+This is the evidence backing the empty-inline-entry rejection in
+_mcp_servers_gate() (marketplace/scripts/validate_manifests.py). The
+temp directory path in the original run has been replaced with
+<plugin-dir> above; nothing else was edited.

--- a/marketplace/scripts/testdata/claude_plugin_validate_nonempty_mcp_server.txt
+++ b/marketplace/scripts/testdata/claude_plugin_validate_nonempty_mcp_server.txt
@@ -1,0 +1,22 @@
+Captured output of the upstream `claude plugin validate` tool (Claude Code
+2.1.224), run against a plugin.json whose "mcpServers" block contains a
+single well-formed entry, for contrast with the empty-entry case in
+claude_plugin_validate_empty_mcp_server.txt:
+
+  {"mcpServers": {"server": {"command": "true", "args": []}}}
+
+Command: claude plugin validate <plugin-dir>
+
+Validating plugin manifest: <plugin-dir>/.claude-plugin/plugin.json
+
+⚠ Found 1 warning:
+
+  ❯ author: No author information provided. Consider adding author details for plugin attribution
+
+✔ Validation passed with warnings
+exit code: 0
+
+The warning is about the unrelated "author" field; the tool does not
+object to the mcpServers block itself when the entry is non-empty. The
+temp directory path in the original run has been replaced with
+<plugin-dir> above; nothing else was edited.

--- a/marketplace/scripts/validate_manifests.py
+++ b/marketplace/scripts/validate_manifests.py
@@ -182,10 +182,16 @@ def _mcp_servers_gate(mcp: object) -> tuple[dict[str, dict], list[str]]:
     returned dict — never left in it — so a caller can keep going without
     calling a dict method on something that turned out not to be one. An empty
     inline entry (``{}``) is rejected to match a behavioral divergence observed
-    against `claude plugin validate` (2.1.220): this validator used to accept
-    it silently where Claude Code itself refuses it. Both the per-plugin and
-    the standalone-scan branch share this gate, so a fix here fixes both at once
-    and the two can never drift back apart.
+    against the upstream `claude plugin validate` command (Claude Code
+    2.1.224): this validator used to accept it silently where that command
+    refuses it with ``mcpServers: Invalid input``. The captured command
+    output backing that observation is checked in at
+    testdata/claude_plugin_validate_empty_mcp_server.txt (rejection) and
+    testdata/claude_plugin_validate_nonempty_mcp_server.txt (a well-formed
+    entry, for contrast) alongside this script, so the parity claim is
+    checkable against a recorded run rather than resting on prose alone. Both
+    the per-plugin and the standalone-scan branch share this gate, so a fix
+    here fixes both at once and the two can never drift back apart.
     """
     if mcp is None:
         return {}, []

--- a/marketplace/scripts/validate_manifests.py
+++ b/marketplace/scripts/validate_manifests.py
@@ -167,18 +167,41 @@ def _frontmatter_problem(path: Path) -> str:
 def _mcp_servers_gate(mcp: object) -> tuple[dict[str, dict], list[str]]:
     """Validate a plugin.json 'mcpServers' block without ever raising.
 
+    The Claude Code plugin schema documents 'mcpServers' as a string (a path to
+    an external MCP config file), an array of those, or an inline object
+    mapping server names to their configuration — this validator used to accept
+    only the object form, refusing valid plugins that used the other two. Only
+    the object form has entries this validator can inspect further (e.g. for
+    the stub check below), so a string or an array passes the type gate with
+    nothing left to check; an array element that is not a string is reported
+    the same way a malformed object entry is.
+
     Returns the entries safe to iterate further (e.g. for the stub check) plus a
     list of problem descriptions. A malformed top-level block, or an entry whose
-    value is not itself an object, is reported and dropped from the returned
-    dict — never left in it — so a caller can keep going without calling a dict
-    method on something that turned out not to be one. Both the per-plugin and
+    value is not itself a non-empty object, is reported and dropped from the
+    returned dict — never left in it — so a caller can keep going without
+    calling a dict method on something that turned out not to be one. An empty
+    inline entry (``{}``) is rejected to match a behavioral divergence observed
+    against `claude plugin validate` (2.1.220): this validator used to accept
+    it silently where Claude Code itself refuses it. Both the per-plugin and
     the standalone-scan branch share this gate, so a fix here fixes both at once
     and the two can never drift back apart.
     """
     if mcp is None:
         return {}, []
+    if isinstance(mcp, str):
+        return {}, []
+    if isinstance(mcp, list):
+        problems = [
+            f"mcpServers[{index}] must be a string, got {type(item).__name__}"
+            for index, item in enumerate(mcp)
+            if not isinstance(item, str)
+        ]
+        return {}, problems
     if not isinstance(mcp, dict):
-        return {}, [f"'mcpServers' must be an object, got {type(mcp).__name__}"]
+        return {}, [
+            f"'mcpServers' must be a string, an array, or an object, got {type(mcp).__name__}"
+        ]
     usable: dict[str, dict] = {}
     problems: list[str] = []
     for server_name, server_cfg in mcp.items():
@@ -186,6 +209,9 @@ def _mcp_servers_gate(mcp: object) -> tuple[dict[str, dict], list[str]]:
             problems.append(
                 f"mcpServers['{server_name}'] must be an object, got {type(server_cfg).__name__}"
             )
+            continue
+        if not server_cfg:
+            problems.append(f"mcpServers['{server_name}'] must not be empty")
             continue
         usable[server_name] = server_cfg
     return usable, problems

--- a/tests/marketplace_lint.py
+++ b/tests/marketplace_lint.py
@@ -1781,15 +1781,15 @@ def test_mcp_servers_gate_accepts_absent_and_empty() -> None:
     assert gate({}) == ({}, [])
 
 
-@pytest.mark.parametrize("bad", ["stub-server", ["lion"], 5, True], ids=type)
+@pytest.mark.parametrize("bad", [5, True], ids=type)
 def test_mcp_servers_gate_rejects_non_object_top_level(bad: object) -> None:
-    """A string, list, number or bool where mcpServers should be an object is
+    """A number or bool where mcpServers should be a string/array/object is
     reported by name and type, and nothing is left for the caller to iterate."""
     gate = _mcp_gate()
     usable, problems = gate(bad)
     assert usable == {}
     assert len(problems) == 1
-    assert "'mcpServers' must be an object" in problems[0]
+    assert "'mcpServers' must be a string, an array, or an object" in problems[0]
     assert type(bad).__name__ in problems[0]
 
 
@@ -1802,6 +1802,49 @@ def test_mcp_servers_gate_drops_non_object_entries_and_keeps_the_rest() -> None:
     assert len(problems) == 2
     assert any("mcpServers['bad']" in p and p.endswith("got str") for p in problems)
     assert any("mcpServers['worse']" in p and p.endswith("got list") for p in problems)
+
+
+def test_mcp_servers_gate_accepts_a_string_naming_an_external_config() -> None:
+    """Claude Code documents a bare string as a valid form: a path to an
+    external MCP config file. This validator used to reject it outright."""
+    gate = _mcp_gate()
+    assert gate("./mcp-config.json") == ({}, [])
+    assert gate("stub-server") == ({}, [])
+
+
+def test_mcp_servers_gate_accepts_an_array_of_config_paths() -> None:
+    """Claude Code also documents an array of those strings as valid."""
+    gate = _mcp_gate()
+    assert gate(["./mcp-config.json"]) == ({}, [])
+    assert gate(["a.json", "b.json"]) == ({}, [])
+
+
+def test_mcp_servers_gate_rejects_a_non_string_array_element() -> None:
+    """The array form is an array of config-path strings; anything else inside
+    it is reported by index and type, the same shape as a bad object entry."""
+    gate = _mcp_gate()
+    usable, problems = gate(["ok.json", 5, {"nope": True}])
+    assert usable == {}
+    assert len(problems) == 2
+    assert any(p == "mcpServers[1] must be a string, got int" for p in problems)
+    assert any(p == "mcpServers[2] must be a string, got dict" for p in problems)
+
+
+def test_mcp_servers_gate_rejects_an_empty_inline_entry() -> None:
+    """`claude plugin validate` (2.1.220) refuses an inline entry with no
+    configuration in it; this validator used to accept it silently."""
+    gate = _mcp_gate()
+    usable, problems = gate({"empty": {}})
+    assert usable == {}
+    assert problems == ["mcpServers['empty'] must not be empty"]
+
+
+def test_mcp_servers_gate_keeps_a_well_formed_sibling_beside_an_empty_one() -> None:
+    """Rejecting the empty entry does not cost the entries beside it."""
+    gate = _mcp_gate()
+    usable, problems = gate({"lion": {"command": "uvx"}, "empty": {}})
+    assert usable == {"lion": {"command": "uvx"}}
+    assert problems == ["mcpServers['empty'] must not be empty"]
 
 
 def _write_marketplace_json(root: Path, plugins: list[dict]) -> None:

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3091,7 +3091,7 @@ def test_discarding_a_reservation_removes_what_the_submission_wrote(sandbox):
     (d / "prompt.txt").write_text("x")
     (d / "mcp-servers.json").write_text("{}")
 
-    jobs._discard_reservation(d)
+    assert jobs._discard_reservation(d) is True
 
     assert not d.exists()
 
@@ -3132,9 +3132,42 @@ def test_discarding_a_reservation_refuses_a_directory_holding_anything_else(sand
     (d / "prompt.txt").write_text("x")
     (d / "console.log").write_bytes(b"a run wrote this\n")
 
-    jobs._discard_reservation(d)
+    assert jobs._discard_reservation(d) is False
 
     assert (d / "console.log").read_bytes() == b"a run wrote this\n"
+
+
+def test_a_rollback_that_could_not_run_marks_the_directory_it_left_behind(sandbox):
+    """A stranded reservation is not indistinguishable from one cleanly given back.
+
+    Both cases previously left nothing behind to tell them apart: a directory
+    under the jobs root either vanished or, if the giveback failed, sat there
+    exactly as anonymous as a job in progress. The marker this leaves is the
+    signal an operator greping for stranded runs has something to correlate
+    against.
+    """
+    d = config.JOBS_DIR / "20260101T000000-444444"
+    d.mkdir(parents=True)
+    (d / "prompt.txt").write_text("x")
+    (d / "console.log").write_bytes(b"a run wrote this\n")
+
+    assert jobs._discard_reservation(d) is False
+
+    marker = d / jobs._RESERVATION_STRANDED_MARKER
+    assert marker.exists()
+    assert "giveback" in marker.read_text()
+
+
+def test_a_clean_rollback_leaves_no_stranded_marker(sandbox):
+    """The marker names a failure; a successful giveback has nothing to mark —
+    and nowhere left to mark it, since the directory is gone."""
+    d = config.JOBS_DIR / "20260101T000000-555555"
+    d.mkdir(parents=True)
+    (d / "prompt.txt").write_text("x")
+
+    assert jobs._discard_reservation(d) is True
+
+    assert not d.exists()
 
 
 def test_a_lock_that_cannot_be_taken_says_so_even_when_the_descriptor_will_not_close(

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -3202,7 +3202,134 @@ def test_a_marker_write_that_also_fails_still_reaches_the_caller_as_a_warning(
 
     assert not (d / jobs._RESERVATION_STRANDED_MARKER).exists()
     assert d.exists()
-    assert any("20260101T000000-666666" in record.message for record in caplog.records)
+    matching = [r.message for r in caplog.records if "20260101T000000-666666" in r.message]
+    assert matching
+    # The marker write itself refused, so the warning must not claim one landed.
+    assert not any("marked" in message for message in matching)
+
+
+def test_a_pre_record_submit_failure_reaches_the_caller_with_an_accurate_warning(
+    sandbox, monkeypatch, caplog
+):
+    """The regression this guards: reverting either `submit()` cleanup call
+    site back to bare `_discard_reservation(d)` must make this go red.
+
+    Both `submit()` cleanup call sites (the pre-record failure path here, and
+    the post-record one below) must reach a rollback through
+    `_discard_reservation_and_warn`, never through `_discard_reservation`
+    directly — the direct-helper tests above cover the wrapper's own
+    behaviour, but say nothing about whether either production caller still
+    uses it. An unlisted file is left in the reservation directory (something
+    `_discard_reservation` never writes or claims) so the directory survives
+    the giveback, and the marker write is refused too, so the only way to
+    learn what happened is the warning this asserts on.
+    """
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc(4242))
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-aaa999")
+
+    real_reserve = jobs._reserve_run_dir
+    reserved: dict = {}
+
+    def reserve_with_a_stray_file():
+        run_id, d = real_reserve()
+        # Not one of _RESERVATION_CONTENTS, so _discard_reservation cannot
+        # remove it and the directory is left behind rather than given back.
+        (d / "unexpected.leftover").write_bytes(b"stray\n")
+        reserved["run_id"] = run_id
+        reserved["d"] = d
+        return run_id, d
+
+    monkeypatch.setattr(jobs, "_reserve_run_dir", reserve_with_a_stray_file)
+
+    real_write_text = Path.write_text
+
+    def refuse_the_prompt_and_the_marker(self, *args, **kwargs):
+        if self.name in (jobs._PROMPT_FILENAME, jobs._RESERVATION_STRANDED_MARKER):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", refuse_the_prompt_and_the_marker)
+
+    with caplog.at_level(logging.WARNING, logger=jobs._log.name):
+        with pytest.raises(OSError) as exc_info:
+            jobs.submit("agent", [], prompt="x", label="pre-record-failure")
+
+    # The triggering exception, not something the failed cleanup replaced it with.
+    assert exc_info.value.errno == errno.ENOSPC
+
+    d = reserved["d"]
+    run_id = reserved["run_id"]
+    assert d.exists(), "the directory must survive: the stray file blocks rmdir"
+    assert (d / "unexpected.leftover").exists()
+    assert not (d / jobs._RESERVATION_STRANDED_MARKER).exists(), (
+        "the marker write was refused too; it must not appear to exist"
+    )
+    matching = [r.message for r in caplog.records if run_id in r.message]
+    assert matching, "the wrapper must warn even when the marker write also failed"
+    assert not any("marked" in message for message in matching), (
+        "the warning must not claim a marker was written when it was not"
+    )
+    assert jobs.list_jobs() == []
+
+
+def test_a_post_record_submit_failure_reaches_the_caller_with_an_accurate_warning(
+    sandbox, monkeypatch, caplog
+):
+    """The post-record twin of the test above: `job.json`'s own publish fails
+    after the prompt has already been written, driving the *second*
+    `_discard_reservation_and_warn` call site (the one guarding `_write_job`)
+    rather than the first.
+    """
+    monkeypatch.setattr(jobs.subprocess, "Popen", lambda argv, **kw: _FakeProc(4242))
+    monkeypatch.setattr(jobs, "new_run_id", lambda: "20260101T000000-bbb888")
+
+    real_reserve = jobs._reserve_run_dir
+    reserved: dict = {}
+
+    def reserve_with_a_stray_file():
+        run_id, d = real_reserve()
+        (d / "unexpected.leftover").write_bytes(b"stray\n")
+        reserved["run_id"] = run_id
+        reserved["d"] = d
+        return run_id, d
+
+    monkeypatch.setattr(jobs, "_reserve_run_dir", reserve_with_a_stray_file)
+
+    real_replace = os.replace
+    real_write_text = Path.write_text
+
+    def refuse_to_publish(src, dst, *args, **kwargs):
+        if str(dst).endswith("job.json"):
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real_replace(src, dst, *args, **kwargs)
+
+    def refuse_the_marker(self, *args, **kwargs):
+        if self.name == jobs._RESERVATION_STRANDED_MARKER:
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(os, "replace", refuse_to_publish)
+    monkeypatch.setattr(Path, "write_text", refuse_the_marker)
+
+    with caplog.at_level(logging.WARNING, logger=jobs._log.name):
+        with pytest.raises(OSError) as exc_info:
+            jobs.submit("agent", [], prompt="x", label="post-record-failure")
+
+    assert exc_info.value.errno == errno.ENOSPC
+
+    d = reserved["d"]
+    run_id = reserved["run_id"]
+    assert d.exists(), "the directory must survive: the stray file blocks rmdir"
+    assert (d / "unexpected.leftover").exists()
+    assert not (d / jobs._RESERVATION_STRANDED_MARKER).exists(), (
+        "the marker write was refused too; it must not appear to exist"
+    )
+    matching = [r.message for r in caplog.records if run_id in r.message]
+    assert matching, "the wrapper must warn even when the marker write also failed"
+    assert not any("marked" in message for message in matching), (
+        "the warning must not claim a marker was written when it was not"
+    )
+    assert jobs.list_jobs() == []
 
 
 def test_a_lock_that_cannot_be_taken_says_so_even_when_the_descriptor_will_not_close(

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import builtins
 import errno
 import json
+import logging
 import math
 import os
 import signal
@@ -3168,6 +3169,40 @@ def test_a_clean_rollback_leaves_no_stranded_marker(sandbox):
     assert jobs._discard_reservation(d) is True
 
     assert not d.exists()
+
+
+def test_a_marker_write_that_also_fails_still_reaches_the_caller_as_a_warning(
+    sandbox, monkeypatch, caplog
+):
+    """The marker is best-effort; the caller's own diagnostics are not.
+
+    Both cleanup call sites in `submit()` reach a rollback through
+    `_discard_reservation_and_warn`, never `_discard_reservation` directly.
+    When the giveback fails AND the marker write meant to record that also
+    fails (disk full, permissions), the boolean returned by
+    `_discard_reservation` is the only signal left — this asserts the wrapper
+    actually turns it into a warning instead of letting it join the exception
+    being reraised on the way out.
+    """
+    d = config.JOBS_DIR / "20260101T000000-666666"
+    d.mkdir(parents=True)
+    (d / "console.log").write_bytes(b"a run wrote this\n")
+
+    real_write_text = Path.write_text
+
+    def refuse_the_marker(self, *args, **kwargs):
+        if self.name == jobs._RESERVATION_STRANDED_MARKER:
+            raise OSError(errno.ENOSPC, "No space left on device")
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", refuse_the_marker)
+
+    with caplog.at_level(logging.WARNING, logger=jobs._log.name):
+        jobs._discard_reservation_and_warn(d, "20260101T000000-666666")
+
+    assert not (d / jobs._RESERVATION_STRANDED_MARKER).exists()
+    assert d.exists()
+    assert any("20260101T000000-666666" in record.message for record in caplog.records)
 
 
 def test_a_lock_that_cannot_be_taken_says_so_even_when_the_descriptor_will_not_close(

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -3448,6 +3448,102 @@ def _test_function_exists(node_id: str) -> bool:
     )
 
 
+_SYMBOL_RE = re.compile(
+    r"^(?P<dotted>[A-Za-z_][\w.]*)(?:\[(?P<quote>['\"])(?P<key>[^'\"]*)(?P=quote)\])?$"
+)
+
+
+def _resolve_module_and_suffix(dotted: str) -> tuple[Path, list[str]] | None:
+    """The real source file *dotted* names, plus the attribute path left over
+    once the module boundary is found — mirrors how Python itself resolves
+    `import a.b.c` vs `from a.b import c`: the longest dotted prefix that is
+    a real file (module or package `__init__`) wins, so `a.b.C.method` finds
+    module `a/b.py` and leaves `["C", "method"]`, never mistaking `C` for a
+    module of its own. None when no prefix at any length is a real file."""
+    parts = dotted.split(".")
+    for split in range(len(parts), 1, -1):
+        module_parts = parts[:split]
+        candidate = REPO_ROOT.joinpath(*module_parts).with_suffix(".py")
+        if candidate.is_file():
+            return candidate, parts[split:]
+        pkg_init = REPO_ROOT.joinpath(*module_parts, "__init__.py")
+        if pkg_init.is_file():
+            return pkg_init, parts[split:]
+    return None
+
+
+def _ast_defines_name(body: list[ast.stmt], name: str) -> ast.AST | None:
+    """The statement in *body* that defines top-level/class-level *name* — a
+    def, a class, or an assignment target — or None. Returns the node itself
+    (not just a bool) so a caller can descend into a class body or read an
+    assignment's value."""
+    for node in body:
+        if (
+            isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef)
+            and node.name == name
+        ):
+            return node
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return node
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+        ):
+            return node
+    return None
+
+
+def _symbol_resolves(symbol: str) -> bool:
+    """Whether a GraphSurface.symbol string names something real, without
+    importing it (same no-import rationale as _test_function_exists: a
+    studio-extra-gated module must still resolve here). Handles a dotted
+    module.name or module.Class.method path, and one special case — a
+    literal string subscript on a module-level dict, e.g.
+    ``pkg.mod._KIND_META['planning']`` — by checking the key is one of the
+    dict literal's own keys rather than merely that the dict exists."""
+    match = _SYMBOL_RE.match(symbol)
+    if not match:
+        return False
+    resolved = _resolve_module_and_suffix(match["dotted"])
+    if resolved is None:
+        return False
+    module_path, suffix = resolved
+    if not suffix:
+        return False  # names a bare module, not something inside it
+    tree = ast.parse(module_path.read_text(), filename=str(module_path))
+    node = _ast_defines_name(tree.body, suffix[0])
+    for name in suffix[1:]:
+        if not isinstance(node, ast.ClassDef):
+            return False
+        node = _ast_defines_name(node.body, name)
+    if node is None:
+        return False
+    key = match["key"]
+    if key is None:
+        return True
+    value = node.value if isinstance(node, ast.Assign | ast.AnnAssign) else None
+    if not isinstance(value, ast.Dict):
+        return False
+    return any(isinstance(k, ast.Constant) and k.value == key for k in value.keys)
+
+
+def test_every_symbol_resolves_to_real_source():
+    """Every manifest entry's symbol must name something that really exists,
+    not just a unique string — the gap test_manifest_keys_and_symbols_are_unique
+    left open for the seven location=None rows, which have no AST-discovered
+    location to check parity against and so had nothing resolving `symbol` at
+    all. A row whose code moved or was deleted now fails loudly here instead
+    of reading as coverage."""
+    for surface in GRAPH_SURFACES:
+        assert _symbol_resolves(surface.symbol), (
+            f"{surface.key}.symbol={surface.symbol!r} does not resolve to real source — "
+            "fix the reference or the manifest entry"
+        )
+
+
 def test_every_required_persistence_surface_has_named_evidence():
     """persistence_evidence must be both present and resolvable: a nonexistent
     file (or a typo'd test name) fails loudly instead of reading as coverage —
@@ -3554,6 +3650,41 @@ def test_manifest_keys_and_symbols_are_unique():
     assert len(keys) == len(set(keys)), "duplicate GraphSurface.key values"
     symbols = [s.symbol for s in GRAPH_SURFACES]
     assert len(symbols) == len(set(symbols)), "duplicate GraphSurface.symbol values"
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    [
+        "lionagi.session.session.Session.flow",
+        "lionagi.cli.orchestrate.flow._resume_flow",
+        "lionagi.cli.engine._KIND_META['planning']",
+        "lionagi.operations.builder.OperationGraphBuilder",
+    ],
+)
+def test_symbol_resolves_accepts_real_symbols(symbol):
+    """Positive arm: every shape a manifest symbol actually takes — a plain
+    module-level function, a class method, and a dict-literal subscript —
+    resolves against real source."""
+    assert _symbol_resolves(symbol)
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    [
+        "lionagi.session.session.Session.nonexistent_method",
+        "lionagi.session.session.NonexistentClass.flow",
+        "lionagi.nonexistent.module.thing",
+        "lionagi.cli.engine._KIND_META['nonexistent_kind']",
+        "not a symbol at all",
+    ],
+)
+def test_symbol_resolves_rejects_broken_symbols(symbol):
+    """Negative arm, same shapes: a deleted method, a deleted class, a
+    deleted module, a stale dict key, and unparseable text all fail rather
+    than silently resolving to something else. Without this the positive
+    arm alone would be unvalidated — a predicate that has only ever
+    returned one answer proves nothing about the answer it returns."""
+    assert not _symbol_resolves(symbol)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/protocols/generic/test_progression_membership_cache.py
+++ b/tests/protocols/generic/test_progression_membership_cache.py
@@ -410,6 +410,59 @@ def test_direct_order_mutator_coverage_keeps_members_consistent():
     assert p._members == set() == set(p.order)
 
 
+def test_progression_method_coverage_keeps_members_consistent_with_order():
+    # Companion to test_direct_order_mutator_coverage_keeps_members_consistent
+    # above, which drives `p.order` directly. This drives the same ground
+    # through Progression's OWN mutating methods instead — append/pop/
+    # popleft/insert/__setitem__/extend all delegate to a `self.order` that
+    # is, by then, a bound `_MembersDeque`, so the membership set is already
+    # correct once that delegation returns. Asserting `_members == set(order)`
+    # after each is what would catch the two layers drifting apart: a change
+    # to one side's discard rule that isn't mirrored on the other still
+    # passes a test that only checks `x in p`, since a set and a deque agree
+    # on simple presence long after they've diverged on exactly *which*
+    # duplicate survived.
+    p = Progression()
+    ids = [uuid4() for _ in range(8)]
+
+    p.append(ids[0])
+    assert p._members == set(p.order)
+
+    p.append(ids[1:3])
+    assert p._members == set(p.order)
+
+    p.insert(1, ids[3])
+    assert p._members == set(p.order)
+
+    p.extend(Progression(order=[ids[4], ids[5]]))
+    assert p._members == set(p.order)
+
+    replaced = p.order[0]
+    p[0] = ids[6]  # length-preserving __setitem__, fresh id, no duplicate
+    assert replaced not in p._members
+    assert p._members == set(p.order)
+
+    p[0] = ids[7]  # another length-preserving __setitem__, fresh id
+    assert p._members == set(p.order)
+
+    popped = p.pop()
+    assert popped not in p._members
+    assert p._members == set(p.order)
+
+    left = p.popleft()
+    assert left not in p._members
+    assert p._members == set(p.order)
+
+    # A duplicate id: popping one occurrence must not evict it from the set
+    # while the other survives.
+    dup = uuid4()
+    p.append(dup)
+    p.append(dup)
+    p.pop()
+    assert dup in p._members
+    assert p._members == set(p.order)
+
+
 # ---------------------------------------------------------------------------
 # Serialization
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Four independent correctness fixes.

### `_MembersDeque` is the sole owner of Progression membership

`append`, `pop`, `popleft`, `insert`, `extend`, and the scalar `__setitem__` branch
all call `_ensure_synced()` first, which guarantees `self.order` is already a
`_MembersDeque` bound to `self._members`. Their subsequent manual `_members.add()` /
`.discard()` calls therefore duplicated what the bound deque's own override had
already applied. The redundant half is removed.

Methods that instead replace `self.order` wholesale (`remove`, `exclude`, the
`__setitem__` slice branch, `__delitem__`, `clear`) are left untouched — they never
go through the bound wrapper's hooks, so their rebuild and manual-clear calls are the
only sync mechanism, not duplicates.

This deliberately does not touch `_rebuild_members`, `model_post_init`, or
`_ensure_synced`. An earlier attempt at this same cleanup cloned `order` into an
independently owned deque inside `_rebuild_members` and broke
`Progression.model_construct(order=other.order)`'s `q.order is p.order` identity
contract.

### Graph entrypoint conformance resolves every manifest symbol against real source

Seven manifest entries with `location=None` were never resolved, so a typo in one of
them was invisible. `_symbol_resolves()` resolves a dotted `module.name` or
`module.Class.method` path via AST rather than by importing — the same rationale as
the file's existing `_test_function_exists`, so a studio-extra-gated module still
resolves without that extra installed. It handles the one dict-literal-subscript
symbol shape in the manifest.

Applied to all 23 `GRAPH_SURFACES` entries, not only the seven.

### Marketplace `mcpServers` validation matches the plugin schema in both directions

`_mcp_servers_gate` previously rejected the string and array-of-strings forms (stricter
than the real schema) and accepted an empty inline object entry (laxer). Both are
corrected in one function. This does not over-fit a deeper inner-field schema beyond
the demonstrated divergence.

### A reservation rollback that could not run now says so

`_discard_reservation` returned `None` whether or not the directory was actually
removed, so a stranded reservation looked exactly like a clean giveback. It now returns
whether the directory is gone, and when it is not, writes a
`RESERVATION_ROLLBACK_INCOMPLETE` marker into what remains — so the leftover directory
explains itself to anyone reading the filesystem.

## Tests

- `test_progression_method_coverage_keeps_members_consistent_with_order` drives
  Progression's own methods rather than mutating `p.order` directly (the existing
  `test_direct_order_mutator_coverage_keeps_members_consistent` covers that path) and
  asserts `_members == set(order)` after each step, including a duplicate-id case.
  Proved to have teeth by breaking `_MembersDeque.pop()`'s discard call and watching it
  go red.
- Positive and negative parametrized tests of the symbol resolver itself, plus the
  full-manifest test. Confirmed red by injecting a typo into one of the seven
  previously unresolved symbols.
- Six new marketplace tests covering the accept and reject arms for the string form,
  the array form, a non-string array element, and an empty inline entry. Confirmed red
  against the pre-fix gate.

Gate: the progression, pile, flow, graph-conformance, marketplace, and MCP jobs suites
all pass. The four skips in the graph conformance file are pre-existing (one requires
Python 3.11 syntax, three require the studio extra).

## Deliberately not included

- **#2656** — the schedule `action_prompt` half lives entirely in files owned elsewhere
  in this split. The submit-by-file half is framed by the issue itself as a question
  worth deciding rather than an obvious yes, so no bound was invented.
- **#2658** — the naive fix (passing the job cwd through) was tried and reverted,
  because the delivery subprocess's cwd is deliberately the submitting directory for
  notice-signing identity, distinct from where notify config is resolved. What remains
  open is how a relative path *inside* notify configuration should resolve now that
  selection and execution happen in two directories. Three options were named and none
  chosen.
- **#2664** — its second half already shipped: `submit()` returns `mcp_config_servers`
  on the run handle and `status()` reports it, with coverage in
  `tests/mcp/test_spawn_reports_its_server_set.py`. The first half, whether the
  orchestration server belongs in a worker's set at all, is explicitly a caller-facing
  decision with arguments both ways.

Closes #2892
Closes #2746
Closes #2759
Closes #2662
