### PR TITLE
fix(protocols): synchronize progression permutation mutators

### DIFF
--- a/lionagi/protocols/generic/progression.py
+++ b/lionagi/protocols/generic/progression.py
@@ -429,6 +429,7 @@ class Progression(Element, Ordering[T], Generic[T]):
         return index
 
     def move(self, from_index: int, to_index: int) -> None:
+        self._ensure_synced()
         from_index = self._validate_index(from_index)
         to_index = self._validate_index(to_index, allow_end=True)
 
@@ -439,6 +440,7 @@ class Progression(Element, Ordering[T], Generic[T]):
         self.order.insert(to_index, item)
 
     def swap(self, index1: int, index2: int) -> None:
+        self._ensure_synced()
         index1 = self._validate_index(index1)
         index2 = self._validate_index(index2)
         self.order[index1], self.order[index2] = (
@@ -447,6 +449,7 @@ class Progression(Element, Ordering[T], Generic[T]):
         )
 
     def reverse(self) -> None:
+        self._ensure_synced()
         self.order.reverse()
 
     def __reversed__(self) -> Progression[T]:

--- a/tests/protocols/generic/test_progression_membership_cache.py
+++ b/tests/protocols/generic/test_progression_membership_cache.py
@@ -311,6 +311,29 @@ def test_direct_order_reassignment_leaves_members_stale_until_synced():
     assert p._members == set(p.order)
 
 
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda p: p.__setitem__(0, uuid4()), id="setitem"),
+        pytest.param(lambda p: p.append(uuid4()), id="append"),
+        pytest.param(lambda p: p.pop(), id="pop"),
+        pytest.param(lambda p: p.popleft(), id="popleft"),
+        pytest.param(lambda p: p.extend(Progression(order=[uuid4()])), id="extend"),
+        pytest.param(lambda p: p.insert(1, uuid4()), id="insert"),
+        pytest.param(lambda p: p.move(0, 2), id="move"),
+        pytest.param(lambda p: p.swap(0, 1), id="swap"),
+        pytest.param(lambda p: p.reverse(), id="reverse"),
+    ],
+)
+def test_order_mutators_sync_membership_after_order_reassignment(mutate):
+    p = Progression(order=[uuid4()])
+    p.order = deque(uuid4() for _ in range(3))
+
+    mutate(p)
+
+    assert p._members == set(p.order)
+
+
 # ---------------------------------------------------------------------------
 # Length-preserving external mutation (the `_ensure_synced` length-only guard
 # cannot see these — the owning `_MembersDeque` must handle them directly).


### PR DESCRIPTION
## Summary

- Call `_ensure_synced()` before `move`, `swap`, and `reverse`.
- Add a parametrized invariant test for all nine explicitly named order-mutating methods after `.order` is replaced with a plain deque.

## Why this shape

This is not reachable as an incorrect public API result today. `__contains__` calls `_ensure_synced()` before reading the membership set, so a public membership check returns the correct answer and repairs a stale binding.

Leaving the methods alone would preserve an undocumented asymmetry: a future membership consumer that omits its own sync would inherit a live stale-cache bug. The already-synchronized path is idempotent and cheap:

    order = self.order
    if (
        not isinstance(order, _MembersDeque)
        or len(order) != self._order_len
        or order._members_ref is not self._members
    ):
        self._rebuild_members()

When already synchronized, this performs only wrapper-type, length, and binding-identity checks, all O(1). Adding the calls removes the trap at negligible steady-state cost.

## Caller-visible behavior

No public semantic result changes. After directly assigning a plain deque to public `.order`, `move`, `swap`, and `reverse` now normalize it to the internal `_MembersDeque` immediately rather than waiting for a later membership-aware operation. Code that inspects the exact concrete type of `.order` could observe that normalization sooner.

## Verification

- Parametrized invariant test: 9 passed.
- Inverse mutation: removing the three calls failed exactly the `move`, `swap`, and `reverse` arms at `assert p._members == set(p.order)`; the other six arms passed.
- Focused membership-cache tests: 60 passed.
- Protocol suite: 2,097 passed, 8 skipped because optional pandas is not installed.
- Ruff format and check: passed.
- `progression.py` focused coverage: 83.12%.

Closes #2906