### PR TITLE
fix(react): give the first analysis round the branch's tools

### DIFF
--- a/lionagi/operations/ReAct/ReAct.py
+++ b/lionagi/operations/ReAct/ReAct.py
@@ -82,7 +82,11 @@ async def ReAct(  # noqa: N802  # public name is the ReAct acronym
     )
 
     action_param = None
-    if tools is not None or tool_schemas is not None:
+    # A branch with registered tools is given them on the first analysis too, not
+    # only on extension rounds. The first round is where the model answers
+    # `extension_needed`, so withholding schemas there lets it conclude it has no
+    # tools, answer False, and end the loop before the round that would show it any.
+    if tools is not None or tool_schemas is not None or branch.acts.registry:
         from ..act.act import _get_default_call_params
 
         action_param = ActionParam(
@@ -185,7 +189,11 @@ def prepare_react_kw(  # noqa: N802
     )
 
     action_param = None
-    if tools is not None or tool_schemas is not None:
+    # A branch with registered tools is given them on the first analysis too, not
+    # only on extension rounds. The first round is where the model answers
+    # `extension_needed`, so withholding schemas there lets it conclude it has no
+    # tools, answer False, and end the loop before the round that would show it any.
+    if tools is not None or tool_schemas is not None or branch.acts.registry:
         from ..act.act import _get_default_call_params
 
         action_param = ActionParam(

--- a/tests/operations/test_react_regressions.py
+++ b/tests/operations/test_react_regressions.py
@@ -223,3 +223,79 @@ def test_react_analysis_optional_analysis_field():
     # Explicit analysis still works.
     b = ReActAnalysis.model_validate({"analysis": "reasoning here"})
     assert b.analysis == "reasoning here"
+
+
+def _react_kw(branch, **overrides):
+    """Build the first-round kwargs the way ReAct does, with no tools named by the caller."""
+    from lionagi.operations.ReAct.ReAct import prepare_react_kw
+
+    return prepare_react_kw(branch, {"instruction": "do the thing"}, **overrides)
+
+
+def test_first_round_gets_tools_when_the_branch_has_them():
+    """Regression: the first analysis round used to be sent with no tool schemas.
+
+    Schemas were attached only from the first extension round onward, but the first
+    round is where the model answers `extension_needed`. A model that looked for its
+    tools, found none, and answered False ended the loop before the round that would
+    have shown it any -- so whether it could act depended on it optimistically
+    assuming capabilities it had not been shown.
+    """
+    branch = Branch()
+    branch.acts.register_tool(multiply)
+
+    kw = _react_kw(branch)
+
+    assert kw["action_param"] is not None, (
+        "first round must carry an action param when the branch has tools; "
+        "operate resolves the schemas from it"
+    )
+    assert kw["action_param"].tools is True
+
+
+def test_first_round_has_no_action_param_when_the_branch_has_no_tools():
+    """Control: the condition must not be vacuously true.
+
+    Without this, the test above passes for a branch with no tools at all and so
+    says nothing about whether registered tools are what triggered it.
+    """
+    branch = Branch()
+    assert not branch.acts.registry
+
+    kw = _react_kw(branch)
+
+    assert kw["action_param"] is None
+
+
+def test_caller_supplied_tools_still_win():
+    """A caller naming tools explicitly keeps the behaviour it always had."""
+    branch = Branch()
+    branch.acts.register_tool(multiply)
+
+    kw = _react_kw(branch, tools=["multiply"])
+
+    assert kw["action_param"] is not None
+    assert kw["action_param"].tools == ["multiply"]
+
+
+@pytest.mark.asyncio
+async def test_first_operate_call_receives_the_action_param():
+    """The fix has to reach the actual first turn, not just the kwargs builder."""
+    from lionagi.operations.ReAct.utils import Analysis
+
+    branch = Branch()
+    branch.acts.register_tool(multiply)
+
+    with patch("lionagi.operations.operate.operate.operate") as mock_operate:
+        mock_operate.side_effect = [
+            ReActAnalysis(analysis="no extension needed", extension_needed=False),
+            Analysis(answer="done"),
+        ]
+        await branch.ReAct(instruct={"instruction": "What is 5 times 3?"}, max_extensions=1)
+
+    assert mock_operate.call_count >= 1
+    first_call = mock_operate.call_args_list[0]
+    action_param = first_call.kwargs.get("action_param")
+    if action_param is None and len(first_call.args) > 3:
+        action_param = first_call.args[3]
+    assert action_param is not None, "the first turn was dispatched with no action param"


### PR DESCRIPTION
Closes #2919.

## What was wrong

`ReAct` attached tool schemas to a turn only when the caller named tools explicitly, or from the first extension round onward. The first round is also where the model answers `extension_needed`. So on a branch with registered tools, the first turn could show the model none of them, and a model that concluded it had no tools available answered `extension_needed: false` — ending the loop before the round that would have supplied them.

Whether the agent could act therefore depended on it optimistically assuming capabilities it had not been shown. A model that answered the question it was actually asked did worse than one that guessed. The run still returned an answer, with nothing recording that the tools were never sent.

## Measured

Counting registered tool names in the prompt actually sent, per round, before this change:

```
rnd    chars   editor   bash
  0    14089        0      0     <- first analysis: no tools
  1    33386        4      2     <- first extension round: tools appear
  3    35849        6      2
  9    42090        6     10
```

Same setup, two phrasings of the task: one answered `extension_needed: true`, ran 13 rounds and did the work; the other looked for its tools, found none, answered `false`, ran 2 rounds and was never offered any. The second run's own analysis said the response format gave it no way to emit a tool call.

After the change, on an agent built from the coding preset, the first `chat()` call receives all 9 registered schemas instead of zero.

## The change

Build the action param when the branch has tools registered, at both round-zero call sites. `operate` already derives the schemas from that param, so nothing else needs to change. Callers naming tools explicitly are unaffected, and a branch with no registered tools still gets no action param.

## Tests

Four cases in `tests/operations/test_react_regressions.py`: the first round carries an action param when the branch has tools; it does not when the branch has none; an explicit caller-supplied tool list still wins; and the first `operate` call actually receives the param.

Mutation-checked rather than assumed: no-oping the change reddens exactly the first and fourth, while the no-tools control and the caller-supplied case stay green, so the tests discriminate on this change and not merely on the branch having tools.

`tests/operations` and `tests/orchestration`: 878 passed, 4 skipped.

End to end, an agent on an API-provider model now completes a task that requires calling a registered tool on its first round, and the tool's side effect was confirmed at the destination rather than read back from the model.
