### PR TITLE
fix(scheduler): keep the tick unblocked, admit ad-hoc work through the global limit, and reconcile dispatched orphans

### DIFF
--- a/docs/adr/ADR-0070-studio-scheduling-and-dispatch-delivery.md
+++ b/docs/adr/ADR-0070-studio-scheduling-and-dispatch-delivery.md
@@ -99,6 +99,9 @@ Relevant settings and defaults are:
 MAX_SCHEDULED_CONCURRENT = int(
     os.environ.get("LIONAGI_STUDIO_MAX_SCHEDULED_CONCURRENT", "4")
 )
+MAX_ADHOC_CONCURRENT = int(
+    os.environ.get("LIONAGI_STUDIO_MAX_ADHOC_CONCURRENT", "4")
+)
 INVOCATION_DEADLINE_SECONDS = int(
     os.environ.get("LIONAGI_STUDIO_INVOCATION_DEADLINE_SECONDS", "7200")
 )
@@ -110,6 +113,13 @@ CHECKPOINT_INTERVAL_SECONDS = int(
     os.environ.get("LIONAGI_STUDIO_CHECKPOINT_INTERVAL_SECONDS", "3600")
 )
 ```
+
+`MAX_ADHOC_CONCURRENT` bounds the host task-worker pass's own executions (step 4 above) from a
+capacity pool independent of `MAX_SCHEDULED_CONCURRENT`: the two lanes are additive, so a daemon
+running both at their defaults permits up to `4 + 4 = 8` concurrent executions, not 4. `0` makes
+either lane unlimited. `GET /api/schedules/limits` reports both caps and both in-flight counts
+(`max_scheduled_concurrent`/`current_inflight` and `max_adhoc_concurrent`/`current_adhoc_inflight`)
+so an operator can read the daemon's actual total capacity rather than assuming one shared ceiling.
 
 Exact lifecycle semantics:
 

--- a/lionagi/cli/machine_schedule.py
+++ b/lionagi/cli/machine_schedule.py
@@ -262,6 +262,7 @@ def _limits(argv: list[str]) -> dict[str, Any]:
     _parse("limits", argv, unhonoured={})
     result = _studio("/limits") or {}
     cap = result.get("max_scheduled_concurrent")
+    adhoc_cap = result.get("max_adhoc_concurrent")
     return {
         # Both are reported because the cap alone is ambiguous: the CLI reads a
         # falsy cap as no cap at all, and a caller should not have to know
@@ -269,6 +270,13 @@ def _limits(argv: list[str]) -> dict[str, Any]:
         "max_scheduled_concurrent": cap,
         "unlimited": not cap,
         "current_inflight": result.get("current_inflight", 0),
+        # The ad-hoc task-worker lane draws from its own independent
+        # capacity pool (see MAX_ADHOC_CONCURRENT), additive to the
+        # scheduled cap above -- a caller provisioning for the scheduled cap
+        # alone would under-provision by this lane's own capacity.
+        "max_adhoc_concurrent": adhoc_cap,
+        "adhoc_unlimited": not adhoc_cap,
+        "current_adhoc_inflight": result.get("current_adhoc_inflight", 0),
     }
 
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -4514,6 +4514,34 @@ class StateDB:
             )
         return [self._row_to_dict(r) for r in rows]
 
+    async def list_dispatched_running_schedule_runs(self) -> list[dict[str, Any]]:
+        """Scheduler-fired occurrence rows confirmed dispatched (an external
+        process was launched) but never reached a terminal status --
+        distinct from ``list_undispatched_schedule_runs()``'s "never
+        launched" case. The scheduler process that dispatched one of these
+        may have crashed before recording its outcome, or the process it
+        launched may still be genuinely alive and working; this method only
+        surfaces candidates for reconciliation, it does not itself decide
+        liveness (see ``SchedulerEngine._reconcile_dispatched_orphans``).
+        Scoped to rows with a linked invocation, the only case that carries
+        independently-observable completion evidence today.
+        """
+        async with self._read() as conn:
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT * FROM schedule_runs WHERE status = 'running' "
+                            "AND dispatched_at IS NOT NULL AND schedule_id IS NOT NULL "
+                            "AND invocation_id IS NOT NULL"
+                        )
+                    )
+                )
+                .mappings()
+                .all()
+            )
+        return [self._row_to_dict(r) for r in rows]
+
     async def get_schedule_run(self, run_id: str) -> dict[str, Any] | None:
         async with self._read() as conn:
             row = (

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -837,8 +837,12 @@ def _cmd_limits(args: argparse.Namespace) -> int:
         return 1
     cap = result.get("max_scheduled_concurrent")
     cap_display = "unlimited" if not cap else str(cap)
-    print(f"Max concurrent fires: {cap_display}")
-    print(f"Current in-flight:    {result.get('current_inflight', 0)}")
+    print(f"Max concurrent fires:      {cap_display}")
+    print(f"Current in-flight:         {result.get('current_inflight', 0)}")
+    adhoc_cap = result.get("max_adhoc_concurrent")
+    adhoc_cap_display = "unlimited" if not adhoc_cap else str(adhoc_cap)
+    print(f"Max concurrent ad-hoc:     {adhoc_cap_display}")
+    print(f"Current ad-hoc in-flight:  {result.get('current_adhoc_inflight', 0)}")
     return 0
 
 

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -237,6 +237,14 @@ MAX_LAUNCHES: int = int(os.environ.get("LIONAGI_STUDIO_MAX_LAUNCHES", "4"))
 # 0 = unlimited. When saturated, a due fire defers to the next tick (never dropped).
 MAX_SCHEDULED_CONCURRENT: int = int(os.environ.get("LIONAGI_STUDIO_MAX_SCHEDULED_CONCURRENT", "4"))
 
+# Maximum concurrent ad-hoc task-worker executions (lionagi.studio.scheduler.worker),
+# reserved from its own capacity pool -- deliberately independent of
+# MAX_SCHEDULED_CONCURRENT. A shared cap between the two lanes lets a
+# continuously replenished stream of scheduled fires reacquire every freed
+# slot before the worker pass gets one, starving ad-hoc work indefinitely.
+# 0 = unlimited (worker executions impose no concurrency limit of their own).
+MAX_ADHOC_CONCURRENT: int = int(os.environ.get("LIONAGI_STUDIO_MAX_ADHOC_CONCURRENT", "4"))
+
 # ── Lifecycle reaper config ───────────────────────────────────────────────────
 # Default invocation deadline in seconds (2 hours). Override per action kind
 # via LIONAGI_STUDIO_INVOCATION_DEADLINE_<KIND>_SECONDS (e.g. _AGENT_SECONDS).

--- a/lionagi/studio/operator/run_progress.py
+++ b/lionagi/studio/operator/run_progress.py
@@ -278,7 +278,10 @@ def _resolution_from_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-_COMPLETED_STATUSES = frozenset({"completed", "completed_empty"})
+# ADR-0064: completed_empty is terminal but unsuccessful (no trusted
+# evidence produced) -- it is not in this set, so it falls through to the
+# SESSION_TERMINAL_STATUSES branch below and counts as an op failure.
+_COMPLETED_STATUSES = frozenset({"completed"})
 
 # Per-node lifecycle lane, mirroring the ONLY existing "how far along is a DAG
 # run" projection this codebase has:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -390,6 +390,11 @@ class SchedulerEngine:
         self._svc = svc if svc is not None else default_scheduler_state
         self._signal_bus = signal_bus if signal_bus is not None else SchedulerSignalBus()
         self._task: asyncio.Task | None = None
+        # Single-flight tracked task for the ad-hoc task-worker pass (see
+        # _maybe_start_worker_pass): a hung/slow pass must not block schedule
+        # evaluation, and a new tick must never start a second overlapping
+        # pass while one is still in flight.
+        self._worker_task: asyncio.Task | None = None
         self._running: dict[str, str] = {}  # schedule_id -> run_id
         self._stopping = False
         self._fire_tasks: set[asyncio.Task] = set()
@@ -667,6 +672,11 @@ class SchedulerEngine:
             except asyncio.CancelledError:
                 pass
             self._task = None
+        if self._worker_task is not None:
+            self._worker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._worker_task
+            self._worker_task = None
         if self._fire_tasks:
             for ft in list(self._fire_tasks):
                 ft.cancel()
@@ -1004,10 +1014,7 @@ class SchedulerEngine:
         except Exception:
             _log.exception("Dispatch outbox delivery scan error")
 
-        try:
-            await self._run_task_worker_tick(now)
-        except Exception:
-            _log.exception("Task worker tick error")
+        self._maybe_start_worker_pass(now)
 
         schedules = await self._svc.list_schedules(enabled=True)
 
@@ -1043,6 +1050,28 @@ class SchedulerEngine:
 
         async with StateDB() as db:
             await deliver_due_dispatches(db, now=now)
+
+    def _maybe_start_worker_pass(self, now: float) -> None:
+        """Kick off the ad-hoc task-worker pass as a tracked, single-flight
+        background task instead of awaiting it inline.
+
+        A worker pass claims rows sequentially and each row waits on its
+        child process with no deadline (see ``spawn_and_wait``), so awaiting
+        it here would block schedule evaluation for the whole pass. If a
+        pass from a prior tick is still running, this tick starts no new one
+        — never more than one worker pass in flight, so this does not
+        increase the row-claiming throughput, only schedule-evaluation
+        latency.
+        """
+        if self._worker_task is not None and not self._worker_task.done():
+            return
+        self._worker_task = asyncio.create_task(self._run_task_worker_tick_guarded(now))
+
+    async def _run_task_worker_tick_guarded(self, now: float) -> None:
+        try:
+            await self._run_task_worker_tick(now)
+        except Exception:
+            _log.exception("Task worker tick error")
 
     async def _run_task_worker_tick(self, now: float) -> None:
         """ADR-0071 D4: reap lapsed leases and claim/execute eligible host

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -57,9 +57,15 @@ _MAX_PREDISPATCH_REFUSALS = 3
 # maps resolve_invocation_terminal()'s invocation-vocabulary result onto the
 # nearest schedule_run status; the finer distinction still survives in the
 # written reason_code (COMPLETED_EMPTY_NO_EVIDENCE, ABORTED_USER, etc).
+# completed_empty maps to "failed", not "completed": a clean leader exit
+# with no completion evidence from the child is explicitly NOT success (see
+# resolve_invocation_terminal's own precedence comment), and the mapped
+# status is also what selects the schedule_run signal class in
+# build_schedule_run_signal() -- mapping it to "completed" would mint
+# ScheduleRunSucceeded for a run nothing confirms actually finished.
 _SCHEDULE_RUN_STATUS_FROM_INVOCATION: dict[str, str] = {
     "completed": "completed",
-    "completed_empty": "completed",
+    "completed_empty": "failed",
     "failed": "failed",
     "timed_out": "timed_out",
     "cancelled": "cancelled",

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -2722,13 +2722,29 @@ class SchedulerEngine:
             # earlier so a cancellation mid-run is classified the same way.
             dispatched = True
             end_time = time.time()
-            status = "completed" if exit_code == 0 else "failed"
-            if exit_code == 0:
+
+            # Resolved BEFORE the schedule_run write below, so that write --
+            # and the signal, telemetry, and chain decisions that follow --
+            # all agree with the invocation's own resolved outcome instead
+            # of trusting the leader's raw exit_code in isolation. A clean
+            # exit (exit_code == 0) with a child session that has not
+            # independently reached a terminal status resolves to
+            # "completed_empty", not "completed": this scheduler treats
+            # that as NOT success, so it cannot pick the same schedule_run
+            # status/reason, signal, or on_success chain action a genuine
+            # completion would.
+            exit_status = "completed" if exit_code == 0 else "failed"
+            inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
+                self._svc, inv_id, fallback_status=exit_status, exit_code=exit_code
+            )
+            success = inv_status == "completed"
+            status = _SCHEDULE_RUN_STATUS_FROM_INVOCATION.get(inv_status, exit_status)
+            if success:
                 reason_code = RunReasons.COMPLETED_OK
                 reason_summary = "Scheduled process completed successfully."
             else:
-                reason_code = RunReasons.FAILED_EXIT_NONZERO
-                reason_summary = f"Scheduled process exited non-zero: {exit_code}."
+                reason_code = inv_rc
+                reason_summary = inv_rs
 
             written = await self._guarded_terminal_status(
                 "schedule_run",
@@ -2739,7 +2755,7 @@ class SchedulerEngine:
                 evidence_refs=[{"kind": "invocation", "id": inv_id}],
                 source="executor",
                 actor=run_id,
-                metadata={"exit_code": exit_code},
+                metadata={"exit_code": exit_code, "invocation_status": inv_status},
                 extra_fields={
                     "exit_code": exit_code,
                     "ended_at": end_time,
@@ -2759,9 +2775,6 @@ class SchedulerEngine:
                         error_detail=stderr_tail if exit_code != 0 else "",
                     )
                 )
-            inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
-                self._svc, inv_id, fallback_status=status, exit_code=exit_code
-            )
             inv_written = await self._guarded_terminal_status(
                 "invocation",
                 inv_id,
@@ -2790,9 +2803,9 @@ class SchedulerEngine:
 
             if chain_depth < _MAX_CHAIN_DEPTH:
                 chain_action = None
-                if exit_code == 0 and schedule.get("on_success"):
+                if success and schedule.get("on_success"):
                     chain_action = schedule["on_success"]
-                elif exit_code != 0 and schedule.get("on_fail"):
+                elif not success and schedule.get("on_fail"):
                     chain_action = schedule["on_fail"]
 
                 if chain_action:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -145,6 +145,30 @@ class _GlobalSlotClaim:
         self._engine._release_global_slot()
 
 
+class _AdhocSlotClaim:
+    """One-shot handle for an in-process ad-hoc task-worker concurrency slot.
+
+    Deliberately a separate pool from ``_GlobalSlotClaim``/
+    ``MAX_SCHEDULED_CONCURRENT``: sharing one counter between the scheduled
+    and ad-hoc lanes let a continuously replenished stream of scheduled
+    fires reacquire every freed slot before the worker pass got one,
+    starving ad-hoc work indefinitely. Same release-once-in-a-finally
+    lifecycle as ``_GlobalSlotClaim``.
+    """
+
+    __slots__ = ("_engine", "_released")
+
+    def __init__(self, engine: SchedulerEngine) -> None:
+        self._engine = engine
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._engine._release_adhoc_slot()
+
+
 class _RateLimitClaim:
     """One-shot reservation against a schedule's rolling-window fire cap."""
 
@@ -426,8 +450,16 @@ class SchedulerEngine:
         self._rate_limit_lock = asyncio.Lock()
         self._rate_limit_inflight: dict[str, dict[str, float]] = {}
         # global concurrent-fire cap (single-process; see _reserve_global_slot).
+        # Scoped to SCHEDULED fires only -- the ad-hoc task-worker lane has
+        # its own independent cap below (see _reserve_adhoc_slot) so the two
+        # lanes cannot starve each other.
         self._global_slot_lock = asyncio.Lock()
         self._global_inflight = 0
+        # ad-hoc task-worker concurrency cap (single-process; see
+        # _reserve_adhoc_slot). Independent of _global_inflight/
+        # MAX_SCHEDULED_CONCURRENT by design.
+        self._adhoc_slot_lock = asyncio.Lock()
+        self._adhoc_inflight = 0
         self._deferred_log_counts: dict[str, int] = {}  # schedule_id -> deferrals since last record
         # threshold-alert cooldown reservations (single-process; see
         # _ThresholdCooldownClaim). Membership means "a fire for this
@@ -1181,11 +1213,14 @@ class SchedulerEngine:
         task applications. Not interval-gated for the same reason as
         ``_deliver_due_dispatches`` — the 30s tick is the latency floor.
 
-        Each execution reserves one of this daemon's global concurrent-fire
-        slots (``_reserve_global_slot``) so ad-hoc executions count against
-        ``MAX_SCHEDULED_CONCURRENT`` the same way scheduled fires do —
-        without this, real top-level concurrency was the configured cap plus
-        one worker lane (see #2751).
+        Each execution reserves one of this daemon's ad-hoc concurrency
+        slots (``_reserve_adhoc_slot``) so ad-hoc executions are bounded by
+        ``MAX_ADHOC_CONCURRENT`` — a pool deliberately independent of
+        ``MAX_SCHEDULED_CONCURRENT``/``_reserve_global_slot``: sharing one
+        counter between the two lanes let a continuously replenished stream
+        of scheduled fires reacquire every freed slot before this pass got
+        one, starving ad-hoc work indefinitely. Each lane now has its own
+        guaranteed capacity instead of competing for one shared pool.
         """
         from lionagi.state.db import StateDB
         from lionagi.studio.scheduler import worker as _worker
@@ -1202,7 +1237,7 @@ class SchedulerEngine:
                 db,
                 worker_id=self._task_worker_id,
                 now=now,
-                reserve_slot=self._reserve_global_slot,
+                reserve_slot=self._reserve_adhoc_slot,
                 release_slot=_release,
             )
 
@@ -1641,6 +1676,28 @@ class SchedulerEngine:
 
     def _release_global_slot(self) -> None:
         self._global_inflight = max(0, self._global_inflight - 1)
+
+    async def _reserve_adhoc_slot(self) -> tuple[bool, _AdhocSlotClaim | None]:
+        """Atomically claim one ad-hoc task-worker concurrency slot.
+
+        Mirrors ``_reserve_global_slot()`` but draws from its own counter
+        (``_adhoc_inflight``/``MAX_ADHOC_CONCURRENT``), independent of the
+        scheduled-fire cap. This is the ad-hoc lane's dedicated capacity: it
+        is never refused because the scheduled lane happens to be saturated,
+        and vice versa, so neither lane can starve the other.
+        """
+        from lionagi.studio.config import MAX_ADHOC_CONCURRENT
+
+        if MAX_ADHOC_CONCURRENT <= 0:
+            return True, None
+        async with self._adhoc_slot_lock:
+            if self._adhoc_inflight >= MAX_ADHOC_CONCURRENT:
+                return False, None
+            self._adhoc_inflight += 1
+            return True, _AdhocSlotClaim(self)
+
+    def _release_adhoc_slot(self) -> None:
+        self._adhoc_inflight = max(0, self._adhoc_inflight - 1)
 
     async def _maybe_record_deferred(self, schedule: dict, now: float) -> None:
         """Emit a throttled skipped-run record for a capacity-deferred fire.

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -1077,14 +1077,31 @@ class SchedulerEngine:
         """ADR-0071 D4: reap lapsed leases and claim/execute eligible host
         task applications. Not interval-gated for the same reason as
         ``_deliver_due_dispatches`` — the 30s tick is the latency floor.
+
+        Each execution reserves one of this daemon's global concurrent-fire
+        slots (``_reserve_global_slot``) so ad-hoc executions count against
+        ``MAX_SCHEDULED_CONCURRENT`` the same way scheduled fires do —
+        without this, real top-level concurrency was the configured cap plus
+        one worker lane (see #2751).
         """
         from lionagi.state.db import StateDB
         from lionagi.studio.scheduler import worker as _worker
 
         if not _worker.TASK_WORKER_ENABLED:
             return
+
+        def _release(claim: Any) -> None:
+            if claim is not None:
+                claim.release()
+
         async with StateDB() as db:
-            await _worker.worker_tick(db, worker_id=self._task_worker_id, now=now)
+            await _worker.worker_tick(
+                db,
+                worker_id=self._task_worker_id,
+                now=now,
+                reserve_slot=self._reserve_global_slot,
+                release_slot=_release,
+            )
 
     async def _tick_github(self, schedule: dict, now: float) -> None:
         poll_interval = resolve_schedule_cadence_seconds(schedule)

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -832,6 +832,12 @@ class SchedulerEngine:
             schedules = await self._svc.list_schedules(enabled=True)
             now = time.time()
             for s in schedules:
+                if s.get("trigger_type") == "github_poll":
+                    # github_poll's cadence is last_fired_at + poll_interval_sec
+                    # (see _tick_github), not next_fire_at -- a stale or
+                    # legacy-persisted next_fire_at here is not a missed
+                    # scheduled occurrence.
+                    continue
                 next_fire_at = s.get("next_fire_at")
                 if next_fire_at is None or next_fire_at > now:
                     continue

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -17,7 +17,7 @@ from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from lionagi.ln.concurrency import ExceptionGroup
-from lionagi.state.db import TERMINAL_RUN_STATUSES
+from lionagi.state.db import SESSION_TERMINAL_STATUSES, TERMINAL_RUN_STATUSES
 from lionagi.state.lifecycle.callbacks import DEFAULT_TERMINAL_CALLBACKS, RunTerminalEnvelope
 from lionagi.state.lifecycle.notify_settings import build_handler, resolve_notify_config
 from lionagi.state.reasons import RunReasons, ScheduleReasons
@@ -50,6 +50,21 @@ _DEFERRED_RECORD_EVERY = 10
 # it's recorded terminal and the cursor moves past it, so one poison event
 # can't block the queue forever.
 _MAX_PREDISPATCH_REFUSALS = 3
+
+# schedule_runs has no 'completed_empty' or 'aborted' status (see
+# lionagi.state.lifecycle.policy's schedule_run_statuses) -- only
+# invocations/sessions distinguish those. _reconcile_dispatched_orphans()
+# maps resolve_invocation_terminal()'s invocation-vocabulary result onto the
+# nearest schedule_run status; the finer distinction still survives in the
+# written reason_code (COMPLETED_EMPTY_NO_EVIDENCE, ABORTED_USER, etc).
+_SCHEDULE_RUN_STATUS_FROM_INVOCATION: dict[str, str] = {
+    "completed": "completed",
+    "completed_empty": "completed",
+    "failed": "failed",
+    "timed_out": "timed_out",
+    "cancelled": "cancelled",
+    "aborted": "cancelled",
+}
 
 
 def _register_schedule_notify(
@@ -748,6 +763,7 @@ class SchedulerEngine:
 
     async def _tick_loop(self) -> None:
         await self._recover_undispatched_fires()
+        await self._reconcile_dispatched_orphans()
         await self._check_missed_fires()
         while not self._stopping:
             try:
@@ -836,6 +852,93 @@ class SchedulerEngine:
             # Raced with something else finalizing this row (e.g. the
             # stale-run reaper) between the scan and here; already resolved.
             pass
+
+    async def _reconcile_dispatched_orphans(self) -> None:
+        """Startup-only reconciliation for schedule_runs rows that were
+        confirmed dispatched (an external process was launched) but never
+        reached a terminal status (see #2755).
+
+        Unlike ``_recover_undispatched_fires()`` (``dispatched_at IS NULL``,
+        safe to re-fire because nothing was ever launched), a row here may
+        have a genuinely live child still working -- re-firing would
+        double-execute it, and blindly terminalizing it would falsely mark
+        live work dead. Neither is safe from wall-clock alone.
+
+        This only acts where positive completion evidence already exists in
+        the DB without needing new process-identity capture: an action that
+        spawned its own session(s) (e.g. ``agent``/``play``) writes each
+        session's own terminal status from *inside* that child process, via
+        its own teardown -- entirely independent of whether the scheduler
+        that dispatched it survived to see the exit code. When every linked
+        session has independently reached a terminal status, the
+        schedule_run is finalized from that evidence via
+        ``resolve_invocation_terminal()`` (the same resolution the live
+        ``_fire()`` path uses for the invocation row). A row with no
+        sessions yet, or with any session still non-terminal, is left
+        untouched -- unknown liveness is never treated as death; it falls
+        through to the existing wall-clock stale reaper
+        (``reap_stale_schedule_runs``) unchanged.
+        """
+        try:
+            rows = await self._svc.list_dispatched_running_schedule_runs()
+        except Exception:
+            _log.exception("Failed to scan for dispatched-but-unterminated schedule_runs")
+            return
+
+        for row in rows:
+            run_id = row["id"]
+            inv_id = row.get("invocation_id")
+            if not inv_id:
+                continue
+            try:
+                sessions = await self._svc.list_sessions_for_invocation(inv_id)
+            except Exception:
+                _log.exception(
+                    "Failed to list sessions for invocation %s (schedule_run %s)", inv_id, run_id
+                )
+                continue
+            if not sessions:
+                continue
+            child_statuses = [str(s.get("status") or "") for s in sessions]
+            if any(s not in SESSION_TERMINAL_STATUSES for s in child_statuses):
+                continue  # at least one child still genuinely non-terminal
+
+            inv_status, inv_rc, inv_rs, inv_ev, _inv_meta = await resolve_invocation_terminal(
+                self._svc, inv_id, fallback_status="completed"
+            )
+            run_status = _SCHEDULE_RUN_STATUS_FROM_INVOCATION.get(inv_status)
+            if run_status is None:
+                _log.warning(
+                    "Unmapped invocation status %r reconciling schedule_run %s; leaving as-is",
+                    inv_status,
+                    run_id,
+                )
+                continue
+
+            written = await self._guarded_terminal_status(
+                "schedule_run",
+                run_id,
+                new_status=run_status,
+                reason_code=inv_rc,
+                reason_summary=(
+                    f"{inv_rs} (reconciled at scheduler startup from child session "
+                    "evidence; the scheduler that dispatched this run did not "
+                    "record its outcome)."
+                ),
+                evidence_refs=inv_ev,
+                source="system",
+                actor="scheduler_startup_reconciliation",
+                metadata={"invocation_id": inv_id, "invocation_status": inv_status},
+                extra_fields={"ended_at": time.time()},
+            )
+            if written:
+                _log.info(
+                    "Reconciled dispatched-orphan schedule_run %s as %s from child "
+                    "session evidence (invocation %s)",
+                    run_id,
+                    run_status,
+                    inv_id,
+                )
 
     async def _check_missed_fires(self) -> None:
         try:

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -919,6 +919,7 @@ class SchedulerEngine:
 
         for row in rows:
             run_id = row["id"]
+            sid = row.get("schedule_id")
             inv_id = row.get("invocation_id")
             if not inv_id:
                 continue
@@ -935,7 +936,7 @@ class SchedulerEngine:
             if any(s not in SESSION_TERMINAL_STATUSES for s in child_statuses):
                 continue  # at least one child still genuinely non-terminal
 
-            inv_status, inv_rc, inv_rs, inv_ev, _inv_meta = await resolve_invocation_terminal(
+            inv_status, inv_rc, inv_rs, inv_ev, inv_meta = await resolve_invocation_terminal(
                 self._svc, inv_id, fallback_status="completed"
             )
             run_status = _SCHEDULE_RUN_STATUS_FROM_INVOCATION.get(inv_status)
@@ -947,6 +948,16 @@ class SchedulerEngine:
                 )
                 continue
 
+            end_time = time.time()
+            chain_depth = row.get("chain_depth") or 0
+            trigger_context = row.get("trigger_context") or {}
+            action_kind = row.get("action_kind") or ""
+
+            # Guarded CAS below is the idempotency boundary against a race
+            # with another finalizer (the live _fire() path, the deadline
+            # reaper, or a concurrent reconciliation pass): losing it means
+            # someone else already owns finalizing this row's follow-on
+            # effects, so this pass does nothing further for it.
             written = await self._guarded_terminal_status(
                 "schedule_run",
                 run_id,
@@ -961,16 +972,90 @@ class SchedulerEngine:
                 source="system",
                 actor="scheduler_startup_reconciliation",
                 metadata={"invocation_id": inv_id, "invocation_status": inv_status},
-                extra_fields={"ended_at": time.time()},
+                extra_fields={"ended_at": end_time},
             )
-            if written:
-                _log.info(
-                    "Reconciled dispatched-orphan schedule_run %s as %s from child "
-                    "session evidence (invocation %s)",
-                    run_id,
-                    run_status,
-                    inv_id,
+            if not written:
+                continue
+            _log.info(
+                "Reconciled dispatched-orphan schedule_run %s as %s from child "
+                "session evidence (invocation %s)",
+                run_id,
+                run_status,
+                inv_id,
+            )
+            await self._dispatch_signal(
+                build_schedule_run_signal(
+                    entity_id=run_id,
+                    new_status=run_status,
+                    reason_code=inv_rc,
+                    schedule_id=sid or "",
+                    action_kind=action_kind,
+                    chain_depth=chain_depth,
+                    trigger_context=trigger_context,
                 )
+            )
+
+            # Finalize the linked invocation too -- otherwise it stays
+            # "running" forever and every normal terminal-invocation side
+            # effect (telemetry flush, chain follow-on) never fires for a
+            # run this pass just marked completed/failed/etc.
+            inv_written = await self._guarded_terminal_status(
+                "invocation",
+                inv_id,
+                new_status=inv_status,
+                reason_code=inv_rc,
+                reason_summary=inv_rs,
+                evidence_refs=inv_ev,
+                source="system",
+                actor="scheduler_startup_reconciliation",
+                metadata=inv_meta,
+                extra_fields={"ended_at": end_time},
+            )
+            if inv_written:
+                await flush_run_telemetry(
+                    self._svc, self._signal_bus, run_id=run_id, invocation_id=inv_id
+                )
+            else:
+                self._signal_bus.pop_run_counters(run_id)
+
+            schedule = await self._svc.get_schedule(sid) if sid else None
+            if schedule is None:
+                continue
+            await self._check_max_runs(schedule, chain_depth)
+            if chain_depth < _MAX_CHAIN_DEPTH:
+                chain_action = None
+                if run_status == "completed" and schedule.get("on_success"):
+                    chain_action = schedule["on_success"]
+                elif run_status != "completed" and schedule.get("on_fail"):
+                    chain_action = schedule["on_fail"]
+
+                if chain_action:
+                    chain_schedule = {**schedule, **chain_action}
+                    chain_schedule["action_kind"] = chain_action.get(
+                        "kind", chain_action.get("action_kind", schedule["action_kind"])
+                    )
+                    if "model" in chain_action:
+                        chain_schedule["action_model"] = chain_action["model"]
+                    if "prompt" in chain_action:
+                        chain_schedule["action_prompt"] = chain_action["prompt"]
+                    if "agent" in chain_action:
+                        chain_schedule["action_agent"] = chain_action["agent"]
+                    if "playbook" in chain_action:
+                        chain_schedule["action_playbook"] = chain_action["playbook"]
+
+                    chain_ctx = {
+                        **trigger_context,
+                        "chain_from": run_id,
+                        "parent_status": run_status,
+                    }
+                    chain_run_id = uuid.uuid4().hex[:12]
+                    self._tracked_fire(
+                        chain_schedule,
+                        chain_run_id,
+                        trigger_context=chain_ctx,
+                        chain_parent_id=run_id,
+                        chain_depth=chain_depth + 1,
+                    )
 
     async def _check_missed_fires(self) -> None:
         try:

--- a/lionagi/studio/scheduler/worker.py
+++ b/lionagi/studio/scheduler/worker.py
@@ -344,14 +344,17 @@ async def claim_and_execute(
     docs/internals/studio.md#lionagistudioschedulerworkerpy for the paging,
     staleness, and return-count contract.
 
-    *reserve_slot*/*release_slot* let a caller enforce a daemon-wide
-    top-level-concurrency cap around each execution (e.g. the Studio
-    scheduler's ``MAX_SCHEDULED_CONCURRENT``), so ad-hoc executions count
-    against the same ceiling scheduled fires do. When *reserve_slot* is
-    supplied and refuses for a candidate, that row is left ``queued`` for the
-    next tick rather than claimed — the same deferral posture ``admit()``
-    already uses for other capacity refusals. Omitted (``None``), this
-    module imposes no concurrency limit of its own, matching prior behavior.
+    *reserve_slot*/*release_slot* let a caller enforce a top-level
+    concurrency cap around each execution. The Studio scheduler passes its
+    own ``MAX_ADHOC_CONCURRENT``-backed reservation here (``_reserve_adhoc_
+    slot``) — a pool deliberately independent of ``MAX_SCHEDULED_CONCURRENT``,
+    so ad-hoc executions have their own guaranteed capacity instead of
+    competing with scheduled fires for one shared ceiling. When
+    *reserve_slot* is supplied and refuses for a candidate, that row is left
+    ``queued`` for the next tick rather than claimed — the same deferral
+    posture ``admit()`` already uses for other capacity refusals. Omitted
+    (``None``), this module imposes no concurrency limit of its own,
+    matching prior behavior.
     """
     execute = execute if execute is not None else default_execute
     now = now if now is not None else time.time()

--- a/lionagi/studio/scheduler/worker.py
+++ b/lionagi/studio/scheduler/worker.py
@@ -158,6 +158,13 @@ _HEARTBEAT_UPSERT_SQL = """
 
 ExecuteFn = Callable[[dict[str, Any]], Awaitable[tuple[int, str]]]
 
+# Optional global-concurrency-slot hooks (see claim_and_execute/worker_tick).
+# The default of None means "unlimited" -- this module stays engine-agnostic
+# and fully backward compatible for standalone callers/tests that never wire
+# a daemon-wide cap.
+ReserveSlotFn = Callable[[], Awaitable[tuple[bool, Any]]]
+ReleaseSlotFn = Callable[[Any], None]
+
 
 def _normalize_json_list(value: Any) -> list[Any]:
     """Normalize a JSON column that is a string on SQLite but a native list
@@ -325,6 +332,8 @@ async def claim_and_execute(
     heartbeat_ttl: float = DEFAULT_HEARTBEAT_TTL_SECONDS,
     waiter_cap_multiplier: int = DEFAULT_WAITER_CAP_MULTIPLIER,
     key_concurrency: int = DEFAULT_KEY_CONCURRENCY,
+    reserve_slot: ReserveSlotFn | None = None,
+    release_slot: ReleaseSlotFn | None = None,
 ) -> int:
     """Claim every eligible queued row this worker can serve, then execute each.
 
@@ -334,6 +343,15 @@ async def claim_and_execute(
     terminal decision transitions to ``skipped`` (see ``_reject_claim``). See
     docs/internals/studio.md#lionagistudioschedulerworkerpy for the paging,
     staleness, and return-count contract.
+
+    *reserve_slot*/*release_slot* let a caller enforce a daemon-wide
+    top-level-concurrency cap around each execution (e.g. the Studio
+    scheduler's ``MAX_SCHEDULED_CONCURRENT``), so ad-hoc executions count
+    against the same ceiling scheduled fires do. When *reserve_slot* is
+    supplied and refuses for a candidate, that row is left ``queued`` for the
+    next tick rather than claimed — the same deferral posture ``admit()``
+    already uses for other capacity refusals. Omitted (``None``), this
+    module imposes no concurrency limit of its own, matching prior behavior.
     """
     execute = execute if execute is not None else default_execute
     now = now if now is not None else time.time()
@@ -409,6 +427,15 @@ async def claim_and_execute(
             if decision.terminal:
                 await _reject_claim(db, row, decision)
             continue
+
+        slot_claim: Any = None
+        if reserve_slot is not None:
+            slot_allowed, slot_claim = await reserve_slot()
+            if not slot_allowed:
+                # No global capacity right now -- leave this row queued for
+                # the next tick, same deferral posture as an admit() refusal.
+                continue
+
         concurrency_key = row["concurrency_key"]
         run_id = row["id"]
         result = await transition(
@@ -432,6 +459,8 @@ async def claim_and_execute(
             },
         )
         if not result.applied:
+            if release_slot is not None:
+                release_slot(slot_claim)
             continue
         claimed += 1
         if concurrency_key is not None:
@@ -442,7 +471,11 @@ async def claim_and_execute(
         # and the reaper reassigns the row, this write's guard mismatches
         # and is dropped instead of clobbering the live lease.
         lease_guard = {"leased_by": worker_id, "lease_expires_at": now + lease_ttl}
-        await _execute_claimed(db, run_id, row, execute, lease_guard)
+        try:
+            await _execute_claimed(db, run_id, row, execute, lease_guard)
+        finally:
+            if release_slot is not None:
+                release_slot(slot_claim)
 
     return claimed
 
@@ -564,10 +597,15 @@ async def worker_tick(
     heartbeat_ttl: float = DEFAULT_HEARTBEAT_TTL_SECONDS,
     waiter_cap_multiplier: int = DEFAULT_WAITER_CAP_MULTIPLIER,
     key_concurrency: int = DEFAULT_KEY_CONCURRENCY,
+    reserve_slot: ReserveSlotFn | None = None,
+    release_slot: ReleaseSlotFn | None = None,
 ) -> dict[str, int]:
     """One worker tick: heartbeat, then reaper pass, then claim pass. Split from
     any sleep loop so tests (and the Studio daemon's own tick) can drive a
-    single pass directly without a timer."""
+    single pass directly without a timer.
+
+    See ``claim_and_execute`` for *reserve_slot*/*release_slot*.
+    """
     now = now if now is not None else time.time()
     await register_heartbeat(
         db,
@@ -588,5 +626,7 @@ async def worker_tick(
         heartbeat_ttl=heartbeat_ttl,
         waiter_cap_multiplier=waiter_cap_multiplier,
         key_concurrency=key_concurrency,
+        reserve_slot=reserve_slot,
+        release_slot=release_slot,
     )
     return {**reaped, "claimed": claimed}

--- a/lionagi/studio/scheduler/worker.py
+++ b/lionagi/studio/scheduler/worker.py
@@ -438,40 +438,42 @@ async def claim_and_execute(
 
         concurrency_key = row["concurrency_key"]
         run_id = row["id"]
-        result = await transition(
-            db,
-            TransitionRequest(
-                entity_type="schedule_run",
-                entity_id=run_id,
-                from_state="queued",
-                to_state="running",
-                reason=StateReason(
-                    code=RunReasons.STARTED_OK,
-                    summary=f"claimed by host worker {worker_id}",
-                ),
-                actor=Actor(type="system", id=worker_id),
-                idempotency_key=f"claim:{run_id}:{worker_id}:{now}",
-            ),
-            patch={
-                "leased_by": worker_id,
-                "lease_expires_at": now + lease_ttl,
-                "lease_attempts": row["lease_attempts"] + 1,
-            },
-        )
-        if not result.applied:
-            if release_slot is not None:
-                release_slot(slot_claim)
-            continue
-        claimed += 1
-        if concurrency_key is not None:
-            # Advisory: nothing else in this same pass may claim a row
-            # sharing this key, even after this row finishes executing.
-            worker_caps.claimed_keys.add(concurrency_key)
-        # Lease identity travels to the terminal write: if it lapses mid-run
-        # and the reaper reassigns the row, this write's guard mismatches
-        # and is dropped instead of clobbering the live lease.
-        lease_guard = {"leased_by": worker_id, "lease_expires_at": now + lease_ttl}
+        # Everything from here through execution runs under this one
+        # try/finally so a reserved slot is always released on every exit --
+        # including an exception or cancellation raised by the
+        # queued->running transition itself, not just by execution.
         try:
+            result = await transition(
+                db,
+                TransitionRequest(
+                    entity_type="schedule_run",
+                    entity_id=run_id,
+                    from_state="queued",
+                    to_state="running",
+                    reason=StateReason(
+                        code=RunReasons.STARTED_OK,
+                        summary=f"claimed by host worker {worker_id}",
+                    ),
+                    actor=Actor(type="system", id=worker_id),
+                    idempotency_key=f"claim:{run_id}:{worker_id}:{now}",
+                ),
+                patch={
+                    "leased_by": worker_id,
+                    "lease_expires_at": now + lease_ttl,
+                    "lease_attempts": row["lease_attempts"] + 1,
+                },
+            )
+            if not result.applied:
+                continue
+            claimed += 1
+            if concurrency_key is not None:
+                # Advisory: nothing else in this same pass may claim a row
+                # sharing this key, even after this row finishes executing.
+                worker_caps.claimed_keys.add(concurrency_key)
+            # Lease identity travels to the terminal write: if it lapses
+            # mid-run and the reaper reassigns the row, this write's guard
+            # mismatches and is dropped instead of clobbering the live lease.
+            lease_guard = {"leased_by": worker_id, "lease_expires_at": now + lease_ttl}
             await _execute_claimed(db, run_id, row, execute, lease_guard)
         finally:
             if release_slot is not None:

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -60,6 +60,8 @@ class SchedulerStateService(Protocol):
 
     async def list_undispatched_schedule_runs(self) -> list[dict[str, Any]]: ...
 
+    async def list_dispatched_running_schedule_runs(self) -> list[dict[str, Any]]: ...
+
     async def tombstone_and_replace_schedule_run(
         self,
         orphan_id: str,
@@ -169,6 +171,10 @@ class _DBSchedulerStateService:
     async def list_undispatched_schedule_runs(self) -> list[dict[str, Any]]:
         async with StateDB() as db:
             return await db.list_undispatched_schedule_runs()
+
+    async def list_dispatched_running_schedule_runs(self) -> list[dict[str, Any]]:
+        async with StateDB() as db:
+            return await db.list_dispatched_running_schedule_runs()
 
     async def tombstone_and_replace_schedule_run(
         self,

--- a/lionagi/studio/services/scheduler_state.py
+++ b/lionagi/studio/services/scheduler_state.py
@@ -363,6 +363,23 @@ async def resolve_invocation_terminal(
                 evidence_refs,
                 metadata,
             )
+        # Nothing above matched: at least one child session has not reached
+        # ANY terminal status (e.g. still "running") even though the
+        # invocation's own leader process has already exited. The leader's
+        # exit is not evidence that a child's own work finished -- it is
+        # only evidence that the leader's stderr pipe closed (see #2535).
+        # Never silently trust fallback_status="completed" here; route to
+        # the same no-evidence bucket a known-empty child already uses.
+        if fallback_status == "completed":
+            return (
+                "completed_empty",
+                RunReasons.COMPLETED_EMPTY_NO_EVIDENCE,
+                "Invocation's leader process exited 0 while at least one "
+                "child session had not reached a terminal status; the "
+                "leader's exit is not evidence that the child's work finished.",
+                evidence_refs,
+                metadata,
+            )
 
     if fallback_status == "completed":
         return (

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -965,9 +965,16 @@ async def schedule_limits_route() -> dict[str, Any]:
 
     from ..scheduler.engine import scheduler
 
+    # The scheduled and ad-hoc lanes draw from independent capacity pools
+    # (see MAX_ADHOC_CONCURRENT's own docstring in config.py) -- an operator
+    # reading only the scheduled cap would under-provision by the ad-hoc
+    # lane's own additive capacity, since the daemon can run both caps'
+    # worth of executions at once.
     return {
         "max_scheduled_concurrent": config.MAX_SCHEDULED_CONCURRENT,
         "current_inflight": scheduler._global_inflight,
+        "max_adhoc_concurrent": config.MAX_ADHOC_CONCURRENT,
+        "current_adhoc_inflight": scheduler._adhoc_inflight,
     }
 
 

--- a/lionagi/studio/services/stats.py
+++ b/lionagi/studio/services/stats.py
@@ -29,7 +29,11 @@ _ACTIVITY_WINDOWS: dict[str, tuple[int, int]] = {
 
 _BUCKET_STATUS_MAP: dict[str, str] = {
     "completed": "completed",
-    "completed_empty": "completed",
+    # ADR-0064: completed_empty is terminal but unsuccessful (no trusted
+    # evidence produced), so it folds into "failed" alongside timed_out --
+    # never into "completed", which the completion_rate denominator treats
+    # as a success.
+    "completed_empty": "failed",
     "failed": "failed",
     "timed_out": "failed",
     "aborted": "cancelled",

--- a/tests/apps_studio_server/test_activity_stats.py
+++ b/tests/apps_studio_server/test_activity_stats.py
@@ -174,12 +174,14 @@ def test_status_aliases_fold_into_rendered_buckets(tmp_path, monkeypatch):
     data = client.get("/api/stats/activity").json()
 
     last = data["buckets"][-1]
-    assert last["completed"] == 1
-    assert last["failed"] == 1
+    # completed_empty is terminal but unsuccessful (ADR-0064) -- it folds
+    # into "failed" alongside timed_out, never into "completed".
+    assert last["completed"] == 0
+    assert last["failed"] == 2
     assert last["cancelled"] == 1
     assert data["total"] == 3
-    # denom = 1 completed + 1 failed + 1 cancelled
-    assert data["completion_rate"] == pytest.approx(1 / 3)
+    # denom = 0 completed + 2 failed + 1 cancelled
+    assert data["completion_rate"] == pytest.approx(0.0)
 
 
 def test_null_and_unknown_statuses_count_in_total_only(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -764,7 +764,12 @@ def test_schedules_limits_response_shape(tmp_path, monkeypatch):
 
     r = client.get("/api/schedules/limits")
     assert r.status_code == 200
-    assert sorted(r.json().keys()) == ["current_inflight", "max_scheduled_concurrent"]
+    assert sorted(r.json().keys()) == [
+        "current_adhoc_inflight",
+        "current_inflight",
+        "max_adhoc_concurrent",
+        "max_scheduled_concurrent",
+    ]
 
 
 def test_schedules_create_response_shape(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_operator_run_progress.py
+++ b/tests/apps_studio_server/test_operator_run_progress.py
@@ -235,6 +235,32 @@ async def test_run_progress_failed_run(db_path):
     assert result["elapsedSeconds"] == pytest.approx(10.0)
 
 
+async def test_run_progress_completed_empty_branch_counts_as_failed(db_path):
+    """ADR-0064: completed_empty is terminal but unsuccessful -- a branch
+    that produced no trusted evidence must not be counted as an op success."""
+    from lionagi.studio.operator.run_progress import run_progress
+
+    sid = str(uuid.uuid4())
+    await seed_session(db_path, session_id=sid, status="failed", started_at=10.0, ended_at=20.0)
+    await seed_branch(
+        db_path,
+        branch_id=f"{sid}-br1",
+        session_id=sid,
+        name="worker",
+        status="completed_empty",
+        started_at=10.0,
+        ended_at=15.0,
+    )
+
+    result = await run_progress({"run": sid})
+
+    assert result["opsTotal"] == 1
+    assert result["opsCompleted"] == 0
+    assert result["opsFailed"] == 1
+    assert result["opsRunning"] == 0
+    assert result["opsPending"] == 0
+
+
 async def test_run_progress_hex_prefix_resolution(db_path):
     from lionagi.studio.operator.run_progress import run_progress
 

--- a/tests/apps_studio_server/test_schedule_limits_route.py
+++ b/tests/apps_studio_server/test_schedule_limits_route.py
@@ -39,13 +39,20 @@ def test_limits_route_returns_cap_and_inflight(tmp_path, monkeypatch):
     _patch_db(monkeypatch, tmp_path / "state.db")
     monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 7)
     monkeypatch.setattr(scheduler, "_global_inflight", 3)
+    monkeypatch.setattr(studio_config, "MAX_ADHOC_CONCURRENT", 5)
+    monkeypatch.setattr(scheduler, "_adhoc_inflight", 2)
 
     client = _make_client()
     resp = client.get("/api/schedules/limits")
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {"max_scheduled_concurrent": 7, "current_inflight": 3}
+    assert body == {
+        "max_scheduled_concurrent": 7,
+        "current_inflight": 3,
+        "max_adhoc_concurrent": 5,
+        "current_adhoc_inflight": 2,
+    }
 
 
 def test_limits_route_resolves_before_schedule_id_param_route(tmp_path, monkeypatch):

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -129,13 +129,19 @@ def test_schedule_limits_subcommand_registered():
 
 
 def test_schedule_limits_dispatches_to_api_and_prints_values(monkeypatch, capsys):
-    """run_schedule limits calls _api('/limits') and prints cap + inflight."""
+    """run_schedule limits calls _api('/limits') and prints cap + inflight
+    for both the scheduled and the ad-hoc lane."""
     import lionagi.studio.cli as sched_mod
 
     monkeypatch.setattr(
         sched_mod,
         "_api",
-        lambda path, **kw: {"max_scheduled_concurrent": 4, "current_inflight": 1},
+        lambda path, **kw: {
+            "max_scheduled_concurrent": 4,
+            "current_inflight": 1,
+            "max_adhoc_concurrent": 6,
+            "current_adhoc_inflight": 2,
+        },
     )
 
     from lionagi.studio.cli import add_schedule_subparser, run_schedule
@@ -150,6 +156,8 @@ def test_schedule_limits_dispatches_to_api_and_prints_values(monkeypatch, capsys
     out = capsys.readouterr().out
     assert "4" in out
     assert "1" in out
+    assert "6" in out
+    assert "2" in out
 
 
 def test_schedule_limits_unlimited_display(monkeypatch, capsys):

--- a/tests/mcp/test_schedule_verbs.py
+++ b/tests/mcp/test_schedule_verbs.py
@@ -63,7 +63,15 @@ class _Studio(BaseHTTPRequestHandler):
                 return self._answer(201, {"id": "sched-1", "name": "nightly", "created_at": 1.5})
             return self._answer(200, {"schedules": [SCHEDULE_ROW]})
         if path == "/api/schedules/limits":
-            return self._answer(200, {"max_scheduled_concurrent": 0, "current_inflight": 2})
+            return self._answer(
+                200,
+                {
+                    "max_scheduled_concurrent": 0,
+                    "current_inflight": 2,
+                    "max_adhoc_concurrent": 4,
+                    "current_adhoc_inflight": 1,
+                },
+            )
         if path.startswith("/api/schedules/missing"):
             return self._answer(404, {"detail": "Schedule 'missing' not found"})
         if path.endswith("/status"):
@@ -172,6 +180,11 @@ def test_limits_says_unlimited_rather_than_leaving_a_falsy_cap_to_be_read(studio
     assert data["max_scheduled_concurrent"] == 0
     assert data["unlimited"] is True
     assert data["current_inflight"] == 2
+    # The ad-hoc lane's own cap is additive to the scheduled cap above, and
+    # must be surfaced independently rather than folded into it.
+    assert data["max_adhoc_concurrent"] == 4
+    assert data["adhoc_unlimited"] is False
+    assert data["current_adhoc_inflight"] == 1
 
 
 def test_a_studio_that_is_not_running_is_unavailable_not_an_empty_list(monkeypatch):

--- a/tests/studio/services/test_task_worker.py
+++ b/tests/studio/services/test_task_worker.py
@@ -424,3 +424,77 @@ async def test_stale_worker_cannot_finalize_a_reclaimed_lease(db: StateDB) -> No
     assert row["status"] == "running"
     assert row["leased_by"] == "w2"
     assert row["lease_expires_at"] == t0 + 3600
+
+
+# ── Global slot reservation hook (#2751) ─────────────────────────────────
+
+
+async def test_worker_tick_respects_injected_global_slot_reservation(db: StateDB) -> None:
+    """The ad-hoc worker takes no global concurrency slot today, so real
+    top-level concurrency is the configured cap plus one. worker_tick/
+    claim_and_execute accept an optional reserve_slot/release_slot pair: a
+    refused reservation leaves the row queued and never calls execute (the
+    row is left for the next tick, same posture as every other admission
+    deferral); an allowed reservation executes normally and releases the
+    slot once the row reaches a terminal status."""
+    run_id = await _submit_host_task(db)
+
+    reserve_calls: list[int] = []
+
+    async def _refusing_reserve() -> tuple[bool, object | None]:
+        reserve_calls.append(1)
+        return False, None
+
+    counts = await worker_tick(
+        db, worker_id="w1", execute=_noop_execute, reserve_slot=_refusing_reserve
+    )
+    assert counts["claimed"] == 0
+    assert reserve_calls == [1]
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "queued"
+
+    release_calls: list[object] = []
+
+    async def _allowing_reserve() -> tuple[bool, object | None]:
+        return True, "token-a"
+
+    def _release(claim: object) -> None:
+        release_calls.append(claim)
+
+    counts = await worker_tick(
+        db,
+        worker_id="w1",
+        execute=_noop_execute,
+        reserve_slot=_allowing_reserve,
+        release_slot=_release,
+    )
+    assert counts["claimed"] == 1
+    assert release_calls == ["token-a"]
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "completed"
+
+
+async def test_worker_tick_releases_slot_when_execute_raises(db: StateDB) -> None:
+    """The reserved slot must be released even when execute() raises, or a
+    crashing action would permanently leak a global concurrency slot."""
+    run_id = await _submit_host_task(db)
+
+    async def _boom_execute(row: dict) -> tuple[int, str]:
+        raise RuntimeError("boom")
+
+    release_calls: list[object] = []
+
+    async def _allowing_reserve() -> tuple[bool, object | None]:
+        return True, "token-b"
+
+    counts = await worker_tick(
+        db,
+        worker_id="w1",
+        execute=_boom_execute,
+        reserve_slot=_allowing_reserve,
+        release_slot=release_calls.append,
+    )
+    assert counts["claimed"] == 1
+    assert release_calls == ["token-b"]
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "failed"

--- a/tests/studio/services/test_task_worker.py
+++ b/tests/studio/services/test_task_worker.py
@@ -498,3 +498,72 @@ async def test_worker_tick_releases_slot_when_execute_raises(db: StateDB) -> Non
     assert release_calls == ["token-b"]
     row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
     assert row["status"] == "failed"
+
+
+async def test_worker_tick_releases_slot_when_queued_to_running_transition_raises(
+    db: StateDB, monkeypatch
+) -> None:
+    """The reserved slot must be released even when the queued->running
+    transition itself raises, not only when execute() raises. Before the
+    fix, the release `finally` started after this transition call, so a
+    raise here leaked the slot permanently while leaving the row `queued`."""
+    from lionagi.studio.scheduler import worker as worker_mod
+
+    run_id = await _submit_host_task(db)
+
+    release_calls: list[object] = []
+
+    async def _allowing_reserve() -> tuple[bool, object | None]:
+        return True, "token-c"
+
+    async def _boom_transition(*args, **kwargs):
+        raise RuntimeError("transition boom")
+
+    monkeypatch.setattr(worker_mod, "transition", _boom_transition)
+
+    with pytest.raises(RuntimeError, match="transition boom"):
+        await worker_tick(
+            db,
+            worker_id="w1",
+            execute=_noop_execute,
+            reserve_slot=_allowing_reserve,
+            release_slot=release_calls.append,
+        )
+
+    assert release_calls == ["token-c"], "reserved slot must be released when transition() raises"
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "queued"
+
+
+async def test_worker_tick_releases_slot_when_queued_to_running_transition_cancelled(
+    db: StateDB, monkeypatch
+) -> None:
+    """Same hazard as above but for asyncio.CancelledError specifically --
+    the reproduction shape from the review: reserve succeeds, then the
+    queued->running transition is cancelled before it can complete."""
+    from lionagi.studio.scheduler import worker as worker_mod
+
+    run_id = await _submit_host_task(db)
+
+    release_calls: list[object] = []
+
+    async def _allowing_reserve() -> tuple[bool, object | None]:
+        return True, "token-d"
+
+    async def _cancelled_transition(*args, **kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(worker_mod, "transition", _cancelled_transition)
+
+    with pytest.raises(asyncio.CancelledError):
+        await worker_tick(
+            db,
+            worker_id="w1",
+            execute=_noop_execute,
+            reserve_slot=_allowing_reserve,
+            release_slot=release_calls.append,
+        )
+
+    assert release_calls == ["token-d"], "reserved slot must be released on cancellation too"
+    row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "queued"

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -625,8 +625,9 @@ async def test_fire_running_child_with_on_success_does_not_run_success_chain():
     independently reached a terminal status resolves to "completed_empty",
     not "completed" -- the leader's exit is not evidence the child's work
     finished. completed_empty is NOT success for scheduling purposes: the
-    schedule_run row's reason_code and the on_success chain decision must
-    both agree with that resolved outcome instead of the raw exit code."""
+    schedule_run row's status, reason_code, emitted signal class, and the
+    on_success chain decision must all independently agree with that
+    resolved outcome instead of the raw exit code."""
     from lionagi.state.reasons import RunReasons
     from lionagi.studio.scheduler.engine import SchedulerEngine
 
@@ -668,6 +669,7 @@ async def test_fire_running_child_with_on_success_does_not_run_success_chain():
     ):
         await original_fire(schedule, "run-empty-success", trigger_context={}, chain_depth=0)
 
+    # Assertion 1: status. completed_empty must not be recorded as "completed".
     terminal_calls = [
         c
         for c in svc.update_status.await_args_list
@@ -676,9 +678,24 @@ async def test_fire_running_child_with_on_success_does_not_run_success_chain():
     ]
     assert terminal_calls
     (call,) = terminal_calls
-    assert call.kwargs["new_status"] == "completed"
+    assert call.kwargs["new_status"] == "failed"
+
+    # Assertion 2: reason. The finer completed_empty distinction must survive
+    # in the reason_code even though the coarse status is "failed".
     assert call.kwargs["reason_code"] == RunReasons.COMPLETED_EMPTY_NO_EVIDENCE
 
+    # Assertion 3: signal class. build_schedule_run_signal() derives the
+    # signal class from the same mapped status, so a completed_empty outcome
+    # must mint ScheduleRunFailed, never ScheduleRunSucceeded.
+    node_metadata_calls = [
+        c.kwargs["node_metadata"]
+        for c in svc.update_invocation.await_args_list
+        if "node_metadata" in c.kwargs
+    ]
+    assert len(node_metadata_calls) == 1
+    assert node_metadata_calls[0]["coordination"]["signals"]["emitted"] == {"ScheduleRunFailed": 1}
+
+    # Assertion 4: chaining. on_success must not fire for a no-evidence outcome.
     chained = [c for c in fire_calls if c[1] == 1]
     assert not chained, "on_success must not fire for a completed_empty (no-evidence) outcome"
 

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -2002,6 +2002,58 @@ async def test_recompute_armed_cron_schedules_unchanged_no_log(monkeypatch, capl
     assert not any("shifted" in r.message for r in caplog.records)
 
 
+@pytest.mark.asyncio
+async def test_check_missed_fires_excludes_github_poll(monkeypatch):
+    """A stale github_poll next_fire_at is not a missed scheduled occurrence
+    -- that trigger's cadence is driven by last_fired_at/poll_interval_sec,
+    not next_fire_at (see _tick_github). _check_missed_fires() must leave it
+    alone. An interval schedule with the same stale next_fire_at is the
+    positive control: it must still record a missed-fire skip."""
+    import lionagi.studio.scheduler.engine as engine_mod
+    from lionagi.state.reasons import ScheduleReasons
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    fixed_now = time.time()
+    monkeypatch.setattr(engine_mod.time, "time", lambda: fixed_now)
+
+    github_schedule = _minimal_schedule(
+        id="sched-gh",
+        trigger_type="github_poll",
+        cron_expr=None,
+        next_fire_at=fixed_now - 3600,
+        missed_fire_policy="skip",
+    )
+    interval_schedule = _minimal_schedule(
+        id="sched-interval",
+        trigger_type="interval",
+        cron_expr=None,
+        interval_sec=60,
+        next_fire_at=fixed_now - 3600,
+        missed_fire_policy="skip",
+    )
+    svc = _make_svc()
+    svc.list_schedules = AsyncMock(return_value=[github_schedule, interval_schedule])
+    engine = SchedulerEngine(svc=svc)
+
+    with patch.object(engine, "_tracked_fire") as mock_tracked:
+        await engine._check_missed_fires()
+
+    mock_tracked.assert_not_called()
+    skip_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.kwargs.get("reason_code") == ScheduleReasons.SKIPPED_MISSED_FIRE
+    ]
+    skipped_run_schedule_ids = set()
+    for c in skip_calls:
+        for ref in c.kwargs.get("evidence_refs") or []:
+            if ref.get("kind") == "schedule":
+                skipped_run_schedule_ids.add(ref.get("id"))
+
+    assert "sched-gh" not in skipped_run_schedule_ids
+    assert "sched-interval" in skipped_run_schedule_ids
+
+
 # ---------------------------------------------------------------------------
 # max_runs / one-shot semantics
 # ---------------------------------------------------------------------------

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -2218,6 +2218,16 @@ async def test_tick_does_not_await_worker_pass_before_evaluating_schedules(monke
         # because worker_may_finish is never set before the deadline.
         await asyncio.wait_for(engine._tick(), timeout=2.0)
 
+    # asyncio.wait_for() does not guarantee that the coroutine it awaits runs
+    # as a separately scheduled Task -- CPython >=3.12 drives a plain
+    # coroutine inline within the caller's own step when timeout > 0, so the
+    # worker task created inside _tick() may not get a scheduling turn
+    # before wait_for() returns. An explicit checkpoint gives the event loop
+    # one turn to run any already-scheduled callback, which is what actually
+    # proves the worker task was created and is runnable -- independent of
+    # whichever internal strategy wait_for() happens to use.
+    await asyncio.sleep(0)
+
     assert worker_started.is_set(), "worker pass never started"
     mock_fire.assert_awaited_once()
 

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -118,6 +118,48 @@ async def test_resolve_terminal_completed_empty_child_taints_invocation():
 
 
 @pytest.mark.asyncio
+async def test_resolve_terminal_nonterminal_child_not_trusted_as_completed():
+    """A leader process exiting 0 is not evidence that a still-running child
+    session's own work finished (see #2535 -- the terminal stamp today comes
+    from the leader's stderr pipe closing, not from the work ending). A
+    child session that has not reached ANY terminal status must not be
+    silently trusted via the fallback_status="completed" path -- it belongs
+    on completed_empty (no positive evidence), the same bucket a
+    known-empty child already uses."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = [
+        {"id": "s1", "status": "running"},
+    ]
+    status, rc, rs, refs, meta = await resolve_invocation_terminal(
+        svc, "inv-1", fallback_status="completed", exit_code=0
+    )
+    assert status == "completed_empty"
+    assert rc == RunReasons.COMPLETED_EMPTY_NO_EVIDENCE
+
+
+@pytest.mark.asyncio
+async def test_resolve_terminal_all_children_terminal_completed_still_trusted():
+    """Positive control for the above: when every child session has
+    genuinely reached a terminal 'completed' status, the invocation is
+    still trusted as 'completed' -- the new non-terminal-child guard must
+    not fire when there is nothing left running."""
+    from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation.return_value = [
+        {"id": "s1", "status": "completed"},
+        {"id": "s2", "status": "completed"},
+    ]
+    status, rc, rs, refs, meta = await resolve_invocation_terminal(
+        svc, "inv-1", fallback_status="completed", exit_code=0
+    )
+    assert status == "completed"
+
+
+@pytest.mark.asyncio
 async def test_resolve_terminal_failed_child():
     from lionagi.studio.services.scheduler_state import resolve_invocation_terminal
 

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -2054,6 +2054,116 @@ async def test_check_missed_fires_excludes_github_poll(monkeypatch):
     assert "sched-interval" in skipped_run_schedule_ids
 
 
+@pytest.mark.asyncio
+async def test_tick_does_not_await_worker_pass_before_evaluating_schedules(monkeypatch, tmp_path):
+    """_tick() must not await the ad-hoc task-worker pass before loading and
+    evaluating due schedules -- a hung/slow worker pass would otherwise defer
+    every schedule's evaluation for the whole pass (see #2750). The worker
+    pass here never completes; _tick() must still return promptly and fire
+    the due schedule in the same cycle."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.scheduler.engine as engine_mod
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+
+    fixed_now = 1_000_000.0
+    monkeypatch.setattr(engine_mod.time, "time", lambda: fixed_now)
+
+    schedule = _minimal_schedule(
+        id="sched-due-mid-pass",
+        trigger_type="interval",
+        cron_expr=None,
+        interval_sec=60,
+        next_fire_at=fixed_now - 1,
+    )
+    svc = _make_svc()
+    svc.list_schedules = AsyncMock(return_value=[schedule])
+    engine = SchedulerEngine(svc=svc)
+
+    worker_started = asyncio.Event()
+    worker_may_finish = asyncio.Event()
+
+    async def _hung_worker_tick(now):
+        worker_started.set()
+        await worker_may_finish.wait()
+
+    engine._run_task_worker_tick = _hung_worker_tick  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "lionagi.studio.services.lifecycle.run_periodic_reapers",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "lionagi.studio.services.db_maintenance.checkpoint_state_db",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(engine, "_maybe_fire", new=AsyncMock()) as mock_fire,
+    ):
+        # If _tick() still awaits the worker pass inline, this times out
+        # because worker_may_finish is never set before the deadline.
+        await asyncio.wait_for(engine._tick(), timeout=2.0)
+
+    assert worker_started.is_set(), "worker pass never started"
+    mock_fire.assert_awaited_once()
+
+    worker_may_finish.set()
+    if engine._worker_task is not None:
+        await asyncio.wait_for(engine._worker_task, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_tick_worker_pass_is_single_flight(monkeypatch, tmp_path):
+    """A second _tick() must not start a second worker-pass task while the
+    first is still running -- single-flight, not an unguarded task per tick
+    (see #2750's fix-shape constraint)."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.scheduler.engine as engine_mod
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(engine_mod.time, "time", lambda: 2_000_000.0)
+
+    svc = _make_svc()
+    svc.list_schedules = AsyncMock(return_value=[])
+    engine = SchedulerEngine(svc=svc)
+
+    start_count = 0
+    worker_may_finish = asyncio.Event()
+
+    async def _hung_worker_tick(now):
+        nonlocal start_count
+        start_count += 1
+        await worker_may_finish.wait()
+
+    engine._run_task_worker_tick = _hung_worker_tick  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "lionagi.studio.services.lifecycle.run_periodic_reapers",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "lionagi.studio.services.db_maintenance.checkpoint_state_db",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await asyncio.wait_for(engine._tick(), timeout=2.0)
+        await asyncio.wait_for(engine._tick(), timeout=2.0)
+
+    assert start_count == 1, (
+        f"Expected exactly one worker-pass task started while the first is "
+        f"still in flight, got {start_count}"
+    )
+
+    worker_may_finish.set()
+    if engine._worker_task is not None:
+        await asyncio.wait_for(engine._worker_task, timeout=2.0)
+
+
 # ---------------------------------------------------------------------------
 # max_runs / one-shot semantics
 # ---------------------------------------------------------------------------

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -620,6 +620,70 @@ async def test_fire_on_success_chain_fires():
 
 
 @pytest.mark.asyncio
+async def test_fire_running_child_with_on_success_does_not_run_success_chain():
+    """A clean leader exit (exit_code=0) with a child session that has not
+    independently reached a terminal status resolves to "completed_empty",
+    not "completed" -- the leader's exit is not evidence the child's work
+    finished. completed_empty is NOT success for scheduling purposes: the
+    schedule_run row's reason_code and the on_success chain decision must
+    both agree with that resolved outcome instead of the raw exit code."""
+    from lionagi.state.reasons import RunReasons
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+
+    svc = _make_svc()
+    svc.list_sessions_for_invocation = AsyncMock(
+        return_value=[{"id": "sess-1", "status": "running"}]
+    )
+    engine = SchedulerEngine(svc=svc)
+    schedule = _minimal_schedule(
+        on_success={"kind": "agent", "prompt": "chained prompt", "model": "gpt-4.1-mini"}
+    )
+
+    fire_calls: list[tuple] = []
+    original_fire = engine._fire
+
+    async def _patched_fire(sched, run_id, *, trigger_context, chain_parent_id=None, chain_depth=0):
+        fire_calls.append((sched["id"], chain_depth))
+        if chain_depth > 0:
+            return
+        return await original_fire(
+            sched,
+            run_id,
+            trigger_context=trigger_context,
+            chain_parent_id=chain_parent_id,
+            chain_depth=chain_depth,
+        )
+
+    engine._fire = _patched_fire  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await original_fire(schedule, "run-empty-success", trigger_context={}, chain_depth=0)
+
+    terminal_calls = [
+        c
+        for c in svc.update_status.await_args_list
+        if c.args[:2] == ("schedule_run", "run-empty-success")
+        and c.kwargs.get("new_status") in ("completed", "failed")
+    ]
+    assert terminal_calls
+    (call,) = terminal_calls
+    assert call.kwargs["new_status"] == "completed"
+    assert call.kwargs["reason_code"] == RunReasons.COMPLETED_EMPTY_NO_EVIDENCE
+
+    chained = [c for c in fire_calls if c[1] == 1]
+    assert not chained, "on_success must not fire for a completed_empty (no-evidence) outcome"
+
+
+@pytest.mark.asyncio
 async def test_fire_invocation_finalization_cas_miss_is_checked_and_does_not_raise():
     """A concurrent finalizer (e.g. the deadline reaper) may already have
     moved the invocation to a terminal status by the time _fire() records its
@@ -662,10 +726,17 @@ async def test_fire_invocation_finalization_cas_miss_is_checked_and_does_not_rai
 
 
 @pytest.mark.asyncio
-async def test_fire_exception_after_terminal_schedule_run_does_not_rewrite_failed():
-    """A late exception after the schedule_run terminal write already
-    succeeded (e.g. resolve_invocation_terminal blowing up) must not attempt
-    an unguarded terminal rewrite from the broad-except handler."""
+async def test_fire_exception_during_invocation_resolution_marks_run_failed_once():
+    """resolve_invocation_terminal() is now consulted BEFORE the
+    schedule_run terminal write in the normal path -- its resolved outcome
+    must be used consistently for the schedule row's own status/reason, not
+    only the invocation row (a completed_empty invocation must not let the
+    schedule row or an on_success chain report success). A raise during
+    that resolution therefore skips the normal-path schedule_run write
+    entirely; the broad-except handler catches it, writes a single guarded
+    'failed' schedule_run terminal status, and still finalizes the
+    invocation via its own retried resolution call."""
+    from lionagi.state.reasons import RunReasons
     from lionagi.studio.scheduler.engine import SchedulerEngine
 
     svc = _make_svc()
@@ -674,22 +745,16 @@ async def test_fire_exception_after_terminal_schedule_run_does_not_rewrite_faile
     async def _update_status(entity_type, entity_id, *, new_status, **kwargs):
         if entity_type == "schedule_run" and new_status in ("completed", "failed"):
             schedule_run_terminal_calls.append(kwargs)
-            if len(schedule_run_terminal_calls) > 1:
-                assert "expected_statuses" in kwargs, (
-                    "a second schedule_run terminal write from the broad-except "
-                    "handler must be guarded, not an unconditional overwrite"
-                )
-                return False
         return True
 
     svc.update_status = AsyncMock(side_effect=_update_status)
     engine = SchedulerEngine(svc=svc)
     schedule = _minimal_schedule()
 
-    # resolve_invocation_terminal() raises on its first call (right after the
-    # schedule_run terminal write in the normal path), but the broad-except
-    # handler's own call to it must still succeed so the test can observe the
-    # handler's schedule_run rewrite attempt in isolation.
+    # resolve_invocation_terminal() raises on its first call (now the very
+    # first thing the normal path awaits after spawn_and_wait returns), but
+    # the broad-except handler's own retry call to it must still succeed so
+    # the test can observe the handler finalizing both rows in isolation.
     resolve_calls = {"n": 0}
 
     async def _resolve_invocation_terminal(*args, **kwargs):
@@ -714,7 +779,12 @@ async def test_fire_exception_after_terminal_schedule_run_does_not_rewrite_faile
     ):
         await engine._fire(schedule, "run-late-exc", trigger_context={"scheduled": True})
 
-    assert len(schedule_run_terminal_calls) == 2
+    assert resolve_calls["n"] == 2, "the broad-except handler must retry invocation resolution"
+    assert len(schedule_run_terminal_calls) == 1, (
+        "the schedule_run terminal write only happens once, from the except handler, "
+        "since resolving the invocation now gates the normal-path write itself"
+    )
+    assert schedule_run_terminal_calls[0]["reason_code"] == RunReasons.FAILED_EXCEPTION
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -526,3 +526,75 @@ async def test_maybe_record_deferred_throttles_after_first(monkeypatch):
     assert svc.create_schedule_run.await_count == 1
     await engine._maybe_record_deferred(schedule, now=1000.0)
     assert svc.create_schedule_run.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _run_task_worker_tick — ad-hoc executions now count against the cap (#2751)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_pass_reserves_global_slot_and_counts_against_cap(monkeypatch, tmp_path):
+    """Measured, not inferred: with the cap already saturated by (simulated)
+    scheduled fires, a queued ad-hoc task must stay queued rather than
+    execute as a cap+1'th concurrent action. Freeing capacity lets it
+    execute and the slot is released once the row reaches a terminal
+    status. Before this fix the worker never called _reserve_global_slot at
+    all, so this row would have executed regardless of cap saturation."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.config as studio_config
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+    from lionagi.studio.services.task_applications import TaskApplication, submit_task
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 4)
+
+    async with StateDB(fake_db) as db:
+        run_id = await submit_task(
+            db, TaskApplication(action_kind="agent", args={}, execution_target="host")
+        )
+
+    engine = SchedulerEngine(svc=_make_svc())
+
+    holders = []
+    for _ in range(4):
+        allowed, claim = await engine._reserve_global_slot()
+        assert allowed is True
+        holders.append(claim)
+    assert engine._global_inflight == 4
+
+    await engine._run_task_worker_tick(1_000.0)
+
+    async with StateDB(fake_db) as db:
+        row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "queued", (
+        "saturated cap must defer the ad-hoc row, not run it as a cap+1'th concurrent execution"
+    )
+    assert engine._global_inflight == 4
+
+    for claim in holders:
+        claim.release()
+    assert engine._global_inflight == 0
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.resolve_li_executable",
+            return_value=(["uv", "run", "li"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        await engine._run_task_worker_tick(1_001.0)
+
+    async with StateDB(fake_db) as db:
+        row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "completed"
+    assert engine._global_inflight == 0

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -529,18 +529,21 @@ async def test_maybe_record_deferred_throttles_after_first(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _run_task_worker_tick — ad-hoc executions now count against the cap (#2751)
+# _run_task_worker_tick — ad-hoc executions draw from their own independent
+# concurrency pool (MAX_ADHOC_CONCURRENT / _adhoc_inflight), never the
+# scheduled-fire cap. A shared counter let a continuously replenished stream
+# of scheduled fires starve the ad-hoc lane indefinitely; each lane now has
+# its own guaranteed capacity.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_worker_pass_reserves_global_slot_and_counts_against_cap(monkeypatch, tmp_path):
-    """Measured, not inferred: with the cap already saturated by (simulated)
-    scheduled fires, a queued ad-hoc task must stay queued rather than
-    execute as a cap+1'th concurrent action. Freeing capacity lets it
-    execute and the slot is released once the row reaches a terminal
-    status. Before this fix the worker never called _reserve_global_slot at
-    all, so this row would have executed regardless of cap saturation."""
+async def test_worker_pass_reserves_adhoc_slot_and_counts_against_adhoc_cap(monkeypatch, tmp_path):
+    """Measured, not inferred: with the ad-hoc pool itself saturated by
+    (simulated) concurrent ad-hoc executions, a queued ad-hoc task must stay
+    queued rather than execute as a cap+1'th concurrent action. Freeing
+    ad-hoc capacity lets it execute and the slot is released once the row
+    reaches a terminal status."""
     import lionagi.state.db as state_db_mod
     import lionagi.studio.config as studio_config
     from lionagi.state.db import StateDB
@@ -549,7 +552,7 @@ async def test_worker_pass_reserves_global_slot_and_counts_against_cap(monkeypat
 
     fake_db = tmp_path / "state.db"
     monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
-    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 4)
+    monkeypatch.setattr(studio_config, "MAX_ADHOC_CONCURRENT", 4)
 
     async with StateDB(fake_db) as db:
         run_id = await submit_task(
@@ -560,23 +563,24 @@ async def test_worker_pass_reserves_global_slot_and_counts_against_cap(monkeypat
 
     holders = []
     for _ in range(4):
-        allowed, claim = await engine._reserve_global_slot()
+        allowed, claim = await engine._reserve_adhoc_slot()
         assert allowed is True
         holders.append(claim)
-    assert engine._global_inflight == 4
+    assert engine._adhoc_inflight == 4
 
     await engine._run_task_worker_tick(1_000.0)
 
     async with StateDB(fake_db) as db:
         row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
     assert row["status"] == "queued", (
-        "saturated cap must defer the ad-hoc row, not run it as a cap+1'th concurrent execution"
+        "saturated ad-hoc cap must defer the ad-hoc row, not run it as a cap+1'th "
+        "concurrent execution"
     )
-    assert engine._global_inflight == 4
+    assert engine._adhoc_inflight == 4
 
     for claim in holders:
         claim.release()
-    assert engine._global_inflight == 0
+    assert engine._adhoc_inflight == 0
 
     with (
         patch(
@@ -597,4 +601,64 @@ async def test_worker_pass_reserves_global_slot_and_counts_against_cap(monkeypat
     async with StateDB(fake_db) as db:
         row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
     assert row["status"] == "completed"
-    assert engine._global_inflight == 0
+    assert engine._adhoc_inflight == 0
+
+
+@pytest.mark.asyncio
+async def test_adhoc_lane_admits_under_continuously_saturated_scheduled_cap(monkeypatch, tmp_path):
+    """Reproduces the starvation scenario a shared counter created: a
+    continuously replenished scheduled-fire stream holds the scheduled cap
+    fully saturated across every tick. With one shared counter, a refused
+    worker-pass reservation only leaves the ad-hoc row queued for the next
+    tick, and a stream of scheduled fires reacquires every freed slot first
+    -- so the ad-hoc row never gets admitted. With the ad-hoc lane's own
+    independent pool, saturation on the scheduled side has no bearing on
+    ad-hoc admission at all: the row is admitted on the very first tick."""
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.config as studio_config
+    from lionagi.state.db import StateDB
+    from lionagi.studio.scheduler.engine import SchedulerEngine
+    from lionagi.studio.services.task_applications import TaskApplication, submit_task
+
+    fake_db = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(studio_config, "MAX_SCHEDULED_CONCURRENT", 1)
+    monkeypatch.setattr(studio_config, "MAX_ADHOC_CONCURRENT", 1)
+
+    async with StateDB(fake_db) as db:
+        run_id = await submit_task(
+            db, TaskApplication(action_kind="agent", args={}, execution_target="host")
+        )
+
+    engine = SchedulerEngine(svc=_make_svc())
+
+    with (
+        patch(
+            "lionagi.studio.scheduler.subprocess.resolve_li_executable",
+            return_value=(["uv", "run", "li"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.build_argv",
+            return_value=(["uv", "run", "li", "agent", "ping"], None),
+        ),
+        patch(
+            "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+            new=AsyncMock(return_value=(0, "")),
+        ),
+    ):
+        for tick in range(5):
+            # A scheduled fire holds the one scheduled slot for this tick,
+            # then releases and immediately reacquires it before the next
+            # tick -- the same "continuously replenished stream" shape that
+            # exposed the starvation.
+            allowed, scheduled_claim = await engine._reserve_global_slot()
+            assert allowed is True
+            await engine._run_task_worker_tick(1_000.0 + tick)
+            scheduled_claim.release()
+
+    async with StateDB(fake_db) as db:
+        row = await db.fetch_one("SELECT status FROM schedule_runs WHERE id = ?", (run_id,))
+    assert row["status"] == "completed", (
+        "the ad-hoc lane must be admitted from its own independent pool even "
+        "while the scheduled cap stays continuously saturated"
+    )

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -948,3 +948,85 @@ async def test_reconcile_leaves_row_running_when_no_sessions_recorded(tmp_path, 
     async with StateDB(db_path) as db:
         run = await db.get_schedule_run(run_id)
     assert run["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_finalizes_completed_empty_orphan_as_failed_not_success(
+    tmp_path, monkeypatch
+):
+    """A dispatched orphan whose child session itself resolved to
+    "completed_empty" (clean exit, no completion evidence) must not be
+    reconciled as a success: the row's status, its reason_code, the emitted
+    signal class, and the on_fail/on_success chain decision must all
+    independently treat it as NOT success -- _reconcile_dispatched_orphans()
+    maps resolve_invocation_terminal()'s result through the same
+    _SCHEDULE_RUN_STATUS_FROM_INVOCATION table the live _fire() path uses,
+    and that table used to map completed_empty onto "completed"."""
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid, run_id, inv_id, sess_id = "sched-k", "run-orphan-k", "inv-k", "sess-k"
+    async with StateDB(db_path) as db:
+        await db.create_schedule(
+            _schedule_row(
+                sid,
+                next_fire_at=2000.0,
+                on_success={"kind": "agent", "prompt": "success chain", "model": "gpt-4.1-mini"},
+                on_fail={"kind": "agent", "prompt": "fail chain", "model": "gpt-4.1-mini"},
+            )
+        )
+        await db.create_invocation(
+            {"id": inv_id, "skill": "agent", "started_at": 1000.0, "status": "running"}
+        )
+        prog_id = f"{sess_id}-prog"
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": sess_id,
+                "progression_id": prog_id,
+                "invocation_id": inv_id,
+                "status": "completed_empty",
+            }
+        )
+        await db.create_schedule_run_and_advance(
+            _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+        await db.update_schedule_run(run_id, dispatched_at=1000.5)
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+    with patch.object(engine, "_tracked_fire") as mock_tracked_fire:
+        await engine._reconcile_dispatched_orphans()
+
+    async with StateDB(db_path) as db:
+        run = await db.get_schedule_run(run_id)
+        invocation = await db.get_invocation(inv_id)
+
+    # Assertion 1: status. Not "completed".
+    assert run["status"] == "failed"
+
+    # Assertion 2: reason. The completed_empty distinction survives in the
+    # reason_code even though the coarse status is "failed".
+    assert run["status_reason_code"] == RunReasons.COMPLETED_EMPTY_NO_EVIDENCE
+    assert invocation["status"] == "completed_empty"
+    assert invocation["status_reason_code"] == RunReasons.COMPLETED_EMPTY_NO_EVIDENCE
+
+    # Assertion 3: signal class. Must mint ScheduleRunFailed, not
+    # ScheduleRunSucceeded.
+    node_metadata = invocation.get("node_metadata") or {}
+    if isinstance(node_metadata, str):
+        import json
+
+        node_metadata = json.loads(node_metadata)
+    assert node_metadata["coordination"]["signals"]["emitted"] == {"ScheduleRunFailed": 1}
+
+    # Assertion 4: chaining. on_fail must fire (run_status is not
+    # "completed"); on_success must not.
+    mock_tracked_fire.assert_called_once()
+    (chain_schedule, _chain_run_id), chain_kwargs = mock_tracked_fire.call_args
+    assert chain_schedule["action_prompt"] == "fail chain"
+    assert chain_kwargs["trigger_context"]["parent_status"] == "failed"

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -815,3 +815,130 @@ async def test_recovery_refire_is_noop_when_dispatch_confirmed_mid_race(tmp_path
     # Only the doomed recovery attempt's invocation was cancelled.
     assert recovery_invocation["status"] == "cancelled"
     assert recovery_invocation["status_reason_code"] == RunReasons.CANCELLED_STALE_AUTO
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_dispatched_orphans -- confirmed-dispatch rows the scheduler
+# never recorded an outcome for (#2755)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_dispatched_run_with_session(
+    db: StateDB,
+    *,
+    sid: str,
+    run_id: str,
+    inv_id: str,
+    sess_id: str,
+    session_status: str,
+) -> None:
+    await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+    await db.create_invocation(
+        {"id": inv_id, "skill": "agent", "started_at": 1000.0, "status": "running"}
+    )
+    prog_id = f"{sess_id}-prog"
+    await db.create_progression(prog_id)
+    await db.create_session(
+        {
+            "id": sess_id,
+            "progression_id": prog_id,
+            "invocation_id": inv_id,
+            "status": session_status,
+        }
+    )
+    await db.create_schedule_run_and_advance(
+        _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id),
+        schedule_id=sid,
+        schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+    )
+    # Launch confirmed, mirroring spawn_and_wait's on_launched callback --
+    # the scheduler then crashes before recording the run's own outcome.
+    await db.update_schedule_run(run_id, dispatched_at=1000.5)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_finalizes_dispatched_orphan_from_terminal_session_evidence(
+    tmp_path, monkeypatch
+):
+    """A schedule_run confirmed-dispatched but never finalized (the
+    scheduler crashed between the two) must be reconciled from its child
+    session's OWN terminal status, written independently by that session's
+    own teardown -- not from any liveness guess about the dead scheduler."""
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid, run_id, inv_id, sess_id = "sched-h", "run-orphan-h", "inv-h", "sess-h"
+    async with StateDB(db_path) as db:
+        await _seed_dispatched_run_with_session(
+            db, sid=sid, run_id=run_id, inv_id=inv_id, sess_id=sess_id, session_status="completed"
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+    await engine._reconcile_dispatched_orphans()
+
+    async with StateDB(db_path) as db:
+        run = await db.get_schedule_run(run_id)
+    assert run["status"] == "completed"
+    assert run["ended_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_leaves_row_running_when_session_still_nonterminal(tmp_path, monkeypatch):
+    """Positive control for the above: when the linked session has NOT
+    reached a terminal status, the row must be left exactly as-is -- unknown
+    liveness is never treated as death. Falls through to the existing
+    wall-clock stale reaper unchanged."""
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid, run_id, inv_id, sess_id = "sched-i", "run-orphan-i", "inv-i", "sess-i"
+    async with StateDB(db_path) as db:
+        await _seed_dispatched_run_with_session(
+            db, sid=sid, run_id=run_id, inv_id=inv_id, sess_id=sess_id, session_status="running"
+        )
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+    await engine._reconcile_dispatched_orphans()
+
+    async with StateDB(db_path) as db:
+        run = await db.get_schedule_run(run_id)
+    assert run["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_leaves_row_running_when_no_sessions_recorded(tmp_path, monkeypatch):
+    """A dispatched row with no sessions at all (e.g. a bare 'command'
+    action, or an agent session row not yet inserted) carries no positive
+    completion evidence -- left running for the wall-clock stale reaper,
+    never guessed at."""
+    import lionagi.state.db as state_db_mod
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    sid, run_id, inv_id = "sched-j", "run-orphan-j", "inv-j"
+    async with StateDB(db_path) as db:
+        await db.create_schedule(_schedule_row(sid, next_fire_at=2000.0))
+        await db.create_invocation(
+            {"id": inv_id, "skill": "command", "started_at": 1000.0, "status": "running"}
+        )
+        await db.create_schedule_run_and_advance(
+            _run_row(run_id, sid, fired_at=1000.0, invocation_id=inv_id, action_kind="command"),
+            schedule_id=sid,
+            schedule_fields={"next_fire_at": 2000.0, "last_fired_at": 1000.0},
+        )
+        await db.update_schedule_run(run_id, dispatched_at=1000.5)
+
+    svc = _DBSchedulerStateService()
+    engine = SchedulerEngine(svc=svc)
+    await engine._reconcile_dispatched_orphans()
+
+    async with StateDB(db_path) as db:
+        run = await db.get_schedule_run(run_id)
+    assert run["status"] == "running"

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -881,8 +881,14 @@ async def test_reconcile_finalizes_dispatched_orphan_from_terminal_session_evide
 
     async with StateDB(db_path) as db:
         run = await db.get_schedule_run(run_id)
+        invocation = await db.get_invocation(inv_id)
     assert run["status"] == "completed"
     assert run["ended_at"] is not None
+    # The linked invocation must be finalized too, not left "running"
+    # forever -- otherwise the normal invocation telemetry/signal/chain
+    # side effects never happen for a run this pass just marked completed.
+    assert invocation["status"] == "completed"
+    assert invocation["ended_at"] is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

Five fixes to the scheduler, three closing an issue outright and two closing the
mechanical half of a larger one.

### The ad-hoc task-worker pass no longer blocks schedule evaluation

The ad-hoc pass ran on the tick's critical path with no bound, so a slow pass delayed
every schedule evaluation behind it. It now runs off the critical path.

### Ad-hoc worker executions reserve a global slot

They previously ran outside the global admission limit, so the configured ceiling did
not describe actual concurrency. They now reserve a slot like every other execution.

### `github_poll` schedules are excluded from missed-fire recovery

Replaying a missed poll re-fires against events that have already been handled. Poll
schedules are inherently catch-up, so recovery does not apply to them.

### A leader's exit is no longer treated as evidence its child finished

Terminal status was stamped when the leader's stderr reached EOF, which is when the
leader stopped writing, not when the work completed. The two diverge whenever the
leader exits before its child session does.

### Confirmed-dispatch orphans are reconciled from child evidence

A run confirmed dispatched but never reaching a terminal status could sit `running`
indefinitely — the scheduler that dispatched it may have crashed before recording an
outcome, or the process may still be genuinely alive. The new
`list_dispatched_running_schedule_runs()` surfaces candidates for reconciliation
without itself deciding liveness; `_reconcile_dispatched_orphans` makes that call from
the child session's own evidence.

It is scoped to rows carrying a linked invocation, the only case with independently
observable completion evidence today.

## Tests

Covered across the scheduler suites. The gate set was derived by grepping for the
changed symbols rather than from the diff's directories: 36 files spanning the
scheduler, task-worker, admission, and state-service suites, all passing. The skips are
pre-existing and environmental (`asyncpg` not installed).

## Deliberately not included

- **#2535 and #2755 are each half closed.** The mechanical halves are here. What remains
  in both is a policy question about what the scheduler should *do* once it knows a run
  is orphaned, which is a maintainer call rather than a mechanism.
- **#1975** asks for a two-stage `supervisor_unknown` / `orphaned` failure detector. That
  is a new state-machine stage, not an extension of the reconciliation added here, and
  it should be designed rather than grown out of this change.

Closes #2750
Closes #2751
Closes #2754
