### PR TITLE
fix(studio): an escalation is work waiting on a decision, not a failure

### DIFF
--- a/apps/studio/frontend/src/components/canvas/StepNode.test.ts
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.ts
@@ -47,10 +47,15 @@ describe("computeNodeVisualStyle", () => {
     expect(completed.railColor).not.toBe("transparent");
   });
 
-  it("failed and escalated read as the same failure-pool visual", () => {
-    expect(computeNodeVisualStyle("failed", false)).toEqual(
-      computeNodeVisualStyle("escalated", false),
-    );
+  it("escalated uses the warning visual while failed keeps the failure visual", () => {
+    const escalated = computeNodeVisualStyle("escalated", false);
+    const failed = computeNodeVisualStyle("failed", false);
+    const warning = computeNodeVisualStyle("awaiting_approval", false);
+
+    expect(escalated).toEqual(warning);
+    expect(escalated).not.toEqual(failed);
+    expect(failed.borderColor).toBe("var(--dag-failed-border)");
+    expect(failed.railColor).toBe("var(--dag-failed-border)");
   });
 
   it("running, completed, and failed are all mutually distinguishable by color at any zoom", () => {

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -21,6 +21,7 @@ let container: HTMLDivElement;
 let root: Root;
 
 beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   // The card asks for the reduced-motion preference on mount; this environment
   // has no matchMedia. Answering "no preference" keeps the running animation on,
   // which is the arm these tests render under.
@@ -37,6 +38,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  vi.unstubAllGlobals();
 });
 
 function renderNode(data: Partial<StepNodeData>) {
@@ -138,5 +140,17 @@ describe("StepNode — the card keeps its shape", () => {
     renderNode({ execStatus: "failed", errorCount: 3, durationSeconds: 12 });
     expect(rows()[0].textContent).toContain("3");
     expect(bottomRightText()).toBe("12s");
+  });
+
+  it("gives escalated a warning icon while failed keeps the error icon", () => {
+    renderNode({ execStatus: "escalated" });
+    const escalatedIcon = rows()[0].querySelector("span.flex.shrink-0.items-center");
+    expect(escalatedIcon?.className).toContain("text-status-warning");
+    expect(escalatedIcon?.className).not.toContain("text-status-error");
+
+    renderNode({ execStatus: "failed" });
+    const failedIcon = rows()[0].querySelector("span.flex.shrink-0.items-center");
+    expect(failedIcon?.className).toContain("text-status-error");
+    expect(failedIcon?.className).not.toContain("text-status-warning");
   });
 });

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -90,8 +90,8 @@ export interface NodeVisualStyle {
 }
 
 export function computeNodeVisualStyle(status: NodeExecStatus, selected: boolean): NodeVisualStyle {
-  const isTerminalError = status === "failed" || status === "escalated";
-  const isWarn = status === "awaiting_approval" || status === "paused";
+  const isTerminalError = status === "failed";
+  const isWarn = status === "awaiting_approval" || status === "paused" || status === "escalated";
 
   const borderColor =
     status === "running"
@@ -230,7 +230,7 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
           </span>
         )}
         {status === "escalated" && (
-          <span className="flex shrink-0 items-center text-status-error">
+          <span className="flex shrink-0 items-center text-status-warning">
             <IconWarning size={10} strokeWidth={2.5} />
           </span>
         )}

--- a/apps/studio/frontend/src/components/history/OperationGraphSection.test.ts
+++ b/apps/studio/frontend/src/components/history/OperationGraphSection.test.ts
@@ -1,14 +1,20 @@
-import { describe, expect, it } from "vitest";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
 
-import type { OperationNode } from "@/lib/operationGraph";
+import type { OperationNode, OperationStatus } from "@/lib/operationGraph";
 
-import { computeLayers } from "./OperationGraphSection";
+import OperationGraphSection, { computeLayers } from "./OperationGraphSection";
 
