### PR TITLE
fix(cli): stop rejecting playbook fields that real playbooks use

### DIFF
--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -47,6 +47,13 @@ _FLOW_SPEC_FIELDS = frozenset(
         "with_synthesis",
         "workers",
     }
+    # Recognized but not applied: these appear in real playbooks in the field,
+    # and the loader has never read them — the run takes its value from the
+    # command-line flag instead. Accepting them keeps working playbooks working;
+    # rejecting them would break files whose only fault is naming a key that
+    # does nothing. Wiring them would silently change how those runs execute,
+    # which is a behavior decision, not a validation one.
+    | {"bypass", "permission_mode", "yolo"}
 )
 
 

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -11,6 +11,7 @@ import yaml
 
 from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.cli.orchestrate import (
+    _load_flow_spec,
     _validate_spec_fields,
     add_orchestrate_subparser,
     run_orchestrate,
@@ -185,9 +186,9 @@ class TestSpecValidationRejectsUnknownFields:
         err = _validate_spec_fields({"reactve": "off"})
         assert err == (
             "unknown spec field 'reactve'; accepted fields: agent, args, argument-hint, "
-            "artifacts, bare, description, dry_run, effort, max_agents, max_ops, model, name, "
-            "pack, prompt, reactive, save, show_graph, team_attach, team_mode, with_synthesis, "
-            "workers"
+            "artifacts, bare, bypass, description, dry_run, effort, max_agents, max_ops, "
+            "model, name, pack, permission_mode, prompt, reactive, save, show_graph, "
+            "team_attach, team_mode, with_synthesis, workers, yolo"
         )
 
     def test_dead_critic_model_field_is_rejected(self):
@@ -235,6 +236,17 @@ class TestSpecValidationAcceptsValidFields:
     def test_name_metadata_field_remains_accepted(self):
         assert _validate_spec_fields({"name": "repo-review"}) is None
 
+    # Named one at a time on purpose. Looping over the implementation's own
+    # accepted set would pass no matter which key was dropped from it.
+    def test_yolo_field_remains_accepted(self):
+        assert _validate_spec_fields({"yolo": True}) is None
+
+    def test_bypass_field_remains_accepted(self):
+        assert _validate_spec_fields({"bypass": True}) is None
+
+    def test_permission_mode_field_remains_accepted(self):
+        assert _validate_spec_fields({"permission_mode": "acceptEdits"}) is None
+
     def test_valid_effort_values(self):
         for effort in ("low", "medium", "high", "xhigh"):
             assert _validate_spec_fields({"effort": effort}) is None
@@ -278,6 +290,30 @@ class TestSpecValidationAcceptsValidFields:
             "team_mode": "ws-terminal",
         }
         assert _validate_spec_fields(spec) is None
+
+    def test_every_playbook_this_repo_ships_validates(self):
+        """The accepted set has to cover the playbooks we ourselves ship.
+
+        Enumerating keys by hand is what lets a real, widely-used field go
+        missing: unit tests over hand-written dicts only ever check the keys
+        someone remembered. This walks the actual files through the same
+        loader the CLI uses, so a field that real playbooks depend on cannot
+        drop out of the accepted set unnoticed.
+        """
+        root = Path(__file__).resolve().parents[3]
+        playbooks = sorted(root.glob("examples/playbooks/*.playbook.yaml")) + sorted(
+            root.glob("lionagi/studio/builtin_playbooks/*.playbook.yaml")
+        )
+        assert playbooks, "found no shipped playbooks — the glob is wrong, not the repo"
+
+        rejected = {}
+        for path in playbooks:
+            spec = _load_flow_spec(str(path))
+            assert spec is not None, f"{path.name} failed to load"
+            error = _validate_spec_fields(spec)
+            if error is not None:
+                rejected[path.name] = error
+        assert not rejected, f"shipped playbooks rejected by the validator: {rejected}"
 
     def test_run_orchestrate_rejects_bad_spec(self, tmp_path, caplog):
         spec_file = tmp_path / "bad.yaml"


### PR DESCRIPTION
> [!IMPORTANT]
> Unknown-field validation currently turns away playbooks that declare `yolo`, `permission_mode` or `bypass`. Measured against the playbooks actually installed on a working machine, **32 of 56 fail to run**. This restores them.

## What happened

The accepted set was built by enumerating the keys the loader applies to its arguments. That is a smaller set than the keys real playbooks legitimately carry, so three widely-used fields were left out. The result is that a playbook naming any of them is refused outright rather than run — worse than the silent typos the check was added to catch.

## Why these three are accepted and not wired

The loader has never read `yolo`, `permission_mode` or `bypass` off a spec. Each value reaches a run from the corresponding command-line flag instead; the spec-to-arguments block does not mention them. So they are inert today.

Honouring them now would change how existing runs execute — including granting elevated permissions to files that have carried the key for a long time without effect. That is a behaviour decision and deserves its own change with its own review. This one only stops working files from being turned away.

Whether they should be wired or removed from the playbooks that declare them is a real open question, and it stays open here.

## Verification

Measured through the production path (`_load_flow_spec` then `_validate_spec_fields`), over every playbook installed on this machine plus every one this repo ships:

| | before | after |
|---|---|---|
| playbooks refused | 32 of 56 | 0 of 56 |

Unknown keys found, and how many playbooks used each: `yolo` 32, `permission_mode` 2, `bypass` 1.

`tests/cli/orchestrate/test_security_hardening.py`: 65 passed.

Mutation check — removing the three keys again, with the reddened arms predicted beforehand and reconciled one by one: the three named-field tests fail, and `test_every_playbook_this_repo_ships_validates` stays green. That second result is the honest limit of the new suite-wide test: the playbooks that broke live outside the repo, so it could not have caught this. It closes the general case only for files the repo can see.

## A related gap, not fixed here

`lionagi/studio/services/playbooks.py::_check_spec_fields` documents itself as mirroring the CLI validator exactly. It has no unknown-field rejection. A playbook that Studio saves without complaint can therefore still be refused by `li play`. Left alone deliberately — adding rejection to a second surface is how this problem started.