### PR TITLE
fix(usage): count cache tokens and whole-tree CLI usage, and stop retries from duplicating creation POSTs

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -517,14 +517,26 @@ async def _teardown_common(
 
     all_msgs = await db.get_progression(session_prog_id)
     completion_evidence_msgs = list(all_msgs)
-    update_kwargs: dict[str, Any] = {"ended_at": time.time()}
+
+    # Fetched before this call's own write so started_at reflects session
+    # creation, not a value this same update is about to touch.
+    session_before_teardown = await db.get_session(session_id) or {}
+    ended_at = time.time()
+    update_kwargs: dict[str, Any] = {"ended_at": ended_at}
+    started_at = session_before_teardown.get("started_at")
+    if isinstance(started_at, int | float):
+        # The prerequisite for telling "never started" / "hung before first
+        # request" / "request sent, no response" apart on a terminal row --
+        # duration_ms was previously left NULL on every session regardless of
+        # outcome, which is loudest on a zero-turn timeout: the record could
+        # not even say how long nothing happened for.
+        update_kwargs["duration_ms"] = max(0.0, (ended_at - started_at) * 1000)
     if all_msgs:
         update_kwargs["first_msg_id"] = all_msgs[0]
         update_kwargs["last_msg_id"] = all_msgs[-1]
 
     if extras:
-        session = await db.get_session(session_id) or {}
-        existing_metadata = session.get("node_metadata") or {}
+        existing_metadata = session_before_teardown.get("node_metadata") or {}
         if isinstance(existing_metadata, str):
             try:
                 existing_metadata = json.loads(existing_metadata)

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -286,6 +286,7 @@ async def _do_engine_run(args: argparse.Namespace) -> int:
                     {
                         "id": run_id,
                         "created_at": started_at,
+                        "started_at": started_at,
                         "progression_id": prog_id,
                         "name": f"engine:{kind}",
                         "status": "running",

--- a/lionagi/cli/engine.py
+++ b/lionagi/cli/engine.py
@@ -470,6 +470,7 @@ async def _maybe_update_db(
                 signal_session_id,
                 new_status=_session_status,
                 reason_code=_reason,
+                extra_fields={"ended_at": ended_at or time.time()},
             )
         except Exception as exc:  # noqa: BLE001
             warn(f"could not update engine session status in StateDB: {exc}")

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -858,6 +858,9 @@ async def stream_claude_code_cli(  # noqa: C901
             elif typ == "result":
                 session.result = obj.get("result", "").strip()
                 session.usage = obj.get("usage", {})
+                # modelUsage is whole-agent-tree (includes Task-tool subagent
+                # spawns); the flat `usage` above is top-level-loop-only.
+                session.model_usage = obj.get("modelUsage") or {}
                 session.total_cost_usd = obj.get("total_cost_usd")
                 session.num_turns = obj.get("num_turns")
                 session.duration_ms = obj.get("duration_ms")
@@ -869,6 +872,8 @@ async def stream_claude_code_cli(  # noqa: C901
                 result_meta: dict[str, Any] = {}
                 if session.usage:
                     result_meta["usage"] = session.usage
+                if session.model_usage:
+                    result_meta["model_usage"] = session.model_usage
                 if session.total_cost_usd is not None:
                     result_meta["total_cost_usd"] = session.total_cost_usd
                 if session.num_turns is not None:

--- a/lionagi/providers/openai/batch.py
+++ b/lionagi/providers/openai/batch.py
@@ -8,6 +8,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from lionagi.service.connections.endpoint import Endpoint
+from lionagi.service.connections.endpoint_config import EndpointConfig
 
 from ._config import OpenAIConfigs
 
@@ -50,3 +51,8 @@ __all__ = (
 @OpenAIConfigs.BATCH.register
 class OpenaiBatchEndpoint(Endpoint):
     """OpenAI batch creation endpoint."""
+
+    def __init__(self, config: EndpointConfig = None, **kwargs):
+        if config is None:
+            kwargs.setdefault("idempotent_retries", True)
+        super().__init__(config=config, **kwargs)

--- a/lionagi/providers/openai/images.py
+++ b/lionagi/providers/openai/images.py
@@ -106,6 +106,7 @@ class OpenaiImageGenerationEndpoint(Endpoint):
         if config is None:
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
+            kwargs.setdefault("idempotent_retries", True)
         super().__init__(config=config, **kwargs)
 
 
@@ -119,6 +120,7 @@ class OpenaiImageEditEndpoint(Endpoint):
         if config is None:
             kwargs.setdefault("timeout", 120)
             kwargs.setdefault("max_retries", 3)
+            kwargs.setdefault("idempotent_retries", True)
         super().__init__(config=config, **kwargs)
 
     async def _call(self, payload: dict, headers: dict, **kwargs):

--- a/lionagi/service/connections/endpoint.py
+++ b/lionagi/service/connections/endpoint.py
@@ -191,6 +191,19 @@ class Endpoint:
         else:
             payload, headers = self.create_payload(request, extra_headers=extra_headers, **kwargs)
 
+        if (
+            self.config.idempotent_retries
+            and self.config.method.upper() == "POST"
+            and "Idempotency-Key" not in headers
+        ):
+            import uuid
+
+            # Minted once per logical request, here -- before either retry path
+            # (native _call_aiohttp or the opt-in RetryConfig wrapper below) is
+            # entered -- and reused verbatim across every attempt, so the
+            # provider can recognize a lost-response replay as the same request.
+            headers = {**headers, "Idempotency-Key": str(uuid.uuid4())}
+
         call_func = self._call
 
         if self.retry_config:

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -54,6 +54,12 @@ class EndpointConfig(BaseModel):
     api_key: str | SecretStr | None = Field(None, exclude=True)
     timeout: int = 300
     max_retries: int = 3
+    # A retried POST to a non-idempotent creation endpoint (image generation,
+    # batch creation) can double-execute billable work when the first attempt
+    # was actually accepted but its response was lost. When True, every retry
+    # of one logical request carries the same "Idempotency-Key" header so the
+    # provider can dedupe the ambiguous replay instead of re-running it.
+    idempotent_retries: bool = False
     openai_compatible: bool = False
     requires_tokens: bool = False
     context_window: int | None = None

--- a/lionagi/service/types/cli_session.py
+++ b/lionagi/service/types/cli_session.py
@@ -27,6 +27,7 @@ class CLISession:
     # final summary
     result: str = ""
     usage: dict[str, Any] = field(default_factory=dict)
+    model_usage: dict[str, Any] = field(default_factory=dict)
     total_cost_usd: float | None = None
     num_turns: int | None = None
     duration_ms: int | None = None

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -57,7 +57,7 @@ class RunStart(Signal):
 
 
 class RunEnd(Signal):
-    """Run lifecycle: completed. total_cost_usd is None (unknown) unless a provider actually reports a dollar cost — never coerced to 0.0 (free). input_tokens is uncached prompt tokens in both provider conventions; cached_tokens/cache_write_tokens carry the billing dimensions that convention otherwise drops or folds in."""
+    """Run lifecycle: completed. total_cost_usd is None (unknown) unless a provider actually reports a dollar cost — never coerced to 0.0 (free). input_tokens is uncached prompt tokens in both provider conventions; cached_tokens/cache_write_tokens carry the billing dimensions that convention otherwise drops or folds in. usage_valid is False when a provider usage report violated a token-count invariant (e.g. cached_tokens > prompt_tokens) — the numeric fields are still a safe clamped shape, but a billing consumer needing to distinguish a real full-cache hit from a provider bug must check this flag."""
 
     input_tokens: int = 0
     output_tokens: int = 0
@@ -66,6 +66,7 @@ class RunEnd(Signal):
     total_cost_usd: float | None = None
     num_turns: int = 0
     duration_ms: float = 0.0
+    usage_valid: bool = True
 
 
 class RunFailed(Signal):
@@ -227,8 +228,8 @@ def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
     return state
 
 
-def _extract_usage_dims(usage: dict[str, Any]) -> tuple[int, int, int, int]:
-    """Split a raw provider usage dict into (input, output, cached, cache_write) tokens.
+def _extract_usage_dims(usage: dict[str, Any]) -> tuple[int, int, int, int, bool]:
+    """Split a raw provider usage dict into (input, output, cached, cache_write, is_valid) tokens.
 
     Anthropic-style: ``input_tokens`` already excludes cache activity; cache
     reads/writes arrive separately as ``cache_read_input_tokens`` /
@@ -236,28 +237,52 @@ def _extract_usage_dims(usage: dict[str, Any]) -> tuple[int, int, int, int]:
     cached reads, split out under ``prompt_tokens_details.cached_tokens`` --
     subtracted here so the returned "input" figure means "uncached prompt
     tokens" under both conventions.
+
+    ``is_valid`` is False when the OpenAI-style provider report violates the
+    token-count invariants (a negative prompt total, or cached_tokens greater
+    than prompt_tokens). The returned numbers are still clamped into a safe,
+    non-negative shape so a caller that ignores validity still gets a sane
+    aggregate -- but a billing consumer that checks ``is_valid`` can tell a
+    genuine full-cache hit from a provider sending garbage, which the clamp
+    alone makes indistinguishable.
     """
     output_tokens = int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0)
     if "cache_read_input_tokens" in usage or "cache_creation_input_tokens" in usage:
         cached = int(usage.get("cache_read_input_tokens", 0) or 0)
         cache_write = int(usage.get("cache_creation_input_tokens", 0) or 0)
         input_tokens = int(usage.get("input_tokens", 0) or 0)
-        return input_tokens, output_tokens, cached, cache_write
+        return input_tokens, output_tokens, cached, cache_write, True
 
     prompt_tokens = int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
     details = usage.get("prompt_tokens_details")
     cached = int(details.get("cached_tokens", 0) or 0) if isinstance(details, dict) else 0
-    # Provider invariant: cached_tokens must not exceed prompt_tokens. A
-    # violation would otherwise produce a negative "uncached input" figure
-    # that reaches billing aggregates -- clamp into [0, prompt_tokens]
-    # instead of propagating it.
+    # Provider invariants: prompt_tokens must be non-negative, and
+    # cached_tokens must not exceed it. A violation would otherwise produce a
+    # negative "uncached input" figure that reaches billing aggregates --
+    # clamp into a safe, non-negative shape instead of propagating it, but
+    # report the violation via is_valid rather than absorbing it silently.
+    is_valid = prompt_tokens >= 0 and 0 <= cached <= prompt_tokens
+    prompt_tokens = max(0, prompt_tokens)
     cached = max(0, min(cached, prompt_tokens))
-    return prompt_tokens - cached, output_tokens, cached, 0
+    return prompt_tokens - cached, output_tokens, cached, 0, is_valid
 
 
 _MODEL_USAGE_ENTRY_KEYS = frozenset(
     {"inputTokens", "outputTokens", "cacheReadInputTokens", "cacheCreationInputTokens"}
 )
+
+
+def _as_nonneg_int(value: Any) -> int | None:
+    """A token count must be a real non-negative integer -- not a truncating
+    float, not None-as-zero, not a numeric-looking string. Returns the int,
+    or None if *value* cannot represent a token count at all."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, float) and value.is_integer():
+        return int(value) if value >= 0 else None
+    return None
 
 
 def _sum_model_usage(model_usage: dict[str, Any]) -> tuple[int, int, int, int, bool]:
@@ -269,21 +294,29 @@ def _sum_model_usage(model_usage: dict[str, Any]) -> tuple[int, int, int, int, b
 
     Returns ``(input, output, cached, cache_write, has_valid_entry)``. An
     entry only counts as valid when it is a dict carrying all four expected
-    keys -- a genuinely zero-usage model still reports the full shape, so a
-    valid entry that happens to sum to zero is distinct from no valid entry
-    at all (missing/partial/non-dict), which the caller must fall back on.
+    keys with non-negative-integer values -- a genuinely zero-usage model
+    still reports the full shape, so a valid entry that happens to sum to
+    zero is distinct from no valid entry at all. If ANY entry in the map is
+    malformed (missing keys, non-dict, or a value that is not a real
+    non-negative integer), the whole map is untrustworthy and
+    ``has_valid_entry`` is False -- summing only the well-shaped entries
+    would silently undercount whatever the malformed entry actually spent.
     """
     input_tokens = output_tokens = cached = cache_write = 0
-    has_valid_entry = False
+    all_valid = bool(model_usage)
     for entry in model_usage.values():
         if not isinstance(entry, dict) or not _MODEL_USAGE_ENTRY_KEYS.issubset(entry):
+            all_valid = False
             continue
-        has_valid_entry = True
-        input_tokens += int(entry.get("inputTokens", 0) or 0)
-        output_tokens += int(entry.get("outputTokens", 0) or 0)
-        cached += int(entry.get("cacheReadInputTokens", 0) or 0)
-        cache_write += int(entry.get("cacheCreationInputTokens", 0) or 0)
-    return input_tokens, output_tokens, cached, cache_write, has_valid_entry
+        counts = {key: _as_nonneg_int(entry.get(key)) for key in _MODEL_USAGE_ENTRY_KEYS}
+        if any(count is None for count in counts.values()):
+            all_valid = False
+            continue
+        input_tokens += counts["inputTokens"]
+        output_tokens += counts["outputTokens"]
+        cached += counts["cacheReadInputTokens"]
+        cache_write += counts["cacheCreationInputTokens"]
+    return input_tokens, output_tokens, cached, cache_write, all_valid
 
 
 def _collect_branch_usage(branch: Any) -> dict[str, Any]:
@@ -294,6 +327,7 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
     cache_write_tokens = 0
     total_cost_usd: float | None = None
     num_turns = 0
+    usage_valid = True
 
     try:
         messages = list(branch.msgs.messages)
@@ -305,6 +339,7 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
             "cache_write_tokens": 0,
             "total_cost_usd": None,
             "num_turns": 0,
+            "usage_valid": True,
         }
 
     for msg in messages:
@@ -326,7 +361,8 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
             )
         if not has_valid_model_usage:
             usage = mr.get("usage") if isinstance(mr.get("usage"), dict) else mr
-            m_in, m_out, m_cached, m_cache_write = _extract_usage_dims(usage)
+            m_in, m_out, m_cached, m_cache_write, m_valid = _extract_usage_dims(usage)
+            usage_valid = usage_valid and m_valid
         input_tokens += m_in
         output_tokens += m_out
         cached_tokens += m_cached
@@ -350,6 +386,7 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
         "cache_write_tokens": cache_write_tokens,
         "total_cost_usd": total_cost_usd,
         "num_turns": num_turns,
+        "usage_valid": usage_valid,
     }
 
 
@@ -361,6 +398,7 @@ def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
     cache_write_tokens = 0
     total_cost_usd: float | None = None
     num_turns = 0
+    usage_valid = True
 
     for branch in branches:
         usage = _collect_branch_usage(branch)
@@ -371,6 +409,7 @@ def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
         if usage["total_cost_usd"] is not None:
             total_cost_usd = (total_cost_usd or 0.0) + usage["total_cost_usd"]
         num_turns += usage["num_turns"]
+        usage_valid = usage_valid and usage["usage_valid"]
 
     return {
         "input_tokens": input_tokens,
@@ -379,6 +418,7 @@ def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
         "cache_write_tokens": cache_write_tokens,
         "total_cost_usd": total_cost_usd,
         "num_turns": num_turns,
+        "usage_valid": usage_valid,
     }
 
 

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -57,10 +57,12 @@ class RunStart(Signal):
 
 
 class RunEnd(Signal):
-    """Run lifecycle: completed. total_cost_usd is None (unknown) unless a provider actually reports a dollar cost — never coerced to 0.0 (free)."""
+    """Run lifecycle: completed. total_cost_usd is None (unknown) unless a provider actually reports a dollar cost — never coerced to 0.0 (free). input_tokens is uncached prompt tokens in both provider conventions; cached_tokens/cache_write_tokens carry the billing dimensions that convention otherwise drops or folds in."""
 
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_tokens: int = 0
+    cache_write_tokens: int = 0
     total_cost_usd: float | None = None
     num_turns: int = 0
     duration_ms: float = 0.0
@@ -225,17 +227,67 @@ def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
     return state
 
 
+def _extract_usage_dims(usage: dict[str, Any]) -> tuple[int, int, int, int]:
+    """Split a raw provider usage dict into (input, output, cached, cache_write) tokens.
+
+    Anthropic-style: ``input_tokens`` already excludes cache activity; cache
+    reads/writes arrive separately as ``cache_read_input_tokens`` /
+    ``cache_creation_input_tokens``. OpenAI-style: ``prompt_tokens`` INCLUDES
+    cached reads, split out under ``prompt_tokens_details.cached_tokens`` --
+    subtracted here so the returned "input" figure means "uncached prompt
+    tokens" under both conventions.
+    """
+    output_tokens = int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0)
+    if "cache_read_input_tokens" in usage or "cache_creation_input_tokens" in usage:
+        cached = int(usage.get("cache_read_input_tokens", 0) or 0)
+        cache_write = int(usage.get("cache_creation_input_tokens", 0) or 0)
+        input_tokens = int(usage.get("input_tokens", 0) or 0)
+        return input_tokens, output_tokens, cached, cache_write
+
+    prompt_tokens = int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
+    details = usage.get("prompt_tokens_details")
+    cached = int(details.get("cached_tokens", 0) or 0) if isinstance(details, dict) else 0
+    return prompt_tokens - cached, output_tokens, cached, 0
+
+
+def _sum_model_usage(model_usage: dict[str, Any]) -> tuple[int, int, int, int]:
+    """Sum per-model whole-tree token counts from a claude_code CLI ``modelUsage`` map.
+
+    Unlike the flat top-level ``usage`` field (top-level-loop only), each
+    entry here already includes descendant subagent spend, so this is the
+    whole-tree figure when present.
+    """
+    input_tokens = output_tokens = cached = cache_write = 0
+    for entry in model_usage.values():
+        if not isinstance(entry, dict):
+            continue
+        input_tokens += int(entry.get("inputTokens", 0) or 0)
+        output_tokens += int(entry.get("outputTokens", 0) or 0)
+        cached += int(entry.get("cacheReadInputTokens", 0) or 0)
+        cache_write += int(entry.get("cacheCreationInputTokens", 0) or 0)
+    return input_tokens, output_tokens, cached, cache_write
+
+
 def _collect_branch_usage(branch: Any) -> dict[str, Any]:
     """Sum provider-reported usage across all AssistantResponse messages on branch. total_cost_usd stays None (unknown) until a message actually reports a cost — never coerced to 0.0 (free)."""
     input_tokens = 0
     output_tokens = 0
+    cached_tokens = 0
+    cache_write_tokens = 0
     total_cost_usd: float | None = None
     num_turns = 0
 
     try:
         messages = list(branch.msgs.messages)
     except Exception:  # noqa: BLE001
-        return {"input_tokens": 0, "output_tokens": 0, "total_cost_usd": None, "num_turns": 0}
+        return {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_tokens": 0,
+            "cache_write_tokens": 0,
+            "total_cost_usd": None,
+            "num_turns": 0,
+        }
 
     for msg in messages:
         mr = (
@@ -243,9 +295,19 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
         )
         if not isinstance(mr, dict):
             continue
-        usage = mr.get("usage") if isinstance(mr.get("usage"), dict) else mr
-        input_tokens += int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
-        output_tokens += int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0)
+        model_usage = mr.get("model_usage")
+        if isinstance(model_usage, dict) and model_usage:
+            # Whole-tree per-model breakdown (claude_code CLI subagent
+            # spawns) supersedes the flat usage dict below, which only
+            # reflects the top-level loop.
+            m_in, m_out, m_cached, m_cache_write = _sum_model_usage(model_usage)
+        else:
+            usage = mr.get("usage") if isinstance(mr.get("usage"), dict) else mr
+            m_in, m_out, m_cached, m_cache_write = _extract_usage_dims(usage)
+        input_tokens += m_in
+        output_tokens += m_out
+        cached_tokens += m_cached
+        cache_write_tokens += m_cache_write
         # Presence, not truthiness: an explicit total_cost_usd=0.0 (real free
         # call) must not fall through `x or y` to the cost/None fallback.
         if "total_cost_usd" in mr and mr["total_cost_usd"] is not None:
@@ -261,6 +323,8 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
+        "cached_tokens": cached_tokens,
+        "cache_write_tokens": cache_write_tokens,
         "total_cost_usd": total_cost_usd,
         "num_turns": num_turns,
     }
@@ -270,6 +334,8 @@ def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
     """Sum _collect_branch_usage across multiple branches (multi-leg DAG runs). duration_ms is excluded — wall-clock across parallel legs isn't simply summable."""
     input_tokens = 0
     output_tokens = 0
+    cached_tokens = 0
+    cache_write_tokens = 0
     total_cost_usd: float | None = None
     num_turns = 0
 
@@ -277,6 +343,8 @@ def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
         usage = _collect_branch_usage(branch)
         input_tokens += usage["input_tokens"]
         output_tokens += usage["output_tokens"]
+        cached_tokens += usage["cached_tokens"]
+        cache_write_tokens += usage["cache_write_tokens"]
         if usage["total_cost_usd"] is not None:
             total_cost_usd = (total_cost_usd or 0.0) + usage["total_cost_usd"]
         num_turns += usage["num_turns"]
@@ -284,6 +352,8 @@ def _collect_multi_branch_usage(branches: Iterable[Any]) -> dict[str, Any]:
     return {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
+        "cached_tokens": cached_tokens,
+        "cache_write_tokens": cache_write_tokens,
         "total_cost_usd": total_cost_usd,
         "num_turns": num_turns,
     }

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -247,25 +247,43 @@ def _extract_usage_dims(usage: dict[str, Any]) -> tuple[int, int, int, int]:
     prompt_tokens = int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
     details = usage.get("prompt_tokens_details")
     cached = int(details.get("cached_tokens", 0) or 0) if isinstance(details, dict) else 0
+    # Provider invariant: cached_tokens must not exceed prompt_tokens. A
+    # violation would otherwise produce a negative "uncached input" figure
+    # that reaches billing aggregates -- clamp into [0, prompt_tokens]
+    # instead of propagating it.
+    cached = max(0, min(cached, prompt_tokens))
     return prompt_tokens - cached, output_tokens, cached, 0
 
 
-def _sum_model_usage(model_usage: dict[str, Any]) -> tuple[int, int, int, int]:
+_MODEL_USAGE_ENTRY_KEYS = frozenset(
+    {"inputTokens", "outputTokens", "cacheReadInputTokens", "cacheCreationInputTokens"}
+)
+
+
+def _sum_model_usage(model_usage: dict[str, Any]) -> tuple[int, int, int, int, bool]:
     """Sum per-model whole-tree token counts from a claude_code CLI ``modelUsage`` map.
 
     Unlike the flat top-level ``usage`` field (top-level-loop only), each
     entry here already includes descendant subagent spend, so this is the
     whole-tree figure when present.
+
+    Returns ``(input, output, cached, cache_write, has_valid_entry)``. An
+    entry only counts as valid when it is a dict carrying all four expected
+    keys -- a genuinely zero-usage model still reports the full shape, so a
+    valid entry that happens to sum to zero is distinct from no valid entry
+    at all (missing/partial/non-dict), which the caller must fall back on.
     """
     input_tokens = output_tokens = cached = cache_write = 0
+    has_valid_entry = False
     for entry in model_usage.values():
-        if not isinstance(entry, dict):
+        if not isinstance(entry, dict) or not _MODEL_USAGE_ENTRY_KEYS.issubset(entry):
             continue
+        has_valid_entry = True
         input_tokens += int(entry.get("inputTokens", 0) or 0)
         output_tokens += int(entry.get("outputTokens", 0) or 0)
         cached += int(entry.get("cacheReadInputTokens", 0) or 0)
         cache_write += int(entry.get("cacheCreationInputTokens", 0) or 0)
-    return input_tokens, output_tokens, cached, cache_write
+    return input_tokens, output_tokens, cached, cache_write, has_valid_entry
 
 
 def _collect_branch_usage(branch: Any) -> dict[str, Any]:
@@ -296,12 +314,17 @@ def _collect_branch_usage(branch: Any) -> dict[str, Any]:
         if not isinstance(mr, dict):
             continue
         model_usage = mr.get("model_usage")
+        has_valid_model_usage = False
         if isinstance(model_usage, dict) and model_usage:
             # Whole-tree per-model breakdown (claude_code CLI subagent
             # spawns) supersedes the flat usage dict below, which only
-            # reflects the top-level loop.
-            m_in, m_out, m_cached, m_cache_write = _sum_model_usage(model_usage)
-        else:
+            # reflects the top-level loop -- but only once validated: a
+            # truthy map with no well-shaped entry (missing keys, non-dict)
+            # must not silently erase real flat usage with zeros.
+            m_in, m_out, m_cached, m_cache_write, has_valid_model_usage = _sum_model_usage(
+                model_usage
+            )
+        if not has_valid_model_usage:
             usage = mr.get("usage") if isinstance(mr.get("usage"), dict) else mr
             m_in, m_out, m_cached, m_cache_write = _extract_usage_dims(usage)
         input_tokens += m_in

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -2302,6 +2302,19 @@ class StateDB:
             adr="ADR-0012",
         )
         now = time.time()
+        # A row can be born terminal (e.g. `li state import` of a completed
+        # run) without ever passing through _transition() or the admin CAS —
+        # both of which derive duration_ms from started_at/ended_at. Derive
+        # it here too so a terminal insert is never the one path that skips
+        # ADR-0035's duration centralization.
+        duration_ms = session.get("duration_ms")
+        if (
+            duration_ms is None
+            and session.get("status") in SESSION_TERMINAL_STATUSES
+            and isinstance(session.get("started_at"), int | float)
+            and isinstance(session.get("ended_at"), int | float)
+        ):
+            duration_ms = max(0.0, (session["ended_at"] - session["started_at"]) * 1000)
         async with self._tx() as conn:
             result = await conn.execute(
                 text(
@@ -2312,7 +2325,7 @@ class StateDB:
                        artifact_verification_json, source_kind,
                        status, started_at, ended_at, last_message_at, invocation_id,
                        model, provider, effort, agent_hash,
-                       project, project_source)
+                       project, project_source, duration_ms)
                        VALUES (:id, :cc_session_id, :run_id, :created_at, :node_metadata, :name, :user,
                                :progression_id, :first_msg_id, :last_msg_id, :updated_at,
                                :playbook_name, :agent_name, :invocation_kind, :show_topic,
@@ -2320,7 +2333,7 @@ class StateDB:
                                :artifact_verification_json, :source_kind,
                                :status, :started_at, :ended_at, :last_message_at, :invocation_id,
                                :model, :provider, :effort, :agent_hash,
-                               :project, :project_source)
+                               :project, :project_source, :duration_ms)
                        ON CONFLICT (id) DO NOTHING"""
                 ).bindparams(
                     bindparam("node_metadata", type_=JSON),
@@ -2361,6 +2374,7 @@ class StateDB:
                     "agent_hash": session.get("agent_hash"),
                     "project": session.get("project"),
                     "project_source": session.get("project_source"),
+                    "duration_ms": duration_ms,
                 },
             )
             # Only increment session_count when INSERT actually created a row.

--- a/lionagi/state/lifecycle/service.py
+++ b/lionagi/state/lifecycle/service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import time
 import uuid
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Protocol, get_args
 
 from sqlalchemy import JSON, bindparam, text
@@ -245,9 +246,21 @@ class SQLAlchemyLifecycleService:
 
         now = time.time()
 
+        # Every session's terminal write (any caller, any patch) derives
+        # ended_at/duration_ms from the same row read here, instead of each
+        # writer computing it independently (or not at all).
+        needs_duration_basis = (
+            command.entity_type == "session"
+            and command.to_status in policy.terminal_statuses
+            and {"started_at", "ended_at"}.isdisjoint(extra_guard)
+        )
+
         async with self._db._tx() as conn:
             guard_cols = list(extra_guard)
-            select_cols = ", ".join(["status", "updated_at", *guard_cols])
+            fetch_cols = ["status", "updated_at", *guard_cols]
+            if needs_duration_basis:
+                fetch_cols += ["started_at", "ended_at"]
+            select_cols = ", ".join(fetch_cols)
             sel = f"SELECT {select_cols} FROM {policy.table} WHERE id = :id"  # noqa: S608
             if self._db.dialect != "sqlite":
                 sel += " FOR UPDATE"
@@ -402,6 +415,19 @@ class SQLAlchemyLifecycleService:
                         current_status=previous_status,
                         transition_id=None,
                     )
+
+            if needs_duration_basis and not same_status:
+                ended_at_value = command.patch.get("ended_at", row["ended_at"])
+                if ended_at_value is None:
+                    ended_at_value = now
+                patch = dict(command.patch)
+                patch.setdefault("ended_at", ended_at_value)
+                if "duration_ms" not in patch:
+                    started_at = row["started_at"]
+                    if isinstance(started_at, int | float):
+                        patch["duration_ms"] = max(0.0, (ended_at_value - started_at) * 1000)
+                if patch != dict(command.patch):
+                    command = replace(command, patch=patch)
 
             transition_id = await self._write(
                 conn,

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -673,10 +673,17 @@ async def transition_sessions(
             # WHERE status='running' only allows a legal forward transition,
             # and the last_message_at/updated_at equality guards stop this
             # from clobbering a session that went active again mid-check.
+            _started_at = current.get("started_at")
+            _duration_ms = (
+                max(0.0, (now - _started_at) * 1000)
+                if isinstance(_started_at, int | float)
+                else None
+            )
             async with db.transaction() as conn:
                 result = await conn.execute(
                     text(
                         "UPDATE sessions SET status=:status, ended_at=:now, updated_at=:now, "
+                        "  duration_ms=:duration_ms, "
                         "  status_reason_code=:rcode, status_reason_summary=:rsummary, "
                         "  status_evidence_refs=:erefs "
                         "WHERE id=:sid AND status='running'"
@@ -686,6 +693,7 @@ async def transition_sessions(
                     {
                         "status": target_status,
                         "now": now,
+                        "duration_ms": _duration_ms,
                         "rcode": effective_reason_code,
                         "rsummary": effective_reason_summary,
                         "erefs": effective_evidence_refs,

--- a/tests/apps_studio_server/test_admin_transition.py
+++ b/tests/apps_studio_server/test_admin_transition.py
@@ -137,6 +137,47 @@ def test_transition_refused_when_heartbeat_changes_health(tmp_path, monkeypatch)
 
 
 # ---------------------------------------------------------------------------
+# Test: the raw-SQL CAS write populates duration_ms like every other terminal write
+# ---------------------------------------------------------------------------
+
+
+def test_transition_sessions_populates_duration_ms(tmp_path, monkeypatch):
+    """transition_sessions() writes status via a hand-rolled UPDATE (not
+    update_status()/_transition()), so it must compute duration_ms itself --
+    this call site is not covered by the centralized derivation."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.admin as adm
+
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    old_ts = time.time() - 7 * 3600
+
+    _run(_seed_stale_session(db_path, sid, last_message_at=old_ts, updated_at=old_ts))
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    result = _run(
+        adm.transition_sessions(
+            session_ids=[sid],
+            target_status="failed",
+            reason_code="run.failed.exception",
+            reason_summary="test duration_ms",
+            actor="test",
+        )
+    )
+    assert sid in result["transitioned"]
+
+    from lionagi.state.db import StateDB
+
+    async def _get(db_path, sid):
+        async with StateDB(db_path) as db:
+            return await db.get_session(sid)
+
+    row = _run(_get(db_path, sid))
+    assert row["ended_at"] is not None
+    assert row["duration_ms"] == pytest.approx((row["ended_at"] - old_ts) * 1000)
+
+
+# ---------------------------------------------------------------------------
 # Test: an already-terminal session is never touched by the reconcile CAS
 # ---------------------------------------------------------------------------
 

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -313,6 +313,38 @@ def test_reap_null_status_sessions_dead_process(tmp_path, monkeypatch):
     assert run_async(_count_transitions(db_path, sid)) >= 1
 
 
+def test_reap_null_status_sessions_populates_duration_ms(tmp_path, monkeypatch):
+    """The reaper pre-sets ended_at via update_session, then transitions status
+    via update_status in a second call -- duration_ms must still land, derived
+    from the same started_at/ended_at pair, not just ended_at alone."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    stale_time = time.time() - 7200
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            artifacts_path=None,
+            started_at=stale_time,
+            updated_at=stale_time,
+        )
+    )
+
+    import lionagi.studio.services.lifecycle as lc_mod
+
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: False)
+
+    from lionagi.studio.services.lifecycle import reap_null_status_sessions
+
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
+    assert count == 1
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess["status"] == "failed"
+    assert sess["duration_ms"] == pytest.approx((sess["ended_at"] - stale_time) * 1000)
+
+
 def test_reap_null_status_sessions_skips_live_process(tmp_path, monkeypatch):
     """Null-status session with live process is not transitioned."""
     db_path = tmp_path / "state.db"
@@ -517,6 +549,32 @@ def test_reap_phantom_sessions_missing_artifacts(tmp_path, monkeypatch):
 
     reason = run_async(_get_reason(db_path, sid))
     assert reason == "phantom_reaped"
+
+
+def test_reap_phantom_sessions_populates_duration_ms(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    missing_dir = str(tmp_path / "ghost_artifacts_duration")
+    stale_time = time.time() - 7200
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status="running",
+            started_at=stale_time,
+            updated_at=stale_time,
+            artifacts_path=missing_dir,
+        )
+    )
+
+    from lionagi.studio.services.lifecycle import reap_phantom_sessions
+
+    count = run_async(reap_phantom_sessions(stale_hours=1.0))
+    assert count == 1
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess["status"] == "failed"
+    assert sess["duration_ms"] == pytest.approx((sess["ended_at"] - stale_time) * 1000)
 
 
 def test_reap_phantom_sessions_completes_mirrored_claude_session(tmp_path, monkeypatch):

--- a/tests/cli/test_engine_cli.py
+++ b/tests/cli/test_engine_cli.py
@@ -946,3 +946,53 @@ async def test_engine_run_skips_signal_binding_on_session_id_collision(
         # The engine_runs record itself still persisted.
         runs = await db.get_engine_run(run_id)
         assert runs is not None
+
+
+async def test_maybe_update_db_mirrors_engines_ended_at_onto_the_session(tmp_path):
+    """_maybe_update_db's engine_runs write and its mirrored session
+    update_status() call must agree on ended_at -- the caller-supplied
+    timestamp, not whatever time.time() the centralizer stamps on its own."""
+    pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+
+    from lionagi.cli.engine import _maybe_update_db
+    from lionagi.state.db import StateDB
+
+    db_path = tmp_path / "state.db"
+    run_id = "engine-ended-at-test-001"
+
+    async with StateDB(db_path) as db:
+        prog_id = f"{run_id}-prog"
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": run_id,
+                "created_at": 100.0,
+                "progression_id": prog_id,
+                "name": "engine:research",
+                "status": "running",
+                "started_at": 100.0,
+                "invocation_kind": None,
+            }
+        )
+        await db.insert_engine_run(
+            run_id=run_id,
+            kind="research",
+            spec_json={"spec": "GQA"},
+            started_at=100.0,
+            session_id=run_id,
+        )
+
+        await _maybe_update_db(
+            db,
+            run_id,
+            "completed",
+            ended_at=130.0,
+            signal_session_id=run_id,
+        )
+
+        session_row = await db.get_session(run_id)
+        engine_row = await db.get_engine_run(run_id)
+
+    assert engine_row["ended_at"] == 130.0
+    assert session_row["ended_at"] == 130.0
+    assert session_row["duration_ms"] == pytest.approx(30000.0)

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -753,6 +753,25 @@ async def test_persist_cancel_sets_status_cancelled(temp_db_path: Path):
         assert row["status"] == "cancelled"
 
 
+async def test_persist_cancel_populates_duration_ms(temp_db_path: Path):
+    async with StateDB() as db:
+        started_at = time.time() - 5.0
+        sid = await _seed_session(db, status="running", started_at=started_at)
+
+        await _persist_cancel(
+            db,
+            "session",
+            sid,
+            reason_code=RunReasons.CANCELLED_MANUAL_KILL,
+            reason_summary="test cancel",
+            evidence={"signal": "sigterm", "pid": 42},
+        )
+
+        row = await db.get_session(sid)
+        assert row["ended_at"] is not None
+        assert row["duration_ms"] == pytest.approx((row["ended_at"] - started_at) * 1000)
+
+
 async def test_persist_cancel_inserts_status_transition(temp_db_path: Path):
     async with StateDB() as db:
         sid = await _seed_session(db, status="running")

--- a/tests/cli/test_monitor_run.py
+++ b/tests/cli/test_monitor_run.py
@@ -1777,6 +1777,48 @@ async def test_dispatch_wait_reconciliation_never_flips_an_already_terminal_row(
 
 
 @pytest.mark.asyncio
+async def test_effective_session_status_reconcile_populates_duration_ms(
+    temp_db_path: Path,
+) -> None:
+    """Reconciling a profile session to its linked engine session's terminal
+    status must derive duration_ms the same as every other terminal write,
+    not leave it NULL because this call site never computed it."""
+    async with StateDB() as db:
+        profile_started_at = time.time() - 9.0
+        profile_prog = str(uuid.uuid4())
+        await db.create_progression(profile_prog)
+        profile_id = str(uuid.uuid4())
+        await db.create_session(
+            {
+                "id": profile_id,
+                "progression_id": profile_prog,
+                "status": "running",
+                "started_at": profile_started_at,
+                "node_metadata": {"linked_engine_session_id": "engine-recon-1"},
+            }
+        )
+        engine_prog = str(uuid.uuid4())
+        await db.create_progression(engine_prog)
+        await db.create_session(
+            {
+                "id": "engine-recon-1",
+                "progression_id": engine_prog,
+                "status": "completed",
+                "started_at": profile_started_at,
+            }
+        )
+
+        row = await db.get_session(profile_id)
+        result = await _effective_session_status(db, row)
+        assert result["status"] == "completed"
+
+        persisted = await db.get_session(profile_id)
+        assert persisted["ended_at"] is not None
+        assert persisted["duration_ms"] == pytest.approx(
+            (persisted["ended_at"] - profile_started_at) * 1000
+        )
+
+
 async def test_effective_session_status_cas_mismatch_reports_persisted_status(
     temp_db_path: Path,
 ) -> None:

--- a/tests/cli/test_state_commands.py
+++ b/tests/cli/test_state_commands.py
@@ -649,6 +649,24 @@ async def test_doctor_sweeps_stale_running_sessions_to_aborted(
     assert s_recent["status"] == "running"
 
 
+async def test_doctor_sweep_populates_duration_ms(temp_db_path: Path):
+    old = time.time() - (48 * 3600)
+    async with StateDB() as db:
+        stale = await _seed_session(db, status="running")
+        await db.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (old, stale),
+        )
+
+    result = await _doctor(stale_hours=24, dry_run=False)
+    assert result["swept"] == 1
+
+    async with StateDB() as db:
+        row = await db.get_session(stale)
+    assert row["ended_at"] is not None
+    assert row["duration_ms"] == pytest.approx((row["ended_at"] - old) * 1000)
+
+
 async def test_doctor_leaves_an_old_session_whose_process_is_still_running(
     temp_db_path: Path,
 ):

--- a/tests/cli/test_state_commands.py
+++ b/tests/cli/test_state_commands.py
@@ -852,3 +852,50 @@ async def test_doctor_with_failed_new_status(temp_db_path: Path):
     async with StateDB() as db:
         s = await db.get_session(sid)
     assert s["status"] == "failed"
+
+
+# ── _import_one_run: a row born terminal must carry a real duration_ms ────────
+
+
+async def test_import_of_a_completed_run_derives_duration_ms(temp_db_path: Path, tmp_path: Path):
+    """`li state import` inserts terminal rows directly via create_session(), a
+    path that never reaches _transition() or the admin CAS. It must derive
+    duration_ms itself rather than leaving the column null."""
+    from lionagi.cli.state import _import_one_run
+
+    run_dir = tmp_path / "runs" / "run-duration"
+    run_dir.mkdir(parents=True)
+
+    async with StateDB() as db:
+        await _import_one_run(
+            db,
+            "run-duration",
+            run_dir,
+            {"kind": "agent", "status": "completed", "started_at": 100.0, "ended_at": 130.0},
+        )
+        session = await db.get_session("run-duration")
+
+    assert session["status"] == "completed"
+    assert session["started_at"] == 100.0
+    assert session["ended_at"] == 130.0
+    assert session["duration_ms"] == 30000.0
+
+
+async def test_import_of_a_running_run_leaves_duration_ms_null(temp_db_path: Path, tmp_path: Path):
+    """A non-terminal import must not have a duration computed for it."""
+    from lionagi.cli.state import _import_one_run
+
+    run_dir = tmp_path / "runs" / "run-open"
+    run_dir.mkdir(parents=True)
+
+    async with StateDB() as db:
+        await _import_one_run(
+            db,
+            "run-open",
+            run_dir,
+            {"kind": "agent", "status": "running", "started_at": 100.0},
+        )
+        session = await db.get_session("run-open")
+
+    assert session["status"] == "running"
+    assert session["duration_ms"] is None

--- a/tests/cli/test_teardown_duration_ms.py
+++ b/tests/cli/test_teardown_duration_ms.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: duration_ms was left NULL on every terminal session row
+regardless of outcome -- loudest on a zero-turn timeout, where the row could
+not even say how long nothing happened for. _teardown_common must derive
+duration_ms from (ended_at - started_at) on the session row it is closing
+out, covering the case where no message was ever appended (no progression
+row exists yet)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from lionagi.cli._runs import _teardown_common
+from lionagi.state.db import StateDB
+
+
+@pytest.fixture
+async def db(tmp_path):
+    database = StateDB(tmp_path / "state.db")
+    await database.open()
+    try:
+        yield database
+    finally:
+        await database.close()
+
+
+async def test_teardown_common_populates_duration_ms_from_started_at(db, monkeypatch):
+    sid = "sess-duration-1"
+    started_at = 1_700_000_000.0
+    await db.create_progression("prog-duration-1")
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": "prog-duration-1",
+            "status": "running",
+            "started_at": started_at,
+        }
+    )
+
+    monkeypatch.setattr(time, "time", lambda: started_at + 12.5)
+    await _teardown_common(
+        db,
+        session_id=sid,
+        session_prog_id="prog-duration-1",
+        status="timed_out",
+        exception=None,
+        artifacts_path=None,
+        artifact_contract=None,
+    )
+
+    row = await db.get_session(sid)
+    assert row["duration_ms"] == pytest.approx(12_500.0)
+
+
+async def test_teardown_common_populates_duration_ms_on_zero_turn_timeout(db, monkeypatch):
+    """The exact #2495 shape: a session that timed out with no message ever
+    appended -- the progression row exists (created alongside the session)
+    but its collection is empty, so num_turns/input_tokens stay 0 and
+    duration_ms was previously the only field that could have said where the
+    time went, yet was itself always NULL."""
+    sid = "sess-duration-zero-turn"
+    started_at = 1_700_000_000.0
+    await db.create_progression("prog-zero-turn")
+    await db.create_session(
+        {
+            "id": sid,
+            "progression_id": "prog-zero-turn",
+            "status": "running",
+            "started_at": started_at,
+        }
+    )
+
+    monkeypatch.setattr(time, "time", lambda: started_at + 300.0)
+    await _teardown_common(
+        db,
+        session_id=sid,
+        session_prog_id="prog-zero-turn",
+        status="timed_out",
+        exception=None,
+        artifacts_path=None,
+        artifact_contract=None,
+    )
+
+    row = await db.get_session(sid)
+    assert row["duration_ms"] == pytest.approx(300_000.0)
+    assert row["first_msg_id"] is None

--- a/tests/cli/test_teardown_duration_ms.py
+++ b/tests/cli/test_teardown_duration_ms.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from lionagi.cli._runs import _teardown_common
+from lionagi.cli._runs import _teardown_common, find_incomplete_session_for_run
 from lionagi.state.db import StateDB
 
 
@@ -88,3 +88,72 @@ async def test_teardown_common_populates_duration_ms_on_zero_turn_timeout(db, mo
     row = await db.get_session(sid)
     assert row["duration_ms"] == pytest.approx(300_000.0)
     assert row["first_msg_id"] is None
+
+
+async def test_find_incomplete_session_for_run_populates_duration_ms(tmp_path, monkeypatch):
+    """setup-recovery path: a session row committed by setup_agent_persist()
+    before it raised is still 'running' forever unless recovered here -- the
+    recovery write must also carry a duration, not just a terminal status."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", db_path)
+
+    started_at = time.time() - 4.0
+    async with StateDB(db_path) as db:
+        prog_id = "prog-recover-1"
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": "sess-recover-1",
+                "run_id": "run-recover-1",
+                "progression_id": prog_id,
+                "status": "running",
+                "started_at": started_at,
+            }
+        )
+
+    row = await find_incomplete_session_for_run("run-recover-1")
+    assert row is not None
+    assert row["status"] == "failed"
+    assert row["ended_at"] is not None
+    assert row["duration_ms"] == pytest.approx((row["ended_at"] - started_at) * 1000)
+
+
+async def test_engine_maybe_update_db_populates_session_duration_ms(db):
+    """`li engine run` links an engine_runs row to a mirrored sessions row and
+    terminalizes both through _maybe_update_db(); the sessions row must carry
+    a duration the same as every other terminal write, and started_at must be
+    set at creation for there to be anything to subtract from."""
+    from lionagi.cli.engine import _maybe_update_db
+
+    started_at = 1_700_000_000.0
+    await db.insert_engine_run(
+        run_id="engine-run-1",
+        kind="research",
+        spec_json={},
+        started_at=started_at,
+    )
+    prog_id = "prog-engine-1"
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {
+            "id": "engine-session-1",
+            "created_at": started_at,
+            "started_at": started_at,
+            "progression_id": prog_id,
+            "name": "engine:research",
+            "status": "running",
+        }
+    )
+
+    await _maybe_update_db(
+        db,
+        "engine-run-1",
+        "completed",
+        ended_at=started_at + 42.0,
+        signal_session_id="engine-session-1",
+    )
+
+    row = await db.get_session("engine-session-1")
+    assert row["status"] == "completed"
+    assert row["ended_at"] is not None
+    assert row["duration_ms"] == pytest.approx((row["ended_at"] - started_at) * 1000)

