### PR TITLE
fix(service): keep a vendor model id whole when it ends in an effort word

### DIFF
--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -92,25 +92,28 @@ class iModel:  # noqa: N801
 
             # Effort-suffixed model names ("gpt-5.6-luna-high") work at every
             # construction site: strip the suffix and route it to the
-            # provider's effort kwarg. Gated to providers with an effort kwarg
-            # so a real model name can never be mangled; an explicit effort
-            # kwarg always wins over the suffix.
+            # provider's effort kwarg. Gated twice so a real model name is not
+            # mangled — to providers that have an effort kwarg at all, and to
+            # names written in lionagi's own grammar rather than borrowed whole
+            # from another vendor's catalogue (see split_effort_suffix). An
+            # explicit effort kwarg always wins over the suffix.
             from .providers import (
                 _CLAUDE_PROVIDER_NAMES,
-                _EFFORT_SUFFIX_RE,
                 PROVIDER_EFFORT_KWARG,
                 _clamp_claude_effort,
                 normalize_effort,
+                split_effort_suffix,
             )
 
             _effort_kwarg = PROVIDER_EFFORT_KWARG.get(provider) if provider else None
             _model_name = kwargs.get("model")
             if _effort_kwarg and isinstance(_model_name, str):
-                _suffix = _EFFORT_SUFFIX_RE.match(_model_name)
-                if _suffix:
-                    kwargs["model"] = _suffix.group(1)
+                _split = split_effort_suffix(_model_name)
+                if _split is not None:
+                    _name, _raw_effort = _split
+                    kwargs["model"] = _name
                     if _effort_kwarg not in kwargs:
-                        _eff = normalize_effort(_suffix.group(2))
+                        _eff = normalize_effort(_raw_effort)
                         if provider in _CLAUDE_PROVIDER_NAMES:
                             _eff = _clamp_claude_effort(_eff, kwargs["model"])
                         kwargs[_effort_kwarg] = _eff

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -22,6 +22,7 @@ __all__ = (
     "PROVIDERS_NO_EFFORT",
     "normalize_effort",
     "parse_model_spec",
+    "split_effort_suffix",
 )
 
 # ── Effort levels (stripped from spec, mapped to provider kwarg) ──────────
@@ -267,6 +268,29 @@ _EFFORT_SUFFIX_RE = re.compile(
 )
 
 
+def split_effort_suffix(model: str) -> tuple[str, str] | None:
+    """Split a bare model name into ``(name, effort)``, or None when it carries none.
+
+    The trailing-effort convention belongs to lionagi's own ``provider/model-effort``
+    grammar, which spends its single slash on the provider. So a slash still present
+    in the model name means the name was not written in that grammar: it is a literal
+    id from another vendor's catalogue, reached for instance through a codex config
+    profile that names its own ``model_provider``. Those ids end in whatever the
+    vendor chose, and a trailing word that happens to spell an effort level is part
+    of the id. Splitting it produces a model nobody serves, and the provider rejects
+    a name the caller never asked for.
+
+    Used by both places that would otherwise strip a suffix, so the rule is stated
+    once rather than drifting between them.
+    """
+    if "/" in model:
+        return None
+    m = _EFFORT_SUFFIX_RE.match(model)
+    if m is None:
+        return None
+    return m.group(1), m.group(2)
+
+
 @dataclass(frozen=True)
 class ModelSpec:
     """Parsed model spec: raw model string (for iModel) + extracted effort."""
@@ -315,18 +339,23 @@ def parse_model_spec(spec: str) -> ModelSpec:
     if spec in BACKENDS:
         return ModelSpec(model=BACKENDS[spec], effort=None)
 
-    provider_raw = spec.split("/")[0] if "/" in spec else spec
+    has_provider = "/" in spec
+    provider_raw = spec.split("/")[0] if has_provider else spec
+    # Match against the model part alone: the provider's own slash must not count
+    # against split_effort_suffix's namespaced-id test, or no spec would ever split.
+    model_part = spec.split("/", 1)[1] if has_provider else spec
 
-    m = _EFFORT_SUFFIX_RE.match(spec)
-    if m:
-        model_clean = m.group(1)
-        effort = normalize_effort(m.group(2))
+    split = split_effort_suffix(model_part)
+    if split is not None:
+        name, raw_effort = split
+        effort = normalize_effort(raw_effort)
 
         if provider_raw in PROVIDERS_NO_EFFORT:
             raise ValueError(
                 f"Provider '{provider_raw}' does not support effort levels. "
                 f"Remove '-{effort}' from '{spec}'."
             )
