### PR TITLE
feat(providers): record what a CLI leg did, bounded and without quoting it

### DIFF
--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -1061,6 +1061,10 @@ class ClaudeCodeCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
             texts.append(session.result)
 
         session.result = "\n".join(texts)
+        # Unconditional: the bounded activity record carries no tool inputs,
+        # so it needs no redaction and costs a few keys. The full summary,
+        # which does carry inputs, stays opt-in.
+        session.populate_activity()
         if request.cli_include_summary:
             session.populate_summary()
 

--- a/lionagi/providers/google/gemini_code.py
+++ b/lionagi/providers/google/gemini_code.py
@@ -670,6 +670,10 @@ class GeminiCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
         if not session.result:
             texts = [c.content for c in session.chunks if c.type == "text" and c.content]
             session.result = "\n".join(texts)
+        # Unconditional: the bounded activity record carries no tool inputs,
+        # so it needs no redaction and costs a few keys. The full summary,
+        # which does carry inputs, stays opt-in.
+        session.populate_activity()
         if request.cli_include_summary:
             session.populate_summary()
 

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -1161,6 +1161,10 @@ class CodexCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
         if not session.result:
             texts = [c.content for c in session.chunks if c.type == "text" and c.content]
             session.result = "\n".join(texts)
+        # Unconditional: the bounded activity record carries no tool inputs,
+        # so it needs no redaction and costs a few keys. The full summary,
+        # which does carry inputs, stays opt-in.
+        session.populate_activity()
         if request.cli_include_summary:
             session.populate_summary()
 

--- a/lionagi/providers/pi/cli.py
+++ b/lionagi/providers/pi/cli.py
@@ -677,6 +677,10 @@ class PiCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
         if not session.result:
             texts = [c.text for c in session.chunks if c.text is not None]
             session.result = "\n".join(texts)
+        # Unconditional: the bounded activity record carries no tool inputs,
+        # so it needs no redaction and costs a few keys. The full summary,
+        # which does carry inputs, stays opt-in.
+        session.populate_activity()
         if request.cli_include_summary:
             session.populate_summary()
 

--- a/lionagi/service/types/cli_session.py
+++ b/lionagi/service/types/cli_session.py
@@ -34,9 +34,60 @@ class CLISession:
     duration_api_ms: int | None = None
     is_error: bool = False
     summary: dict | None = None
+    activity: dict | None = None
 
     def populate_summary(self) -> None:
         self.summary = _extract_summary(self)
+
+    def populate_activity(self) -> None:
+        self.activity = _extract_activity(self)
+
+
+# Tool-name families, named once because two extractors classify against
+# them. Two copies of these lists could drift into disagreeing about whether
+# a given tool counts as a file edit.
+_READ_TOOLS = ("Read", "read", "read_file")
+_WRITE_TOOLS = ("Write", "write", "write_file", "create_file")
+_EDIT_TOOLS = ("Edit", "edit", "edit_file", "patch", "MultiEdit")
+
+
+def _extract_activity(session: CLISession) -> dict[str, Any]:
+    """Bounded, metadata-only record of what a leg did.
+
+    Carries no tool inputs by design. Tool arguments hold file paths, shell
+    command strings and prompts, so a block containing them could not be
+    recorded on the default path without a redactor in front of it; counting
+    instead of quoting removes the need for one. The full detail, inputs
+    included, stays available through populate_summary() under the caller's
+    explicit opt-in.
+
+    Usage and cost are absent for a different reason: they already travel in
+    the response metadata and are summed per branch downstream, so repeating
+    them here would create a second value for one fact, free to disagree
+    with the first.
+
+    Size is bounded by the number of DISTINCT tool names rather than by the
+    number of calls, so a long run costs the same few keys as a short one.
+    """
+    tool_counts: dict[str, int] = {}
+    file_operations = {"reads": 0, "writes": 0, "edits": 0}
+
+    for tool_use in session.tool_uses:
+        tool_name = tool_use.get("name", "unknown")
+        tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+
+        if tool_name in _READ_TOOLS:
+            file_operations["reads"] += 1
+        elif tool_name in _WRITE_TOOLS:
+            file_operations["writes"] += 1
+        elif tool_name in _EDIT_TOOLS:
+            file_operations["edits"] += 1
+
+    return {
+        "tool_counts": tool_counts,
+        "total_tool_calls": sum(tool_counts.values()),
+        "file_operations": file_operations,
+    }
 
 
 def _extract_summary(session: CLISession) -> dict[str, Any]:
@@ -53,17 +104,17 @@ def _extract_summary(session: CLISession) -> dict[str, Any]:
         tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
         tool_details.append({"tool": tool_name, "id": tool_id, "input": tool_input})
 