--- a/tests/protocols/test_event_schema_drift.py
+++ b/tests/protocols/test_event_schema_drift.py
@@ -119,6 +119,8 @@ EXPECTED_SIGNAL_FIELDS: dict[str, tuple[str, ...]] = {
     ),
     "RunStart": ("created_at", "data", "emitter_role", "id", "metadata", "schema_version"),
     "RunEnd": (
+        "cache_write_tokens",
+        "cached_tokens",
         "created_at",
         "data",
         "duration_ms",

--- a/tests/protocols/test_event_schema_drift.py
+++ b/tests/protocols/test_event_schema_drift.py
@@ -132,6 +132,7 @@ EXPECTED_SIGNAL_FIELDS: dict[str, tuple[str, ...]] = {
         "output_tokens",
         "schema_version",
         "total_cost_usd",
+        "usage_valid",
     ),
     "RunFailed": ("created_at", "data", "emitter_role", "id", "metadata", "schema_version"),
     "NodeSpawned": (

--- a/tests/providers/test_claude_code_result_usage.py
+++ b/tests/providers/test_claude_code_result_usage.py
@@ -70,6 +70,46 @@ async def test_result_event_yields_result_chunk_with_usage_and_cost():
 
 
 @pytest.mark.asyncio
+async def test_result_event_with_model_usage_surfaces_it_on_result_chunk():
+    """The CLI's "result" event carries a whole-agent-tree per-model
+    ``modelUsage`` breakdown (includes Task-tool subagent spend) alongside
+    the top-level-loop-only ``usage`` field. It must be forwarded verbatim
+    on the result chunk so _collect_branch_usage can prefer it (#2379)."""
+    chunks = await _chunks_from_events(
+        [
+            _result_event(
+                usage={"input_tokens": 100, "output_tokens": 40},
+                modelUsage={
+                    "claude-sonnet-5": {
+                        "inputTokens": 100,
+                        "outputTokens": 40,
+                        "cacheReadInputTokens": 0,
+                        "cacheCreationInputTokens": 0,
+                    },
+                    "claude-haiku-4-5": {
+                        "inputTokens": 300,
+                        "outputTokens": 150,
+                        "cacheReadInputTokens": 0,
+                        "cacheCreationInputTokens": 0,
+                    },
+                },
+            )
+        ]
+    )
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert len(result_chunks) == 1
+    meta = result_chunks[0].metadata
+    assert meta["model_usage"]["claude-haiku-4-5"]["inputTokens"] == 300
+
+
+@pytest.mark.asyncio
+async def test_result_event_without_model_usage_omits_it_from_result_chunk():
+    chunks = await _chunks_from_events([_result_event()])
+    result_chunks = [c for c in chunks if c.type == "result"]
+    assert "model_usage" not in result_chunks[0].metadata
+
+
+@pytest.mark.asyncio
 async def test_result_event_without_usage_yields_no_result_chunk():
     """A result event carrying no usage/cost/turns/duration must not fabricate
     one -- no StreamChunk(type="result") at all, rather than one with zeros."""

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -1334,3 +1334,187 @@ class TestRetryConfigDefaultRetriesRealErrors:
                     with pytest.raises(ConnectionError):
                         await endpoint.call({}, skip_payload_creation=True)
         assert call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# #2393 — a retried POST to a non-idempotent creation endpoint must carry a
+# stable Idempotency-Key reused across every attempt, so an ambiguous lost
+# response cannot be replayed into a second billable job.
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotencyKeyOnRetriedPosts:
+    def _make_endpoint(self, *, idempotent_retries: bool, max_retries: int = 3) -> Endpoint:
+        config = EndpointConfig(
+            name="test",
+            provider="test",
+            endpoint="v1/images/generations",
+            base_url="https://api.test.com",
+            auth_type="bearer",
+            api_key="test-key",
+            method="POST",
+            max_retries=max_retries,
+            idempotent_retries=idempotent_retries,
+        )
+        return Endpoint(config=config)
+
+    def _make_ok_response(self, body: dict | None = None):
+        r = AsyncMock(spec=aiohttp.ClientResponse)
+        r.status = 200
+        r.closed = False
+        r.release = MagicMock()
+        r.json = AsyncMock(return_value=body or {"ok": True})
+        return r
+
+    def _make_error_response(self, status: int):
+        r = AsyncMock(spec=aiohttp.ClientResponse)
+        r.status = status
+        r.closed = False
+        r.release = MagicMock()
+        r.request_info = MagicMock()
+        r.history = []
+        r.headers = {}
+        r.json = AsyncMock(return_value={"error": f"status {status}"})
+
+        def _raise_for_status():
+            raise aiohttp.ClientResponseError(
+                request_info=r.request_info,
+                history=r.history,
+                status=status,
+                message=f"status {status}",
+                headers=r.headers,
+            )
+
+        r.raise_for_status = _raise_for_status
+        return r
+
+    @pytest.mark.asyncio
+    async def test_same_idempotency_key_reused_across_retries(self):
+        """A 500 on attempt 1 followed by a 200 on attempt 2 must reach the
+        server with the SAME Idempotency-Key both times -- a fresh key per
+        attempt would defeat server-side dedup of the ambiguous first try."""
+        endpoint = self._make_endpoint(idempotent_retries=True, max_retries=3)
+        sent_headers: list[dict] = []
+
+        attempt = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal attempt
+            attempt += 1
+            resp = self._make_error_response(500) if attempt == 1 else self._make_ok_response()
+
+            mock_session = AsyncMock(spec=aiohttp.ClientSession)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+
+            async def _request(*a, **kw):
+                sent_headers.append(dict(kw["headers"]))
+                return resp
+
+            mock_session.request = _request
+            return mock_session
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                with patch("lionagi.ln.concurrency.patterns.anyio.sleep", AsyncMock()):
+                    await endpoint.call({"prompt": "a cat"})
+
+        assert attempt == 2
+        assert len(sent_headers) == 2
+        assert "Idempotency-Key" in sent_headers[0]
+        assert sent_headers[0]["Idempotency-Key"] == sent_headers[1]["Idempotency-Key"]
+
+    @pytest.mark.asyncio
+    async def test_two_separate_calls_get_different_keys(self):
+        """Two distinct logical requests must not collide on the same key."""
+        endpoint = self._make_endpoint(idempotent_retries=True, max_retries=1)
+        sent_headers: list[dict] = []
+
+        def _make_new_session(*args, **kwargs):
+            mock_session = AsyncMock(spec=aiohttp.ClientSession)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+
+            async def _request(*a, **kw):
+                sent_headers.append(dict(kw["headers"]))
+                return self._make_ok_response()
+
+            mock_session.request = _request
+            return mock_session
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                await endpoint.call({"prompt": "a cat"})
+                await endpoint.call({"prompt": "a dog"})
+
+        assert len(sent_headers) == 2
+        assert sent_headers[0]["Idempotency-Key"] != sent_headers[1]["Idempotency-Key"]
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_absent_when_not_opted_in(self):
+        endpoint = self._make_endpoint(idempotent_retries=False, max_retries=1)
+        sent_headers: list[dict] = []
+
+        def _make_new_session(*args, **kwargs):
+            mock_session = AsyncMock(spec=aiohttp.ClientSession)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+
+            async def _request(*a, **kw):
+                sent_headers.append(dict(kw["headers"]))
+                return self._make_ok_response()
+
+            mock_session.request = _request
+            return mock_session
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                await endpoint.call({"prompt": "a cat"})
+
+        assert "Idempotency-Key" not in sent_headers[0]
+
+    @pytest.mark.asyncio
+    async def test_same_key_reused_across_retries_via_retry_config(self):
+        """The opt-in RetryConfig path re-invokes ``self._call`` (and therefore
+        ``_call_aiohttp``) fresh on every attempt from outside -- the key must
+        be minted in ``call()``, before that wrapper is entered, or each
+        attempt would silently mint its own."""
+        from lionagi.service.resilience import RetryConfig
+
+        config = EndpointConfig(
+            name="test",
+            provider="test",
+            endpoint="v1/images/generations",
+            base_url="https://api.test.com",
+            auth_type="bearer",
+            api_key="test-key",
+            method="POST",
+            idempotent_retries=True,
+        )
+        endpoint = Endpoint(config=config, retry_config=RetryConfig(max_retries=2, base_delay=0.01))
+        sent_headers: list[dict] = []
+        attempt = 0
+
+        def _make_new_session(*args, **kwargs):
+            nonlocal attempt
+            attempt += 1
+            resp = self._make_error_response(500) if attempt == 1 else self._make_ok_response()
+
+            mock_session = AsyncMock(spec=aiohttp.ClientSession)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=False)
+
+            async def _request(*a, **kw):
+                sent_headers.append(dict(kw["headers"]))
+                return resp
+
+            mock_session.request = _request
+            return mock_session
+
+        with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=True):
+            with patch.object(endpoint, "_create_http_session", side_effect=_make_new_session):
+                await endpoint.call({"prompt": "a cat"})
+
+        assert attempt == 2
+        assert len(sent_headers) == 2
+        assert sent_headers[0]["Idempotency-Key"] == sent_headers[1]["Idempotency-Key"]

