### PR TITLE
fix(flow): a resumed run must not report a permanently-failed op as completed

### DIFF
--- a/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
+++ b/docs/adr/ADR-0023-dependency-aware-operation-graph-execution-kernel.md
@@ -361,17 +361,20 @@ The static result envelope is:
     "operation_results": dict[UUID, Any],
     "final_context": dict[str, Any],
     "skipped_operations": list[UUID],
+    "failed_operations": list[UUID],
 }
 ```
 
 Exact condition, context, and result semantics:
 
 - A node with no incoming edges has a valid path. With incoming edges, an edge whose predecessor was
-  skipped is ignored; the node runs when **at least one** remaining edge condition returns true.
-  An edge with no condition returns true. If no incoming path passes, the node is marked `SKIPPED`.
-- Condition checks wait on the predecessor's completion event before reading its result. A failed
-  predecessor contributes its error mapping and may still satisfy an unconditional edge; failure
-  does not automatically skip all dependents.
+  skipped or was already `FAILED` when execution began is ignored; the node runs when **at least
+  one** remaining edge condition returns true. An edge with no condition returns true. If no
+  incoming path passes, the node is marked `SKIPPED`.
+- Condition checks wait on the predecessor's completion event before reading its result. A failure
+  produced during the current execution contributes its error mapping and may still satisfy an
+  unconditional edge for compatibility. A restored, preterminal failure never contributes its
+  error mapping to a dependent.
 - `_wait_for_dependencies()` then waits for every graph predecessor. Aggregations also wait for each
   UUID string named in `aggregation_sources` when it matches a completion-event id.
 - Predecessor results are converted recursively to mappings except for string, integer, float, and
@@ -399,13 +402,14 @@ Exact condition, context, and result semantics:
   context, and can omit the ordinary completed progress callback.
 - Parallel operations can finish in either order. When their returned context mappings collide,
   there is no namespace or reducer; whichever deep merge executes later wins for that key.
-- An exception raised while checking a condition is caught as an executor-level error mapping and
-  releases the completion event, but the node's `EventStatus` is not explicitly set to `FAILED`.
-  Static results therefore include the error entry as settled, and D6's status projection can label
-  this defensive path `completed`. Invoked operation failures do set `FAILED` and project correctly.
-- `completed_operations` is computed as every id in `results` that is not skipped. Because failed
-  operations also receive error entries in `results`, the name includes failures. It means
-  “settled with a result entry and not skipped,” not `EventStatus.COMPLETED`.
+- An exception raised while checking a condition is caught as an executor-level error mapping,
+  added to `failed_operations`, and releases the completion event, but the node's `EventStatus` is
+  not explicitly set to `FAILED`. Static results still include this in `completed_operations`, and
+  D6's status projection can label this defensive path `completed`. Invoked operation failures do
+  set `FAILED` and project correctly.
+- `completed_operations` is computed as every id in `results` that is not skipped and was not
+  already `FAILED` when execution began. A failure produced during execution still appears in
+  `completed_operations` for compatibility; a restored preterminal failure does not.
 - `operation_results` is the authoritative per-id value/error mapping. `skipped_operations` is
   disjoint from `completed_operations`; `_validate_execution_results()` raises if the lists overlap.
 
@@ -600,10 +604,10 @@ documented above.
 - Live operator messages are rendered once as an instruction prefix and withheld from raw model
   context. The shared queue is mutated with consumption breadcrumbs, so callers treating their
   input context as immutable will observe otherwise.
-- `completed_operations` is a compatibility hazard because failures appear in it. Consumers needing
-  truth must inspect operation status and results together. `FlowEvent.status` improves ordinary
-  failure reporting but still labels defensive executor errors completed when no event failure was
-  set.
+- `completed_operations` is a compatibility hazard because failures produced during execution
+  appear in it, although restored preterminal failures do not. Consumers needing truth must inspect
+  operation status and results together. `FlowEvent.status` improves ordinary failure reporting but
+  still labels defensive executor errors completed when no event failure was set.
 - Reactive mutation is bounded and cycle-safe, but object-identity de-duplication does not provide
   durable or semantic idempotency across reconstruction, and reinjecting an existing operation UUID
   can schedule that node again without a fresh branch or completion event.

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -163,6 +163,9 @@ class DependencyAwareExecutor:
         # caller can tell a dead node from a genuine completion without
         # inspecting every result value by hand.
         self.failed_operations = set()
+        # Operations that were already FAILED when execution began must not
+        # open dependency paths or contribute their restored error payloads.
+        self._preterminal_failed_operations = set()
         # Gate-reject bookkeeping (see the module-level contract comment).
         # ``_gate_rejections``: op_id of a completed ``is_gate`` node -> the
         # reason payload to attribute to anything downstream of it.
@@ -221,9 +224,7 @@ class DependencyAwareExecutor:
             finally:
                 self._tg = None
 
-        completed_ops = [
-            op_id for op_id in self.results.keys() if op_id not in self.skipped_operations
-        ]
+        completed_ops = self._completed_operation_ids()
 
         result = {
             "completed_operations": completed_ops,
@@ -237,6 +238,10 @@ class DependencyAwareExecutor:
         self._validate_execution_results(result)
 
         return result
+
+    def _completed_operation_ids(self) -> list[Any]:
+        excluded = self.skipped_operations | self._preterminal_failed_operations
+        return [op_id for op_id in self.results if op_id not in excluded]
 
     def _gate_result_fields(self) -> dict[str, Any]:
         """``gate_rejected_operations``: ``is_gate`` nodes whose result carried
@@ -473,6 +478,9 @@ class DependencyAwareExecutor:
 
     async def _execute_operation(self, operation: Operation, limiter: CapacityLimiter):
         if operation.execution.status in Event._TERMINAL_STATUSES:
+            if operation.execution.status == EventStatus.FAILED:
+                self.failed_operations.add(operation.id)
+                self._preterminal_failed_operations.add(operation.id)
             if self.verbose:
                 logger.debug(
                     "Skipping %s operation: %s",
@@ -696,7 +704,10 @@ class DependencyAwareExecutor:
                 gate_reason = gate_reason or upstream_reason
                 continue
 
-            if edge.head in self.skipped_operations:
+            if (
+                edge.head in self.skipped_operations
+                or edge.head in self._preterminal_failed_operations
+            ):
                 continue
 
             if has_valid_path:
@@ -755,7 +766,10 @@ class DependencyAwareExecutor:
         if predecessors:
             pred_ctx = Note()
             for pred in predecessors:
-                if pred.id in self.skipped_operations:
+                if (
+                    pred.id in self.skipped_operations
+                    or pred.id in self._preterminal_failed_operations
+                ):
                     continue
 
                 if pred.id in self.results:
@@ -998,9 +1012,7 @@ class ReactiveExecutor(DependencyAwareExecutor):
             observer.unobserve(self._on_bus_spawn)
             observer.unobserve(self._on_bus_escalation)
 
-        completed_ops = [
-            op_id for op_id in self.results.keys() if op_id not in self.skipped_operations
-        ]
+        completed_ops = self._completed_operation_ids()
         result = {
             "completed_operations": completed_ops,
             "operation_results": self.results,

--- a/tests/operations/test_flow_failure_rollup.py
+++ b/tests/operations/test_flow_failure_rollup.py
@@ -14,6 +14,7 @@ import pytest
 
 from lionagi.operations import flow
 from lionagi.operations.builder import OperationGraphBuilder
+from lionagi.protocols.types import EventStatus
 from lionagi.session.session import Session
 
 
@@ -48,6 +49,47 @@ def _make_ops(executed: list[str]):
         raise RuntimeError("CLI subprocess exited with code 1 and wrote nothing to stderr")
 
     return {"first": first, "last": last}
+
+
+@pytest.mark.asyncio
+async def test_preterminal_failed_op_is_not_completed_and_blocks_dependents_in_both_executors():
+    outcomes = {}
+
+    for reactive in (False, True):
+        executed = []
+
+        async def should_not_run(**_kwargs):
+            executed.append("ran")
+            return "unexpected"
+
+        session = _session_with_ops(failed_source=should_not_run, dependent=should_not_run)
+        builder = OperationGraphBuilder()
+        failed_id = builder.add_operation("failed_source", depends_on=[])
+        dependent_id = builder.add_operation("dependent", depends_on=[failed_id])
+        graph = builder.get_graph()
+        failed_node = graph.internal_nodes[failed_id]
+        failed_node.execution.status = EventStatus.FAILED
+        failed_node.execution.response = {"error": "boom"}
+
+        result = await flow(session, graph, reactive=reactive)
+        outcomes[reactive] = {
+            "failed_is_completed": failed_id in result["completed_operations"],
+            "failed_is_failed": failed_id in result["failed_operations"],
+            "dependent_is_completed": dependent_id in result["completed_operations"],
+            "dependent_is_skipped": dependent_id in result["skipped_operations"],
+            "executed": executed,
+            "failed_result": result["operation_results"].get(failed_id),
+        }
+
+    expected = {
+        "failed_is_completed": False,
+        "failed_is_failed": True,
+        "dependent_is_completed": False,
+        "dependent_is_skipped": True,
+        "executed": [],
+        "failed_result": {"error": "boom"},
+    }
+    assert outcomes == {False: expected, True: expected}
 
 
 @pytest.mark.asyncio
@@ -153,3 +195,52 @@ async def test_non_mapping_response_context_is_rolled_up_as_failed():
     assert ids["last"] in result["failed_operations"]
     assert ids["first"] not in result["failed_operations"]
     assert ids["last"] in result["completed_operations"]
+
+
+@pytest.mark.parametrize("reactive", [False, True])
+@pytest.mark.asyncio
+async def test_failed_predecessor_payload_does_not_reach_a_running_dependent(reactive):
+    """A dependent with two predecessors, one healthy and one carrying a
+    restored terminal failure, still runs -- the healthy edge gives it a
+    valid path. Context preparation iterates ALL predecessors, so without
+    the omission for a pre-terminal failure the dead predecessor's error
+    payload is handed to the dependent as though it were an input.
+
+    Shape::
+
+        good_source ---\\
+                        +--> dependent
+        failed_source --/    (restored FAILED, response={"error": ...})
+    """
+    seen: dict[str, object] = {}
+
+    async def good_source(**kw):
+        return "good"
+
+    async def failed_source(**kw):  # must never run
+        return "unexpected"
+
+    async def dependent(**kw):
+        seen["context"] = kw.get("context")
+        return "dependent ok"
+
+    session = _session_with_ops(
+        good_source=good_source, failed_source=failed_source, dependent=dependent
+    )
+    builder = OperationGraphBuilder()
+    good_id = builder.add_operation("good_source", depends_on=[])
+    failed_id = builder.add_operation("failed_source", depends_on=[])
+    dep_id = builder.add_operation("dependent", depends_on=[good_id, failed_id])
+    graph = builder.get_graph()
+    restored = graph.internal_nodes[failed_id]
+    restored.execution.status = EventStatus.FAILED
+    restored.execution.response = {"error": "boom"}
+
+    result = await flow(session, graph, reactive=reactive, verbose=False)
+
+    # Preconditions: without these the assertion below proves nothing.
+    assert dep_id in result["completed_operations"]
+    assert "context" in seen
+
+    blob = repr(seen["context"])
+    assert "boom" not in blob, f"failed predecessor payload leaked into dependent: {blob}"


### PR DESCRIPTION
Closes #2939.

## The defect

`_execute_operation` short-circuits on an operation that already carries a terminal status: it copies the stored response into `self.results`, sets the completion event, and adds the operation to **neither** failure set. Completion was computed as results-minus-skipped, so a permanently-failed operation was counted as completed, and its dependents executed against an error payload as though it were a successful input.

A resumed run therefore reported success while carrying a node that had failed and would never run again.

## Why the fix is shaped this way

That completion computation existed **twice** in `flow.py`, at two executor entrypoints (`DependencyAwareExecutor.execute` and `ReactiveExecutor.execute`). Patching one site would have left the other producing the same false green, and made it harder to find afterwards because the obvious site would then look correct. So the duplication is removed: a single `_completed_operation_ids()` helper excludes both `skipped_operations` and the new `_preterminal_failed_operations`, and both callers reach it.

Context preparation also omits a restored preterminal failure's error mapping, so a dependent never receives a dead predecessor's error as an input.

## Coverage

The context-omission branch is only reachable when the dependent has a *second*, healthy predecessor giving it a valid path — a single-predecessor graph skips the dependent entirely and never prepares it. A fan-in test covers exactly that shape (one healthy source, one restored-`FAILED` source, both feeding one dependent), parameterised over static and reactive execution.

Verified by mutation: no-op'ing the omission reddens both arms of that test with the payload visible in the assertion (`{'error': 'boom'}` in the dependent's context) and leaves the other five tests in the file green.

`tests/operations/` is green (175 passed, 4 pre-existing skips).

## Behaviour change for callers

A resumed run carrying a permanently-failed operation now reports run status `failed` where it previously reported `completed`. This is the point of the change, but it is visible to anyone reading resumed-run status, so it is called out here rather than buried.

Failures produced during the *current* execution still appear in `completed_operations`, unchanged. That is a long-standing compatibility hazard documented in ADR-0023; this PR does not alter it, and the ADR text is updated to say precisely which failures are now excluded and which are not.