### PR TITLE
fix(cli): report unswept plays honestly, and keep stopping the invocation that owns a session

### DIFF
--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -304,13 +304,18 @@ async def _list_running_children(
         )
         for row in rows:
             session_row = db._row_to_dict(row)
-            # Deepest first: the session's own children are signalled before
-            # the session, so a worker is never orphaned by its parent going
+            # Deepest first: whatever the session reaches is signalled before
+            # the session, so no process is orphaned by its owner going
             # terminal ahead of it.
             children.extend(await _list_running_children(db, "session", session_row["id"]))
             children.append(("sessions", "session", session_row))
 
     if entity_type == "session":
+        # `sessions.invocation_id` points at the invocation that OWNS this
+        # session, so this walks up rather than down. It belongs here anyway:
+        # stopping a session has to stop the process running it, and that
+        # process is the owning invocation. Traversal order still holds, since
+        # the owner is signalled before the session that named it.
         rows = await db.fetch_all(
             "SELECT * FROM invocations "
             "WHERE status = 'running' AND id IN ("
@@ -913,9 +918,9 @@ async def _do_kill_all_stale(
         # never records the sessions it started, so this is a property of how
         # plays are written rather than an observation about these rows.
         warn(
-            f"{skipped_unlinked_plays} running play row(s) were not considered: "
-            "a play created by a live run records no worker session, so there is "
-            "nothing to test for staleness. Sweep the worker session ids instead "
+            f"{skipped_unlinked_plays} running play row(s) were not swept: "
+            "plays created by live runs record no link to the sessions they started, "
+            "so their worker state cannot be determined. Sweep the worker session ids instead "
             "(`li monitor` lists them)."
         )
     return 0

--- a/lionagi/cli/kill.py
+++ b/lionagi/cli/kill.py
@@ -304,23 +304,12 @@ async def _list_running_children(
         )
         for row in rows:
             session_row = db._row_to_dict(row)
-            # Deepest first: the session's own children are signalled before
-            # the session, so a worker is never orphaned by its parent going
-            # terminal ahead of it.
-            children.extend(await _list_running_children(db, "session", session_row["id"]))
             children.append(("sessions", "session", session_row))
 
     if entity_type == "session":
-        rows = await db.fetch_all(
-            "SELECT * FROM invocations "
-            "WHERE status = 'running' AND id IN ("
-            "  SELECT invocation_id FROM sessions "
-            "  WHERE invocation_id IS NOT NULL AND id = ?"
-            ")",
-            (entity_id,),
-        )
-        for row in rows:
-            children.append(("invocations", "invocation", db._row_to_dict(row)))
+        # sessions.invocation_id names the invocation that owns the session.
+        # That is an upward edge; sessions have no children in this model.
+        return children
 
     if entity_type == "invocation":
         rows = await db.fetch_all(
@@ -913,9 +902,9 @@ async def _do_kill_all_stale(
         # never records the sessions it started, so this is a property of how
         # plays are written rather than an observation about these rows.
         warn(
-            f"{skipped_unlinked_plays} running play row(s) were not considered: "
-            "a play created by a live run records no worker session, so there is "
-            "nothing to test for staleness. Sweep the worker session ids instead "
+            f"{skipped_unlinked_plays} running play row(s) were not swept: "
+            "plays created by live runs record no link to the sessions they started, "
+            "so their worker state cannot be determined. Sweep the worker session ids instead "
             "(`li monitor` lists them)."
         )
     return 0

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -1660,13 +1660,13 @@ async def test_do_kill_play_leaves_workers_running_and_exits_non_zero(
     assert f"is marked {play_status}" in captured.err.replace("\n", " ")
 
 
-async def test_list_running_children_play_returns_worker_chain_deepest_first(
+async def test_list_running_children_play_returns_linked_session_only(
     temp_db_path: Path,
 ):
-    """A play with a recorded session resolves that session and its invocation.
+    """A play with a recorded session resolves that session, not its parent.
 
-    The invocation comes first: a child is signalled before the parent that
-    owns it, so terminating the session never leaves its invocation orphaned.
+    ``sessions.invocation_id`` points upward to the invocation that owns the
+    session. It is not another worker below the session.
     """
     async with StateDB() as db:
         invocation_id = await _seed_invocation(db, status="running", pid=43002)
@@ -1677,20 +1677,17 @@ async def test_list_running_children_play_returns_worker_chain_deepest_first(
 
         children = await _list_running_children(db, "play", play_id)
 
-    assert [(kind, row["id"]) for _, kind, row in children] == [
-        ("invocation", invocation_id),
-        ("session", worker_session_id),
-    ]
+    assert [(kind, row["id"]) for _, kind, row in children] == [("session", worker_session_id)]
 
 
-async def test_do_kill_play_with_recorded_session_reaps_the_worker_chain(
+async def test_do_kill_play_stops_linked_session_without_cancelling_parent(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ):
-    """A play whose row records its worker session has that chain terminated.
+    """A play whose row records its worker session stops only that session.
 
     This is the shape the Studio show importer writes: `plays.session_id` is
-    bound to the session it matched by name. Both worker pids are signalled,
-    both rows go terminal, and the kill exits 0 — it did stop the work.
+    bound to the session it matched by name. The invocation linked from that
+    session owns it, so the invocation is not a descendant of the play.
     """
     import lionagi.cli.kill as kill_mod
     from lionagi.cli._logging import configure_cli_logging
@@ -1717,7 +1714,7 @@ async def test_do_kill_play_with_recorded_session_reaps_the_worker_chain(
     captured = capsys.readouterr()
 
     assert rc == 0
-    assert signalled_pids == [44002, 44001]
+    assert signalled_pids == [44001]
     assert "no worker process was stopped" not in captured.err.replace("\n", " ")
     async with StateDB() as db:
         assert (
@@ -1725,16 +1722,16 @@ async def test_do_kill_play_with_recorded_session_reaps_the_worker_chain(
         )["status"] == "cancelled"
         assert (
             await db.fetch_one("SELECT status FROM invocations WHERE id = ?", (invocation_id,))
-        )["status"] == "cancelled"
+        )["status"] == "running"
         assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[
             "status"
         ] == "blocked"
 
 
-async def test_do_kill_play_reaps_worker_chain_without_recursive_flag(
+async def test_do_kill_play_stops_linked_session_without_recursive_flag(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """The play's worker chain is not gated behind `--recursive`.
+    """The play's linked session is not gated behind `--recursive`.
 
     A play row carries no PID of its own, so resolving the sessions it started
     is the whole kill rather than an opt-in extra.
@@ -1915,25 +1912,73 @@ async def test_do_kill_play_emits_blocked_terminal_envelope(temp_db_path: Path):
     assert envelope.reason_code == RunReasons.CANCELLED_MANUAL_KILL
 
 
-async def test_do_kill_recursive_kills_child_invocations(
+async def test_do_kill_recursive_session_leaves_parent_and_sibling_running(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """--recursive: a session's linked invocation is also cancelled."""
-    monkeypatch.setattr("lionagi.cli.kill._terminate_pid", lambda pid, **kw: "sigterm")
+    """A recursive session kill must not walk its parent invocation upward."""
+    signalled_pids: list[int] = []
+    monkeypatch.setattr(
+        "lionagi.cli.kill._terminate_pid",
+        lambda pid, **kw: (signalled_pids.append(pid), "sigterm")[1],
+    )
 
     async with StateDB() as db:
-        sid = await _seed_session(db, status="running")
-        # Create an invocation and link it to the session.
-        inv_id = await _seed_invocation(db, status="running")
-        await db.update_session(sid, invocation_id=inv_id)
+        invocation_id = await _seed_invocation(db, status="running", pid=46003)
+        target_session_id = await _seed_session(db, status="running", pid=46001)
+        sibling_session_id = await _seed_session(db, status="running", pid=46002)
+        await db.update_session(target_session_id, invocation_id=invocation_id)
+        await db.update_session(sibling_session_id, invocation_id=invocation_id)
 
-    rc = await _do_kill(sid, recursive=True)
-    assert rc == 0
+    assert await _do_kill(target_session_id, recursive=True) == 0
 
     async with StateDB() as db:
-        assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,)))[
-            "status"
-        ] == "cancelled"
+        target = await db.fetch_one(
+            "SELECT status FROM sessions WHERE id = ?", (target_session_id,)
+        )
+        sibling = await db.fetch_one(
+            "SELECT status FROM sessions WHERE id = ?", (sibling_session_id,)
+        )
+        invocation = await db.fetch_one(
+            "SELECT status FROM invocations WHERE id = ?", (invocation_id,)
+        )
+
+    assert target is not None and target["status"] == "cancelled"
+    assert invocation is not None and invocation["status"] == "running", (
+        "recursive session kill must not cancel its parent invocation"
+    )
+    assert sibling is not None and sibling["status"] == "running", (
+        "recursive session kill must not cancel a sibling session"
+    )
+    assert signalled_pids == [46001], (
+        "recursive session kill must signal only the requested session"
+    )
+
+
+async def test_do_kill_recursive_invocation_cancels_child_sessions(temp_db_path: Path):
+    """The inverse schema edge remains the valid downward recursive step."""
+    async with StateDB() as db:
+        invocation_id = await _seed_invocation(db, status="running")
+        child_ids = [
+            await _seed_session(db, status="running"),
+            await _seed_session(db, status="running"),
+        ]
+        for child_id in child_ids:
+            await db.update_session(child_id, invocation_id=invocation_id)
+
+    assert await _do_kill(invocation_id, recursive=True) == 0
+
+    async with StateDB() as db:
+        invocation = await db.fetch_one(
+            "SELECT status FROM invocations WHERE id = ?", (invocation_id,)
+        )
+        children = await db.fetch_all(
+            "SELECT id, status FROM sessions WHERE invocation_id = ?", (invocation_id,)
+        )
+
+    assert invocation is not None and invocation["status"] == "cancelled"
+    assert {row["id"]: row["status"] for row in children} == {
+        child_id: "cancelled" for child_id in child_ids
+    }
 
 
 # ── CLI wiring smoke test ──────────────────────────────────────────────────────
@@ -2108,16 +2153,14 @@ async def test_do_kill_all_stale_does_NOT_touch_play_at_all(
         assert row["status"] == "running"
 
 
-async def test_do_kill_all_stale_reports_plays_it_could_not_assess(
+async def test_do_kill_all_stale_reports_unlinked_plays_were_not_swept(
     temp_db_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ):
-    """A play with no recorded worker session is counted and named once.
+    """A play with no recorded worker session is named as not swept.
 
     The sweep has no way to tell whether such a play is abandoned, so it leaves
-    it alone. Saying so once per sweep, with a count in the closing line, keeps
-    the operator from reading silence as "nothing was stale". A per-row message
-    would read as an observation about that row rather than the structural fact
-    it is.
+    it alone. Saying plainly that it was not swept keeps the operator from
+    reading silence as "nothing was stale".
     """
     from lionagi.cli._logging import configure_cli_logging
 
@@ -2131,11 +2174,13 @@ async def test_do_kill_all_stale_reports_plays_it_could_not_assess(
         await db.execute("UPDATE plays SET started_at = ? WHERE id = ?", (old_start, play_id))
 
     capsys.readouterr()
-    assert await _do_kill_all_stale(threshold_seconds=3600, dry_run=False) == 0
+    assert await _do_kill_all_stale(threshold_seconds=3600, dry_run=False, verbose=True) == 0
     captured = capsys.readouterr()
 
     assert "skipped_unlinked_plays=1" in captured.out
-    assert "records no worker session" in captured.err.replace("\n", " ")
+    operator_output = captured.err.replace("\n", " ")
+    assert "1 running play row(s) were not swept" in operator_output
+    assert "record no link to the sessions they started" in operator_output
 
     async with StateDB() as db:
         assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[

--- a/tests/cli/test_kill.py
+++ b/tests/cli/test_kill.py
@@ -1934,6 +1934,44 @@ async def test_do_kill_recursive_kills_child_invocations(
         assert (await db.fetch_one("SELECT status FROM sessions WHERE id = ?", (sid,)))[
             "status"
         ] == "cancelled"
+        # The name of this test promises the invocation goes too, and until
+        # now nothing checked it: the traversal could have been dropped
+        # entirely and this stayed green.
+        assert (await db.fetch_one("SELECT status FROM invocations WHERE id = ?", (inv_id,)))[
+            "status"
+        ] == "cancelled"
+
+
+async def test_do_kill_recursive_invocation_cancels_child_sessions(temp_db_path: Path):
+    """The downward edge: an invocation's sessions are cancelled with it.
+
+    `sessions.invocation_id` is read in both directions — up from a session to
+    the invocation running it, and down from an invocation to the sessions it
+    owns. This pins the downward half, which the upward tests do not cover.
+    """
+    async with StateDB() as db:
+        invocation_id = await _seed_invocation(db, status="running")
+        child_ids = [
+            await _seed_session(db, status="running"),
+            await _seed_session(db, status="running"),
+        ]
+        for child_id in child_ids:
+            await db.update_session(child_id, invocation_id=invocation_id)
+
+    assert await _do_kill(invocation_id, recursive=True) == 0
+
+    async with StateDB() as db:
+        invocation = await db.fetch_one(
+            "SELECT status FROM invocations WHERE id = ?", (invocation_id,)
+        )
+        children = await db.fetch_all(
+            "SELECT id, status FROM sessions WHERE invocation_id = ?", (invocation_id,)
+        )
+
+    assert invocation is not None and invocation["status"] == "cancelled"
+    assert {row["id"]: row["status"] for row in children} == {
+        child_id: "cancelled" for child_id in child_ids
+    }
 
 
 # ── CLI wiring smoke test ──────────────────────────────────────────────────────
@@ -2135,7 +2173,9 @@ async def test_do_kill_all_stale_reports_plays_it_could_not_assess(
     captured = capsys.readouterr()
 
     assert "skipped_unlinked_plays=1" in captured.out
-    assert "records no worker session" in captured.err.replace("\n", " ")
+    operator_output = captured.err.replace("\n", " ")
+    assert "1 running play row(s) were not swept" in operator_output
+    assert "record no link to the sessions they started" in operator_output
 
     async with StateDB() as db:
         assert (await db.fetch_one("SELECT status FROM plays WHERE id = ?", (play_id,)))[


### PR DESCRIPTION
Closes #2916

## The `--all-stale` message (the original scope)

A play row created by a live run records no link to the sessions it started, so the stale sweep cannot assess it and leaves it alone. The old wording said such rows "were not considered: ... there is nothing to test for staleness", which reads as though the rows were judged and found uninteresting. It now says they were **not swept**, and why: the link does not exist, so their worker state cannot be determined. The closing line still carries the count, so silence is not read as "nothing was stale".

## The traversal change, reverted

An earlier revision of this branch removed the `session` branch of `_list_running_children`, reasoning that `sessions.invocation_id` names the invocation that *owns* the session, making the edge upward rather than downward, and therefore not a child relationship at all.

The premise is correct. The conclusion was not. Stopping a session has to stop the process running it, and that process is the owning invocation. With the traversal removed, cancelling a run from the Operator marked the session terminal and left its process alive.

`tests/apps_studio_server/test_operator_cancel_run.py::test_execute_cancel_command_reaps_a_running_child_invocation` says this outright in its own docstring — "must not leave its **owning** invocation's process running" — so the behaviour was deliberate and already covered. It failed on both Python versions on the earlier revision. Only the test's *name* was misleading: it says "child" for an edge that runs the other way.

The traversal is restored, with the direction spelled out in a comment so the next reader does not re-derive the same wrong conclusion from the same correct observation.

## Why it was deletable with tests green

`test_do_kill_recursive_kills_child_invocations` promised in its name that the linked invocation is cancelled, and asserted only that the *session* was. The whole traversal could be removed with that test still passing. It now asserts the invocation too.

A second test covers the downward reading of the same column — an invocation cancelling the sessions it owns — which nothing pinned before. Both directions of `sessions.invocation_id` are now held by a test.

## Not closing #2917

The earlier revision claimed the unlinked-play skip was silent. It is not: the warning already existed before this branch. `Closes #2917` is deliberately absent; that issue rests on a premise that does not hold, and it should be closed on its own merits rather than by a PR that did not fix it.

## Verification

- `tests/cli/test_kill.py`: 86 passed.
- `tests/apps_studio_server/test_operator_cancel_run.py`: 26 passed — the suite that was red.
- Mutation, arms predicted before running and reconciled one by one: removing the session traversal again reddens `test_list_running_children_play_returns_worker_chain_deepest_first`, `test_do_kill_play_with_recorded_session_reaps_the_worker_chain`, and the strengthened `test_do_kill_recursive_kills_child_invocations`, while the new downward-edge test stays green because it exercises the other direction.