### PR TITLE
fix(cli,providers): grant sandboxed workers the paths their own capabilities need

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -32,6 +32,7 @@ from lionagi.operations.builder import OperationGraphBuilder
 from lionagi.protocols.generic.log import DataLoggerConfig
 from lionagi.state import provenance as _provenance
 
+from .. import team as _team_module
 from .._logging import hint, warn
 from .._providers import (
     AgentProfile,
@@ -864,9 +865,15 @@ async def build_worker_branch(
     env.worker_artifact_dirs[agent_id] = artifact_dir
     if is_cli:
         project_root = str(Path(env.cwd).resolve()) if env.cwd else str(Path.cwd().resolve())
-        w_imodel.endpoint.config.kwargs.setdefault("add_dir", [])
-        if project_root not in w_imodel.endpoint.config.kwargs["add_dir"]:
-            w_imodel.endpoint.config.kwargs["add_dir"].append(project_root)
+        add_dir = w_imodel.endpoint.config.kwargs.setdefault("add_dir", [])
+        if project_root not in add_dir:
+            add_dir.append(project_root)
+        if (
+            getattr(env, "team_data", None)
+            and w_imodel.endpoint.config.provider == "codex"
+            and (teams_dir := str(_team_module.TEAMS_DIR.resolve())) not in add_dir
+        ):
+            add_dir.append(teams_dir)
 
     if explicit_name is not None:
         env.register_name(explicit_name)

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -7,6 +7,7 @@ import asyncio
 import contextlib
 import logging
 import re
+import subprocess
 import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from pathlib import Path
@@ -134,6 +135,31 @@ def toml_override_value(value: Any) -> str:
     if isinstance(value, str | int | float | bool):
         return _toml_scalar(value)
     raise TypeError(f"Unsupported codex `-c` override value type: {type(value)!r}")
+
+
+def _linked_worktree_git_dir(cwd: Path) -> Path | None:
+    """Return a linked worktree's private Git directory, if *cwd* is in one."""
+    resolved_cwd = cwd.resolve()
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-dir", "--git-common-dir"],  # noqa: S607
+            cwd=resolved_cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    paths = result.stdout.splitlines()
+    if result.returncode != 0 or len(paths) != 2 or not all(paths):
+        return None
+
+    def _resolve(value: str) -> Path:
+        path = Path(value)
+        return path.resolve() if path.is_absolute() else (resolved_cwd / path).resolve()
+
+    git_dir, common_dir = map(_resolve, paths)
+    return git_dir if git_dir != common_dir else None
 
 
 # --------------------------------------------------------------------------- request model
@@ -521,8 +547,13 @@ class CodexCodeRequest(BaseModel):
     def as_cmd_args(self) -> list[str]:
         """Build argument list for ``codex exec`` subcommand."""
         args: list[str] = ["exec", "--json"]
+        cwd = self.cwd()
 
         args.extend(self._build_declarative_args())
+
+        linked_git_dir = _linked_worktree_git_dir(cwd)
+        if linked_git_dir is not None and str(linked_git_dir) not in (self.add_dir or []):
+            args.extend(["--add-dir", str(linked_git_dir)])
 
         # Approval & sandbox: mutually exclusive hierarchy
         if self.bypass_approvals:
@@ -572,7 +603,7 @@ class CodexCodeRequest(BaseModel):
             args.extend(["-c", f"{key}={toml_override_value(value)}"])
 
         # Working directory (always emit)
-        args.extend(["-C", str(self.cwd())])
+        args.extend(["-C", str(cwd)])
 
         # Prompt goes to stdin, not argv (a whole conversation can exceed the
         # OS arg-length limit). `-` is codex's stdin marker; it stays after

--- a/tests/cli/orchestrate/test_worker_artifact_directive.py
+++ b/tests/cli/orchestrate/test_worker_artifact_directive.py
@@ -119,6 +119,8 @@ def _build_worker(
     profile=None,
     is_cli=True,
     system_prompt_override=None,
+    provider="claude_code",
+    team_data=None,
 ):
     """Run `build_worker_branch` with no model, no MCP, and no I/O.
 
@@ -137,7 +139,7 @@ def _build_worker(
 
     class _Endpoint:
         def __init__(self):
-            self.config = SimpleNamespace(kwargs={}, provider="claude_code")
+            self.config = SimpleNamespace(kwargs={}, provider=provider)
 
     class _IModel:
         def __init__(self):
@@ -172,6 +174,7 @@ def _build_worker(
         verbose=False,
         fast=False,
         cwd=str(tmp_path),
+        team_data=team_data,
     )
 
     mp = _pytest.MonkeyPatch()
@@ -199,6 +202,48 @@ def _build_worker(
         mp.undo()
 
     return env, imodel, built
+
+
+def _add_dir_values(args: list[str]) -> list[str]:
+    return [args[index + 1] for index, value in enumerate(args) if value == "--add-dir"]
+
+
+def _codex_worker_args(tmp_path, *, team_data=None) -> list[str]:
+    from lionagi.providers.openai.codex import CodexCodeRequest
+
+    _env, imodel, _built = _build_worker(
+        tmp_path,
+        agent_id="worker-1",
+        role="worker",
+        provider="codex",
+        team_data=team_data,
+    )
+    request = CodexCodeRequest(prompt="work", **imodel.endpoint.config.kwargs)
+    return request.as_cmd_args()
+
+
+def test_codex_team_worker_grants_only_the_teams_directory(tmp_path, monkeypatch):
+    from lionagi.cli import team as team_module
+
+    teams_dir = tmp_path / "state" / "teams"
+    teams_dir.mkdir(parents=True)
+    monkeypatch.setattr(team_module, "TEAMS_DIR", teams_dir)
+
+    args = _codex_worker_args(tmp_path, team_data={"id": "team-1"})
+
+    assert _add_dir_values(args) == [str(tmp_path.resolve()), str(teams_dir.resolve())]
+
+
+def test_codex_worker_without_team_does_not_grant_the_teams_directory(tmp_path, monkeypatch):
+    from lionagi.cli import team as team_module
+
+    teams_dir = tmp_path / "state" / "teams"
+    teams_dir.mkdir(parents=True)
+    monkeypatch.setattr(team_module, "TEAMS_DIR", teams_dir)
+
+    args = _codex_worker_args(tmp_path)
+
+    assert _add_dir_values(args) == [str(tmp_path.resolve())]
 
 
 def test_worker_prompt_names_the_cwd_it_is_launched_with(tmp_path):

--- a/tests/providers/openai/codex/test_sandbox_writable_roots.py
+++ b/tests/providers/openai/codex/test_sandbox_writable_roots.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from lionagi.providers.openai.codex import CodexCodeRequest, toml_override_value
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _resolve_git_path(cwd: Path, value: str) -> Path:
+    path = Path(value)
+    return path.resolve() if path.is_absolute() else (cwd / path).resolve()
+
+
+def _add_dir_values(args: list[str]) -> list[str]:
+    return [args[index + 1] for index, value in enumerate(args) if value == "--add-dir"]
+
+
+def _git_checkouts(tmp_path: Path) -> tuple[Path, Path]:
+    ordinary = tmp_path / "ordinary"
+    linked = tmp_path / "linked"
+    ordinary.mkdir()
+    _git(ordinary, "init", "-q")
+    _git(
+        ordinary,
+        "-c",
+        "user.name=Test User",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "--allow-empty",
+        "-qm",
+        "initial",
+    )
+    _git(ordinary, "worktree", "add", "--detach", "-q", str(linked))
+    return ordinary, linked
+
+
+def test_linked_worktree_grants_exact_per_worktree_git_directory(tmp_path):
+    ordinary, linked = _git_checkouts(tmp_path)
+    configured_root = tmp_path / "configured-root"
+    configured_root.mkdir()
+    git_dir = _resolve_git_path(linked, _git(linked, "rev-parse", "--git-dir"))
+    common_dir = _resolve_git_path(linked, _git(linked, "rev-parse", "--git-common-dir"))
+
+    args = CodexCodeRequest(
+        prompt="work",
+        repo=linked,
+        full_auto=True,
+        config_overrides={
+            "sandbox_workspace_write.writable_roots": [str(configured_root.resolve())]
+        },
+    ).as_cmd_args()
+
+    assert git_dir != common_dir
+    assert _add_dir_values(args) == [str(git_dir)]
+    configured_override = (
+        "sandbox_workspace_write.writable_roots="
+        f"{toml_override_value([str(configured_root.resolve())])}"
+    )
+    assert configured_override in args
+
+
+def test_ordinary_checkout_gets_no_automatic_git_directory(tmp_path):
+    ordinary, _linked = _git_checkouts(tmp_path)
+
+    args = CodexCodeRequest(prompt="work", repo=ordinary, full_auto=True).as_cmd_args()
+
+    assert _add_dir_values(args) == []


### PR DESCRIPTION
Closes #2945.

A codex worker runs under a workspace-write sandbox rooted at its working directory. Two paths that lionagi itself hands the worker sit outside that root, so capabilities the framework advertises fail at the filesystem:

1. **Team messaging.** `li team send` writes under the canonical teams directory, which lives beside the working tree. A worker instructed to coordinate through the team channel got a `PermissionError` on every send — while the prompt template told it the channel was available.
2. **Linked worktrees.** In a linked worktree `.git` is a pointer file; the real index lives under the main checkout's `.git/worktrees/<name>/`. `git add` therefore fails for any worker running in one. Observed three times in one day, each time as a worker honestly reporting it could not stage a commit it had been asked to make.

## Shape of the grant

The teams grant is derived from **the resolved teams path**, not from a capability flag. That matters: keying it off a flag means the negative case is a rule someone has to remember, while deriving it from the path makes the negative case structural, and it follows `LIONAGI_HOME` automatically. The directory is guaranteed to exist wherever the grant applies, because team creation ensures it and returns the very team data the grant keys on.

The worktree grant is the **exact** per-worktree git directory and nothing more: `--git-dir` and `--git-common-dir` are resolved and compared, and an ordinary checkout (where they are equal) is granted nothing. Resolution failure is non-fatal.

## Why `--add-dir` and not a config override

`--add-dir` is additive to the sandbox roots. The `-c sandbox_workspace_write.writable_roots=[...]` form looks equivalent and is not: a session-level override **replaces** a non-table value rather than extending it, so using it here would silently drop whatever roots a user had configured. This was established against the released source matching the installed executable (`codex-cli 0.144.0`, tag `rust-v0.144.0`), not inferred from help text.

## Tests

Four arms, each asserting the **full** `--add-dir` value list rather than substring membership, so a spurious grant fails as loudly as a missing one:

- codex worker with team data → project root and teams dir, exactly
- worker without team data → project root only
- linked worktree → that worktree's git directory, exactly
- ordinary checkout → nothing added

The linked-worktree arm builds a real temporary repository and worktree rather than mocking the git query, and supplies a pre-existing `writable_roots` override to prove the implementation does not convert an additive grant into a replacement.

Each arm was verified to discriminate by mutation, including independently here after the fact: removing the linked-worktree grant reddens that arm with the missing path named in the assertion, and restoring it returns the suite to green.

`tests/providers/openai/codex` and `tests/cli/orchestrate/test_worker_artifact_directive.py` are green (128 tests).

## Adjacent finding, not fixed here

`lionagi/libs/path_safety.py` documents `add_dir` as a **read** grant, and a test asserts that wording. The provider describes it correctly as write access. The validator's docstring therefore asserts a weaker constraint than codex actually enforces. Left alone as out of scope for this fix, but it is worth a follow-up because it is the kind of wrong-mechanism comment that survives review by being adjacent to correct code.