### PR TITLE
fix(mcp): reject unselected servers before connection

### DIFF
--- a/docs/adr/ADR-0112-mcp-tool-registration-naming-and-collisions.md
+++ b/docs/adr/ADR-0112-mcp-tool-registration-naming-and-collisions.md
@@ -373,6 +373,11 @@ D1 — is a parallel list, not the thing compared.
   "registered > 0": a server that legitimately advertises no tools (a resources-only
   server) is not an error, and a non-empty check would fail it while still passing every
   case where a server advertises three tools and registers one.
+- Server-set selection precedes acquisition. When a caller supplies an already-resolved
+  set (including the explicit no-config case), that selection is authoritative:
+  factory-side native discovery is skipped, so a server outside the set never reaches
+  `MCPConnectionPool.get_client` and is neither connected nor recorded as an empty
+  registration. D3 applies only after a server has been selected for registration.
 - A server advertising zero tools registers zero and succeeds.
 - `PermissionError` continues to propagate unchanged — an admission denial is already
   fail-closed and is not a shortfall.

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -147,7 +147,8 @@ async def create_agent(
     _apply_permissions(spec)
     _register_tools(branch, spec)
     _register_providers(branch, spec)
-    await _load_mcp(branch, spec, trust_project_settings=trust_project_settings)
+    if resolved_mcp_servers is Unset:
+        await _load_mcp(branch, spec, trust_project_settings=trust_project_settings)
     _forward_mcp_to_cli_request(
         branch,
         spec,

--- a/lionagi/agent/factory.py
+++ b/lionagi/agent/factory.py
@@ -560,14 +560,17 @@ async def _load_mcp(
         mcp_security=MCPSecurityConfig.trusted(),
     )
 
-    # MCP-discovered tools register after static ones and would otherwise
-    # keep their bare default pre/postprocessor; reuse _attach_hooks so both
-    # paths apply the same spec-derived hook chain.
-    for tool_names in loaded.values():
+    # MCP-discovered tools register after static ones; reuse _attach_hooks so
+    # both paths apply the same spec-derived hook chain.
+    for server_name, tool_names in loaded.items():
         for tool_name in tool_names:
             tool = branch.acts.registry.get(tool_name)
-            if tool is not None:
-                _attach_hooks(tool, spec, tool_name)
+            if tool is None:
+                raise RuntimeError(
+                    f"MCP server {server_name!r} returned registered tool "
+                    f"{tool_name!r}, but the branch registry does not contain it"
+                )
+            _attach_hooks(tool, spec, tool_name)
 
 
 _MCP_FORWARDING_PROVIDERS = frozenset({*_CLAUDE_PROVIDER_NAMES, "codex"})

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -25,6 +26,28 @@ from .tool_hooks import (
 )
 
 logger = logging.getLogger(__name__)
+
+_QUALIFIED_MCP_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+
+
+def qualified_mcp_name(server_name: str, tool_name: str) -> str:
+    """Return the registry name for a tool discovered on an MCP server."""
+    if not isinstance(server_name, str) or not server_name:
+        raise ValueError(
+            f"MCP tool {tool_name!r} requires a non-empty server alias; "
+            "load the server under a shorter alias before registration."
+        )
+
+    qualified_name = f"mcp__{server_name}__{tool_name}"
+    if _QUALIFIED_MCP_NAME_PATTERN.fullmatch(qualified_name):
+        return qualified_name
+
+    raise ValueError(
+        f"Invalid qualified MCP tool name for server {server_name!r}, tool "
+        f"{tool_name!r}: {qualified_name!r} has length {len(qualified_name)}; "
+        "the name must match ^[a-zA-Z0-9_-]{1,64}$. Load the server under "
+        "a shorter alias using only letters, digits, underscores, or hyphens."
+    )
 
 
 class ActionManager(Manager):
@@ -69,6 +92,10 @@ class ActionManager(Manager):
             return tool.function in self.registry
         elif isinstance(tool, str):
             return tool in self.registry
+        elif isinstance(tool, dict):
+            if len(tool) == 1:
+                return next(iter(tool)) in self.registry
+            return False
         elif callable(tool):
             return tool.__name__ in self.registry
         return False
@@ -334,20 +361,42 @@ class ActionManager(Manager):
         if isinstance(server_config, dict) and "server" in server_config:
             server_name = server_config["server"]
 
-        if request_options:
-            for k in list(request_options.keys()):
-                if not k.startswith(f"{server_name}_"):
-                    request_options[f"{server_name}_{k}"] = request_options.pop(k)
+        def request_options_for(tool_name: str) -> type | None:
+            return request_options.get(tool_name) if request_options else None
+
+        def register_mcp_tool(tool: Tool, registry_name: str) -> None:
+            existing = self.registry.get(registry_name)
+            if existing is not None and existing.mcp_config is None:
+                raise ValueError(
+                    f"MCP tool {registry_name!r} cannot replace an existing local tool"
+                )
+            self.register_tool(tool, update=update)
 
         if tool_names:
             from lionagi.service.connections.mcp_wrapper import (
                 validate_mcp_tool_admission,
             )
 
+            advertised = set(tool_names)
+            if request_options:
+                unknown_options = sorted(set(request_options) - advertised)
+                if unknown_options:
+                    raise ValueError(
+                        f"Request options for MCP server {server_name!r} reference "
+                        f"unknown tool(s): {unknown_options}"
+                    )
+
             # Validate the whole list before registering any tool: a denial
             # anywhere must leave the registry unchanged, not partially populated.
             for tool_name in tool_names:
                 validate_mcp_tool_admission(tool_name, None, None)
+
+            if not isinstance(server_name, str) or not server_name:
+                raise ValueError(
+                    f"MCP tool {tool_names[0]!r} requires a non-empty server alias; "
+                    "load the server under a shorter alias before registration."
+                )
+            server_alias = server_name
 
             for tool_name in tool_names:
                 logger.warning(
@@ -360,19 +409,16 @@ class ActionManager(Manager):
                 config_with_metadata = dict(server_config)
                 config_with_metadata["_original_tool_name"] = tool_name
 
-                mcp_config = {tool_name: config_with_metadata}
-
-                tool_request_options = None
-                if request_options and tool_name in request_options:
-                    tool_request_options = request_options[tool_name]
+                registry_name = qualified_mcp_name(server_alias, tool_name)
+                mcp_config = {registry_name: config_with_metadata}
 
                 tool = Tool(
                     mcp_config=mcp_config,
-                    request_options=tool_request_options,
+                    request_options=request_options_for(tool_name),
                     mcp_capability=capability,
                 )
-                self.register_tool(tool, update=update)
-                registered_tools.append(tool_name)
+                register_mcp_tool(tool, registry_name)
+                registered_tools.append(registry_name)
         else:
             from lionagi.service.connections.mcp_wrapper import (
                 validate_mcp_tool_admission,
@@ -380,6 +426,17 @@ class ActionManager(Manager):
 
             client = await MCPConnectionPool.get_client(server_config, security=security)
             tools = await client.list_tools()
+            advertised = {tool.name for tool in tools}
+            registered_wire_names: set[str] = set()
+            registration_errors: dict[str, Exception] = {}
+
+            if request_options:
+                unknown_options = sorted(set(request_options) - advertised)
+                if unknown_options:
+                    raise ValueError(
+                        f"Request options for MCP server {server_name!r} reference "
+                        f"unknown tool(s): {unknown_options}"
+                    )
 
             # Validate every descriptor before mutating the registry: a
             # denial anywhere must leave the registry unchanged.
@@ -390,48 +447,65 @@ class ActionManager(Manager):
                     getattr(tool, "description", None),
                 )
 
+            if not isinstance(server_name, str) or not server_name:
+                if tools:
+                    raise ValueError(
+                        f"MCP tool {tools[0].name!r} requires a non-empty server alias; "
+                        "load the server under a shorter alias before registration."
+                    )
+                return registered_tools
+            server_alias = server_name
+
             for tool in tools:
                 tool_name = tool.name
-                input_schema = getattr(tool, "inputSchema", None)
-                description = getattr(tool, "description", None)
+                registry_name = qualified_mcp_name(server_alias, tool_name)
 
                 config_with_metadata = dict(server_config)
                 config_with_metadata["_original_tool_name"] = tool_name
 
-                mcp_config = {tool_name: config_with_metadata}
-
-                tool_request_options = None
-                if request_options and tool_name in request_options:
-                    tool_request_options = request_options[tool_name]
+                mcp_config = {registry_name: config_with_metadata}
 
                 tool_schema = None
                 try:
+                    input_schema = getattr(tool, "inputSchema", None)
+                    description = getattr(tool, "description", None)
                     if isinstance(input_schema, dict):
                         tool_schema = {
                             "type": "function",
                             "function": {
-                                "name": tool_name,
+                                "name": registry_name,
                                 "description": description,
                                 "parameters": input_schema,
                             },
                         }
                 except Exception as schema_error:
-                    logging.warning(f"Could not extract schema for {tool_name}: {schema_error}")
+                    logger.warning("Could not extract schema for %s: %s", tool_name, schema_error)
                     tool_schema = None
 
                 try:
                     tool_obj = Tool(
                         mcp_config=mcp_config,
-                        request_options=tool_request_options,
+                        request_options=request_options_for(tool_name),
                         tool_schema=tool_schema,
                         mcp_capability=capability,
                     )
-                    self.register_tool(tool_obj, update=update)
-                    registered_tools.append(tool_name)
+                    register_mcp_tool(tool_obj, registry_name)
+                    registered_tools.append(registry_name)
+                    registered_wire_names.add(tool_name)
                 except PermissionError:
                     raise
                 except Exception as e:
-                    logging.warning(f"Failed to register tool {tool_name}: {e}")
+                    registration_errors[tool_name] = e
+
+            if registered_wire_names != advertised:
+                missing = sorted(advertised - registered_wire_names)
+                error = RuntimeError(
+                    f"MCP server {server_name!r} advertised {len(advertised)} tool(s) "
+                    f"but {len(registered_wire_names)} registered; missing: {missing}"
+                )
+                if missing and missing[0] in registration_errors:
+                    raise error from registration_errors[missing[0]]
+                raise error
 
         return registered_tools
 
@@ -474,7 +548,7 @@ class ActionManager(Manager):
                 raise
             except Exception as e:
                 logger.warning("Failed to register server '%s': %s", server_name, e)
-                all_tools[server_name] = []
+                raise
 
         return all_tools
 
@@ -523,8 +597,9 @@ async def load_mcp_tools(
             raise
         except Exception as e:
             logger.warning("Failed to load server '%s': %s", server_name, e)
+            raise
 
     return list(manager.registry.values())
 
 
-__all__ = ["ActionManager", "load_mcp_tools"]
+__all__ = ["ActionManager", "load_mcp_tools", "qualified_mcp_name"]

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -824,6 +824,34 @@ def _write_mcp_config(tmp_path, servers: dict) -> str:
     return str(p)
 
 
+async def test_resolved_cli_mcp_set_rejects_ambient_server_before_connection(tmp_path, monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+    home_mcp_dir = tmp_path / "home" / ".lionagi"
+    home_mcp_dir.mkdir(parents=True)
+    _write_mcp_config(
+        home_mcp_dir,
+        {"decoy": {"command": "not-the-submitted-server"}},
+    )
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    connect = AsyncMock(side_effect=AssertionError("excluded ambient server must not be connected"))
+    monkeypatch.setattr(MCPConnectionPool, "get_client", connect)
+
+    submitted = {"khive": {"command": "kkernel", "args": ["serve"]}}
+    config = AgentSpec.compose("reviewer", model="claude_code/sonnet")
+
+    branch = await create_agent(
+        config,
+        load_settings=False,
+        resolved_mcp_servers=submitted,
+    )
+
+    assert branch.chat_model.endpoint.config.kwargs["mcp_servers"] == submitted
+
+
 async def test_forward_mcp_populates_claude_code_request_mcp_servers(tmp_path):
     """Test plan item 5: claude_code leg + mcp_config_path -> ClaudeCodeRequest
     carries the same servers, and --mcp-config shows up in as_cmd_args()."""

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -210,6 +210,26 @@ async def test_mcp_discovered_tool_composes_existing_preprocessor(tmp_path, monk
     assert calls == [{"action": "call", "foo": "bar"}]
 
 
+async def test_mcp_loader_rejects_returned_name_missing_from_registry(tmp_path, monkeypatch):
+    from lionagi.protocols.action.manager import ActionManager
+
+    mcp_file = tmp_path / "custom.mcp.json"
+    mcp_file.write_text('{"mcpServers": {"demo": {"command": "true"}}}')
+
+    async def fake_load_mcp_config(
+        self, config_path, server_names=None, update=False, mcp_security=None
+    ):
+        return {"demo": ["mcp__demo__request"]}
+
+    monkeypatch.setattr(ActionManager, "load_mcp_config", fake_load_mcp_config)
+
+    config = AgentSpec.compose("implementer")
+    config.mcp_config_path = str(mcp_file)
+
+    with pytest.raises(RuntimeError, match="mcp__demo__request"):
+        await create_agent(config, load_settings=False)
+
+
 async def test_create_agent_coding_permissions_recheck_user_mutated_args(tmp_path):
     """User pre-hooks must not be able to rewrite safe args after permission checks."""
     from lionagi.agent.permissions import PermissionPolicy
@@ -778,9 +798,17 @@ async def test_load_mcp_breaks_at_lionagi_dir(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_mcp_pool_state():
+def _isolate_mcp_pool_state(request, monkeypatch):
     """MCPConnectionPool accumulates configs process-globally; snapshot and restore its class-level state around tests that load real config files through create_agent, so loads don't leak into other test files on the same worker."""
+    from lionagi.protocols.action.manager import ActionManager
     from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+    if request.node.name.startswith("test_forward_mcp_"):
+
+        async def skip_native_registration(self, *args, **kwargs):
+            return {}
+
+        monkeypatch.setattr(ActionManager, "load_mcp_config", skip_native_registration)
 
     saved_configs = dict(MCPConnectionPool._configs)
     yield

--- a/tests/protocols/action/test_manager_edge_cases.py
+++ b/tests/protocols/action/test_manager_edge_cases.py
@@ -1,10 +1,16 @@
 """Coverage boost tests for ActionManager: MCP support, dict tool registration, edge cases."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from pydantic import BaseModel
 
-from lionagi.protocols.action.manager import ActionManager, load_mcp_tools
+from lionagi.protocols.action.manager import (
+    ActionManager,
+    load_mcp_tools,
+    qualified_mcp_name,
+)
 from lionagi.protocols.action.tool import Tool
 from lionagi.protocols.messages.action_request import ActionRequest
 
@@ -33,22 +39,13 @@ class TestActionManagerDictRegistration:
         manager = ActionManager()
 
         mcp_config = {"duplicate_tool": {"command": "python", "args": ["-m", "test"]}}
-
-        # First registration should succeed
         manager.register_tool(mcp_config)
-
-        # Due to __contains__ not handling dict inputs, dict tools don't trigger
-        # duplicate detection. This is a known limitation. Instead, test that
-        # the tool was registered correctly and we can detect duplicates by name.
-        assert "duplicate_tool" in manager.registry
-
-        # Test duplicate detection by registering with same name but different format
         mcp_config_same_name = {"duplicate_tool": {"command": "different_command"}}
 
-        # This will overwrite since dict duplicate detection doesn't work
-        # But we can verify the behavior is consistent
-        manager.register_tool(mcp_config_same_name, update=True)
-        assert "duplicate_tool" in manager.registry
+        with pytest.raises(ValueError, match="Tool duplicate_tool is already registered"):
+            manager.register_tool(mcp_config_same_name, update=False)
+
+        assert manager.registry["duplicate_tool"].mcp_config == mcp_config
 
     def test_register_tool_dict_with_update(self):
         manager = ActionManager()
@@ -80,7 +77,7 @@ class TestActionManagerDictRegistration:
 
         manager.register_tool(mcp_config)
 
-        # Test contains with string name
+        assert mcp_config in manager
         assert "dict_tool" in manager
         assert "nonexistent_tool" not in manager
 
@@ -219,6 +216,7 @@ class TestActionManagerMCPMethodStubs:
             mock_pool.get_client = AsyncMock(return_value=mock_client)
 
             server_config = {
+                "server": "test_server",
                 "command": "python",
                 "args": ["-m", "test_server"],
             }
@@ -249,6 +247,286 @@ class TestActionManagerMCPMethodStubs:
             assert isinstance(result, dict)
             assert "test_server" in result
             assert result["test_server"] == ["tool1", "tool2"]
+
+
+class TestActionManagerMCPNaming:
+    @staticmethod
+    def _tool(name: str):
+        return SimpleNamespace(
+            name=name,
+            description=f"Call {name}",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        )
+
+    def test_qualified_name_accepts_provider_limit(self):
+        server_name = "a" * 50
+
+        name = qualified_mcp_name(server_name, "request")
+
+        assert name == f"mcp__{server_name}__request"
+        assert len(name) == 64
+
+    def test_qualified_name_requires_server_alias(self):
+        with pytest.raises(ValueError, match="non-empty server alias"):
+            qualified_mcp_name("", "request")
+
+    @pytest.mark.asyncio
+    async def test_two_servers_keep_distinct_registry_names_and_routes(self):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        manager = ActionManager()
+        clients = {"alpha": AsyncMock(), "beta": AsyncMock()}
+        for server_name, client in clients.items():
+            client.list_tools.return_value = [self._tool("request")]
+            client.call_tool.return_value = server_name
+
+        async def get_client(server_config, security=None):
+            return clients[server_config["server"]]
+
+        with (
+            patch.object(MCPConnectionPool, "load_config", return_value=["alpha", "beta"]),
+            patch.object(MCPConnectionPool, "get_client", side_effect=get_client),
+        ):
+            loaded = await manager.load_mcp_config("/fake/path.json")
+
+        assert loaded == {
+            "alpha": ["mcp__alpha__request"],
+            "beta": ["mcp__beta__request"],
+        }
+        assert set(manager.registry) == {"mcp__alpha__request", "mcp__beta__request"}
+
+        for server_name in clients:
+            registry_name = f"mcp__{server_name}__request"
+            tool = manager.registry[registry_name]
+            assert tool.function == registry_name
+            assert tool.tool_schema["function"]["name"] == registry_name
+            assert tool.mcp_config[registry_name]["_original_tool_name"] == "request"
+
+        async def reconnect(server_config, capability=None):
+            return clients[server_config["server"]]
+
+        with patch.object(MCPConnectionPool, "_get_reconnect_client", side_effect=reconnect):
+            await manager.registry["mcp__alpha__request"].func_callable()
+            await manager.registry["mcp__beta__request"].func_callable()
+
+        clients["alpha"].call_tool.assert_awaited_once_with("request", {})
+        clients["beta"].call_tool.assert_awaited_once_with("request", {})
+
+    @pytest.mark.asyncio
+    async def test_tool_names_shortcut_uses_qualified_registry_name(self):
+        manager = ActionManager()
+
+        names = await manager.register_mcp_server({"server": "alpha"}, tool_names=["request"])
+
+        assert names == ["mcp__alpha__request"]
+        assert "request" not in manager.registry
+        tool = manager.registry["mcp__alpha__request"]
+        assert tool.mcp_config["mcp__alpha__request"]["_original_tool_name"] == "request"
+
+    @pytest.mark.asyncio
+    async def test_nonempty_inline_config_requires_server_alias(self):
+        manager = ActionManager()
+
+        with pytest.raises(ValueError, match="non-empty server alias"):
+            await manager.register_mcp_server({"command": "python"}, tool_names=["request"])
+
+        assert manager.registry == {}
+
+    @pytest.mark.asyncio
+    async def test_registration_shortfall_names_missing_tools(self):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        manager = ActionManager()
+
+        async def occupied():
+            return None
+
+        occupied.__name__ = "mcp__alpha__second"
+        manager.register_tool(occupied)
+
+        client = AsyncMock()
+        client.list_tools.return_value = [self._tool("first"), self._tool("second")]
+
+        with patch.object(MCPConnectionPool, "get_client", return_value=client):
+            with pytest.raises(RuntimeError) as exc_info:
+                await manager.register_mcp_server({"server": "alpha"})
+
+        message = str(exc_info.value)
+        assert "advertised 2 tool(s) but 1 registered" in message
+        assert "missing: ['second']" in message
+
+    @pytest.mark.asyncio
+    async def test_update_does_not_replace_local_qualified_tool(self):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        manager = ActionManager()
+
+        async def occupied():
+            return None
+
+        occupied.__name__ = "mcp__alpha__request"
+        manager.register_tool(occupied)
+        original = manager.registry["mcp__alpha__request"]
+
+        client = AsyncMock()
+        client.list_tools.return_value = [self._tool("request")]
+
+        with patch.object(MCPConnectionPool, "get_client", return_value=client):
+            with pytest.raises(RuntimeError, match=r"missing: \['request'\]"):
+                await manager.register_mcp_server({"server": "alpha"}, update=True)
+
+        assert manager.registry["mcp__alpha__request"] is original
+
+    @pytest.mark.asyncio
+    async def test_tool_names_update_does_not_replace_local_qualified_tool(self):
+        manager = ActionManager()
+
+        async def occupied():
+            return None
+
+        occupied.__name__ = "mcp__alpha__request"
+        manager.register_tool(occupied)
+        original = manager.registry["mcp__alpha__request"]
+
+        with pytest.raises(ValueError, match="cannot replace an existing local tool"):
+            await manager.register_mcp_server(
+                {"server": "alpha"}, tool_names=["request"], update=True
+            )
+
+        assert manager.registry["mcp__alpha__request"] is original
+
+    @pytest.mark.asyncio
+    async def test_empty_server_tool_list_succeeds(self):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        manager = ActionManager()
+        client = AsyncMock()
+        client.list_tools.return_value = []
+
+        with patch.object(MCPConnectionPool, "get_client", return_value=client):
+            names = await manager.register_mcp_server({"command": "unused"})
+
+        assert names == []
+        assert manager.registry == {}
+
+    @pytest.mark.asyncio
+    async def test_load_mcp_config_propagates_server_failure(self):
+        manager = ActionManager()
+        manager.register_mcp_server = AsyncMock(side_effect=RuntimeError("incomplete tools"))
+
+        with patch("lionagi.service.connections.mcp_wrapper.MCPConnectionPool") as mock_pool:
+            mock_pool.load_config.return_value = ["alpha"]
+            with pytest.raises(RuntimeError, match="incomplete tools"):
+                await manager.load_mcp_config("/fake/path.json")
+
+    @pytest.mark.asyncio
+    async def test_request_options_use_wire_name_keys(self):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        class RequestOptions(BaseModel):
+            query: str
+
+        manager = ActionManager()
+        client = AsyncMock()
+        client.list_tools.return_value = [self._tool("request")]
+        options = {"request": RequestOptions}
+
+        with patch.object(MCPConnectionPool, "get_client", return_value=client):
+            await manager.register_mcp_server({"server": "alpha"}, request_options=options)
+
+        assert options == {"request": RequestOptions}
+        assert manager.registry["mcp__alpha__request"].request_options is RequestOptions
+
+    @pytest.mark.asyncio
+    async def test_unknown_request_options_raise_before_mutation(self):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        manager = ActionManager()
+        client = AsyncMock()
+        client.list_tools.return_value = [self._tool("request")]
+
+        with patch.object(MCPConnectionPool, "get_client", return_value=client):
+            with pytest.raises(ValueError, match="unknown"):
+                await manager.register_mcp_server(
+                    {"server": "alpha"}, request_options={"unknown": BaseModel}
+                )
+
+        assert manager.registry == {}
+
+    @pytest.mark.asyncio
+    async def test_overlong_qualified_name_fails_during_load(self):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        server_name = "a" * 58
+        manager = ActionManager()
+        client = AsyncMock()
+        client.list_tools.return_value = [self._tool("request")]
+
+        with (
+            patch.object(MCPConnectionPool, "load_config", return_value=[server_name]),
+            patch.object(MCPConnectionPool, "get_client", return_value=client),
+        ):
+            with pytest.raises(ValueError) as exc_info:
+                await manager.load_mcp_config("/fake/path.json")
+
+        message = str(exc_info.value)
+        assert server_name in message
+        assert "request" in message
+        assert "72" in message
+        assert "shorter alias" in message
+
+    @pytest.mark.asyncio
+    async def test_invalid_qualified_name_character_fails_registration(self):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        manager = ActionManager()
+        client = AsyncMock()
+        client.list_tools.return_value = [self._tool("request")]
+
+        with patch.object(MCPConnectionPool, "get_client", return_value=client):
+            with pytest.raises(ValueError) as exc_info:
+                await manager.register_mcp_server({"server": "bad.alias"})
+
+        message = str(exc_info.value)
+        assert "bad.alias" in message
+        assert "request" in message
+        assert "23" in message
+        assert "shorter alias" in message
+
+    @pytest.mark.asyncio
+    async def test_schema_warning_uses_package_logger(self, caplog):
+        from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
+
+        class Descriptor:
+            name = "request"
+            description = "Call request"
+            reads = 0
+
+            @property
+            def inputSchema(self):
+                self.reads += 1
+                if self.reads > 1:
+                    raise ValueError("schema unavailable")
+                return {"type": "object", "properties": {}}
+
+        manager = ActionManager()
+        client = AsyncMock()
+        client.list_tools.return_value = [Descriptor()]
+
+        caplog.set_level("WARNING", logger="lionagi.protocols.action.manager")
+        with patch.object(MCPConnectionPool, "get_client", return_value=client):
+            names = await manager.register_mcp_server({"server": "alpha"})
+
+        assert names == ["mcp__alpha__request"]
+        assert any(
+            record.name == "lionagi.protocols.action.manager"
+            and "Could not extract schema for request" in record.getMessage()
+            for record in caplog.records
+        )
 
 
 class TestActionManagerMCPAdmission:
@@ -299,10 +577,12 @@ class TestActionManagerMCPAdmission:
             mock_client.list_tools = AsyncMock(return_value=[mock_tool])
             mock_pool.get_client = AsyncMock(return_value=mock_client)
 
-            result = await manager.register_mcp_server({"command": "python", "args": ["-m", "srv"]})
+            result = await manager.register_mcp_server(
+                {"server": "srv", "command": "python", "args": ["-m", "srv"]}
+            )
 
-        assert result == ["run_tests"]
-        assert "run_tests" in manager.registry
+        assert result == ["mcp__srv__run_tests"]
+        assert "mcp__srv__run_tests" in manager.registry
 
     @pytest.mark.asyncio
     async def test_register_mcp_server_denial_error_is_actionable(self):
@@ -374,12 +654,12 @@ class TestActionManagerMCPAdmission:
         manager = ActionManager()
 
         result = await manager.register_mcp_server(
-            {"command": "python", "args": ["-m", "srv"]},
+            {"server": "srv", "command": "python", "args": ["-m", "srv"]},
             tool_names=["run_tests"],
         )
 
-        assert result == ["run_tests"]
-        assert "run_tests" in manager.registry
+        assert result == ["mcp__srv__run_tests"]
+        assert "mcp__srv__run_tests" in manager.registry
 
     def test_register_tool_denies_raw_dict_shell_executor(self):
         manager = ActionManager()
@@ -403,6 +683,22 @@ class TestActionManagerMCPAdmission:
 
         assert tool_name in str(exc_info.value)
         assert tool_name not in manager.registry
+
+    def test_qualified_tool_admission_checks_wire_name(self):
+        manager = ActionManager()
+        tool = Tool(
+            mcp_config={
+                "mcp__alpha__bash": {
+                    "server": "alpha",
+                    "_original_tool_name": "bash",
+                }
+            }
+        )
+
+        with pytest.raises(PermissionError, match="bash"):
+            manager.register_tool(tool)
+
+        assert "mcp__alpha__bash" not in manager.registry
 
     def test_register_tool_admits_prebuilt_tool_with_rich_bounded_descriptor(self):
         """A prebuilt `Tool` carrying a genuine, bounded remote descriptor
@@ -448,12 +744,12 @@ class TestActionManagerMCPAdmission:
         manager = ActionManager()
 
         result = await manager.register_mcp_server(
-            {"command": "python", "args": ["-m", "srv"]},
+            {"server": "srv", "command": "python", "args": ["-m", "srv"]},
             tool_names=["format_run_command"],
         )
 
-        assert result == ["format_run_command"]
-        assert "format_run_command" in manager.registry
+        assert result == ["mcp__srv__format_run_command"]
+        assert "mcp__srv__format_run_command" in manager.registry
 
     async def _discover_and_register(self, descriptor):
         """Helper: register a server whose discovery returns a single mock
@@ -468,7 +764,7 @@ class TestActionManagerMCPAdmission:
             mock_client.list_tools = AsyncMock(return_value=[mock_tool])
             mock_pool.get_client = AsyncMock(return_value=mock_client)
             return manager, await manager.register_mcp_server(
-                {"command": "python", "args": ["-m", "srv"]}
+                {"server": "srv", "command": "python", "args": ["-m", "srv"]}
             )
 
     async def _discover_and_expect_denial(self, descriptor):
@@ -585,8 +881,8 @@ class TestActionManagerMCPAdmission:
                 },
             }
         )
-        assert result == ["exec"]
-        assert "exec" in manager.registry
+        assert result == ["mcp__srv__exec"]
+        assert "mcp__srv__exec" in manager.registry
 
     @pytest.mark.asyncio
     async def test_register_mcp_server_admits_nested_config_without_command_fields(self):
@@ -608,8 +904,8 @@ class TestActionManagerMCPAdmission:
                 },
             }
         )
-        assert result == ["maintenance"]
-        assert "maintenance" in manager.registry
+        assert result == ["mcp__srv__maintenance"]
+        assert "mcp__srv__maintenance" in manager.registry
 
     @pytest.mark.asyncio
     async def test_register_mcp_server_denied_tool_leaves_registry_untouched_with_earlier_allowed(
@@ -885,6 +1181,9 @@ class TestLoadMCPToolsFunction:
 
     @pytest.mark.asyncio
     async def test_load_mcp_tools_with_server_names(self):
+        class RequestOptions(BaseModel):
+            query: str
+
         # Mock the ActionManager and its methods
         with patch("lionagi.protocols.action.manager.ActionManager") as mock_manager_class:
             mock_manager = Mock()
@@ -895,11 +1194,33 @@ class TestLoadMCPToolsFunction:
             mock_manager.register_mcp_server = AsyncMock(return_value=["tool1", "tool2"])
             mock_manager_class.return_value = mock_manager
 
-            result = await load_mcp_tools(server_names=["test_server"])
+            result = await load_mcp_tools(
+                server_names=["test_server"],
+                request_options_map={"test_server": {"request": RequestOptions}},
+            )
 
             # Should return list of Tool objects
             assert isinstance(result, list)
             assert len(result) == 2
+            mock_manager.register_mcp_server.assert_awaited_once_with(
+                {"server": "test_server"},
+                request_options={"request": RequestOptions},
+                update=False,
+                security=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_load_mcp_tools_propagates_registration_error(self):
+        with patch("lionagi.protocols.action.manager.ActionManager") as manager_class:
+            manager = Mock()
+            manager.registry = {}
+            manager.register_mcp_server = AsyncMock(
+                side_effect=ValueError("unknown request options")
+            )
+            manager_class.return_value = manager
+
+            with pytest.raises(ValueError, match="unknown request options"):
+                await load_mcp_tools(server_names=["alpha"])
 
 
 class TestActionManagerValidation:

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -706,11 +706,11 @@ class TestPerServerPolicyPersistence:
             # each Tool must still carry its own recovery capability for
             # first-invocation recovery, bound to this call's policy.
             await mgr.register_mcp_server(
-                {"command": "echo", "args": []},
+                {"server": "srv", "command": "echo", "args": []},
                 tool_names=["foo"],
                 security=policy,
             )
-            tool = mgr.registry["foo"]
+            tool = mgr.registry["mcp__srv__foo"]
             assert tool.mcp_capability is not None
             assert tool.mcp_capability.security is policy
             # The capability never appears in serialized state.


### PR DESCRIPTION
Refs #2921

## Confirmed cause

ADR-0112 makes registration of an accepted server complete-or-fail, and the branch correctly changed `load_mcp_config` to propagate registration failures. `create_agent`, however, still ran native `_load_mcp` before applying a caller-resolved CLI handoff set. That allowed an ambient home-level server to reach `MCPConnectionPool.get_client` even when the caller had selected a different set or explicitly selected no config.

The qualification change did not create the unwanted connection. Its stricter failure propagation exposed a pre-existing selection-order bug that had previously been hidden by recording the failed server as an empty registration.

## ADR amendment and rule

ADR-0112 did not specify whether selection happens before acquisition, so an amendment was required. D3 now states that server-set selection precedes acquisition: a server outside an authoritative caller-resolved set is neither connected nor recorded as an empty registration. D3 still applies unchanged once a server has actually been selected for registration.

`create_agent` now runs native MCP discovery only when `resolved_mcp_servers` is `Unset`. A supplied mapping and the explicit no-config `None` case both suppress native discovery before the selected set is forwarded.

Caller-visible behavior change: CLI handoffs with a caller-resolved set no longer start ambient MCP subprocesses or register ambient native MCP tools. The CLI request still receives exactly the selected server set. Native discovery remains unchanged when no resolved set is supplied, and failures from accepted servers still raise.

## Verification

- Python 3.10 handover file: 48 passed.
- Python 3.14 handover file: 48 passed.
- Agent factory and MCP security tests: passed with an isolated empty home.
- Full `tests/protocols/action/`: passed.
- Mutation check: removing the new selection guard produced exactly 11 failures—the direct no-connect assertion and the five handover functions under both model parameters; restoring it produced 49 passes.
- `ruff format`, `ruff check`, and pyright completed successfully; pyright reported zero errors.