### PR TITLE
fix(service): the Opus line accepts xhigh, so stop silently downgrading it

### DIFF
--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -74,13 +74,29 @@ def _clamp_codex_effort(effort: str, model: str | None) -> str:
     return effort
 
 
-# Claude: only opus-4-7 accepts xhigh. All other models clamp to high.
-# Claude has no ultra tier at all: ultra clamps to max for every model.
-_CLAUDE_XHIGH_MODELS = frozenset({"opus", "opus-4-7", "claude-opus-4-7"})
+# Claude: the Opus line accepts xhigh from 4.7 onward. Everything else clamps
+# to high. Claude has no ultra tier at all: ultra clamps to max for every model.
+#
+# This is an allow-list of exact model strings, so a new Opus release is absent
+# until it is added here, and its absence costs it xhigh silently -- the request
+# still succeeds, one tier lower, with nothing in the result saying so. Add new
+# Opus identifiers in the same change that makes them routable, both the bare
+# alias and the claude- prefixed form, since callers pass either.
+_CLAUDE_XHIGH_MODELS = frozenset(
+    {
+        "opus",
+        "opus-4-7",
+        "claude-opus-4-7",
+        "opus-4-8",
+        "claude-opus-4-8",
+        "opus-5",
+        "claude-opus-5",
+    }
+)
 
 
 def _clamp_claude_effort(effort: str, model: str) -> str:
-    """Clamp ultra to max, and xhigh to high for non-opus-4-7 Claude models."""
+    """Clamp ultra to max, and xhigh to high for Claude models without an xhigh tier."""
     if effort == "ultra":
         return "max"
     if effort != "xhigh":

