### PR TITLE
feat(studio): editable skills with dedicated detail panes, and invocation counts that stop capping at the page limit

### DIFF
--- a/apps/studio/frontend/package-lock.json
+++ b/apps/studio/frontend/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.61.1",
         "@tanstack/router-plugin": "^1.168.18",
         "@types/node": "^20.12.0",
@@ -542,9 +542,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -623,9 +623,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -660,24 +660,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -3063,9 +3055,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4145,9 +4137,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4229,9 +4221,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4306,19 +4298,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4327,9 +4306,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5687,9 +5666,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/apps/studio/frontend/package.json
+++ b/apps/studio/frontend/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@playwright/test": "^1.61.1",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.4",
     "@tanstack/router-plugin": "^1.168.18",
     "@types/node": "^20.12.0",
     "@types/react": "^19.2.15",

--- a/apps/studio/frontend/src/components/library/AgentDetail.tsx
+++ b/apps/studio/frontend/src/components/library/AgentDetail.tsx
@@ -9,7 +9,12 @@ import {
   getCasts,
   deleteAgent,
 } from "@/lib/api";
-import type { CastMode, DefinitionDetail, DefinitionVersion } from "@/lib/api";
+import type {
+  CastMode,
+  DefinitionDetail,
+  DefinitionVersion,
+  DefinitionVersionDetail,
+} from "@/lib/api";
 import type { AgentProfileSummary } from "@/lib/types";
 import SectionLabel from "@/components/ui/SectionLabel";
 import Button from "@/components/ui/Button";
@@ -78,7 +83,7 @@ export function AgentDetail({ agent, onBack, onDeleted }: Props) {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savedOk, setSavedOk] = useState(false);
 
-  const [previewVer, setPreviewVer] = useState<DefinitionDetail | null>(null);
+  const [previewVer, setPreviewVer] = useState<DefinitionVersionDetail | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const [modes, setModes] = useState<CastMode[]>([]);
@@ -325,9 +330,11 @@ export function AgentDetail({ agent, onBack, onDeleted }: Props) {
                   {t("saveDone")}
                 </span>
               )}
