### PR TITLE
fix(studio): make a run's reported state match what actually happened

### DIFF
--- a/apps/studio/frontend/src/components/fleet/FleetView.test.ts
+++ b/apps/studio/frontend/src/components/fleet/FleetView.test.ts
@@ -298,8 +298,25 @@ describe("selectedRunId validation", () => {
 
 // ─── Formatter helpers ────────────────────────────────────────────────────────
 
-import { formatElapsed, formatCompactCount, patchSearch } from "./FleetView";
+import { formatElapsed, formatCompactCount, patchSearch, isPlayRoot } from "./FleetView";
 import { resetDetailScrollPosition } from "./SessionDetail";
+
+// ─── isPlayRoot — the play-vs-single-agent discriminator (issue #2842) ───────
+
+describe("isPlayRoot", () => {
+  it("is true for every multi-agent invocation_kind", () => {
+    expect(isPlayRoot("play")).toBe(true);
+    expect(isPlayRoot("flow")).toBe(true);
+    expect(isPlayRoot("fanout")).toBe(true);
+    expect(isPlayRoot("show-play")).toBe(true);
+  });
+
+  it("is false for a single agent and for a missing kind", () => {
+    expect(isPlayRoot("agent")).toBe(false);
+    expect(isPlayRoot(null)).toBe(false);
+    expect(isPlayRoot(undefined)).toBe(false);
+  });
+});
 
 // ─── patchSearch — URL search patching without smuggling `undefined` in ──────
 // FleetSearch's index signature is RetiredSearchValue (no `undefined`), so a

--- a/apps/studio/frontend/src/components/fleet/FleetView.tsx
+++ b/apps/studio/frontend/src/components/fleet/FleetView.tsx
@@ -33,6 +33,15 @@ export function formatCompactCount(n: number): string {
 
 // ─── Agent row ────────────────────────────────────────────────────────────────
 
+// invocation_kind values that mean "this row is the root of a multi-agent
+// execution, not a single agent" (issue #2842) — the closed vocabulary lives
+// in lionagi/state/db.py's sessions.invocation_kind CHECK constraint.
+const PLAY_ROOT_KINDS = new Set(["play", "flow", "fanout", "show-play"]);
+
+export function isPlayRoot(invocationKind: string | null | undefined): boolean {
+  return invocationKind != null && PLAY_ROOT_KINDS.has(invocationKind);
+}
+
 function AgentRowItem({
   agent,
   selected,
@@ -54,6 +63,14 @@ function AgentRowItem({
       aria-label={t("agentRow.ariaLabel", { name: agent.name })}
     >
       <StatusDot status={agent.status} />
+      {isPlayRoot(agent.invocationKind) && (
+        <span
+          className="shrink-0 rounded border border-edge px-1 py-0.5 font-data text-[length:var(--t-xs)] uppercase tracking-[0.04em] text-content-muted"
+          title={agent.invocationKind ?? undefined}
+        >
+          play
+        </span>
+      )}
       <span className="min-w-0 flex-1 truncate font-data text-[length:var(--t-sm)] text-content-primary">
         {agent.name}
       </span>

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
@@ -186,6 +186,20 @@ describe("fleetReducer — invocation join", () => {
     expect(s.orgUnits[0].agents[0].name).toBe(resolveRunLabel(run));
   });
 
+  it("carries invocation_kind onto the agent row so a play root is distinguishable from a single agent", () => {
+    const s = dispatchOk(
+      initialFleetState(),
+      [],
+      [
+        makeRun({ run_id: "r1", status: "running", invocation_kind: "play" }),
+        makeRun({ run_id: "r2", status: "running", invocation_kind: "agent" }),
+      ],
+    );
+    const agents = s.orgUnits[0].agents;
+    expect(agents.find((a) => a.id === "r1")?.invocationKind).toBe("play");
+    expect(agents.find((a) => a.id === "r2")?.invocationKind).toBe("agent");
+  });
+
   it("invocation without runs still appears when no scope is active", () => {
     // Names the case that would have passed either way: no project/search
     // filter is in play here, so this test exercises the same code path

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -43,6 +43,10 @@ export interface AgentRow {
   message_count: number;
   kind: "run" | "invocation";
   invocation_id: string | null;
+  // agent | play | flow | fanout | show-play (issue #2842) — the discriminator
+  // that says whether this row is a single agent or the root of a multi-agent
+  // execution. `agentName`/label text alone never establishes that.
+  invocationKind: string | null;
 }
 
 export interface OrgUnit {
@@ -198,6 +202,7 @@ function buildOrgUnits(
       message_count: run.message_count ?? 0,
       kind: "run",
       invocation_id: run.invocation_id ?? null,
+      invocationKind: run.invocation_kind ?? null,
     };
 
     const parent = run.invocation_id ? invMap.get(run.invocation_id) : undefined;

--- a/apps/studio/frontend/src/components/mission/LiveBoard.test.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.test.tsx
@@ -45,7 +45,12 @@ vi.mock("@tanstack/react-router", () => ({
   ),
 }));
 
-const { default: LiveBoard, DEAD_HEALTH, isDeadHealth } = await import("./LiveBoard");
+const {
+  default: LiveBoard,
+  DEAD_HEALTH,
+  isDeadHealth,
+  isUnknownHealth,
+} = await import("./LiveBoard");
 
 describe("isDeadHealth", () => {
   it("is true for every DEAD_HEALTH member", () => {
@@ -145,6 +150,69 @@ function invocation(overrides: Partial<InvocationSummary> = {}): InvocationSumma
     ...overrides,
   };
 }
+
+describe("isUnknownHealth", () => {
+  it("is true only for the literal 'unknown' verdict", () => {
+    expect(isUnknownHealth("unknown")).toBe(true);
+    expect(isUnknownHealth("healthy")).toBe(false);
+    expect(isUnknownHealth("stale")).toBe(false);
+    expect(isUnknownHealth(null)).toBe(false);
+    expect(isUnknownHealth(undefined)).toBe(false);
+  });
+});
+
+describe("LiveBoard — InvocationCard health rendering (issue #2851)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    installLocalStorageStub();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function mount(invocations: InvocationSummary[]) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <LiveBoard activeRuns={[]} activeInvocations={invocations} nowSec={100} />
+        </IntlProvider>,
+      );
+    });
+  }
+
+  it("renders a live pulsing dot with no stale label when health=healthy", () => {
+    mount([invocation({ health: "healthy" })]);
+    const dot = container.querySelector('[aria-hidden="true"].rounded-full');
+    expect(dot?.className).toContain("live-pulse-dot");
+    expect(container.textContent).not.toContain("quiet — check?");
+  });
+
+  it("never renders an unconditional 'running' pulsing dot when health=orphaned", () => {
+    mount([invocation({ health: "orphaned" })]);
+    const dot = container.querySelector('[aria-hidden="true"].rounded-full');
+    expect(dot).not.toBeNull();
+    expect(dot?.className).not.toContain("live-pulse-dot");
+    expect(container.textContent).toContain("quiet — check?");
+  });
+
+  it("renders a static, non-pulsing dot with no false stale/healthy claim when health=unknown", () => {
+    mount([invocation({ health: "unknown" })]);
+    const dot = container.querySelector('[aria-hidden="true"].rounded-full');
+    expect(dot).not.toBeNull();
+    expect(dot?.className).not.toContain("live-pulse-dot");
+    // Not the dead label either — "unknown" is not a confirmed-dead verdict.
+    expect(container.textContent).not.toContain("quiet — check?");
+  });
+});
 
 describe("LiveBoard — combined card order and view switching", () => {
   let container: HTMLDivElement;

--- a/apps/studio/frontend/src/components/mission/LiveBoard.tsx
+++ b/apps/studio/frontend/src/components/mission/LiveBoard.tsx
@@ -38,6 +38,15 @@ export function isDeadHealth(health: string | null | undefined): boolean {
   return health != null && DEAD_HEALTH.has(health);
 }
 
+/**
+ * Whether an invocation's health means liveness genuinely could not be
+ * determined (e.g. no child session has landed yet) — distinct from
+ * isDeadHealth, which means a process was observed and it's gone.
+ */
+export function isUnknownHealth(health: string | null | undefined): boolean {
+  return health === "unknown";
+}
+
 /** Placeholder card count while the first fetch is in flight. */
 const SKELETON_CARDS = 4;
 
@@ -111,11 +120,14 @@ function RunCard({ run, nowSec }: { run: RunSummary; nowSec: number }) {
 function InvocationCard({ inv, nowSec }: { inv: InvocationSummary; nowSec: number }) {
   const t = useTranslations("mission");
   const elapsed = elapsedSec(inv.started_at, nowSec);
-  // InvocationSummary carries no per-message heartbeat field — updated_at is
-  // the coarsest available proxy for "last activity" (bumped on any change
-  // to the invocation row, not strictly a heartbeat). Flagged as a data-field
-  // gap: a real invocation heartbeat would need a backend addition.
-  const lastActivity = elapsedSec(inv.updated_at ?? inv.started_at, nowSec);
+  // Health axis, same as RunCard: never an unconditional "running" dot
+  // regardless of whether there's evidence behind it (issue #2851).
+  const dead = isDeadHealth(inv.health);
+  const unknown = isUnknownHealth(inv.health);
+  // last_activity_at is the real worst-of child-session heartbeat now that
+  // the backend computes one; updated_at (bumped on any row change, not
+  // strictly a heartbeat) is only the fallback for older/unhealthy rows.
+  const lastActivity = elapsedSec(inv.last_activity_at ?? inv.updated_at ?? inv.started_at, nowSec);
 
   return (
     <Link
@@ -123,14 +135,21 @@ function InvocationCard({ inv, nowSec }: { inv: InvocationSummary; nowSec: numbe
       className="group flex flex-col gap-2 rounded border border-edge bg-surface-raised p-3 transition-colors duration-100"
     >
       <div className="flex items-center gap-2">
-        <StatusDot status="running" />
+        <StatusDot status={dead ? "stale" : unknown ? "unknown" : "running"} />
         <span className="min-w-0 flex-1 truncate font-data text-[length:var(--t-sm)] font-medium text-content-primary group-hover:opacity-80">
           {inv.skill}
         </span>
+        {dead && (
+          <span className="shrink-0 font-data text-[length:var(--t-xs)] uppercase text-content-muted">
+            {t("liveBoard.staleLabel")}
+          </span>
+        )}
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="min-w-0 flex-1 truncate font-data tabular-nums text-[length:var(--t-xs)] text-status-running">
+        <span
+          className={`min-w-0 flex-1 truncate font-data tabular-nums text-[length:var(--t-xs)] ${dead || unknown ? "text-content-muted" : "text-status-running"}`}
+        >
           {t("liveBoard.durationStatus", {
             duration: formatElapsed(elapsed),
             age: formatElapsed(lastActivity),
@@ -269,9 +288,14 @@ function BoardTableRow({ card, nowSec }: { card: LiveCard; nowSec: number }) {
   const elapsed = elapsedSec(startedAt, nowSec);
   const lastActivityAt = isRun
     ? (card.run.last_message_at ?? card.run.started_at ?? undefined)
-    : (card.invocation.updated_at ?? card.invocation.started_at);
+    : (card.invocation.last_activity_at ??
+      card.invocation.updated_at ??
+      card.invocation.started_at);
   const lastActivity = elapsedSec(lastActivityAt, nowSec);
-  const dead = isRun && isDeadHealth(card.run.effective_health);
+  const dead = isRun
+    ? isDeadHealth(card.run.effective_health)
+    : isDeadHealth(card.invocation.health);
+  const unknown = !isRun && isUnknownHealth(card.invocation.health);
   const status = isRun ? card.run.status : card.invocation.status;
   const linkProps = isRun ? runDeepLink(card.run.run_id) : invocationDeepLink();
 
@@ -287,9 +311,9 @@ function BoardTableRow({ card, nowSec }: { card: LiveCard; nowSec: number }) {
       </td>
       <td className="px-3 py-2">
         <span className="flex items-center gap-1.5">
-          <StatusDot status={dead ? "stale" : status} />
+          <StatusDot status={dead ? "stale" : unknown ? "unknown" : status} />
           <span className="font-data text-[length:var(--t-xs)] text-content-secondary">
-            {dead ? t("liveBoard.staleLabel") : status}
+            {dead ? t("liveBoard.staleLabel") : unknown ? "unknown" : status}
           </span>
         </span>
       </td>

--- a/apps/studio/frontend/src/components/ui/Markdown.test.ts
+++ b/apps/studio/frontend/src/components/ui/Markdown.test.ts
@@ -12,7 +12,8 @@ import * as path from "node:path";
 import { createElement } from "react";
 import type { ComponentType, ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import Markdown, * as MarkdownModule from "./Markdown";
+import Markdown, { isNoArtifactRootDetail } from "./Markdown";
+import * as MarkdownModule from "./Markdown";
 
 const SRC = fs.readFileSync(path.resolve(__dirname, "Markdown.tsx"), "utf-8");
 
@@ -74,6 +75,25 @@ describe("Markdown.tsx — file-link resolution wiring", () => {
 
   it("never fabricates a target from text alone — file surface comes only from fileContext.knownFiles", () => {
     expect(SRC).toMatch(/knownFiles: fileContext\.knownFiles/);
+  });
+
+  it("renders a distinct no-artifact-root state, not the generic missing-file message (issue #2848)", () => {
+    expect(SRC).toMatch(/status === "no_artifact_root"/);
+    expect(SRC).toMatch(/isNoArtifactRootDetail\(result\.detail\)/);
+  });
+});
+
+// ─── isNoArtifactRootDetail — the get_run_file 404 detail classifier ─────────
+
+describe("isNoArtifactRootDetail", () => {
+  it("is true for both no-artifact-root 404 details get_run_file sends", () => {
+    expect(isNoArtifactRootDetail("Run 'abc123' has no artifact root")).toBe(true);
+    expect(isNoArtifactRootDetail("Run artifact root no longer exists")).toBe(true);
+  });
+
+  it("is false for a genuinely missing file and for no detail at all", () => {
+    expect(isNoArtifactRootDetail("File 'notes.md' not found")).toBe(false);
+    expect(isNoArtifactRootDetail(undefined)).toBe(false);
   });
 });
 

--- a/apps/studio/frontend/src/components/ui/Markdown.tsx
+++ b/apps/studio/frontend/src/components/ui/Markdown.tsx
@@ -132,6 +132,15 @@ function FileRef({
   return <>{fallback}</>;
 }
 
+// issue #2848: get_run_file 404s for two different reasons -- the run never
+// recorded an artifact root, or a file inside a recorded root is genuinely
+// gone -- and the detail string is the only thing that tells them apart.
+// Matches both `get_run_file` 404 details ("has no artifact root" and
+// "artifact root no longer exists") without hardcoding the run id.
+export function isNoArtifactRootDetail(detail: string | undefined): boolean {
+  return detail != null && detail.toLowerCase().includes("artifact root");
+}
+
 function FileViewerModal({
   runId,
   path,
@@ -145,6 +154,7 @@ function FileViewerModal({
     | { status: "loading" }
     | { status: "ready"; content: string; truncated: boolean }
     | { status: "missing" }
+    | { status: "no_artifact_root" }
     | { status: "error"; detail?: string }
   >({ status: "loading" });
 
@@ -154,8 +164,15 @@ function FileViewerModal({
       .then((result) => {
         if (cancelled) return;
         if (!result.ok) {
-          if (result.status === 404) setState({ status: "missing" });
-          else setState({ status: "error", detail: result.detail });
+          if (result.status === 404) {
+            setState(
+              isNoArtifactRootDetail(result.detail)
+                ? { status: "no_artifact_root" }
+                : { status: "missing" },
+            );
+          } else {
+            setState({ status: "error", detail: result.detail });
+          }
           return;
         }
         setState({
@@ -194,6 +211,12 @@ function FileViewerModal({
           <p className="flex items-center gap-1.5 text-body text-content-muted">
             <IconWarning size={12} strokeWidth={2} />
             File not found — it may have been moved or deleted since this message was written.
+          </p>
+        )}
+        {state.status === "no_artifact_root" && (
+          <p className="flex items-center gap-1.5 text-body text-content-muted">
+            <IconWarning size={12} strokeWidth={2} />
+            This run has no recorded artifact root, so its files were never linked here.
           </p>
         )}
         {state.status === "error" && (

--- a/apps/studio/frontend/src/components/ui/StatusDot.tsx
+++ b/apps/studio/frontend/src/components/ui/StatusDot.tsx
@@ -18,9 +18,11 @@ const TERMINAL_STATUSES = new Set([
   "timed_out",
 ]);
 
-// Process-dead-but-non-terminal health states: muted and static — a dead
-// process must never pulse as if alive.
-const STALE_STATUSES = new Set(["stale", "orphaned", "zombie", "unresponsive"]);
+// Process-dead-but-non-terminal health states, plus "unknown" (liveness
+// genuinely undetermined, e.g. no evidence has landed yet): muted and
+// static either way — neither a dead process nor an undetermined one may
+// pulse as if confirmed alive.
+const STALE_STATUSES = new Set(["stale", "orphaned", "zombie", "unresponsive", "unknown"]);
 
 function statusColor(status: string): string {
   const s = status.toLowerCase();

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1348,6 +1348,12 @@ export interface InvocationSummary {
   // ADR-0026: project provenance from the most-recently updated child session.
   project?: string | null;
   project_source?: string | null;
+  // ADR-0057 health verdict (worst-of across child sessions) + the real
+  // last-activity timestamp behind it, "unknown" when the invocation has
+  // no child sessions yet (issue #2851) — same vocabulary runs use, plus
+  // "unknown" for a case runs never hit (a run always has itself).
+  health?: "healthy" | "idle" | "unresponsive" | "stale" | "orphaned" | "zombie" | "unknown" | null;
+  last_activity_at?: number | null;
 }
 
 export interface InvocationSession {

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -517,7 +517,12 @@ async def _teardown_common(
 
     all_msgs = await db.get_progression(session_prog_id)
     completion_evidence_msgs = list(all_msgs)
-    update_kwargs: dict[str, Any] = {"ended_at": time.time()}
+    # ended_at is a terminal field and must land in the same atomic write as
+    # the status transition below (see the CAS/TransitionRejectedError branch) --
+    # never written here on its own, or a failed/lost status write leaves a
+    # row with status="running" and a non-null ended_at.
+    ended_at = time.time()
+    update_kwargs: dict[str, Any] = {}
     if all_msgs:
         update_kwargs["first_msg_id"] = all_msgs[0]
         update_kwargs["last_msg_id"] = all_msgs[-1]
@@ -535,7 +540,8 @@ async def _teardown_common(
         markers = identity_markers or {}
         update_kwargs["node_metadata"] = json.dumps({**existing_metadata, **extras, **markers})
 
-    await db.update_session(session_id, **update_kwargs)
+    if update_kwargs:
+        await db.update_session(session_id, **update_kwargs)
 
     reason_code, reason_summary, evidence_refs = resolve_run_reason(
         status=status, exception=exception
@@ -822,6 +828,7 @@ async def _teardown_common(
                 actor=session_id,
                 metadata=metadata,
                 expected_statuses={pre_write_status},
+                extra_fields={"ended_at": ended_at},
             )
             if not written:
                 # CAS miss: a concurrent teardown of the same session won the race.

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -104,6 +104,9 @@ class _FileState:
     tool_names: dict[str, str] = field(default_factory=dict)
     project: str | None = None
     project_source: str | None = None
+    # Raw transcript cwd, the session's artifact root (issue #2848) -- unlike
+    # `project`, never bucketed/fallen-back, just the directory as reported.
+    cwd: str | None = None
     model: str | None = None
     name: str | None = None
     created: bool = False
@@ -341,6 +344,7 @@ def _derive_metadata(state: _FileState, events: list[dict[str, Any]]) -> None:
         cwd = next((e.get("cwd") for e in events if e.get("cwd")), None)
         if cwd:
             state.project, state.project_source = _resolve_project_for_mirror(cwd)
+            state.cwd = cwd
             if state.name is None:
                 state.name = f"Claude · {state.project.split('/')[-1]}"
     if state.model is None:
@@ -394,18 +398,27 @@ def _peek_head(path: Path) -> tuple[str, str | None]:
 async def _attribute_idle(db, state: _FileState, cwd: str) -> None:
     """Attribute an idle/already-read transcript and backfill its session row.
 
-    Covers sessions mirrored before project attribution existed, which have no new
-    events to trigger the normal (streamed-event) attribution path.
+    Covers sessions mirrored before project/artifact-root attribution existed,
+    which have no new events to trigger the normal (streamed-event) attribution
+    path. The two backfills are independent: a row can already carry a project
+    from an earlier mirror pass while still missing artifacts_path (issue #2848's
+    dominant case), so each is only (re)written when actually missing.
     """
     from lionagi.state.claude_mirror import session_db_id
 
     state.project, state.project_source = _resolve_project_for_mirror(cwd)
+    state.cwd = cwd
     row = await db.get_session(session_db_id(state.session_uid))
-    if row is not None and not row.get("project"):
+    if row is None:
+        return
+    missing_project = not row.get("project")
+    missing_artifacts_path = not row.get("artifacts_path")
+    if missing_project or missing_artifacts_path:
         await db.set_session_provenance(
             session_db_id(state.session_uid),
-            project=state.project,
-            project_source=state.project_source,
+            project=state.project if missing_project else None,
+            project_source=state.project_source if missing_project else None,
+            artifacts_path=cwd if missing_artifacts_path else None,
         )
 
 
@@ -458,6 +471,7 @@ async def _mirror_one(db, path: Path, state: _FileState, lineage: _Lineage) -> i
         model=state.model,
         name=state.name,
         status="running",
+        cwd=state.cwd,
         source_path=str(path),
         event_sources=sources,
         max_preview_chars=MIRROR_PREVIEW_CHARS,
@@ -630,6 +644,7 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
             state.session_uid = meta["rollout_uid"] or path.stem
             if meta.get("cwd"):
                 state.project, state.project_source = _resolve_project_for_mirror(meta["cwd"])
+                state.cwd = meta["cwd"]
     if not state.session_uid:
         state.session_uid = path.stem
 
@@ -658,6 +673,7 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
         model=state.model,
         name=state.name,
         status="running",
+        cwd=state.cwd,
         node_metadata=node_metadata,
         source_path=str(path),
         turn=state.turn,

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -536,9 +536,15 @@ async def _one_pass(db, root: Path, states, offsets, *, since, live_window, line
                 if not state.session_uid:
                     state.session_uid = uid
                 if state.project is None and not state.attr_peeked:
-                    state.attr_peeked = True
+                    # Set the flag only after a successful backfill (mirrors
+                    # the codex_provenance_peeked fix below): _one_pass's
+                    # per-transcript exception handler swallows a failure
+                    # here, and a flag set beforehand would then suppress
+                    # every later retry for the process lifetime of this
+                    # in-memory state.
                     if cwd:
                         await _attribute_idle(db, state, cwd)
+                    state.attr_peeked = True
             seen.add(state.session_uid)
         except FileNotFoundError:
             continue
@@ -677,8 +683,12 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
     if not records:
         state.offset = new_offset
         if state.cwd and not state.codex_provenance_peeked:
-            state.codex_provenance_peeked = True
+            # Set the flag only after a successful backfill: _codex_pass's
+            # per-rollout exception handler swallows a failure here, and a
+            # flag set beforehand would then suppress every later retry for
+            # the process lifetime of this in-memory state.
             await _attribute_idle_codex(db, state)
+            state.codex_provenance_peeked = True
         return 0
 
     _derive_codex_metadata(state, records)

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -123,6 +123,11 @@ class _FileState:
     # session of its own. Derived from the head peek, so it is re-derived after
     # a restart rather than persisted.
     orchestrated: bool = False
+    # Whether an idle-Codex-session provenance backfill was attempted this
+    # process. A rollout already fully read (offset restored at EOF) recovers
+    # cwd from its header but never reaches mirror_session again, so without
+    # this the backfill would otherwise be retried every poll forever.
+    codex_provenance_peeked: bool = False
 
 
 @dataclass
@@ -422,6 +427,26 @@ async def _attribute_idle(db, state: _FileState, cwd: str) -> None:
         )
 
 
+async def _attribute_idle_codex(db, state: _FileState) -> None:
+    """Backfill artifacts_path for an already-read Codex rollout.
+
+    ``_mirror_one_codex`` recovers ``cwd`` from the rollout header on the
+    head-check pass, but if the file has no new records that same pass (its
+    offset was restored at EOF, e.g. after a restart), it returns before ever
+    calling ``mirror_session`` — the only place ``set_session_provenance``
+    normally runs for an existing row. Without this, such a row's
+    artifacts_path stays NULL forever, even though the header supplied it.
+    """
+    from lionagi.state.codex_mirror import session_db_id
+
+    if not state.session_uid or not state.cwd:
+        return
+    row = await db.get_session(session_db_id(state.session_uid))
+    if row is None or row.get("artifacts_path"):
+        return
+    await db.set_session_provenance(session_db_id(state.session_uid), artifacts_path=state.cwd)
+
+
 def _first_prompt(events: list[dict[str, Any]]) -> str | None:
     for e in events:
         if e.get("type") != "user" or e.get("isMeta"):
@@ -651,6 +676,9 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
     records, sources, new_offset, unreadable = _read_new_events(path, state)
     if not records:
         state.offset = new_offset
+        if state.cwd and not state.codex_provenance_peeked:
+            state.codex_provenance_peeked = True
+            await _attribute_idle_codex(db, state)
         return 0
 
     _derive_codex_metadata(state, records)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -2334,7 +2334,10 @@ async def _run_flow(
                         invocation_id, fallback_status=_terminal_status
                     )
                     async with StateDB() as _inv_db:
-                        await _inv_db.update_invocation(invocation_id, ended_at=_ended_at)
+                        # ended_at rides in extra_fields so it lands in the same
+                        # atomic transition as the status write below -- a
+                        # separate prior update_invocation() call could persist
+                        # ended_at on a row this status write then fails to move.
                         await _inv_db.update_status(
                             "invocation",
                             invocation_id,
@@ -2345,6 +2348,7 @@ async def _run_flow(
                             source="executor",
                             actor=invocation_id,
                             metadata=inv_meta,
+                            extra_fields={"ended_at": _ended_at},
                         )
                 except Exception:
                     import logging as _logging

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -208,6 +208,7 @@ async def mirror_session(
     provider: str | None = "anthropic",
     name: str | None = None,
     status: str = "running",
+    cwd: str | None = None,
     source_path: str | None = None,
     event_sources: list[tuple[int, int, str]] | None = None,
     max_preview_chars: int | None = None,
@@ -222,6 +223,10 @@ async def mirror_session(
     ``bound_mirror_content`` before it is written, with a resolvable source pointer
     on ``node_metadata.mirror_source``. Omitting them keeps the legacy unbounded
     write, for callers with no live transcript file behind the events.
+
+    ``cwd`` is the transcript's own working directory -- the CLI's artifact root
+    (issue #2848) -- written to ``artifacts_path`` on create, and backfilled on an
+    existing row that lacks one without ever overwriting one that is already set.
     """
     sid = session_db_id(session_uid)
     branch_id = _det(session_uid, "branch")
@@ -272,6 +277,7 @@ async def mirror_session(
                 "provider": provider,
                 "project": project,
                 "project_source": project_source,
+                "artifacts_path": cwd,
                 "started_at": first_ts,
                 "updated_at": last_ts,
             }
@@ -279,7 +285,12 @@ async def mirror_session(
     else:
         cc_session_id = session_uid if existing.get("cc_session_id") is None else None
         provenance_project = project if project and not existing.get("project") else None
-        if cc_session_id is not None or provenance_project is not None:
+        provenance_artifacts_path = cwd if cwd and not existing.get("artifacts_path") else None
+        if (
+            cc_session_id is not None
+            or provenance_project is not None
+            or provenance_artifacts_path is not None
+        ):
             # Backfill attribution for an already-seen session (INSERT OR IGNORE never
             # updates); writes without disturbing the liveness clock.
             await db.set_session_provenance(
@@ -287,6 +298,7 @@ async def mirror_session(
                 cc_session_id=cc_session_id,
                 project=provenance_project,
                 project_source=project_source if provenance_project is not None else None,
+                artifacts_path=provenance_artifacts_path,
             )
     await db.create_branch(
         {

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -406,6 +406,7 @@ async def mirror_session(
     provider: str | None = "openai",
     name: str | None = None,
     status: str = "running",
+    cwd: str | None = None,
     node_metadata: dict[str, Any] | None = None,
     source_path: str | None = None,
     turn: dict[str, Any] | None = None,
@@ -504,6 +505,7 @@ async def mirror_session(
                 "effort": (turn or {}).get("effort"),
                 "project": project,
                 "project_source": project_source,
+                "artifacts_path": cwd,
                 "node_metadata": meta,
                 "started_at": first_ts,
                 "updated_at": last_ts,
@@ -512,6 +514,7 @@ async def mirror_session(
     else:
         cc_session_id = rollout_uid if existing.get("cc_session_id") is None else None
         provenance_project = project if project and not existing.get("project") else None
+        provenance_artifacts_path = cwd if cwd and not existing.get("artifacts_path") else None
         # A file mirrored across several passes accumulates its counts, so the
         # subtraction a consumer does is against the whole file rather than the
         # last batch of it.
@@ -524,6 +527,7 @@ async def mirror_session(
             cc_session_id=cc_session_id,
             project=provenance_project,
             project_source=project_source if provenance_project is not None else None,
+            artifacts_path=provenance_artifacts_path,
             node_metadata=meta,
         )
     await db.create_branch(

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -3037,6 +3037,7 @@ class StateDB:
         project: str | None = None,
         project_source: str | None = None,
         cc_session_id: str | None = None,
+        artifacts_path: str | None = None,
     ) -> None:
         """Write attribution/provenance fields without touching updated_at.
 
@@ -3046,6 +3047,11 @@ class StateDB:
         project_source are written together (the source is meaningless alone).
         The session update and the projects-registry upsert run as one locked
         write so neither can commit without the other.
+
+        ``artifacts_path`` is written via ``COALESCE`` rather than a plain
+        assignment: a mirrored CLI session's artifact root is its transcript's
+        ``cwd``, a weaker signal than a launcher-set root (issue #2848), so a
+        later, more precise write must never be clobbered by an earlier guess.
         """
         sets: list[str] = []
         params: dict[str, Any] = {}
@@ -3060,6 +3066,9 @@ class StateDB:
         if cc_session_id is not None:
             sets.append("cc_session_id = :cc_session_id")
             params["cc_session_id"] = cc_session_id
+        if artifacts_path is not None:
+            sets.append('artifacts_path = COALESCE("artifacts_path", :artifacts_path)')
+            params["artifacts_path"] = artifacts_path
         if not sets:
             return
         params["_id"] = session_id

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -434,6 +434,7 @@ EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "session": frozenset({"ended_at", "node_metadata"}),
     "invocation": frozenset({"ended_at"}),
     "schedule_run": frozenset({"ended_at", "error_detail", "exit_code"}),
+    "play": frozenset({"ended_at"}),
 }
 
 # ── ADR-0035 status vocabulary (valid, not just terminal) ──────────────

--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -135,7 +135,14 @@ _TOOL_MODELS: dict[str, type[BaseModel]] = {
 }
 
 _TOOL_DESCRIPTIONS = {
-    "list_recent_runs": ("List at most 20 recent Studio runs as a redacted read-only projection."),
+    "list_recent_runs": (
+        "List at most 20 recent Studio runs as a redacted read-only projection. "
+        "Each entry carries 'kind' (agent, play, flow, fanout, or show-play) and "
+        "'playbookName' when set -- a run may be a play root coordinating other "
+        "runs, and 'agentName' alone never establishes that a run is a single "
+        "agent. Read 'kind' before characterizing a run. For 'how is this play "
+        "going', use run_progress instead."
+    ),
     "run_stats": (
         "Count runs over a whole window (24h or 7d) with per-status totals and "
         "completion rate. Use this for 'how many runs did I have', which "
@@ -244,6 +251,8 @@ async def list_recent_runs(arguments: dict[str, Any]) -> dict[str, Any]:
             "startedAt": row.get("started_at"),
             "endedAt": row.get("ended_at"),
             "href": f"/runs/{row.get('id')}",
+            "kind": row.get("invocation_kind"),
+            "playbookName": row.get("playbook_name"),
         }
         for row in rows[: args.limit]
         if isinstance(row.get("id"), str)

--- a/lionagi/studio/services/invocations.py
+++ b/lionagi/studio/services/invocations.py
@@ -5,15 +5,54 @@
 from __future__ import annotations
 
 import json
+import time
 from typing import Any
 
 from fastapi import Query
 
 from lionagi._errors import NotFoundError
 from lionagi.state.db import StateDB, state_db_known_absent
+from lionagi.state.health import SessionHealth, classify_session_health, worst_health
 
 from ..registry import studio_route
 from ._io import parse_json_col as _parse_json_col
+
+
+def _invocation_health(
+    sessions: list[dict[str, Any]],
+    *,
+    now: float,
+    ps_snapshot: str | None,
+) -> tuple[str, float | None]:
+    """Worst-of health verdict + latest activity timestamp across an
+    invocation's child sessions, reusing the session health classifier
+    (ADR-0057) rather than a second vocabulary (issue #2851). "unknown"
+    when the invocation has no child sessions yet — liveness genuinely
+    cannot be determined, never silently defaulted to "healthy"."""
+    if not sessions:
+        return "unknown", None
+
+    from .admin import _artifacts_path, process_liveness
+
+    healths: list[SessionHealth] = []
+    last_activity: float | None = None
+    for s in sessions:
+        artifacts = _artifacts_path(s)
+        process_alive = process_liveness(s, artifacts, ps_snapshot)
+        healths.append(
+            classify_session_health(
+                s,
+                now=now,
+                process_alive=process_alive,
+                has_artifacts=artifacts is not None,
+                has_stale_locks=False,
+            )
+        )
+        activity = s.get("last_message_at") or s.get("updated_at") or s.get("started_at")
+        if activity is not None and (last_activity is None or activity > last_activity):
+            last_activity = activity
+
+    return worst_health(healths).value, last_activity
 
 
 async def list_invocations(
@@ -27,40 +66,54 @@ async def list_invocations(
         return []
     async with StateDB() as db:
         rows = await db.list_invocations(skill=skill, status=status, limit=limit, offset=offset)
-    out: list[dict[str, Any]] = []
-    for r in rows:
-        node_meta = r.get("node_metadata")
-        if isinstance(node_meta, str):
-            try:
-                node_meta = json.loads(node_meta)
-            except json.JSONDecodeError:
-                node_meta = None
-        out.append(
-            {
-                "id": r["id"],
-                "skill": r["skill"],
-                "plugin": r.get("plugin"),
-                "prompt": r.get("prompt"),
-                "started_at": r["started_at"],
-                "ended_at": r.get("ended_at"),
-                "status": r["status"],
-                "status_reason_code": r.get("status_reason_code"),
-                "status_reason_summary": r.get("status_reason_summary"),
-                "status_evidence_refs": _parse_json_col(r.get("status_evidence_refs")),
-                "session_count": r.get("session_count", 0),
-                "created_at": r["created_at"],
-                "updated_at": r["updated_at"],
-                "node_metadata": node_meta,
-                # ADR-0063: project provenance from the most-recently updated
-                # child session.  NULL when the invocation has no sessions yet.
-                "project": r.get("project"),
-                "project_source": r.get("project_source"),
-                # From the schedule_run that fired this invocation (ADR-0070),
-                # when it was a scheduled run. NULL for interactive invocations.
-                "schedule_run_exit_code": r.get("schedule_run_exit_code"),
-                "schedule_run_error_detail": r.get("schedule_run_error_detail"),
-            }
-        )
+        now = time.time()
+        ps_snapshot: str | None = None
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            child_sessions = await db.list_sessions_for_invocation(r["id"])
+            if child_sessions and ps_snapshot is None:
+                from .admin import _ps_snapshot
+
+                ps_snapshot = _ps_snapshot()
+            health, last_activity_at = _invocation_health(
+                child_sessions, now=now, ps_snapshot=ps_snapshot
+            )
+            node_meta = r.get("node_metadata")
+            if isinstance(node_meta, str):
+                try:
+                    node_meta = json.loads(node_meta)
+                except json.JSONDecodeError:
+                    node_meta = None
+            out.append(
+                {
+                    "id": r["id"],
+                    "skill": r["skill"],
+                    "plugin": r.get("plugin"),
+                    "prompt": r.get("prompt"),
+                    "started_at": r["started_at"],
+                    "ended_at": r.get("ended_at"),
+                    "status": r["status"],
+                    "status_reason_code": r.get("status_reason_code"),
+                    "status_reason_summary": r.get("status_reason_summary"),
+                    "status_evidence_refs": _parse_json_col(r.get("status_evidence_refs")),
+                    "session_count": r.get("session_count", 0),
+                    "created_at": r["created_at"],
+                    "updated_at": r["updated_at"],
+                    "node_metadata": node_meta,
+                    # ADR-0063: project provenance from the most-recently updated
+                    # child session.  NULL when the invocation has no sessions yet.
+                    "project": r.get("project"),
+                    "project_source": r.get("project_source"),
+                    # From the schedule_run that fired this invocation (ADR-0070),
+                    # when it was a scheduled run. NULL for interactive invocations.
+                    "schedule_run_exit_code": r.get("schedule_run_exit_code"),
+                    "schedule_run_error_detail": r.get("schedule_run_error_detail"),
+                    # ADR-0057 health verdict + last-activity, derived from child
+                    # sessions (issue #2851) — same vocabulary runs already use.
+                    "health": health,
+                    "last_activity_at": last_activity_at,
+                }
+            )
     return out
 
 
@@ -83,6 +136,14 @@ async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
         # The schedule_run that fired this invocation, when scheduled, so the
         # detail page can show exit_code/error_detail without correlating IDs.
         schedule_run = await db.get_schedule_run_by_invocation(invocation_id)
+        ps_snapshot: str | None = None
+        if sessions:
+            from .admin import _ps_snapshot
+
+            ps_snapshot = _ps_snapshot()
+        health, last_activity_at = _invocation_health(
+            sessions, now=time.time(), ps_snapshot=ps_snapshot
+        )
     return {
         "id": row["id"],
         "skill": row["skill"],
@@ -100,6 +161,8 @@ async def get_invocation(invocation_id: str) -> dict[str, Any] | None:
         "node_metadata": node_meta,
         "schedule_run_exit_code": schedule_run.get("exit_code") if schedule_run else None,
         "schedule_run_error_detail": schedule_run.get("error_detail") if schedule_run else None,
+        "health": health,
+        "last_activity_at": last_activity_at,
         "sessions": [
             {
                 "id": s["id"],

--- a/lionagi/studio/services/launches.py
+++ b/lionagi/studio/services/launches.py
@@ -285,7 +285,10 @@ async def _spawn_detached(
         )
         try:
             async with StateDB() as db:
-                await db.update_invocation(inv_id, ended_at=time.time())
+                # ended_at rides in extra_fields so it lands in the same
+                # atomic transition as the status write -- a separate prior
+                # update_invocation() call could persist ended_at on a row
+                # this status write then fails or loses the race to update.
                 await db.update_status(
                     "invocation",
                     inv_id,
@@ -296,6 +299,7 @@ async def _spawn_detached(
                     source="executor",
                     actor=inv_id,
                     metadata={},
+                    extra_fields={"ended_at": time.time()},
                 )
         except Exception:
             _log.exception(
@@ -309,7 +313,6 @@ async def _spawn_detached(
 
     try:
         async with StateDB() as db:
-            await db.update_invocation(inv_id, ended_at=time.time())
             await db.update_status(
                 "invocation",
                 inv_id,
@@ -320,6 +323,7 @@ async def _spawn_detached(
                 source="executor",
                 actor=inv_id,
                 metadata={},
+                extra_fields={"ended_at": time.time()},
             )
     except Exception:
         _log.exception("Failed to update invocation %s after detached launch", inv_id)

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -232,8 +232,6 @@ async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
             _log.info("Reaping null-status session %s: process is dead", sid)
             try:
                 async with StateDB() as db:
-                    if row["ended_at"] is None:
-                        await db.update_session(sid, ended_at=now)
                     transitioned = await db.update_status(
                         "session",
                         sid,
@@ -246,6 +244,12 @@ async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
                         metadata={"detector": "null_status_dead_process"},
                         expected_statuses={None},
                     )
+                    if transitioned:
+                        # Stamp ended_at only after the guarded transition wins,
+                        # so a lost CAS never leaves ended_at set on a row whose
+                        # status did not actually move (issue #2844).
+                        if row["ended_at"] is None:
+                            await db.update_session(sid, ended_at=now)
                 if transitioned:
                     reaped += 1
                 else:
@@ -302,8 +306,6 @@ async def reap_phantom_sessions(
                 if current.get("status") != "running":
                     # Already transitioned by another path.
                     continue
-                if current.get("ended_at") is None:
-                    await db.update_session(sid, ended_at=now)
                 if current.get("agent_name") == "claude-code":
                     # A mirrored external session has no lionagi process, so the
                     # phantom model misfires: an idle transcript is a normal
@@ -339,6 +341,11 @@ async def reap_phantom_sessions(
                         metadata={"phantom_reaped": True, "phantom_reason": phantom_reason},
                         expected_statuses={"running"},
                     )
+                if transitioned and current.get("ended_at") is None:
+                    # Stamp ended_at only after the guarded transition wins,
+                    # so a lost CAS never leaves ended_at set on a row whose
+                    # status did not actually move (issue #2844).
+                    await db.update_session(sid, ended_at=now)
             if transitioned:
                 _log.info("Phantom session %s reaped (reason=%s)", sid, phantom_reason)
                 reaped += 1

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -113,7 +113,6 @@ async def reap_stale_invocations(
                         started_at,
                         effective_deadline,
                     )
-                    await db.update_invocation(inv_id, ended_at=now)
                     transitioned = await db.update_status(
                         "invocation",
                         inv_id,
@@ -131,6 +130,11 @@ async def reap_stale_invocations(
                         expected_statuses={"running"},
                     )
                     if transitioned:
+                        # Stamp ended_at only after the guarded transition wins,
+                        # so a lost CAS never leaves ended_at set on a row whose
+                        # status did not actually move (issue #2844).
+                        if inv.get("ended_at") is None:
+                            await db.update_invocation(inv_id, ended_at=now)
                         reaped += 1
                     else:
                         _log.debug("Invocation %s skipped (status changed before CAS lock)", inv_id)
@@ -152,7 +156,6 @@ async def reap_stale_invocations(
                         inv_id,
                         zero_session_grace_seconds,
                     )
-                    await db.update_invocation(inv_id, ended_at=now)
                     transitioned = await db.update_status(
                         "invocation",
                         inv_id,
@@ -169,6 +172,11 @@ async def reap_stale_invocations(
                         expected_statuses={"running"},
                     )
                     if transitioned:
+                        # Stamp ended_at only after the guarded transition wins,
+                        # so a lost CAS never leaves ended_at set on a row whose
+                        # status did not actually move (issue #2844).
+                        if inv.get("ended_at") is None:
+                            await db.update_invocation(inv_id, ended_at=now)
                         reaped += 1
                     else:
                         _log.debug("Invocation %s skipped (status changed before CAS lock)", inv_id)

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -113,6 +113,13 @@ async def reap_stale_invocations(
                         started_at,
                         effective_deadline,
                     )
+                    # ended_at rides in extra_fields so it lands in the same
+                    # atomic UPDATE as the status transition — a winning CAS
+                    # followed by a separate update_invocation() call could
+                    # leave status="timed_out" with ended_at never patched if
+                    # that second write failed (issue #2844). Preserving a
+                    # pre-existing ended_at (rather than overwriting it) is
+                    # still decided off this same pre-write snapshot.
                     transitioned = await db.update_status(
                         "invocation",
                         inv_id,
@@ -128,13 +135,9 @@ async def reap_stale_invocations(
                             "started_at": started_at,
                         },
                         expected_statuses={"running"},
+                        extra_fields={"ended_at": now} if inv.get("ended_at") is None else None,
                     )
                     if transitioned:
-                        # Stamp ended_at only after the guarded transition wins,
-                        # so a lost CAS never leaves ended_at set on a row whose
-                        # status did not actually move (issue #2844).
-                        if inv.get("ended_at") is None:
-                            await db.update_invocation(inv_id, ended_at=now)
                         reaped += 1
                     else:
                         _log.debug("Invocation %s skipped (status changed before CAS lock)", inv_id)
@@ -156,6 +159,8 @@ async def reap_stale_invocations(
                         inv_id,
                         zero_session_grace_seconds,
                     )
+                    # See the deadline-exceeded branch above for why ended_at
+                    # rides in extra_fields instead of a follow-up write.
                     transitioned = await db.update_status(
                         "invocation",
                         inv_id,
@@ -170,13 +175,9 @@ async def reap_stale_invocations(
                             "updated_at": updated_at,
                         },
                         expected_statuses={"running"},
+                        extra_fields={"ended_at": now} if inv.get("ended_at") is None else None,
                     )
                     if transitioned:
-                        # Stamp ended_at only after the guarded transition wins,
-                        # so a lost CAS never leaves ended_at set on a row whose
-                        # status did not actually move (issue #2844).
-                        if inv.get("ended_at") is None:
-                            await db.update_invocation(inv_id, ended_at=now)
                         reaped += 1
                     else:
                         _log.debug("Invocation %s skipped (status changed before CAS lock)", inv_id)
@@ -240,6 +241,9 @@ async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
             _log.info("Reaping null-status session %s: process is dead", sid)
             try:
                 async with StateDB() as db:
+                    # ended_at rides in extra_fields so it lands in the same
+                    # atomic UPDATE as the status transition; see
+                    # reap_stale_invocations for why a follow-up write is unsafe.
                     transitioned = await db.update_status(
                         "session",
                         sid,
@@ -251,13 +255,8 @@ async def reap_null_status_sessions(*, stale_hours: float | None = None) -> int:
                         actor="studio_lifecycle_reaper",
                         metadata={"detector": "null_status_dead_process"},
                         expected_statuses={None},
+                        extra_fields={"ended_at": now} if row["ended_at"] is None else None,
                     )
-                    if transitioned:
-                        # Stamp ended_at only after the guarded transition wins,
-                        # so a lost CAS never leaves ended_at set on a row whose
-                        # status did not actually move (issue #2844).
-                        if row["ended_at"] is None:
-                            await db.update_session(sid, ended_at=now)
                 if transitioned:
                     reaped += 1
                 else:
@@ -314,6 +313,10 @@ async def reap_phantom_sessions(
                 if current.get("status") != "running":
                     # Already transitioned by another path.
                     continue
+                # ended_at rides in extra_fields on both branches below so it
+                # lands in the same atomic UPDATE as the status transition;
+                # see reap_stale_invocations for why a follow-up write is unsafe.
+                _extra = {"ended_at": now} if current.get("ended_at") is None else None
                 if current.get("agent_name") == "claude-code":
                     # A mirrored external session has no lionagi process, so the
                     # phantom model misfires: an idle transcript is a normal
@@ -329,6 +332,7 @@ async def reap_phantom_sessions(
                         actor=actor,
                         metadata={"mirror_idle_reaped": True},
                         expected_statuses={"running"},
+                        extra_fields=_extra,
                     )
                 else:
                     transitioned = await db.update_status(
@@ -348,12 +352,8 @@ async def reap_phantom_sessions(
                         actor=actor,
                         metadata={"phantom_reaped": True, "phantom_reason": phantom_reason},
                         expected_statuses={"running"},
+                        extra_fields=_extra,
                     )
-                if transitioned and current.get("ended_at") is None:
-                    # Stamp ended_at only after the guarded transition wins,
-                    # so a lost CAS never leaves ended_at set on a row whose
-                    # status did not actually move (issue #2844).
-                    await db.update_session(sid, ended_at=now)
             if transitioned:
                 _log.info("Phantom session %s reaped (reason=%s)", sid, phantom_reason)
                 reaped += 1
@@ -453,6 +453,9 @@ async def reap_stale_plays(*, stale_hours: float | None = None) -> int:
                     # version we validated: a claim landing between this read
                     # and the write bumps updated_at, so the guarded write loses
                     # the race and we skip rather than block a live play.
+                    # ended_at rides in extra_fields so it lands in the same
+                    # atomic UPDATE as the status transition; see
+                    # reap_stale_invocations for why a follow-up write is unsafe.
                     transitioned = await db.update_status(
                         "play",
                         play_id,
@@ -470,12 +473,9 @@ async def reap_stale_plays(*, stale_hours: float | None = None) -> int:
                         },
                         expected_statuses=_REAPABLE_PLAY_STATUSES,
                         expected_updated_at=updated_at_raw,
+                        extra_fields={"ended_at": now} if row.get("ended_at") is None else None,
                     )
                     if transitioned:
-                        # Stamp ended_at only after the guarded transition wins,
-                        # so a lost CAS never mutates a row we did not reap.
-                        if row.get("ended_at") is None:
-                            await db.update_play(play_id, ended_at=now)
                         reaped += 1
                     else:
                         _log.debug("Play %s skipped (status changed before CAS lock)", play_id)

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -552,6 +552,17 @@ async def list_runs(
     return out
 
 
+def _status_ended_at_mismatch(run: dict[str, Any]) -> bool:
+    """A row reporting ``status="running"`` alongside a non-null ``ended_at``
+    is the exact write-path defect from issue #2844: two fields describing
+    the same lifecycle event that disagree about it. Scoped to this one
+    direction (not the reverse, a terminal row with a null ``ended_at``)
+    because that population includes legitimate pre-existing rows -- rows
+    written before the ``ended_at`` column, or imported from elsewhere --
+    and flagging those would be a separate, undecided policy question."""
+    return run.get("status") == "running" and run.get("ended_at") is not None
+
+
 def paginate_runs(
     page_runs: list[dict[str, Any]],
     *,
@@ -571,6 +582,10 @@ def paginate_runs(
         "total_pages": total_pages,
         "has_next": page < total_pages,
         "has_prev": page > 1,
+        # Recomputed on every page fetch, not read from a stored flag, so a
+        # future divergence between status and ended_at is visible without
+        # anyone querying for it (issue #2844).
+        "status_ended_at_mismatches": sum(1 for r in page_runs if _status_ended_at_mismatch(r)),
     }
 
 

--- a/lionagi/studio/services/shows.py
+++ b/lionagi/studio/services/shows.py
@@ -451,54 +451,48 @@ async def import_shows() -> dict[str, int]:
                 elif imported_play_status == "merged":
                     play_reason_code = PlayReasons.MERGED_OK
                     play_reason_summary = "Play was imported as merged."
-                elif imported_play_status not in {
-                    "pending",
-                    "running",
-                    "running_complete",
-                    "prepared",
-                    "gated",
-                    "redoing",
-                    "aborted_after_finish",
-                }:
+
+                # create_play() is the single validating writer for plays.status
+                # (ADR-0011 vocabulary, same enum update_play()/update_status()
+                # enforce) -- importing through a raw INSERT let an undeclared
+                # on-disk status either silently vanish (INSERT OR IGNORE drops
+                # a CHECK violation with no error) or, on a store predating the
+                # CHECK, land unconstrained. Catching the ValueError here keeps
+                # one bad _meta.json from aborting the rest of the show import.
+                try:
+                    await db.create_play(
+                        {
+                            "id": play_id,
+                            "show_id": show_id,
+                            "name": play_name,
+                            "playbook": None,
+                            "effort": meta.get("effort"),
+                            "status": imported_play_status,
+                            "attempt": play_attempt,
+                            "session_id": session_id,
+                            "started_at": started_at,
+                            "ended_at": ended_at,
+                            "exit_code": meta.get("exit_code"),
+                            "worktree": meta.get("worktree"),
+                            "branch": meta.get("branch"),
+                            "merge_sha": meta.get("merge_sha"),
+                            "merged_at": merged_at,
+                            "gate_passed": gate_passed,
+                            "gate_feedback": gate_feedback,
+                            "depends_on": [],
+                            "sort_order": idx,
+                            "created_at": play_created,
+                        }
+                    )
+                except ValueError:
                     _log.warning(
-                        "play %s/%s imported with status %s but no ADR-0028 reason code matched",
+                        "play %s/%s: refusing undeclared status %r (ADR-0011 "
+                        "vocabulary); skipping this play, show import continues",
                         topic,
                         play_name,
                         imported_play_status,
                     )
-
-                await db.execute(
-                    """INSERT OR IGNORE INTO plays
-                       (id, show_id, name, playbook, effort, status, attempt,
-                        session_id, started_at, ended_at, exit_code,
-                        worktree, branch, merge_sha, merged_at,
-                        gate_passed, gate_feedback, depends_on,
-                        sort_order, created_at, updated_at)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        play_id,
-                        show_id,
-                        play_name,
-                        None,
-                        meta.get("effort"),
-                        imported_play_status,
-                        play_attempt,
-                        session_id,
-                        started_at,
-                        ended_at,
-                        meta.get("exit_code"),
-                        meta.get("worktree"),
-                        meta.get("branch"),
-                        meta.get("merge_sha"),
-                        merged_at,
-                        gate_passed,
-                        gate_feedback,
-                        json.dumps([]),
-                        idx,
-                        play_created,
-                        play_created,
-                    ),
-                )
+                    continue
                 plays_count += 1
 
                 if play_reason_code is not None:

--- a/tests/apps_studio_server/test_invocations_service.py
+++ b/tests/apps_studio_server/test_invocations_service.py
@@ -174,6 +174,73 @@ async def test_list_invocations_includes_schedule_run_failure_fields(tmp_path, m
     assert by_id[inv_b]["schedule_run_error_detail"] is None
 
 
+async def test_get_invocation_health_unknown_with_no_child_sessions(tmp_path, monkeypatch):
+    """An invocation with zero child sessions has no liveness evidence at
+    all -- it must report health="unknown", never a false "healthy"."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    async with StateDB(db_path) as db:
+        inv_id = await _create_invocation(db)
+
+    result = await invocations_mod.get_invocation(inv_id)
+
+    assert result is not None
+    assert result["health"] == "unknown"
+    assert result["last_activity_at"] is None
+
+
+async def test_get_invocation_health_reflects_dead_child_process(tmp_path, monkeypatch):
+    """An invocation whose sole child session is 'running' but its recorded
+    process is dead and it has no artifacts/messages must surface the real
+    (orphaned) health verdict, not an unconditional "running" reading."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+    now = time.time()
+
+    async with StateDB(db_path) as db:
+        inv_id = await _create_invocation(db)
+        pid = uuid.uuid4().hex
+        await db.create_progression(pid)
+        session_id = str(uuid.uuid4())
+        await db.create_session(
+            {
+                "id": session_id,
+                "progression_id": pid,
+                "name": "child",
+                "status": "running",
+                "started_at": now,
+                "invocation_id": inv_id,
+            }
+        )
+
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod, "process_liveness", lambda *_a, **_k: False)
+
+    result = await invocations_mod.get_invocation(inv_id)
+
+    assert result is not None
+    assert result["health"] == "orphaned"
+    assert result["last_activity_at"] is not None
+
+
+async def test_list_invocations_includes_health_field(tmp_path, monkeypatch):
+    """list_invocations carries the same health field as get_invocation, not
+    just the detail route -- the mission board reads the list endpoint."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    async with StateDB(db_path) as db:
+        inv_id = await _create_invocation(db)
+
+    rows = await invocations_mod.list_invocations()
+    by_id = {r["id"]: r for r in rows}
+
+    assert by_id[inv_id]["health"] == "unknown"
+    assert by_id[inv_id]["last_activity_at"] is None
+
+
 async def test_list_invocations_includes_reason_fields(tmp_path, monkeypatch):
     """list_invocations serializer includes status_reason_code and
     status_reason_summary with exact values for both the set and null cases."""

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -514,6 +514,87 @@ class TestSpawnDetachedTerminalUpdate:
         validate_reason_code(captured["reason_code"])
 
 
+class TestSpawnDetachedEndedAtAtomicity:
+    """ended_at must ride the same atomic update_status() write as the
+    terminal status, not a separate update_invocation() call that could
+    independently fail after a winning status transition and leave the row
+    terminal with ended_at unset."""
+
+    def test_normal_exit_never_calls_update_invocation(self):
+        """The completed/failed path stamps ended_at via extra_fields; it
+        must never fall back to a standalone update_invocation() call."""
+        from lionagi.studio.services import launches
+
+        captured = {}
+        mock_db = AsyncMock()
+
+        async def _capture_status(entity_type, entity_id, **kw):
+            captured.update(kw)
+
+        mock_db.update_status = _capture_status
+
+        async def _fake_spawn(argv, inv_id, *, tmp_path=None, cwd=None, action_kind=None):
+            return (0, "")
+
+        with patch("lionagi.studio.services.launches.StateDB") as MockDB:
+            MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+            with patch(
+                "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+                side_effect=_fake_spawn,
+            ):
+                asyncio.run(
+                    launches._spawn_detached(["uv", "run", "li"], "inv-atomic1", tmp_path=None)
+                )
+
+        mock_db.update_invocation.assert_not_called()
+        assert isinstance(captured.get("extra_fields", {}).get("ended_at"), float)
+
+    def test_cancelled_never_calls_update_invocation(self):
+        """The cancellation path stamps ended_at via extra_fields too; it
+        must never fall back to a standalone update_invocation() call."""
+        from lionagi.studio.services import launches
+
+        captured = {}
+        mock_db = AsyncMock()
+
+        async def _capture_status(entity_type, entity_id, **kw):
+            captured.update(kw)
+
+        mock_db.update_status = _capture_status
+
+        async def _blocking_spawn(argv, inv_id, *, tmp_path=None, cwd=None, action_kind=None):
+            await asyncio.sleep(999)
+            return (0, "")
+
+        async def _run():
+            async def _inner():
+                with patch("lionagi.studio.services.launches.StateDB") as MockDB:
+                    MockDB.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+                    MockDB.return_value.__aexit__ = AsyncMock(return_value=False)
+                    with patch(
+                        "lionagi.studio.scheduler.subprocess.spawn_and_wait",
+                        side_effect=_blocking_spawn,
+                    ):
+                        await launches._spawn_detached(
+                            ["uv", "run", "li"], "inv-atomic2", tmp_path=None
+                        )
+
+            task = asyncio.ensure_future(_inner())
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(_run())
+        assert captured.get("new_status") == "cancelled"
+        mock_db.update_invocation.assert_not_called()
+        assert isinstance(captured.get("extra_fields", {}).get("ended_at"), float)
+
+
 # ---------------------------------------------------------------------------
 # MAJOR 1 — Admission cap: 429 when in-flight launches >= MAX_LAUNCHES
 # ---------------------------------------------------------------------------

--- a/tests/apps_studio_server/test_lifecycle_play_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_play_reaper.py
@@ -412,3 +412,32 @@ def test_reap_stale_plays_version_guard_skips_claim_after_revalidation(tmp_path,
 
     play = run_async(_get_play(db_path, play_id))
     assert play["status"] == "running"
+
+
+def test_reap_stale_plays_write_is_atomic_with_ended_at(tmp_path, monkeypatch):
+    """The winning transition must stamp ended_at in the same write as the
+    status change, not depend on a follow-up update_play() call that could
+    independently fail and leave status="blocked" with ended_at=None while
+    `reaped` still counts the row. Proven by making update_play() raise: the
+    reaper must never call it at all for this transition."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    show_id = run_async(_seed_show(db_path))
+    play_id = run_async(
+        _seed_play(db_path, show_id, status="running", session_id=None, updated_at=_STALE)
+    )
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("update_play must not be called by this reaper")
+
+    monkeypatch.setattr(state_db_mod.StateDB, "update_play", _boom)
+
+    from lionagi.studio.services.lifecycle import reap_stale_plays
+
+    count = run_async(reap_stale_plays(stale_hours=6.0))
+    assert count == 1
+
+    play = run_async(_get_play(db_path, play_id))
+    assert play["status"] == "blocked"
+    assert play["ended_at"] is not None

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -221,6 +221,69 @@ def test_reap_stale_invocations_zero_session_within_grace(tmp_path, monkeypatch)
     assert inv["status"] == "running"
 
 
+def test_reap_stale_invocations_deadline_lost_cas_does_not_stamp_ended_at(tmp_path, monkeypatch):
+    """A lost CAS race on the deadline path must not leave ended_at stamped
+    while status is still "running" — the same "status and ended_at
+    disagree" defect as issue #2844, on the invocation deadline path.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    old_started = time.time() - 8000  # well past default 7200s deadline
+    iid = run_async(_seed_invocation(db_path, started_at=old_started, session_count=1))
+
+    async def _lost_race(*_a, **_k):
+        return False
+
+    monkeypatch.setattr(StateDB, "update_status", _lost_race)
+
+    from lionagi.studio.services.lifecycle import reap_stale_invocations
+
+    count = run_async(reap_stale_invocations(deadline_seconds=7200))
+    assert count == 0
+
+    inv = run_async(_get_invocation(db_path, iid))
+    assert inv is not None
+    assert inv["status"] == "running"
+    assert inv["ended_at"] is None
+
+
+def test_reap_stale_invocations_zero_session_lost_cas_does_not_stamp_ended_at(
+    tmp_path, monkeypatch
+):
+    """A lost CAS race on the zero-session path must not leave ended_at
+    stamped while status is still "running" — the same "status and ended_at
+    disagree" defect as issue #2844, on the invocation zero-session path.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    stale_updated = time.time() - 600  # 10 min ago, past 5 min grace
+    iid = run_async(
+        _seed_invocation(
+            db_path,
+            started_at=time.time() - 120,
+            updated_at=stale_updated,
+            session_count=0,
+        )
+    )
+
+    async def _lost_race(*_a, **_k):
+        return False
+
+    monkeypatch.setattr(StateDB, "update_status", _lost_race)
+
+    from lionagi.studio.services.lifecycle import reap_stale_invocations
+
+    count = run_async(reap_stale_invocations(deadline_seconds=7200, zero_session_grace_seconds=300))
+    assert count == 0
+
+    inv = run_async(_get_invocation(db_path, iid))
+    assert inv is not None
+    assert inv["status"] == "running"
+    assert inv["ended_at"] is None
+
+
 # ── per-action-kind deadline override ────────────────────────────────────────
 
 

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -476,6 +476,45 @@ def test_reap_null_status_sessions_fresh_unknown_liveness_not_reaped(tmp_path, m
     assert sess["status"] is None
 
 
+def test_reap_null_status_sessions_lost_cas_does_not_stamp_ended_at(tmp_path, monkeypatch):
+    """A lost CAS race on the status write must not leave ended_at stamped
+    with status still NULL — that mismatch is exactly the "status and
+    ended_at disagree" defect: a reader trusting either field alone is wrong.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    stale_time = time.time() - 7200  # past default 1h grace
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            artifacts_path=None,
+            started_at=stale_time,
+            updated_at=stale_time,
+        )
+    )
+
+    import lionagi.studio.services.lifecycle as lc_mod
+
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: False)
+
+    async def _lost_race(*_a, **_k):
+        return False
+
+    monkeypatch.setattr(StateDB, "update_status", _lost_race)
+
+    from lionagi.studio.services.lifecycle import reap_null_status_sessions
+
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
+    assert count == 0
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess is not None
+    assert sess["status"] is None
+    assert sess["ended_at"] is None
+
+
 # ── automatic phantom reaper ─────────────────────────────────────────────────
 
 
@@ -613,6 +652,42 @@ def test_reap_phantom_sessions_skips_healthy_running(tmp_path, monkeypatch):
 
     sess = run_async(_get_session(db_path, sid))
     assert sess["status"] == "running"
+
+
+def test_reap_phantom_sessions_lost_cas_does_not_stamp_ended_at(tmp_path, monkeypatch):
+    """A lost CAS race on the status write must not leave ended_at stamped
+    while status is still "running" — that mismatch is exactly the
+    "status and ended_at disagree" defect from issue #2844.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    missing_dir = str(tmp_path / "ghost_artifacts_lost_race")
+    stale_time = time.time() - 7200
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status="running",
+            started_at=stale_time,
+            updated_at=stale_time,
+            artifacts_path=missing_dir,
+        )
+    )
+
+    async def _lost_race(*_a, **_k):
+        return False
+
+    monkeypatch.setattr(StateDB, "update_status", _lost_race)
+
+    from lionagi.studio.services.lifecycle import reap_phantom_sessions
+
+    count = run_async(reap_phantom_sessions(stale_hours=1.0))
+    assert count == 0
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess is not None
+    assert sess["status"] == "running"
+    assert sess["ended_at"] is None
 
 
 # ── admin prune delegates to transition-based reaper ─────────────────────────

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -284,6 +284,66 @@ def test_reap_stale_invocations_zero_session_lost_cas_does_not_stamp_ended_at(
     assert inv["ended_at"] is None
 
 
+def test_reap_stale_invocations_deadline_write_is_atomic_with_ended_at(tmp_path, monkeypatch):
+    """The winning transition must stamp ended_at in the SAME write as the
+    status change, not depend on a follow-up update_invocation() call that
+    could independently fail and leave status="timed_out" with ended_at=None
+    while `reaped` still counts the row (the "winning CAS can still lose
+    ended_at" defect). Proven by making update_invocation() raise: the
+    reaper must never call it at all for this transition.
+    """
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    old_started = time.time() - 8000
+    iid = run_async(_seed_invocation(db_path, started_at=old_started, session_count=1))
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("update_invocation must not be called by this reaper")
+
+    monkeypatch.setattr(StateDB, "update_invocation", _boom)
+
+    from lionagi.studio.services.lifecycle import reap_stale_invocations
+
+    count = run_async(reap_stale_invocations(deadline_seconds=7200))
+    assert count == 1
+
+    inv = run_async(_get_invocation(db_path, iid))
+    assert inv["status"] == "timed_out"
+    assert inv["ended_at"] is not None
+
+
+def test_reap_stale_invocations_zero_session_write_is_atomic_with_ended_at(tmp_path, monkeypatch):
+    """Same atomicity requirement as the deadline path, for the zero-session
+    branch."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    stale_updated = time.time() - 600
+    iid = run_async(
+        _seed_invocation(
+            db_path,
+            started_at=time.time() - 120,
+            updated_at=stale_updated,
+            session_count=0,
+        )
+    )
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("update_invocation must not be called by this reaper")
+
+    monkeypatch.setattr(StateDB, "update_invocation", _boom)
+
+    from lionagi.studio.services.lifecycle import reap_stale_invocations
+
+    count = run_async(reap_stale_invocations(deadline_seconds=7200, zero_session_grace_seconds=300))
+    assert count == 1
+
+    inv = run_async(_get_invocation(db_path, iid))
+    assert inv["status"] == "timed_out"
+    assert inv["ended_at"] is not None
+
+
 # ── per-action-kind deadline override ────────────────────────────────────────
 
 
@@ -578,6 +638,44 @@ def test_reap_null_status_sessions_lost_cas_does_not_stamp_ended_at(tmp_path, mo
     assert sess["ended_at"] is None
 
 
+def test_reap_null_status_sessions_write_is_atomic_with_ended_at(tmp_path, monkeypatch):
+    """The winning transition must stamp ended_at in the same write as the
+    status change, not depend on a follow-up update_session() call. Proven
+    by making update_session() raise: the reaper must never call it at all
+    for this transition."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    stale_time = time.time() - 7200
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status=None,
+            artifacts_path=None,
+            started_at=stale_time,
+            updated_at=stale_time,
+        )
+    )
+
+    import lionagi.studio.services.lifecycle as lc_mod
+
+    monkeypatch.setattr(lc_mod, "process_liveness", lambda *_a, **_k: False)
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("update_session must not be called by this reaper")
+
+    monkeypatch.setattr(StateDB, "update_session", _boom)
+
+    from lionagi.studio.services.lifecycle import reap_null_status_sessions
+
+    count = run_async(reap_null_status_sessions(stale_hours=1.0))
+    assert count == 1
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess["status"] == "failed"
+    assert sess["ended_at"] is not None
+
+
 # ── automatic phantom reaper ─────────────────────────────────────────────────
 
 
@@ -751,6 +849,44 @@ def test_reap_phantom_sessions_lost_cas_does_not_stamp_ended_at(tmp_path, monkey
     assert sess is not None
     assert sess["status"] == "running"
     assert sess["ended_at"] is None
+
+
+def test_reap_phantom_sessions_write_is_atomic_with_ended_at(tmp_path, monkeypatch):
+    """The winning transition must stamp ended_at in the same write as the
+    status change, not depend on a follow-up update_session() call that
+    could independently fail and leave status="failed" with ended_at=None
+    while `reaped` still counts the row. Proven by making update_session()
+    raise: the reaper must never call it at all for this transition (covers
+    both the generic-failed and mirror-idle-completed branches, which share
+    the same extra_fields construction)."""
+    db_path = tmp_path / "state.db"
+    _monkey_db(monkeypatch, db_path)
+
+    missing_dir = str(tmp_path / "ghost_artifacts_atomic")
+    stale_time = time.time() - 7200
+    sid = run_async(
+        _seed_session(
+            db_path,
+            status="running",
+            started_at=stale_time,
+            updated_at=stale_time,
+            artifacts_path=missing_dir,
+        )
+    )
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("update_session must not be called by this reaper")
+
+    monkeypatch.setattr(StateDB, "update_session", _boom)
+
+    from lionagi.studio.services.lifecycle import reap_phantom_sessions
+
+    count = run_async(reap_phantom_sessions(stale_hours=1.0))
+    assert count == 1
+
+    sess = run_async(_get_session(db_path, sid))
+    assert sess["status"] == "failed"
+    assert sess["ended_at"] is not None
 
 
 # ── admin prune delegates to transition-based reaper ─────────────────────────

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -257,6 +257,8 @@ async def test_application_mcp_read_query_is_bounded_and_redacted(monkeypatch):
                 "ended_at": 2.0,
                 "prompt": "must not leave the service",
                 "artifacts_path": "/secret/path",
+                "invocation_kind": "play",
+                "playbook_name": "daily-triage",
             },
             {
                 "id": "run-2",
@@ -265,6 +267,8 @@ async def test_application_mcp_read_query_is_bounded_and_redacted(monkeypatch):
                 "project": "acme/research",
                 "started_at": 3.0,
                 "ended_at": 4.0,
+                "invocation_kind": "agent",
+                "playbook_name": None,
             },
         ]
 
@@ -281,6 +285,8 @@ async def test_application_mcp_read_query_is_bounded_and_redacted(monkeypatch):
                 "startedAt": 1.0,
                 "endedAt": 2.0,
                 "href": "/runs/run-1",
+                "kind": "play",
+                "playbookName": "daily-triage",
             },
             {
                 "id": "run-2",
@@ -290,6 +296,8 @@ async def test_application_mcp_read_query_is_bounded_and_redacted(monkeypatch):
                 "startedAt": 3.0,
                 "endedAt": 4.0,
                 "href": "/runs/run-2",
+                "kind": "agent",
+                "playbookName": None,
             },
         ],
         "count": 2,

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -468,3 +468,44 @@ def test_runs_list_node_metadata_dead_pid_reports_stale_without_monkeypatch(tmp_
     target = next((run for run in r.json()["runs"] if run["id"] == sid), None)
     assert target is not None
     assert target["effective_health"] == "stale"
+
+
+def test_runs_list_reports_status_ended_at_mismatch_count(tmp_path, monkeypatch):
+    """A row whose status is 'running' but whose ended_at is already stamped
+    (issue #2844 -- status and ended_at disagreeing) must be visible as a
+    recomputed consistency count on the listing envelope, not something a
+    caller can only find by cross-checking every row's two fields by hand."""
+    db_path = tmp_path / "state.db"
+    good_running_id = str(uuid.uuid4())
+    good_completed_id = str(uuid.uuid4())
+    mismatched_id = str(uuid.uuid4())
+
+    async def _seed() -> None:
+        async with StateDB(db_path) as db:
+            for sid, status in (
+                (good_running_id, "running"),
+                (good_completed_id, "completed"),
+                (mismatched_id, "running"),
+            ):
+                pid = str(uuid.uuid4())
+                await db.create_progression(pid)
+                await db.create_session(
+                    {
+                        "id": sid,
+                        "progression_id": pid,
+                        "name": "test-mismatch",
+                        "status": status,
+                        "started_at": time.time() - 60,
+                    }
+                )
+            # Simulate the write-path bug directly at the data layer: ended_at
+            # stamped while status is still "running".
+            await db.update_session(mismatched_id, ended_at=time.time())
+
+    _run(_seed())
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    r = client.get("/api/runs")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status_ended_at_mismatches"] == 1

--- a/tests/apps_studio_server/test_shows.py
+++ b/tests/apps_studio_server/test_shows.py
@@ -321,3 +321,65 @@ def test_get_show_returns_404_when_dir_absent_and_no_db_row(docker_patched_app):
     client, _topic = docker_patched_app
     r = client.get("/api/shows/nonexistent-topic-xyz")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# import_shows() must not write an undeclared plays.status value (issue #2619)
+# ---------------------------------------------------------------------------
+
+
+def test_import_shows_refuses_undeclared_play_status(tmp_path, monkeypatch):
+    """A play whose on-disk _meta.json carries a status outside the ADR-0011
+    vocabulary (e.g. "success", a near-miss of "completed"/"merged" that was
+    never declared) must not land in plays.status verbatim -- create_play()
+    already refuses this for every other writer; import_shows() wrote around
+    it via a raw INSERT. The bad play is skipped (loud log, not a crash);
+    every write that does land is a member of the declared vocabulary.
+    """
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.config as config_mod
+    import lionagi.studio.services.shows as shows_mod
+    from lionagi.state.db import VALID_STATUSES_BY_ENTITY_TYPE, StateDB
+
+    shows_root = tmp_path / "shows"
+    topic = "undeclared-status-show"
+    show_dir = shows_root / topic
+    play_dir = show_dir / "play-001"
+    play_dir.mkdir(parents=True)
+    (show_dir / "_show.md").write_text("# Show: undeclared-status-show\n")
+    (play_dir / "_meta.json").write_text(json.dumps({"status": "success"}))
+
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(config_mod, "SHOWS_ROOT", shows_root)
+    monkeypatch.setattr(shows_mod, "SHOWS_ROOT", shows_root)
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    async def _run() -> tuple[dict, dict | None]:
+        result = await shows_mod.import_shows()
+        async with StateDB(db_path) as db:
+            row = await db.fetch_one(
+                "SELECT status FROM plays WHERE show_id IN (SELECT id FROM shows WHERE topic = ?)",
+                (topic,),
+            )
+        return result, row
+
+    loop = asyncio.new_event_loop()
+    try:
+        result, row = loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+    if row is not None:
+        assert row["status"] in VALID_STATUSES_BY_ENTITY_TYPE["play"], (
+            f"import_shows() wrote undeclared play status {row['status']!r} "
+            "directly from _meta.json"
+        )
+    else:
+        # The raw INSERT OR IGNORE silently drops a CHECK-violating row today
+        # -- no exception, no row. plays_imported must not claim a play that
+        # never actually landed; a caller trusting this count over-reports.
+        assert result["plays_imported"] == 0, (
+            f"import_shows() reported plays_imported={result['plays_imported']} "
+            "but the play with an undeclared status was silently dropped -- "
+            "the count is lying about what actually landed in the DB"
+        )

--- a/tests/cli/orchestrate/test_flow_terminal_notify.py
+++ b/tests/cli/orchestrate/test_flow_terminal_notify.py
@@ -436,6 +436,52 @@ async def test_run_flow_notify_still_fires_when_invocation_finalize_raises(
     assert payload["status"] == "completed"
 
 
+async def test_run_flow_invocation_finalize_never_calls_update_invocation(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """ended_at must ride the same atomic update_status() write as the
+    terminal status in the finally block's invocation finalizer, not a
+    separate update_invocation(ended_at=...) call that could independently
+    fail after a winning status transition and leave the row terminal with
+    ended_at unset."""
+    env = _make_env(tmp_path)
+    invocation_id = str(uuid4())
+    await _make_invocation(temp_db_path, invocation_id)
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("update_invocation must not be called by this finalizer")
+
+    monkeypatch.setattr(StateDB, "update_invocation", _boom)
+
+    with (
+        patch(
+            "lionagi.cli.orchestrate.flow.setup_orchestration",
+            AsyncMock(return_value=env),
+        ),
+        patch(
+            "lionagi.cli.orchestrate.flow._run_flow_inner",
+            AsyncMock(return_value="ok result"),
+        ),
+    ):
+        result, terminal_status = await _run_flow(
+            "claude",
+            "do the thing",
+            invocation_id=invocation_id,
+        )
+
+    assert result == "ok result"
+    assert terminal_status == "completed"
+
+    db = StateDB(str(temp_db_path))
+    await db.open()
+    try:
+        row = await db.get_invocation(invocation_id)
+    finally:
+        await db.close()
+    assert row["status"] == "completed"
+    assert row["ended_at"] is not None
+
+
 async def test_fallback_terminal_envelope_has_last_known_previous_status(
     temp_db_path: Path, tmp_path: Path
 ):

--- a/tests/cli/test_agent_live_persist.py
+++ b/tests/cli/test_agent_live_persist.py
@@ -613,6 +613,31 @@ async def test_teardown_updates_session_bookmarks_and_status(
     assert s["ended_at"] is not None
 
 
+async def test_teardown_does_not_stamp_ended_at_when_status_write_is_lost(
+    temp_db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """ended_at must ride the same atomic write as the terminal status, not a
+    separate call that lands unconditionally regardless of whether the
+    status transition itself wins. Simulate a lost CAS (a concurrent
+    teardown of the same session won the race) and confirm ended_at stays
+    unset rather than being stamped by an earlier, independent write."""
+    branch = Branch(name="b1")
+    ctx = await _setup_live_persist(branch)
+
+    async def _lost_race(self, *a, **k):
+        return False
+
+    monkeypatch.setattr(StateDB, "update_status", _lost_race)
+
+    await _teardown_live_persist(ctx, status="completed")
+
+    async with StateDB() as db:
+        s = await db.get_session(ctx["session_id"])
+    assert s["status"] == "running"
+    assert s["ended_at"] is None
+
+
 async def test_teardown_extras_preserve_existing_node_metadata(
     temp_db_path: Path,
 ):

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1045,6 +1045,18 @@ def test_derive_metadata_others_when_cwd_gone() -> None:
     assert state.project_source == "cwd_missing"
 
 
+def test_derive_metadata_captures_raw_cwd_as_artifact_root(tmp_path: Path) -> None:
+    # issue #2848: the raw cwd (not the bucketed project name) is the session's
+    # artifact root -- every file the CLI touched lives under it.
+    work = tmp_path / "my-workspace"
+    work.mkdir()
+    state = _FileState(session_uid=SID)
+    _derive_metadata(
+        state, [_user_text("u1", "hi", ts="2026-06-20T00:00:00.000Z") | {"cwd": str(work)}]
+    )
+    assert state.cwd == str(work)
+
+
 @pytest.mark.asyncio
 async def test_mirror_session_backfills_missing_project(temp_db_path: Path) -> None:
     # A session first mirrored with no project must be backfilled on a later pass
@@ -1068,6 +1080,37 @@ async def test_mirror_session_backfills_missing_project(temp_db_path: Path) -> N
     assert after["project_source"] == "cwd_dir"
     # Provenance backfill is not activity: the liveness clock must not move.
     assert after["updated_at"] == before["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_mirror_session_writes_artifacts_path_from_cwd(temp_db_path: Path) -> None:
+    # issue #2848: a mirrored CLI session's cwd is its artifact root -- the run
+    # file viewer is otherwise structurally dead for every mirrored session.
+    events = _conversation()
+    async with StateDB() as db:
+        await mirror_session(
+            db, session_uid=SID, events=events, tool_names={}, cwd="/work/acme-widget"
+        )
+        row = await db.get_session(session_db_id(SID))
+    assert row["artifacts_path"] == "/work/acme-widget"
+
+
+@pytest.mark.asyncio
+async def test_mirror_session_does_not_clobber_an_existing_artifacts_path(
+    temp_db_path: Path,
+) -> None:
+    # A launcher-set artifact root is more precise than the mirror's cwd guess
+    # and must never be overwritten by a later mirror pass.
+    events = _conversation()
+    async with StateDB() as db:
+        await mirror_session(
+            db, session_uid=SID, events=events, tool_names={}, cwd="/work/first-guess"
+        )
+        await mirror_session(
+            db, session_uid=SID, events=events, tool_names={}, cwd="/work/second-guess"
+        )
+        row = await db.get_session(session_db_id(SID))
+    assert row["artifacts_path"] == "/work/first-guess"
 
 
 # ── conversation-lineage detector ────────────────────────────────────────────
@@ -1202,6 +1245,39 @@ async def test_idle_session_backfilled_with_project(temp_db_path: Path, tmp_path
         row = await db.get_session(session_db_id(uid))
     assert row["project"] == "ghost-proj"
     assert row["project_source"] == "cwd_dir"
+
+
+@pytest.mark.asyncio
+async def test_idle_session_backfilled_with_artifacts_path_even_when_project_already_set(
+    temp_db_path: Path, tmp_path: Path
+) -> None:
+    # issue #2848: the dominant NULL-artifacts_path population is sessions the
+    # mirror already attributed a project to (in an earlier process) before this
+    # fix existed -- artifacts_path must backfill on its own, not only when
+    # project is also missing.
+    work = tmp_path / "ghost-proj-2"
+    work.mkdir()
+    uid = "ffffffff-0000-0000-0000-000000000006"
+    root = tmp_path / "projects"
+    path = root / "-w-proj" / f"{uid}.jsonl"
+    events = [
+        _lineage_event(uid, "f-1", None, "user", "hi") | {"cwd": str(work)},
+        _lineage_event(uid, "f-2", "f-1", "assistant", "ok"),
+    ]
+    _write_lineage_file(path, events)
+    async with StateDB() as db:
+        # Simulate a pre-fix row: project already attributed, artifacts_path never was.
+        await mirror_session(
+            db, session_uid=uid, events=events, tool_names={}, project="ghost-proj-2"
+        )
+        before = await db.get_session(session_db_id(uid))
+        assert before["project"] == "ghost-proj-2"
+        assert before["artifacts_path"] is None
+        offsets = {str(path): path.stat().st_size}
+        await _one_pass(db, root, {}, offsets, since=None, live_window=300)
+        row = await db.get_session(session_db_id(uid))
+    assert row["artifacts_path"] == str(work)
+    assert row["project"] == "ghost-proj-2"
 
 
 @pytest.mark.asyncio
@@ -1441,6 +1517,46 @@ async def test_interactive_rollout_still_mirrors(tmp_path):
         row = await db.get_session(codex_sid(uid))
         assert row is not None
         assert row["source_kind"] == CODEX_SOURCE_KIND
+
+
+async def test_interactive_rollout_records_artifacts_path_from_header_cwd(tmp_path):
+    # issue #2848: the session_meta header's cwd is the rollout's artifact root,
+    # the same gap claude_mirror had.
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-000000000005"
+    path = tmp_path / "rollout-artifacts.jsonl"
+    path.write_text(_codex_rollout_lines(uid, "Codex Desktop"))
+    state = _FileState(session_uid="")
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        await _mirror_one_codex(db, path, state, {})
+        row = await db.get_session(codex_sid(uid))
+    assert row["artifacts_path"] == "/x"
+
+
+async def test_codex_mirror_session_does_not_clobber_an_existing_artifacts_path(tmp_path):
+    from lionagi.state.codex_mirror import mirror_session as codex_mirror_session
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-000000000006"
+    records = [
+        {
+            "type": "response_item",
+            "timestamp": "2026-07-31T09:00:01Z",
+            "payload": {"type": "message", "role": "user", "id": "m1", "content": [{"text": "q"}]},
+        }
+    ]
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        await codex_mirror_session(
+            db, rollout_uid=uid, records=records, tool_names={}, cwd="/work/first-guess"
+        )
+        await codex_mirror_session(
+            db, rollout_uid=uid, records=records, tool_names={}, cwd="/work/second-guess"
+        )
+        row = await db.get_session(codex_sid(uid))
+    assert row["artifacts_path"] == "/work/first-guess"
 
 
 async def test_partial_header_defers_classification_instead_of_bypassing_it(tmp_path):

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1559,6 +1559,38 @@ async def test_codex_mirror_session_does_not_clobber_an_existing_artifacts_path(
     assert row["artifacts_path"] == "/work/first-guess"
 
 
+async def test_idle_codex_rollout_backfills_artifacts_path_from_header_cwd(tmp_path):
+    # An existing row (mirrored before cwd attribution existed, or by a process
+    # that crashed before this pass) has artifacts_path=NULL. A later process
+    # restarts with its offset already restored to EOF -- _read_new_events
+    # yields no records even though the header (re-read on this fresh
+    # _FileState) still carries cwd. Without an idle backfill this row's
+    # artifacts_path would never be set.
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import mirror_session as codex_mirror_session
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-000000000007"
+    path = tmp_path / "rollout-idle.jsonl"
+    contents = _codex_rollout_lines(uid, "Codex Desktop")
+    path.write_text(contents)
+
+    records = [json.loads(line) for line in contents.splitlines()]
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        await codex_mirror_session(db, rollout_uid=uid, records=records, tool_names={}, cwd=None)
+        before = await db.get_session(codex_sid(uid))
+        assert before is not None
+        assert before["artifacts_path"] is None
+
+        # Fresh state (as after a restart), offset restored to EOF.
+        state = _FileState(session_uid="", offset=len(contents.encode()))
+        written = await _mirror_one_codex(db, path, state, {})
+        assert written == 0
+
+        row = await db.get_session(codex_sid(uid))
+    assert row["artifacts_path"] == "/x"
+
+
 async def test_partial_header_defers_classification_instead_of_bypassing_it(tmp_path):
     """A rollout whose first line is still being written must not settle its
     classification: committing the head check on an unreadable header would let

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1281,6 +1281,59 @@ async def test_idle_session_backfilled_with_artifacts_path_even_when_project_alr
 
 
 @pytest.mark.asyncio
+async def test_attr_peeked_flag_not_set_on_backfill_failure(
+    temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same failure-atomicity requirement as the codex idle backfill
+    (test_codex_provenance_peeked_flag_not_set_on_backfill_failure): a
+    transient set_session_provenance failure inside the idle project
+    backfill must not permanently mark this in-memory state as peeked, or no
+    later pass in this process ever retries it."""
+    from lionagi.cli import mirror as mirror_mod
+
+    work = tmp_path / "ghost-proj-flaky"
+    work.mkdir()
+    uid = "eeeeeeee-0000-0000-0000-000000000099"
+    root = tmp_path / "projects"
+    path = root / "-w-proj" / f"{uid}.jsonl"
+    events = [
+        _lineage_event(uid, "g-1", None, "user", "hi") | {"cwd": str(work)},
+        _lineage_event(uid, "g-2", "g-1", "assistant", "ok"),
+    ]
+    _write_lineage_file(path, events)
+
+    attempts = []
+    real_attribute = mirror_mod._attribute_idle
+
+    async def flaky_attribute(db, state, cwd):
+        attempts.append(state.session_uid)
+        if len(attempts) == 1:
+            raise RuntimeError("set_session_provenance transient failure")
+        return await real_attribute(db, state, cwd)
+
+    monkeypatch.setattr(mirror_mod, "_attribute_idle", flaky_attribute)
+
+    async with StateDB() as db:
+        await mirror_session(db, session_uid=uid, events=events, tool_names={}, project=None)
+        assert (await db.get_session(session_db_id(uid)))["project"] is None
+
+        offsets = {str(path): path.stat().st_size}
+        states: dict[str, _FileState] = {}
+        # _one_pass's own per-transcript exception handler swallows the raise.
+        await _one_pass(db, root, states, offsets, since=None, live_window=300)
+        state = states[str(path)]
+        assert not state.attr_peeked, (
+            "the flag was set even though the backfill raised, so no later pass will retry it"
+        )
+
+        await _one_pass(db, root, states, offsets, since=None, live_window=300)
+        row = await db.get_session(session_db_id(uid))
+    assert state.attr_peeked
+    assert row["project"] == "ghost-proj-flaky"
+    assert len(attempts) == 2, f"backfill was attempted {len(attempts)} time(s), not 2"
+
+
+@pytest.mark.asyncio
 async def test_peek_head_skips_non_dict_head_line(temp_db_path: Path, tmp_path: Path) -> None:
     # A valid-JSON-but-non-dict head line (e.g. `[]`) must not wedge the idle
     # reconcile path: _peek_head must skip it like _read_new_events, so an
@@ -1589,6 +1642,56 @@ async def test_idle_codex_rollout_backfills_artifacts_path_from_header_cwd(tmp_p
 
         row = await db.get_session(codex_sid(uid))
     assert row["artifacts_path"] == "/x"
+
+
+async def test_codex_provenance_peeked_flag_not_set_on_backfill_failure(tmp_path, monkeypatch):
+    """codex_provenance_peeked is never persisted -- it only exists to avoid a
+    redundant DB round-trip on every idle pass within one process's lifetime.
+    Setting it before the backfill it guards succeeds means a transient
+    set_session_provenance failure (e.g. a DB hiccup) permanently blocks
+    retry for the rest of that process, even though the flag's own docstring
+    promise is "attempted", not "attempted once and given up on"."""
+    from lionagi.cli import mirror as mirror_mod
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import mirror_session as codex_mirror_session
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-000000000010"
+    path = tmp_path / "rollout-idle-flaky.jsonl"
+    contents = _codex_rollout_lines(uid, "Codex Desktop")
+    path.write_text(contents)
+    records = [json.loads(line) for line in contents.splitlines()]
+
+    attempts = []
+    real_attribute = mirror_mod._attribute_idle_codex
+
+    async def flaky_attribute(db, state):
+        attempts.append(state.session_uid)
+        if len(attempts) == 1:
+            raise RuntimeError("set_session_provenance transient failure")
+        return await real_attribute(db, state)
+
+    monkeypatch.setattr(mirror_mod, "_attribute_idle_codex", flaky_attribute)
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        await codex_mirror_session(db, rollout_uid=uid, records=records, tool_names={}, cwd=None)
+        before = await db.get_session(codex_sid(uid))
+        assert before["artifacts_path"] is None
+
+        state = _FileState(session_uid="", offset=len(contents.encode()))
+        with pytest.raises(RuntimeError):
+            await _mirror_one_codex(db, path, state, {})
+        assert not state.codex_provenance_peeked, (
+            "the flag was set even though the backfill raised, so no later pass will retry it"
+        )
+
+        written = await _mirror_one_codex(db, path, state, {})
+        assert written == 0
+        assert state.codex_provenance_peeked
+
+        row = await db.get_session(codex_sid(uid))
+    assert row["artifacts_path"] == "/x"
+    assert len(attempts) == 2, f"backfill was attempted {len(attempts)} time(s), not 2"
 
 
 async def test_partial_header_defers_classification_instead_of_bypassing_it(tmp_path):


### PR DESCRIPTION
## What changed

Five fixes to what a run actually reports about itself.

### `ended_at` is no longer stamped ahead of a lost status transition

`reap_null_status_sessions` and `reap_phantom_sessions` stamped `ended_at` through a
separate `update_session()` call *before* attempting the guarded `update_status()`
transition. When that transition's compare-and-set lost a race, the row was left with
`ended_at` set and `status` unmoved — which is exactly the measured symptom: two rows
sharing one `ended_at`, status stuck at "running" for weeks.

Both reapers now stamp `ended_at` only after the transition wins, matching what
`reap_stale_plays` already did. The periodic reaper self-heals already-mismatched rows on
its next pass, since phantom detection keys on `status='running'` alone.

`/api/runs/` also reports a `status_ended_at_mismatches` count, scoped precisely to the
measured direction (running with a non-null `ended_at`). The reverse direction — terminal
with a null `ended_at` — includes a large population of legitimate imported rows and is a
separate policy question, deliberately not folded into this count.

### The "running now" panel stops claiming things it does not know

Invocation cards rendered an unconditional pulsing "running" dot regardless of whether
anything was alive. `list_invocations` and `get_invocation` now carry a real `health`
verdict — reusing the existing worst-of-child-sessions classification rather than
inventing a second vocabulary, plus a new `unknown` state for invocations with no child
sessions — and a real `last_activity_at` instead of the coarser `updated_at` proxy.

The UI uses both: dead renders as static stale styling, unknown as a static neutral dot.
Neither makes a claim the data does not support.

### A second writer was bypassing play-status validation

The filed cause did not reproduce. `create_play` and `update_play` both validate, every
status write funnels through `update_status()`, and the `plays` table has had a SQL CHECK
constraint covering all 11 declared values since the table was created — unlike sessions,
schedules, invocations, and schedule runs, this table never needed a constraint-widening
migration, so there was no pre-constraint era to leak through.

Looking for a second writer instead of stopping there turned one up:
`import_shows()` wrote play rows through a raw `INSERT OR IGNORE INTO plays (...)`,
bypassing validation entirely. `INSERT OR IGNORE` silently swallows a CHECK violation, not
just primary-key and uniqueness conflicts — verified with a standalone reproduction rather
than assumed. So an undeclared status produced no exception, no row, and an incremented
success counter. Show import now goes through the one validating path.

### Operator and Fleet distinguish a play root from a single-agent run

They previously read the same.

### Mirrored CLI sessions record their artifact root

`artifacts_path` was absent on mirrored sessions.

## Tests

Red-then-green throughout, including
`test_reap_null_status_sessions_lost_cas_does_not_stamp_ended_at` and its phantom-reaper
counterpart, which fail against the old ordering.

Gates: backend 4240 passed, 20 skipped across 168 files (set derived by grepping the
changed modules); frontend `tsc --noEmit` clean, `eslint .` clean, 1358 vitest tests pass.
Skips are environmental.

Closes #2844
Closes #2851
Closes #2619
Closes #2842
Closes #2848