+        model_clean = f"{provider_raw}/{name}" if has_provider else name
         return ModelSpec(model=_normalize_model(model_clean, provider_raw), effort=effort)
 
     return ModelSpec(model=_normalize_model(spec, provider_raw), effort=None)

--- a/tests/cli/test_codex_config_profile_spec.py
+++ b/tests/cli/test_codex_config_profile_spec.py
@@ -258,3 +258,37 @@ class TestForwardedMcpServersSurviveTheMerge:
         assert overrides["model_provider"] == "openrouter"
         # The forwarded server set is still present alongside it.
         assert any("mcp_servers" in str(k) for k in overrides), overrides
+
+
+class TestAProfilesVendorIdSurvivesEffortParsing:
+    """A profile's model is a literal vendor id, and one of the fleet's ends in
+    ``-max``. Parsed as a lionagi spec it became ``qwen/qwen3.8``, which
+    OpenRouter does not serve, so the leg died at the provider naming a model
+    nobody had asked for."""
+
+    def test_a_max_suffixed_vendor_id_reaches_the_endpoint_whole(self, codex_home):
+        _write(
+            codex_home,
+            "qwen-38",
+            'model_provider = "openrouter"\nmodel = "qwen/qwen3.8-max"\n',
+        )
+        im = build_imodel_from_spec("codex/qwen-38", yolo=True, effort_override="xhigh")
+
+        assert im.endpoint.config.kwargs["model"] == "qwen/qwen3.8-max"
+        # The effort the caller asked for still routes to codex's own kwarg.
+        assert im.endpoint.config.kwargs["reasoning_effort"] == "xhigh"
+
+    def test_build_chat_model_keeps_it_whole_too(self, codex_home):
+        """The other entry point. A fix applied to one builder and not the
+        other leaves half the fleet's legs still failing."""
+        _write(
+            codex_home,
+            "qwen-38",
+            'model_provider = "openrouter"\nmodel = "qwen/qwen3.8-max"\n',
+        )
+        out = build_chat_model(
+            provider="codex", model="qwen-38", yolo=True, verbose=False, theme=None, effort="high"
+        )
+
+        model = out if isinstance(out, str) else out.endpoint.config.kwargs["model"]
+        assert "qwen/qwen3.8-max" in model

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -509,3 +509,27 @@ def test_slash_profile_miss_includes_available_plugin_profiles(monkeypatch, tmp_
     message = str(exc_info.value)
     assert "Agent profile 'myplugin/reviewr' not found" in message
     assert "Available: myplugin/reviewer" in message
+
+
+# ── Vendor model ids are not lionagi specs ────────────────────────────────
+# The trailing-effort convention belongs to lionagi's own provider/model-effort
+# grammar. A model id borrowed whole from another vendor's catalogue — reached
+# through a codex config profile naming its own model_provider — ends in
+# whatever that vendor chose, and a trailing word that happens to spell an
+# effort level is part of the id.
+
+
+def test_parse_model_spec_keeps_a_trailing_effort_word_in_a_namespaced_vendor_id():
+    ms = parse_model_spec("codex/qwen/qwen3.8-max")
+
+    assert ms.model == "codex/qwen/qwen3.8-max"
+    assert ms.effort is None
+
+
+def test_parse_model_spec_still_splits_a_plain_model_name():
+    """The must-split arm. Deleting the split entirely would satisfy the test
+    above and quietly drop effort routing for every ordinary spec."""
+    ms = parse_model_spec("codex/gpt-5.4-max")
+
+    assert ms.model == "codex/gpt-5.4"
+    assert ms.effort == "max"

--- a/tests/service/imodel/test_init.py
+++ b/tests/service/imodel/test_init.py
@@ -558,3 +558,50 @@ class TestiModel:
 
         assert isinstance(result, APICalling)
         assert result.status == EventStatus.COMPLETED
+
+
+class TestEffortSuffixIsNotStrippedFromVendorModelIds:
+    """iModel strips a trailing effort word off a model name and routes it to
+    the provider's effort kwarg, so ``codex/gpt-5.4-max`` means gpt-5.4 at max
+    effort. That convenience belongs to lionagi's own ``provider/model-effort``
+    grammar, which spends its single slash on the provider.
+
+    A model name that still contains a slash after the provider is known came
+    from another vendor's catalogue -- codex reaches OpenRouter models this way
+    -- and its trailing token is part of the id. Stripping it produced a model
+    id nobody serves, and the provider answered with a 400 naming a model that
+    was never requested.
+    """
+
+    def test_namespaced_vendor_id_keeps_a_trailing_effort_word(self):
+        m = iModel(
+            provider="codex",
+            model="qwen/qwen3.8-max",
+            endpoint="query_cli",
+            api_key="dummy",
+        )
+        assert m.endpoint.config.kwargs["model"] == "qwen/qwen3.8-max"
+        assert "reasoning_effort" not in m.endpoint.config.kwargs
+
+    def test_a_bare_model_name_still_gives_up_its_effort_suffix(self):
+        """The must-strip arm. Without it a fix that simply deletes the strip
+        passes the test above and silently drops effort routing everywhere."""
+        m = iModel(
+            provider="codex",
+            model="gpt-5.4-max",
+            endpoint="query_cli",
+            api_key="dummy",
+        )
+        assert m.endpoint.config.kwargs["model"] == "gpt-5.4"
+        assert m.endpoint.config.kwargs["reasoning_effort"] == "max"
+
+    def test_a_namespaced_id_with_no_effort_word_is_untouched_either_way(self):
+        """Control: the fleet's other OpenRouter ids never collided in the
+        first place, so they must read identically before and after."""
+        m = iModel(
+            provider="codex",
+            model="deepseek/deepseek-v4-flash-0731",
+            endpoint="query_cli",
+            api_key="dummy",
+        )
+        assert m.endpoint.config.kwargs["model"] == "deepseek/deepseek-v4-flash-0731"


### PR DESCRIPTION
## The bug

A model name ending in an effort word was split into a name plus an effort level wherever it appeared. So a codex config profile declaring

```toml
model_provider = "openrouter"
model = "qwen/qwen3.8-max"
```

reached the provider as `qwen/qwen3.8`, and the run died on `{"message":"qwen/qwen3.8 is not a valid model ID","code":400}` — a 400 naming a model the caller never asked for.

## Why it happened

The trailing-effort convention belongs to lionagi's own `provider/model-effort` grammar, which spends its single slash on the provider. A slash still present in the *model* name therefore means the name was not written in that grammar at all: it is a literal id from another vendor's catalogue, reached through a profile that names its own `model_provider`. Those ids end in whatever the vendor chose, and a trailing word that happens to spell an effort level is part of the id.

Two independent places stripped suffixes — `parse_model_spec` and `iModel` construction — with no shared notion of what a suffix was.

## The change

One function, `split_effort_suffix`, states the rule once and both sites use it. It declines to split a namespaced name and otherwise behaves exactly as before.

`parse_model_spec` now matches against the model part alone, so the provider's own slash does not count against the namespaced-id test.

Ordinary specs are unaffected. `codex/gpt-5.4-max` still yields `gpt-5.4` at max effort, and `claude/opus-max` still resolves the same way.

## Tests

Both arms at each site, in the same test class, so deleting the split outright fails rather than passing half the suite:

- a namespaced vendor id keeps its trailing word, and carries no effort kwarg
- a plain model name still gives its suffix up to the provider's effort kwarg
- a namespaced id with no effort word reads identically before and after
- end to end through a real config profile, on both builder entry points

The first of these fails on the unfixed tree with `assert 'qwen/qwen3.8' == 'qwen/qwen3.8-max'`.

## Known boundary, and it is reachable

`parse_model_spec("qwen/qwen3.8-max")` still splits, and this change does not fix that. Written that way the leading `qwen` is read as the provider and `qwen3.8-max` as a bare model name, which at that point is indistinguishable from an ordinary `provider/model-effort` spec.

That form is reachable by typing. Two call sites hand a user-supplied string straight to the parser:

- `lionagi/cli/agent.py:721` parses the `MODEL` positional and the `--model` value
- `lionagi/cli/_providers.py:92` parses `spec` in `build_imodel_from_spec`

So `--model qwen/qwen3.8-max` still reaches the provider as `qwen/qwen3.8` at max effort, which is the original bug on a route a person walks by hand.

What this change does fix is the route where the id arrives with an explicit provider in front of it, which is how a codex config profile delivers one, and that is the route that was breaking real runs.

There is a signal available for the remaining case that this change deliberately does not use yet: `qwen` is not present in any of lionagi's known-provider sets, so an unrecognised leading segment could mark the whole string as a vendor id. That needs its own consideration, because providers reached through an explicit `base_url` are also absent from those sets, and getting it wrong would break them.
