### PR TITLE
fix(mcp): retain terminal notification attempt state

### DIFF
--- a/docs/adr/ADR-0107-conclusive-orphan-terminal-reaping.md
+++ b/docs/adr/ADR-0107-conclusive-orphan-terminal-reaping.md
@@ -424,10 +424,13 @@ notification configuration path.
 
 Concurrent readers can race after the transition and before delivery. Only the
 reader whose guarded operation returns `won_transition=true` may initiate the
-delivery. Other readers return the durable terminal state. Crash after the
-terminal write but before delivery remains visible as absent
-`notify_delivery`; notification is best-effort, and ADR-0106 D9 still requires
-reconciliation by reading state.
+delivery. Other readers return the durable terminal state. The terminal
+transition writes `{"attempted": false}` and delivery replaces it with an
+attempted/unknown outcome before launching the notifier. A crash after the
+external side effect but before the final result therefore remains visible as
+an attempt whose outcome is unknown rather than absent `notify_delivery`;
+notification is still best-effort, and ADR-0106 D9 still requires reconciliation
+by reading state.
 
 This is tension with the ideal that a terminal transition and its wake-up are
 indivisible. They are not indivisible today either: the terminal hook records

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -761,9 +761,11 @@ variables `LIONAGI_MCP_NOTIFY_COMMAND` and `LIONAGI_MCP_NOTIFY_TARGET` set a
 process-wide default. Delivery outcome is recorded on the job and surfaced in
 `job.status` (`notify_delivery`), so a notice that failed to send is visible
 rather than silently lost. `job.list` carries the same outcome collapsed to one
-word in `notify_delivery_state` — `delivered`, `failed`, or `none` when no
-notifier was configured — so a run whose notice never went out is spotted while
-scanning runs, not only when one is looked up.
+word in `notify_delivery_state` — `delivered`, `failed`, `unknown` when an
+attempt's final result was interrupted, or `none` when no notifier was
+configured — so a run whose notice never went out is spotted while scanning
+runs, not only when one is looked up. The full `job.status.notify_delivery`
+object is null only for a non-terminal run.
 
 ---
 

--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -263,6 +263,11 @@ Inconclusive (settle nothing about death):
   `lifecycle_cache` / `spawn_failure` / `mcp_orphan_reaper` / null for
   pre-field records); `terminal_evidence` carries bounded evidence for an end
   nobody reported.
+- `notify_delivery` is null only while `terminal` is false. A terminal run with
+  no configured notifier reports `{"attempted": false}`. Delivery writes an
+  attempted/unknown object before launching the notifier and replaces it with
+  success or failure afterward, so cancellation after an external side effect
+  cannot erase the fact that an attempt occurred.
 - `possibly_orphaned` flags a gone process with no end recorded whose loss
   wasn't conclusively established (unaskable pid, or an unpublishable
   transition) — advisory, never makes the run terminal.
@@ -281,13 +286,15 @@ Inconclusive (settle nothing about death):
 A caller who suspects nothing still needs to find the run whose terminal
 notice never arrived — by construction that run announced itself to nobody.
 `job.list` is that surface: every row carries `notify_delivery_state`