-              <span className="font-data text-[length:var(--t-xs)] text-content-muted">
-                v{def.version}
-              </span>
+              {def.version != null && (
+                <span className="font-data text-[length:var(--t-xs)] text-content-muted">
+                  v{def.version}
+                </span>
+              )}
               {isProtected && (
                 <span
                   title="System agent — not editable or deletable"
@@ -494,7 +501,7 @@ export function AgentDetail({ agent, onBack, onDeleted }: Props) {
       <div className="flex min-h-0 flex-1 flex-col">
         <div className="flex shrink-0 items-center justify-between border-b border-edge px-4 py-2">
           <SectionLabel>{t("systemPrompt")}</SectionLabel>
-          {def.versions.length > 0 && (
+          {def.versions && def.versions.length > 0 && (
             <span className="text-[length:var(--t-xs)] text-content-muted">
               {t("versionCount", { count: def.versions.length })}
             </span>
@@ -532,8 +539,9 @@ export function AgentDetail({ agent, onBack, onDeleted }: Props) {
         )}
       </div>
 
-      {/* Version history strip */}
-      {!editing && def.versions.length > 0 && (
+      {/* Version history strip — omitted (not crashed) when the history
+          store is unreadable; def.content above still renders either way. */}
+      {!editing && def.versions && def.versions.length > 0 && (
         <div className="shrink-0 overflow-x-auto border-t border-edge">
           <div className="flex gap-0" style={{ minWidth: "max-content" }}>
             {[...def.versions]

--- a/apps/studio/frontend/src/components/library/PluginDetail.tsx
+++ b/apps/studio/frontend/src/components/library/PluginDetail.tsx
@@ -1,0 +1,369 @@
+/**
+ * Detail pane for a plugin — a bundle of skills + agents, not a single item.
+ * Renders composition (counts, hooks/mcp presence), the bundled skill and
+ * agent lists (each opening a nested read-only detail view in-place), and
+ * usage stats scoped to this plugin specifically (server-side filter, not a
+ * best-effort scan of the most recent invocations).
+ */
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "use-intl";
+import { getPlugin, getPluginAgent } from "@/lib/api";
+import type { PluginAgentDetail, PluginDetail as PluginDetailData } from "@/lib/api";
+import { formatInvocationAge, useInvocationStats } from "@/lib/useInvocationStats";
+import { SkillDetail } from "@/components/library/SkillDetail";
+import DrawerBackButton from "@/components/ui/DrawerBackButton";
+import DrawerHeader from "@/components/ui/DrawerHeader";
+import SectionLabel from "@/components/ui/SectionLabel";
+import StatusPill from "@/components/ui/StatusPill";
+import { Link } from "@tanstack/react-router";
+
+interface PluginDetailProps {
+  name: string;
+  onBack?: () => void;
+}
+
+type NestedSelection = { kind: "skill" | "agent"; name: string } | null;
+
+export function PluginDetail({ name, onBack }: PluginDetailProps) {
+  const t = useTranslations("library.drawer");
+  const [plugin, setPlugin] = useState<PluginDetailData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [nested, setNested] = useState<NestedSelection>(null);
+
+  const { stats, loading: statsLoading } = useInvocationStats("plugin", name);
+
+  useEffect(() => {
+    let alive = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronous reset clears stale state before the async fetch resolves
+    setLoading(true);
+    setError(null);
+    setPlugin(null);
+    setNested(null);
+
+    getPlugin(name)
+      .then((p) => {
+        if (alive) setPlugin(p);
+      })
+      .catch((e) => {
+        if (alive) setError(e instanceof Error ? e.message : "Failed to load");
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [name]);
+
+  if (nested?.kind === "skill") {
+    return <SkillDetail name={nested.name} pluginName={name} onBack={() => setNested(null)} />;
+  }
+  if (nested?.kind === "agent") {
+    return (
+      <PluginAgentDetailView
+        pluginName={name}
+        agentName={nested.name}
+        onBack={() => setNested(null)}
+      />
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-meta text-content-muted">
+        {t("loading")}
+      </div>
+    );
+  }
+
+  if (error || !plugin) {
+    return <div className="p-4 text-meta text-status-failure">{error ?? t("notFound")}</div>;
+  }
+
+  const mcpServerNames = plugin.mcp ? Object.keys(plugin.mcp) : [];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {onBack && <DrawerBackButton onClick={onBack}>{t("back")}</DrawerBackButton>}
+
+      <DrawerHeader
+        name={plugin.name}
+        badge="plugin"
+        trailing={
+          <span className="font-data text-[length:var(--t-xs)] text-content-muted">
+            v{plugin.version}
+          </span>
+        }
+      />
+
+      <div className="shrink-0 border-b border-edge px-4 py-1.5 font-data text-[length:var(--t-xs)] text-content-muted">
+        {plugin.source}
+        {plugin.path ? ` · ${plugin.path}` : ""}
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <div className="flex flex-col gap-4 p-4">
+          {plugin.description && (
+            <p className="text-[length:var(--t-sm)] text-content-secondary">{plugin.description}</p>
+          )}
+
+          {/* Composition strip */}
+          <div className="flex flex-wrap gap-x-5 gap-y-2 text-[length:var(--t-xs)]">
+            <div className="flex items-center gap-1.5">
+              <span className="text-content-muted">{t("skillCount")}</span>
+              <span className="font-data text-content-primary">{plugin.skill_count}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-content-muted">{t("agentCount")}</span>
+              <span className="font-data text-content-primary">{plugin.agent_count}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-content-muted">{t("pluginHooks")}</span>
+              <span className="font-data text-content-primary">
+                {plugin.has_hooks ? t("yes") : t("no")}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-content-muted">{t("pluginMcp")}</span>
+              <span className="font-data text-content-primary">
+                {plugin.has_mcp ? t("yes") : t("no")}
+              </span>
+            </div>
+          </div>
+
+          {plugin.skills.length > 0 && (
+            <div>
+              <SectionLabel className="mb-1.5">{t("skillCount")}</SectionLabel>
+              <div className="flex flex-col rounded border border-edge" style={{ borderRadius: 4 }}>
+                {plugin.skills.map((s, i) => (
+                  <button
+                    key={s.name}
+                    type="button"
+                    onClick={() => setNested({ kind: "skill", name: s.name })}
+                    className="flex items-center gap-2 px-2.5 py-2 text-left font-data text-[length:var(--t-sm)] text-content-primary hover:bg-surface-overlay"
+                    style={{ borderTop: i > 0 ? "1px solid var(--edge-hairline)" : undefined }}
+                  >
+                    <span className="min-w-0 shrink-0 font-medium">{s.name}</span>
+                    {s.description && (
+                      <span className="min-w-0 flex-1 truncate text-content-muted">
+                        {s.description}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {plugin.agents.length > 0 && (
+            <div>
+              <SectionLabel className="mb-1.5">{t("agentCount")}</SectionLabel>
+              <div className="flex flex-col rounded border border-edge" style={{ borderRadius: 4 }}>
+                {plugin.agents.map((a, i) => (
+                  <button
+                    key={a.name}
+                    type="button"
+                    onClick={() => setNested({ kind: "agent", name: a.name })}
+                    className="flex items-center gap-2 px-2.5 py-2 text-left font-data text-[length:var(--t-sm)] text-content-primary hover:bg-surface-overlay"
+                    style={{ borderTop: i > 0 ? "1px solid var(--edge-hairline)" : undefined }}
+                  >
+                    <span className="min-w-0 shrink-0 font-medium">{a.name}</span>
+                    {a.description && (
+                      <span className="min-w-0 flex-1 truncate text-content-muted">
+                        {a.description}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {mcpServerNames.length > 0 && (
+            <div>
+              <SectionLabel className="mb-1.5">{t("pluginMcpServers")}</SectionLabel>
+              <div className="flex flex-wrap gap-1.5">
+                {mcpServerNames.map((n) => (
+                  <span
+                    key={n}
+                    className="rounded border border-edge bg-surface-overlay px-1.5 py-0.5 font-data text-[length:var(--t-xs)] text-content-secondary"
+                  >
+                    {n}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {plugin.hooks != null && (
+            <details className="rounded border border-edge">
+              <summary className="cursor-pointer px-3 py-2 text-[length:var(--t-xs)] font-medium uppercase tracking-[0.08em] text-content-muted">
+                {t("pluginHooksSection")}
+              </summary>
+              <pre className="overflow-auto border-t border-edge bg-surface-base px-3 py-2 font-data text-[length:var(--t-xs)] text-content-secondary">
+                {JSON.stringify(plugin.hooks, null, 2)}
+              </pre>
+            </details>
+          )}
+
+          {plugin.readme && (
+            <details className="rounded border border-edge">
+              <summary className="cursor-pointer px-3 py-2 text-[length:var(--t-xs)] font-medium uppercase tracking-[0.08em] text-content-muted">
+                {t("pluginReadmeSection")}
+              </summary>
+              <div className="whitespace-pre-wrap border-t border-edge bg-surface-base px-3 py-2 font-data text-[length:var(--t-sm)] leading-relaxed text-content-secondary">
+                {plugin.readme}
+              </div>
+            </details>
+          )}
+
+          {/* Stats strip */}
+          <div className="grid grid-cols-3 gap-px overflow-hidden rounded border border-edge bg-edge">
+            {[
+              { label: t("invocations"), value: statsLoading ? "—" : String(stats?.total ?? 0) },
+              {
+                label: t("successRate"),
+                value: statsLoading
+                  ? "—"
+                  : stats?.successRate != null
+                    ? `${stats.successRate}%`
+                    : "—",
+              },
+              {
+                label: t("lastUsed"),
+                value: statsLoading
+                  ? "—"
+                  : stats?.lastUsedSec != null
+                    ? formatInvocationAge(stats.lastUsedSec)
+                    : t("never"),
+              },
+            ].map(({ label, value }) => (
+              <div key={label} className="flex flex-col gap-0.5 bg-surface-raised px-3 py-2">
+                <SectionLabel>{label}</SectionLabel>
+                <span className="font-data tabular-nums text-[length:var(--t-base)] text-content-primary">
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div>
+            <SectionLabel className="mb-1.5">{t("recentInvocations")}</SectionLabel>
+            {statsLoading ? (
+              <p className="text-[length:var(--t-sm)] text-content-muted">{t("loading")}</p>
+            ) : !stats || stats.recent.length === 0 ? (
+              <p className="text-[length:var(--t-sm)] text-content-muted">{t("noInvocations")}</p>
+            ) : (
+              <div className="flex flex-col rounded border border-edge" style={{ borderRadius: 4 }}>
+                {stats.recent.map((inv, i) => (
+                  <Link
+                    key={inv.id}
+                    to="/fleet"
+                    className="flex items-center gap-2 px-2.5 py-2 font-data text-[length:var(--t-sm)] text-content-primary hover:underline"
+                    style={{ borderTop: i > 0 ? "1px solid var(--edge-hairline)" : undefined }}
+                  >
+                    <StatusPill value={inv.status} kind="lifecycle" taxonomy="session" />
+                    <span className="min-w-0 flex-1 truncate">
+                      {inv.status === "failed" && inv.status_reason_summary
+                        ? inv.status_reason_summary
+                        : inv.skill}
+                    </span>
+                    <span className="shrink-0 tabular-nums text-[length:var(--t-xs)] text-content-muted">
+                      {formatInvocationAge(inv.ended_at ?? inv.started_at)}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Nested agent view (read-only) ───────────────────────────────────────────
+//
+// A lightweight, plugin-scoped view — not the full agent editor (AgentDetail
+// reads/writes through the standalone-agent definitions path, which a
+// plugin-bundled agent isn't part of).
+
+function PluginAgentDetailView({
+  pluginName,
+  agentName,
+  onBack,
+}: {
+  pluginName: string;
+  agentName: string;
+  onBack: () => void;
+}) {
+  const t = useTranslations("library.drawer");
+  const [agent, setAgent] = useState<PluginAgentDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronous reset clears stale state before the async fetch resolves
+    setLoading(true);
+    setError(null);
+    setAgent(null);
+
+    getPluginAgent(pluginName, agentName)
+      .then((a) => {
+        if (alive) setAgent(a);
+      })
+      .catch((e) => {
+        if (alive) setError(e instanceof Error ? e.message : "Failed to load");
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [pluginName, agentName]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <DrawerBackButton onClick={onBack}>{t("back")}</DrawerBackButton>
+      {loading ? (
+        <div className="flex h-full items-center justify-center text-meta text-content-muted">
+          {t("loading")}
+        </div>
+      ) : error || !agent ? (
+        <div className="p-4 text-meta text-status-failure">{error ?? t("notFound")}</div>
+      ) : (
+        <>
+          <DrawerHeader
+            name={agent.name}
+            badge="agent"
+            trailing={
+              <span className="rounded border border-edge bg-surface-overlay px-1.5 py-0.5 text-[length:var(--t-xs)] uppercase tracking-[0.08em] text-content-muted">
+                {t("readOnly")}
+              </span>
+            }
+          />
+          <div className="flex-1 overflow-auto p-4">
+            {agent.description && (
+              <p className="mb-3 text-[length:var(--t-sm)] text-content-secondary">
+                {agent.description}
+              </p>
+            )}
+            {agent.content.trim() ? (
+              <pre className="whitespace-pre-wrap break-words font-data text-[length:var(--t-sm)] leading-relaxed text-content-secondary">
+                {agent.content.trim()}
+              </pre>
+            ) : (
+              <span className="italic text-content-muted">{t("noContent")}</span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/studio/frontend/src/components/library/SkillDetail.test.tsx
+++ b/apps/studio/frontend/src/components/library/SkillDetail.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * SkillDetail — history-unavailable fallback payload.
+ *
+ * The backend deliberately answers `versions: null, version: null,
+ * history_available: false` when the version-history store can't be read
+ * (see lionagi/studio/services/definitions.py's `_get_skill_definition`).
+ * That's the right backend behavior, but a frontend that assumes `versions`
+ * is always an array crashes exactly during the outage an operator most
+ * needs to read the pane. This asserts the pane renders the disk-backed
+ * skill content instead of throwing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import enMessages from "@/messages/en.json";
+import type { DefinitionDetail, SkillDetail as SkillSummaryDetail } from "@/lib/api";
+
+const api = vi.hoisted(() => ({
+  getSkill: vi.fn(),
+  getDefinition: vi.fn(),
+  getDefinitionVersion: vi.fn(),
+  getPluginSkill: vi.fn(),
+  rollbackDefinition: vi.fn(),
+  saveDefinition: vi.fn(),
+  validateSkill: vi.fn(),
+  listInvocations: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => api);
+
+const { SkillDetail } = await import("./SkillDetail");
+
+function skillSummary(overrides: Partial<SkillSummaryDetail> = {}): SkillSummaryDetail {
+  return {
+    name: "my-skill",
+    description: "Does a thing.",
+    path: "skills/my-skill/SKILL.md",
+    content: "Body content that must still render during a history outage.",
+    allowed_tools: [],
+    ...overrides,
+  };
+}
+
+function historyUnavailableDef(overrides: Partial<DefinitionDetail> = {}): DefinitionDetail {
+  return {
+    kind: "skill",
+    name: "my-skill",
+    path: "skills/my-skill/SKILL.md",
+    content: "Body content that must still render during a history outage.",
+    version: null,
+    versions: null,
+    history_available: false,
+    ...overrides,
+  };
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("SkillDetail — history-unavailable fallback", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    Object.values(api).forEach((fn) => fn.mockReset());
+    api.listInvocations.mockResolvedValue({ invocations: [], total: 0, completed_total: 0 });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the disk-backed content without throwing when versions/version are null", async () => {
+    api.getSkill.mockResolvedValue(skillSummary());
+    api.getDefinition.mockResolvedValue(historyUnavailableDef());
+
+    await act(async () => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <SkillDetail name="my-skill" />
+        </IntlProvider>,
+      );
+    });
+    await flush();
+
+    expect(container.textContent).toContain(
+      "Body content that must still render during a history outage.",
+    );
+    // No version badge and no version-history strip when history is
+    // unavailable -- but the pane itself must not have crashed rendering.
+    expect(container.textContent).not.toContain("vnull");
+    expect(api.getDefinition).toHaveBeenCalledTimes(1);
+  });
+
+  it("still shows the version-history strip and badge when history is available", async () => {
+    api.getSkill.mockResolvedValue(skillSummary());
+    api.getDefinition.mockResolvedValue(
+      historyUnavailableDef({
+        version: 2,
+        history_available: true,
+        versions: [
+          { id: "v2", version: 2, created_at: 200, message: "second" },
+          { id: "v1", version: 1, created_at: 100, message: "first" },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <SkillDetail name="my-skill" />
+        </IntlProvider>,
+      );
+    });
+    await flush();
+
+    expect(container.textContent).toContain("v2");
+    const versionButtons = [...container.querySelectorAll("button")].filter((b) =>
+      /^v\d/.test(b.textContent ?? ""),
+    );
+    expect(versionButtons.length).toBe(2);
+  });
+});

--- a/apps/studio/frontend/src/components/library/SkillDetail.tsx
+++ b/apps/studio/frontend/src/components/library/SkillDetail.tsx
@@ -1,0 +1,447 @@
+/**
+ * Detail pane for a skill — either a standalone, user-authored skill (full
+ * view/edit/save/version-history, via the definitions API) or a skill
+ * bundled inside a plugin (read-only, via the plugin-nested endpoint; that
+ * content belongs to the plugin, not the user's local skill directory).
+ */
+
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "use-intl";
+import {
+  getDefinition,
+  getDefinitionVersion,
+  getPluginSkill,
+  getSkill,
+  rollbackDefinition,
+  saveDefinition,
+  validateSkill,
+} from "@/lib/api";
+import type {
+  DefinitionDetail,
+  DefinitionVersion,
+  SkillDetail as SkillSummaryDetail,
+} from "@/lib/api";
+import { formatInvocationAge, useInvocationStats } from "@/lib/useInvocationStats";
+import DrawerBackButton from "@/components/ui/DrawerBackButton";
+import DrawerHeader from "@/components/ui/DrawerHeader";
+import SectionLabel from "@/components/ui/SectionLabel";
+import Button from "@/components/ui/Button";
+import StatusPill from "@/components/ui/StatusPill";
+import { Link } from "@tanstack/react-router";
+
+const Markdown = lazy(() => import("@/components/ui/Markdown"));
+
+interface SkillDetailProps {
+  name: string;
+  /** Set when this skill is bundled inside a plugin — read-only, fetched
+   * from the plugin's nested endpoint instead of the definitions editor. */
+  pluginName?: string;
+  onBack?: () => void;
+}
+
+export function SkillDetail({ name, pluginName, onBack }: SkillDetailProps) {
+  const t = useTranslations("library.drawer");
+  const readOnly = pluginName != null;
+
+  const [summary, setSummary] = useState<SkillSummaryDetail | null>(null);
+  const [def, setDef] = useState<DefinitionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editing, setEditing] = useState(false);
+  const [content, setContent] = useState("");
+  const [commitMsg, setCommitMsg] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [validationErrors, setValidationErrors] = useState<string[] | null>(null);
+  const [savedOk, setSavedOk] = useState(false);
+
+  const [previewVer, setPreviewVer] = useState<DefinitionDetail | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const { stats, loading: statsLoading } = useInvocationStats("skill", name);
+
+  useEffect(() => {
+    let alive = true;
+    /* eslint-disable react-hooks/set-state-in-effect -- synchronous resets clear stale state before the async fetch resolves */
+    setLoading(true);
+    setError(null);
+    setSummary(null);
+    setDef(null);
+    setEditing(false);
+    setPreviewVer(null);
+    setSaveError(null);
+    setValidationErrors(null);
+    setSavedOk(false);
+    /* eslint-enable react-hooks/set-state-in-effect */
+
+    const fetchSummary = readOnly ? getPluginSkill(pluginName, name) : getSkill(name);
+    const fetchDef = readOnly ? Promise.resolve(null) : getDefinition("skill", name);
+
+    Promise.all([fetchSummary, fetchDef])
+      .then(([s, d]) => {
+        if (!alive) return;
+        setSummary(s);
+        setDef(d);
+        if (d) setContent(d.content);
+      })
+      .catch((e) => {
+        if (alive) setError(e instanceof Error ? e.message : "Failed to load");
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [name, pluginName, readOnly]);
+
+  const startEdit = useCallback(() => {
+    if (!def) return;
+    setContent(def.content);
+    setEditing(true);
+    setSaveError(null);
+    setValidationErrors(null);
+    setSavedOk(false);
+    setPreviewVer(null);
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, [def]);
+
+  const cancelEdit = useCallback(() => {
+    setEditing(false);
+    setSaveError(null);
+    setValidationErrors(null);
+    if (def) setContent(def.content);
+    setCommitMsg("");
+  }, [def]);
+
+  const handleSave = useCallback(async () => {
+    if (!def || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    setValidationErrors(null);
+    try {
+      const validation = await validateSkill(name, content);
+      if (!validation.ok) {
+        setValidationErrors(validation.errors ?? [t("skillValidationFailed")]);
+        return;
+      }
+      await saveDefinition("skill", name, content, commitMsg || undefined);
+      const [updatedSummary, updatedDef] = await Promise.all([
+        getSkill(name),
+        getDefinition("skill", name),
+      ]);
+      setSummary(updatedSummary);
+      setDef(updatedDef);
+      setContent(updatedDef.content);
+      setEditing(false);
+      setCommitMsg("");
+      setSavedOk(true);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }, [def, saving, name, content, commitMsg, t]);
+
+  const handleViewVersion = useCallback(
+    async (v: DefinitionVersion) => {
+      try {
+        const d = await getDefinitionVersion("skill", name, v.version);
+        setPreviewVer(d);
+        setEditing(false);
+      } catch {
+        /* silent */
+      }
+    },
+    [name],
+  );
+
+  const handleRestoreVersion = useCallback(
+    async (version: number) => {
+      try {
+        await rollbackDefinition("skill", name, version);
+        const [updatedSummary, updatedDef] = await Promise.all([
+          getSkill(name),
+          getDefinition("skill", name),
+        ]);
+        setSummary(updatedSummary);
+        setDef(updatedDef);
+        setContent(updatedDef.content);
+        setPreviewVer(null);
+      } catch {
+        /* silent */
+      }
+    },
+    [name],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-meta text-content-muted">
+        {t("loading")}
+      </div>
+    );
+  }
+
+  if (error || !summary) {
+    return <div className="p-4 text-meta text-status-failure">{error ?? t("notFound")}</div>;
+  }
+
+  const displayBody = previewVer ? previewVer.content : summary.content;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {onBack && <DrawerBackButton onClick={onBack}>{t("back")}</DrawerBackButton>}
+
+      <DrawerHeader
+        name={summary.name}
+        badge="skill"
+        trailing={
+          readOnly ? (
+            <span
+              title={t("pluginOwnedSkillHint")}
+              className="rounded border border-edge bg-surface-overlay px-1.5 py-0.5 text-[length:var(--t-xs)] uppercase tracking-[0.08em] text-content-muted"
+            >
+              {t("readOnly")}
+            </span>
+          ) : previewVer ? (
+            <>
+              <span className="text-[length:var(--t-xs)] text-content-muted">
+                v{previewVer.version}
+              </span>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => void handleRestoreVersion(previewVer.version)}
+              >
+                {t("restore")}
+              </Button>
+              <Button size="sm" variant="secondary" onClick={() => setPreviewVer(null)}>
+                {t("back")}
+              </Button>
+            </>
+          ) : editing ? (
+            <>
+              <input
+                type="text"
+                value={commitMsg}
+                onChange={(e) => setCommitMsg(e.target.value)}
+                placeholder={t("commitPlaceholder")}
+                className="w-36 rounded border border-edge bg-surface-overlay px-2 py-1 font-ui text-[length:var(--t-xs)] text-content-primary"
+              />
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => void handleSave()}
+                disabled={saving}
+              >
+                {saving ? t("saving") : t("save")}
+              </Button>
+              <Button size="sm" variant="secondary" onClick={cancelEdit}>
+                {t("cancel")}
+              </Button>
+            </>
+          ) : (
+            <>
+              {savedOk && (
+                <span className="text-[length:var(--t-xs)] text-status-success">
+                  {t("saveDone")}
+                </span>
+              )}
+              {def && (
+                <span className="font-data text-[length:var(--t-xs)] text-content-muted">
+                  v{def.version}
+                </span>
+              )}
+              <Button size="sm" variant="secondary" onClick={startEdit} disabled={!def}>
+                {t("edit")}
+              </Button>
+            </>
+          )
+        }
+      />
+
+      {summary.path && (
+        <div className="shrink-0 border-b border-edge px-4 py-1.5 font-data text-[length:var(--t-xs)] text-content-muted">
+          {summary.path}
+        </div>
+      )}
+
+      {saveError && (
+        <div className="shrink-0 border-b border-edge px-4 py-2 text-[length:var(--t-xs)] text-status-failure">
+          {saveError}
+        </div>
+      )}
+
+      {validationErrors && validationErrors.length > 0 && (
+        <div className="shrink-0 border-b border-edge px-4 py-2 text-[length:var(--t-xs)] text-status-failure">
+          <div>{t("skillValidationFailed")}</div>
+          <ul className="ml-4 list-disc">
+            {validationErrors.map((err) => (
+              <li key={err}>{err}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto">
+        <div className="flex flex-col gap-4 p-4">
+          {summary.description && (
+            <p className="text-[length:var(--t-sm)] text-content-secondary">
+              {summary.description}
+            </p>
+          )}
+
+          {summary.allowed_tools.length > 0 && (
+            <div>
+              <SectionLabel className="mb-1.5">{t("skillTools")}</SectionLabel>
+              <div className="flex flex-wrap gap-1.5">
+                {summary.allowed_tools.map((tool) => (
+                  <span
+                    key={tool}
+                    className="rounded border border-edge bg-surface-overlay px-1.5 py-0.5 font-data text-[length:var(--t-xs)] text-content-secondary"
+                  >
+                    {tool}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Stats strip */}
+          <div className="grid grid-cols-3 gap-px overflow-hidden rounded border border-edge bg-edge">
+            {[
+              { label: t("invocations"), value: statsLoading ? "—" : String(stats?.total ?? 0) },
+              {
+                label: t("successRate"),
+                value: statsLoading
+                  ? "—"
+                  : stats?.successRate != null
+                    ? `${stats.successRate}%`
+                    : "—",
+              },
+              {
+                label: t("lastUsed"),
+                value: statsLoading
+                  ? "—"
+                  : stats?.lastUsedSec != null
+                    ? formatInvocationAge(stats.lastUsedSec)
+                    : t("never"),
+              },
+            ].map(({ label, value }) => (
+              <div key={label} className="flex flex-col gap-0.5 bg-surface-raised px-3 py-2">
+                <SectionLabel>{label}</SectionLabel>
+                <span className="font-data tabular-nums text-[length:var(--t-base)] text-content-primary">
+                  {value}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {/* Recent invocations */}
+          <div>
+            <SectionLabel className="mb-1.5">{t("recentInvocations")}</SectionLabel>
+            {statsLoading ? (
+              <p className="text-[length:var(--t-sm)] text-content-muted">{t("loading")}</p>
+            ) : !stats || stats.recent.length === 0 ? (
+              <p className="text-[length:var(--t-sm)] text-content-muted">{t("noInvocations")}</p>
+            ) : (
+              <div className="flex flex-col rounded border border-edge" style={{ borderRadius: 4 }}>
+                {stats.recent.map((inv, i) => (
+                  <Link
+                    key={inv.id}
+                    to="/fleet"
+                    className="flex items-center gap-2 px-2.5 py-2 font-data text-[length:var(--t-sm)] text-content-primary hover:underline"
+                    style={{
+                      borderTop: i > 0 ? "1px solid var(--edge-hairline)" : undefined,
+                    }}
+                  >
+                    <StatusPill value={inv.status} kind="lifecycle" taxonomy="session" />
+                    <span className="min-w-0 flex-1 truncate">
+                      {inv.status === "failed" && inv.status_reason_summary
+                        ? inv.status_reason_summary
+                        : inv.skill}
+                    </span>
+                    <span className="shrink-0 tabular-nums text-[length:var(--t-xs)] text-content-muted">
+                      {formatInvocationAge(inv.ended_at ?? inv.started_at)}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Instructions */}
+          <div>
+            <SectionLabel className="mb-1.5">{t("skillInstructions")}</SectionLabel>
+            {editing ? (
+              <textarea
+                ref={textareaRef}
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                spellCheck={false}
+                className="w-full resize-none rounded border border-edge bg-surface-base p-3 font-data text-[length:var(--t-sm)] leading-relaxed text-content-primary focus:outline-none"
+                style={{ minHeight: "50vh" }}
+              />
+            ) : displayBody.trim() ? (
+              <div className="rounded border border-edge bg-surface-base px-4 py-3">
+                <Suspense
+                  fallback={
+                    <pre className="whitespace-pre-wrap break-words font-data text-[length:var(--t-sm)] leading-relaxed text-content-secondary">
+                      {displayBody.trim()}
+                    </pre>
+                  }
+                >
+                  <Markdown className="max-w-4xl text-[length:var(--t-sm)]">
+                    {displayBody.trim()}
+                  </Markdown>
+                </Suspense>
+              </div>
+            ) : (
+              <span className="italic text-content-muted">{t("noContent")}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Version history strip */}
+      {!readOnly && !editing && def && def.versions.length > 0 && (
+        <div className="shrink-0 overflow-x-auto border-t border-edge">
+          <div className="flex gap-0" style={{ minWidth: "max-content" }}>
+            {[...def.versions]
+              .sort((a, b) => b.version - a.version)
+              .slice(0, 8)
+              .map((v) => {
+                const isCurrent = v.version === def.version;
+                const isPreviewing = previewVer?.version === v.version;
+                return (
+                  <button
+                    key={v.id}
+                    type="button"
+                    onClick={() => void handleViewVersion(v)}
+                    className="flex flex-col gap-0.5 border-r border-edge px-3 py-2 text-left text-[length:var(--t-xs)]"
+                    style={{
+                      background: isPreviewing ? "var(--surface-overlay)" : "transparent",
+                      color: isCurrent ? "var(--accent)" : "var(--content-muted)",
+                    }}
+                  >
+                    <span className="font-data font-medium">
+                      v{v.version}
+                      {isCurrent ? " ●" : ""}
+                    </span>
+                    {v.message && (
+                      <span className="max-w-[80px] truncate" title={v.message}>
+                        {v.message}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/studio/frontend/src/components/library/SkillDetail.tsx
+++ b/apps/studio/frontend/src/components/library/SkillDetail.tsx
@@ -19,6 +19,7 @@ import {
 import type {
   DefinitionDetail,
   DefinitionVersion,
+  DefinitionVersionDetail,
   SkillDetail as SkillSummaryDetail,
 } from "@/lib/api";
 import { formatInvocationAge, useInvocationStats } from "@/lib/useInvocationStats";
@@ -56,7 +57,7 @@ export function SkillDetail({ name, pluginName, onBack }: SkillDetailProps) {
   const [validationErrors, setValidationErrors] = useState<string[] | null>(null);
   const [savedOk, setSavedOk] = useState(false);
 
-  const [previewVer, setPreviewVer] = useState<DefinitionDetail | null>(null);
+  const [previewVer, setPreviewVer] = useState<DefinitionVersionDetail | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const { stats, loading: statsLoading } = useInvocationStats("skill", name);
@@ -250,7 +251,7 @@ export function SkillDetail({ name, pluginName, onBack }: SkillDetailProps) {
                   {t("saveDone")}
                 </span>
               )}
-              {def && (
+              {def && def.version != null && (
                 <span className="font-data text-[length:var(--t-xs)] text-content-muted">
                   v{def.version}
                 </span>
@@ -406,8 +407,9 @@ export function SkillDetail({ name, pluginName, onBack }: SkillDetailProps) {
         </div>
       </div>
 
-      {/* Version history strip */}
-      {!readOnly && !editing && def && def.versions.length > 0 && (
+      {/* Version history strip — omitted (not crashed) when the history
+          store is unreadable; def.content above still renders either way. */}
+      {!readOnly && !editing && def && def.versions && def.versions.length > 0 && (
         <div className="shrink-0 overflow-x-auto border-t border-edge">
           <div className="flex gap-0" style={{ minWidth: "max-content" }}>
             {[...def.versions]

--- a/apps/studio/frontend/src/components/library/library.test.ts
+++ b/apps/studio/frontend/src/components/library/library.test.ts
@@ -471,3 +471,100 @@ describe("library URL sel param — playbook subKind encoding", () => {
     expect(parseSel("playbook:no-subkind")).toBeNull();
   });
 });
+
+// ─── Skill + plugin detail panes (2733, 2734) ─────────────────────────────────
+//
+// Skills and plugins used to both open into the same placeholder detail view.
+// These tests cover the fix: dedicated components, dispatched by kind, with
+// skill editing gated to standalone (non-plugin-owned) skills only.
+
+describe("routes/library.tsx — dispatches skill/plugin kind to their own detail panes", () => {
+  const src = fs.readFileSync(path.join(ROUTES_DIR, "library.tsx"), "utf-8");
+
+  it("imports SkillDetail and PluginDetail", () => {
+    expect(src).toMatch(/import\s*\{\s*SkillDetail\s*\}\s*from/);
+    expect(src).toMatch(/import\s*\{\s*PluginDetail\s*\}\s*from/);
+  });
+
+  it("dispatches skill kind to SkillDetail, plugin kind to PluginDetail", () => {
+    expect(src).toMatch(/parsed\?\.kind === "skill"[\s\S]{0,80}<SkillDetail/);
+    expect(src).toMatch(/parsed\?\.kind === "plugin"[\s\S]{0,80}<PluginDetail/);
+  });
+
+  it("hides the toolbar create button on skill/plugin tabs (NO_CREATE_KINDS)", () => {
+    expect(src).toMatch(/NO_CREATE_KINDS\s*=\s*new Set<LibraryKind>\(\["skill",\s*"plugin"\]\)/);
+    expect(src).toMatch(/!NO_CREATE_KINDS\.has\(kindFilter/);
+  });
+
+  it("gives an empty skill/plugin tab its own copy, distinct from the search-filtered message", () => {
+    expect(src).toMatch(/isEmptyLibraryTab/);
+    expect(src).toMatch(/t\("empty\.allSkill"\)/);
+    expect(src).toMatch(/t\("empty\.allSkillHint"\)/);
+    expect(src).toMatch(/t\("empty\.allPlugin"\)/);
+    expect(src).toMatch(/t\("empty\.allPluginHint"\)/);
+  });
+});
+
+describe("SkillDetail — detail pane contract", () => {
+  const filePath = path.join(LIBRARY_DIR, "SkillDetail.tsx");
+  const src = fs.readFileSync(filePath, "utf-8");
+
+  it("exists at components/library/SkillDetail.tsx", () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("exports SkillDetail", () => {
+    expect(src).toMatch(/export function SkillDetail/);
+  });
+
+  it("accepts onBack prop (collapsed back affordance)", () => {
+    expect(src).toMatch(/onBack\?/);
+  });
+
+  it("does not import shell/Drawer", () => {
+    expect(src).not.toMatch(/from.*shell\/Drawer/);
+  });
+
+  it("validates content server-side before saving", () => {
+    expect(src).toMatch(/validateSkill/);
+  });
+
+  it("plugin-owned skills render read-only, not the edit affordance", () => {
+    expect(src).toMatch(/pluginOwnedSkillHint/);
+    expect(src).toMatch(/readOnly/);
+  });
+
+  it("pulls usage stats from useInvocationStats, not a raw fetch", () => {
+    expect(src).toMatch(/useInvocationStats/);
+  });
+});
+
+describe("PluginDetail — detail pane contract", () => {
+  const filePath = path.join(LIBRARY_DIR, "PluginDetail.tsx");
+  const src = fs.readFileSync(filePath, "utf-8");
+
+  it("exists at components/library/PluginDetail.tsx", () => {
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it("exports PluginDetail", () => {
+    expect(src).toMatch(/export function PluginDetail/);
+  });
+
+  it("accepts onBack prop (collapsed back affordance)", () => {
+    expect(src).toMatch(/onBack\?/);
+  });
+
+  it("does not import shell/Drawer", () => {
+    expect(src).not.toMatch(/from.*shell\/Drawer/);
+  });
+
+  it("navigates into a bundled skill or agent as a nested sub-view", () => {
+    expect(src).toMatch(/setNested\(\s*\{\s*kind:\s*"skill"/);
+    expect(src).toMatch(/setNested\(\s*\{\s*kind:\s*"agent"/);
+  });
+
+  it("pulls usage stats from useInvocationStats, not a raw fetch", () => {
+    expect(src).toMatch(/useInvocationStats/);
+  });
+});

--- a/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
+++ b/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
@@ -270,6 +270,8 @@ describe("useLiveBoard — schedules degrade-to-null on fetch failure", () => {
       limit: 100,
       offset: 0,
       has_next: false,
+      total: 0,
+      completed_total: 0,
     });
     vi.mocked(listSchedules).mockRejectedValue(new Error("schedules endpoint down"));
 
@@ -322,7 +324,14 @@ describe("useLiveBoard — schedules degrade-to-null on fetch failure", () => {
       has_next: false,
       has_prev: false,
     };
-    const invsResp = { invocations: [], limit: 100, offset: 0, has_next: false };
+    const invsResp = {
+      invocations: [],
+      limit: 100,
+      offset: 0,
+      has_next: false,
+      total: 0,
+      completed_total: 0,
+    };
 
     vi.mocked(listRuns).mockResolvedValue(runsResp);
     vi.mocked(listInvocations).mockResolvedValue(invsResp);

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -201,8 +201,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 929 leaves", () => {
-    expect(EN_LEAVES.size).toBe(929);
+  it("en.json has 945 leaves", () => {
+    expect(EN_LEAVES.size).toBe(945);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1441,7 +1441,9 @@ export interface DefinitionSummary {
   name: string;
   path: string;
   disk_path: string;
-  has_versions: boolean;
+  // null when the version-history store could not be read for the listing
+  // (distinct from false, which means "never saved a version").
+  has_versions: boolean | null;
   version: number;
   updated_at: number;
 }
@@ -1458,8 +1460,11 @@ export interface DefinitionDetail {
   name: string;
   path: string;
   content: string;
-  version: number;
-  versions: DefinitionVersion[];
+  // version/versions are null when the version-history store could not be
+  // read; content/path are always disk-backed and always present.
+  version: number | null;
+  versions: DefinitionVersion[] | null;
+  history_available: boolean;
 }
 
 export async function listDefinitions(
@@ -1475,12 +1480,26 @@ export async function getDefinition(kind: string, name: string): Promise<Definit
   );
 }
 
+// A specific historical version's content -- distinct from DefinitionDetail
+// (the current definition): the backend's single-version read has nothing
+// to fall back on, so it either answers with a real version number and
+// content or refuses outright; it never returns the versions/history_available
+// fields DefinitionDetail carries.
+export interface DefinitionVersionDetail {
+  kind: string;
+  name: string;
+  version: number;
+  content: string;
+  created_at: number;
+  message: string | null;
+}
+
 export async function getDefinitionVersion(
   kind: string,
   name: string,
   version: number,
-): Promise<DefinitionDetail> {
-  return fetchJson<DefinitionDetail>(
+): Promise<DefinitionVersionDetail> {
+  return fetchJson<DefinitionVersionDetail>(
     `/api/definitions/${encodeURIComponent(kind)}/${encodeURIComponent(name)}/versions/${version}`,
   );
 }

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1345,6 +1345,7 @@ export interface InvocationSummary {
   created_at: number;
   updated_at: number;
   node_metadata: Record<string, unknown> | null;
+  status_reason_summary?: string | null;
   // ADR-0026: project provenance from the most-recently updated child session.
   project?: string | null;
   project_source?: string | null;
@@ -1400,10 +1401,17 @@ export interface InvocationListResponse {
   limit: number;
   offset: number;
   has_next: boolean;
+  /** Real total matching the filters, not just this page's row count —
+   * `limit` caps at 200, so counting `invocations` instead plateaus there. */
+  total: number;
+  /** Total matching the filters with status == "completed" specifically,
+   * ignoring `params.status` — always a meaningful success-rate numerator. */
+  completed_total: number;
 }
 
 export interface InvocationListParams {
   skill?: string;
+  plugin?: string;
   status?: string;
   limit?: number;
   offset?: number;
@@ -1414,6 +1422,7 @@ export async function listInvocations(
 ): Promise<InvocationListResponse> {
   const query = new URLSearchParams();
   if (params?.skill) query.set("skill", params.skill);
+  if (params?.plugin) query.set("plugin", params.plugin);
   if (params?.status) query.set("status", params.status);
   if (params?.limit !== undefined) query.set("limit", String(params.limit));
   if (params?.offset !== undefined) query.set("offset", String(params.offset));
@@ -1553,6 +1562,19 @@ export async function listSkills(): Promise<{ skills: SkillSummary[] }> {
 
 export async function getSkill(name: string): Promise<SkillDetail> {
   return fetchJson<SkillDetail>(`/api/skills/${encodeURIComponent(name)}`);
+}
+
+export interface SkillValidationResult {
+  ok: boolean;
+  errors: string[] | null;
+}
+
+export async function validateSkill(name: string, content: string): Promise<SkillValidationResult> {
+  return fetchJson<SkillValidationResult>(`/api/skills/${encodeURIComponent(name)}/validate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
 }
 
 // ─── Plugins ──────────────────────────────────────────────────────────────────
@@ -1739,6 +1761,22 @@ export async function getPluginSkill(
 ): Promise<PluginSkillDetail> {
   return fetchJson<PluginSkillDetail>(
     `/api/plugins/${encodeURIComponent(pluginName)}/skills/${encodeURIComponent(skillName)}`,
+  );
+}
+
+export interface PluginAgentDetail {
+  name: string;
+  description: string;
+  path: string;
+  content: string;
+}
+
+export async function getPluginAgent(
+  pluginName: string,
+  agentName: string,
+): Promise<PluginAgentDetail> {
+  return fetchJson<PluginAgentDetail>(
+    `/api/plugins/${encodeURIComponent(pluginName)}/agents/${encodeURIComponent(agentName)}`,
   );
 }
 

--- a/apps/studio/frontend/src/lib/useInvocationStats.ts
+++ b/apps/studio/frontend/src/lib/useInvocationStats.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { listInvocations } from "@/lib/api";
+import type { InvocationSummary } from "@/lib/api";
+
+export interface InvocationStats {
+  total: number;
+  successRate: number | null;
+  lastUsedSec: number | null;
+  recent: InvocationSummary[];
+}
+
+const RECENT_LIMIT = 5;
+
+/**
+ * Usage stats for a skill or plugin's Library detail panel. `total` and
+ * `successRate` come from the server's real counts (ADR: invocation counts
+ * stop silently capping at the page limit) rather than the size of whatever
+ * page happened to be fetched, and both skill and plugin filter server-side
+ * — a plugin's stats are no longer a best-effort sample over the last 200
+ * invocations system-wide.
+ */
+export function useInvocationStats(
+  kind: "skill" | "plugin",
+  name: string,
+): {
+  stats: InvocationStats | null;
+  loading: boolean;
+} {
+  const [stats, setStats] = useState<InvocationStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset stale state before async fetch; setState fires synchronously in effect body only, callbacks are guarded by alive flag
+    setStats(null);
+    setLoading(true);
+
+    const scope = kind === "skill" ? { skill: name } : { plugin: name };
+
+    listInvocations({ ...scope, limit: RECENT_LIMIT })
+      .then((res) => {
+        if (!alive) return;
+        const successRate =
+          res.total > 0 ? Math.round((res.completed_total / res.total) * 100) : null;
+        // Rows are ordered by updated_at DESC, so the first row is already
+        // the most recently touched invocation — no need to scan for a max.
+        const first = res.invocations[0];
+        const lastUsedSec = first ? (first.ended_at ?? first.started_at) : null;
+        setStats({ total: res.total, successRate, lastUsedSec, recent: res.invocations });
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!alive) return;
+        setStats(null);
+        setLoading(false);
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [kind, name]);
+
+  return { stats, loading };
+}
+
+export function formatInvocationAge(epochSec: number): string {
+  const diffSec = Math.max(0, Math.floor(Date.now() / 1000) - epochSec);
+  if (diffSec < 60) return `${diffSec}s`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h`;
+  return `${Math.floor(diffSec / 86400)}d`;
+}

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -235,7 +235,11 @@
       "filteredHint": "جرّب نوعًا آخر أو امسح البحث.",
       "createFirst": "أنشئ أول",
       "createWorkflow": "سير عمل جديد",
-      "createAgent": "وكيل جديد"
+      "createAgent": "وكيل جديد",
+      "allSkill": "لم يتم العثور على مهارات.",
+      "allSkillHint": "أضف ملف SKILL.md ضمن ~/.lionagi/skills/<name>/ لتظهر هنا.",
+      "allPlugin": "لم يتم العثور على إضافات.",
+      "allPluginHint": "ثبّت إضافة ضمن ~/.claude/plugins/ لتظهر هنا."
     },
     "table": {
       "kind": "النوع",
@@ -296,7 +300,19 @@
       "lastUsed": "آخر استخدام",
       "never": "أبدًا",
       "recentInvocations": "الاستدعاءات الأخيرة",
-      "noInvocations": "لم تُسجّل أي استدعاءات بعد."
+      "noInvocations": "لم تُسجّل أي استدعاءات بعد.",
+      "skillValidationFailed": "فشل التحقق. أصلح الأخطاء أدناه قبل الحفظ.",
+      "pluginOwnedSkillHint": "مرفقة ضمن إضافة — عدّل ملفات الإضافة مباشرة لتغييرها.",
+      "readOnly": "للقراءة فقط",
+      "skillTools": "الأدوات المسموح بها",
+      "skillInstructions": "التعليمات",
+      "pluginHooks": "الخطافات",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "خوادم MCP",
+      "pluginHooksSection": "إعدادات الخطافات",
+      "pluginReadmeSection": "README",
+      "yes": "نعم",
+      "no": "لا"
     },
     "template": {
       "badge": "مدمج",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -235,7 +235,11 @@
       "filteredHint": "অন্য ধরনের চেষ্টা করুন বা সার্চ পরিষ্কার করুন।",
       "createFirst": "প্রথমটি তৈরি করুন",
       "createWorkflow": "নতুন ওয়ার্কফ্লো",
-      "createAgent": "নতুন এজেন্ট"
+      "createAgent": "নতুন এজেন্ট",
+      "allSkill": "কোনো স্কিল পাওয়া যায়নি।",
+      "allSkillHint": "এখানে দেখতে ~/.lionagi/skills/<name>/ এর অধীনে একটি SKILL.md যোগ করুন।",
+      "allPlugin": "কোনো প্লাগইন পাওয়া যায়নি।",
+      "allPluginHint": "এখানে দেখতে ~/.claude/plugins/ এর অধীনে একটি প্লাগইন ইনস্টল করুন।"
     },
     "table": {
       "kind": "ধরন",
@@ -296,7 +300,19 @@
       "lastUsed": "শেষ ব্যবহৃত",
       "never": "কখনও নয়",
       "recentInvocations": "সাম্প্রতিক ইনভোকেশন",
-      "noInvocations": "এখনও কোনো ইনভোকেশন রেকর্ড করা হয়নি।"
+      "noInvocations": "এখনও কোনো ইনভোকেশন রেকর্ড করা হয়নি।",
+      "skillValidationFailed": "যাচাই ব্যর্থ হয়েছে। সংরক্ষণের আগে নিচের ত্রুটিগুলো ঠিক করুন।",
+      "pluginOwnedSkillHint": "একটি প্লাগইনের সাথে বান্ডিল করা — পরিবর্তন করতে সরাসরি প্লাগইনের ফাইল সম্পাদনা করুন।",
+      "readOnly": "শুধুমাত্র পঠনযোগ্য",
+      "skillTools": "অনুমোদিত টুলস",
+      "skillInstructions": "নির্দেশনা",
+      "pluginHooks": "হুকস",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP সার্ভার",
+      "pluginHooksSection": "হুক কনফিগারেশন",
+      "pluginReadmeSection": "README",
+      "yes": "হ্যাঁ",
+      "no": "না"
     },
     "template": {
       "badge": "বিল্ট-ইন",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -235,7 +235,11 @@
       "filteredHint": "Versuche einen anderen Typ oder setze die Suche zurück.",
       "createFirst": "Ersten erstellen",
       "createWorkflow": "Neuer Workflow",
-      "createAgent": "Neuer Agent"
+      "createAgent": "Neuer Agent",
+      "allSkill": "Keine Skills gefunden.",
+      "allSkillHint": "Füge eine SKILL.md unter ~/.lionagi/skills/<name>/ hinzu, um sie hier zu sehen.",
+      "allPlugin": "Keine Plugins gefunden.",
+      "allPluginHint": "Installiere ein Plugin unter ~/.claude/plugins/, um es hier zu sehen."
     },
     "table": {
       "kind": "Typ",
@@ -296,7 +300,19 @@
       "lastUsed": "Zuletzt verwendet",
       "never": "nie",
       "recentInvocations": "Letzte Aufrufe",
-      "noInvocations": "Noch keine Aufrufe aufgezeichnet."
+      "noInvocations": "Noch keine Aufrufe aufgezeichnet.",
+      "skillValidationFailed": "Validierung fehlgeschlagen. Behebe die Fehler unten, bevor du speicherst.",
+      "pluginOwnedSkillHint": "Teil eines Plugins — bearbeite die Dateien des Plugins direkt, um es zu ändern.",
+      "readOnly": "Schreibgeschützt",
+      "skillTools": "Erlaubte Tools",
+      "skillInstructions": "Anweisungen",
+      "pluginHooks": "Hooks",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP-Server",
+      "pluginHooksSection": "Hooks-Konfiguration",
+      "pluginReadmeSection": "README",
+      "yes": "Ja",
+      "no": "Nein"
     },
     "template": {
       "badge": "Integriert",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -237,7 +237,11 @@
       "filteredHint": "Try a different kind or clear the search.",
       "createFirst": "Create your first",
       "createWorkflow": "New Workflow",
-      "createAgent": "New Agent"
+      "createAgent": "New Agent",
+      "allSkill": "No skills found.",
+      "allSkillHint": "Add a SKILL.md under ~/.lionagi/skills/<name>/ to see it here.",
+      "allPlugin": "No plugins found.",
+      "allPluginHint": "Install a plugin under ~/.claude/plugins/ to see it here."
     },
     "table": {
       "kind": "Kind",
@@ -298,7 +302,19 @@
       "lastUsed": "Last used",
       "never": "never",
       "recentInvocations": "Recent invocations",
-      "noInvocations": "No invocations recorded yet."
+      "noInvocations": "No invocations recorded yet.",
+      "skillValidationFailed": "Validation failed. Fix the errors below before saving.",
+      "pluginOwnedSkillHint": "Bundled with a plugin — edit the plugin's files directly to change it.",
+      "readOnly": "Read-only",
+      "skillTools": "Allowed Tools",
+      "skillInstructions": "Instructions",
+      "pluginHooks": "Hooks",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP Servers",
+      "pluginHooksSection": "Hooks Configuration",
+      "pluginReadmeSection": "README",
+      "yes": "Yes",
+      "no": "No"
     },
     "template": {
       "badge": "Built-in",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -235,7 +235,11 @@
       "filteredHint": "Prueba otro tipo o borra la búsqueda.",
       "createFirst": "Crea el primero",
       "createWorkflow": "Nuevo flujo de trabajo",
-      "createAgent": "Nuevo agente"
+      "createAgent": "Nuevo agente",
+      "allSkill": "No se encontraron skills.",
+      "allSkillHint": "Agrega un SKILL.md en ~/.lionagi/skills/<name>/ para verlo aquí.",
+      "allPlugin": "No se encontraron plugins.",
+      "allPluginHint": "Instala un plugin en ~/.claude/plugins/ para verlo aquí."
     },
     "table": {
       "kind": "Tipo",
@@ -296,7 +300,19 @@
       "lastUsed": "Último uso",
       "never": "nunca",
       "recentInvocations": "Invocaciones recientes",
-      "noInvocations": "Aún no hay invocaciones registradas."
+      "noInvocations": "Aún no hay invocaciones registradas.",
+      "skillValidationFailed": "La validación falló. Corrige los errores antes de guardar.",
+      "pluginOwnedSkillHint": "Incluido en un plugin — edita los archivos del plugin directamente para cambiarlo.",
+      "readOnly": "Solo lectura",
+      "skillTools": "Herramientas permitidas",
+      "skillInstructions": "Instrucciones",
+      "pluginHooks": "Hooks",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "Servidores MCP",
+      "pluginHooksSection": "Configuración de hooks",
+      "pluginReadmeSection": "README",
+      "yes": "Sí",
+      "no": "No"
     },
     "template": {
       "badge": "Integrado",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -235,7 +235,11 @@
       "filteredHint": "Essayez un autre type ou effacez la recherche.",
       "createFirst": "Créer le premier",
       "createWorkflow": "Nouveau workflow",
-      "createAgent": "Nouvel agent"
+      "createAgent": "Nouvel agent",
+      "allSkill": "Aucun skill trouvé.",
+      "allSkillHint": "Ajoutez un SKILL.md sous ~/.lionagi/skills/<name>/ pour le voir ici.",
+      "allPlugin": "Aucun plugin trouvé.",
+      "allPluginHint": "Installez un plugin sous ~/.claude/plugins/ pour le voir ici."
     },
     "table": {
       "kind": "Type",
@@ -296,7 +300,19 @@
       "lastUsed": "Dernière utilisation",
       "never": "jamais",
       "recentInvocations": "Invocations récentes",
-      "noInvocations": "Aucune invocation enregistrée pour le moment."
+      "noInvocations": "Aucune invocation enregistrée pour le moment.",
+      "skillValidationFailed": "Échec de la validation. Corrigez les erreurs ci-dessous avant d'enregistrer.",
+      "pluginOwnedSkillHint": "Fourni avec un plugin — modifiez les fichiers du plugin directement pour le changer.",
+      "readOnly": "Lecture seule",
+      "skillTools": "Outils autorisés",
+      "skillInstructions": "Instructions",
+      "pluginHooks": "Hooks",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "Serveurs MCP",
+      "pluginHooksSection": "Configuration des hooks",
+      "pluginReadmeSection": "README",
+      "yes": "Oui",
+      "no": "Non"
     },
     "template": {
       "badge": "Intégré",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -235,7 +235,11 @@
       "filteredHint": "कोई और प्रकार आज़माएँ या खोज साफ़ करें।",
       "createFirst": "अपना पहला बनाएँ",
       "createWorkflow": "नया वर्कफ़्लो",
-      "createAgent": "नया एजेंट"
+      "createAgent": "नया एजेंट",
+      "allSkill": "कोई स्किल नहीं मिली।",
+      "allSkillHint": "यहाँ देखने के लिए ~/.lionagi/skills/<name>/ के अंतर्गत एक SKILL.md जोड़ें।",
+      "allPlugin": "कोई प्लगइन नहीं मिला।",
+      "allPluginHint": "यहाँ देखने के लिए ~/.claude/plugins/ के अंतर्गत एक प्लगइन इंस्टॉल करें।"
     },
     "table": {
       "kind": "प्रकार",
@@ -296,7 +300,19 @@
       "lastUsed": "आखिरी उपयोग",
       "never": "कभी नहीं",
       "recentInvocations": "हाल के इनवोकेशन",
-      "noInvocations": "अभी तक कोई इनवोकेशन रिकॉर्ड नहीं है।"
+      "noInvocations": "अभी तक कोई इनवोकेशन रिकॉर्ड नहीं है।",
+      "skillValidationFailed": "सत्यापन विफल रहा। सहेजने से पहले नीचे दी गई त्रुटियाँ ठीक करें।",
+      "pluginOwnedSkillHint": "यह एक प्लगइन के साथ बंडल है — बदलने के लिए प्लगइन की फ़ाइलें सीधे संपादित करें।",
+      "readOnly": "केवल पढ़ने योग्य",
+      "skillTools": "अनुमत टूल",
+      "skillInstructions": "निर्देश",
+      "pluginHooks": "हुक्स",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP सर्वर",
+      "pluginHooksSection": "हुक कॉन्फ़िगरेशन",
+      "pluginReadmeSection": "README",
+      "yes": "हाँ",
+      "no": "नहीं"
     },
     "template": {
       "badge": "बिल्ट-इन",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -235,7 +235,11 @@
       "filteredHint": "Coba jenis lain atau bersihkan pencarian.",
       "createFirst": "Buat yang pertama",
       "createWorkflow": "Alur kerja baru",
-      "createAgent": "Agen baru"
+      "createAgent": "Agen baru",
+      "allSkill": "Tidak ada skill ditemukan.",
+      "allSkillHint": "Tambahkan SKILL.md di ~/.lionagi/skills/<name>/ agar muncul di sini.",
+      "allPlugin": "Tidak ada plugin ditemukan.",
+      "allPluginHint": "Instal plugin di ~/.claude/plugins/ agar muncul di sini."
     },
     "table": {
       "kind": "Jenis",
@@ -296,7 +300,19 @@
       "lastUsed": "Terakhir digunakan",
       "never": "tidak pernah",
       "recentInvocations": "Invokasi terbaru",
-      "noInvocations": "Belum ada invokasi yang tercatat."
+      "noInvocations": "Belum ada invokasi yang tercatat.",
+      "skillValidationFailed": "Validasi gagal. Perbaiki kesalahan di bawah sebelum menyimpan.",
+      "pluginOwnedSkillHint": "Disertakan dalam plugin — edit file plugin secara langsung untuk mengubahnya.",
+      "readOnly": "Hanya baca",
+      "skillTools": "Alat yang Diizinkan",
+      "skillInstructions": "Instruksi",
+      "pluginHooks": "Hook",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "Server MCP",
+      "pluginHooksSection": "Konfigurasi Hook",
+      "pluginReadmeSection": "README",
+      "yes": "Ya",
+      "no": "Tidak"
     },
     "template": {
       "badge": "Bawaan",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -235,7 +235,11 @@
       "filteredHint": "別の種類を試すか、検索をクリアしてください。",
       "createFirst": "最初の項目を作成",
       "createWorkflow": "新規ワークフロー",
-      "createAgent": "新規エージェント"
+      "createAgent": "新規エージェント",
+      "allSkill": "スキルが見つかりません。",
+      "allSkillHint": "~/.lionagi/skills/<name>/ に SKILL.md を追加するとここに表示されます。",
+      "allPlugin": "プラグインが見つかりません。",
+      "allPluginHint": "~/.claude/plugins/ にプラグインをインストールするとここに表示されます。"
     },
     "table": {
       "kind": "種類",
@@ -296,7 +300,19 @@
       "lastUsed": "最終使用",
       "never": "未使用",
       "recentInvocations": "最近の呼び出し",
-      "noInvocations": "呼び出しはまだ記録されていません。"
+      "noInvocations": "呼び出しはまだ記録されていません。",
+      "skillValidationFailed": "検証に失敗しました。保存する前に以下のエラーを修正してください。",
+      "pluginOwnedSkillHint": "プラグインに同梱されています — 変更するにはプラグインのファイルを直接編集してください。",
+      "readOnly": "読み取り専用",
+      "skillTools": "許可されたツール",
+      "skillInstructions": "手順",
+      "pluginHooks": "フック",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCPサーバー",
+      "pluginHooksSection": "フック設定",
+      "pluginReadmeSection": "README",
+      "yes": "はい",
+      "no": "いいえ"
     },
     "template": {
       "badge": "ビルトイン",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -235,7 +235,11 @@
       "filteredHint": "다른 종류를 시도하거나 검색을 지우세요.",
       "createFirst": "첫 항목 만들기",
       "createWorkflow": "새 워크플로",
-      "createAgent": "새 에이전트"
+      "createAgent": "새 에이전트",
+      "allSkill": "스킬을 찾을 수 없습니다.",
+      "allSkillHint": "여기에 표시하려면 ~/.lionagi/skills/<name>/ 아래에 SKILL.md를 추가하세요.",
+      "allPlugin": "플러그인을 찾을 수 없습니다.",
+      "allPluginHint": "여기에 표시하려면 ~/.claude/plugins/ 아래에 플러그인을 설치하세요."
     },
     "table": {
       "kind": "종류",
@@ -296,7 +300,19 @@
       "lastUsed": "마지막 사용",
       "never": "사용 이력 없음",
       "recentInvocations": "최근 호출",
-      "noInvocations": "아직 기록된 호출이 없습니다."
+      "noInvocations": "아직 기록된 호출이 없습니다.",
+      "skillValidationFailed": "검증에 실패했습니다. 저장하기 전에 아래 오류를 수정하세요.",
+      "pluginOwnedSkillHint": "플러그인에 포함되어 있습니다 — 변경하려면 플러그인 파일을 직접 편집하세요.",
+      "readOnly": "읽기 전용",
+      "skillTools": "허용된 도구",
+      "skillInstructions": "지침",
+      "pluginHooks": "훅",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP 서버",
+      "pluginHooksSection": "훅 설정",
+      "pluginReadmeSection": "README",
+      "yes": "예",
+      "no": "아니오"
     },
     "template": {
       "badge": "내장",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -235,7 +235,11 @@
       "filteredHint": "Tente outro tipo ou limpe a busca.",
       "createFirst": "Criar o primeiro",
       "createWorkflow": "Novo fluxo de trabalho",
-      "createAgent": "Novo agente"
+      "createAgent": "Novo agente",
+      "allSkill": "Nenhuma skill encontrada.",
+      "allSkillHint": "Adicione um SKILL.md em ~/.lionagi/skills/<name>/ para vê-la aqui.",
+      "allPlugin": "Nenhum plugin encontrado.",
+      "allPluginHint": "Instale um plugin em ~/.claude/plugins/ para vê-lo aqui."
     },
     "table": {
       "kind": "Tipo",
@@ -296,7 +300,19 @@
       "lastUsed": "Usado pela última vez",
       "never": "nunca",
       "recentInvocations": "Invocações recentes",
-      "noInvocations": "Nenhuma invocação registrada ainda."
+      "noInvocations": "Nenhuma invocação registrada ainda.",
+      "skillValidationFailed": "Falha na validação. Corrija os erros abaixo antes de salvar.",
+      "pluginOwnedSkillHint": "Incluída em um plugin — edite os arquivos do plugin diretamente para alterá-la.",
+      "readOnly": "Somente leitura",
+      "skillTools": "Ferramentas permitidas",
+      "skillInstructions": "Instruções",
+      "pluginHooks": "Hooks",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "Servidores MCP",
+      "pluginHooksSection": "Configuração de hooks",
+      "pluginReadmeSection": "README",
+      "yes": "Sim",
+      "no": "Não"
     },
     "template": {
       "badge": "Integrado",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -235,7 +235,11 @@
       "filteredHint": "Попробуйте другой тип или очистите поиск.",
       "createFirst": "Создать первый",
       "createWorkflow": "Новый рабочий процесс",
-      "createAgent": "Новый агент"
+      "createAgent": "Новый агент",
+      "allSkill": "Навыки не найдены.",
+      "allSkillHint": "Добавьте SKILL.md в ~/.lionagi/skills/<name>/, чтобы увидеть его здесь.",
+      "allPlugin": "Плагины не найдены.",
+      "allPluginHint": "Установите плагин в ~/.claude/plugins/, чтобы увидеть его здесь."
     },
     "table": {
       "kind": "Тип",
@@ -296,7 +300,19 @@
       "lastUsed": "Последнее использование",
       "never": "никогда",
       "recentInvocations": "Последние вызовы",
-      "noInvocations": "Вызовы еще не записаны."
+      "noInvocations": "Вызовы еще не записаны.",
+      "skillValidationFailed": "Проверка не пройдена. Исправьте ошибки ниже перед сохранением.",
+      "pluginOwnedSkillHint": "Поставляется с плагином — чтобы изменить, редактируйте файлы плагина напрямую.",
+      "readOnly": "Только чтение",
+      "skillTools": "Разрешённые инструменты",
+      "skillInstructions": "Инструкции",
+      "pluginHooks": "Хуки",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP-серверы",
+      "pluginHooksSection": "Настройка хуков",
+      "pluginReadmeSection": "README",
+      "yes": "Да",
+      "no": "Нет"
     },
     "template": {
       "badge": "Встроенный",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -235,7 +235,11 @@
       "filteredHint": "başka bir tür dene veya aramayı temizle.",
       "createFirst": "ilkini oluştur",
       "createWorkflow": "yeni iş akışı",
-      "createAgent": "yeni ajan"
+      "createAgent": "yeni ajan",
+      "allSkill": "Skill bulunamadı.",
+      "allSkillHint": "Burada görmek için ~/.lionagi/skills/<name>/ altına bir SKILL.md ekleyin.",
+      "allPlugin": "Eklenti bulunamadı.",
+      "allPluginHint": "Burada görmek için ~/.claude/plugins/ altına bir eklenti kurun."
     },
     "table": {
       "kind": "tür",
@@ -296,7 +300,19 @@
       "lastUsed": "son kullanım",
       "never": "hiçbir zaman",
       "recentInvocations": "son çağrılar",
-      "noInvocations": "henüz kayıtlı çağrı yok."
+      "noInvocations": "henüz kayıtlı çağrı yok.",
+      "skillValidationFailed": "Doğrulama başarısız oldu. Kaydetmeden önce aşağıdaki hataları düzeltin.",
+      "pluginOwnedSkillHint": "Bir eklentiyle birlikte gelir — değiştirmek için eklentinin dosyalarını doğrudan düzenleyin.",
+      "readOnly": "Salt okunur",
+      "skillTools": "İzin Verilen Araçlar",
+      "skillInstructions": "Talimatlar",
+      "pluginHooks": "Kancalar",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP Sunucuları",
+      "pluginHooksSection": "Kanca Yapılandırması",
+      "pluginReadmeSection": "README",
+      "yes": "Evet",
+      "no": "Hayır"
     },
     "template": {
       "badge": "yerleşik",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -235,7 +235,11 @@
       "filteredHint": "دوسری قسم آزمائیں یا تلاش صاف کریں۔",
       "createFirst": "اپنا پہلا بنائیں",
       "createWorkflow": "نیا ورک فلو",
-      "createAgent": "نیا ایجنٹ"
+      "createAgent": "نیا ایجنٹ",
+      "allSkill": "کوئی سکل نہیں ملی۔",
+      "allSkillHint": "یہاں دیکھنے کے لیے ~/.lionagi/skills/<name>/ کے تحت ایک SKILL.md شامل کریں۔",
+      "allPlugin": "کوئی پلگ ان نہیں ملا۔",
+      "allPluginHint": "یہاں دیکھنے کے لیے ~/.claude/plugins/ کے تحت ایک پلگ ان انسٹال کریں۔"
     },
     "table": {
       "kind": "قسم",
@@ -296,7 +300,19 @@
       "lastUsed": "آخری استعمال",
       "never": "کبھی نہیں",
       "recentInvocations": "حالیہ انووکیشنز",
-      "noInvocations": "ابھی تک کوئی انووکیشن ریکارڈ نہیں ہوئی۔"
+      "noInvocations": "ابھی تک کوئی انووکیشن ریکارڈ نہیں ہوئی۔",
+      "skillValidationFailed": "توثیق ناکام ہو گئی۔ محفوظ کرنے سے پہلے نیچے دی گئی خرابیاں درست کریں۔",
+      "pluginOwnedSkillHint": "یہ ایک پلگ ان کے ساتھ شامل ہے — تبدیل کرنے کے لیے پلگ ان کی فائلیں براہ راست ترمیم کریں۔",
+      "readOnly": "صرف پڑھنے کے لیے",
+      "skillTools": "اجازت یافتہ ٹولز",
+      "skillInstructions": "ہدایات",
+      "pluginHooks": "ہکس",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP سرورز",
+      "pluginHooksSection": "ہک کنفیگریشن",
+      "pluginReadmeSection": "README",
+      "yes": "ہاں",
+      "no": "نہیں"
     },
     "template": {
       "badge": "بلٹ اِن",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -235,7 +235,11 @@
       "filteredHint": "thử loại khác hoặc xóa tìm kiếm.",
       "createFirst": "tạo mục đầu tiên",
       "createWorkflow": "quy trình làm việc mới",
-      "createAgent": "tác nhân mới"
+      "createAgent": "tác nhân mới",
+      "allSkill": "Không tìm thấy skill nào.",
+      "allSkillHint": "Thêm SKILL.md vào ~/.lionagi/skills/<name>/ để hiển thị ở đây.",
+      "allPlugin": "Không tìm thấy plugin nào.",
+      "allPluginHint": "Cài đặt plugin vào ~/.claude/plugins/ để hiển thị ở đây."
     },
     "table": {
       "kind": "loại",
@@ -296,7 +300,19 @@
       "lastUsed": "dùng gần nhất",
       "never": "chưa bao giờ",
       "recentInvocations": "lần gọi gần đây",
-      "noInvocations": "chưa ghi nhận lần gọi nào."
+      "noInvocations": "chưa ghi nhận lần gọi nào.",
+      "skillValidationFailed": "Xác thực thất bại. Sửa các lỗi bên dưới trước khi lưu.",
+      "pluginOwnedSkillHint": "Được đóng gói cùng plugin — chỉnh sửa trực tiếp tệp của plugin để thay đổi.",
+      "readOnly": "Chỉ đọc",
+      "skillTools": "Công cụ được phép",
+      "skillInstructions": "Hướng dẫn",
+      "pluginHooks": "Hook",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "Máy chủ MCP",
+      "pluginHooksSection": "Cấu hình Hook",
+      "pluginReadmeSection": "README",
+      "yes": "Có",
+      "no": "Không"
     },
     "template": {
       "badge": "tích hợp sẵn",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -235,7 +235,11 @@
       "filteredHint": "换个类型试试，或清除搜索条件。",
       "createFirst": "创建你的第一个",
       "createWorkflow": "新建工作流",
-      "createAgent": "新建智能体"
+      "createAgent": "新建智能体",
+      "allSkill": "未找到技能。",
+      "allSkillHint": "在 ~/.lionagi/skills/<name>/ 下添加 SKILL.md 即可在此显示。",
+      "allPlugin": "未找到插件。",
+      "allPluginHint": "在 ~/.claude/plugins/ 下安装插件即可在此显示。"
     },
     "table": {
       "kind": "类型",
@@ -296,7 +300,19 @@
       "lastUsed": "最近使用",
       "never": "从未",
       "recentInvocations": "最近调用",
-      "noInvocations": "暂无调用记录。"
+      "noInvocations": "暂无调用记录。",
+      "skillValidationFailed": "验证失败，请先修正以下错误再保存。",
+      "pluginOwnedSkillHint": "该技能随插件一起提供 — 请直接编辑插件文件来修改它。",
+      "readOnly": "只读",
+      "skillTools": "允许的工具",
+      "skillInstructions": "使用说明",
+      "pluginHooks": "钩子",
+      "pluginMcp": "MCP",
+      "pluginMcpServers": "MCP 服务器",
+      "pluginHooksSection": "钩子配置",
+      "pluginReadmeSection": "README",
+      "yes": "是",
+      "no": "否"
     },
     "template": {
       "badge": "内置",

--- a/apps/studio/frontend/src/routes/library.tsx
+++ b/apps/studio/frontend/src/routes/library.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { useTranslations } from "use-intl";
 import { AgentDetail } from "@/components/library/AgentDetail";
@@ -6,14 +6,14 @@ import { CreateAgentPanel } from "@/components/library/CreateAgentPanel";
 import { WorkflowDetail, CreateWorkflowPanel } from "@/components/library/WorkflowDetail";
 import { PlaybookTemplateDetail } from "@/components/library/PlaybookTemplateDetail";
 import { McpServerDetail, CreateMcpServerPanel } from "@/components/library/McpServerDetail";
+import { SkillDetail } from "@/components/library/SkillDetail";
+import { PluginDetail } from "@/components/library/PluginDetail";
 import { KindBadge } from "@/components/library/KindBadge";
 import SplitPane from "@/components/ui/SplitPane";
 import TabBar from "@/components/shell/TabBar";
-import { IconCheck, IconClose, IconDotFilled } from "@/components/ui/icons";
-import SectionLabel from "@/components/ui/SectionLabel";
-import Button from "@/components/ui/Button";
 import EmptyState from "@/components/ui/EmptyState";
 import Skeleton from "@/components/ui/Skeleton";
+import Button from "@/components/ui/Button";
 import DrawerBackButton from "@/components/ui/DrawerBackButton";
 import DrawerHeader from "@/components/ui/DrawerHeader";
 import type { LibraryKind } from "@/components/library/KindBadge";
@@ -23,14 +23,18 @@ import {
   listSkills,
   listPlugins,
   listEngineDefs,
-  listInvocations,
   listBuiltinPlaybooks,
   listPlaybooks,
   listMcpServers,
 } from "@/lib/api";
-import type { InvocationSummary } from "@/lib/api";
 import type { AgentProfileSummary } from "@/lib/types";
 import type { EngineDef } from "@/lib/api";
+
+// Kinds with no creation flow at all — the toolbar's "+ New" button and the
+// empty-state's create CTA are both meaningless here (skills come from
+// ~/.lionagi/skills/, plugins from the marketplace/installed-plugin cache;
+// neither is created from this page).
+const NO_CREATE_KINDS = new Set<LibraryKind>(["skill", "plugin"]);
 
 const LIBRARY_TABS = [
   "all",
@@ -455,6 +459,11 @@ function LibraryPage() {
 
   const isEmpty = !loading && filtered.length === 0;
   const isFiltered = kindFilter !== "all" || search.trim().length > 0;
+  // A skill/plugin tab with nothing on it and no active text search is
+  // "nothing installed here", not "a search matched nothing" — it earns its
+  // own empty-state copy pointing at where these are discovered from.
+  const isEmptyLibraryTab =
+    NO_CREATE_KINDS.has(kindFilter as LibraryKind) && search.trim().length === 0;
 
   const detailPaneActive = detailActive || showCreate || !!parsed;
 
@@ -471,29 +480,31 @@ function LibraryPage() {
           placeholder={t("searchPlaceholder")}
           className="min-w-0 flex-1 rounded border border-edge bg-surface-overlay px-2 py-1 font-ui text-[length:var(--t-sm)] text-content-primary focus:outline-none"
         />
-        <Button
-          size="sm"
-          variant="primary"
-          onClick={() => {
-            setShowCreate(true);
-            setDetailActive(true);
-            void navigate({
-              search: (prev) => {
-                const next = { ...prev };
-                delete next.sel;
-                return next;
-              },
-              replace: false,
-            });
-          }}
-        >
-          +{" "}
-          {kindFilter === "mcp"
-            ? t("newMcpServer")
-            : kindFilter === "agent"
-              ? t("newAgent")
-              : t("newWorkflow")}
-        </Button>
+        {!NO_CREATE_KINDS.has(kindFilter as LibraryKind) && (
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => {
+              setShowCreate(true);
+              setDetailActive(true);
+              void navigate({
+                search: (prev) => {
+                  const next = { ...prev };
+                  delete next.sel;
+                  return next;
+                },
+                replace: false,
+              });
+            }}
+          >
+            +{" "}
+            {kindFilter === "mcp"
+              ? t("newMcpServer")
+              : kindFilter === "agent"
+                ? t("newAgent")
+                : t("newWorkflow")}
+          </Button>
+        )}
       </div>
 
       {/* Error banner */}
@@ -516,8 +527,28 @@ function LibraryPage() {
         ) : isEmpty ? (
           <EmptyState
             glyph="▤"
-            title={isFiltered ? t("empty.filtered") : t("empty.all")}
-            body={isFiltered ? t("empty.filteredHint") : t("empty.allHint")}
+            title={
+              // An empty skill/plugin tab with no active text search is a
+              // "nothing installed here" state, distinct from "a search
+              // matched nothing" — it gets its own copy pointing at where
+              // these are discovered from, not the generic filtered message.
+              isEmptyLibraryTab
+                ? kindFilter === "skill"
+                  ? t("empty.allSkill")
+                  : t("empty.allPlugin")
+                : isFiltered
+                  ? t("empty.filtered")
+                  : t("empty.all")
+            }
+            body={
+              isEmptyLibraryTab
+                ? kindFilter === "skill"
+                  ? t("empty.allSkillHint")
+                  : t("empty.allPluginHint")
+                : isFiltered
+                  ? t("empty.filteredHint")
+                  : t("empty.allHint")
+            }
             action={
               !isFiltered ? (
                 <Button
@@ -725,16 +756,10 @@ function LibraryPage() {
         }}
       />
     );
-  } else if (parsed?.kind === "skill" || parsed?.kind === "plugin") {
-    const item = filtered.find((i) => i.kind === parsed.kind && i.name === parsed.name);
-    detailPane = (
-      <SimpleDetail
-        kind={parsed.kind}
-        name={parsed.name}
-        description={item?.description}
-        onBack={handleBack}
-      />
-    );
+  } else if (parsed?.kind === "skill") {
+    detailPane = <SkillDetail name={parsed.name} onBack={handleBack} />;
+  } else if (parsed?.kind === "plugin") {
+    detailPane = <PluginDetail name={parsed.name} onBack={handleBack} />;
   } else if (parsed?.kind === "engine") {
     detailPane = (
       <EngineDetail name={parsed.name} def={selectedEngine ?? null} onBack={handleBack} />
@@ -779,194 +804,6 @@ function LibraryPage() {
           ariaLabelMaster={t("masterAria")}
           ariaLabelDetail={t("detailAria")}
         />
-      </div>
-    </div>
-  );
-}
-
-// ── Simple detail (skill / plugin) ─────────────────────────────────────────
-
-interface InvocationStats {
-  total: number;
-  successRate: number | null;
-  lastUsedSec: number | null;
-  recent: InvocationSummary[];
-}
-
-/**
- * Fetch invocations for a skill or plugin and compute stats client-side.
- * The backend filters by skill but not by plugin, so plugin stats scan the
- * most recent 200 invocations and filter locally.
- */
-function useInvocationStats(
-  kind: "skill" | "plugin",
-  name: string,
-): {
-  stats: InvocationStats | null;
-  loading: boolean;
-} {
-  const [stats, setStats] = useState<InvocationStats | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let alive = true;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset stale state before async fetch; setState fires synchronously in effect body only, callbacks are guarded by alive flag
-    setStats(null);
-    setLoading(true);
-
-    const fetchParams =
-      kind === "skill"
-        ? listInvocations({ skill: name, limit: 200 })
-        : // No plugin filter on the server — fetch all and filter client-side
-          listInvocations({ limit: 200 });
-
-    fetchParams
-      .then((res) => {
-        if (!alive) return;
-        const rows =
-          kind === "plugin"
-            ? res.invocations.filter((inv) => inv.plugin === name)
-            : res.invocations;
-
-        const total = rows.length;
-        const success = rows.filter((inv) => inv.status === "completed").length;
-        const successRate = total > 0 ? Math.round((success / total) * 100) : null;
-        const lastUsedSec =
-          rows.length > 0 ? Math.max(...rows.map((inv) => inv.ended_at ?? inv.started_at)) : null;
-        const recent = rows.slice(0, 5);
-        setStats({ total, successRate, lastUsedSec, recent });
-        setLoading(false);
-      })
-      .catch(() => {
-        if (!alive) return;
-        setStats(null);
-        setLoading(false);
-      });
-
-    return () => {
-      alive = false;
-    };
-  }, [kind, name]);
-
-  return { stats, loading };
-}
-
-function formatAge(epochSec: number): string {
-  const diffSec = Math.max(0, Math.floor(Date.now() / 1000) - epochSec);
-  if (diffSec < 60) return `${diffSec}s`;
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m`;
-  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h`;
-  return `${Math.floor(diffSec / 86400)}d`;
-}
-
-interface SimpleDetailProps {
-  kind: LibraryKind;
-  name: string;
-  description?: string;
-  onBack?: () => void;
-}
-
-function SimpleDetail({ kind, name, description, onBack }: SimpleDetailProps) {
-  const t = useTranslations("library.drawer");
-  const isStatKind = kind === "skill" || kind === "plugin";
-  const { stats, loading: statsLoading } = useInvocationStats(isStatKind ? kind : "skill", name);
-
-  return (
-    <div className="flex h-full flex-col overflow-hidden">
-      {onBack && <DrawerBackButton onClick={onBack}>{t("back")}</DrawerBackButton>}
-      <DrawerHeader name={name} badge={kind} />
-      <div className="flex-1 overflow-auto p-4">
-        <p className="text-[length:var(--t-sm)] text-content-secondary">
-          {description ?? <span className="italic text-content-muted">{t("noDescription")}</span>}
-        </p>
-
-        {/* Invocation stats — skill and plugin only */}
-        {isStatKind && (
-          <div className="mt-4 flex flex-col gap-3">
-            {/* Stats strip */}
-            <div className="grid grid-cols-3 gap-px overflow-hidden rounded border border-edge bg-edge">
-              {[
-                {
-                  label: t("invocations"),
-                  value: statsLoading ? "—" : String(stats?.total ?? 0),
-                },
-                {
-                  label: t("successRate"),
-                  value: statsLoading
-                    ? "—"
-                    : stats?.successRate != null
-                      ? `${stats.successRate}%`
-                      : "—",
-                },
-                {
-                  label: t("lastUsed"),
-                  value: statsLoading
-                    ? "—"
-                    : stats?.lastUsedSec != null
-                      ? formatAge(stats.lastUsedSec)
-                      : t("never"),
-                },
-              ].map(({ label, value }) => (
-                <div key={label} className="flex flex-col gap-0.5 bg-surface-raised px-3 py-2">
-                  <SectionLabel>{label}</SectionLabel>
-                  <span className="font-data tabular-nums text-[length:var(--t-base)] text-content-primary">
-                    {value}
-                  </span>
-                </div>
-              ))}
-            </div>
-
-            {/* Recent invocations */}
-            <div>
-              <SectionLabel className="mb-1.5">{t("recentInvocations")}</SectionLabel>
-              {statsLoading ? (
-                <p className="text-[length:var(--t-sm)] text-content-muted">{t("loading")}</p>
-              ) : !stats || stats.recent.length === 0 ? (
-                <p className="text-[length:var(--t-sm)] text-content-muted">{t("noInvocations")}</p>
-              ) : (
-                <div
-                  className="flex flex-col rounded border border-edge"
-                  style={{ borderRadius: 4 }}
-                >
-                  {stats.recent.map((inv, i) => (
-                    <Link
-                      key={inv.id}
-                      to="/fleet"
-                      className="flex items-center gap-2 px-2.5 py-2 font-data text-[length:var(--t-sm)] text-content-primary hover:underline"
-                      style={{
-                        borderTop: i > 0 ? "1px solid var(--edge-hairline)" : undefined,
-                      }}
-                    >
-                      <span
-                        className="flex shrink-0 items-center"
-                        style={{
-                          color:
-                            inv.status === "completed"
-                              ? "var(--status-success)"
-                              : inv.status === "failed"
-                                ? "var(--status-failure)"
-                                : "var(--content-muted)",
-                        }}
-                      >
-                        {inv.status === "completed" ? (
-                          <IconCheck size={10} strokeWidth={2.5} />
-                        ) : inv.status === "failed" ? (
-                          <IconClose size={10} strokeWidth={2.5} />
-                        ) : (
-                          <IconDotFilled size={5} />
-                        )}
-                      </span>
-                      <span className="min-w-0 flex-1 truncate">{inv.skill}</span>
-                      <span className="shrink-0 tabular-nums text-[length:var(--t-xs)] text-content-muted">
-                        {formatAge(inv.ended_at ?? inv.started_at)}
-                      </span>
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/lionagi/libs/frontmatter.py
+++ b/lionagi/libs/frontmatter.py
@@ -26,14 +26,20 @@ def parse_frontmatter_strict(text: str) -> tuple[dict[str, Any], str]:
     """Like ``parse_frontmatter``, but raises on a broken frontmatter block instead of
     discarding it silently. For save-time validation, where a swallowed parse error
     would let bad content through and only surface the next time it's read.
+
+    Unlike ``parse_frontmatter``, an opening ``---`` with no matching closing
+    ``---`` is treated as malformed (raises) rather than as "no frontmatter
+    present" -- and a frontmatter block that parses to something other than a
+    YAML mapping (including an explicit ``null`` document, or an empty body)
+    raises too, instead of being coerced into an empty metadata dict.
     """
     text = text.strip()
     if not text.startswith("---"):
         return {}, text
     parts = _FM_SPLIT.split(text, maxsplit=2)
     if len(parts) < 3:
-        return {}, text
-    fm = yaml.safe_load(parts[1]) or {}
+        raise yaml.YAMLError("frontmatter opening delimiter has no matching closing delimiter")
+    fm = yaml.safe_load(parts[1])
     if not isinstance(fm, dict):
         raise yaml.YAMLError("frontmatter must be a YAML mapping, not a list or scalar")
     return fm, parts[2].strip()

--- a/lionagi/libs/frontmatter.py
+++ b/lionagi/libs/frontmatter.py
@@ -20,3 +20,20 @@ def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     except yaml.YAMLError:
         fm = {}
     return fm if isinstance(fm, dict) else {}, parts[2].strip()
+
+
+def parse_frontmatter_strict(text: str) -> tuple[dict[str, Any], str]:
+    """Like ``parse_frontmatter``, but raises on a broken frontmatter block instead of
+    discarding it silently. For save-time validation, where a swallowed parse error
+    would let bad content through and only surface the next time it's read.
+    """
+    text = text.strip()
+    if not text.startswith("---"):
+        return {}, text
+    parts = _FM_SPLIT.split(text, maxsplit=2)
+    if len(parts) < 3:
+        return {}, text
+    fm = yaml.safe_load(parts[1]) or {}
+    if not isinstance(fm, dict):
+        raise yaml.YAMLError("frontmatter must be a YAML mapping, not a list or scalar")
+    return fm, parts[2].strip()

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -4786,6 +4786,7 @@ class StateDB:
         self,
         *,
         skill: str | None = None,
+        plugin: str | None = None,
         status: str | None = None,
         limit: int = 100,
         offset: int = 0,
@@ -4841,6 +4842,9 @@ class StateDB:
         if skill:
             conds.append("inv.skill = :skill")
             params["skill"] = skill
+        if plugin:
+            conds.append("inv.plugin = :plugin")
+            params["plugin"] = plugin
         if status:
             conds.append("inv.status = :status")
             params["status"] = status
@@ -4852,6 +4856,38 @@ class StateDB:
         async with self._read() as conn:
             rows = (await conn.execute(text(query), params)).mappings().all()
         return [self._row_to_dict(r) for r in rows]
+
+    async def count_invocations(
+        self,
+        *,
+        skill: str | None = None,
+        plugin: str | None = None,
+        status: str | None = None,
+    ) -> int:
+        """Real total matching the same filters ``list_invocations`` accepts.
+
+        ``list_invocations`` is paginated (its ``limit`` caps at 200 at the
+        route layer); counting the rows of one page instead of this is what
+        makes a well-used skill's invocation count silently plateau at 200
+        with nothing distinguishing that from an exact count.
+        """
+        conds: list[str] = []
+        params: dict[str, Any] = {}
+        if skill:
+            conds.append("skill = :skill")
+            params["skill"] = skill
+        if plugin:
+            conds.append("plugin = :plugin")
+            params["plugin"] = plugin
+        if status:
+            conds.append("status = :status")
+            params["status"] = status
+        query = "SELECT COUNT(*) AS n FROM invocations"
+        if conds:
+            query += " WHERE " + " AND ".join(conds)
+        async with self._read() as conn:
+            row = (await conn.execute(text(query), params)).mappings().first()
+        return row["n"]
 
     async def list_sessions_for_invocation(self, invocation_id: str) -> list[dict[str, Any]]:
         async with self._read() as conn:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import re
 import shutil
 import sqlite3
 import struct
@@ -2085,10 +2086,22 @@ class StateDB:
             _rebuild,
         )
 
-    # Substring present only in a definitions CREATE SQL whose kind CHECK
-    # admits 'skill'; its absence indicates a legacy DB whose definitions
-    # table still carries the pre-skill-editor 2-value CHECK.
-    _LEGACY_DEFINITIONS_SKILL_MARKER = "'skill'"
+    # The pre-skill-editor definitions.kind CHECK admitted exactly these two
+    # values. A substring search for "'skill'" over the whole CREATE TABLE
+    # SQL false-positives on unrelated columns (e.g. a message TEXT DEFAULT
+    # 'skill'), so detection parses the kind CHECK constraint's own value
+    # set instead of scanning the statement for a marker string.
+    _LEGACY_DEFINITIONS_KIND_VALUES = frozenset({"agent", "playbook"})
+
+    @staticmethod
+    def _definitions_kind_check_values(create_sql: str) -> frozenset[str] | None:
+        """Extract the allowed ``kind`` values from a ``definitions`` CREATE
+        TABLE statement's CHECK constraint, or ``None`` if no such
+        constraint is found in the SQL."""
+        match = re.search(r"\bkind\b\s+IN\s*\(([^)]*)\)", create_sql, re.IGNORECASE)
+        if match is None:
+            return None
+        return frozenset(re.findall(r"'([^']*)'", match.group(1)))
 
     async def _drop_legacy_definitions_kind_check(self) -> None:
         """Rebuild ``definitions`` if it still carries the pre-skill-editor kind CHECK.
@@ -2117,8 +2130,9 @@ class StateDB:
         if row is None or row["sql"] is None:
             return
         create_sql: str = row["sql"]
-        if self._LEGACY_DEFINITIONS_SKILL_MARKER in create_sql:
-            # Table was already created / rebuilt with 'skill' in the CHECK.
+        if self._definitions_kind_check_values(create_sql) != self._LEGACY_DEFINITIONS_KIND_VALUES:
+            # Not the known legacy 2-value CHECK (already migrated, or an
+            # unrecognized shape) -- leave it alone.
             return
 
         # definitions holds every version of every agent/playbook/skill ever
@@ -2182,7 +2196,10 @@ class StateDB:
 
         await self._rebuild_check_constraint(
             "definitions",
-            lambda sql: sql is not None and self._LEGACY_DEFINITIONS_SKILL_MARKER in sql,
+            lambda sql: (
+                sql is not None
+                and self._definitions_kind_check_values(sql) != self._LEGACY_DEFINITIONS_KIND_VALUES
+            ),
             _rebuild,
         )
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -67,6 +67,7 @@ from lionagi.state.reasons import (
 from lionagi.state.reasons import (
     validate_reason_code as _validate_reason_code,
 )
+from lionagi.state.schema_meta import definitions as _definitions_table
 from lionagi.state.schema_meta import metadata
 from lionagi.state.schema_meta import schedules as _schedules_table
 from lionagi.state.schema_migrations import MIGRATION_COLUMNS as _MIGRATION_COLUMNS
@@ -476,7 +477,7 @@ _PLAY_STATUSES = frozenset(
     }
 )
 
-_DEFINITION_KINDS = frozenset({"agent", "playbook"})
+_DEFINITION_KINDS = frozenset({"agent", "playbook", "skill"})
 
 
 def _validate_columns(fields: dict[str, Any], allowed: frozenset[str]) -> None:
@@ -971,6 +972,9 @@ class StateDB:
             # schedule_runs.status and a NOT NULL schedule_id, from before
             # schedule_runs was generalized into the task-application entity.
             await self._drop_legacy_schedule_runs_check()
+            # Existing DBs carry a 2-value CHECK on definitions.kind that
+            # omits 'skill', from before the skill editor.
+            await self._drop_legacy_definitions_kind_check()
         async with self._engine.begin() as conn:
             await self._refuse_newer_schema(conn)
             await conn.run_sync(metadata.create_all)
@@ -2078,6 +2082,107 @@ class StateDB:
         await self._rebuild_check_constraint(
             "schedule_runs",
             lambda sql: sql is not None and self._LEGACY_SCHEDULE_RUNS_QUEUE_MARKER in sql,
+            _rebuild,
+        )
+
+    # Substring present only in a definitions CREATE SQL whose kind CHECK
+    # admits 'skill'; its absence indicates a legacy DB whose definitions
+    # table still carries the pre-skill-editor 2-value CHECK.
+    _LEGACY_DEFINITIONS_SKILL_MARKER = "'skill'"
+
+    async def _drop_legacy_definitions_kind_check(self) -> None:
+        """Rebuild ``definitions`` if it still carries the pre-skill-editor kind CHECK.
+
+        SQLite cannot widen a CHECK constraint via ALTER TABLE, so this uses
+        the same rename → CREATE new → INSERT SELECT → DROP old pattern as
+        ``_drop_legacy_action_kind_check``. ``definitions`` is not itself an
+        FK target, but the foreign_keys-off dance is applied anyway to match
+        every other rebuild in this file rather than special-casing this one
+        on an invariant that could change later.
+        """
+        if self.dialect != "sqlite":
+            return
+        async with self._engine.connect() as conn:
+            row = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master WHERE type='table' AND name='definitions'"
+                        )
+                    )
+                )
+                .mappings()
+                .first()
+            )
+        if row is None or row["sql"] is None:
+            return
+        create_sql: str = row["sql"]
+        if self._LEGACY_DEFINITIONS_SKILL_MARKER in create_sql:
+            # Table was already created / rebuilt with 'skill' in the CHECK.
+            return
+
+        # definitions holds every version of every agent/playbook/skill ever
+        # saved through Studio -- same stakes as schedule_runs, same
+        # pre-rebuild backup.
+        await self._backup_before_rebuild("definitions")
+
+        async with self._engine.connect() as conn:
+            index_rows = (
+                (
+                    await conn.execute(
+                        text(
+                            "SELECT sql FROM sqlite_master "
+                            "WHERE type='index' AND tbl_name='definitions' AND sql IS NOT NULL"
+                        )
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            index_sqls = [r["sql"] for r in index_rows]
+
+            cols_rows = (
+                (await conn.execute(text("PRAGMA table_info(definitions)"))).mappings().all()
+            )
+            cols = [r["name"] for r in cols_rows]
+        col_list = ", ".join(cols)
+
+        # Derive the rebuild DDL from the canonical schema_meta Table rather
+        # than a hand-kept literal, so this migration path can never drift
+        # from the live schema (schema.sql / schema_meta.py parity is
+        # test-enforced).
+        rebuild_table = _definitions_table.to_metadata(MetaData(), name="definitions_new")
+        create_stmt = str(CreateTable(rebuild_table).compile(dialect=self._engine.dialect))
+
+        async def _rebuild() -> None:
+            async with self._engine.connect() as conn:
+                driver = (await conn.get_raw_connection()).driver_connection
+                try:
+                    await driver.execute("PRAGMA foreign_keys = OFF")
+                    await driver.commit()
+                    await driver.execute("BEGIN IMMEDIATE")
+                    try:
+                        await self._refuse_newer_sqlite_schema(driver)
+                        await driver.execute(create_stmt)
+                        insert_sql = (
+                            f"INSERT INTO definitions_new ({col_list}) "  # noqa: S608
+                            f"SELECT {col_list} FROM definitions"
+                        )
+                        await driver.execute(insert_sql)
+                        await driver.execute("DROP TABLE definitions")
+                        await driver.execute("ALTER TABLE definitions_new RENAME TO definitions")
+                        for idx_sql in index_sqls:
+                            await driver.execute(idx_sql)
+                        await driver.commit()
+                    except BaseException:
+                        await driver.rollback()
+                        raise
+                finally:
+                    await _restore_foreign_keys(conn, driver)
+
+        await self._rebuild_check_constraint(
+            "definitions",
+            lambda sql: sql is not None and self._LEGACY_DEFINITIONS_SKILL_MARKER in sql,
             _rebuild,
         )
 

--- a/lionagi/state/schema.sql
+++ b/lionagi/state/schema.sql
@@ -263,14 +263,14 @@ CREATE INDEX IF NOT EXISTS idx_branches_system_msg_id
 CREATE INDEX IF NOT EXISTS idx_branches_progression_id
   ON branches(progression_id);
 
--- ── Definitions (versioned agent + playbook files) ───────────────────────────
+-- ── Definitions (versioned agent + playbook + skill files) ───────────────────
 -- Disk files remain source of truth; this table tracks edit history.
 -- Current version = MAX(version) per (kind, name).
 
 CREATE TABLE IF NOT EXISTS definitions (
   id          TEXT    PRIMARY KEY,
   kind        TEXT    NOT NULL
-              CHECK(kind IN ('agent', 'playbook')),  -- ADR-0016 editable set
+              CHECK(kind IN ('agent', 'playbook', 'skill')),  -- ADR-0016 editable set
   name        TEXT    NOT NULL,           -- e.g. 'analyst', 'review-flow'
   path        TEXT    NOT NULL,           -- disk path relative to .lionagi/
   content     TEXT    NOT NULL,           -- full file content at this version

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -292,7 +292,7 @@ definitions = Table(
     Column(
         "kind",
         Text,
-        CheckConstraint("kind IN ('agent','playbook')", name="ck_definitions_kind"),
+        CheckConstraint("kind IN ('agent','playbook','skill')", name="ck_definitions_kind"),
         nullable=False,
     ),
     Column("name", Text, nullable=False),

--- a/lionagi/studio/services/definitions.py
+++ b/lionagi/studio/services/definitions.py
@@ -18,7 +18,7 @@ from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
 from lionagi.state.engine import mask_credentials
 
 from ..registry import studio_route
-from ._path_safety import validate_name_component
+from ._path_safety import safe_path_join, validate_name_component
 from .agents import _canonicalize_casts, _is_protected_system
 from .redaction import (
     RedactedPayloadError,
@@ -45,6 +45,10 @@ async def _lock_for(kind: str, name: str) -> asyncio.Lock:
 
 AGENTS_DIR = LIONAGI_HOME / "agents"
 PLAYBOOKS_DIR = LIONAGI_HOME / "playbooks"
+# Resolved independently of skills.py's own SKILLS_ROOT (same pattern as
+# agents.py's _AGENTS_ROOT vs. this module's AGENTS_DIR) so this module's
+# constant stays test-patchable without reaching into skills.py's module state.
+SKILLS_DIR = LIONAGI_HOME / "skills"
 
 KIND_DIRS: dict[str, Path] = {
     "agent": AGENTS_DIR,
@@ -213,11 +217,70 @@ async def list_definitions(kind: str | None = None) -> list[dict[str, Any]]:
     return result
 
 
+def _resolve_skill_file(name: str) -> Path | None:
+    """Locate a skill's current content file, tolerating the legacy bare
+    ``<name>.md`` shape that some installed skills still use.
+
+    Mirrors ``skills.py``'s own resolution (canonical ``<name>/SKILL.md``
+    first, then any other ``.md`` in the directory) so Studio's editor and
+    the CLI's skill runner agree on what file a name refers to when reading.
+    Writing does not carry the same tolerance -- see ``_save_skill_definition``,
+    which always targets the canonical shape regardless of what this finds.
+    """
+    from .skills import _find_skill_md
+
+    safe_path_join(SKILLS_DIR, name)
+
+    skill_dir = SKILLS_DIR / name
+    if skill_dir.is_dir():
+        return _find_skill_md(skill_dir)
+    bare = SKILLS_DIR / f"{name}.md"
+    return bare if bare.exists() else None
+
+
+async def _get_skill_definition(name: str) -> dict[str, Any] | None:
+    disk_file = await anyio.to_thread.run_sync(partial(_resolve_skill_file, name))
+    if disk_file is None:
+        return None
+
+    content = await anyio.to_thread.run_sync(disk_file.read_text)
+    path = _relative_path(disk_file)
+
+    try:
+        versions = await _read_history("skill", name)
+    except HistoryUnavailableError:
+        return {
+            "kind": "skill",
+            "name": name,
+            "path": path,
+            "content": content,
+            "version": None,
+            "versions": None,
+            "history_available": False,
+        }
+
+    return {
+        "kind": "skill",
+        "name": name,
+        "path": path,
+        "content": content,
+        "version": versions[0]["version"] if versions else 0,
+        "versions": versions,
+        "history_available": True,
+    }
+
+
 async def get_definition(kind: str, name: str) -> dict[str, Any] | None:
     """Get current definition content from disk + version history from DB."""
     # Validate at service boundary before any filesystem operation.
     validate_name_component(kind, label="kind")
     validate_name_component(name, label="name")
+
+    # Skills live outside KIND_DIRS/_find_definition_file's generic multi-kind
+    # scan -- see the KIND_DIRS comment on list_definitions_route for why --
+    # so they get a dedicated resolution path instead.
+    if kind == "skill":
+        return await _get_skill_definition(name)
 
     base = KIND_DIRS.get(kind)
     if not base:
@@ -343,6 +406,9 @@ async def save_definition(
     validate_name_component(kind, label="kind")
     validate_name_component(name, label="name")
 
+    if kind == "skill":
+        return await _save_skill_definition(name, content, message, validate=validate)
+
     base = KIND_DIRS.get(kind)
     if not base:
         raise ValueError(f"Unknown kind: {kind}")
@@ -402,6 +468,58 @@ async def save_definition(
     # ADR-0077 D2: response field is "saved_at", not "created_at"
     return {
         "kind": kind,
+        "name": name,
+        "version": version,
+        "saved_at": now,
+        "message": message,
+    }
+
+
+async def _save_skill_definition(
+    name: str, content: str, message: str | None, *, validate: bool
+) -> dict[str, Any]:
+    """Skill counterpart to ``save_definition``'s generic path.
+
+    Always writes ``<SKILLS_DIR>/<name>/SKILL.md`` regardless of what shape (if
+    any) currently exists on disk -- a save through Studio normalizes a skill
+    to the one shape ``li skill`` actually resolves (see
+    ``skills.py::_find_skill_md`` / ``lionagi/cli/skill.py``), rather than
+    preserving whatever legacy layout it started from. Plugin-bundled skills
+    live under a plugin directory, never under ``SKILLS_DIR``, so they are
+    unreachable through this path by construction, not by an extra check.
+    """
+    if validate:
+        from .skills import validate_skill_content
+
+        errors = validate_skill_content(content, name)
+        if errors:
+            raise ValueError("; ".join(errors))
+
+    disk_file = SKILLS_DIR / name / "SKILL.md"
+
+    from lionagi.state.db import StateDB
+
+    lock = await _lock_for("skill", name)
+    async with lock:
+        now = time.time()
+
+        async with StateDB() as db:
+            version = await db.save_definition(
+                kind="skill",
+                name=name,
+                path=_relative_path(disk_file),
+                content=content,
+                message=message,
+            )
+
+        def _write_disk() -> None:
+            ensure_lionagi_dir(disk_file.parent)
+            disk_file.write_text(content)
+
+        await anyio.to_thread.run_sync(_write_disk)
+
+    return {
+        "kind": "skill",
         "name": name,
         "version": version,
         "saved_at": now,
@@ -544,7 +662,12 @@ class SaveBody(BaseModel):
 
 @studio_route("/definitions/", method="GET", area="definitions", name="list_definitions")
 async def list_definitions_route(
-    # ADR-0077: "skill" removed -- KIND_DIRS excludes it as not editable.
+    # "skill" is not a KIND_DIRS entry, so it never appears in this generic
+    # multi-kind listing (its shape -- <name>/SKILL.md, not <name>.<ext> --
+    # doesn't fit KIND_DIRS/_find_definition_file's shared scan). It is still
+    # editable: GET/POST /definitions/skill/{name} route through the dedicated
+    # _get_skill_definition/_save_skill_definition path below. Listing itself
+    # comes from GET /skills/, which Studio's Library page already calls.
     kind: str | None = Query(default=None, description="Filter by kind: agent, playbook"),
 ) -> dict[str, Any]:
     return {"definitions": await list_definitions(kind)}
@@ -589,8 +712,9 @@ async def get_version_route(kind: str, name: str, version: int) -> dict[str, Any
     "/definitions/{kind}/{name}", method="POST", area="definitions", name="save_definition"
 )
 async def save_definition_route(kind: str, name: str, body: SaveBody) -> dict[str, Any]:
-    # ADR-0077: unknown kind (e.g. "skill") raises ValueError in the
-    # service layer; catch it and return 422 instead of propagating a 500.
+    # ADR-0077: an unknown kind, or content a kind's validator rejects (e.g.
+    # unparseable skill frontmatter), raises ValueError in the service layer;
+    # catch it and return 422 instead of propagating a 500.
     try:
         return await save_definition(kind, name, body.content, body.message)
     except (PermissionError, RedactedPayloadError) as e:

--- a/lionagi/studio/services/invocations.py
+++ b/lionagi/studio/services/invocations.py
@@ -19,6 +19,7 @@ from ._io import parse_json_col as _parse_json_col
 async def list_invocations(
     *,
     skill: str | None = None,
+    plugin: str | None = None,
     status: str | None = None,
     limit: int = 50,
     offset: int = 0,
@@ -26,7 +27,9 @@ async def list_invocations(
     if state_db_known_absent():
         return []
     async with StateDB() as db:
-        rows = await db.list_invocations(skill=skill, status=status, limit=limit, offset=offset)
+        rows = await db.list_invocations(
+            skill=skill, plugin=plugin, status=status, limit=limit, offset=offset
+        )
     out: list[dict[str, Any]] = []
     for r in rows:
         node_meta = r.get("node_metadata")
@@ -62,6 +65,18 @@ async def list_invocations(
             }
         )
     return out
+
+
+async def count_invocations(
+    *,
+    skill: str | None = None,
+    plugin: str | None = None,
+    status: str | None = None,
+) -> int:
+    if state_db_known_absent():
+        return 0
+    async with StateDB() as db:
+        return await db.count_invocations(skill=skill, plugin=plugin, status=status)
 
 
 async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
@@ -163,17 +178,29 @@ async def get_artifact(artifact_id: str) -> dict[str, Any] | None:
 @studio_route("/invocations/", method="GET", area="invocations", name="list_invocations")
 async def list_invocations_route(
     skill: str | None = Query(default=None),
+    plugin: str | None = Query(default=None),
     status: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ) -> dict[str, Any]:
-    rows = await list_invocations(skill=skill, status=status, limit=limit, offset=offset)
+    rows = await list_invocations(
+        skill=skill, plugin=plugin, status=status, limit=limit, offset=offset
+    )
+    # Real totals, not a count of this page: `limit` caps at 200, so counting
+    # `rows` instead silently plateaus there with nothing distinguishing an
+    # exact count from a capped one. completed_total always means status ==
+    # "completed" specifically -- it ignores the caller's own `status` filter
+    # (which scopes `total`/`rows`) so success-rate math stays meaningful
+    # even when a caller has filtered the list by some other status.
+    total = await count_invocations(skill=skill, plugin=plugin, status=status)
+    completed_total = await count_invocations(skill=skill, plugin=plugin, status="completed")
     return {
         "invocations": rows,
         "limit": limit,
         "offset": offset,
-        # No separate total: pagination uses has_next instead of absolute totals.
         "has_next": len(rows) == limit,
+        "total": total,
+        "completed_total": completed_total,
     }
 
 

--- a/lionagi/studio/services/skills.py
+++ b/lionagi/studio/services/skills.py
@@ -4,10 +4,14 @@ from functools import partial
 from typing import Any
 
 import anyio
+import yaml
 from fastapi import HTTPException
+from pydantic import BaseModel
 
 from lionagi._paths import LIONAGI_HOME
 from lionagi.libs.frontmatter import parse_frontmatter as _parse_frontmatter
+from lionagi.libs.frontmatter import parse_frontmatter_strict as _parse_frontmatter_strict
+from lionagi.libs.path_safety import validate_bare_name
 
 from ..registry import studio_route
 from ._path_safety import public_path, safe_path_join
@@ -99,6 +103,42 @@ def get_skill(name: str) -> dict[str, Any] | None:
     }
 
 
+def validate_skill_content(content: str, name: str) -> list[str]:
+    """Pre-save checks for a skill's raw file content: safe directory name,
+    parseable frontmatter, well-shaped ``allowed-tools``.
+
+    ``parse_frontmatter`` (the tolerant reader used everywhere else) swallows
+    a broken YAML block into ``{}`` rather than raising, so a skill saved with
+    invalid frontmatter would silently lose its name/description/tool list on
+    the very next read with no error anywhere. This is the one place that
+    error is allowed to surface, before the content ever reaches disk.
+    """
+    errors: list[str] = []
+
+    try:
+        validate_bare_name(name, "skill name")
+    except ValueError as exc:
+        errors.append(str(exc))
+
+    try:
+        fm, _ = _parse_frontmatter_strict(content)
+    except yaml.YAMLError as exc:
+        errors.append(f"frontmatter is not valid YAML: {exc}")
+    else:
+        allowed_tools = fm.get("allowed-tools")
+        if allowed_tools is not None and (
+            not isinstance(allowed_tools, list)
+            or not all(isinstance(t, str) for t in allowed_tools)
+        ):
+            errors.append("allowed-tools must be a list of tool name strings")
+
+    return errors
+
+
+class SkillValidateBody(BaseModel):
+    content: str
+
+
 @studio_route("/skills/", method="GET", area="skills", name="list_skills")
 async def list_skills_route() -> dict[str, Any]:
     skills = await anyio.to_thread.run_sync(list_skills)
@@ -111,3 +151,9 @@ async def get_skill_route(name: str) -> dict[str, Any]:
     if skill is None:
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found")
     return skill
+
+
+@studio_route("/skills/{name}/validate", method="POST", area="skills", name="validate_skill")
+async def validate_skill_route(name: str, body: SkillValidateBody) -> dict[str, Any]:
+    errors = await anyio.to_thread.run_sync(partial(validate_skill_content, body.content, name))
+    return {"ok": not errors, "errors": errors or None}

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -127,6 +127,7 @@ _GOLDEN_ROUTES: tuple[tuple[str, str], ...] = (
     ("GET", "/api/shows/{topic}/stream"),
     ("GET", "/api/skills/"),
     ("GET", "/api/skills/{name}"),
+    ("POST", "/api/skills/{name}/validate"),
     ("GET", "/api/stats"),
     ("GET", "/api/stats/activity"),
     ("GET", "/api/stats/spend"),
@@ -275,7 +276,7 @@ def test_golden_route_table_matches_pinned_snapshot():
 
 
 def test_golden_route_count_pinned():
-    assert len(_GOLDEN_ROUTES) == 129
+    assert len(_GOLDEN_ROUTES) == 130
 
 
 def _compiled_match_shape(path_template: str) -> str:

--- a/tests/apps_studio_server/test_definitions.py
+++ b/tests/apps_studio_server/test_definitions.py
@@ -217,7 +217,13 @@ async def test_rollback_definition_succeeds_for_already_invalid_historical_versi
 
 @pytest.mark.asyncio
 async def test_save_definition_unknown_kind_raises(tmp_path, monkeypatch):
-    """save_definition() with an unknown kind must raise ValueError (not return success)."""
+    """save_definition() with an unknown kind must raise ValueError (not return success).
+
+    "skill" used to be this test's example of an unknown kind (pre-skill-editor
+    ADR-0077 exclusion); it is now a first-class editable kind with its own
+    dedicated path (see test_skills_service.py), so a genuinely unknown kind
+    stands in here instead.
+    """
     import lionagi.cli._runs as cli_runs_mod
     import lionagi.studio.services.definitions as defs_mod
 
@@ -232,7 +238,7 @@ async def test_save_definition_unknown_kind_raises(tmp_path, monkeypatch):
     )
 
     with pytest.raises(ValueError, match="Unknown kind"):
-        await defs_mod.save_definition("skill", "my-skill", "content")
+        await defs_mod.save_definition("widget", "my-widget", "content")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_invocations_service.py
+++ b/tests/apps_studio_server/test_invocations_service.py
@@ -134,6 +134,82 @@ async def test_get_invocation_surfaces_schedule_run_failure_fields(tmp_path, mon
     assert "unable to resolve" in result["schedule_run_error_detail"]
 
 
+# ── count_invocations() / plugin filter (real total, not a page count) ────────
+
+
+async def test_count_invocations_service_reports_real_total_past_a_small_page(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    async with StateDB(db_path) as db:
+        for _ in range(5):
+            await _create_invocation(db)
+
+    page = await invocations_mod.list_invocations(limit=2)
+    assert len(page) == 2
+
+    total = await invocations_mod.count_invocations()
+    assert total == 5
+    assert total != len(page)
+
+
+async def test_list_invocations_service_filters_by_plugin(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    async with StateDB(db_path) as db:
+        await db.create_invocation(
+            {
+                "id": uuid.uuid4().hex[:12],
+                "skill": "code-review",
+                "plugin": "review-toolkit",
+                "started_at": time.time(),
+            }
+        )
+        await db.create_invocation(
+            {
+                "id": uuid.uuid4().hex[:12],
+                "skill": "code-review",
+                "started_at": time.time(),
+            }
+        )
+
+    scoped = await invocations_mod.list_invocations(plugin="review-toolkit")
+    assert len(scoped) == 1
+    assert scoped[0]["plugin"] == "review-toolkit"
+
+    assert await invocations_mod.count_invocations(plugin="review-toolkit") == 1
+    assert await invocations_mod.count_invocations() == 2
+
+
+async def test_list_invocations_route_reports_total_and_completed_total(tmp_path, monkeypatch):
+    """The route response must carry real totals, not just this page's rows —
+    the frontend stats strip reads total/completed_total instead of
+    len(invocations) so a well-used skill's count doesn't plateau at 200."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    async with StateDB(db_path) as db:
+        a = await _create_invocation(db, status="completed")
+        await _create_invocation(db, status="failed")
+        await _create_invocation(db, status="completed")
+        assert a  # keep a referenced; content doesn't matter for this assertion
+
+    # FastAPI resolves the route's Query(default=None) params at request
+    # time; calling the function directly bypasses that, so every Query-
+    # defaulted param must be passed explicitly here or the raw Query
+    # sentinel object leaks through as a bind parameter.
+    result = await invocations_mod.list_invocations_route(
+        skill=None, plugin=None, status=None, limit=1, offset=0
+    )
+
+    assert result["total"] == 3
+    assert result["completed_total"] == 2
+    assert len(result["invocations"]) == 1
+
+
 async def test_get_invocation_schedule_run_fields_none_for_interactive_invocation(
     tmp_path, monkeypatch
 ):

--- a/tests/apps_studio_server/test_skills_service.py
+++ b/tests/apps_studio_server/test_skills_service.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the skill editor: validate_skill_content(), and definitions.py's
+skill-kind save/get/rollback path (issue: skills can be viewed but not
+edited or saved)."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
+
+from lionagi.studio.services.skills import validate_skill_content  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# validate_skill_content() — both arms per finding
+# ---------------------------------------------------------------------------
+
+VALID_SKILL = """---
+name: my-skill
+description: Does a thing.
+allowed-tools:
+  - Read
+  - Bash
+---
+Body text.
+"""
+
+
+def test_validate_skill_content_accepts_well_formed_skill():
+    errors = validate_skill_content(VALID_SKILL, "my-skill")
+    assert errors == []
+
+
+def test_validate_skill_content_rejects_broken_yaml_frontmatter():
+    broken = "---\nname: [unterminated\n---\nBody.\n"
+    errors = validate_skill_content(broken, "my-skill")
+    assert errors
+    assert any("YAML" in e for e in errors)
+
+
+def test_validate_skill_content_rejects_non_mapping_frontmatter():
+    # A YAML list, not a mapping, at the top of the frontmatter block.
+    content = "---\n- one\n- two\n---\nBody.\n"
+    errors = validate_skill_content(content, "my-skill")
+    assert errors
+    assert any("mapping" in e for e in errors)
+
+
+def test_validate_skill_content_rejects_non_list_allowed_tools():
+    content = "---\nname: x\nallowed-tools: Bash\n---\nBody.\n"
+    errors = validate_skill_content(content, "x")
+    assert errors
+    assert any("allowed-tools" in e for e in errors)
+
+
+def test_validate_skill_content_rejects_allowed_tools_with_non_string_entries():
+    content = "---\nname: x\nallowed-tools: [Bash, 5]\n---\nBody.\n"
+    errors = validate_skill_content(content, "x")
+    assert errors
+    assert any("allowed-tools" in e for e in errors)
+
+
+def test_validate_skill_content_accepts_missing_allowed_tools():
+    content = "---\nname: x\ndescription: y\n---\nBody.\n"
+    errors = validate_skill_content(content, "x")
+    assert errors == []
+
+
+@pytest.mark.parametrize("bad_name", ["../escape", "a/b", "a\\b", "", ".", ".."])
+def test_validate_skill_content_rejects_unsafe_names(bad_name):
+    errors = validate_skill_content(VALID_SKILL, bad_name)
+    assert errors
+    assert any("skill name" in e for e in errors)
+
+
+def test_validate_skill_content_accepts_bare_identifier_name():
+    errors = validate_skill_content(VALID_SKILL, "my-skill_2")
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# definitions.py — skill kind save / get / rollback
+# ---------------------------------------------------------------------------
+
+from tests.apps_studio_server._helpers import run_async as _run  # noqa: E402
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_skill_definition_writes_canonical_skill_md_shape(tmp_path, monkeypatch):
+    """Saving a skill through the definitions system must always land at
+    <name>/SKILL.md -- the shape lionagi/cli/skill.py's resolve_skill_path()
+    actually looks for -- never a bare <name>.md."""
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    skills_dir = fake_home / "skills"
+    skills_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "SKILLS_DIR", skills_dir)
+
+    content = "---\nname: my-skill\ndescription: does a thing\n---\nBody text.\n"
+    result = await defs_mod.save_definition("skill", "my-skill", content, "initial save")
+
+    assert result["kind"] == "skill"
+    assert result["version"] == 1
+
+    skill_md = skills_dir / "my-skill" / "SKILL.md"
+    assert skill_md.exists()
+    assert skill_md.read_text() == content
+    assert not (skills_dir / "my-skill.md").exists()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_skill_definition_normalizes_legacy_bare_md_shape(tmp_path, monkeypatch):
+    """An existing skill saved in the legacy bare <name>.md shape still gets
+    read correctly, and a save through Studio normalizes it to <name>/SKILL.md
+    rather than overwriting the bare file in place."""
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    skills_dir = fake_home / "skills"
+    skills_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "SKILLS_DIR", skills_dir)
+
+    legacy = skills_dir / "legacy-skill.md"
+    legacy.write_text("---\nname: legacy-skill\n---\nOld body.\n")
+
+    # Reading resolves the legacy shape.
+    fetched = await defs_mod.get_definition("skill", "legacy-skill")
+    assert fetched is not None
+    assert "Old body." in fetched["content"]
+
+    # Saving normalizes to the canonical directory shape.
+    new_content = "---\nname: legacy-skill\n---\nNew body.\n"
+    await defs_mod.save_definition("skill", "legacy-skill", new_content, "normalize")
+
+    canonical = skills_dir / "legacy-skill" / "SKILL.md"
+    assert canonical.exists()
+    assert canonical.read_text() == new_content
+    # The old bare file is left in place (untouched), not deleted out from
+    # under anything else that might still reference it, but the canonical
+    # path is now what both Studio and `li skill` resolve.
+    assert legacy.exists()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_skill_definition_rejects_broken_frontmatter(tmp_path, monkeypatch):
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    skills_dir = fake_home / "skills"
+    skills_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "SKILLS_DIR", skills_dir)
+
+    broken = "---\nname: [unterminated\n---\nBody.\n"
+    with pytest.raises(ValueError, match="YAML"):
+        await defs_mod.save_definition("skill", "bad-skill", broken)
+
+    assert not (skills_dir / "bad-skill").exists()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_skill_definition_increments_version_and_supports_rollback(
+    tmp_path, monkeypatch
+):
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    skills_dir = fake_home / "skills"
+    skills_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "SKILLS_DIR", skills_dir)
+
+    v1 = "---\nname: s\n---\nv1 body.\n"
+    v2 = "---\nname: s\n---\nv2 body.\n"
+    r1 = await defs_mod.save_definition("skill", "s", v1)
+    r2 = await defs_mod.save_definition("skill", "s", v2)
+    assert r1["version"] == 1
+    assert r2["version"] == 2
+
+    current = await defs_mod.get_definition("skill", "s")
+    assert current["content"] == v2
+    assert current["version"] == 2
+    assert len(current["versions"]) == 2
+
+    rolled_back = await defs_mod.rollback_definition("skill", "s", 1)
+    assert rolled_back is not None
+    assert rolled_back["version"] == 3
+
+    after_rollback = await defs_mod.get_definition("skill", "s")
+    assert after_rollback["content"] == v1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_skill_definition_returns_none_for_unknown_skill(tmp_path, monkeypatch):
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    skills_dir = fake_home / "skills"
+    skills_dir.mkdir()
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(defs_mod, "SKILLS_DIR", skills_dir)
+
+    result = await defs_mod.get_definition("skill", "does-not-exist")
+    assert result is None

--- a/tests/apps_studio_server/test_skills_service.py
+++ b/tests/apps_studio_server/test_skills_service.py
@@ -80,6 +80,24 @@ def test_validate_skill_content_accepts_bare_identifier_name():
     assert errors == []
 
 
+def test_validate_skill_content_rejects_missing_closing_delimiter():
+    """An opening --- with no closing --- must not be accepted as "no
+    frontmatter" -- it's malformed content, not absent content."""
+    content = "---\nname: valid\nBody without closing delimiter"
+    errors = validate_skill_content(content, "my-skill")
+    assert errors
+    assert any("YAML" in e for e in errors)
+
+
+def test_validate_skill_content_rejects_null_frontmatter():
+    """An explicit YAML null document must not be coerced into valid, empty
+    metadata."""
+    content = "---\nnull\n---\nBody.\n"
+    errors = validate_skill_content(content, "my-skill")
+    assert errors
+    assert any("YAML" in e or "mapping" in e for e in errors)
+
+
 # ---------------------------------------------------------------------------
 # definitions.py — skill kind save / get / rollback
 # ---------------------------------------------------------------------------
@@ -182,6 +200,58 @@ async def test_save_skill_definition_rejects_broken_frontmatter(tmp_path, monkey
         await defs_mod.save_definition("skill", "bad-skill", broken)
 
     assert not (skills_dir / "bad-skill").exists()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_skill_definition_rejects_missing_closing_delimiter(tmp_path, monkeypatch):
+    """The save endpoint must reject an opening --- with no closing --- as
+    malformed content, not silently store it as a skill with no metadata."""
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    skills_dir = fake_home / "skills"
+    skills_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "SKILLS_DIR", skills_dir)
+
+    unterminated = "---\nname: valid\nBody without closing delimiter"
+    with pytest.raises(ValueError, match="YAML"):
+        await defs_mod.save_definition("skill", "bad-skill-2", unterminated)
+
+    assert not (skills_dir / "bad-skill-2").exists()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_skill_definition_rejects_null_frontmatter(tmp_path, monkeypatch):
+    """The save endpoint must reject an explicit YAML null frontmatter
+    document instead of coercing it into valid, empty metadata."""
+    import lionagi.cli._runs as cli_runs_mod
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.definitions as defs_mod
+
+    fake_home = tmp_path / "lionagi_home"
+    fake_home.mkdir()
+    skills_dir = fake_home / "skills"
+    skills_dir.mkdir()
+    fake_db = tmp_path / "state.db"
+
+    monkeypatch.setattr(cli_runs_mod, "LIONAGI_HOME", fake_home)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", fake_db)
+    monkeypatch.setattr(defs_mod, "SKILLS_DIR", skills_dir)
+
+    null_fm = "---\nnull\n---\nBody.\n"
+    with pytest.raises(ValueError):
+        await defs_mod.save_definition("skill", "bad-skill-3", null_fm)
+
+    assert not (skills_dir / "bad-skill-3").exists()
 
 
 @pytest.mark.integration

--- a/tests/libs/test_frontmatter.py
+++ b/tests/libs/test_frontmatter.py
@@ -12,6 +12,8 @@ VALID = "---\nname: x\ndescription: y\n---\nBody.\n"
 BROKEN = "---\nname: [unterminated\n---\nBody.\n"
 NON_MAPPING = "---\n- one\n- two\n---\nBody.\n"
 NO_FRONTMATTER = "Just a body, no frontmatter block.\n"
+NO_CLOSING_DELIMITER = "---\nname: valid\nBody without closing delimiter"
+NULL_FRONTMATTER = "---\nnull\n---\n"
 
 
 def test_parse_frontmatter_swallows_broken_yaml():
@@ -40,3 +42,34 @@ def test_parse_frontmatter_strict_returns_empty_for_no_frontmatter_block():
     fm, body = parse_frontmatter_strict(NO_FRONTMATTER)
     assert fm == {}
     assert body == NO_FRONTMATTER.strip()
+
+
+def test_parse_frontmatter_tolerates_no_closing_delimiter():
+    """The loose reader's contract is unchanged: an opener with no matching
+    closer is treated the same as no frontmatter block at all."""
+    fm, body = parse_frontmatter(NO_CLOSING_DELIMITER)
+    assert fm == {}
+    assert body == NO_CLOSING_DELIMITER.strip()
+
+
+def test_parse_frontmatter_strict_raises_on_missing_closing_delimiter():
+    """An opening ``---`` with no closing ``---`` is malformed, not merely
+    absent -- the strict reader must reject it instead of silently treating
+    the whole input as body text with empty metadata."""
+    with pytest.raises(yaml.YAMLError):
+        parse_frontmatter_strict(NO_CLOSING_DELIMITER)
+
+
+def test_parse_frontmatter_tolerates_null_frontmatter():
+    """The loose reader's contract is unchanged: an explicit YAML ``null``
+    document still coerces to an empty metadata dict."""
+    fm, body = parse_frontmatter(NULL_FRONTMATTER)
+    assert fm == {}
+
+
+def test_parse_frontmatter_strict_raises_on_null_frontmatter():
+    """An explicit YAML ``null`` document is not a mapping -- the strict
+    reader must reject it instead of coercing it to an empty metadata dict
+    that then reads as successfully-parsed, empty frontmatter."""
+    with pytest.raises(yaml.YAMLError):
+        parse_frontmatter_strict(NULL_FRONTMATTER)

--- a/tests/libs/test_frontmatter.py
+++ b/tests/libs/test_frontmatter.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from lionagi.libs.frontmatter import parse_frontmatter, parse_frontmatter_strict
+
+VALID = "---\nname: x\ndescription: y\n---\nBody.\n"
+BROKEN = "---\nname: [unterminated\n---\nBody.\n"
+NON_MAPPING = "---\n- one\n- two\n---\nBody.\n"
+NO_FRONTMATTER = "Just a body, no frontmatter block.\n"
+
+
+def test_parse_frontmatter_swallows_broken_yaml():
+    fm, body = parse_frontmatter(BROKEN)
+    assert fm == {}
+    assert body == "Body."
+
+
+def test_parse_frontmatter_strict_raises_on_broken_yaml():
+    with pytest.raises(yaml.YAMLError):
+        parse_frontmatter_strict(BROKEN)
+
+
+def test_parse_frontmatter_strict_raises_on_non_mapping():
+    with pytest.raises(yaml.YAMLError):
+        parse_frontmatter_strict(NON_MAPPING)
+
+
+def test_parse_frontmatter_strict_matches_tolerant_reader_for_valid_input():
+    fm, body = parse_frontmatter_strict(VALID)
+    assert fm == {"name": "x", "description": "y"}
+    assert body == "Body."
+
+
+def test_parse_frontmatter_strict_returns_empty_for_no_frontmatter_block():
+    fm, body = parse_frontmatter_strict(NO_FRONTMATTER)
+    assert fm == {}
+    assert body == NO_FRONTMATTER.strip()

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -1541,10 +1541,11 @@ async def test_list_definition_versions(db: StateDB):
 
 
 async def test_save_definition_rejects_non_editable_kind(db: StateDB):
-    """ADR-0077: skills + arbitrary kinds are read-only and must be rejected."""
+    """ADR-0077: arbitrary kinds outside the editable set (agent, playbook,
+    skill) are read-only and must be rejected."""
     import pytest
 
-    for bad_kind in ("skill", "plugin", "something_else"):
+    for bad_kind in ("plugin", "something_else"):
         with pytest.raises(ValueError, match="Invalid definition kind"):
             await db.save_definition(
                 kind=bad_kind,
@@ -1552,6 +1553,17 @@ async def test_save_definition_rejects_non_editable_kind(db: StateDB):
                 path=".lionagi/x",
                 content="content",
             )
+
+
+async def test_save_definition_accepts_skill_kind(db: StateDB):
+    """Skills joined the editable set alongside agent/playbook (skill editor)."""
+    version = await db.save_definition(
+        kind="skill",
+        name="x",
+        path=".lionagi/skills/x/SKILL.md",
+        content="content",
+    )
+    assert version == 1
 
 
 async def test_get_definition_missing(db: StateDB):

--- a/tests/state/test_definitions_kind_check_migration.py
+++ b/tests/state/test_definitions_kind_check_migration.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for ``StateDB._drop_legacy_definitions_kind_check``.
+
+The migration decides whether ``definitions`` still carries the
+pre-skill-editor 2-value ``kind`` CHECK by parsing the CHECK constraint's
+own value set out of ``sqlite_master.sql`` -- not by searching the whole
+CREATE TABLE statement for the substring ``'skill'``, which false-positives
+on unrelated columns (e.g. a ``message`` column whose own default literal
+happens to be ``'skill'``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import aiosqlite
+import pytest
+from sqlalchemy import text
+
+from lionagi.state.db import StateDB
+
+# ── Legacy fixture builders ─────────────────────────────────────────────────
+
+
+def _create_legacy_definitions_db(db_path: Path, *, unrelated_skill_literal: bool = False) -> None:
+    """Full current schema, except ``definitions.kind`` still carries the
+    legacy 2-value CHECK that predates the skill editor. When
+    ``unrelated_skill_literal`` is set, the (untouched) ``message`` column
+    definition is also given a ``'skill'`` default literal -- a value that
+    has nothing to do with the CHECK constraint, but which the old
+    substring-based detector would misread as "already migrated"."""
+    from lionagi.state.db import _SCHEMA_PATH
+
+    schema_sql = _SCHEMA_PATH.read_text()
+    current_check = "CHECK(kind IN ('agent', 'playbook', 'skill')),  -- ADR-0016 editable set"
+    legacy_check = "CHECK(kind IN ('agent', 'playbook')),  -- ADR-0016 editable set"
+    assert schema_sql.count(current_check) == 1, (
+        "definitions.kind CHECK definition not found (or found more than once) in schema.sql "
+        "-- schema.sql layout changed, update this fixture"
+    )
+    legacy_sql = schema_sql.replace(current_check, legacy_check, 1)
+
+    if unrelated_skill_literal:
+        current_message_col = "  message     TEXT                        -- optional edit note"
+        legacy_message_col = "  message     TEXT DEFAULT 'skill'         -- optional edit note"
+        assert legacy_sql.count(current_message_col) == 1, (
+            "definitions.message column definition not found (or found more than once) in "
+            "schema.sql -- schema.sql layout changed, update this fixture"
+        )
+        legacy_sql = legacy_sql.replace(current_message_col, legacy_message_col, 1)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(legacy_sql)
+
+
+async def _definitions_create_sql(db_path: Path) -> str:
+    async with aiosqlite.connect(db_path) as conn:
+        cur = await conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='definitions'"
+        )
+        row = await cur.fetchone()
+    assert row is not None
+    return row[0]
+
+
+# ── Arm 1: exact legacy schema migrates ──────────────────────────────────────
+
+
+async def test_exact_legacy_schema_migrates(tmp_path: Path) -> None:
+    """A definitions table with exactly the legacy 2-value CHECK is rebuilt
+    on open() to admit 'skill', and a skill can then be saved."""
+    db_path = tmp_path / "legacy-definitions.db"
+    _create_legacy_definitions_db(db_path)
+
+    create_sql_before = await _definitions_create_sql(db_path)
+    assert StateDB._definitions_kind_check_values(create_sql_before) == frozenset(
+        {"agent", "playbook"}
+    )
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        version = await state.save_definition(
+            kind="skill", name="demo-skill", path="skills/demo.md", content="# demo"
+        )
+        assert version == 1
+    finally:
+        await state.close()
+
+    create_sql_after = await _definitions_create_sql(db_path)
+    assert StateDB._definitions_kind_check_values(create_sql_after) == frozenset(
+        {"agent", "playbook", "skill"}
+    )
+
+
+# ── Arm 2: exact widened (current) schema skips the rebuild ────────────────
+
+
+async def test_current_schema_skips_rebuild(tmp_path: Path) -> None:
+    """A definitions table that already admits 'skill' is left untouched --
+    no rebuild runs, and the CREATE TABLE SQL is byte-for-byte identical
+    after open()."""
+    db_path = tmp_path / "current-definitions.db"
+    with sqlite3.connect(db_path) as conn:
+        from lionagi.state.db import _SCHEMA_PATH
+
+        conn.executescript(_SCHEMA_PATH.read_text())
+
+    create_sql_before = await _definitions_create_sql(db_path)
+    assert StateDB._definitions_kind_check_values(create_sql_before) == frozenset(
+        {"agent", "playbook", "skill"}
+    )
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        version = await state.save_definition(
+            kind="skill", name="demo-skill", path="skills/demo.md", content="# demo"
+        )
+        assert version == 1
+    finally:
+        await state.close()
+
+    create_sql_after = await _definitions_create_sql(db_path)
+    assert create_sql_after == create_sql_before
+
+
+# ── Arm 3: the false-positive fixture -- old CHECK + unrelated 'skill' ─────
+
+
+async def test_legacy_schema_with_unrelated_skill_literal_still_migrates(tmp_path: Path) -> None:
+    """The core regression: a legacy 2-value CHECK table whose CREATE TABLE
+    SQL *also* contains an unrelated ``'skill'`` substring (a ``message``
+    column default) must still be recognized as legacy and migrated. A
+    substring search for ``'skill'`` over the whole statement would
+    misidentify this table as already migrated and skip the rebuild,
+    leaving the old 2-value CHECK in force -- so a 'skill' write would then
+    fail with a CHECK constraint violation."""
+    db_path = tmp_path / "legacy-definitions-false-positive.db"
+    _create_legacy_definitions_db(db_path, unrelated_skill_literal=True)
+
+    create_sql_before = await _definitions_create_sql(db_path)
+    # The false-positive condition: the raw SQL contains 'skill' as a
+    # substring, yet the CHECK constraint itself only admits the legacy set.
+    assert "'skill'" in create_sql_before
+    assert StateDB._definitions_kind_check_values(create_sql_before) == frozenset(
+        {"agent", "playbook"}
+    )
+
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        version = await state.save_definition(
+            kind="skill", name="demo-skill", path="skills/demo.md", content="# demo"
+        )
+        assert version == 1
+    finally:
+        await state.close()
+
+    create_sql_after = await _definitions_create_sql(db_path)
+    assert StateDB._definitions_kind_check_values(create_sql_after) == frozenset(
+        {"agent", "playbook", "skill"}
+    )
+
+
+async def test_old_substring_detector_would_have_false_positived(tmp_path: Path) -> None:
+    """Documents the defect directly: the false-positive fixture satisfies
+    the retired substring marker while the CHECK constraint is still the
+    legacy 2-value set, proving the substring check alone cannot
+    distinguish the two states."""
+    db_path = tmp_path / "legacy-definitions-false-positive-2.db"
+    _create_legacy_definitions_db(db_path, unrelated_skill_literal=True)
+    create_sql = await _definitions_create_sql(db_path)
+
+    false_positive_detector = "'skill'" in create_sql
+    old_check_still_present = StateDB._definitions_kind_check_values(create_sql) == frozenset(
+        {"agent", "playbook"}
+    )
+    assert false_positive_detector is True
+    assert old_check_still_present is True
+
+
+# ── Arm 4: failed copy retries ───────────────────────────────────────────────
+
+
+async def test_rebuild_crash_mid_sequence_rolls_back_and_reopen_completes(tmp_path: Path) -> None:
+    """The raw-driver rebuild is one BEGIN IMMEDIATE transaction. A crash
+    injected during the INSERT..SELECT copy must roll the whole rebuild
+    back -- leaving the legacy table intact with its rows -- so a later
+    open() can retry and complete the migration cleanly."""
+    db_path = tmp_path / "legacy-definitions-crash.db"
+    _create_legacy_definitions_db(db_path)
+    with sqlite3.connect(db_path) as seed:
+        seed.execute(
+            "INSERT INTO definitions (id, kind, name, path, content, version, created_at) "
+            "VALUES ('def-1', 'agent', 'demo', 'agents/demo.md', 'x', 1, 0)"
+        )
+        seed.commit()
+
+    real_execute = aiosqlite.Connection.execute
+    crash = {"armed": True}
+
+    def _crashing_execute(self, sql, *args, **kwargs):
+        if crash["armed"] and "INSERT INTO definitions_new" in str(sql):
+            raise sqlite3.OperationalError("disk I/O error")
+        return real_execute(self, sql, *args, **kwargs)
+
+    aiosqlite.Connection.execute = _crashing_execute
+    try:
+        state = StateDB(db_path)
+        with pytest.raises(sqlite3.OperationalError):
+            await state.open()
+        await state.close()
+    finally:
+        aiosqlite.Connection.execute = real_execute
+
+    # Atomic rollback: legacy table intact with its row, no stray _new table.
+    with sqlite3.connect(db_path) as check:
+        tables = {
+            r[0]
+            for r in check.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'definitions%'"
+            )
+        }
+        assert tables == {"definitions"}, tables
+        rows = list(check.execute("SELECT id FROM definitions"))
+        assert rows == [("def-1",)]
+
+    # And the DB is healable: a clean re-open completes the rebuild, and the
+    # pre-existing row survives the rebuild.
+    crash["armed"] = False
+    state = StateDB(db_path)
+    await state.open()
+    try:
+        create_sql = await _definitions_create_sql(db_path)
+        assert StateDB._definitions_kind_check_values(create_sql) == frozenset(
+            {"agent", "playbook", "skill"}
+        )
+        async with state._read() as conn:
+            row = (
+                (await conn.execute(text("SELECT id FROM definitions WHERE id = 'def-1'")))
+                .mappings()
+                .first()
+            )
+        assert row is not None
+    finally:
+        await state.close()

--- a/tests/state/test_invocations.py
+++ b/tests/state/test_invocations.py
@@ -269,3 +269,50 @@ async def test_list_invocations_filters_by_status(db: StateDB):
 
     done_only = await db.list_invocations(status="completed")
     assert {r["id"] for r in done_only} == {a["id"]}
+
+
+async def test_list_invocations_filters_by_plugin(db: StateDB):
+    await _make_invocation(db, plugin="review-toolkit")
+    await _make_invocation(db, plugin="other-plugin")
+    await _make_invocation(db)  # no plugin — standalone skill invocation
+
+    only_review_toolkit = await db.list_invocations(plugin="review-toolkit")
+    assert len(only_review_toolkit) == 1
+    assert only_review_toolkit[0]["plugin"] == "review-toolkit"
+
+
+# ── Count (real total, not a page count) ───────────────────────────────────────
+
+
+async def test_count_invocations_matches_row_count_below_the_page_limit(db: StateDB):
+    for _ in range(3):
+        await _make_invocation(db, skill="show")
+    await _make_invocation(db, skill="other")
+
+    assert await db.count_invocations(skill="show") == 3
+    assert await db.count_invocations() == 4
+
+
+async def test_count_invocations_exceeds_a_page_limit_smaller_than_the_real_total(db: StateDB):
+    """The count must not silently plateau at a page size the way counting
+    len(list_invocations(...)) does once more rows exist than `limit`."""
+    for _ in range(5):
+        await _make_invocation(db, skill="show")
+
+    page = await db.list_invocations(skill="show", limit=2)
+    assert len(page) == 2
+
+    total = await db.count_invocations(skill="show")
+    assert total == 5
+    assert total != len(page)
+
+
+async def test_count_invocations_filters_by_plugin_and_status(db: StateDB):
+    a = await _make_invocation(db, plugin="review-toolkit")
+    await _make_invocation(db, plugin="review-toolkit")
+    await _make_invocation(db, plugin="other-plugin")
+    await db.update_invocation(a["id"], status="completed", ended_at=time.time())
+
+    assert await db.count_invocations(plugin="review-toolkit") == 2
+    assert await db.count_invocations(plugin="review-toolkit", status="completed") == 1
+    assert await db.count_invocations(plugin="does-not-exist") == 0


### PR DESCRIPTION
## What changed

The Studio library's skills and plugins surface, plus the counting bug underneath it.

### Skills are editable and saveable

Skills were listed but read-only. They can now be edited and saved through the
definitions API. Saving is guarded by a dry-run check on a new
`POST /api/skills/{name}/validate`: it verifies the directory name is safe, that the
frontmatter parses, and that `allowed-tools` is a list of strings.

That check exists because `parse_frontmatter` — the tolerant reader used everywhere
else — swallows a broken YAML block into `{}` rather than raising. A skill saved with
invalid frontmatter would silently lose its name, description, and tool list on the very
next read, with no error surfacing anywhere. This is the one place that error is allowed
to surface, before the content reaches disk.

### Skills and plugins get real detail panes

Both previously opened into the same placeholder view. Each now has a dedicated pane
showing real usage statistics.

### Invocation counts stop silently capping at the page limit

`list_invocations()` only ever returned a page, capped at 200, and the UI used
`len(rows)` as a stand-in for the total. Any skill or plugin with more than 200
invocations displayed exactly 200 as though it were the true count, and its success rate
was computed over that truncated page rather than the real history.

- New `StateDB.count_invocations()` does a real `SELECT COUNT(*)`, filterable by skill,
  plugin, and status.
- The `/invocations` route now returns `total` and `completed_total`. `completed_total`
  is fixed to `status="completed"` regardless of the caller's own status filter —
  deriving it from the caller's filter would have made it mean "how many match your
  filter" rather than "how many completed".
- A `plugin` filter was added to both list and count. It existed for `skill` but not for
  `plugin`, so a plugin's statistics were previously a best-effort sample over the last
  200 invocations **system-wide**, not scoped to that plugin at all.
- The frontend hook reads `total` / `completed_total` from the server instead of
  `res.invocations.length`, so nothing in the UI presents a capped number as complete.

### eslint toolchain

Resolved the dependency vulnerabilities and an invalid dependency pairing that were
blocking the lint toolchain.

## Tests

- `test_count_invocations_exceeds_a_page_limit_smaller_than_the_real_total` — asserts a
  real count above a small page limit, which is the failing case the fix targets.
- `test_list_invocations_route_reports_total_and_completed_total` — route-level.
- New skills-service and frontmatter coverage.

Gates: backend 4251 passed across 169 files (set derived by grepping the changed
modules); frontend `tsc --noEmit` clean, `eslint .` clean, 1367 vitest tests pass. Skips
are environmental (`asyncpg`, `numpy` absent).

## Deliberately not included

**#2732 is half closed.** The cap is fixed. The other symptom in that issue — that most
skills show *no* statistics, because most never call the invocation-tracking convention
from their `SKILL.md` — needs a way to distinguish "never instrumented" from
"instrumented, zero runs". The one heuristic that looked plausible without a design
decision (grep a skill body for the tracking call) was tried against real installed
skills, including ones known to use the convention, and matched none of them. So either
the convention is not literal-string-greppable or those skills predate it. Either way,
shipping that heuristic would trade a silently capped number for a silently wrong one.
Marking a skill as instrumented needs a real marker convention, such as a frontmatter
field, which is a decision for whoever owns the skill-authoring contract.

## Notes for reviewers

- One file outside this change's scope was touched as a compile-time consequence:
  `useLiveBoard.test.ts` needed two fields added to two mock fixtures once
  `InvocationListResponse` grew `total` / `completed_total`. No behavioural change.
- The frontend work for the three UI issues landed as one commit. `SkillDetail.tsx` is
  simultaneously the editable surface and the dedicated pane, and the locale keys and the
  API plumbing are shared by both; splitting it would have meant staging partial files or
  landing a commit that does not typecheck on its own. The backend halves are separate
  commits and independently revertable.
- `test_golden_route_count_pinned` asserts a hardcoded route count, so admitting a route
  is a two-place edit. That is the same hardcoded-count pattern #2745 removes elsewhere in
  the schema docs, and this gate has it too.

Closes #2699
Closes #2733
Closes #2734