-        if tool_name in ("Read", "read", "read_file"):
+        if tool_name in _READ_TOOLS:
             file_path = tool_input.get("file_path", tool_input.get("path", "unknown"))
             file_operations["reads"].append(file_path)
             key_actions.append(f"Read {file_path}")
 
-        elif tool_name in ("Write", "write", "write_file", "create_file"):
+        elif tool_name in _WRITE_TOOLS:
             file_path = tool_input.get("file_path", tool_input.get("path", "unknown"))
             file_operations["writes"].append(file_path)
             key_actions.append(f"Wrote {file_path}")
 
-        elif tool_name in ("Edit", "edit", "edit_file", "patch", "MultiEdit"):
+        elif tool_name in _EDIT_TOOLS:
             file_path = tool_input.get("file_path", tool_input.get("path", "unknown"))
             file_operations["edits"].append(file_path)
             key_actions.append(f"Edited {file_path}")

--- a/tests/providers/test_cli_leg_activity.py
+++ b/tests/providers/test_cli_leg_activity.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The bounded per-leg activity record: what a CLI leg did, without quoting it."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from lionagi.service.types.cli_session import CLISession
+
+CLI_PROVIDERS = [
+    "lionagi/providers/anthropic/claude_code.py",
+    "lionagi/providers/openai/codex.py",
+    "lionagi/providers/google/gemini_code.py",
+    "lionagi/providers/pi/cli.py",
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _session_with_tools(tool_uses):
+    session = CLISession(session_id="s1", model="m")
+    session.tool_uses = tool_uses
+    return session
+
+
+def test_activity_counts_tools_and_file_operations():
+    session = _session_with_tools(
+        [
+            {"name": "Read", "input": {"file_path": "/a.py"}},
+            {"name": "Read", "input": {"file_path": "/b.py"}},
+            {"name": "Write", "input": {"file_path": "/c.py"}},
+            {"name": "MultiEdit", "input": {"file_path": "/d.py"}},
+            {"name": "Bash", "input": {"command": "ls"}},
+        ]
+    )
+    session.populate_activity()
+
+    assert session.activity["total_tool_calls"] == 5
+    assert session.activity["tool_counts"] == {
+        "Read": 2,
+        "Write": 1,
+        "MultiEdit": 1,
+        "Bash": 1,
+    }
+    # MultiEdit is in the edit family, so it must count as an edit rather
+    # than falling through to uncategorised.
+    assert session.activity["file_operations"] == {"reads": 2, "writes": 1, "edits": 1}
+
+
+def test_activity_carries_no_tool_inputs():
+    """The property that lets this record default to on.
+
+    If any tool argument can reach the activity block, the block needs a
+    redactor in front of it and can no longer be written unconditionally.
+    """
+    secret_path = "/Users/someone/.ssh/id_rsa_UNIQUEMARKER"
+    secret_cmd = "curl -H 'Authorization: Bearer TOKENMARKER' https://example.invalid"
+
+    session = _session_with_tools(
+        [
+            {"name": "Read", "input": {"file_path": secret_path}, "id": "IDMARKER"},
+            {"name": "Bash", "input": {"command": secret_cmd}},
+        ]
+    )
+    session.populate_activity()
+
+    blob = json.dumps(session.activity)
+    assert "UNIQUEMARKER" not in blob
+    assert "TOKENMARKER" not in blob
+    assert "IDMARKER" not in blob
+    assert secret_path not in blob
+    assert secret_cmd not in blob
+    # Positive control: the tool NAMES are the thing it is supposed to keep,
+    # so an empty/broken extractor cannot pass the assertions above.
+    assert "Read" in blob and "Bash" in blob
+
+
+def test_activity_size_is_bounded_by_distinct_tool_names_not_call_count():
+    """Key count tracks distinct tool names; only the integers grow.
+
+    This is what makes the record safe to write on every leg: a run with
+    three thousand calls stores the same handful of keys as one with three.
+    """
+    names = ["Read", "Write", "Bash"]
+    few = _session_with_tools([{"name": n, "input": {"file_path": "/a"}} for n in names])
+    many = _session_with_tools(
+        [{"name": n, "input": {"file_path": "/a"}} for n in names for _ in range(1000)]
+    )
+    few.populate_activity()
+    many.populate_activity()
+
+    assert many.activity["total_tool_calls"] == 3000
+    assert few.activity["total_tool_calls"] == 3
+    # The structure is identical; only the counts differ.
+    assert many.activity.keys() == few.activity.keys()
+    assert many.activity["tool_counts"].keys() == few.activity["tool_counts"].keys()
+    assert len(many.activity["tool_counts"]) == len(names)
+    assert many.activity["file_operations"].keys() == few.activity["file_operations"].keys()
+
+
+def test_full_summary_still_carries_detail_when_opted_in():
+    """The opt-in path keeps what the default path drops, or the detail is gone."""
+    session = _session_with_tools([{"name": "Read", "input": {"file_path": "/secret.py"}}])
+    session.populate_summary()
+
+    blob = json.dumps(session.summary)
+    assert "/secret.py" in blob
+    assert session.summary["tool_details"]
+
+
+@pytest.mark.parametrize("rel_path", CLI_PROVIDERS)
+def test_provider_populates_activity_outside_the_opt_in_gate(rel_path):
+    """Every CLI provider must record activity unconditionally.
+
+    A provider that calls populate_activity() inside the
+    ``if request.cli_include_summary:`` block would record nothing on the
+    default path while still passing any test that only checks the call
+    exists. Asserted structurally rather than by grep so an indentation
+    change cannot silently move the call under the gate.
+    """
+    tree = ast.parse((REPO_ROOT / rel_path).read_text())
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "populate_activity"
+    ]
+    # Non-empty input assert: an unparsed or renamed file must fail here
+    # rather than pass the gated-call check vacuously.
+    assert len(calls) >= 1, f"{rel_path} never calls populate_activity()"
+
+    gated = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        if "cli_include_summary" not in ast.dump(node.test):
+            continue
+        for inner in ast.walk(node):
+            if (
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Attribute)
+                and inner.func.attr == "populate_activity"
+            ):
+                gated.append(inner)
+
+    assert not gated, f"{rel_path} calls populate_activity() inside the opt-in gate"
+
+    # Positive control for the gate detector itself: the summary call IS
+    # gated, so a detector that finds nothing anywhere is broken, not clean.
+    gated_summary = [
+        inner
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If) and "cli_include_summary" in ast.dump(node.test)
+        for inner in ast.walk(node)
+        if isinstance(inner, ast.Call)
+        and isinstance(inner.func, ast.Attribute)
+        and inner.func.attr == "populate_summary"
+    ]
+    assert gated_summary, f"{rel_path}: gate detector found no gated populate_summary"
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "bucket"),
+    [
+        ("Read", "reads"),
+        ("read_file", "reads"),
+        ("Write", "writes"),
+        ("create_file", "writes"),
+        ("Edit", "edits"),
+        ("MultiEdit", "edits"),
+        ("patch", "edits"),
+    ],
+)
+def test_both_extractors_agree_on_file_operation_family(tool_name, bucket):
+    """The two views classify against one shared set of tool names.
+
+    They report differently (counts here, paths there) but must never
+    disagree about which family a tool belongs to.
+    """
+    session = _session_with_tools([{"name": tool_name, "input": {"file_path": "/x.py"}}])
+    session.populate_activity()
+    session.populate_summary()
+
+    assert session.activity["file_operations"][bucket] == 1
+    assert session.summary["file_operations"][bucket] == ["/x.py"]