-(`none` / `delivered` / `delivered_unverified` / `failed`, collapsed from the
+(`none` / `delivered` / `delivered_unverified` / `failed` / `unknown`, collapsed from the
 full `notify_delivery` object `status()` reports for one-run detail), so the
-sweep is "list, act on `failed`" with no per-run reads. `none` covers both
+sweep is "list, act on `failed` or `unknown`" with no per-run reads. `none` covers both
 not-terminal-yet and no-notifier-configured — silence is the documented
 default there, never a failure — and `delivered_unverified` is deliberately
 not collapsed into either neighbor (a zero exit from a command shape whose
-zero exit doesn't prove a send supports neither claim).
+zero exit doesn't prove a send supports neither claim). `unknown` means the
+attempt began but the process ended before its final result could replace the
+write-ahead record; inspect or reconcile it rather than treating it as success.
 
 #### signal-leader-group-safety
 

--- a/lionagi/mcp/_notify_hook.py
+++ b/lionagi/mcp/_notify_hook.py
@@ -449,6 +449,11 @@ def main(argv: list[str] | None = None) -> int:
     if cause is not None:
         jobs.record_failure_cause(args.run_id, cause)
 
+    started = jobs.begin_notify_delivery(args.run_id)
+    if started.refused:
+        _note_persistence_failure(args.run_id, "delivery attempt")
+        return 1
+
     outcome = deliver_terminal_notice(
         args.run_id,
         terminal.record,

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -1565,6 +1565,7 @@ def reap_orphan(run_id: str, *, finding: str, observed_at: str) -> ReapResult:
                 "finished_at_precision": FINISHED_AT_UPPER_BOUND,
                 "terminal_source": TERMINAL_SOURCE_ORPHAN_REAPER,
                 "terminal_evidence": {"kind": EVIDENCE_PROCESS_GONE, "finding": finding},
+                "notify_delivery": {"attempted": False},
             }
         )
         return ReapResult(True, job, "reaped")
@@ -1595,17 +1596,20 @@ def _deliver_reap_notice(run_id: str, record: dict[str, Any]) -> dict[str, Any] 
 
     Best-effort and after the fact. The end is already durable when this runs,
     so nothing here can change how the run came out: a refusal, a non-zero exit
-    or a timeout is recorded as a delivery failure, and a delivery that never
-    gets to record anything leaves ``notify_delivery`` absent, which is what a
-    crash between the two writes looks like from outside.
+    or a timeout is recorded as a delivery failure. Before delivery starts, a
+    write-ahead outcome records that the attempt's result is unknown; a crash
+    before the final result therefore remains machine-readable.
 
     The guard is total for the same reason: this is called from a read path, and
     a notifier that comes apart in a way the hook does not classify must not
-    turn a status read of an already-ended run into a failed call. What is lost
-    is the delivery result, which is the same thing the crash gap loses.
+    turn a status read of an already-ended run into a failed call. What can be
+    lost is the final delivery result, while the attempted state stays durable.
     """
     from ._notify_hook import deliver_terminal_notice
 
+    started = begin_notify_delivery(run_id)
+    if started.refused:
+        return record
     try:
         outcome = deliver_terminal_notice(
             run_id,
@@ -1616,12 +1620,9 @@ def _deliver_reap_notice(run_id: str, record: dict[str, Any]) -> dict[str, Any] 
             sender=record.get("notify_sender"),
         )
     except Exception:  # noqa: BLE001 — the end is published; delivery may not undo it
-        return None
-    # A result that could not be recorded reads back the same way a crash
-    # between the two writes does: the end is durable and the delivery outcome
-    # is absent. Nothing here can be failed by that — this is a read path, and
-    # the end it reports is already published.
-    return record_notify_delivery(run_id, outcome).record
+        return started.record
+    recorded = record_notify_delivery(run_id, outcome)
+    return recorded.record or started.record
 
 
 def _reap_if_conclusively_gone(
@@ -1669,6 +1670,9 @@ def status(run_id: str) -> dict[str, Any]:
     job = _reap_if_conclusively_gone(run_id, job, liveness)
 
     derived = _derive(job, alive, lifecycle)
+    notify_delivery = (job or {}).get("notify_delivery")
+    if notify_delivery is None and derived["terminal"]:
+        notify_delivery = {"attempted": False}
     persistence_degraded_reason = (
         manifest.get(_PERSISTENCE_DEGRADED_REASON_FIELD) if isinstance(manifest, dict) else None
     )
@@ -1696,7 +1700,7 @@ def status(run_id: str) -> dict[str, Any]:
         # Whether finished_at is the end or only a bound on it. Null on records
         # written before the field existed, which is not the same as "observed".
         "finished_at_precision": (job or {}).get("finished_at_precision"),
-        "notify_delivery": (job or {}).get("notify_delivery"),
+        "notify_delivery": notify_delivery,
         "mcp_config": (job or {}).get("mcp_config"),
         "mcp_config_source": (job or {}).get("mcp_config_source"),
         "mcp_config_reason": (job or {}).get("mcp_config_reason"),
@@ -2155,10 +2159,13 @@ def _notify_delivery_state(outcome: Any) -> str:
     (refused, couldn't start, timed out, non-zero exit) — one fact to a caller
     waiting on it. ``"delivered_unverified"``: ran and exited zero, but for that
     command shape a zero exit doesn't mean the message was sent — collapsing it
-    into either neighbor would report a claim this can't support.
+    into either neighbor would report a claim this can't support. ``"unknown"``:
+    the attempt started but its final outcome could not be recorded.
     """
     if not isinstance(outcome, dict):
         return "none"
+    if outcome.get("attempted") and outcome.get("ok") is None:
+        return "unknown"
     if outcome.get("ok"):
         if outcome.get("delivery_verified") is False:
             return "delivered_unverified"
@@ -2400,7 +2407,10 @@ def mark_terminal(run_id: str, cli_status: str) -> WriteResult:
     """
     with _locked_job(run_id) as guard:
         job = guard.record
-        if job is None or job.get("finished_at") is not None:
+        if job is None:
+            return WriteResult(job, guard.state)
+        job.setdefault("notify_delivery", {"attempted": False})
+        if job.get("finished_at") is not None:
             return WriteResult(job, guard.state)
         job["status"] = cli_status
         job["cli_status"] = cli_status
@@ -2426,6 +2436,25 @@ def record_notify_delivery(run_id: str, outcome: dict[str, Any]) -> WriteResult:
             return WriteResult(None, guard.state)
         job["notify_delivery"] = outcome
         return WriteResult(job, guard.state)
+
+
+def begin_notify_delivery(run_id: str) -> WriteResult:
+    """Write ahead that terminal delivery is about to be attempted.
+
+    The final result replaces this object. If the delivery process is cancelled
+    or crashes after its side effect but before that replacement, readers retain
+    an attempted outcome whose success is unknown instead of a false absence.
+    """
+    return record_notify_delivery(
+        run_id,
+        {
+            "attempted": True,
+            "ok": None,
+            "exit_code": None,
+            "error": "delivery_outcome_unknown",
+            "command": None,
+        },
+    )
 
 
 def record_failure_cause(run_id: str, cause: dict[str, Any]) -> WriteResult:

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -451,8 +451,8 @@ _REGISTERED: tuple[Verb, ...] = (
         summary=(
             "Recent background jobs, newest first, optionally filtered by status. "
             "Each row carries notify_delivery_state (none/delivered/"
-            "delivered_unverified/failed) — sweeping for terminal notices that "
-            "never arrived means reading this column and acting on 'failed'; no "
+            "delivered_unverified/failed/unknown) — sweeping for terminal notices that "
+            "never arrived means reading this column and acting on 'failed' or 'unknown'; no "
             "prior suspicion about any particular run is needed."
         ),
         executor="job",

--- a/tests/mcp/test_jobs.py
+++ b/tests/mcp/test_jobs.py
@@ -2761,6 +2761,8 @@ def test_listing_does_not_read_an_absent_notifier_as_a_failure(sandbox):
     states = {j["run_id"]: j["notify_delivery_state"] for j in jobs.list_jobs()}
     assert states[nothing_configured] == "none"
     assert states[still_running] == "none"
+    assert jobs.status(nothing_configured)["notify_delivery"] == {"attempted": False}
+    assert jobs.status(still_running)["notify_delivery"] is None
     # the three outcomes a caller branches on are three different words
     assert len({states[nothing_configured], states[delivered], states[failed]}) == 3
 

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -73,6 +73,7 @@ def test_marks_terminal_without_delivery(job, monkeypatch):
     assert rec["status"] == "completed"
     assert calls == []  # nothing delivered
     assert rec["notify_delivery"] == {"attempted": False}
+    assert jobs.status(job)["notify_delivery"] == {"attempted": False}
 
 
 def test_command_override_substitutes_and_delivers(job, monkeypatch):
@@ -115,6 +116,7 @@ def test_command_override_substitutes_and_delivers(job, monkeypatch):
         # this was without keeping anything the command itself printed
         "command": "notify",
     }
+    assert jobs.status(job)["notify_delivery"]["ok"] is True
 
 
 def test_delivery_failure_is_recorded_not_silent(job, monkeypatch):
@@ -134,6 +136,7 @@ def test_delivery_failure_is_recorded_not_silent(job, monkeypatch):
         "failure_class": "unknown",
         "command": "notify",
     }
+    assert jobs.status(job)["notify_delivery"]["ok"] is False
 
 
 def test_delivery_spawn_error_is_recorded(job, monkeypatch):
@@ -625,6 +628,120 @@ subprocess.run(
 )
 sys.stdout.write("ordinary final output\\n")
 """
+
+
+_LI_SHIM_WITH_A_SHORT_OUTER_NOTIFY_BUDGET = """\
+import asyncio, json, os, sys, time
+from pathlib import Path
+
+from lionagi.cli.orchestrate._notify import register_flow_notify_scope
+from lionagi.mcp import config
+from lionagi.state.lifecycle.callbacks import (
+    EntityRef,
+    RunTerminalEnvelope,
+    TerminalCallbackRegistry,
+)
+
+
+async def main():
+    argv = sys.argv[1:]
+    template = argv[argv.index("--notify") + 1]
+    run_id = os.environ[config.RUN_ID_ENV_VAR]
+    run_dir = config.run_dir(run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    manifest = run_dir / "run.json"
+    manifest.write_text(json.dumps({"status": "running"}))
+
+    registry = TerminalCallbackRegistry(budget_seconds=1.0)
+    register_flow_notify_scope(
+        registry,
+        override=template,
+        entity_kind="session",
+        entity_id="session-1",
+        invocation_id=None,
+        flow_kind="agent",
+        playbook=None,
+        save_dir=None,
+        cwd=os.getcwd(),
+        started_at=time.time(),
+    )
+    await registry.emit(
+        RunTerminalEnvelope(
+            event_id="event-1",
+            entity=EntityRef(kind="session", id="session-1"),
+            previous_status="running",
+            terminal_status="completed",
+            reason_code="run.completed.ok",
+            occurred_at=time.time(),
+        )
+    )
+    manifest.write_text(json.dumps({"status": "completed"}))
+    print("terminal manifest written", flush=True)
+
+
+asyncio.run(main())
+"""
+
+
+_DELIVERY_THAT_SIGNALS_THEN_HANGS = """\
+import sys, time
+from pathlib import Path
+
+Path(sys.argv[1]).write_text("delivered")
+time.sleep(5)
+"""
+
+
+def test_outer_notify_timeout_keeps_an_attempt_record_after_delivery(monkeypatch, tmp_path):
+    """A delivered notice cannot become null when the CLI times out its hook.
+
+    The CLI callback owns a shorter deadline than the hook's delivery command.
+    The delivery signals its externally visible side effect, then remains alive
+    until the outer callback cancels the hook process group. The CLI writes its
+    terminal manifest only after that callback returns, matching production
+    ordering rather than calling the two writers sequentially in the test.
+    """
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    monkeypatch.setenv("PYTHONPATH", str(Path(__file__).resolve().parents[2]))
+    monkeypatch.setattr(config, "JOBS_DIR", tmp_path / "mcp" / "jobs")
+    monkeypatch.setattr(config, "RUNS_DIR", tmp_path / "runs")
+
+    shim = tmp_path / "li_shim.py"
+    shim.write_text(_LI_SHIM_WITH_A_SHORT_OUTER_NOTIFY_BUDGET)
+    delivery = tmp_path / "delivery.py"
+    delivery.write_text(_DELIVERY_THAT_SIGNALS_THEN_HANGS)
+    delivered = tmp_path / "delivered"
+
+    def _li_command():
+        return [sys.executable, str(shim)]
+
+    monkeypatch.setattr(config, "li_command", _li_command)
+
+    handle = jobs.submit(
+        "agent",
+        [],
+        notify_command=json.dumps([sys.executable, str(delivery), str(delivered)]),
+        no_mcp_config=True,
+    )
+    run_id = handle["run_id"]
+    manifest = tmp_path / "runs" / run_id / "run.json"
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if delivered.exists() and manifest.exists():
+            if json.loads(manifest.read_text()).get("status") == "completed":
+                break
+        time.sleep(0.05)
+    else:
+        raise AssertionError(f"the timeout race did not complete; log:\n{_console_log(run_id)}")
+
+    assert delivered.read_text() == "delivered"
+    status = jobs.status(run_id)
+    assert status["terminal_source"] == jobs.TERMINAL_SOURCE_HOOK
+    assert status["notify_delivery"]["attempted"] is True
+    assert status["notify_delivery"]["ok"] is None
+    assert status["notify_delivery"]["error"] == "delivery_outcome_unknown"
+    row = next(item for item in jobs.list_jobs() if item["run_id"] == run_id)
+    assert row["notify_delivery_state"] == "unknown"
 
 
 def test_the_failure_notice_survives_the_runs_own_remaining_output(monkeypatch, tmp_path):

--- a/tests/mcp/test_orphan_reaping.py
+++ b/tests/mcp/test_orphan_reaping.py
@@ -461,14 +461,13 @@ def test_every_delivery_outcome_is_visible_and_none_of_them_changes_the_run(
     assert st["terminal"] is True
 
 
-def test_a_delivery_that_comes_apart_leaves_a_terminal_run_to_be_reconciled(sandbox, monkeypatch):
+def test_a_delivery_that_comes_apart_keeps_the_attempt_unknown(sandbox, monkeypatch):
     """The fault is injected after the end is durable and before the notice.
 
-    This is the crash gap the design accepts: the transition is published, the
-    delivery does not happen, and nothing records why. What must survive it is
-    the end itself — reconciliation is reading the state, so the state has to
-    say the run is over and how it came out, with the missing notice visible as
-    a missing notice rather than as a run still going.
+    The transition and its no-attempt outcome are published together, then an
+    attempted-with-unknown-outcome marker is written before delivery begins.
+    An unexpected exception therefore cannot make a terminal run look like it
+    never reached the notification path.
     """
 
     def _crash(*_a, **_k):
@@ -482,11 +481,19 @@ def test_a_delivery_that_comes_apart_leaves_a_terminal_run_to_be_reconciled(sand
 
     assert st["terminal"] is True
     assert st["outcome"] == jobs.OUTCOME_INDETERMINATE
-    assert st["notify_delivery"] is None
+    expected = {
+        "attempted": True,
+        "ok": None,
+        "exit_code": None,
+        "error": "delivery_outcome_unknown",
+        "command": None,
+    }
+    assert st["notify_delivery"] == expected
 
     on_disk = jobs._read_job(rid)
     assert on_disk["finished_at"] == st["finished_at"]
     assert on_disk["terminal_source"] == jobs.TERMINAL_SOURCE_ORPHAN_REAPER
+    assert on_disk["notify_delivery"] == expected
 
 
 def test_the_notice_is_the_one_the_run_configured(sandbox, monkeypatch):
@@ -616,14 +623,10 @@ def test_a_terminal_write_that_cannot_be_serialized_sends_no_notice(
     assert "could not record the terminal status" in _console(rid)
 
 
-def test_a_delivery_result_that_cannot_be_recorded_is_reported(sandbox, monkeypatch, no_delivery):
-    """The notice went out against a durable end; its result did not land.
-
-    A different case from the one above and reported the same way: the end is
-    on disk, so the notice was owed and was attempted, and what is missing is
-    the record of how it went. A hook that exits 0 here would say the run's
-    completion signal is accounted for when nothing on disk accounts for it.
-    """
+def test_an_attempt_marker_that_cannot_be_serialized_sends_no_notice(
+    sandbox, monkeypatch, no_delivery
+):
+    """No delivery starts unless its attempted state is already durable."""
     rid = _stranded()
     real_lock = jobs._lock_fd
     taken: list[int] = []
@@ -639,8 +642,44 @@ def test_a_delivery_result_that_cannot_be_recorded_is_reported(sandbox, monkeypa
     rc = _notify_hook.main(["--run-id", rid, "--status", "completed"])
 
     assert rc != 0
+    assert no_delivery == []
+    assert jobs._read_job(rid)["notify_delivery"] == {"attempted": False}
+    assert "could not record the delivery attempt" in _console(rid)
+
+
+def test_a_final_delivery_result_that_cannot_be_recorded_keeps_the_attempt(
+    sandbox, monkeypatch, no_delivery
+):
+    """The notice went out against a durable end; its result did not land.
+
+    A different case from the one above and reported the same way: the end is
+    on disk, so the notice was owed and was attempted, and what is missing is
+    the record of how it went. A hook that exits 0 here would say the run's
+    completion signal is accounted for when nothing on disk accounts for it.
+    """
+    rid = _stranded()
+    real_lock = jobs._lock_fd
+    taken: list[int] = []
+
+    def _refuse_after_the_second(fd):
+        taken.append(fd)
+        if len(taken) > 2:
+            raise OSError(11, "resource temporarily unavailable")
+        real_lock(fd)
+
+    monkeypatch.setattr(jobs, "_lock_fd", _refuse_after_the_second)
+
+    rc = _notify_hook.main(["--run-id", rid, "--status", "completed"])
+
+    assert rc != 0
     assert no_delivery == [rid]
-    assert jobs._read_job(rid).get("notify_delivery") is None
+    assert jobs._read_job(rid)["notify_delivery"] == {
+        "attempted": True,
+        "ok": None,
+        "exit_code": None,
+        "error": "delivery_outcome_unknown",
+        "command": None,
+    }
     assert "could not record the delivery result" in _console(rid)
 
 


### PR DESCRIPTION
## Summary

- persist a no-attempt notification state with each terminal transition
- write an attempted/unknown outcome before launching the notifier, then replace it with the final result
- expose the unknown state in `job.list` and reserve `job.status.notify_delivery: null` for non-terminal runs

## Root cause

The CLI terminal callback enforces a 10-second budget around a hook whose delivery subprocess allows 30 seconds. When the outer deadline won after the delivery side effect, it terminated the hook after the terminal row write but before the delivery-result write. The terminal manifest is rewritten only after the callback returns, so neither a manifest overwrite nor an early `job.status` assembly caused the missing value.

## Tests

- added an end-to-end nested-timeout race that observes delivery before the hook process group is terminated
- pinned not-attempted, attempted-and-failed, completed-success, and attempted-with-unknown outcomes separately
- verified the full MCP test suite with the declared `mcp` and `studio` extras

Fixes #2897
