### PR TITLE
fix(deps): bump js-yaml to 4.3.1 for the omap CPU exhaustion advisory

### DIFF
--- a/apps/vscode/package-lock.json
+++ b/apps/vscode/package-lock.json
@@ -3487,9 +3487,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
js-yaml 4.0.0 through 4.3.0 resolve the `!!omap` tag in quadratic time, so a
small crafted document can consume disproportionate CPU. Advisory
GHSA-5p4m-2wfm-xmqj, fixed upstream in 4.3.1.

**Scope.** The dependency is development-only and transitive, reaching us
through `@textlint/linter-formatter` and `rc-config-loader`. It is not present
in any published runtime artifact: the Python wheel excludes `apps/`, and the
extension bundle does not carry dev dependencies. The practical exposure is a
CPU denial of service against a developer machine parsing hostile YAML, not
anything reachable by a user of the published packages.

**Change.** The lockfile only. Both parents already accept `^4.1.1`, which
4.3.1 satisfies, so nothing in `package.json` moved and js-yaml remains a
transitive dependency. The diff is three lines: version, resolved URL, and
integrity hash.

`npm audit` in `apps/vscode` reports no vulnerabilities after the bump.

`apps/studio/frontend` is already on 4.3.1 and is untouched.

**Adjacent gap, not addressed here.** `.github/dependabot.yml` configures
version updates for `pip` and `github-actions` only. npm is absent, so npm
dependencies receive no proactive update PRs and move only when a security
advisory fires, which is how this one reached 4.3.0. Adding npm ecosystems
would change the PR volume on this repository, so it is left as a separate
decision rather than folded into a security fix.