### PR DESCRIPTION
## What

A CLI agent session already computes a detailed record of its own activity, but only under an opt-in flag that defaults off, and nothing reads the field it fills. A run could report what it cost and not what it did.

Cost was never the gap. Usage, cost and turn counts already travel in the response metadata and are summed per branch downstream. What was missing is the activity itself, which is also the part a person actually asks about.

## How

`CLISession.populate_activity()`, called unconditionally by all four CLI providers. The block carries tool counts, a total, and per-category file-operation counts.

It deliberately carries **no tool inputs**. Tool arguments hold file paths, shell command strings and prompts, so a block containing them could not be written on the default path without a redactor in front of it. Counting instead of quoting removes the need for one. The full detail, inputs included, stays behind the existing `cli_include_summary` opt-in.

The record is bounded by the number of *distinct tool names* rather than the number of calls, so a long run stores the same handful of keys as a short one. It rides the existing response metadata rather than introducing a second place for usage figures to live and disagree.

Tool-name families are now named once and shared by both extractors, so the two views cannot drift into disagreeing about whether a given tool is a file edit.

## Tests

15 new tests asserting properties rather than shape:

- no tool input can reach the activity block, with a positive control that tool *names* are still kept, so a broken extractor cannot pass by emitting nothing
- key count tracks distinct tool names, not call count
- per provider, **structurally**, that the call sits outside the opt-in gate — parsed rather than grepped, because an indentation change could otherwise move the call under the gate while a test that only looked for the call still passed. Includes a positive control that the gate detector can see the genuinely-gated summary call.

Both load-bearing tests were mutation-checked with predictions declared before running: moving the call inside the gate in one provider reddened exactly that parametrized case; letting tool inputs into the block reddened only the privacy test. Both mutations restored byte-identical.

Full `tests/providers/` suite green.