### PR TITLE
fix(mcp): expose degraded persistence reason

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -50,6 +50,7 @@ __all__ = (
 _LEGACY_AGENTS_ROOT = LIONAGI_HOME / "logs" / "agents"
 _LAST_BRANCH_POINTER = LIONAGI_HOME / "last_branch.json"
 _RUN_ID_ENV_VAR = "LIONAGI_RUN_ID"
+PERSISTENCE_DEGRADED_REASON_FIELD = "persistence_degraded_reason"
 
 
 def _new_run_id() -> str:
@@ -227,6 +228,44 @@ class RunDir:
 
     def ensure_artifact_root(self) -> None:
         ensure_lionagi_dir(self.artifact_root)
+
+
+def _record_persistence_degraded(
+    exc: BaseException,
+    *,
+    run: RunDir | None = None,
+    run_id: str | None = None,
+    run_manifest: dict[str, Any] | None = None,
+) -> str:
+    """Record why lifecycle persistence was disabled outside the failed store."""
+    reason = repr(exc)
+    if run_manifest is not None:
+        run_manifest[PERSISTENCE_DEGRADED_REASON_FIELD] = reason
+    resolved_id = run.run_id if run is not None else run_id
+    manifest_path = (
+        run.manifest_path
+        if run is not None
+        else (RUNS_ROOT / resolved_id / "run.json" if resolved_id else None)
+    )
+    if manifest_path is None:
+        _log.warning("could not record persistence degradation: no active run id")
+        return reason
+    try:
+        manifest = json.loads(manifest_path.read_text())
+        if not isinstance(manifest, dict):
+            raise TypeError("run manifest is not a JSON object")
+        if run_manifest is not None:
+            manifest.update(run_manifest)
+        manifest[PERSISTENCE_DEGRADED_REASON_FIELD] = reason
+        _atomic_write_json(manifest_path, manifest)
+    except Exception as record_exc:  # noqa: BLE001 — degradation must not become a run failure
+        _log.warning(
+            "could not record persistence degradation for run %s: %r",
+            resolved_id,
+            record_exc,
+            exc_info=True,
+        )
+    return reason
 
 
 def allocate_run(
@@ -1294,6 +1333,7 @@ async def setup_agent_persist(
     effort: str | None = None,
     project: str | None = None,
     run_id: str | None = None,
+    run_manifest: dict[str, Any] | None = None,
     share_db: bool = True,
     drains_controls: bool = False,
 ) -> dict | None:
@@ -1534,10 +1574,11 @@ async def setup_agent_persist(
         return ctx
     except Exception as exc:
         _log.warning(
-            "live persist setup failed (%s) — disabling persistence for this run",
+            "live persist setup failed (%r) — disabling persistence for this run",
             exc,
             exc_info=True,
         )
+        _record_persistence_degraded(exc, run_id=run_id, run_manifest=run_manifest)
         # If the wrapper session already claimed the branch, release it so a
         # later setup (or retry) can wrap the same branch again.
         if session is not None:

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -981,6 +981,8 @@ async def _run_agent(
         provider=provider,
         effort=effort,
         project=project,
+        run_id=run.run_id,
+        run_manifest=run_manifest,
         # This runner drains queued operator messages at turn end and
         # tombstones whatever it did not take, so controls aimed at it have a
         # consumer.

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -15,7 +15,7 @@ from lionagi._errors import LionError
 from lionagi._paths import RUNS_ROOT
 from lionagi.ln._json_dump import raise_if_non_finite
 
-from .._runs import RunDir
+from .._runs import PERSISTENCE_DEGRADED_REASON_FIELD, RunDir
 from .._util import AmbiguousIdError
 
 __all__ = (
@@ -186,6 +186,19 @@ def _find_run_dir_by_id(run_id: str) -> RunDir | None:
     return RunDir(run_id=match.name, state_root=match, artifact_root=match / "artifacts")
 
 
+def _raise_if_persistence_degraded(run_dir: RunDir) -> None:
+    """Explain a missing checkpoint using state that survived the failed database."""
+    try:
+        reason = run_dir.read_manifest().get(PERSISTENCE_DEGRADED_REASON_FIELD)
+    except (OSError, UnicodeError, json.JSONDecodeError, AttributeError):
+        return
+    if isinstance(reason, str) and reason:
+        raise FlowResumeError(
+            f"Cannot resume run {run_dir.run_id!r}: persistence was disabled "
+            f"for that run ({reason}); no checkpoint is available."
+        )
+
+
 async def resolve_checkpoint_target(target: str) -> tuple[RunDir, dict[str, Any]]:
     """Resolve a run_id, or a session/invocation/play id, to (RunDir, checkpoint dict).
 
@@ -195,8 +208,10 @@ async def resolve_checkpoint_target(target: str) -> tuple[RunDir, dict[str, Any]
     node_metadata carries the run_id every flow run stamps at startup.
     """
     run_dir = _find_run_dir_by_id(target)
-    if run_dir is not None and run_dir.checkpoint_path.exists():
-        return run_dir, load_checkpoint(run_dir.checkpoint_path)
+    if run_dir is not None:
+        if run_dir.checkpoint_path.exists():
+            return run_dir, load_checkpoint(run_dir.checkpoint_path)
+        _raise_if_persistence_degraded(run_dir)
 
     from lionagi.cli.status import _resolve_any_target, _resolve_primary_session
     from lionagi.state.db import StateDB
@@ -219,7 +234,12 @@ async def resolve_checkpoint_target(target: str) -> tuple[RunDir, dict[str, Any]
         )
 
     run_dir = _find_run_dir_by_id(run_id)
-    if run_dir is None or not run_dir.checkpoint_path.exists():
+    if run_dir is None:
+        raise FlowResumeError(
+            f"No checkpoint.json found for run {run_id!r} (resolved from {target!r})."
+        )
+    if not run_dir.checkpoint_path.exists():
+        _raise_if_persistence_degraded(run_dir)
         raise FlowResumeError(
             f"No checkpoint.json found for run {run_id!r} (resolved from {target!r})."
         )

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -47,6 +47,7 @@ from .._runs import (
     RunDir,
     _make_message_handler,
     _open_shared_db,
+    _record_persistence_degraded,
     _resolve_project,
     allocate_run,
     save_last_branch_pointer,
@@ -1377,6 +1378,8 @@ _log_orch = logging.getLogger("lionagi.cli")
 async def setup_orchestration_persist(
     session: Any,
     *,
+    run: RunDir | None = None,
+    run_manifest: dict[str, Any] | None = None,
     invocation_kind: str | None = None,
     playbook_name: str | None = None,
     agent_name: str | None = None,
@@ -1466,10 +1469,11 @@ async def setup_orchestration_persist(
         return ctx
     except Exception as exc:
         _log_orch.warning(
-            "live persist setup failed (%s) — disabling persistence for this run",
+            "live persist setup failed (%r) — disabling persistence for this run",
             exc,
             exc_info=True,
         )
+        _record_persistence_degraded(exc, run=run, run_manifest=run_manifest)
         if db is not None:
             try:
                 await db.close()
@@ -1593,6 +1597,8 @@ async def start_live_persist(
     env.run.write_manifest(env._run_manifest)
     ctx = await setup_orchestration_persist(
         env.session,
+        run=env.run,
+        run_manifest=env._run_manifest,
         invocation_kind=invocation_kind,
         playbook_name=playbook_name,
         agent_name=agent_name,

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -167,6 +167,7 @@ LIFECYCLE_TIMEOUT_SECONDS = 20.0
 
 # The most the lifecycle command may write on its result channel.
 _LIFECYCLE_OUTPUT_LIMIT = 1_000_000
+_PERSISTENCE_DEGRADED_REASON_FIELD = "persistence_degraded_reason"
 
 # Bounds for wait(). The maximum sits below ordinary MCP client timeouts so a
 # bounded observation returns partial results rather than being cut off mid-call.
@@ -1668,6 +1669,11 @@ def status(run_id: str) -> dict[str, Any]:
     job = _reap_if_conclusively_gone(run_id, job, liveness)
 
     derived = _derive(job, alive, lifecycle)
+    persistence_degraded_reason = (
+        manifest.get(_PERSISTENCE_DEGRADED_REASON_FIELD) if isinstance(manifest, dict) else None
+    )
+    if not isinstance(persistence_degraded_reason, str) or not persistence_degraded_reason:
+        persistence_degraded_reason = None
 
     return {
         "run_id": run_id,
@@ -1695,6 +1701,7 @@ def status(run_id: str) -> dict[str, Any]:
         "mcp_config_source": (job or {}).get("mcp_config_source"),
         "mcp_config_reason": (job or {}).get("mcp_config_reason"),
         "mcp_config_servers": (job or {}).get("mcp_config_servers"),
+        _PERSISTENCE_DEGRADED_REASON_FIELD: persistence_degraded_reason,
         "run": manifest,
         "log_tail": _tail((job or {}).get("log")),
         "known": job is not None,
@@ -2210,6 +2217,7 @@ def list_jobs(limit: int = 50, status_filter: str | None = None) -> list[dict[st
                 "finished_at_precision": st["finished_at_precision"],
                 "terminal_source": st["terminal_source"],
                 "record_state": st["record_state"],
+                _PERSISTENCE_DEGRADED_REASON_FIELD: st[_PERSISTENCE_DEGRADED_REASON_FIELD],
                 "notify_delivery_state": _notify_delivery_state(st["notify_delivery"]),
             }
         )

--- a/tests/mcp/test_degraded_persistence.py
+++ b/tests/mcp/test_degraded_persistence.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""Caller-visible coverage for runs that continue without lifecycle persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lionagi import Branch, Session
+from lionagi.cli import _runs
+from lionagi.cli.orchestrate import _checkpoint, _orchestration
+from lionagi.cli.orchestrate._checkpoint import FlowResumeError
+from lionagi.mcp import config, jobs
+
+
+def _env(run: _runs.RunDir) -> _orchestration.OrchestrationEnv:
+    branch = Branch(name="orchestrator")
+    return _orchestration.OrchestrationEnv(
+        run=run,
+        session=Session(default_branch=branch),
+        orc_branch=branch,
+        builder=MagicMock(),
+        orc_profile=None,
+        orc_profile_name=None,
+        default_model_spec="codex",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+
+
+def _run_dir(root: Path, run_id: str) -> _runs.RunDir:
+    run = _runs.RunDir(
+        run_id=run_id,
+        state_root=root / run_id,
+        artifact_root=root / run_id / "artifacts",
+    )
+    run.ensure_state_dirs()
+    run.ensure_artifact_root()
+    return run
+
+
+def _write_terminal_job(run_id: str) -> None:
+    jobs._write_job(
+        {
+            "run_id": run_id,
+            "pid": None,
+            "kind": "flow",
+            "status": "completed",
+            "spawn_state": "started",
+            "submitted_at": "2026-08-08T00:00:00+00:00",
+            "finished_at": "2026-08-08T00:01:00+00:00",
+            "log": None,
+        }
+    )
+
+
+async def _seed_runs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[str, str]:
+    runs_root = tmp_path / "runs"
+    open_shared_db = _orchestration._open_shared_db
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", runs_root)
+    monkeypatch.setattr(_checkpoint, "RUNS_ROOT", runs_root)
+    monkeypatch.setattr("lionagi.state.db.DEFAULT_DB_PATH", tmp_path / "state.db")
+    monkeypatch.setattr(jobs, "_read_lifecycle", lambda run_id: None)
+
+    degraded_id = "20260808T000002-000002"
+    healthy_id = "20260808T000001-000001"
+    degraded = _run_dir(runs_root, degraded_id)
+    healthy = _run_dir(runs_root, healthy_id)
+
+    async def unavailable(*args, **kwargs):
+        raise OSError()
+
+    monkeypatch.setattr(_orchestration, "_open_shared_db", unavailable)
+    await _orchestration.start_live_persist(_env(degraded), invocation_kind="flow")
+
+    monkeypatch.setattr(_orchestration, "_open_shared_db", open_shared_db)
+    healthy_env = _env(healthy)
+    await _orchestration.start_live_persist(healthy_env, invocation_kind="flow")
+    assert healthy_env._live_persist is not None
+    await _orchestration.stop_live_persist(healthy_env)
+
+    _write_terminal_job(degraded_id)
+    _write_terminal_job(healthy_id)
+    return degraded_id, healthy_id
+
+
+async def test_status_reports_persistence_reason_and_healthy_control(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    degraded_id, healthy_id = await _seed_runs(monkeypatch, tmp_path)
+
+    degraded = jobs.status(degraded_id)
+    healthy = jobs.status(healthy_id)
+
+    assert degraded["persistence_degraded_reason"] == "OSError()"
+    assert degraded["persistence_degraded_reason"]
+    assert healthy["persistence_degraded_reason"] is None
+
+
+async def test_agent_degradation_survives_terminal_manifest_rewrite(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    run = _run_dir(tmp_path / "runs", "20260808T000003-000003")
+    run_manifest = {
+        "branch_id": "agent-branch",
+        "status": "running",
+        "started_at": 1.0,
+        "ended_at": None,
+    }
+    run.write_manifest(run_manifest)
+
+    async def unavailable(*args, **kwargs):
+        raise OSError()
+
+    monkeypatch.setattr(_runs, "_open_shared_db", unavailable)
+    live = await _runs.setup_agent_persist(Branch(), run_id=run.run_id, run_manifest=run_manifest)
+
+    assert live is None
+    run_manifest.update(status="completed", ended_at=2.0)
+    run.write_manifest(run_manifest)
+    assert run.read_manifest()["persistence_degraded_reason"] == "OSError()"
+
+
+async def test_listing_distinguishes_degraded_run_from_healthy_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    degraded_id, healthy_id = await _seed_runs(monkeypatch, tmp_path)
+
+    listed = {row["run_id"]: row for row in jobs.list_jobs()}
+
+    assert listed[degraded_id]["persistence_degraded_reason"] == "OSError()"
+    assert listed[healthy_id]["persistence_degraded_reason"] is None
+
+
+async def test_resume_without_checkpoint_reports_persistence_reason(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    degraded_id, _ = await _seed_runs(monkeypatch, tmp_path)
+
+    with pytest.raises(FlowResumeError, match=r"persistence.*OSError\(\)"):
+        await _checkpoint.resolve_checkpoint_target(degraded_id)
+
+
+async def test_resume_with_unreadable_degradation_state_keeps_generic_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runs_root = tmp_path / "runs"
+    run_id = "20260808T000004-000004"
+    run = _run_dir(runs_root, run_id)
+    run.manifest_path.write_bytes(b"\xff")
+    monkeypatch.setattr(_checkpoint, "RUNS_ROOT", runs_root)
+
+    class EmptyStateDB:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+    async def unresolved(db, target):
+        return None
+
+    monkeypatch.setattr("lionagi.state.db.StateDB", EmptyStateDB)
+    monkeypatch.setattr("lionagi.cli.status._resolve_any_target", unresolved)
+
+    with pytest.raises(FlowResumeError, match=r"No run, session, invocation, or play found"):
+        await _checkpoint.resolve_checkpoint_target(run_id)


### PR DESCRIPTION
## Summary

- Record `persistence_degraded_reason = repr(error)` in the per-run manifest whenever StateDB setup fails and the run continues without persistence.
- Surface the reason on `job.status` and every `job.list` row; healthy runs expose the same field as `null`.
- Make a direct run-ID resume without a checkpoint fail with the recorded persistence reason instead of a generic lookup error.

## Why the record survives

The degraded state lives in the filesystem `run.json`, not in the lifecycle database that failed to open. `RunDir` and its manifest are allocated before `_open_shared_db()` runs, and the two stores are independent. The failure handler atomically updates `run.json` and also updates the caller-owned manifest dictionary, because agent and orchestration terminalization replace the whole manifest later and would otherwise erase a one-off write.

This does not change the refusal-to-write guard, `record_state` semantics, or WAL configuration.

## Surfaces and limits

Now carries the field:

- `job.status` (including detailed status)
- `job.list`, which makes degraded rows distinguishable and client-filterable
- direct run-ID checkpoint resume when no checkpoint exists

Cannot carry the field:

- `state.ls` / `state.stats`, because an unpersisted run has no lifecycle row to query
- session/invocation/play-ID resume, because the alias-to-run mapping exists only in StateDB; the direct run ID remains recoverable from `run.json`
- direct CLI runs in `job.list`, because that command enumerates MCP `job.json` records only

`job.output` and `job.wait` have separate manual projections and are outside this issue's requested surfaces.

## Verification

- Required caller-visible degraded, healthy-control, list, and resume tests use temporary run/job/StateDB paths.
- Adjacent agent, orchestration, checkpoint, and MCP job suites pass; one process-table test skips under the sandbox permission model.
- Changed executable-line coverage: 40/43 (93.0%).
- Ruff format/check pass; Pyright reports 0 errors (existing warning-level backlog remains).
- Mutations independently proved the writer, status projection, list projection, resume guard, agent terminal rewrite, and healthy control each fail their intended assertion when removed or inverted.
- The full MCP selection encounters missing optional FastMCP, Studio, and cron dependencies; the same capped failures reproduce on the unmodified base. The remaining MCP core passes when those unavailable optional modules are excluded.

Closes #2895