--- a/tests/session/test_run_event_contract.py
+++ b/tests/session/test_run_event_contract.py
@@ -144,6 +144,162 @@ def test_collect_branch_usage_anthropic_convention():
     assert usage["output_tokens"] == 30
 
 
+# ---------------------------------------------------------------------------
+# #2889 — cache-token dimensions (Anthropic cache_read/cache_creation,
+# OpenAI prompt_tokens_details.cached_tokens)
+# ---------------------------------------------------------------------------
+
+
+def test_run_end_cache_token_fields_default():
+    sig = RunEnd()
+    assert sig.cached_tokens == 0
+    assert sig.cache_write_tokens == 0
+
+
+def test_run_end_cache_token_fields_explicit():
+    sig = RunEnd(cached_tokens=500, cache_write_tokens=25)
+    assert sig.cached_tokens == 500
+    assert sig.cache_write_tokens == 25
+
+
+def test_collect_branch_usage_anthropic_convention_pins_cache_dimensions():
+    """Anthropic-style payload: input_tokens already excludes cache; cache
+    reads/writes arrive as separate keys the old projection dropped entirely."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {
+                "input_tokens": 80,
+                "output_tokens": 30,
+                "cache_read_input_tokens": 500,
+                "cache_creation_input_tokens": 25,
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 80
+    assert usage["output_tokens"] == 30
+    assert usage["cached_tokens"] == 500
+    assert usage["cache_write_tokens"] == 25
+
+
+def test_collect_branch_usage_openai_convention_splits_cached_from_prompt_tokens():
+    """OpenAI-style payload: prompt_tokens INCLUDES cached reads; the old
+    projection folded them into input_tokens with no way to separate them
+    back out. cached_tokens must be split OUT of input_tokens, not added
+    alongside it."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {
+                "prompt_tokens": 1000,
+                "completion_tokens": 20,
+                "prompt_tokens_details": {"cached_tokens": 800},
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 200
+    assert usage["output_tokens"] == 20
+    assert usage["cached_tokens"] == 800
+    assert usage["cache_write_tokens"] == 0
+
+
+def test_collect_multi_branch_usage_sums_cache_dimensions():
+    branch_a = MagicMock()
+    branch_a.msgs.messages = [
+        MagicMock(
+            metadata={
+                "model_response": {
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "cache_read_input_tokens": 100,
+                        "cache_creation_input_tokens": 3,
+                    },
+                }
+            }
+        )
+    ]
+    branch_b = MagicMock()
+    branch_b.msgs.messages = [
+        MagicMock(
+            metadata={
+                "model_response": {
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 8,
+                        "cache_read_input_tokens": 50,
+                        "cache_creation_input_tokens": 7,
+                    },
+                }
+            }
+        )
+    ]
+    usage = _collect_multi_branch_usage([branch_a, branch_b])
+    assert usage["cached_tokens"] == 150
+    assert usage["cache_write_tokens"] == 10
+
+
+# ---------------------------------------------------------------------------
+# #2379 — claude_code whole-agent-tree usage: a per-model modelUsage
+# breakdown (subagent spend included) must be preferred over the flat,
+# top-level-loop-only usage dict when both are present on the same message.
+# ---------------------------------------------------------------------------
+
+
+def test_collect_branch_usage_prefers_model_usage_whole_tree_over_flat_usage():
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            # Flat usage: top-level loop only, undercounts a Task-tool subagent spawn.
+            "usage": {"input_tokens": 100, "output_tokens": 40},
+            # modelUsage: whole tree, includes the subagent's spend too.
+            "model_usage": {
+                "claude-sonnet-5": {
+                    "inputTokens": 100,
+                    "outputTokens": 40,
+                    "cacheReadInputTokens": 10,
+                    "cacheCreationInputTokens": 2,
+                },
+                "claude-haiku-4-5": {
+                    "inputTokens": 300,
+                    "outputTokens": 150,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                },
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 400
+    assert usage["output_tokens"] == 190
+    assert usage["cached_tokens"] == 10
+    assert usage["cache_write_tokens"] == 2
+    # Not the flat (self-only) figures -- those would undercount the subagent.
+    assert usage["input_tokens"] != 100
+
+
+def test_collect_branch_usage_falls_back_to_flat_usage_when_model_usage_absent():
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 100, "output_tokens": 40},
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 40
+
+
 def test_build_run_end_populates_from_branch():
     msg = MagicMock()
     msg.metadata = {

--- a/tests/session/test_run_event_contract.py
+++ b/tests/session/test_run_event_contract.py
@@ -300,6 +300,105 @@ def test_collect_branch_usage_falls_back_to_flat_usage_when_model_usage_absent()
     assert usage["output_tokens"] == 40
 
 
+def test_collect_branch_usage_model_usage_zero_valued_map_stays_zero():
+    """A genuinely zero-usage run reports a complete, well-shaped model_usage
+    map whose values are all zero -- must NOT be misrouted to flat usage just
+    because its sum is zero. Distinguishes 'valid entries summing to zero'
+    from 'no valid entries' (the malformed-map case below)."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 999, "output_tokens": 999},
+            "model_usage": {
+                "claude-sonnet-5": {
+                    "inputTokens": 0,
+                    "outputTokens": 0,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                },
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 0
+    assert usage["output_tokens"] == 0
+    assert usage["cached_tokens"] == 0
+    assert usage["cache_write_tokens"] == 0
+
+
+def test_collect_branch_usage_partial_model_usage_falls_back_to_flat():
+    """A truthy but partial/malformed model_usage map (entries missing the
+    expected keys) must not erase real flat usage with zeros."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 80, "output_tokens": 30},
+            "model_usage": {"claude-sonnet-5": {"inputTokens": 0, "outputTokens": 0}},
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 80
+    assert usage["output_tokens"] == 30
+
+
+def test_collect_branch_usage_truncated_model_usage_entry_falls_back_to_flat():
+    """A model_usage entry that is present but not a dict (e.g. truncated /
+    corrupted mid-stream) must be treated as no valid entry."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 55, "output_tokens": 12},
+            "model_usage": {"claude-sonnet-5": "truncated"},
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 55
+    assert usage["output_tokens"] == 12
+
+
+def test_collect_branch_usage_no_subagent_result_uses_flat_usage():
+    """No model_usage key at all (no subagent spawn occurred) -- ordinary
+    flat-usage path, unaffected by the validation added for model_usage."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 21, "output_tokens": 9},
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 21
+    assert usage["output_tokens"] == 9
+
+
+def test_collect_branch_usage_openai_cached_tokens_exceeding_prompt_clamps_to_zero():
+    """OpenAI cache metadata can report cached_tokens > prompt_tokens (a
+    provider invariant violation); prompt_tokens - cached_tokens must clamp
+    at 0 rather than reach an aggregate as a negative billable dimension."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {
+                "prompt_tokens": 80,
+                "completion_tokens": 5,
+                "prompt_tokens_details": {"cached_tokens": 100},
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 0
+    assert usage["cached_tokens"] == 80
+
+
 def test_build_run_end_populates_from_branch():
     msg = MagicMock()
     msg.metadata = {

--- a/tests/session/test_run_event_contract.py
+++ b/tests/session/test_run_event_contract.py
@@ -362,6 +362,107 @@ def test_collect_branch_usage_truncated_model_usage_entry_falls_back_to_flat():
     assert usage["output_tokens"] == 12
 
 
+def test_collect_branch_usage_one_valid_entry_beside_one_incomplete_entry_falls_back():
+    """A map with one well-shaped entry and one incomplete entry must not be
+    trusted just because one entry passed -- that silently undercounts
+    whatever the incomplete entry actually spent. The whole map falls back
+    to flat usage rather than reporting the partial sum."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 80, "output_tokens": 30},
+            "model_usage": {
+                "claude-sonnet-5": {
+                    "inputTokens": 10,
+                    "outputTokens": 5,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                },
+                "claude-haiku-4-5": {"inputTokens": 999, "outputTokens": 999},
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 80
+    assert usage["output_tokens"] == 30
+
+
+def test_collect_branch_usage_model_usage_non_integer_float_falls_back_to_flat():
+    """A float token count (e.g. 10.9) must not silently truncate into the
+    aggregate -- it is not a real token count, so the whole map is
+    untrustworthy and flat usage is used instead."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 80, "output_tokens": 30},
+            "model_usage": {
+                "claude-sonnet-5": {
+                    "inputTokens": 10.9,
+                    "outputTokens": 5,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                },
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 80
+    assert usage["output_tokens"] == 30
+
+
+def test_collect_branch_usage_model_usage_none_value_falls_back_to_flat():
+    """A None token count must not silently become zero -- it invalidates
+    the entry rather than being coerced."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 80, "output_tokens": 30},
+            "model_usage": {
+                "claude-sonnet-5": {
+                    "inputTokens": None,
+                    "outputTokens": 5,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                },
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 80
+    assert usage["output_tokens"] == 30
+
+
+def test_collect_branch_usage_model_usage_string_value_falls_back_without_raising():
+    """A non-numeric string token count must not raise out of the usage
+    collector -- it invalidates the entry and the collector falls back to
+    flat usage."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {"input_tokens": 80, "output_tokens": 30},
+            "model_usage": {
+                "claude-sonnet-5": {
+                    "inputTokens": "oops",
+                    "outputTokens": 5,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                },
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 80
+    assert usage["output_tokens"] == 30
+
+
 def test_collect_branch_usage_no_subagent_result_uses_flat_usage():
     """No model_usage key at all (no subagent spawn occurred) -- ordinary
     flat-usage path, unaffected by the validation added for model_usage."""
@@ -381,7 +482,9 @@ def test_collect_branch_usage_no_subagent_result_uses_flat_usage():
 def test_collect_branch_usage_openai_cached_tokens_exceeding_prompt_clamps_to_zero():
     """OpenAI cache metadata can report cached_tokens > prompt_tokens (a
     provider invariant violation); prompt_tokens - cached_tokens must clamp
-    at 0 rather than reach an aggregate as a negative billable dimension."""
+    at 0 rather than reach an aggregate as a negative billable dimension.
+    The clamped numbers alone look identical to a real full-cache hit, so
+    usage_valid must mark the report as untrustworthy."""
     msg = MagicMock()
     msg.metadata = {
         "model_response": {
@@ -397,6 +500,48 @@ def test_collect_branch_usage_openai_cached_tokens_exceeding_prompt_clamps_to_ze
     usage = _collect_branch_usage(branch)
     assert usage["input_tokens"] == 0
     assert usage["cached_tokens"] == 80
+    assert usage["usage_valid"] is False
+
+
+def test_collect_branch_usage_openai_valid_full_cache_hit_stays_valid():
+    """A genuine full-cache hit (cached_tokens == prompt_tokens) produces the
+    same clamped numbers as the invariant-violation case above, but must be
+    distinguishable via usage_valid=True."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {
+                "prompt_tokens": 80,
+                "completion_tokens": 5,
+                "prompt_tokens_details": {"cached_tokens": 80},
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 0
+    assert usage["cached_tokens"] == 80
+    assert usage["usage_valid"] is True
+
+
+def test_collect_branch_usage_openai_negative_prompt_tokens_clamps_and_marks_invalid():
+    """A malformed negative prompt total must not escape into the aggregate
+    as a negative input_tokens figure, and must be flagged invalid."""
+    msg = MagicMock()
+    msg.metadata = {
+        "model_response": {
+            "usage": {
+                "prompt_tokens": -5,
+                "completion_tokens": 0,
+            },
+        }
+    }
+    branch = MagicMock()
+    branch.msgs.messages = [msg]
+    usage = _collect_branch_usage(branch)
+    assert usage["input_tokens"] == 0
+    assert usage["usage_valid"] is False
 
 
 def test_build_run_end_populates_from_branch():


### PR DESCRIPTION
## What changed

Four fixes to usage accounting and provider paths that under-report.

### Cache token dimensions are no longer lost (one arithmetic fix, two symptoms)

`_collect_branch_usage` in `lionagi/session/signal.py` projected a provider's raw usage
dict onto `input_tokens` / `output_tokens` in a way that either dropped Anthropic's cache
dimensions entirely or folded OpenAI's cached-read tokens into `input_tokens` with no way
to split them back out.

- `RunEnd` gains `cached_tokens` and `cache_write_tokens`, both defaulting to 0.
- `_extract_usage_dims()` splits a flat usage dict into input, output, cached, and
  cache-write under both conventions: Anthropic's `cache_read_input_tokens` /
  `cache_creation_input_tokens` are additive because `input_tokens` already excludes
  cache, while OpenAI's `prompt_tokens_details.cached_tokens` is subtracted from
  `prompt_tokens`. After this, `input_tokens` means "uncached" under both.
- `_collect_multi_branch_usage` sums the two new fields across branches.

### Whole-tree cost for the Claude CLI

The same function never looked at a CLI result's `modelUsage` breakdown, so any run where a
Task-tool subagent spawned inside one CLI invocation was undercounted — the flat `usage`
field is top-level-loop-only, while `modelUsage` is whole-agent-tree per the agent SDK's own
contract.

`_sum_model_usage()` sums the per-model `modelUsage` map, `stream_claude_code_cli` captures
`modelUsage` from the terminal result event and forwards it as `result_meta["model_usage"]`,
and `_collect_branch_usage` prefers it over the flat dict when present and non-empty.

This is not hypothetical: the codebase's own `cli_session.py::_extract_summary` already
special-cases `Task` / `Agent` tool names as spawned agents, so the undercount is live.

### Retries no longer duplicate non-idempotent creation POSTs

`EndpointConfig` gains `idempotent_retries` (default false). When a config opts in and the
method is POST, `Endpoint.call()` mints one `Idempotency-Key` per logical request — before
either retry path is entered, so the native retry loop and the opt-in retry wrapper both
reuse the same key across every attempt rather than minting a fresh one per try.

### `duration_ms` is populated on every terminal session row

Previously it was absent on some terminal paths, so a row could report a terminal status
with no duration.

## Tests

- `tests/session/test_run_event_contract.py` — 7 new tests, arithmetic-pinned rather than
  shape-pinned: `{"prompt_tokens": 1000, "cached_tokens": 800}` must yield
  `input_tokens=200`, not 1000 and not 800; a mixed `model_usage` fixture must yield
  `input_tokens=400` from two models, not the flat `100`.
- `tests/providers/test_claude_code_result_usage.py` — 2 new tests for `modelUsage`
  passthrough.
- `tests/service/connections/test_endpoint.py` and `tests/cli/test_teardown_duration_ms.py`
  cover the other two fixes.
- The `RunEnd` golden in `tests/protocols/test_event_schema_drift.py` is updated in the same
  commit, as that file's own docstring requires.

Red was confirmed by restoring the three changed source files to their pre-change content and
re-running: 6 failures, all on the new assertions, then restored and green.

## Gate

The gate set was derived by grepping for the changed symbols rather than from the diff's own
directories. Every test passes except six that fail identically at the base commit and are
environmental rather than code: two need the `ollama` extra, one needs `pandas`, and three in
`test_cli_cancellation.py` assert `create_subprocess_exec` was called once, which is false on
any machine with a keychain-backed secrets lookup configured — the lookup shells out before the
CLI call. That last group is the same machine-sensitivity as the known-noisy
`test_ndjson_from_cli_inherits_stamped_depth`.

## Deliberately not included

**#2048** (gemini records zero tool calls) was investigated and not fixed. Tool events are only
available on the CLI's `stream-json` transport, which emits a materially different event shape:
text extraction, error and empty-success detection, and `num_turns` / duration semantics all move
from top-level fields into a nested result object plus multiple step-update events. The current
single-object JSON contract is pinned by roughly 20 tests across 552 lines. Switching transports
is a parsing-contract change, not a narrow patch. Separately, that CLI only accepts MCP servers
through config files, with no per-invocation flag, so per-request MCP scoping is not a flag
addition either.

Closes #2889
Closes #2379
Closes #2393
Closes #2495
