### PR TITLE
fix(state): stop plain reads from reserving the writer lock, and stop teardown from claiming unrecorded status

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -985,6 +985,18 @@ async def teardown_persist(
         return final_status
     except Exception as exc:
         _log.warning("live persist teardown failed: %s", exc, exc_info=True)
+        # A failure anywhere in the block above (any of _teardown_common's
+        # separate write transactions, or the bookkeeping around them) must
+        # not make this return the *requested* terminal status as if it had
+        # landed -- that status may never have reached the database. Read
+        # back what is actually durable instead; only fall back to the
+        # caller's request if even that read fails.
+        try:
+            persisted = await db.get_session(ctx["session_id"])
+        except Exception:  # noqa: BLE001 -- best-effort; the DB itself may be unreachable
+            persisted = None
+        if persisted is not None and persisted.get("status"):
+            return persisted["status"]
         return status
     finally:
         # Release branch ownership even when the bookkeeping above failed -- a

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -997,7 +997,12 @@ async def teardown_persist(
             persisted = None
         if persisted is not None and persisted.get("status"):
             return persisted["status"]
-        return status
+        # The readback itself failed (or found nothing) -- there is no
+        # evidence the requested terminal status ever reached the database.
+        # Reporting `status` here would be the same false-terminal-status
+        # class this teardown path exists to prevent, so surface an
+        # explicit unknown outcome instead of a guess.
+        return "unknown"
     finally:
         # Release branch ownership even when the bookkeeping above failed -- a
         # stranded owner marker would make the long-lived branch unresumable.

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1027,11 +1027,17 @@ async def _execute_dag(
         env._finalize_extras = extras
 
         async def _do():
-            with contextlib.suppress(Exception):
+            try:
                 # Merge kill-identity markers last so segment writes keep the PID.
                 _markers = ctx.get("identity_markers") or {}
                 await ctx["db"].update_session(
                     ctx["session_id"], node_metadata=json.dumps({**extras, **_markers})
+                )
+            except Exception:
+                logger.warning(
+                    "segment metadata write failed for session %s",
+                    ctx["session_id"],
+                    exc_info=True,
                 )
 
         _segment_tasks.append(_asyncio.ensure_future(_do()))
@@ -1194,10 +1200,16 @@ async def _execute_dag(
         env._finalize_extras = extras
 
         async def _do():
-            with contextlib.suppress(Exception):
+            try:
                 _markers = ctx.get("identity_markers") or {}
                 await ctx["db"].update_session(
                     ctx["session_id"], node_metadata=json.dumps({**extras, **_markers})
+                )
+            except Exception:
+                logger.warning(
+                    "control-log metadata write failed for session %s",
+                    ctx["session_id"],
+                    exc_info=True,
                 )
 
         _control_log_tasks.append(_asyncio.ensure_future(_do()))
@@ -1509,6 +1521,27 @@ async def _execute_dag(
                         "still alive after cancellation grace period"
                     )
 
+        async def _drain_metadata_tasks_bounded(tasks: list, label: str) -> None:
+            # Same bounded grace/cancellation shape as
+            # _drain_escalation_links_bounded: a hung metadata write (stuck
+            # DB call) must not block teardown forever. Give in-flight
+            # writes a short grace period, then cancel whatever is left and
+            # wait for it to actually unwind before returning.
+            with contextlib.suppress(Exception), move_on_after(2):
+                await _asyncio.gather(*tasks, return_exceptions=True)
+            _survivors = [t for t in tasks if not t.done()]
+            for _t in _survivors:
+                _t.cancel()
+            if _survivors:
+                with contextlib.suppress(Exception), move_on_after(2):
+                    await _asyncio.gather(*_survivors, return_exceptions=True)
+                _abandoned = [t for t in _survivors if not t.done()]
+                if _abandoned:
+                    _warn(
+                        f"abandoned {len(_abandoned)} {label} task(s) "
+                        "still alive after cancellation grace period"
+                    )
+
         # Completion observers schedule persistence writes synchronously but the
         # writes themselves are async. Drain them while the live DB is still open.
         with CancelScope(shield=True):
@@ -1519,11 +1552,9 @@ async def _execute_dag(
                 with contextlib.suppress(Exception):
                     await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
             if _segment_tasks:
-                with contextlib.suppress(Exception):
-                    await _asyncio.gather(*_segment_tasks, return_exceptions=True)
+                await _drain_metadata_tasks_bounded(_segment_tasks, "segment-metadata")
             if _control_log_tasks:
-                with contextlib.suppress(Exception):
-                    await _asyncio.gather(*_control_log_tasks, return_exceptions=True)
+                await _drain_metadata_tasks_bounded(_control_log_tasks, "control-log-metadata")
             if _escalation_link_tasks:
                 if _dag_cancelled:
                     # Cancellation already landed while run_dag() was running,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -969,6 +969,8 @@ async def _execute_dag(
     _checkpoint_tasks: list = []
     _branch_status_tasks: list = []
     _escalation_link_tasks: list = []
+    _segment_tasks: list = []
+    _control_log_tasks: list = []
 
     _checkpoint_writer: CheckpointWriter | None = None
     if checkpoint_config is not None:
@@ -1032,7 +1034,7 @@ async def _execute_dag(
                     ctx["session_id"], node_metadata=json.dumps({**extras, **_markers})
                 )
 
-        _asyncio.ensure_future(_do())
+        _segment_tasks.append(_asyncio.ensure_future(_do()))
 
     def _update_branch_status(branch_name: str, new_status: str):
         ctx = getattr(env, "_live_persist", None)
@@ -1198,7 +1200,7 @@ async def _execute_dag(
                     ctx["session_id"], node_metadata=json.dumps({**extras, **_markers})
                 )
 
-        _asyncio.ensure_future(_do())
+        _control_log_tasks.append(_asyncio.ensure_future(_do()))
 
     # Only wired when team messaging + reactive mode are on and at least
     # one worker got a branch built (nothing to inject otherwise).
@@ -1516,6 +1518,12 @@ async def _execute_dag(
             if _checkpoint_tasks:
                 with contextlib.suppress(Exception):
                     await _asyncio.gather(*_checkpoint_tasks, return_exceptions=True)
+            if _segment_tasks:
+                with contextlib.suppress(Exception):
+                    await _asyncio.gather(*_segment_tasks, return_exceptions=True)
+            if _control_log_tasks:
+                with contextlib.suppress(Exception):
+                    await _asyncio.gather(*_control_log_tasks, return_exceptions=True)
             if _escalation_link_tasks:
                 if _dag_cancelled:
                     # Cancellation already landed while run_dag() was running,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -1541,6 +1541,18 @@ async def _execute_dag(
                         f"abandoned {len(_abandoned)} {label} task(s) "
                         "still alive after cancellation grace period"
                     )
+            # A task can finish cancelled either here or already during the
+            # first move_on_after(2) above (its timeout cancels the host
+            # task's gather() await, which cascades cancel() onto every
+            # not-yet-done child). Either way it's a lost write, not a
+            # success: the write body's own `except Exception` never sees
+            # CancelledError (a BaseException), so without this check the
+            # caller gets no record at all that the metadata never landed.
+            _cancelled = [t for t in tasks if t.cancelled()]
+            if _cancelled:
+                _warn(
+                    f"cancelled {len(_cancelled)} {label} task(s) after timeout; write not durable"
+                )
 
         # Completion observers schedule persistence writes synchronously but the
         # writes themselves are async. Drain them while the live DB is still open.

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -561,6 +561,13 @@ def _install_begin_immediate(sync_engine) -> None:
 
     @event.listens_for(sync_engine, "begin")
     def _on_begin(conn):
+        # AUTOCOMMIT reads (see _read()) reach this listener too -- the DBAPI
+        # driver already runs in autocommit, but Core still autobegins a
+        # logical transaction and dispatches "begin" for it. Only a real
+        # (non-AUTOCOMMIT) transaction should reserve the writer slot; an
+        # ordinary read must not contend for it.
+        if conn.get_execution_options().get("isolation_level") == "AUTOCOMMIT":
+            return
         conn.exec_driver_sql("BEGIN IMMEDIATE")
 
 

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""SQLAlchemy MetaData for all 28 StateDB tables — single source of truth for schema DDL."""
+"""SQLAlchemy MetaData for every StateDB table — single source of truth for schema DDL."""
 
 from __future__ import annotations
 

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -379,7 +379,34 @@ class TestStoreProbe:
             blocker.rollback()
             blocker.close()
 
-    def test_a_caller_that_gives_up_first_also_leaves_nothing_running(self, seeded):
+        # The real-thread assertion above passes the same way whether or not
+        # the predicate checks is_alive() -- by the time it runs, a
+        # correctly-cleaned-up worker has already dropped out of
+        # threading.enumerate() entirely, so a target-only predicate and the
+        # correct one agree by coincidence, not because either was exercised.
+        # Force the discriminating case: splice a terminating-but-not-alive
+        # stand-in into the real thread listing and confirm _workers() (the
+        # same computation the assertion above relies on) does not count it.
+        real_enumerate = threading.enumerate
+
+        class _TerminatingWorker:
+            def __init__(self) -> None:
+                # Set on the instance, not the class -- a plain function
+                # assigned as a class attribute binds as a method on access
+                # (breaking `is target` identity below).
+                self._target = _connection_worker_thread
+
+            def is_alive(self) -> bool:
+                return False
+
+        monkeypatch.setattr(
+            threading, "enumerate", lambda: [*real_enumerate(), _TerminatingWorker()]
+        )
+        assert _workers() == before, (
+            "a terminating-but-not-alive worker must not be counted as live"
+        )
+
+    def test_a_caller_that_gives_up_first_also_leaves_nothing_running(self, seeded, monkeypatch):
         """The same cleanup, with the cancellation coming from outside.
 
         Readiness is served inside a request, and a request can be abandoned:
@@ -430,6 +457,31 @@ class TestStoreProbe:
         finally:
             blocker.rollback()
             blocker.close()
+
+        # Same coincidence as the previous test: by assertion time a
+        # correctly-cleaned-up worker is already gone from
+        # threading.enumerate(), so this passes whether or not the predicate
+        # checks is_alive(). Splice in a terminating-but-not-alive stand-in
+        # and confirm _workers() -- the same computation the assertion above
+        # relies on -- does not count it as live.
+        real_enumerate = threading.enumerate
+
+        class _TerminatingWorker:
+            def __init__(self) -> None:
+                # Set on the instance, not the class -- a plain function
+                # assigned as a class attribute binds as a method on access
+                # (breaking `is target` identity below).
+                self._target = _connection_worker_thread
+
+            def is_alive(self) -> bool:
+                return False
+
+        monkeypatch.setattr(
+            threading, "enumerate", lambda: [*real_enumerate(), _TerminatingWorker()]
+        )
+        assert _workers() == before, (
+            "a terminating-but-not-alive worker must not be counted as live"
+        )
 
     def test_live_connection_worker_predicate_excludes_a_reaped_thread(self):
         """Both arms of the worker-count predicate: a thread still actually

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -17,6 +17,21 @@ from fastapi.testclient import TestClient
 from lionagi.studio.app import create_app
 
 
+def _is_live_connection_worker(t, target) -> bool:
+    """True for a thread object that is both aiosqlite's connection worker
+    *and* still actually running.
+
+    aiosqlite's worker schedules its close future's result via
+    ``call_soon_threadsafe`` and only then breaks out of its loop, so the
+    event loop can observe the future as done -- and an awaiting ``close()``
+    can return -- a moment before the OS thread has finished tearing itself
+    down and dropped out of ``threading.enumerate()``'s backing registry.
+    Matching by ``_target`` alone counts that terminating-but-not-yet-reaped
+    thread object as a live leak; ``is_alive()`` does not.
+    """
+    return getattr(t, "_target", None) is target and t.is_alive()
+
+
 def _seed(db_path, *, sessions: int, branches_per_session: int = 1) -> list[str]:
     from lionagi.state.db import _SCHEMA_PATH
 
@@ -351,7 +366,7 @@ class TestStoreProbe:
             return sum(
                 1
                 for t in threading.enumerate()
-                if getattr(t, "_target", None) is _connection_worker_thread
+                if _is_live_connection_worker(t, _connection_worker_thread)
             )
 
         blocker = _hold_the_write_lock(db_path)
@@ -396,7 +411,7 @@ class TestStoreProbe:
             return sum(
                 1
                 for t in threading.enumerate()
-                if getattr(t, "_target", None) is _connection_worker_thread
+                if _is_live_connection_worker(t, _connection_worker_thread)
             )
 
         blocker = _hold_the_write_lock(db_path)
@@ -415,6 +430,32 @@ class TestStoreProbe:
         finally:
             blocker.rollback()
             blocker.close()
+
+    def test_live_connection_worker_predicate_excludes_a_reaped_thread(self):
+        """Both arms of the worker-count predicate: a thread still actually
+        running is counted, and a thread object whose target has already
+        returned (is_alive() is False) is not, even though it still shares
+        the same ``_target`` and has not yet dropped out of
+        ``threading.enumerate()``'s backing registry."""
+
+        def _target():
+            pass
+
+        class _FakeThread:
+            def __init__(self, target, alive: bool):
+                self._target = target
+                self._alive = alive
+
+            def is_alive(self) -> bool:
+                return self._alive
+
+        running = _FakeThread(_target, alive=True)
+        terminating = _FakeThread(_target, alive=False)
+        other = _FakeThread(lambda: None, alive=True)
+
+        assert _is_live_connection_worker(running, _target) is True
+        assert _is_live_connection_worker(terminating, _target) is False
+        assert _is_live_connection_worker(other, _target) is False
 
     def test_a_connect_is_never_abandoned_partway(self, seeded, monkeypatch):
         """Whatever else is cancelled, the connect runs to completion.

--- a/tests/apps_studio_server/test_stats_db_health.py
+++ b/tests/apps_studio_server/test_stats_db_health.py
@@ -14,6 +14,7 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
 import lionagi.state.db as state_db_mod
+import lionagi.state.engine as state_engine_mod
 from lionagi.state.db import StateDB  # noqa: E402
 
 
@@ -65,9 +66,28 @@ def test_stats_db_health_with_existing_db(tmp_path, monkeypatch):
     assert db["tables"]["sessions"] == 2
     assert db["sessions_by_status"].get("running", 0) == 1
     assert db["sessions_by_status"].get("completed", 0) == 1
-    assert db["pragmas"]["busy_timeout"] == 5000
+    # The pragma must reflect this process's configured busy_timeout, not a
+    # hardcoded default -- LIONAGI_SQLITE_BUSY_TIMEOUT_MS lets a deployment
+    # raise it, and this process (and the test suite) may already be running
+    # under such a deployment's environment.
+    assert db["pragmas"]["busy_timeout"] == state_engine_mod.SQLITE_BUSY_TIMEOUT_MS
     assert isinstance(db["connections_active"], int)
     assert db["last_checkpoint_at"] is None
+
+
+def test_stats_db_health_busy_timeout_reflects_deployment_knob_not_default(tmp_path, monkeypatch):
+    """A deployment that raises the busy_timeout above the 5000ms default
+    must see its own value reported back, not the suite's default."""
+    monkeypatch.setattr(state_engine_mod, "SQLITE_BUSY_TIMEOUT_MS", 30000)
+    db_path = tmp_path / "state.db"
+    _run(_seed_two_sessions(db_path))
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/stats")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["db"]["pragmas"]["busy_timeout"] == 30000
+    assert data["db"]["pragmas"]["busy_timeout"] != 5000
 
 
 def test_stats_db_health_missing_db_returns_zeroes(tmp_path, monkeypatch):

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -967,6 +967,68 @@ async def test_execute_dag_role_attributed_node_missing_spawn_id_fails_loud(tmp_
             await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
 
 
+async def test_execute_dag_drains_segment_metadata_write_before_returning(tmp_path):
+    """Node-completion segment metadata is written by a fire-and-forget task.
+    If _execute_dag returned before that write landed, a caller running
+    finalization right after (as teardown does) could overwrite the
+    session's whole node_metadata object without ever seeing the segment.
+    The write must be drained -- awaited -- before _execute_dag returns."""
+    import asyncio as _real_asyncio
+
+    class _SlowFakeDB(_FakeDB):
+        async def update_session(self, session_id, **kw):
+            await _real_asyncio.sleep(0.05)
+            await super().update_session(session_id, **kw)
+
+    fake_db = _SlowFakeDB()
+    env = _make_env(
+        tmp_path,
+        live_persist={"db": fake_db, "session_id": "sess-1", "identity_markers": {}},
+    )
+    env.session.include_branches(_FakeBranch("researcher"))
+
+    assignments = [TaskAssignment(task="x", assignee="researcher")]
+    plan_result = _PlanResult(
+        assignments=assignments,
+        agent_ids=["researcher"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=set(),
+        role_base={},
+        worker_models=["codex/gpt-5.5"],
+    )
+
+    from lionagi.engines import PlanningEngine
+    from lionagi.session.signal import NodeCompleted, NodeStarted
+
+    async def _run_dag_and_emit_node_signals(*_args, **_kwargs):
+        handlers = dict(env.session._observers)
+        handlers[NodeStarted](NodeStarted(op_id="node-0", name="researcher"), None)
+        handlers[NodeCompleted](NodeCompleted(op_id="node-0", name="researcher"), None)
+        return {"operation_results": {"node-0": "output"}, "spawned_operations": 0}
+
+    fake_engine_run = MagicMock()
+    fake_engine_run.run_dag = _run_dag_and_emit_node_signals
+
+    with patch.object(PlanningEngine, "new_run", return_value=fake_engine_run):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    segment_writes = [
+        json.loads(kw["node_metadata"])
+        for _sid, kw in fake_db.calls
+        if "node_metadata" in kw and "segments" in json.loads(kw["node_metadata"])
+    ]
+    assert segment_writes, "expected the node-completion segment write to have landed"
+    assert segment_writes[-1]["segments"], "segment entry for the completed node was not recorded"
+
+
 # ── Reactive spawn artifact enforcement through REAL teardown ─────────────────
 # Replaces the old interim regression test that pinned spawned artifacts as
 # permanently non-required (a spawned node used to have no way to learn its

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -4036,3 +4036,191 @@ async def test_execute_dag_run_level_cancellation_skips_reconciliation_entirely(
     assert not getattr(env, "_failed_operation_evidence", None)
 
     await stop_live_persist(env, status="cancelled")
+
+
+async def test_execute_dag_records_control_log_write_failure_when_update_session_raises(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A control-log metadata write (``update_session()``) that raises used to
+    be swallowed by a bare ``contextlib.suppress(Exception)`` inside the
+    fire-and-forget task -- the applied control was recorded in memory but the
+    write that was supposed to persist it silently vanished. It must now be
+    logged instead of dropped."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate import flow as flow_module
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.engines import PlanningEngine
+
+    monkeypatch.setattr(flow_module, "_CONTROL_POLL_INTERVAL", 0.01)
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    calls = {"n": 0}
+
+    async def _list_pending(session_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return [{"id": "control-1", "verb": "pause"}]
+        return []
+
+    real_update_session = ctx["db"].update_session
+
+    async def _raising_update_session(session_id, **kwargs):
+        if "node_metadata" in kwargs:
+            raise RuntimeError("db unavailable")
+        return await real_update_session(session_id, **kwargs)
+
+    monkeypatch.setattr(ctx["db"], "list_pending_session_controls", _list_pending)
+    monkeypatch.setattr(ctx["db"], "update_session", _raising_update_session)
+
+    async def _stub_apply_session_control(db, executor, row):
+        return "applied"
+
+    monkeypatch.setattr(flow_module, "_apply_session_control", _stub_apply_session_control)
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["test/model"],
+    )
+
+    async def run_dag(graph, **kwargs):
+        kwargs["executor_ref"]["executor"] = object()
+        # Long enough for the (fast-forwarded) control poller to tick at
+        # least once before this returns.
+        await asyncio.sleep(0.1)
+        return {"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    with (
+        patch.object(PlanningEngine, "new_run", return_value=engine_run),
+        caplog.at_level("WARNING", logger="lionagi.cli.orchestrate.flow"),
+    ):
+        await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    await stop_live_persist(env, status="completed")
+
+    assert any(
+        "control-log metadata write failed" in record.message for record in caplog.records
+    ), "a raising control-log write must be logged, not silently dropped"
+
+
+async def test_execute_dag_bounds_control_log_drain_on_hanging_update_session(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The same drain, but ``update_session()`` hangs instead of raising.
+    Before the fix, the finally block's plain ``gather()`` over the
+    control-log tasks had no bound: a hung write meant ``_execute_dag`` never
+    returned, teardown never ran, and the live database stayed open forever.
+    The drain must now give the write a grace period, then cancel and
+    abandon it -- completing in bounded time and recording that it did."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.cli.orchestrate import flow as flow_module
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.engines import PlanningEngine
+
+    monkeypatch.setattr(flow_module, "_CONTROL_POLL_INTERVAL", 0.01)
+
+    env = _minimal_env()
+    await start_live_persist(env, invocation_kind="flow")
+    ctx = env._live_persist
+    assert ctx is not None
+
+    calls = {"n": 0}
+
+    async def _list_pending(session_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return [{"id": "control-1", "verb": "pause"}]
+        return []
+
+    real_update_session = ctx["db"].update_session
+    write_started = asyncio.Event()
+    write_cancelled = asyncio.Event()
+
+    async def _hanging_update_session(session_id, **kwargs):
+        if "node_metadata" not in kwargs:
+            return await real_update_session(session_id, **kwargs)
+        write_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            write_cancelled.set()
+            raise
+
+    monkeypatch.setattr(ctx["db"], "list_pending_session_controls", _list_pending)
+    monkeypatch.setattr(ctx["db"], "update_session", _hanging_update_session)
+
+    async def _stub_apply_session_control(db, executor, row):
+        return "applied"
+
+    monkeypatch.setattr(flow_module, "_apply_session_control", _stub_apply_session_control)
+
+    warnings: list[str] = []
+    monkeypatch.setattr(flow_module, "_warn", warnings.append)
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="do it", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=["node-0"],
+        known_nodes={"node-0"},
+        deps_by_node={"node-0": []},
+        reactive=False,
+        spawn_roles=None,
+        role_base={},
+        worker_models=["test/model"],
+    )
+
+    async def run_dag(graph, **kwargs):
+        kwargs["executor_ref"]["executor"] = object()
+        # Hangs until _execute_dag's own task is cancelled from outside --
+        # by that point the control-log write is already in flight.
+        await write_started.wait()
+        await asyncio.Event().wait()
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    with patch.object(PlanningEngine, "new_run", return_value=engine_run):
+        execute_task = asyncio.create_task(
+            _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+        )
+        await write_started.wait()
+        execute_task.cancel()
+
+        start = asyncio.get_event_loop().time()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(execute_task, timeout=8)
+        elapsed = asyncio.get_event_loop().time() - start
+
+    assert elapsed < 6, f"teardown took {elapsed}s -- the control-log drain is unbounded again"
+    assert write_cancelled.is_set(), (
+        "the hung control-log write must be cancelled during teardown, not left running"
+    )
+    await stop_live_persist(env, status="completed")

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -4223,4 +4223,13 @@ async def test_execute_dag_bounds_control_log_drain_on_hanging_update_session(
     assert write_cancelled.is_set(), (
         "the hung control-log write must be cancelled during teardown, not left running"
     )
+    assert any("cancelled" in w and "control-log-metadata" in w for w in warnings), (
+        "a cancelled-after-timeout metadata write must be recorded through the "
+        f"caller-visible warning sink, not dropped silently; got {warnings!r}"
+    )
+    # _teardown_common's final metadata merge (lionagi/cli/_runs.py:538) also calls
+    # update_session() with node_metadata whenever extras is non-empty, which it is
+    # here (the control log). The hanging double must not still be wired for that
+    # call or this cleanup step hangs too.
+    monkeypatch.setattr(ctx["db"], "update_session", real_update_session)
     await stop_live_persist(env, status="completed")

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -722,6 +722,36 @@ async def test_stop_closes_db_even_if_bookmark_update_fails(
     assert _aiosqlite_thread_count() <= before
 
 
+async def test_stop_does_not_claim_a_terminal_status_the_db_never_recorded(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If a later write inside teardown raises after an earlier one already
+    committed, the returned status must reflect what is durably persisted
+    (still "running"), never the terminal status the caller asked for."""
+    env = _minimal_env()
+    await start_live_persist(env)
+    session_id = env._live_persist["session_id"]
+
+    async def boom(self, session_id, verification):
+        raise RuntimeError("simulated artifact verification write failure")
+
+    monkeypatch.setattr(StateDB, "update_artifact_verification", boom)
+
+    final_status = await stop_live_persist(env, status="completed")
+
+    assert final_status != "completed"
+
+    checker = StateDB(temp_db_path)
+    await checker.open()
+    try:
+        row = await checker.get_session(session_id)
+        assert row["status"] == "running"
+        assert final_status == row["status"]
+    finally:
+        await checker.close()
+
+
 async def test_stop_with_none_context_is_noop(temp_db_path: Path):
     """If start failed, env._live_persist is None and stop is a no-op."""
     env = _minimal_env()

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -2904,9 +2904,13 @@ async def test_execute_dag_bounds_escalation_link_drain_on_cancellation(
             await asyncio.wait_for(execute_task, timeout=5)
         elapsed = time.monotonic() - start
 
-    assert elapsed < 5, f"teardown took {elapsed}s — the escalation-link drain is unbounded again"
-    assert link_cancelled.is_set()
-    await stop_live_persist(env, status="completed")
+    try:
+        assert elapsed < 5, (
+            f"teardown took {elapsed}s — the escalation-link drain is unbounded again"
+        )
+        assert link_cancelled.is_set()
+    finally:
+        await stop_live_persist(env, status="completed")
 
 
 async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
@@ -3012,11 +3016,13 @@ async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
             await asyncio.wait_for(execute_task, timeout=8)
         elapsed = time.monotonic() - start
 
-    assert elapsed < 6, (
-        f"teardown took {elapsed}s — a late-arriving cancellation still hangs the drain"
-    )
-    assert link_cancelled.is_set()
-    await stop_live_persist(env, status="completed")
+    try:
+        assert elapsed < 6, (
+            f"teardown took {elapsed}s — a late-arriving cancellation still hangs the drain"
+        )
+        assert link_cancelled.is_set()
+    finally:
+        await stop_live_persist(env, status="completed")
 
 
 async def test_execute_dag_bounds_escalation_link_drain_survivor_await(
@@ -3130,11 +3136,13 @@ async def test_execute_dag_bounds_escalation_link_drain_survivor_await(
             await asyncio.wait_for(execute_task, timeout=8)
         elapsed = time.monotonic() - start
 
-    assert elapsed < 6, (
-        f"teardown took {elapsed}s — the escalation-link survivor await is unbounded again"
-    )
-    assert link_cancelled.is_set()
-    await stop_live_persist(env, status="completed")
+    try:
+        assert elapsed < 6, (
+            f"teardown took {elapsed}s — the escalation-link survivor await is unbounded again"
+        )
+        assert link_cancelled.is_set()
+    finally:
+        await stop_live_persist(env, status="completed")
 
 
 async def test_execute_dag_late_cancellation_does_not_clobber_dag_exception(
@@ -4219,17 +4227,20 @@ async def test_execute_dag_bounds_control_log_drain_on_hanging_update_session(
             await asyncio.wait_for(execute_task, timeout=8)
         elapsed = asyncio.get_event_loop().time() - start
 
-    assert elapsed < 6, f"teardown took {elapsed}s -- the control-log drain is unbounded again"
-    assert write_cancelled.is_set(), (
-        "the hung control-log write must be cancelled during teardown, not left running"
-    )
-    assert any("cancelled" in w and "control-log-metadata" in w for w in warnings), (
-        "a cancelled-after-timeout metadata write must be recorded through the "
-        f"caller-visible warning sink, not dropped silently; got {warnings!r}"
-    )
-    # _teardown_common's final metadata merge (lionagi/cli/_runs.py:538) also calls
-    # update_session() with node_metadata whenever extras is non-empty, which it is
-    # here (the control log). The hanging double must not still be wired for that
-    # call or this cleanup step hangs too.
-    monkeypatch.setattr(ctx["db"], "update_session", real_update_session)
-    await stop_live_persist(env, status="completed")
+    try:
+        assert elapsed < 6, f"teardown took {elapsed}s -- the control-log drain is unbounded again"
+        assert write_cancelled.is_set(), (
+            "the hung control-log write must be cancelled during teardown, not left running"
+        )
+        assert any("cancelled" in w and "control-log-metadata" in w for w in warnings), (
+            "a cancelled-after-timeout metadata write must be recorded through the "
+            f"caller-visible warning sink, not dropped silently; got {warnings!r}"
+        )
+    finally:
+        # _teardown_common's final metadata merge (lionagi/cli/_runs.py:538) also calls
+        # update_session() with node_metadata whenever extras is non-empty, which it is
+        # here (the control log). The hanging double must not still be wired for that
+        # call or this cleanup step hangs too. This must run even if an assertion
+        # above fails, or the hanging double stays wired and later cleanup hangs.
+        monkeypatch.setattr(ctx["db"], "update_session", real_update_session)
+        await stop_live_persist(env, status="completed")

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -1981,6 +1981,54 @@ async def test_readonly_rejects_write_attempt(tmp_path):
         await ro.close()
 
 
+async def test_writable_read_does_not_issue_begin_immediate(tmp_path):
+    """StateDB._read() on a writable engine must not reserve the SQLite
+    writer slot. Tracing the raw driver connection during a plain read must
+    show no BEGIN IMMEDIATE -- only the SELECT."""
+    db_path = tmp_path / "read_no_lock.db"
+    db = StateDB(db_path)
+    await db.open()
+    try:
+        statements: list[str] = []
+        async with db._read() as conn:
+            raw_conn = await conn.get_raw_connection()
+            await raw_conn.driver_connection.set_trace_callback(statements.append)
+            result = await conn.execute(text("SELECT 42 AS answer"))
+            assert result.scalar() == 42
+            await raw_conn.driver_connection.set_trace_callback(None)
+        upper = [s.strip().upper() for s in statements]
+        assert "BEGIN IMMEDIATE" not in upper, upper
+    finally:
+        await db.close()
+
+
+async def test_writable_read_survives_a_concurrent_write_lock(tmp_path):
+    """A read must complete while a separate connection holds SQLite's
+    writer lock via BEGIN IMMEDIATE -- it must not wait out the busy
+    timeout behind a lock it never needed to contend for."""
+    db_path = tmp_path / "read_survives_lock.db"
+    seed = StateDB(db_path)
+    await seed.open()
+    await seed.close()
+
+    db = StateDB(db_path)
+    await db.open()
+    try:
+        blocker = sqlite3.connect(str(db_path), timeout=0)
+        blocker.execute("BEGIN IMMEDIATE")
+        try:
+            start = time.monotonic()
+            rows = await db.fetch_all("SELECT 42 AS answer")
+            elapsed = time.monotonic() - start
+        finally:
+            blocker.rollback()
+            blocker.close()
+        assert rows == [{"answer": 42}]
+        assert elapsed < 1.0, f"read waited {elapsed}s behind a lock it should not contend for"
+    finally:
+        await db.close()
+
+
 # ── update_status extra_fields: schedule_run ────────────────────────────────
 
 

--- a/tests/state/test_db_locking.py
+++ b/tests/state/test_db_locking.py
@@ -132,6 +132,41 @@ async def test_busy_timeout_eventually_returns_locked_error(
         await db2.close()
 
 
+# ── fanout: reads must not queue behind a held writer lock ──────────────────
+
+
+async def test_many_concurrent_reads_survive_a_held_write_lock(db_path: Path):
+    """A pile of concurrent readers -- standing in for many `li` processes
+    checking session state during a wide fanout -- must all complete while a
+    separate connection holds the SQLite writer lock, instead of queuing
+    behind it and burning the busy-timeout budget one at a time."""
+    seed = StateDB(db_path)
+    await seed.open()
+    await seed.insert_message(_make_msg())
+    await seed.close()
+
+    db = StateDB(db_path)
+    await db.open()
+    try:
+        import sqlite3
+
+        blocker = sqlite3.connect(str(db_path), timeout=0)
+        blocker.execute("BEGIN IMMEDIATE")
+        try:
+            start = time.monotonic()
+            results = await asyncio.gather(
+                *(db.fetch_all("SELECT COUNT(*) AS n FROM messages") for _ in range(20))
+            )
+            elapsed = time.monotonic() - start
+        finally:
+            blocker.rollback()
+            blocker.close()
+        assert all(rows == [{"n": 1}] for rows in results)
+        assert elapsed < 1.0, f"20 concurrent reads took {elapsed}s behind a held write lock"
+    finally:
+        await db.close()
+
+
 # ── save_definition under contention ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## What changed

Seven fixes across the state layer, teardown, and two tests that were asserting the
wrong thing.

### Plain reads no longer reserve the SQLite writer lock

`StateDB._read()` runs on the writable engine with `isolation_level="AUTOCOMMIT"`, but the
global `BEGIN IMMEDIATE` listener fired for it anyway: the DBAPI driver is already in
autocommit, yet SQLAlchemy Core still autobegins a logical transaction and dispatches
`begin` for it. So every ordinary read took the writer slot and contended with real
writers.

The listener now returns early when the execution options report `AUTOCOMMIT`. Only a
real transaction reserves the writer slot.

This is the direct cause of the single-writer contention seen under concurrent fanout.

### Teardown no longer claims a status the database never recorded

`teardown_persist()` wrapped several separate writes and returned a terminal status
regardless of whether those writes landed, so a caller could be told a run finished in a
state the database never held.

### Untracked metadata writers can no longer overwrite finalization keys

`_persist_segments()` and `_persist_control_log()` could write after teardown and clobber
finalization keys. Both are now drained before teardown completes.

### Two tests corrected

- The health endpoint test asserted `busy_timeout == 5000`, which is only the default —
  it now pins the wiring rather than one configured value, so a machine with a different
  timeout no longer reads as a failure.
- The worker-thread leak check raced thread teardown on Python 3.10 (confirmed by reading
  aiosqlite's `Connection.close()` path rather than by guessing at flakiness).

### The schema table count is no longer hardcoded

It went stale on every table addition. The issue's own reproduction — adding a column in
`schema_meta.py` — was reproduced before the fix.

## Tests

New coverage for concurrent reads against a held writer lock, which is the assertion the
first fix actually needs: a read must proceed while a writer holds the lock.

Gate: 1613 passed, 2 skipped across 63 files, derived by grepping for the changed modules
rather than from the diff's directories. Both skips are environmental (`asyncpg` absent,
and one test requiring Python 3.11 syntax).

## Note for reviewers

This touches `lionagi/state/db.py`, as does #2901. The two edits are about 4000 lines
apart and independent — one adds a scheduler query method, this one guards the
transaction listener — and a merge of the two branches produces no conflict and no
duplicate definitions. Order of merge should not matter, but the second one in will want
a rebase.

Closes #2757
Closes #2275
Closes #2752
Closes #2753
Closes #2890
Closes #2891
Closes #2745
