### PR TITLE
fix: runtime signals measure what they claim (stall, spawn routing, context errors)

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import psutil
+
 from lionagi._errors import EmptyOutgoingContentError, LionError
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.casts.emission import SpawnRequest, TaskAssignment
@@ -61,6 +63,55 @@ from ._orchestration import (
 )
 
 logger = logging.getLogger(__name__)
+
+_DescendantCpuSample = tuple[dict[int, float], bool]
+
+
+def _sample_descendant_cpu(pid: int) -> _DescendantCpuSample:
+    try:
+        descendants = psutil.Process(pid).children(recursive=True)
+    except (psutil.Error, OSError):
+        return {}, False
+
+    totals: dict[int, float] = {}
+    for descendant in descendants:
+        try:
+            cpu_times = descendant.cpu_times()
+        except (psutil.Error, OSError):
+            return totals, False
+        totals[descendant.pid] = cpu_times.user + cpu_times.system
+    return totals, True
+
+
+def _heartbeat_warning(
+    segment: dict,
+    *,
+    now: float,
+    max_idle_seconds: float,
+    previous: _DescendantCpuSample | None,
+    current: _DescendantCpuSample,
+) -> str | None:
+    elapsed = now - segment.get("started_at", now)
+    if elapsed <= max_idle_seconds or previous is None:
+        return None
+
+    previous_cpu, previous_complete = previous
+    current_cpu, current_complete = current
+    if not previous_complete or not current_complete:
+        return None
+    if not previous_cpu and not current_cpu:
+        return (
+            f"  ⚠ NO DESCENDANTS: {segment['branch_name']} running {elapsed:.0f}s "
+            "with no active descendants"
+        )
+    if not current_cpu or current_cpu.keys() != previous_cpu.keys():
+        return None
+    if all(current_cpu[pid] == previous_cpu[pid] for pid in current_cpu):
+        return (
+            f"  ⚠ IDLE STALL: {segment['branch_name']} running {elapsed:.0f}s; "
+            "descendants accumulated no CPU time since the previous heartbeat"
+        )
+    return None
 
 
 class FlowPlanError(LionError):