--- a/tests/cli/test_providers.py
+++ b/tests/cli/test_providers.py
@@ -313,8 +313,9 @@ def test_build_imodel_from_spec_mixed_case_max_clamps_codex_to_xhigh(monkeypatch
 
 
 def test_build_imodel_from_spec_mixed_case_xhigh_clamps_claude_to_high(monkeypatch):
-    """--effort XHigh on a non-opus-4-7 Claude model must clamp to 'high',
-    matching the lowercase 'xhigh' behavior (case must not bypass the clamp)."""
+    """--effort XHigh on a Claude model with no xhigh tier must clamp to
+    'high', matching the lowercase 'xhigh' behavior (case must not bypass the
+    clamp). Sonnet has no xhigh tier; the Opus line does."""
     import lionagi.cli._providers as pmod
     from lionagi.testing import IModelKwargCaptor
 

--- a/tests/service/test_claude_effort_clamp.py
+++ b/tests/service/test_claude_effort_clamp.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""The Claude effort clamp downgrades silently by design: an unsupported
+tier becomes a supported one and the request succeeds, so a model missing
+from the xhigh allow-list runs a tier lower with nothing in the result
+saying so. That makes the membership itself the thing worth pinning --
+these tests fail when an Opus identifier is dropped, which is the only
+signal the downgrade produces."""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi.service.providers import _clamp_claude_effort
+
+# Every spelling a caller can reach the Opus line by. Callers pass the bare
+# alias, the claude- prefixed id, or a provider-qualified spec, and the clamp
+# has to answer the same way for all three.
+OPUS_IDENTIFIERS = [
+    "opus",
+    "opus-4-7",
+    "claude-opus-4-7",
+    "opus-4-8",
+    "claude-opus-4-8",
+    "opus-5",
+    "claude-opus-5",
+    "claude/claude-opus-5",
+    "claude_code/opus",
+]
+
+# Claude models with no xhigh tier. Sonnet and Fable are current releases, so
+# they are not placeholders -- an implementation that granted xhigh to every
+# Claude model would pass the Opus cases above and fail here.
+NON_XHIGH_CLAUDE_MODELS = [
+    "sonnet",
+    "haiku",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude/claude-sonnet-5",
+]
+
+
+@pytest.mark.parametrize("model", OPUS_IDENTIFIERS)
+def test_opus_line_keeps_xhigh(model):
+    assert _clamp_claude_effort("xhigh", model) == "xhigh"
+
+
+@pytest.mark.parametrize("model", NON_XHIGH_CLAUDE_MODELS)
+def test_models_without_an_xhigh_tier_fall_back_to_high(model):
+    assert _clamp_claude_effort("xhigh", model) == "high"
+
+
+@pytest.mark.parametrize("model", OPUS_IDENTIFIERS + NON_XHIGH_CLAUDE_MODELS)
+def test_max_is_a_real_claude_tier_and_is_never_clamped(model):
+    """Claude has max on every model, so the clamp must leave it alone. It is
+    the tier above xhigh, so a table that gates xhigh must not be read as
+    gating max as well."""
+    assert _clamp_claude_effort("max", model) == "max"
+
+
+@pytest.mark.parametrize("model", OPUS_IDENTIFIERS + NON_XHIGH_CLAUDE_MODELS)
+def test_ultra_is_not_a_claude_tier_and_becomes_max(model):
+    assert _clamp_claude_effort("ultra", model) == "max"
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high"])
+@pytest.mark.parametrize("model", ["opus", "claude-opus-5", "claude-sonnet-5"])
+def test_ordinary_tiers_pass_through_untouched(effort, model):
+    assert _clamp_claude_effort(effort, model) == effort


### PR DESCRIPTION
The Claude xhigh allow-list held only `opus-4-7` and its aliases. Opus 4.8 and Opus 5 accept xhigh, so a caller asking for it on either got a request that **succeeded one tier lower**, with nothing in the result saying so.

Measured before this change:

| model | xhigh resolves to | max resolves to |
|---|---|---|
| `opus` | `xhigh` | `max` |
| `claude-opus-5` | **`high`** | `max` |
| `claude-sonnet-5` | `high` | `max` |

This reaches the request path, not just a display: `_clamp_claude_effort` is called from `cli/agent.py`, `cli/_providers.py` (twice), `service/imodel.py`, and the Studio operator engine. Any profile written with xhigh on Opus 5 has been running at high.

## What changed

`opus-4-8`, `claude-opus-4-8`, `opus-5` and `claude-opus-5` join the allow-list. `max` and `ultra` are untouched, and `max` was never affected: Claude has a max tier on every model, and the clamp returns before consulting this table for anything that is not `ultra` or `xhigh`. That distinction is now pinned by a test, because "the table gates xhigh" is easy to misread as "the table gates the top tier".

## The shape of the bug, which the fix does not remove

An allow-list of exact model strings means every future release is absent until someone adds it, and absence costs a tier **silently**. The failure biases toward looking fine: the request works, the answer is slightly worse, nothing raises. The comment now says so and asks for new identifiers in the same change that makes them routable, and the test pins membership so a dropped entry fails loudly. Making the downgrade *report itself* is the real fix for the class and is tracked separately, since a naive warning inside this function would fire on every catalog query that merely asks which efforts a model offers.

## Tests

`tests/service/test_claude_effort_clamp.py` covers every spelling a caller can reach the Opus line by, including bare aliases, `claude-` prefixed ids, and provider-qualified specs such as `claude/claude-opus-5`. The non-xhigh cases are pinned by current releases (Sonnet 5, Fable 5, Haiku) rather than placeholders, so an implementation that granted xhigh to *every* Claude model would pass the Opus cases and fail these.

Verified by mutation: reverting the table to its previous value reddens exactly the five new Opus arms and nothing else. That was re-run with the failure cap lifted, because the first run stopped at exactly five failures and a capped list cannot support a claim about what did *not* fail.

Five pre-existing failures elsewhere in `tests/service/connections/` (ollama endpoint, `start_new_session`, ndjson stdin) reproduce identically in an unmodified checkout of the same base commit and are unrelated to this change.

## Adjacent, not fixed here

On `main` the Studio Operator model picker offers no Claude 5 models at all: `model_effort_choices` returns an empty tuple for `claude-opus-5` and `claude-sonnet-5` because they are absent from the catalog. The commit adding them is on an unmerged branch. So the picker cannot select these models regardless of effort. Out of scope here and left to that lane.