-function node(opId: string, causeOpId: string | null = null): OperationNode {
+function node(
+  opId: string,
+  causeOpId: string | null = null,
+  status: OperationStatus = "succeeded",
+): OperationNode {
   return {
     opId,
     name: opId,
-    status: "succeeded",
+    status,
     causeOpId,
     elapsed: 0,
     firstTs: 0,
@@ -60,5 +66,153 @@ describe("computeLayers", () => {
       { source: "ghost", target: "b" },
     ];
     expect(layerIds(computeLayers(nodes, edges))).toEqual([["a"], ["b"]]);
+  });
+
+  it("excludes continuations from depth while ordinary dependencies still layer", () => {
+    const nodes = [node("origin"), node("retry"), node("dependent")];
+    const edges = [
+      { source: "origin", target: "retry", continuation: true },
+      { source: "origin", target: "dependent" },
+    ];
+
+    expect(layerIds(computeLayers(nodes, edges))).toEqual([["origin", "retry"], ["dependent"]]);
+  });
+});
+
+describe("OperationGraphSection status presentation", () => {
+  it("renders escalated with warning tokens while failed keeps error tokens", () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      act(() => {
+        root.render(
+          React.createElement(OperationGraphSection, {
+            state: {
+              nodes: [node("escalated-op", null, "escalated"), node("failed-op", null, "failed")],
+              edges: [],
+            },
+            live: false,
+          }),
+        );
+      });
+
+      const cards = container.querySelectorAll(":scope > div > div > div");
+      const escalatedCard = cards[0];
+      const failedCard = cards[1];
+
+      expect(escalatedCard?.className).toContain("border-l-status-warning");
+      expect(escalatedCard?.className).not.toContain("border-l-status-error");
+      expect(escalatedCard?.querySelector(".bg-status-warning")).not.toBeNull();
+      expect(escalatedCard?.querySelector(".bg-status-error")).toBeNull();
+      expect(failedCard?.className).toContain("border-l-status-error");
+      expect(failedCard?.className).not.toContain("border-l-status-warning");
+      expect(failedCard?.querySelector(".bg-status-error")).not.toBeNull();
+      expect(failedCard?.querySelector(".bg-status-warning")).toBeNull();
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("OperationGraphSection continuation presentation", () => {
+  it("keeps a continuation visible with the established dotted low-weight style", () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      act(() => {
+        root.render(
+          React.createElement(OperationGraphSection, {
+            state: {
+              nodes: [node("origin"), node("retry"), node("dependent")],
+              edges: [
+                { source: "origin", target: "retry", continuation: true },
+                { source: "origin", target: "dependent" },
+              ],
+            },
+            live: false,
+          }),
+        );
+      });
+
+      const paths = container.querySelectorAll("svg path");
+      const continuation = container.querySelector('svg path[stroke-dasharray="2 6"]');
+      const dependency = Array.from(paths).find((path) => path !== continuation);
+      expect(paths).toHaveLength(2);
+      expect(continuation?.getAttribute("d")).toBeTruthy();
+      expect(continuation?.getAttribute("stroke-dasharray")).toBe("2 6");
+      expect(continuation?.getAttribute("stroke-opacity")).toBe("0.35");
+      expect(continuation?.getAttribute("stroke-width")).toBe("1.25");
+      expect(continuation?.getAttribute("marker-end")).toBeNull();
+      expect(dependency?.getAttribute("stroke-dasharray")).toBeNull();
+      expect(dependency?.getAttribute("stroke-opacity")).toBe("0.5");
+      expect(dependency?.getAttribute("stroke-width")).toBe("1.5");
+
+      const pathCoordinates =
+        continuation
+          ?.getAttribute("d")
+          ?.match(/-?\d+(?:\.\d+)?/g)
+          ?.map(Number) ?? [];
+      expect(pathCoordinates).toHaveLength(8);
+      const [sourceX, , firstControlX, , secondControlX, , targetX] = pathCoordinates;
+      expect(targetX).toBe(sourceX);
+      expect(firstControlX).toBeGreaterThan(sourceX!);
+      expect(secondControlX).toBeGreaterThan(sourceX!);
+      expect(Number(container.querySelector("svg")?.getAttribute("width"))).toBeGreaterThan(
+        firstControlX!,
+      );
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps a forward continuation between layers on the ordinary curve", () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      act(() => {
+        root.render(
+          React.createElement(OperationGraphSection, {
+            state: {
+              nodes: [node("source"), node("anchor"), node("target")],
+              edges: [
+                { source: "source", target: "target", continuation: true },
+                { source: "anchor", target: "target" },
+              ],
+            },
+            live: false,
+          }),
+        );
+      });
+
+      const continuation = container.querySelector('svg path[stroke-dasharray="2 6"]');
+      const pathCoordinates =
+        continuation
+          ?.getAttribute("d")
+          ?.match(/-?\d+(?:\.\d+)?/g)
+          ?.map(Number) ?? [];
+      expect(pathCoordinates).toHaveLength(8);
+      const [sourceX, , firstControlX, , secondControlX, , targetX] = pathCoordinates;
+      expect(targetX).toBeGreaterThan(sourceX!);
+      expect(firstControlX).toBeGreaterThan(sourceX!);
+      expect(firstControlX).toBeLessThan(targetX!);
+      expect(secondControlX).toBe(firstControlX);
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/apps/studio/frontend/src/components/history/OperationGraphSection.tsx
+++ b/apps/studio/frontend/src/components/history/OperationGraphSection.tsx
@@ -9,7 +9,7 @@ const STATUS_BORDER: Record<OperationStatus, string> = {
   paused: "border-l-status-warning",
   succeeded: "border-l-status-success",
   failed: "border-l-status-error",
-  escalated: "border-l-status-error",
+  escalated: "border-l-status-warning",
 };
 
 const STATUS_DOT: Record<OperationStatus, string> = {
@@ -19,8 +19,14 @@ const STATUS_DOT: Record<OperationStatus, string> = {
   paused: "bg-status-warning",
   succeeded: "bg-status-success",
   failed: "bg-status-error",
-  escalated: "bg-status-error",
+  escalated: "bg-status-warning",
 };
+
+// Match the continuation treatment in ConditionEdge: finely dotted, faint,
+// thin, and without an arrowhead.
+const CONTINUATION_DASHARRAY = "2 6";
+const CONTINUATION_OPACITY = 0.35;
+const CONTINUATION_WIDTH = 1.25;
 
 // ── Node card ─────────────────────────────────────────────────────────────────
 
@@ -65,10 +71,12 @@ function NodeCard({ node, live }: { node: OperationNode; live: boolean }) {
 
 // ── Layer computation (longest-path layering over edges) ──────────────────────
 
-// Depth is the longest path from any root, computed over ALL edges — not just a
-// node's single causeOpId. Fan-in nodes (multiple predecessors, causeOpId null
-// because parent_id was absent) must land after every predecessor, else their
-// edges render backwards through the cards.
+// Depth is the longest path from any root, computed over every dependency edge
+// rather than a node's single causeOpId. Fan-in nodes (multiple predecessors,
+// causeOpId null because parent_id was absent) must land after every predecessor,
+// else their edges render backwards through the cards. Continuations are causal
+// annotations, not scheduling dependencies, so they stay visible without moving
+// either endpoint to a different layer.
 export function computeLayers(
   nodes: OperationNode[],
   edges: OperationGraphState["edges"],
@@ -78,6 +86,7 @@ export function computeLayers(
   const known = new Set(nodes.map((n) => n.opId));
   const predsByOp = new Map<string, string[]>();
   for (const e of edges) {
+    if (e.continuation) continue;
     if (!known.has(e.source) || !known.has(e.target)) continue;
     (predsByOp.get(e.target) ?? predsByOp.set(e.target, []).get(e.target)!).push(e.source);
   }
@@ -142,7 +151,7 @@ export default function OperationGraphSection({
   const colGap = 40;
   const cardHeight = 60;
   const rowGap = 8;
-  const totalWidth = layers.length * colWidth + Math.max(0, layers.length - 1) * colGap;
+  const contentWidth = layers.length * colWidth + Math.max(0, layers.length - 1) * colGap;
   const maxRows = Math.max(...layers.map((l) => l.length), 1);
   const totalHeight = maxRows * cardHeight + Math.max(0, maxRows - 1) * rowGap;
 
@@ -160,6 +169,18 @@ export default function OperationGraphSection({
     });
   });
 
+  // A continuation can point within or behind its source layer because it does
+  // not affect depth. Give those return paths an outer gutter so the dotted
+  // causal line is not hidden beneath opaque node cards.
+  const usesContinuationGutter = edges.some((edge) => {
+    if (!edge.continuation) return false;
+    const src = opToLayerCol.get(edge.source);
+    const tgt = opToLayerCol.get(edge.target);
+    return Boolean(src && tgt && tgt.col <= src.col);
+  });
+  const totalWidth = contentWidth + (usesContinuationGutter ? colGap : 0);
+  const continuationGutterX = contentWidth + colGap / 2;
+
   return (
     <div className="overflow-x-auto">
       <div className="relative inline-block" style={{ width: totalWidth, height: totalHeight }}>
@@ -176,20 +197,23 @@ export default function OperationGraphSection({
             const srcLayer = layers[src.col];
             const tgtLayer = layers[tgt.col];
             if (!srcLayer || !tgtLayer) return null;
+            const isContinuation = edge.continuation === true;
+            const usesOuterGutter = isContinuation && tgt.col <= src.col;
             const x1 = cardCenterX(src.col) + colWidth / 2;
             const y1 = cardCenterY(src.row, srcLayer.length);
-            const x2 = cardCenterX(tgt.col) - colWidth / 2;
+            const x2 = cardCenterX(tgt.col) + (usesOuterGutter ? colWidth / 2 : -colWidth / 2);
             const y2 = cardCenterY(tgt.row, tgtLayer.length);
-            const mx = (x1 + x2) / 2;
+            const mx = usesOuterGutter ? continuationGutterX : (x1 + x2) / 2;
             return (
               <path
                 key={`${edge.source}-${edge.target}`}
                 d={`M ${x1} ${y1} C ${mx} ${y1}, ${mx} ${y2}, ${x2} ${y2}`}
                 fill="none"
                 stroke="currentColor"
-                strokeWidth={1.5}
+                strokeWidth={isContinuation ? CONTINUATION_WIDTH : 1.5}
                 className="text-edge"
-                strokeOpacity={0.5}
+                strokeOpacity={isContinuation ? CONTINUATION_OPACITY : 0.5}
+                strokeDasharray={isContinuation ? CONTINUATION_DASHARRAY : undefined}
               />
             );
           })}

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -928,55 +928,94 @@ describe("history/RunDetail.tsx — overview aggregates are lifetime totals", ()
   });
 });
 
-// ─── NodeEscalated route=notify badge ──────────────────────────────────────────
-// A soft ("fyi" urgency) EscalationRequest resolves to route="notify" and
-// fires NodeEscalated purely for observability — the node itself keeps
-// working. The per-event timeline badge must not label that "escalated"
-// (error tone) the same as a real, terminal escalation.
+// ─── NodeEscalated badge tone ─────────────────────────────────────────────────
+// Every escalation route is attention-worthy rather than failed. Soft notify
+// keeps its distinct label, while hard and legacy escalation shapes retain the
+// escalated label; a real NodeFailed remains the error-tone control.
 
-describe("history/RunDetail.tsx — badgeForEvent (NodeEscalated route=notify)", () => {
-  it("labels a route=notify NodeEscalated as notify, not escalated", async () => {
+describe("history/RunDetail.tsx — badgeForEvent escalation presentation", () => {
+  it("uses warning for every escalation shape while genuine failure stays error-toned", async () => {
     const { badgeForEvent } = await import("./RunDetail");
-    const badge = badgeForEvent({
-      id: "1",
-      session_id: "s1",
-      seq: 0,
-      kind: "NodeEscalated",
-      op_id: "op-a",
-      ts: 1,
-      payload: { route: "notify" },
-    });
-    expect(badge.label).toBe("notify");
-    expect(badge.tone).not.toMatch(/error/);
-  });
+    const escalationCases = [
+      [{ route: "notify" }, "notify"],
+      [{ route: "higher_tier" }, "escalated"],
+      [{}, "escalated"],
+    ] as const;
 
-  it("still labels a route=higher_tier NodeEscalated as escalated", async () => {
-    const { badgeForEvent } = await import("./RunDetail");
-    const badge = badgeForEvent({
-      id: "1",
-      session_id: "s1",
-      seq: 0,
-      kind: "NodeEscalated",
-      op_id: "op-a",
-      ts: 1,
-      payload: { route: "higher_tier" },
-    });
-    expect(badge.label).toBe("escalated");
-    expect(badge.tone).toMatch(/error/);
-  });
+    for (const [payload, label] of escalationCases) {
+      const badge = badgeForEvent({
+        id: `escalated-${label}`,
+        session_id: "s1",
+        seq: 0,
+        kind: "NodeEscalated",
+        op_id: "op-escalated",
+        ts: 1,
+        payload,
+      });
+      expect(badge.label).toBe(label);
+      expect(badge.tone).toMatch(/warning/);
+      expect(badge.tone).not.toMatch(/error/);
+    }
 
-  it("still labels a bare NodeEscalated (no route) as escalated — back-compat", async () => {
-    const { badgeForEvent } = await import("./RunDetail");
-    const badge = badgeForEvent({
-      id: "1",
+    const failed = badgeForEvent({
+      id: "failed",
       session_id: "s1",
-      seq: 0,
-      kind: "NodeEscalated",
-      op_id: "op-a",
-      ts: 1,
+      seq: 1,
+      kind: "NodeFailed",
+      op_id: "op-failed",
+      ts: 2,
       payload: {},
     });
-    expect(badge.label).toBe("escalated");
+    expect(failed.label).toBe("failed");
+    expect(failed.tone).toMatch(/error/);
+    expect(failed.tone).not.toMatch(/warning/);
+  });
+});
+
+describe("history/RunDetail.tsx — operation lane escalation presentation", () => {
+  it("uses a warning lane for escalated while a failed lane stays error-toned", async () => {
+    const { EventsSection } = await import("./RunDetail");
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    try {
+      act(() => {
+        root.render(
+          <IntlProvider locale="en" messages={enMessages}>
+            <EventsSection
+              live={false}
+              events={[
+                sig({
+                  id: "escalated",
+                  kind: "NodeEscalated",
+                  op_id: "op-escalated",
+                  payload: { route: "higher_tier" },
+                }),
+                sig({ id: "failed", kind: "NodeFailed", op_id: "op-failed", payload: {} }),
+              ]}
+            />
+          </IntlProvider>,
+        );
+      });
+
+      const laneSummary = Array.from(container.querySelectorAll("#run-events > div")).find((div) =>
+        div.className.includes("gap-1.5"),
+      );
+      const laneBadges = Array.from(laneSummary?.querySelectorAll("span") ?? []);
+      const escalated = laneBadges.find((span) => span.textContent === "escalated");
+      const failed = laneBadges.find((span) => span.textContent === "failed");
+
+      expect(escalated?.className).toContain("text-status-warning");
+      expect(escalated?.className).not.toMatch(/status-error/);
+      expect(failed?.className).toContain("text-status-error");
+      expect(failed?.className).not.toMatch(/status-warning/);
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+      vi.unstubAllGlobals();
+    }
   });
 });
 
@@ -1627,13 +1666,18 @@ describe("history/RunDetail.tsx — computeReconciledNodeStatuses / computeProgr
     expect(counts?.hasFailure).toBe(false);
   });
 
-  it("hasFailure trips the unmissable-failure header tone when any node is failed or escalated", async () => {
+  it("counts escalated separately while genuine failed still trips the failure header", async () => {
     const { computeReconciledNodeStatuses, computeProgressCountsForGraph } =
       await import("./RunDetail");
-    const reconciled = computeReconciledNodeStatuses(graph, { a: "escalated" }, true);
-    const counts = computeProgressCountsForGraph(graph, reconciled);
-    expect(counts?.hasFailure).toBe(true);
-    expect(counts?.failed).toBe(1);
+    const reconciled = computeReconciledNodeStatuses(graph, { a: "escalated", b: "failed" }, true);
+    const pairedCounts = computeProgressCountsForGraph(graph, reconciled);
+    expect(pairedCounts).toMatchObject({ escalated: 1, failed: 1, hasFailure: true });
+
+    const escalatedOnly = computeProgressCountsForGraph(
+      { nodes: graph.nodes.slice(0, 1) },
+      { a: "escalated" },
+    );
+    expect(escalatedOnly).toMatchObject({ escalated: 1, failed: 0, hasFailure: false });
   });
 
   it("returns undefined/null gracefully when there is no run graph yet", async () => {

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -602,6 +602,9 @@ function ProgressSummaryBar({
         {counts.hasFailure ? "⚠ " : ""}
         {t("progressFailed")} {counts.failed}
       </span>
+      <span className={counts.escalated > 0 ? "font-semibold text-status-warning" : undefined}>
+        {t("graphNodeStatusEscalated")} {counts.escalated}
+      </span>
       <span>
         {t("progressPending")} {pending}
       </span>
@@ -1058,7 +1061,7 @@ const KIND_BADGE: Record<string, { label: string; tone: string }> = {
   NodeCompleted: { label: "done", tone: "bg-status-success-bg text-status-success" },
   NodeFailed: { label: "failed", tone: "bg-status-error-bg text-status-error" },
   NodeAwaitingApproval: { label: "approval", tone: "bg-status-warning-bg text-status-warning" },
-  NodeEscalated: { label: "escalated", tone: "bg-status-error-bg text-status-error" },
+  NodeEscalated: { label: "escalated", tone: "bg-status-warning-bg text-status-warning" },
   GateDenied: { label: "gate-denied", tone: "bg-status-error-bg text-status-error" },
   RunStart: { label: "run-start", tone: "bg-status-running-bg text-status-running" },
   RunEnd: { label: "run-end", tone: "bg-status-success-bg text-status-success" },
@@ -1068,9 +1071,9 @@ const KIND_BADGE: Record<string, { label: string; tone: string }> = {
   StructuredOutput: { label: "output", tone: "bg-surface-overlay text-content-secondary" },
 };
 
-// A NodeEscalated with route="notify" is a soft ("fyi") help signal, not a
-// real escalation — badge it distinctly (warning tone, like an approval
-// request) instead of the unconditional error-toned "escalated" label.
+// A NodeEscalated with route="notify" is a soft ("fyi") help signal rather
+// than a terminal escalation. Both use the attention tone, while the soft
+// route keeps its distinct label because the node itself continues working.
 export function badgeForEvent(ev: SignalEvent): { label: string; tone: string } {
   if (ev.kind === "NodeEscalated" && ev.payload?.route === "notify") {
     return { label: "notify", tone: "bg-status-warning-bg text-status-warning" };
@@ -1087,7 +1090,7 @@ const LANE_TONE: Record<LaneState, string> = {
   paused: "bg-status-warning-bg text-status-warning",
   succeeded: "bg-status-success-bg text-status-success",
   failed: "bg-status-error-bg text-status-error",
-  escalated: "bg-status-error-bg text-status-error",
+  escalated: "bg-status-warning-bg text-status-warning",
 };
 
 interface LaneSummary {

--- a/apps/studio/frontend/src/lib/execGraphProgress.test.ts
+++ b/apps/studio/frontend/src/lib/execGraphProgress.test.ts
@@ -38,8 +38,8 @@ describe("deriveProgressCounts — summary counts from the canonical status sour
     expect(counts.awaitingApproval).toBe(1);
     expect(counts.paused).toBe(1);
     expect(counts.completed).toBe(1);
-    // failed + escalated collapse into one failure pool
-    expect(counts.failed).toBe(2);
+    expect(counts.failed).toBe(1);
+    expect(counts.escalated).toBe(1);
     expect(counts.hasFailure).toBe(true);
   });
 
@@ -55,6 +55,7 @@ describe("deriveProgressCounts — summary counts from the canonical status sour
       counts.awaitingApproval +
       counts.paused +
       counts.completed +
+      counts.escalated +
       counts.failed;
     expect(sum).toBe(counts.total);
   });
@@ -69,6 +70,7 @@ describe("deriveProgressCounts — summary counts from the canonical status sour
       awaitingApproval: 0,
       paused: 0,
       completed: 0,
+      escalated: 0,
       failed: 0,
       hasFailure: false,
     });
@@ -86,10 +88,16 @@ describe("deriveProgressCounts — summary counts from the canonical status sour
     expect(counts.hasFailure).toBe(false);
   });
 
-  it("flags failure from escalated alone, not only failed", () => {
-    const counts = deriveProgressCounts(["a"], { a: "escalated" });
-    expect(counts.hasFailure).toBe(true);
-    expect(counts.failed).toBe(1);
+  it("counts escalated separately while genuine failed remains a failure", () => {
+    const paired = deriveProgressCounts(["a", "b"], { a: "escalated", b: "failed" });
+    expect(paired.escalated).toBe(1);
+    expect(paired.failed).toBe(1);
+    expect(paired.hasFailure).toBe(true);
+
+    const escalatedOnly = deriveProgressCounts(["a"], { a: "escalated" });
+    expect(escalatedOnly.escalated).toBe(1);
+    expect(escalatedOnly.failed).toBe(0);
+    expect(escalatedOnly.hasFailure).toBe(false);
   });
 });
 

--- a/apps/studio/frontend/src/lib/execGraphProgress.ts
+++ b/apps/studio/frontend/src/lib/execGraphProgress.ts
@@ -25,7 +25,7 @@ export interface ProgressCounts {
   awaitingApproval: number;
   paused: number;
   completed: number;
-  /** failed + escalated, counted as one failure pool per the design brief. */
+  escalated: number;
   failed: number;
   hasFailure: boolean;
 }
@@ -39,6 +39,7 @@ function emptyCounts(total = 0): ProgressCounts {
     awaitingApproval: 0,
     paused: 0,
     completed: 0,
+    escalated: 0,
     failed: 0,
     hasFailure: false,
   };
@@ -76,8 +77,10 @@ export function deriveProgressCounts(
         counts.completed++;
         break;
       case "failed":
-      case "escalated":
         counts.failed++;
+        break;
+      case "escalated":
+        counts.escalated++;
         break;
     }
   }

--- a/apps/studio/frontend/src/lib/operationGraph.test.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.test.ts
@@ -374,6 +374,159 @@ describe("buildOperationGraph — cause edges", () => {
   });
 });
 
+describe("buildOperationGraph — escalation continuations", () => {
+  it("names and links a recorded-shape higher-tier retry without changing lifecycle counts", () => {
+    const parentId = "11111111-1111-4111-8111-111111111111";
+    const childId = "22222222-2222-4222-8222-222222222222";
+    const events = [
+      ev("1", "NodeStarted", parentId, { name: "worker" }, 1),
+      ev("2", "NodeEscalated", parentId, { name: "worker", route: "higher_tier" }, 2),
+      ev("3", "NodeSpawned", childId, { parent_id: parentId, independent: true }, 3),
+      ev("4", "NodeQueued", childId, { name: childId.slice(0, 8), depends_on: [] }, 4),
+      ev("5", "NodeFailed", "op-broken", { name: "broken" }, 5),
+    ];
+
+    const g = buildOperationGraph(events);
+    const parent = g.nodes.find((node) => node.opId === parentId)!;
+    const child = g.nodes.find((node) => node.opId === childId)!;
+    const broken = g.nodes.find((node) => node.opId === "op-broken")!;
+
+    expect(parent.status).toBe("escalated");
+    expect(broken.status).toBe("failed");
+    expect(child).toMatchObject({
+      name: "worker escalation retry",
+      status: "queued",
+      causeOpId: null,
+      eventCount: 1,
+    });
+    expect(g.edges).toContainEqual({
+      source: parentId,
+      target: childId,
+      continuation: true,
+    });
+  });
+
+  it("recognizes an out-of-order spawn after the full event fold", () => {
+    const events = [
+      ev("1", "NodeSpawned", "retry-op", { parent_id: "parent-op", independent: true }, 1),
+      ev("2", "NodeQueued", "retry-op", { name: "retry-op" }, 2),
+      ev("3", "NodeEscalated", "parent-op", { name: "planner", route: "higher_tier" }, 3),
+    ];
+
+    const g = buildOperationGraph(events);
+    expect(g.nodes.find((node) => node.opId === "retry-op")?.name).toBe("planner escalation retry");
+    expect(g.edges).toContainEqual({
+      source: "parent-op",
+      target: "retry-op",
+      continuation: true,
+    });
+  });
+
+  it("leaves a soft escalation and an ordinary independent spawn exactly as the signals described them", () => {
+    const events = [
+      ev("1", "NodeEscalated", "soft-parent", { name: "watcher", route: "notify" }, 1),
+      ev("2", "NodeSpawned", "soft-child", { parent_id: "soft-parent", independent: true }, 2),
+      ev(
+        "3",
+        "NodeQueued",
+        "soft-child",
+        { name: "child", parent_id: "soft-parent", depends_on: ["soft-parent"] },
+        3,
+      ),
+      ev("4", "NodeStarted", "plain-parent", { name: "plain" }, 4),
+      ev("5", "NodeSpawned", "plain-child", { parent_id: "plain-parent", independent: true }, 5),
+      ev(
+        "6",
+        "NodeQueued",
+        "plain-child",
+        { name: "plain-child", parent_id: "plain-parent", depends_on: ["plain-parent"] },
+        6,
+      ),
+    ];
+
+    // Two separate claims, and only the first is about spawn metadata. Neither
+    // of these is a higher-tier escalation, so no continuation may be invented
+    // for them. But their plain dependency edges were stated outright by
+    // NodeQueued's depends_on, and reclassifying a parent link belongs to
+    // escalation retries alone — an ordinary independent spawn that declares a
+    // dependency still has one.
+    const g = buildOperationGraph(events);
+    expect(g.edges.filter((e) => e.continuation)).toEqual([]);
+    expect(g.edges).toContainEqual({ source: "soft-parent", target: "soft-child" });
+    expect(g.edges).toContainEqual({ source: "plain-parent", target: "plain-child" });
+  });
+
+  it("keeps a continuation even when a plain dependency path reaches the retry child", () => {
+    const events = [
+      ev("1", "NodeEscalated", "parent", { name: "worker", route: "higher_tier" }, 1),
+      ev("2", "NodeQueued", "middle", { depends_on: ["parent"] }, 2),
+      ev("3", "NodeSpawned", "retry", { parent_id: "parent", independent: true }, 3),
+      ev("4", "NodeQueued", "retry", { name: "retry", depends_on: ["middle"] }, 4),
+    ];
+
+    const g = buildOperationGraph(events);
+    expect(g.edges).toContainEqual({ source: "parent", target: "middle" });
+    expect(g.edges).toContainEqual({ source: "middle", target: "retry" });
+    expect(g.edges).toContainEqual({
+      source: "parent",
+      target: "retry",
+      continuation: true,
+    });
+  });
+
+  it("does not use a continuation path to remove a plain dependency edge", () => {
+    const events = [
+      ev("1", "NodeEscalated", "parent", { name: "worker", route: "higher_tier" }, 1),
+      ev("2", "NodeSpawned", "retry", { parent_id: "parent", independent: true }, 2),
+      ev("3", "NodeQueued", "retry", { name: "retry" }, 3),
+      ev("4", "NodeQueued", "downstream", { depends_on: ["parent", "retry"] }, 4),
+    ];
+
+    const g = buildOperationGraph(events);
+    expect(g.edges).toContainEqual({ source: "parent", target: "downstream" });
+    expect(g.edges).toContainEqual({ source: "retry", target: "downstream" });
+    expect(g.edges).toContainEqual({
+      source: "parent",
+      target: "retry",
+      continuation: true,
+    });
+  });
+
+  it("keeps a non-independent spawn link as a plain dependency", () => {
+    const events = [
+      ev("1", "NodeStarted", "parent", { name: "worker" }, 1),
+      ev("2", "NodeSpawned", "child", { parent_id: "parent", independent: false }, 2),
+      ev("3", "NodeQueued", "child", { name: "child", parent_id: "parent" }, 3),
+    ];
+
+    expect(buildOperationGraph(events).edges).toEqual([{ source: "parent", target: "child" }]);
+  });
+
+  it("preserves a readable child name already supplied by a lifecycle signal", () => {
+    const events = [
+      ev("1", "NodeEscalated", "parent", { name: "worker", route: "higher_tier" }, 1),
+      ev("2", "NodeSpawned", "retry", { parent_id: "parent", independent: true }, 2),
+      ev("3", "NodeQueued", "retry", { name: "specialized worker" }, 3),
+    ];
+
+    expect(buildOperationGraph(events).nodes.find((node) => node.opId === "retry")?.name).toBe(
+      "specialized worker",
+    );
+  });
+
+  it("ignores invalid and self-referential spawn parents", () => {
+    const events = [
+      ev("1", "NodeEscalated", "parent", { name: "worker", route: "higher_tier" }, 1),
+      ev("2", "NodeSpawned", "child-a", { parent_id: 42, independent: true }, 2),
+      ev("3", "NodeSpawned", "child-b", { parent_id: "child-b", independent: true }, 3),
+      ev("4", "NodeQueued", "child-a", { name: "child-a" }, 4),
+      ev("5", "NodeQueued", "child-b", { name: "child-b" }, 5),
+    ];
+
+    expect(buildOperationGraph(events).edges).toEqual([]);
+  });
+});
+
 describe("buildOperationGraph — multiple operations", () => {
   it("handles multiple independent operations", () => {
     const events = [

--- a/apps/studio/frontend/src/lib/operationGraph.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.ts
@@ -22,9 +22,15 @@ export interface OperationNode {
   eventCount: number;
 }
 
+export interface OperationEdge {
+  source: string;
+  target: string;
+  continuation?: boolean;
+}
+
 export interface OperationGraphState {
   nodes: OperationNode[];
-  edges: { source: string; target: string }[];
+  edges: OperationEdge[];
 }
 
 // ── Status projection ─────────────────────────────────────────────────────────
@@ -255,10 +261,31 @@ export function buildOperationGraph(events: SignalEvent[]): OperationGraphState 
   const lastTsByOp = new Map<string, number>();
   const causeOpIdByOp = new Map<string, string | null>();
   const edgeSet = new Set<string>();
+  const independentSpawnOrigins = new Map<string, { source: string; target: string }>();
+  const higherTierEscalations = new Set<string>();
 
   for (const ev of events) {
     if (!ev.op_id) continue;
+
+    if (ev.kind === "NodeSpawned") {
+      const parentId = ev.payload?.parent_id;
+      if (
+        ev.payload?.independent === true &&
+        typeof parentId === "string" &&
+        parentId &&
+        parentId !== ev.op_id
+      ) {
+        const key = `${parentId}→${ev.op_id}`;
+        independentSpawnOrigins.set(key, { source: parentId, target: ev.op_id });
+      }
+      continue;
+    }
+
     if (!KIND_TO_STATE[ev.kind]) continue;
+
+    if (ev.kind === "NodeEscalated" && ev.payload?.route === "higher_tier") {
+      higherTierEscalations.add(ev.op_id);
+    }
 
     if (!kindsByOp.has(ev.op_id)) {
       kindsByOp.set(ev.op_id, []);
@@ -312,6 +339,30 @@ export function buildOperationGraph(events: SignalEvent[]): OperationGraphState 
     }
   }
 
+  const continuationEdges: OperationEdge[] = [];
+  for (const [key, origin] of independentSpawnOrigins) {
+    // Only an escalation retry gets its parent link reclassified. Everything
+    // else that spawns independently keeps whatever the lifecycle signals
+    // said about it, including a plain dependency edge repeating the parent.
+    if (!higherTierEscalations.has(origin.source)) continue;
+
+    // For a retry, the parent link is causal provenance rather than a
+    // scheduling dependency, so the repeated plain edge is removed and the
+    // cause cleared before the continuation replaces them.
+    edgeSet.delete(key);
+    causeOpIdByOp.set(origin.target, null);
+
+    continuationEdges.push({ ...origin, continuation: true });
+
+    const originName = nameByOp.get(origin.source);
+    const childName = nameByOp.get(origin.target);
+    const originHasReadableName = Boolean(originName) && originName !== origin.source.slice(0, 8);
+    const childHasFallbackName = !childName || childName === origin.target.slice(0, 8);
+    if (originHasReadableName && childHasFallbackName) {
+      nameByOp.set(origin.target, `${originName} escalation retry`);
+    }
+  }
+
   const nodes: OperationNode[] = order.map((opId) => ({
     opId,
     name: nameByOp.get(opId) ?? "",
@@ -323,12 +374,17 @@ export function buildOperationGraph(events: SignalEvent[]): OperationGraphState 
     eventCount: (kindsByOp.get(opId) ?? []).length,
   }));
 
-  const edges = transitiveReduce(
-    Array.from(edgeSet).map((key) => {
-      const [source, target] = key.split("→");
-      return { source: source!, target: target! };
-    }),
-  );
+  // Continuations are annotative provenance, so they neither participate in
+  // dependency reachability nor get removed as transitively redundant.
+  const edges: OperationEdge[] = [
+    ...transitiveReduce(
+      Array.from(edgeSet).map((key) => {
+        const [source, target] = key.split("→");
+        return { source: source!, target: target! };
+      }),
+    ),
+    ...continuationEdges,
+  ];
 
   return { nodes, edges };
 }

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -1178,6 +1178,9 @@ class ReactiveExecutor(DependencyAwareExecutor):
             # node it retries (e.g. mirroring a CLI engine's transcript) — cheaper to
             # carry now than to re-derive `name` from a stale emitter reference later.
             child.metadata["escalated_from_name"] = name
+            # Lifecycle signals prefer reference_id over the operation UUID,
+            # so the retry is readable before its branch has been assigned.
+            child.metadata["reference_id"] = f"{name} escalation retry"
             if self._accept_node(child, emitter_id=emitter_id, independent=True):
                 self._escalated_ids.add(emitter_id)
         elif route == "notify":

--- a/lionagi/studio/operator/run_progress.py
+++ b/lionagi/studio/operator/run_progress.py
@@ -370,7 +370,7 @@ async def _dag_progress(session_id: str, graph: dict[str, Any]) -> dict[str, Any
     ]
     lanes = await _node_lanes_by_name(session_id)
 
-    completed = running = failed = pending = unknown = 0
+    completed = running = failed = pending = unknown = escalated = 0
     node_out: list[dict[str, Any]] = []
     for node in nodes:
         node_id = node["id"]
@@ -388,6 +388,13 @@ async def _dag_progress(session_id: str, graph: dict[str, Any]) -> dict[str, Any
                 failed += 1
             else:
                 pending += 1
+            # Counted alongside the buckets rather than inside them: an
+            # escalation folds into pending for the sum, but a caller reading
+            # only the scalars cannot otherwise tell a node that is queued
+            # from one that has stopped and is waiting on a human decision,
+            # and those ask for opposite responses.
+            if lane == "escalated":
+                escalated += 1
         node_out.append(
             {
                 "id": node_id,
@@ -407,6 +414,10 @@ async def _dag_progress(session_id: str, graph: dict[str, Any]) -> dict[str, Any
         # scalars must sum to "total", the per-node list stays honest.
         "pending": pending + unknown,
         "unknownCount": unknown,
+        # Always present, including as zero. A count that only appears when
+        # non-zero is the field callers never wire up, because every run they
+        # develop against lacks it.
+        "escalatedCount": escalated,
         "nodes": node_out,
     }
 

--- a/lionagi/studio/operator/run_progress.py
+++ b/lionagi/studio/operator/run_progress.py
@@ -310,7 +310,10 @@ _NODE_STATE_BUCKET = {
     "paused": "running",
     "succeeded": "completed",
     "failed": "failed",
-    "escalated": "failed",
+    # The scalar API has four buckets that must sum to total. Keep the
+    # per-node "escalated" outcome distinct while its aggregate waits for
+    # follow-up in pending rather than inflating failure.
+    "escalated": "pending",
 }
 # Matches services.signals.get_signals_after's own default bound — this is
 # not a new cap invented for this tool.

--- a/tests/apps_studio_server/test_operator_run_progress.py
+++ b/tests/apps_studio_server/test_operator_run_progress.py
@@ -572,6 +572,111 @@ async def test_run_progress_dag_keeps_escalated_distinct_from_failed(db_path):
     assert by_id["broken"]["status"] == "failed"
 
 
+async def test_run_progress_escalated_count_separates_the_two_kinds_of_pending(db_path):
+    """The scalar buckets must sum to total, so an escalation folds into
+    pending — but a caller reading only the scalars still has to tell a node
+    that is merely waiting to start from one that has stopped and is asking
+    for a decision. The graph here makes those two different numbers: one
+    escalated node and one node with no lifecycle signal at all both land in
+    pending, and escalatedCount must name only the first."""
+    from lionagi.studio.operator.run_progress import run_progress
+
+    sid = str(uuid.uuid4())
+    node_metadata = {
+        "early_graph": {
+            "nodes": [
+                {"id": "needs-help", "label": "needs-help"},
+                {"id": "broken", "label": "broken"},
+                {"id": "waiting", "label": "waiting"},
+            ],
+            "edges": [],
+        }
+    }
+    async with StateDB(db_path) as db:
+        prog_id = f"{sid}-prog"
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": prog_id,
+                "name": "escalation-count-run",
+                "status": "running",
+                "started_at": 1000.0,
+                "node_metadata": node_metadata,
+                "invocation_kind": "agent",
+                "source_kind": "live",
+                "updated_at": time.time(),
+            }
+        )
+        await db.insert_session_signal(
+            session_id=sid,
+            kind="NodeEscalated",
+            op_id="op-needs-help",
+            ts=1001.0,
+            payload={"name": "needs-help", "route": "higher_tier"},
+        )
+        await db.insert_session_signal(
+            session_id=sid,
+            kind="NodeFailed",
+            op_id="op-broken",
+            ts=1002.0,
+            payload={"name": "broken"},
+        )
+        # "waiting" deliberately gets no signal, so it reaches pending by the
+        # other route and the two counts cannot be the same number.
+
+    dag = (await run_progress({"run": sid}))["dagProgress"]
+
+    assert dag["total"] == 3
+    assert dag["failed"] == 1
+    assert dag["pending"] == 2
+    assert dag["unknownCount"] == 1
+    assert dag["escalatedCount"] == 1
+    # The scalars still account for every node.
+    assert dag["completed"] + dag["running"] + dag["failed"] + dag["pending"] == dag["total"]
+
+
+async def test_run_progress_escalated_count_is_present_as_zero_when_nothing_escalated(
+    db_path,
+):
+    """Present on every response, including as zero. A count that appears only
+    when non-zero is the one callers never wire up, because every run they
+    develop against lacks it."""
+    from lionagi.studio.operator.run_progress import run_progress
+
+    sid = str(uuid.uuid4())
+    node_metadata = {"early_graph": {"nodes": [{"id": "broken", "label": "broken"}], "edges": []}}
+    async with StateDB(db_path) as db:
+        prog_id = f"{sid}-prog"
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": prog_id,
+                "name": "no-escalation-run",
+                "status": "running",
+                "started_at": 1000.0,
+                "node_metadata": node_metadata,
+                "invocation_kind": "agent",
+                "source_kind": "live",
+                "updated_at": time.time(),
+            }
+        )
+        await db.insert_session_signal(
+            session_id=sid,
+            kind="NodeFailed",
+            op_id="op-broken",
+            ts=1001.0,
+            payload={"name": "broken"},
+        )
+
+    dag = (await run_progress({"run": sid}))["dagProgress"]
+
+    assert "escalatedCount" in dag
+    assert dag["escalatedCount"] == 0
+    assert dag["failed"] == 1
+
+
 async def test_run_progress_no_graph_has_null_dag_progress(db_path):
     from lionagi.studio.operator.run_progress import run_progress
 

--- a/tests/apps_studio_server/test_operator_run_progress.py
+++ b/tests/apps_studio_server/test_operator_run_progress.py
@@ -500,6 +500,78 @@ async def test_run_progress_dag_progress_derives_from_graph_not_branches(db_path
     assert by_id["review"]["status"] == "unknown"
 
 
+async def test_run_progress_dag_keeps_escalated_distinct_from_failed(db_path):
+    """A hard escalation is pending follow-up, not a failed operation; a
+    genuine NodeFailed in the same recorded-state shape remains failed."""
+    from lionagi.studio.operator.run_progress import run_progress
+
+    sid = str(uuid.uuid4())
+    escalated_op_id = "op-needs-help"
+    failed_op_id = "op-broken"
+    node_metadata = {
+        "early_graph": {
+            "nodes": [
+                {"id": "needs-help", "label": "needs-help"},
+                {"id": "broken", "label": "broken"},
+            ],
+            "edges": [],
+        }
+    }
+    async with StateDB(db_path) as db:
+        prog_id = f"{sid}-prog"
+        await db.create_progression(prog_id)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": prog_id,
+                "name": "escalation-run",
+                "status": "running",
+                "started_at": 1000.0,
+                "node_metadata": node_metadata,
+                "invocation_kind": "agent",
+                "source_kind": "live",
+                "updated_at": time.time(),
+            }
+        )
+        await db.insert_session_signal(
+            session_id=sid,
+            kind="NodeEscalated",
+            op_id=escalated_op_id,
+            ts=1001.0,
+            payload={"name": "needs-help", "route": "higher_tier"},
+        )
+        await db.insert_session_signal(
+            session_id=sid,
+            kind="NodeSpawned",
+            op_id="op-retry",
+            ts=1002.0,
+            payload={
+                "parent_id": escalated_op_id,
+                "independent": True,
+            },
+        )
+        await db.insert_session_signal(
+            session_id=sid,
+            kind="NodeFailed",
+            op_id=failed_op_id,
+            ts=1003.0,
+            payload={"name": "broken"},
+        )
+
+    result = await run_progress({"run": sid})
+
+    assert result["opsTotal"] == 2
+    assert result["opsFailed"] == 1
+    assert result["opsPending"] == 1
+
+    dag = result["dagProgress"]
+    assert dag["failed"] == 1
+    assert dag["pending"] == 1
+    by_id = {node["id"]: node for node in dag["nodes"]}
+    assert by_id["needs-help"]["status"] == "escalated"
+    assert by_id["broken"]["status"] == "failed"
+
+
 async def test_run_progress_no_graph_has_null_dag_progress(db_path):
     from lionagi.studio.operator.run_progress import run_progress
 

--- a/tests/operations/test_escalation_routing.py
+++ b/tests/operations/test_escalation_routing.py
@@ -22,7 +22,7 @@ from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.operations.node import create_operation
 from lionagi.session.branch import Branch
 from lionagi.session.session import Session
-from lionagi.session.signal import NodeEscalated
+from lionagi.session.signal import NodeEscalated, NodeSpawned
 
 
 def _session(**ops):
@@ -110,16 +110,32 @@ async def test_escalation_child_carries_readable_name_and_parent_pointer():
     the node it retries) needs the label without re-deriving it from a
     possibly-stale reference to the parent op."""
 
+    attempts = 0
+    spawned_signals: list[NodeSpawned] = []
+    progress_events: list[tuple[str, str, str]] = []
+
     async def cheap(**kw):
-        return EscalationRequest(reason="too hard", context={"route": "higher_tier"})
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return EscalationRequest(reason="too hard", context={"route": "higher_tier"})
+        return "completed after retry"
 
     session = _session(cheap=cheap)
+    session.observe(NodeSpawned, handler=lambda signal, _: spawned_signals.append(signal))
 
     builder = OperationGraphBuilder()
     parent_id = builder.add_operation("cheap", node_id="cheap")
     graph = builder.get_graph()
 
-    await flow(session, graph, reactive=True)
+    await flow(
+        session,
+        graph,
+        reactive=True,
+        on_progress=lambda op_id, name, status, _elapsed: progress_events.append(
+            (op_id, name, status)
+        ),
+    )
 
     child = next(
         n
@@ -127,6 +143,11 @@ async def test_escalation_child_carries_readable_name_and_parent_pointer():
         if isinstance(n, Operation) and n.metadata.get("escalated_from") == str(parent_id)
     )
     assert child.metadata["escalated_from_name"] == "cheap"
+    assert child.metadata["reference_id"] == "cheap escalation retry"
+    assert (str(child.id), "cheap escalation retry", "queued") in progress_events
+    assert len(spawned_signals) == 1
+    assert spawned_signals[0].parent_id == child.metadata["escalated_from"] == str(parent_id)
+    assert spawned_signals[0].independent is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An escalated node was rendered and counted as a failure across the app, and the
retry it spawned was drawn with no name and no edge back to the node it came
from. On the execution graph that reads as a failed run plus an unrelated
orphan, when it is actually one operation that stopped and asked for a decision.

## What changes

**Escalation stops reading as failure.** Four sites conflated them: the
Operator's node-state buckets mapped `escalated` to `failed`, and the step node,
the run detail badge, and the operation graph section all used the error tone.
They now use the warning tone already carried by `awaiting_approval` and
`paused`, which is what an escalation is: attention needed, not a loss. The
summary strip gains its own `escalated` figure so the `Failed` count stops
absorbing it.

**The retry becomes findable.** The escalation child is created with a name
derived from the node it came from, so it draws as that role's escalation retry
rather than a bare hex prefix. The spawn signal carrying the parent link now
reaches the graph builder, which previously dropped it, and the link renders as
a continuation rather than a dependency: the emitter has already finished, so a
normal edge would assert the retry waits on it. Continuations are excluded from
layering so an annotative edge cannot reorder the graph.

**Run progress reports escalations as their own count.** The scalar buckets must
sum to the total, so an escalation folds into `pending` rather than inflating
`failed`. That left anything reading only the scalars unable to distinguish a
node that is queued from one that has stopped and is waiting on a human
decision, which call for opposite responses. `escalatedCount` is now reported
beside `unknownCount`, present on every response including as zero, and each
node keeps its own status.

Soft (`notify`) escalations are untouched; they were already handled correctly
and are the precedent this follows.

## Verification

Every status change is tested with both arms in the same test: an escalation
must not read as a failure, and a genuine failure must still read as one. A
change that merely stopped flagging things fails all of them.

The graph work is verified against a real recorded signal stream rather than a
fixture: replaying it yields both retry children named, each carrying exactly
one incoming continuation from its recorded origin.

Frontend 1566 tests across 69 files, plus tsc, eslint and prettier. Backend
suites for the touched paths, plus ruff check and format.