@@ -1032,6 +1083,7 @@ async def _execute_dag(
 
     heartbeat_interval = 60
     max_idle_seconds = 600
+    heartbeat_pid = os.getpid()
 
     def _persist_segments():
         ctx = getattr(env, "_live_persist", None)
@@ -1186,20 +1238,27 @@ async def _execute_dag(
 
     # ADR-0034 §4: run_dag drives the session bus; observers above consume the signals.
     async def _heartbeat_loop() -> None:
+        previous_cpu_sample: _DescendantCpuSample | None = None
         while True:
             await _asyncio.sleep(heartbeat_interval)
             _now = time.time()
+            current_cpu_sample = _sample_descendant_cpu(heartbeat_pid)
             for _seg in _op_segments:
                 if _seg["status"] != "running":
                     continue
                 _elapsed = _now - _seg.get("started_at", _now)
                 _seg["last_heartbeat_at"] = _now
                 progress(f"  · {_seg['branch_name']} heartbeat {_elapsed / 60:.0f}m")
-                if _elapsed > max_idle_seconds:
-                    progress(
-                        f"  ⚠ IDLE STALL: {_seg['branch_name']} running {_elapsed:.0f}s "
-                        "with no completion — possible hung child process"
-                    )
+                warning = _heartbeat_warning(
+                    _seg,
+                    now=_now,
+                    max_idle_seconds=max_idle_seconds,
+                    previous=previous_cpu_sample,
+                    current=current_cpu_sample,
+                )
+                if warning is not None:
+                    progress(warning)
+            previous_cpu_sample = current_cpu_sample
 
     # ADR-0069 D1: control poller, the only consumer of session_controls rows.
     # _executor_ref is populated synchronously by DependencyAwareExecutor's

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -111,19 +111,18 @@ def _heartbeat_warning(
         )
 
     surviving_pids = previous_cpu.keys() & current_cpu.keys()
-    if not surviving_pids:
-        return (
-            f"  ⚠ NO CPU OVERLAP: {segment['branch_name']} running {elapsed:.0f}s; "
-            "no descendants survived from the previous heartbeat"
-        )
-
     deltas = [current_cpu[pid] - previous_cpu[pid] for pid in surviving_pids]
-    if any(not math.isfinite(delta) or delta < 0 for delta in deltas):
+    new_pids = current_cpu.keys() - previous_cpu.keys()
+    # A new PID has no baseline, but its accumulated CPU still proves activity.
+    # Keep the maximum so many helper floor ticks cannot manufacture work.
+    new_totals = [current_cpu[pid] for pid in new_pids]
+    activity = [*deltas, *new_totals]
+    if any(not math.isfinite(value) or value < 0 for value in activity):
         return None
 
-    max_delta = max(deltas)
-    if max_delta > _DESCENDANT_CPU_ACTIVITY_SECONDS or math.isclose(
-        max_delta,
+    max_activity = max(activity)
+    if max_activity > _DESCENDANT_CPU_ACTIVITY_SECONDS or math.isclose(
+        max_activity,
         _DESCENDANT_CPU_ACTIVITY_SECONDS,
         abs_tol=1e-9,
     ):
@@ -131,7 +130,7 @@ def _heartbeat_warning(
 
     return (
         f"  ⚠ IDLE STALL: {segment['branch_name']} running {elapsed:.0f}s; "
-        "surviving descendants stayed below the 0.10s CPU activity cutoff"
+        "descendants stayed below the 0.10s CPU activity cutoff"
     )
 
 

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -8,6 +8,7 @@ import asyncio as _asyncio
 import contextlib
 import json
 import logging
+import math
 import os
 import sys
 import time
@@ -66,6 +67,10 @@ logger = logging.getLogger(__name__)
 
 _DescendantCpuSample = tuple[dict[int, float], bool]
 
+# CPU totals commonly advance in 0.01s quanta. A 0.10s cutoff is more than
+# three times the observed 0.01-0.03s helper jitter at the 60s heartbeat cadence.
+_DESCENDANT_CPU_ACTIVITY_SECONDS = 0.10
+
 
 def _sample_descendant_cpu(pid: int) -> _DescendantCpuSample:
     try:
@@ -99,19 +104,35 @@ def _heartbeat_warning(
     current_cpu, current_complete = current
     if not previous_complete or not current_complete:
         return None
-    if not previous_cpu and not current_cpu:
+    if not current_cpu:
         return (
             f"  ⚠ NO DESCENDANTS: {segment['branch_name']} running {elapsed:.0f}s "
             "with no active descendants"
         )
-    if not current_cpu or current_cpu.keys() != previous_cpu.keys():
-        return None
-    if all(current_cpu[pid] == previous_cpu[pid] for pid in current_cpu):
+
+    surviving_pids = previous_cpu.keys() & current_cpu.keys()
+    if not surviving_pids:
         return (
-            f"  ⚠ IDLE STALL: {segment['branch_name']} running {elapsed:.0f}s; "
-            "descendants accumulated no CPU time since the previous heartbeat"
+            f"  ⚠ NO CPU OVERLAP: {segment['branch_name']} running {elapsed:.0f}s; "
+            "no descendants survived from the previous heartbeat"
         )
-    return None
+
+    deltas = [current_cpu[pid] - previous_cpu[pid] for pid in surviving_pids]
+    if any(not math.isfinite(delta) or delta < 0 for delta in deltas):
+        return None
+
+    max_delta = max(deltas)
+    if max_delta > _DESCENDANT_CPU_ACTIVITY_SECONDS or math.isclose(
+        max_delta,
+        _DESCENDANT_CPU_ACTIVITY_SECONDS,
+        abs_tol=1e-9,
+    ):
+        return None
+
+    return (
+        f"  ⚠ IDLE STALL: {segment['branch_name']} running {elapsed:.0f}s; "
+        "surviving descendants stayed below the 0.10s CPU activity cutoff"
+    )
 
 
 def _surface_dropped_spawns(env: OrchestrationEnv, dropped_spawns: list[dict]) -> None:

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -114,6 +114,21 @@ def _heartbeat_warning(
     return None
 
 
+def _surface_dropped_spawns(env: OrchestrationEnv, dropped_spawns: list[dict]) -> None:
+    rejected = [item for item in dropped_spawns if item.get("reason") == "builder_error"]
+    if not rejected:
+        return
+
+    evidence = []
+    for item in rejected:
+        assignee = item.get("assignee") or "unassigned"
+        error = item.get("error") or "spawn routing failed"
+        progress(f"  ⚠ SPAWN REJECTED: {assignee} — {error}")
+        evidence.append({"kind": "unroutable_spawn", "id": assignee, "label": error})
+    prior = getattr(env, "_failed_operation_evidence", None) or []
+    env._failed_operation_evidence = [*prior, *evidence]
+
+
 class FlowPlanError(LionError):
     """Orchestrator failed to produce a usable plan."""
 
@@ -1483,7 +1498,7 @@ async def _execute_dag(
     def _decorate_spawn_instruction(req: SpawnRequest, spawn_id: str) -> str:
         """Give a reactively spawned node the same artifact-dir + REQUIRED
         text a planned leg gets, mirroring the block _build_dag composes."""
-        role_defaults = dag_state.role_artifact_defaults.get(req.assignee) if req.assignee else None
+        role_defaults = _artifact_defaults_for_assignee(req.assignee)
         leg_expected = _leg_artifact_entries(spawn_id, role_defaults)
         note = _artifact_directive(env.run, spawn_id, leg_expected)
         # A node whose instruction has been composed is a worker this run
@@ -1536,6 +1551,7 @@ async def _execute_dag(
                 role_node_builder(
                     role_base,
                     decorate_instruction=_decorate_spawn_instruction,
+                    role_aliases=role_by_worker,
                     start=_spawn_seq_start,
                 )
                 if reactive
@@ -1685,6 +1701,7 @@ async def _execute_dag(
                         raise
     t_exec_elapsed = time.monotonic() - t_exec
 
+    _surface_dropped_spawns(env, list(dag_result.get("dropped_spawns") or []))
     op_results = dag_result.get("operation_results", {})
     # Includes restored spawns from a prior checkpoint generation, not just
     # this generation's — else a resume with zero NEW spawns would report

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -10,6 +10,7 @@ import json
 import logging
 import math
 import os
+import statistics
 import sys
 import time
 from dataclasses import dataclass, field
@@ -67,9 +68,11 @@ logger = logging.getLogger(__name__)
 
 _DescendantCpuSample = tuple[dict[int, float], bool]
 
-# CPU totals commonly advance in 0.01s quanta. A 0.10s cutoff is more than
-# three times the observed 0.01-0.03s helper jitter at the 60s heartbeat cadence.
-_DESCENDANT_CPU_ACTIVITY_SECONDS = 0.10
+# A working descendant must clear both the peer activity floor and a sublinear
+# CPU-quantum guard, without assuming healthy totals grow linearly with the window.
+_DESCENDANT_CPU_ACTIVITY_RATIO = 4.0
+_DESCENDANT_CPU_FALLBACK_SECONDS = 0.10
+_DESCENDANT_CPU_FALLBACK_INTERVAL_SECONDS = 60.0
 
 
 def _sample_descendant_cpu(pid: int) -> _DescendantCpuSample:
@@ -93,6 +96,7 @@ def _heartbeat_warning(
     *,
     now: float,
     max_idle_seconds: float,
+    sample_interval_seconds: float,
     previous: _DescendantCpuSample | None,
     current: _DescendantCpuSample,
 ) -> str | None:
@@ -119,18 +123,41 @@ def _heartbeat_warning(
     activity = [*deltas, *new_totals]
     if any(not math.isfinite(value) or value < 0 for value in activity):
         return None
+    if not math.isfinite(sample_interval_seconds) or sample_interval_seconds <= 0:
+        return None
 
-    max_activity = max(activity)
-    if max_activity > _DESCENDANT_CPU_ACTIVITY_SECONDS or math.isclose(
-        max_activity,
-        _DESCENDANT_CPU_ACTIVITY_SECONDS,
+    activity_rates = [value / sample_interval_seconds for value in activity]
+    max_activity_rate = max(activity_rates)
+    peer_rates = activity_rates.copy()
+    peer_rates.remove(max_activity_rate)
+    activity_floor = statistics.median(peer_rates) if peer_rates else 0.0
+    ratio_activity_cutoff = activity_floor * _DESCENDANT_CPU_ACTIVITY_RATIO
+    fallback_activity_seconds = _DESCENDANT_CPU_FALLBACK_SECONDS * math.sqrt(
+        sample_interval_seconds / _DESCENDANT_CPU_FALLBACK_INTERVAL_SECONDS
+    )
+    fallback_activity_cutoff = fallback_activity_seconds / sample_interval_seconds
+    activity_cutoff = max(ratio_activity_cutoff, fallback_activity_cutoff)
+    if max_activity_rate > activity_cutoff or math.isclose(
+        max_activity_rate,
+        activity_cutoff,
         abs_tol=1e-9,
     ):
         return None
 
+    if ratio_activity_cutoff >= fallback_activity_cutoff:
+        warning_detail = (
+            "no positive descendant CPU rate reached "
+            f"{_DESCENDANT_CPU_ACTIVITY_RATIO:g}x the median peer rate"
+        )
+    else:
+        warning_detail = (
+            "descendant CPU activity stayed below the "
+            f"{fallback_activity_seconds:.3g}s fallback cutoff"
+        )
+
     return (
         f"  ⚠ IDLE STALL: {segment['branch_name']} running {elapsed:.0f}s; "
-        "descendants stayed below the 0.10s CPU activity cutoff"
+        f"{warning_detail} during the {sample_interval_seconds:g}s sample"
     )
 
 
@@ -1288,6 +1315,7 @@ async def _execute_dag(
                     _seg,
                     now=_now,
                     max_idle_seconds=max_idle_seconds,
+                    sample_interval_seconds=heartbeat_interval,
                     previous=previous_cpu_sample,
                     current=current_cpu_sample,
                 )

--- a/lionagi/orchestration/patterns.py
+++ b/lionagi/orchestration/patterns.py
@@ -105,10 +105,14 @@ def role_node_builder(
     roles: dict[str, Branch],
     *,
     decorate_instruction: Callable[[SpawnRequest, str], str] | None = None,
+    role_aliases: dict[str, str] | None = None,
     start: int = 1,
 ):
     """Return a node_builder closure that routes SpawnRequests to role branches.
-    *decorate_instruction* customizes child instruction text (CLI artifact injection); *start* seeds spawn-id past prior-generation ordinals to avoid collisions on resume."""
+    *role_aliases* maps advertised names to role keys while exact role keys win.
+    *decorate_instruction* customizes child instruction text (CLI artifact injection);
+    *start* seeds spawn-id past prior-generation ordinals to avoid collisions on resume.
+    """
     # Closure-scoped monotonic sequence: must be allocated at construction
     # time, not at completion, or spawn_id is not a stable correlation key.
     _next_spawn_seq = itertools.count(start)
@@ -127,8 +131,12 @@ def role_node_builder(
             op = "operate"
 
         target = None
+        resolved_assignee = req.assignee
         if req.assignee:
             target = roles.get(req.assignee)
+            if target is None and role_aliases is not None:
+                resolved_assignee = role_aliases.get(req.assignee, req.assignee)
+                target = roles.get(resolved_assignee)
             if target is None:
                 raise ValueError(
                     f"SpawnRequest assignee {req.assignee!r} is not a "
@@ -140,7 +148,12 @@ def role_node_builder(
         spawn_id = f"spawn-{next(_next_spawn_seq)}"
         instruction = req.instruction
         if decorate_instruction is not None:
-            instruction = decorate_instruction(req, spawn_id)
+            routed_request = (
+                req
+                if resolved_assignee == req.assignee
+                else req.model_copy(update={"assignee": resolved_assignee})
+            )
+            instruction = decorate_instruction(routed_request, spawn_id)
 
         node = create_operation(
             op,
@@ -152,7 +165,7 @@ def role_node_builder(
         node.metadata["reference_id"] = spawn_id
         if target is not None:
             node.branch_id = target.id
-            node.metadata["assignee"] = req.assignee
+            node.metadata["assignee"] = resolved_assignee
         return node
 
     return build

--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -159,7 +159,11 @@ _AUTH_PATTERNS: list[re.Pattern[str]] = [
 
 _CONTEXT_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"context[\s._-]?(window|length)[\s._-]?(exceeded|too\s+long)", re.IGNORECASE),
-    re.compile(r"prompt\s+is\s+too\s+long", re.IGNORECASE),
+    re.compile(
+        r"prompt\s+is\s+too\s+long[\s\S]*?"
+        r"request\s+is\s+~?[\d,]+\s+tokens?\s+\(limit\s+~?[\d,]+\)",
+        re.IGNORECASE,
+    ),
     # "Codex ran out of room in the model's context window." never uses the
     # exceeded/too-long wording the pattern above expects.
     re.compile(r"ran\s+out\s+of\s+room.*context\s+window", re.IGNORECASE),

--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -159,6 +159,7 @@ _AUTH_PATTERNS: list[re.Pattern[str]] = [
 
 _CONTEXT_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"context[\s._-]?(window|length)[\s._-]?(exceeded|too\s+long)", re.IGNORECASE),
+    re.compile(r"prompt\s+is\s+too\s+long", re.IGNORECASE),
     # "Codex ran out of room in the model's context window." never uses the
     # exceeded/too-long wording the pattern above expects.
     re.compile(r"ran\s+out\s+of\s+room.*context\s+window", re.IGNORECASE),

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -3803,6 +3803,80 @@ async def test_execute_dag_dropped_spawn_does_not_trip_lost_operation_evidence(
     await stop_live_persist(env, status="completed")
 
 
+async def test_unknown_spawn_assignee_reaches_terminal_failure(
+    temp_db_path: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import json as _json
+
+    from lionagi.casts.emission import SpawnRequest, TaskAssignment
+    from lionagi.cli.orchestrate import flow as flow_mod
+    from lionagi.cli.orchestrate.flow import _DagState, _execute_dag, _PlanResult
+    from lionagi.operations.builder import OperationGraphBuilder
+
+    branch = Branch(name="architect")
+    env = _minimal_env(branch)
+    env.run.agent_artifact_dir.side_effect = lambda agent_id: tmp_path / agent_id
+    env.builder = OperationGraphBuilder()
+    node_id = env.builder.add_operation("spawner", depends_on=[])
+
+    async def spawner(**_kwargs):
+        return SpawnRequest(instruction="missing work", assignee="ghost", independent=True)
+
+    env.session.register_operation("spawner", spawner)
+    await start_live_persist(
+        env,
+        invocation_kind="flow",
+        artifacts_path=str(tmp_path / "artifacts"),
+    )
+    ctx = env._live_persist
+    assert ctx is not None
+
+    plan_result = _PlanResult(
+        assignments=[TaskAssignment(task="spawn missing work", assignee="architect")],
+        agent_ids=["architect"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = _DagState(
+        node_ids=[node_id],
+        known_nodes={node_id},
+        deps_by_node={node_id: []},
+        reactive=True,
+        spawn_roles=None,
+        role_base={"architect": branch},
+        worker_models=["test/model"],
+    )
+    emitted: list[str] = []
+    monkeypatch.setattr(flow_mod, "progress", emitted.append)
+    expected_error = "SpawnRequest assignee 'ghost' is not a recognized role (known: ['architect'])"
+    expected_evidence = [{"kind": "unroutable_spawn", "id": "ghost", "label": expected_error}]
+
+    try:
+        result = await _execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=2)
+        assert result.n_spawned == 0
+        assert env._failed_operation_evidence == expected_evidence
+        assert any(
+            "SPAWN REJECTED" in line and "ghost" in line and expected_error in line
+            for line in emitted
+        )
+    finally:
+        final_status = await stop_live_persist(env, status="completed")
+
+    assert final_status == "failed"
+    async with StateDB() as db:
+        session_row = await db.get_session(ctx["session_id"])
+    assert session_row is not None
+    assert session_row["status"] == "failed"
+    assert session_row["status_reason_code"] == "run.failed.exception"
+    evidence_refs = session_row["status_evidence_refs"]
+    if isinstance(evidence_refs, str):
+        evidence_refs = _json.loads(evidence_refs)
+    assert evidence_refs == expected_evidence
+
+
 async def test_execute_dag_cancelled_spawn_records_lost_operation_evidence(
     temp_db_path: Path,
     tmp_path: Path,

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -93,45 +93,17 @@ async def test_heartbeat_skips_completed_ops():
     assert emitted == []
 
 
-@pytest.mark.asyncio
-async def test_heartbeat_emits_idle_stall_warning_after_threshold():
-    """When elapsed > max_idle_seconds, heartbeat must emit a STALL warning."""
-    warnings = []
+def test_elapsed_threshold_requires_descendant_activity_signal():
+    now = time.time()
+    warning = flow_mod._heartbeat_warning(
+        _running_segment(now, 601),
+        now=now,
+        max_idle_seconds=600,
+        previous=({41: 8.0}, True),
+        current=({41: 8.2}, True),
+    )
 
-    max_idle = 5  # tiny threshold for testing
-    _op_segments = [
-        {
-            "op_id": "o1",
-            "branch_name": "implementer",
-            "status": "running",
-            "started_at": time.time() - (max_idle + 1),  # already past threshold
-            "ended_at": None,
-            "last_heartbeat_at": None,
-        }
-    ]
-
-    async def _heartbeat_loop(interval: float = 0.05) -> None:
-        while True:
-            await asyncio.sleep(interval)
-            _now = time.time()
-            for seg in _op_segments:
-                if seg["status"] != "running":
-                    continue
-                elapsed = _now - seg.get("started_at", _now)
-                seg["last_heartbeat_at"] = _now
-                if elapsed > max_idle:
-                    warnings.append(f"IDLE STALL: {seg['branch_name']}")
-
-    task = asyncio.ensure_future(_heartbeat_loop(interval=0.05))
-    await asyncio.sleep(0.12)
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
-
-    assert any("IDLE STALL" in w for w in warnings)
-    assert any("implementer" in w for w in warnings)
+    assert warning is None
 
 
 def _running_segment(now: float, age: float) -> dict:
@@ -200,7 +172,7 @@ def test_external_io_without_output_writes_suppresses_warning(monkeypatch, tmp_p
     with socket.create_connection(listener.getsockname(), timeout=5) as client:
         assert connected.wait(timeout=5), "loopback client did not connect"
         previous = flow_mod._sample_descendant_cpu(7)
-        payload = b"x" * 65536
+        payload = b"x" * 200000
         client.sendall(payload)
         received = bytearray()
         while len(received) < len(payload):
@@ -263,10 +235,9 @@ def test_incomplete_descendant_sample_suppresses_warning():
     ("previous", "current"),
     [
         (None, ({41: 8.0}, True)),
-        (({41: 8.0}, True), ({42: 1.0}, True)),
         (({41: 8.0}, True), ({41: 7.9}, True)),
     ],
-    ids=["first-sample", "descendant-set-change", "counter-regression"],
+    ids=["first-sample", "counter-regression"],
 )
 def test_unproven_descendant_delta_suppresses_warning(previous, current):
     now = time.time()
@@ -278,6 +249,21 @@ def test_unproven_descendant_delta_suppresses_warning(previous, current):
         current=current,
     )
     assert warning is None
+
+
+def test_nonoverlapping_descendants_emit_distinct_condition():
+    now = time.time()
+    warning = flow_mod._heartbeat_warning(
+        _running_segment(now, 601),
+        now=now,
+        max_idle_seconds=600,
+        previous=({41: 8.0}, True),
+        current=({42: 1.0}, True),
+    )
+
+    assert warning is not None
+    assert "NO CPU OVERLAP" in warning
+    assert "IDLE STALL" not in warning
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -99,6 +99,7 @@ def test_elapsed_threshold_requires_descendant_activity_signal():
         _running_segment(now, 601),
         now=now,
         max_idle_seconds=600,
+        sample_interval_seconds=60,
         previous=({41: 8.0}, True),
         current=({41: 8.2}, True),
     )
@@ -120,6 +121,7 @@ def test_busy_descendants_suppress_idle_warning():
         _running_segment(now, 601),
         now=now,
         max_idle_seconds=600,
+        sample_interval_seconds=60,
         previous=({41: 8.0}, True),
         current=({41: 8.2}, True),
     )
@@ -132,6 +134,7 @@ def test_quiet_descendants_emit_idle_warning():
         _running_segment(now, 601),
         now=now,
         max_idle_seconds=600,
+        sample_interval_seconds=60,
         previous=({41: 8.0}, True),
         current=({41: 8.0}, True),
     )
@@ -189,6 +192,7 @@ def test_external_io_without_output_writes_suppresses_warning(monkeypatch, tmp_p
             _running_segment(now, 601),
             now=now,
             max_idle_seconds=600,
+            sample_interval_seconds=60,
             previous=previous,
             current=current,
         )
@@ -209,6 +213,7 @@ def test_empty_descendant_samples_emit_distinct_warning():
         _running_segment(now, 601),
         now=now,
         max_idle_seconds=600,
+        sample_interval_seconds=60,
         previous=({}, True),
         current=({}, True),
     )
@@ -224,6 +229,7 @@ def test_incomplete_descendant_sample_suppresses_warning():
             _running_segment(now, 601),
             now=now,
             max_idle_seconds=600,
+            sample_interval_seconds=60,
             previous=({41: 8.0}, True),
             current=({}, False),
         )
@@ -245,6 +251,7 @@ def test_unproven_descendant_delta_suppresses_warning(previous, current):
         _running_segment(now, 601),
         now=now,
         max_idle_seconds=600,
+        sample_interval_seconds=60,
         previous=previous,
         current=current,
     )
@@ -257,6 +264,7 @@ def test_busy_new_descendant_suppresses_warning_without_overlap():
         _running_segment(now, 601),
         now=now,
         max_idle_seconds=600,
+        sample_interval_seconds=60,
         previous=({41: 8.0}, True),
         current=({42: 1.0}, True),
     )
@@ -278,6 +286,7 @@ def test_under_threshold_never_emits_activity_warning(previous, current):
         _running_segment(now, 599),
         now=now,
         max_idle_seconds=600,
+        sample_interval_seconds=60,
         previous=previous,
         current=current,
     )
@@ -521,5 +530,8 @@ def test_op_segment_schema_includes_heartbeat_field():
     assert "_heartbeat_loop" in src, "flow.py must define _heartbeat_loop"
     assert "_hb_task" in src, "flow.py must create and cancel _hb_task"
     assert "heartbeat_interval" in src, "flow.py must define heartbeat_interval"
+    assert "sample_interval_seconds=heartbeat_interval" in src, (
+        "the stall predicate must receive the actual heartbeat interval"
+    )
     assert "max_idle_seconds" in src, "flow.py must define max_idle_seconds"
     assert "IDLE STALL" in src, "flow.py must emit an IDLE STALL warning"

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -5,9 +5,14 @@
 from __future__ import annotations
 
 import asyncio
+import socket
+import threading
 import time
+from types import SimpleNamespace
 
 import pytest
+
+from lionagi.cli.orchestrate import flow as flow_mod
 
 # ── Unit tests for the heartbeat loop logic ──────────────────────────────────
 
@@ -127,6 +132,319 @@ async def test_heartbeat_emits_idle_stall_warning_after_threshold():
 
     assert any("IDLE STALL" in w for w in warnings)
     assert any("implementer" in w for w in warnings)
+
+
+def _running_segment(now: float, age: float) -> dict:
+    return {
+        "branch_name": "worker",
+        "status": "running",
+        "started_at": now - age,
+    }
+
+
+def test_busy_descendants_suppress_idle_warning():
+    now = time.time()
+    warning = flow_mod._heartbeat_warning(
+        _running_segment(now, 601),
+        now=now,
+        max_idle_seconds=600,
+        previous=({41: 8.0}, True),
+        current=({41: 8.2}, True),
+    )
+    assert warning is None
+
+
+def test_quiet_descendants_emit_idle_warning():
+    now = time.time()
+    warning = flow_mod._heartbeat_warning(
+        _running_segment(now, 601),
+        now=now,
+        max_idle_seconds=600,
+        previous=({41: 8.0}, True),
+        current=({41: 8.0}, True),
+    )
+    assert warning is not None
+    assert "IDLE STALL" in warning
+
+
+def test_external_io_without_output_writes_suppresses_warning(monkeypatch, tmp_path):
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    connected = threading.Event()
+    server_errors: list[OSError] = []
+    activity = {"cpu": 0.0}
+    tree_walks: list[bool] = []
+
+    def echo_traffic() -> None:
+        try:
+            connection, _address = listener.accept()
+            connected.set()
+            with connection:
+                while data := connection.recv(65536):
+                    activity["cpu"] += len(data) / 1_000_000
+                    connection.sendall(data)
+        except OSError as exc:
+            server_errors.append(exc)
+
+    server_thread = threading.Thread(target=echo_traffic, daemon=True)
+    server_thread.start()
+
+    child = SimpleNamespace(
+        pid=41,
+        cpu_times=lambda: SimpleNamespace(user=activity["cpu"], system=0.0),
+    )
+    root = SimpleNamespace(children=lambda recursive: tree_walks.append(recursive) or [child])
+    monkeypatch.setattr(flow_mod.psutil, "Process", lambda _pid: root)
+
+    with socket.create_connection(listener.getsockname(), timeout=5) as client:
+        assert connected.wait(timeout=5), "loopback client did not connect"
+        previous = flow_mod._sample_descendant_cpu(7)
+        payload = b"x" * 65536
+        client.sendall(payload)
+        received = bytearray()
+        while len(received) < len(payload):
+            received.extend(client.recv(len(payload) - len(received)))
+        assert bytes(received) == payload
+        current = flow_mod._sample_descendant_cpu(7)
+        assert previous[1] and current[1]
+        assert previous[0].keys() == current[0].keys()
+        assert current[0][41] > previous[0][41]
+
+        now = time.time()
+        output_path = tmp_path / "output"
+        warning = flow_mod._heartbeat_warning(
+            _running_segment(now, 601),
+            now=now,
+            max_idle_seconds=600,
+            previous=previous,
+            current=current,
+        )
+        assert warning is None
+        assert not output_path.exists()
+
+    listener.close()
+    server_thread.join(timeout=5)
+
+    assert not server_thread.is_alive()
+    assert server_errors == []
+    assert tree_walks == [True, True]
+
+
+def test_empty_descendant_samples_emit_distinct_warning():
+    now = time.time()
+    warning = flow_mod._heartbeat_warning(
+        _running_segment(now, 601),
+        now=now,
+        max_idle_seconds=600,
+        previous=({}, True),
+        current=({}, True),
+    )
+    assert warning is not None
+    assert "NO DESCENDANTS" in warning
+    assert "IDLE STALL" not in warning
+
+
+def test_incomplete_descendant_sample_suppresses_warning():
+    now = time.time()
+    assert (
+        flow_mod._heartbeat_warning(
+            _running_segment(now, 601),
+            now=now,
+            max_idle_seconds=600,
+            previous=({41: 8.0}, True),
+            current=({}, False),
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("previous", "current"),
+    [
+        (None, ({41: 8.0}, True)),
+        (({41: 8.0}, True), ({42: 1.0}, True)),
+        (({41: 8.0}, True), ({41: 7.9}, True)),
+    ],
+    ids=["first-sample", "descendant-set-change", "counter-regression"],
+)
+def test_unproven_descendant_delta_suppresses_warning(previous, current):
+    now = time.time()
+    warning = flow_mod._heartbeat_warning(
+        _running_segment(now, 601),
+        now=now,
+        max_idle_seconds=600,
+        previous=previous,
+        current=current,
+    )
+    assert warning is None
+
+
+@pytest.mark.parametrize(
+    ("previous", "current"),
+    [
+        (({41: 8.0}, True), ({41: 8.2}, True)),
+        (({41: 8.0}, True), ({41: 8.0}, True)),
+        (({}, True), ({}, True)),
+    ],
+)
+def test_under_threshold_never_emits_activity_warning(previous, current):
+    now = time.time()
+    warning = flow_mod._heartbeat_warning(
+        _running_segment(now, 599),
+        now=now,
+        max_idle_seconds=600,
+        previous=previous,
+        current=current,
+    )
+    assert warning is None
+
+
+def test_descendant_sampler_sums_each_cpu_total(monkeypatch):
+    calls: list[bool] = []
+    children = [
+        SimpleNamespace(pid=41, cpu_times=lambda: SimpleNamespace(user=1.2, system=0.3)),
+        SimpleNamespace(pid=42, cpu_times=lambda: SimpleNamespace(user=2.0, system=0.4)),
+    ]
+    root = SimpleNamespace(children=lambda recursive: calls.append(recursive) or children)
+    monkeypatch.setattr(flow_mod.psutil, "Process", lambda _pid: root)
+
+    assert flow_mod._sample_descendant_cpu(7) == ({41: 1.5, 42: 2.4}, True)
+    assert calls == [True]
+
+
+def test_descendant_sampler_marks_denied_walk_incomplete(monkeypatch):
+    def denied(_pid):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(flow_mod.psutil, "Process", denied)
+    assert flow_mod._sample_descendant_cpu(7) == ({}, False)
+
+
+def test_descendant_sampler_marks_denied_cpu_read_incomplete(monkeypatch):
+    def denied():
+        raise PermissionError("denied")
+
+    child = SimpleNamespace(pid=41, cpu_times=denied)
+    root = SimpleNamespace(children=lambda recursive: [child])
+    monkeypatch.setattr(flow_mod.psutil, "Process", lambda _pid: root)
+    assert flow_mod._sample_descendant_cpu(7) == ({}, False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", ["completed", "failed"])
+async def test_execute_dag_heartbeat_tracks_samples_and_terminal_state(
+    monkeypatch,
+    tmp_path,
+    terminal_status,
+):
+    from lionagi import Branch, Session
+    from lionagi.casts.emission import TaskAssignment
+    from lionagi.engines import PlanningEngine
+    from lionagi.operations.builder import OperationGraphBuilder
+    from lionagi.session.signal import NodeCompleted, NodeFailed, NodeStarted
+
+    branch = Branch(name="worker")
+    session = Session(default_branch=branch)
+    builder = OperationGraphBuilder()
+    node_id = builder.add_operation("operate", depends_on=[])
+    plan_result = flow_mod._PlanResult(
+        assignments=[TaskAssignment(task="work", assignee="worker")],
+        agent_ids=["worker"],
+        dep_indices=[[]],
+        pool=[],
+        budget_preambles={},
+    )
+    dag_state = flow_mod._DagState(
+        node_ids=[node_id],
+        known_nodes={node_id},
+        deps_by_node={node_id: []},
+        reactive=False,
+        spawn_roles=set(),
+        role_base={},
+        worker_models=["test/model"],
+    )
+    env = SimpleNamespace(
+        run=SimpleNamespace(agent_artifact_dir=lambda agent_id: tmp_path / agent_id),
+        session=session,
+        builder=builder,
+        verbose=False,
+        team_data=None,
+        cwd=None,
+        _live_persist=None,
+    )
+
+    emitted: list[str] = []
+    clock = [1000.0]
+    real_sleep = asyncio.sleep
+    heartbeat_permits: asyncio.Queue[None] = asyncio.Queue()
+    sampled = [asyncio.Event() for _ in range(4)]
+    sample_values = [
+        ({41: 8.0}, True),
+        ({41: 8.2}, True),
+        ({41: 8.2}, True),
+        ({41: 8.2}, True),
+    ]
+    sample_count = 0
+
+    async def controlled_sleep(delay: float) -> None:
+        if delay == 60:
+            await heartbeat_permits.get()
+            return
+        await real_sleep(3600)
+
+    def sample_cpu(_pid: int):
+        nonlocal sample_count
+        sample = sample_values[sample_count]
+        sampled[sample_count].set()
+        sample_count += 1
+        return sample
+
+    stall_counts: list[int] = []
+
+    async def run_dag(*_args, **_kwargs):
+        await session.emit(NodeStarted(op_id=str(node_id), name="worker", elapsed=0.0))
+        clock[0] = 1701.0
+        for index in range(3):
+            heartbeat_permits.put_nowait(None)
+            await asyncio.wait_for(sampled[index].wait(), timeout=1)
+            await real_sleep(0)
+            stall_counts.append(sum("IDLE STALL" in line for line in emitted))
+
+        signal_type = NodeCompleted if terminal_status == "completed" else NodeFailed
+        await session.emit(signal_type(op_id=str(node_id), name="worker", elapsed=1.0))
+        heartbeat_permits.put_nowait(None)
+        await asyncio.wait_for(sampled[3].wait(), timeout=1)
+        await real_sleep(0)
+        stall_counts.append(sum("IDLE STALL" in line for line in emitted))
+        return {
+            "operation_results": {node_id: "result"},
+            "spawned_operations": 0,
+            "failed_operations": [node_id] if terminal_status == "failed" else [],
+        }
+
+    engine_run = SimpleNamespace(run_dag=run_dag)
+    monkeypatch.setattr(PlanningEngine, "new_run", lambda *_args, **_kwargs: engine_run)
+    monkeypatch.setattr(flow_mod, "progress", emitted.append)
+    monkeypatch.setattr(flow_mod.time, "time", lambda: clock[0])
+    monkeypatch.setattr(flow_mod._asyncio, "sleep", controlled_sleep)
+    monkeypatch.setattr(flow_mod, "_sample_descendant_cpu", sample_cpu)
+
+    await flow_mod._execute_dag(env, plan_result, dag_state, max_concurrent=1, max_ops=0)
+
+    assert stall_counts == [0, 0, 1, 1]
+    assert sum("worker heartbeat" in line for line in emitted) == 3
+    assert dag_state.op_segments == [
+        {
+            "op_id": str(node_id),
+            "branch_id": str(branch.id),
+            "branch_name": "worker",
+            "status": terminal_status,
+            "started_at": 1000.0,
+            "ended_at": 1701.0,
+            "last_heartbeat_at": 1701.0,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_heartbeat.py
+++ b/tests/cli/test_heartbeat.py
@@ -251,7 +251,7 @@ def test_unproven_descendant_delta_suppresses_warning(previous, current):
     assert warning is None
 
 
-def test_nonoverlapping_descendants_emit_distinct_condition():
+def test_busy_new_descendant_suppresses_warning_without_overlap():
     now = time.time()
     warning = flow_mod._heartbeat_warning(
         _running_segment(now, 601),
@@ -261,9 +261,7 @@ def test_nonoverlapping_descendants_emit_distinct_condition():
         current=({42: 1.0}, True),
     )
 
-    assert warning is not None
-    assert "NO CPU OVERLAP" in warning
-    assert "IDLE STALL" not in warning
+    assert warning is None
 
 
 @pytest.mark.parametrize(

--- a/tests/orchestration/test_heartbeat.py
+++ b/tests/orchestration/test_heartbeat.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for descendant CPU heartbeat warnings."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from lionagi.cli.orchestrate import flow as flow_mod
+
+
+def _running_segment(now: float, age: float = 601) -> dict:
+    return {
+        "branch_name": "node",
+        "status": "running",
+        "started_at": now - age,
+    }
+
+
+def _warning(
+    previous: flow_mod._DescendantCpuSample | None,
+    current: flow_mod._DescendantCpuSample,
+    *,
+    age: float = 601,
+) -> str | None:
+    now = time.time()
+    return flow_mod._heartbeat_warning(
+        _running_segment(now, age),
+        now=now,
+        max_idle_seconds=600,
+        previous=previous,
+        current=current,
+    )
+
+
+def test_floor_ticks_without_working_delta_emit_stall_warning():
+    warning = _warning(
+        ({41: 8.0, 42: 3.0, 43: 5.0, 44: 2.0}, True),
+        ({41: 8.0, 42: 3.01, 43: 5.02, 44: 2.03}, True),
+    )
+
+    assert warning is not None
+    assert "IDLE STALL" in warning
+
+
+def test_delta_at_working_cutoff_suppresses_stall_warning():
+    assert (
+        _warning(
+            ({41: 8.0, 42: 3.0}, True),
+            ({41: 8.1, 42: 3.02}, True),
+        )
+        is None
+    )
+
+
+def test_busy_survivor_suppresses_warning_during_pid_churn():
+    assert (
+        _warning(
+            ({41: 8.0, 42: 3.0}, True),
+            ({41: 8.2, 43: 1.0}, True),
+        )
+        is None
+    )
+
+
+def test_quiet_survivor_emits_warning_during_pid_churn():
+    warning = _warning(
+        ({41: 8.0, 42: 3.0}, True),
+        ({41: 8.03, 43: 1.0}, True),
+    )
+
+    assert warning is not None
+    assert "IDLE STALL" in warning
+
+
+def test_empty_pid_intersection_emits_distinct_condition():
+    warning = _warning(
+        ({41: 8.0}, True),
+        ({42: 1.0}, True),
+    )
+
+    assert warning is not None
+    assert "NO CPU OVERLAP" in warning
+    assert "IDLE STALL" not in warning
+    assert "hung" not in warning.lower()
+
+
+@pytest.mark.parametrize(
+    ("previous", "current"),
+    [
+        (({41: 8.0}, True), ({41: 8.2}, True)),
+        (({41: 8.0}, True), ({41: 8.0}, True)),
+        (({41: 8.0}, True), ({42: 1.0}, True)),
+        (({}, True), ({}, True)),
+    ],
+    ids=["busy", "quiet", "churn", "empty"],
+)
+def test_under_elapsed_threshold_never_warns(previous, current):
+    assert _warning(previous, current, age=599) is None
+
+
+def test_no_descendants_emits_louder_condition():
+    warning = _warning(({}, True), ({}, True))
+
+    assert warning is not None
+    assert "NO DESCENDANTS" in warning
+    assert "IDLE STALL" not in warning
+    assert "hung" not in warning.lower()
+
+
+@pytest.mark.parametrize(
+    ("previous", "current"),
+    [
+        (None, ({41: 8.0}, True)),
+        (({41: 8.0}, False), ({41: 8.0}, True)),
+        (({41: 8.0}, True), ({41: 8.0}, False)),
+    ],
+    ids=["first", "previous-incomplete", "current-incomplete"],
+)
+def test_unreadable_or_first_sample_is_silent(previous, current):
+    assert _warning(previous, current) is None

--- a/tests/orchestration/test_heartbeat.py
+++ b/tests/orchestration/test_heartbeat.py
@@ -23,6 +23,7 @@ def _warning(
     previous: flow_mod._DescendantCpuSample | None,
     current: flow_mod._DescendantCpuSample,
     *,
+    sample_interval_seconds: float,
     age: float = 601,
 ) -> str | None:
     now = time.time()
@@ -30,6 +31,7 @@ def _warning(
         _running_segment(now, age),
         now=now,
         max_idle_seconds=600,
+        sample_interval_seconds=sample_interval_seconds,
         previous=previous,
         current=current,
     )
@@ -39,10 +41,71 @@ def test_floor_ticks_without_working_delta_emit_stall_warning():
     warning = _warning(
         ({41: 8.0, 42: 3.0, 43: 5.0, 44: 2.0, 45: 4.0}, True),
         ({41: 8.03, 42: 3.03, 43: 5.03, 44: 2.03, 45: 4.03}, True),
+        sample_interval_seconds=60,
     )
 
     assert warning is not None
     assert "IDLE STALL" in warning
+    assert "median peer rate" in warning
+    assert "60s sample" in warning
+
+
+@pytest.mark.parametrize(
+    "current",
+    [
+        ({41: 8.03}, True),
+        ({41: 8.03, 42: 3.0, 43: 5.0}, True),
+        ({41: 8.03, 42: 3.01, 43: 5.0}, True),
+    ],
+    ids=["single-descendant", "zero-peer-median", "mixed-jitter"],
+)
+def test_default_interval_floor_ticks_warn(current):
+    warning = _warning(
+        ({41: 8.0, 42: 3.0, 43: 5.0}, True),
+        current,
+        sample_interval_seconds=60,
+    )
+
+    assert warning is not None
+    assert "fallback cutoff" in warning
+    assert "60s sample" in warning
+
+
+@pytest.mark.parametrize(
+    ("sample_interval_seconds", "activity"),
+    [(5, 0.09), (5, 0.15), (75, 0.375)],
+    ids=["short-low", "short-maximum", "long-low-rate"],
+)
+def test_healthy_activity_without_peer_floor_does_not_warn(
+    sample_interval_seconds,
+    activity,
+):
+    warning = _warning(
+        ({41: 8.0}, True),
+        ({41: 8.0 + activity}, True),
+        sample_interval_seconds=sample_interval_seconds,
+    )
+
+    assert warning is None
+
+
+@pytest.mark.parametrize(
+    "maximum_activity",
+    [0.09, 0.15],
+    ids=["below-legacy-cutoff", "observed-maximum"],
+)
+def test_short_interval_healthy_activity_does_not_warn(maximum_activity):
+    now = time.time()
+    warning = flow_mod._heartbeat_warning(
+        _running_segment(now),
+        now=now,
+        max_idle_seconds=600,
+        sample_interval_seconds=5,
+        previous=({41: 8.0, 42: 3.0, 43: 5.0}, True),
+        current=({41: 8.01, 42: 3.02, 43: 5.0 + maximum_activity}, True),
+    )
+
+    assert warning is None
 
 
 def test_delta_at_working_cutoff_suppresses_stall_warning():
@@ -50,6 +113,7 @@ def test_delta_at_working_cutoff_suppresses_stall_warning():
         _warning(
             ({41: 8.0, 42: 3.0}, True),
             ({41: 8.1, 42: 3.02}, True),
+            sample_interval_seconds=60,
         )
         is None
     )
@@ -60,6 +124,7 @@ def test_busy_survivor_suppresses_warning_during_pid_churn():
         _warning(
             ({41: 8.0, 42: 3.0}, True),
             ({41: 8.2, 43: 1.0}, True),
+            sample_interval_seconds=60,
         )
         is None
     )
@@ -69,6 +134,7 @@ def test_quiet_survivor_emits_warning_during_pid_churn():
     warning = _warning(
         ({41: 8.0, 42: 3.0}, True),
         ({41: 8.03, 43: 0.01}, True),
+        sample_interval_seconds=60,
     )
 
     assert warning is not None
@@ -80,6 +146,7 @@ def test_busy_new_pid_suppresses_warning_during_pid_churn():
         _warning(
             ({41: 8.0, 42: 3.0}, True),
             ({42: 3.03, 43: 1.80}, True),
+            sample_interval_seconds=60,
         )
         is None
     )
@@ -89,6 +156,7 @@ def test_floor_cpu_new_pids_emit_stall_warning():
     warning = _warning(
         ({41: 8.0}, True),
         ({42: 0.01, 43: 0.02, 44: 0.03}, True),
+        sample_interval_seconds=60,
     )
 
     assert warning is not None
@@ -96,7 +164,14 @@ def test_floor_cpu_new_pids_emit_stall_warning():
 
 
 def test_busy_new_pid_suppresses_warning_without_overlap():
-    assert _warning(({41: 8.0}, True), ({42: 1.0}, True)) is None
+    assert (
+        _warning(
+            ({41: 8.0}, True),
+            ({42: 1.0}, True),
+            sample_interval_seconds=60,
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(
@@ -110,11 +185,11 @@ def test_busy_new_pid_suppresses_warning_without_overlap():
     ids=["busy", "quiet", "churn", "empty"],
 )
 def test_under_elapsed_threshold_never_warns(previous, current):
-    assert _warning(previous, current, age=599) is None
+    assert _warning(previous, current, sample_interval_seconds=60, age=599) is None
 
 
 def test_no_descendants_emits_louder_condition():
-    warning = _warning(({}, True), ({}, True))
+    warning = _warning(({}, True), ({}, True), sample_interval_seconds=60)
 
     assert warning is not None
     assert "NO DESCENDANTS" in warning
@@ -132,4 +207,4 @@ def test_no_descendants_emits_louder_condition():
     ids=["first", "previous-incomplete", "current-incomplete"],
 )
 def test_unreadable_or_first_sample_is_silent(previous, current):
-    assert _warning(previous, current) is None
+    assert _warning(previous, current, sample_interval_seconds=60) is None

--- a/tests/orchestration/test_heartbeat.py
+++ b/tests/orchestration/test_heartbeat.py
@@ -37,8 +37,8 @@ def _warning(
 
 def test_floor_ticks_without_working_delta_emit_stall_warning():
     warning = _warning(
-        ({41: 8.0, 42: 3.0, 43: 5.0, 44: 2.0}, True),
-        ({41: 8.0, 42: 3.01, 43: 5.02, 44: 2.03}, True),
+        ({41: 8.0, 42: 3.0, 43: 5.0, 44: 2.0, 45: 4.0}, True),
+        ({41: 8.03, 42: 3.03, 43: 5.03, 44: 2.03, 45: 4.03}, True),
     )
 
     assert warning is not None
@@ -68,23 +68,35 @@ def test_busy_survivor_suppresses_warning_during_pid_churn():
 def test_quiet_survivor_emits_warning_during_pid_churn():
     warning = _warning(
         ({41: 8.0, 42: 3.0}, True),
-        ({41: 8.03, 43: 1.0}, True),
+        ({41: 8.03, 43: 0.01}, True),
     )
 
     assert warning is not None
     assert "IDLE STALL" in warning
 
 
-def test_empty_pid_intersection_emits_distinct_condition():
+def test_busy_new_pid_suppresses_warning_during_pid_churn():
+    assert (
+        _warning(
+            ({41: 8.0, 42: 3.0}, True),
+            ({42: 3.03, 43: 1.80}, True),
+        )
+        is None
+    )
+
+
+def test_floor_cpu_new_pids_emit_stall_warning():
     warning = _warning(
         ({41: 8.0}, True),
-        ({42: 1.0}, True),
+        ({42: 0.01, 43: 0.02, 44: 0.03}, True),
     )
 
     assert warning is not None
-    assert "NO CPU OVERLAP" in warning
-    assert "IDLE STALL" not in warning
-    assert "hung" not in warning.lower()
+    assert "IDLE STALL" in warning
+
+
+def test_busy_new_pid_suppresses_warning_without_overlap():
+    assert _warning(({41: 8.0}, True), ({42: 1.0}, True)) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/orchestration/test_patterns.py
+++ b/tests/orchestration/test_patterns.py
@@ -72,6 +72,57 @@ class TestRoleNodeBuilder:
         with pytest.raises(ValueError, match="not a recognized role"):
             nb(SpawnRequest(instruction="x", assignee="ghost"), None)
 
+    def test_advertised_instance_routes_to_first_role_branch(self):
+        session, roles = _roles("writer")
+        later = Branch(name="writer-2")
+        session.include_branches(later)
+        decorated: list[str | None] = []
+
+        def decorate(req: SpawnRequest, _spawn_id: str) -> str:
+            decorated.append(req.assignee)
+            return req.instruction
+
+        nb = role_node_builder(
+            roles,
+            decorate_instruction=decorate,
+            role_aliases={"writer-2": "writer"},
+        )
+
+        node = nb(SpawnRequest(instruction="x", assignee="writer-2"), None)
+
+        assert node.branch_id == roles["writer"].id
+        assert node.branch_id != later.id
+        assert node.metadata["assignee"] == "writer"
+        assert decorated == ["writer"]
+
+    def test_unadvertised_instance_remains_rejected(self):
+        session, roles = _roles("writer")
+        nb = role_node_builder(roles, role_aliases={"writer-2": "writer"})
+
+        with pytest.raises(ValueError, match="not a recognized role"):
+            nb(SpawnRequest(instruction="x", assignee="writer-3"), None)
+
+    def test_rejected_spawn_is_visible_in_run_state(self, monkeypatch):
+        from lionagi.cli.orchestrate import flow as flow_mod
+
+        emitted: list[str] = []
+        env = SimpleNamespace()
+        dropped = [
+            {
+                "reason": "builder_error",
+                "assignee": "missing",
+                "error": "not a recognized role",
+            }
+        ]
+        monkeypatch.setattr(flow_mod, "progress", emitted.append)
+
+        flow_mod._surface_dropped_spawns(env, dropped)
+
+        assert env._failed_operation_evidence == [
+            {"kind": "unroutable_spawn", "id": "missing", "label": "not a recognized role"}
+        ]
+        assert any("SPAWN REJECTED" in line and "missing" in line for line in emitted)
+
     def test_custom_operation_preserved(self):
         session, roles = _roles("researcher")
         nb = role_node_builder(roles)

--- a/tests/providers/test_provider_errors.py
+++ b/tests/providers/test_provider_errors.py
@@ -127,6 +127,13 @@ def test_classify_unrelated_too_long_returns_base_error():
     assert type(err) is ProviderError
 
 
+def test_classify_terminal_truncation_returns_base_error():
+    err = classify_provider_error(
+        "Prompt is too long to display in the terminal; output was truncated."
+    )
+    assert type(err) is ProviderError
+
+
 def test_classify_context_case_insensitive():
     err = classify_provider_error("CONTEXT WINDOW EXCEEDED")
     assert isinstance(err, ProviderContextError)

--- a/tests/providers/test_provider_errors.py
+++ b/tests/providers/test_provider_errors.py
@@ -112,6 +112,21 @@ def test_classify_context_length_too_long_returns_context_error():
     assert isinstance(err, ProviderContextError)
 
 
+def test_classify_prompt_too_long_returns_context_error():
+    err = classify_provider_error(
+        "Prompt is too long · the request is ~225306 tokens (limit 200000) but "
+        "this conversation is only ~163811 tokens — the rest is system prompt, "
+        "tool definitions, and attachment content. A single-exchange conversation "
+        "cannot be compacted; reduce attached files/tools or start with less context."
+    )
+    assert isinstance(err, ProviderContextError)
+
+
+def test_classify_unrelated_too_long_returns_base_error():
+    err = classify_provider_error("The tool output is too long to display.")
+    assert type(err) is ProviderError
+
+
 def test_classify_context_case_insensitive():
     err = classify_provider_error("CONTEXT WINDOW EXCEEDED")
     assert isinstance(err, ProviderContextError)


### PR DESCRIPTION
Closes #2926, closes #2929. Also lands the classifier half of #2927 (the mirrored-status derivation is deliberately untouched — it is a separate semantics change).

## What changed

- **#2926** — the IDLE STALL warning now measures idleness instead of elapsed time. It samples cumulative CPU across the run's descendant process tree and warns only when no surviving descendant accumulated more than a 0.10s activity cutoff between heartbeats (calibrated: >3x the 0.01-0.03s clock-granularity ticks long-lived helpers accumulate perpetually, far below the ~1.8s deltas of genuinely working children). A changed pid set no longer suppresses the signal — deltas compare over the surviving intersection, an empty intersection reports `NO CPU OVERLAP`, and an empty tree reports the louder `NO DESCENDANTS`. Directory-mtime detection was deliberately rejected: a child running network or cache I/O writes nothing under its worktree and would read as stalled while alive.
- **#2929** — a spawn request naming a worker instance (`architect-2`) now resolves to its base role after an exact-name miss, instead of raising and being dropped in a warning nobody reads. Genuinely unknown roles still reject. **Behavioral note: a run that drops an unroutable spawn now records terminal status `failed` rather than `completed`** — a dropped spawn is missing work, and the run's status now says so.
- **#2927 (classifier half)** — the Claude CLI's real prompt-length phrasing ("Prompt is too long ...") now classifies as `ProviderContextError`; a must-not-match arm keeps unrelated "too long" messages out.

## Verification

- 36 heartbeat tests including the discriminating arms: floor-ticks-must-warn, at-cutoff-must-suppress, churn-with-busy-survivor suppresses, churn-with-quiet-survivor warns.
- Mutation check: rebinding the predicate to the previous exact-zero form turns the floor-tick arm red while the cutoff arm stays green — the tests discriminate on the signal, not the threshold.
- Spawn routing: instance-name resolution asserted against the first-cast branch identity; unknown-role rejection retained in the same file.