### PR TITLE
Validate playbook specs before job creation

### DIFF
--- a/lionagi/_flow_spec.py
+++ b/lionagi/_flow_spec.py
@@ -1,0 +1,201 @@
+"""Shared parsing and static validation for flow and playbook specs."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
+from lionagi.service.providers import EFFORT_LEVELS
+
+FLOW_SPEC_FIELDS = frozenset(
+    {
+        "agent",
+        "argument-hint",
+        "args",
+        "artifacts",
+        "bare",
+        "description",
+        "dry_run",
+        "effort",
+        "max_agents",
+        "max_ops",
+        "model",
+        "name",
+        "pack",
+        "prompt",
+        "reactive",
+        "save",
+        "show_graph",
+        "team_attach",
+        "team_mode",
+        "with_synthesis",
+        "workers",
+    }
+    | {"bypass", "permission_mode", "yolo"}
+)
+
+_PRESERVE_DASHED = frozenset({"argument-hint"})
+
+
+def normalize_flow_spec_keys(data: dict[Any, Any]) -> dict[str, Any]:
+    """Normalize dashed top-level keys exactly as the CLI loader does."""
+    normalized: dict[str, Any] = {}
+    for key, value in data.items():
+        if not isinstance(key, str):
+            raise ValueError(f"spec keys must be strings, got {type(key).__name__}")
+        if key in _PRESERVE_DASHED or "-" not in key:
+            normalized[key] = value
+        else:
+            normalized[key.replace("-", "_")] = value
+    return normalized
+
+
+def load_flow_spec(path: str | Path) -> dict[str, Any]:
+    """Load and normalize one YAML or JSON flow spec."""
+    spec_path = Path(path).expanduser()
+    if not spec_path.is_file():
+        raise ValueError(f"spec file not found: {spec_path}")
+    try:
+        text = spec_path.read_text()
+        suffix = spec_path.suffix.lower()
+        if suffix in (".yaml", ".yml"):
+            import yaml
+
+            data = yaml.safe_load(text) or {}
+        elif suffix == ".json":
+            import json
+
+            data = json.loads(text)
+        else:
+            import yaml
+
+            try:
+                data = yaml.safe_load(text) or {}
+            except Exception:
+                import json
+
+                data = json.loads(text)
+    except Exception as exc:
+        raise ValueError(f"failed to parse spec file {spec_path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("spec file must contain a YAML/JSON object")
+    return normalize_flow_spec_keys(data)
+
+
+def validate_flow_args_schema(args_schema: Any) -> str | None:
+    """Validate a playbook's declared argument schema."""
+    if not isinstance(args_schema, dict):
+        return f"spec field 'args' must be a dict, got {type(args_schema).__name__}"
+    valid_types = {"str", "int", "float", "bool"}
+    for name, spec in args_schema.items():
+        if not isinstance(name, str) or not name.replace("_", "").isalnum():
+            return f"args key {name!r} must be an alphanumeric identifier"
+        if not isinstance(spec, dict):
+            return f"args[{name!r}] must be a dict, got {type(spec).__name__}"
+        type_str = spec.get("type", "str")
+        if type_str not in valid_types:
+            return f"args[{name!r}].type must be one of {sorted(valid_types)}, got {type_str!r}"
+    return None
+
+
+def validate_flow_spec_fields(spec: dict[str, Any]) -> str | None:
+    """Validate the top-level fields shared by every flow-spec surface."""
+    for key in spec:
+        if key not in FLOW_SPEC_FIELDS:
+            accepted = ", ".join(sorted(FLOW_SPEC_FIELDS))
+            return f"unknown spec field {key!r}; accepted fields: {accepted}"
+
+    if "workers" in spec:
+        workers = spec["workers"]
+        if not isinstance(workers, int) or isinstance(workers, bool):
+            return f"spec field 'workers' must be an integer, got {type(workers).__name__}"
+        if not (1 <= workers <= 32):
+            return f"spec field 'workers' must be in [1, 32], got {workers}"
+
+    for key in ("max_ops", "max_agents"):
+        if key not in spec:
+            continue
+        value = spec[key]
+        if not isinstance(value, int) or isinstance(value, bool):
+            return f"spec field {key!r} must be an integer, got {type(value).__name__}"
+        if not (0 <= value <= 50):
+            return (
+                f"spec field {key!r} must be in [0, 50] "
+                f"(0 = no shared ceiling; reactive spawns are capped at 20), got {value}"
+            )
+
+    effort = spec.get("effort")
+    if effort is not None:
+        if not isinstance(effort, str):
+            return f"spec field 'effort' must be a string, got {type(effort).__name__}"
+        if effort not in EFFORT_LEVELS:
+            allowed = sorted(EFFORT_LEVELS)
+            return f"spec field 'effort' must be one of {allowed}, got {effort!r}"
+
+    if "with_synthesis" in spec:
+        value = spec["with_synthesis"]
+        if not isinstance(value, bool | str):
+            return (
+                f"spec field 'with_synthesis' must be bool or str (model spec), "
+                f"got {type(value).__name__}"
+            )
+
+    for bool_field in ("bare", "dry_run", "show_graph"):
+        if bool_field in spec:
+            value = spec[bool_field]
+            if not isinstance(value, bool):
+                return f"spec field {bool_field!r} must be a bool, got {type(value).__name__}"
+
+    if "prompt" in spec:
+        prompt = spec["prompt"]
+        if not isinstance(prompt, str):
+            return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
+        if len(prompt) > MAX_SPEC_PROMPT_CHARS:
+            return (
+                f"spec field 'prompt' exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters"
+            )
+
+    if "save" in spec:
+        save = spec["save"]
+        if not isinstance(save, str):
+            return f"spec field 'save' must be a string, got {type(save).__name__}"
+
+    for str_field in ("model", "agent", "team_mode", "team_attach", "reactive"):
+        if str_field in spec:
+            value = spec[str_field]
+            if not isinstance(value, str):
+                return f"spec field {str_field!r} must be a string, got {type(value).__name__}"
+
+    if "artifacts" in spec:
+        artifacts = spec["artifacts"]
+        if artifacts is None:
+            return "spec field 'artifacts' must be a dict, got NoneType"
+        try:
+            from lionagi.state.artifact_verifier import (
+                validate_artifact_contract,
+                warn_unknown_artifact_keys,
+            )
+
+            validate_artifact_contract(artifacts)
+            warn_unknown_artifact_keys(
+                artifacts,
+                source="playbook",
+                emit=logging.getLogger("lionagi.cli").warning,
+            )
+        except Exception as exc:
+            return f"spec field 'artifacts' is invalid: {exc}"
+
+    return None
+
+
+def validate_flow_spec(spec: dict[str, Any]) -> str | None:
+    """Run every check decidable from normalized spec content alone."""
+    error = validate_flow_spec_fields(spec)
+    if error is not None:
+        return error
+    if "args" in spec:
+        return validate_flow_args_schema(spec["args"])
+    return None

--- a/lionagi/_flow_spec.py
+++ b/lionagi/_flow_spec.py
@@ -33,7 +33,7 @@ FLOW_SPEC_FIELDS = frozenset(
         "with_synthesis",
         "workers",
     }
-    | {"bypass", "permission_mode", "yolo"}
+    | {"bypass", "links", "permission_mode", "steps", "use", "yolo"}
 )
 
 _PRESERVE_DASHED = frozenset({"argument-hint"})

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -10,6 +10,12 @@ from pathlib import Path
 
 from lionagi._auto import CliDeclaration, auto_register
 from lionagi._errors import TimeoutError as LionTimeoutError
+from lionagi._flow_spec import (
+    FLOW_SPEC_FIELDS,
+    load_flow_spec,
+    validate_flow_args_schema,
+    validate_flow_spec_fields,
+)
 from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
 from lionagi.libs.path_safety import validate_path_component as validate_path_component
 from lionagi.ln.concurrency import is_cancelled, run_async
@@ -23,38 +29,9 @@ from .flow import FlowPlanError, _resume_flow, _run_flow
 
 # ── flow-spec helpers ────────────────────────────────────────────────────────
 
-_FLOW_SPEC_FIELDS = frozenset(
-    {
-        "agent",
-        "argument-hint",
-        "args",
-        "artifacts",
-        "bare",
-        "description",
-        "dry_run",
-        "effort",
-        "max_agents",
-        "max_ops",
-        "model",
-        "name",
-        "pack",
-        "prompt",
-        "reactive",
-        "save",
-        "show_graph",
-        "team_attach",
-        "team_mode",
-        "with_synthesis",
-        "workers",
-    }
-    # Recognized but not applied: these appear in real playbooks in the field,
-    # and the loader has never read them — the run takes its value from the
-    # command-line flag instead. Accepting them keeps working playbooks working;
-    # rejecting them would break files whose only fault is naming a key that
-    # does nothing. Wiring them would silently change how those runs execute,
-    # which is a behavior decision, not a validation one.
-    | {"bypass", "permission_mode", "yolo"}
-)
+_FLOW_SPEC_FIELDS = FLOW_SPEC_FIELDS
+_validate_args_schema = validate_flow_args_schema
+_validate_spec_fields = validate_flow_spec_fields
 
 
 def _scan_argv_for_playbook_name(argv: list[str]) -> str | None:
@@ -342,21 +319,6 @@ def _parse_argument_hint(hint: str) -> dict:
     return schema
 
 
-def _validate_args_schema(args_schema) -> str | None:
-    if not isinstance(args_schema, dict):
-        return f"spec field 'args' must be a dict, got {type(args_schema).__name__}"
-    valid_types = {"str", "int", "float", "bool"}
-    for name, spec in args_schema.items():
-        if not isinstance(name, str) or not name.replace("_", "").isalnum():
-            return f"args key {name!r} must be an alphanumeric identifier"
-        if not isinstance(spec, dict):
-            return f"args[{name!r}] must be a dict, got {type(spec).__name__}"
-        type_str = spec.get("type", "str")
-        if type_str not in valid_types:
-            return f"args[{name!r}].type must be one of {sorted(valid_types)}, got {type_str!r}"
-    return None
-
-
 def _coerce_arg_value(name: str, value, type_str: str):
     if value is None:
         return None, None
@@ -378,141 +340,11 @@ def _coerce_arg_value(name: str, value, type_str: str):
 
 
 def _load_flow_spec(path: str) -> dict | None:
-    from pathlib import Path
-
-    p = Path(path).expanduser()
-    if not p.is_file():
-        log_error(f"spec file not found: {p}")
-        return None
-    text = p.read_text()
-    suffix = p.suffix.lower()
     try:
-        if suffix in (".yaml", ".yml"):
-            import yaml
-
-            data = yaml.safe_load(text) or {}
-        elif suffix == ".json":
-            import json
-
-            data = json.loads(text)
-        else:
-            import yaml
-
-            try:
-                data = yaml.safe_load(text) or {}
-            except Exception:
-                import json
-
-                data = json.loads(text)
-    except Exception as e:
-        log_error(f"failed to parse spec file {p}: {e}")
+        return load_flow_spec(path)
+    except ValueError as exc:
+        log_error(str(exc))
         return None
-
-    if not isinstance(data, dict):
-        log_error("spec file must contain a YAML/JSON object")
-        return None
-    preserve_dashed = {"argument-hint"}
-    normalized: dict = {}
-    for key, value in data.items():
-        if key in preserve_dashed or "-" not in key:
-            normalized[key] = value
-        else:
-            normalized[key.replace("-", "_")] = value
-    return normalized
-
-
-def _validate_spec_fields(spec: dict) -> str | None:
-    for key in spec:
-        if key not in _FLOW_SPEC_FIELDS:
-            accepted = ", ".join(sorted(_FLOW_SPEC_FIELDS))
-            return f"unknown spec field {key!r}; accepted fields: {accepted}"
-
-    if "workers" in spec:
-        workers = spec["workers"]
-        if not isinstance(workers, int) or isinstance(workers, bool):
-            return f"spec field 'workers' must be an integer, got {type(workers).__name__}"
-        if not (1 <= workers <= 32):
-            return f"spec field 'workers' must be in [1, 32], got {workers}"
-
-    for key in ("max_ops", "max_agents"):
-        if key not in spec:
-            continue
-        value = spec[key]
-        if not isinstance(value, int) or isinstance(value, bool):
-            return f"spec field {key!r} must be an integer, got {type(value).__name__}"
-        if not (0 <= value <= 50):
-            return (
-                f"spec field {key!r} must be in [0, 50] "
-                f"(0 = no shared ceiling; reactive spawns are capped at 20), got {value}"
-            )
-
-    effort = spec.get("effort")
-    if effort is not None:
-        from .._providers import EFFORT_LEVELS
-
-        if not isinstance(effort, str):
-            return f"spec field 'effort' must be a string, got {type(effort).__name__}"
-        if effort not in EFFORT_LEVELS:
-            allowed = sorted(EFFORT_LEVELS)
-            return f"spec field 'effort' must be one of {allowed}, got {effort!r}"
-
-    if "with_synthesis" in spec:
-        val = spec["with_synthesis"]
-        if not isinstance(val, bool | str):
-            return (
-                f"spec field 'with_synthesis' must be bool or str (model spec), "
-                f"got {type(val).__name__}"
-            )
-
-    for bool_field in ("bare", "dry_run", "show_graph"):
-        if bool_field in spec:
-            val = spec[bool_field]
-            if not isinstance(val, bool):
-                return f"spec field {bool_field!r} must be a bool, got {type(val).__name__}"
-
-    if "prompt" in spec:
-        prompt = spec["prompt"]
-        if not isinstance(prompt, str):
-            return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
-        if len(prompt) > MAX_SPEC_PROMPT_CHARS:
-            return (
-                f"spec field 'prompt' exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters"
-            )
-
-    if "save" in spec:
-        save = spec["save"]
-        if not isinstance(save, str):
-            return f"spec field 'save' must be a string, got {type(save).__name__}"
-
-    for str_field in ("model", "agent", "team_mode", "team_attach", "reactive"):
-        if str_field in spec:
-            val = spec[str_field]
-            if not isinstance(val, str):
-                return f"spec field {str_field!r} must be a string, got {type(val).__name__}"
-
-    if "artifacts" in spec:
-        artifacts = spec["artifacts"]
-        if artifacts is None:
-            return "spec field 'artifacts' must be a dict, got NoneType"
-        try:
-            from lionagi.state.artifact_verifier import (
-                validate_artifact_contract,
-                warn_unknown_artifact_keys,
-            )
-
-            validate_artifact_contract(artifacts)
-            import logging as _logging
-
-            _cli_log = _logging.getLogger("lionagi.cli")
-            warn_unknown_artifact_keys(
-                artifacts,
-                source="playbook",
-                emit=_cli_log.warning,
-            )
-        except Exception as exc:
-            return f"spec field 'artifacts' is invalid: {exc}"
-
-    return None
 
 
 def _interpolate_prompt(template: str, positional: str | None, playbook_args: dict) -> str:

--- a/lionagi/mcp/dispatch.py
+++ b/lionagi/mcp/dispatch.py
@@ -713,7 +713,25 @@ def _resolve_cwd(args: dict[str, Any]) -> str | None:
     return str(resolved)
 
 
+def _refuse_invalid_playbook_spec(schema: dict[str, Any]) -> None:
+    path = schema.get("x-playbook-path")
+    if path is None:
+        return
+
+    from lionagi._flow_spec import load_flow_spec, validate_flow_spec
+
+    name = schema.get("x-playbook")
+    try:
+        spec = load_flow_spec(path)
+    except ValueError as exc:
+        raise OpError("invalid_input", f"playbook {name!r} has an invalid spec: {exc}") from exc
+    error = validate_flow_spec(spec)
+    if error is not None:
+        raise OpError("invalid_input", f"playbook {name!r} has an invalid spec: {error}")
+
+
 def _run_spawn(verb: Verb, schema: dict[str, Any], args: dict[str, Any]) -> dict[str, Any]:
+    _refuse_invalid_playbook_spec(schema)
     prompt = _resolve_prompt(args)
     _refuse_too_many_positionals(verb, args, prompt)
     _refuse_without_model(verb, schema, args, prompt)

--- a/lionagi/studio/services/playbooks.py
+++ b/lionagi/studio/services/playbooks.py
@@ -10,9 +10,13 @@ import anyio
 import yaml
 from fastapi import Body, HTTPException
 
+from lionagi._flow_spec import (
+    normalize_flow_spec_keys as _normalize_spec_keys,
+)
+from lionagi._flow_spec import (
+    validate_flow_spec_fields as _check_spec_fields,
+)
 from lionagi._paths import LIONAGI_HOME, ensure_lionagi_dir
-from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
-from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
 
 from ..registry import studio_route
 from ._path_safety import public_path, safe_path_join
@@ -22,95 +26,6 @@ _PLAYBOOKS_ROOT = LIONAGI_HOME / "playbooks"
 # Bundled read-only templates, shipped inside the installed package (see
 # builtin_playbooks/README.md) so they're available on a real deployment.
 _BUILTIN_PLAYBOOKS_ROOT = Path(__file__).resolve().parent.parent / "builtin_playbooks"
-
-# Keys that stay dashed per CLI convention (all others: hyphens → underscores).
-_PRESERVE_DASHED: frozenset[str] = frozenset({"argument-hint"})
-
-
-def _normalize_spec_keys(data: dict[str, Any]) -> dict[str, Any]:
-    """Convert hyphenated YAML keys to underscored, mirroring CLI normalization."""
-    out: dict[str, Any] = {}
-    for key, value in data.items():
-        if key in _PRESERVE_DASHED or "-" not in key:
-            out[key] = value
-        else:
-            out[key.replace("-", "_")] = value
-    return out
-
-
-def _check_spec_fields(spec: dict[str, Any]) -> str | None:
-    """Validate playbook spec fields; return an error string or None. Mirrors lionagi/cli/orchestrate/__init__.py::_validate_spec_fields() exactly -- keep the two in sync."""
-    if "workers" in spec:
-        workers = spec["workers"]
-        if not isinstance(workers, int) or isinstance(workers, bool):
-            return f"spec field 'workers' must be an integer, got {type(workers).__name__}"
-        if not (1 <= workers <= 32):
-            return f"spec field 'workers' must be in [1, 32], got {workers}"
-
-    for key in ("max_ops", "max_agents"):
-        if key not in spec:
-            continue
-        value = spec[key]
-        if not isinstance(value, int) or isinstance(value, bool):
-            return f"spec field {key!r} must be an integer, got {type(value).__name__}"
-        if not (0 <= value <= 50):
-            return f"spec field {key!r} must be in [0, 50] (0 = unlimited), got {value}"
-
-    effort = spec.get("effort")
-    if effort is not None:
-        if not isinstance(effort, str):
-            return f"spec field 'effort' must be a string, got {type(effort).__name__}"
-        if effort not in _VALID_EFFORT_LEVELS:
-            return (
-                f"spec field 'effort' must be one of {sorted(_VALID_EFFORT_LEVELS)}, got {effort!r}"
-            )
-
-    if "with_synthesis" in spec:
-        val = spec["with_synthesis"]
-        if not isinstance(val, bool | str):
-            return (
-                f"spec field 'with_synthesis' must be bool or str (model spec), "
-                f"got {type(val).__name__}"
-            )
-
-    for bool_field in ("bare", "dry_run", "show_graph"):
-        if bool_field in spec:
-            val = spec[bool_field]
-            if not isinstance(val, bool):
-                return f"spec field {bool_field!r} must be a bool, got {type(val).__name__}"
-
-    if "prompt" in spec:
-        prompt = spec["prompt"]
-        if not isinstance(prompt, str):
-            return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
-        if len(prompt) > MAX_SPEC_PROMPT_CHARS:
-            return (
-                f"spec field 'prompt' exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters"
-            )
-
-    if "save" in spec:
-        save = spec["save"]
-        if not isinstance(save, str):
-            return f"spec field 'save' must be a string, got {type(save).__name__}"
-
-    for str_field in ("model", "agent", "team_mode", "team_attach", "reactive"):
-        if str_field in spec:
-            val = spec[str_field]
-            if not isinstance(val, str):
-                return f"spec field {str_field!r} must be a string, got {type(val).__name__}"
-
-    if "artifacts" in spec:
-        artifacts = spec["artifacts"]
-        if artifacts is None:
-            return "spec field 'artifacts' must be a dict, got NoneType"
-        try:
-            from lionagi.state.artifact_verifier import validate_artifact_contract
-
-            validate_artifact_contract(artifacts)
-        except Exception as exc:
-            return f"spec field 'artifacts' is invalid: {exc}"
-
-    return None
 
 
 class _PlaybookDumper(yaml.SafeDumper):

--- a/lionagi/studio/services/schedules.py
+++ b/lionagi/studio/services/schedules.py
@@ -18,8 +18,7 @@ from fastapi import HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
-from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
-from lionagi.service.providers import EFFORT_LEVELS as _VALID_EFFORT_LEVELS
+from lionagi._flow_spec import normalize_flow_spec_keys, validate_flow_spec_fields
 from lionagi.state.db import StateDB, read_only_open_supported, state_db_known_absent
 
 from ..registry import studio_route
@@ -31,8 +30,6 @@ _log = logging.getLogger(__name__)
 class NameConflictError(Exception):
     """Raised when a schedule name already exists."""
 
-
-_PRESERVE_DASHED: frozenset[str] = frozenset({"argument-hint"})
 
 # schedules columns declared NOT NULL — a PATCH that explicitly sets one of
 # these to null must be rejected (400) rather than passed through to a DB
@@ -324,85 +321,7 @@ def _validate_flow_yaml_spec(yaml_text: str) -> str | None:
         if not isinstance(key, str):
             return f"flow_yaml spec keys must be strings, got {type(key).__name__}"
 
-    # Normalize hyphenated keys (e.g. max-ops → max_ops) before field checks.
-    spec: dict[str, Any] = {}
-    for key, value in data.items():
-        if key in _PRESERVE_DASHED or "-" not in key:
-            spec[key] = value
-        else:
-            spec[key.replace("-", "_")] = value
-
-    if "workers" in spec:
-        workers = spec["workers"]
-        if not isinstance(workers, int) or isinstance(workers, bool):
-            return f"spec field 'workers' must be an integer, got {type(workers).__name__}"
-        if not (1 <= workers <= 32):
-            return f"spec field 'workers' must be in [1, 32], got {workers}"
-
-    for key in ("max_ops", "max_agents"):
-        if key not in spec:
-            continue
-        value = spec[key]
-        if not isinstance(value, int) or isinstance(value, bool):
-            return f"spec field {key!r} must be an integer, got {type(value).__name__}"
-        if not (0 <= value <= 50):
-            return f"spec field {key!r} must be in [0, 50] (0 = unlimited), got {value}"
-
-    effort = spec.get("effort")
-    if effort is not None:
-        if not isinstance(effort, str):
-            return f"spec field 'effort' must be a string, got {type(effort).__name__}"
-        if effort not in _VALID_EFFORT_LEVELS:
-            return (
-                f"spec field 'effort' must be one of {sorted(_VALID_EFFORT_LEVELS)}, got {effort!r}"
-            )
-
-    if "with_synthesis" in spec:
-        val = spec["with_synthesis"]
-        if not isinstance(val, bool | str):
-            return (
-                f"spec field 'with_synthesis' must be bool or str (model spec), "
-                f"got {type(val).__name__}"
-            )
-
-    for bool_field in ("bare", "dry_run", "show_graph"):
-        if bool_field in spec:
-            val = spec[bool_field]
-            if not isinstance(val, bool):
-                return f"spec field {bool_field!r} must be a bool, got {type(val).__name__}"
-
-    if "prompt" in spec:
-        prompt = spec["prompt"]
-        if not isinstance(prompt, str):
-            return f"spec field 'prompt' must be a string, got {type(prompt).__name__}"
-        if len(prompt) > MAX_SPEC_PROMPT_CHARS:
-            return (
-                f"spec field 'prompt' exceeds maximum length of {MAX_SPEC_PROMPT_CHARS} characters"
-            )
-
-    if "save" in spec:
-        save = spec["save"]
-        if not isinstance(save, str):
-            return f"spec field 'save' must be a string, got {type(save).__name__}"
-
-    for str_field in ("model", "agent", "team_mode", "team_attach", "reactive"):
-        if str_field in spec:
-            val = spec[str_field]
-            if not isinstance(val, str):
-                return f"spec field {str_field!r} must be a string, got {type(val).__name__}"
-
-    if "artifacts" in spec:
-        artifacts = spec["artifacts"]
-        if artifacts is None:
-            return "spec field 'artifacts' must be a dict, got NoneType"
-        try:
-            from lionagi.state.artifact_verifier import validate_artifact_contract
-
-            validate_artifact_contract(artifacts)
-        except Exception as exc:
-            return f"spec field 'artifacts' is invalid: {exc}"
-
-    return None
+    return validate_flow_spec_fields(normalize_flow_spec_keys(data))
 
 
 # Health severity is computed from cadence + observed schedule_runs rows,

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -186,9 +186,9 @@ class TestSpecValidationRejectsUnknownFields:
         err = _validate_spec_fields({"reactve": "off"})
         assert err == (
             "unknown spec field 'reactve'; accepted fields: agent, args, argument-hint, "
-            "artifacts, bare, bypass, description, dry_run, effort, max_agents, max_ops, "
+            "artifacts, bare, bypass, description, dry_run, effort, links, max_agents, max_ops, "
             "model, name, pack, permission_mode, prompt, reactive, save, show_graph, "
-            "team_attach, team_mode, with_synthesis, workers, yolo"
+            "steps, team_attach, team_mode, use, with_synthesis, workers, yolo"
         )
 
     def test_dead_critic_model_field_is_rejected(self):

--- a/tests/cli/orchestrate/test_spec_prompt_cap.py
+++ b/tests/cli/orchestrate/test_spec_prompt_cap.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import yaml
 
 from lionagi._spec_limits import MAX_SPEC_PROMPT_CHARS
-from lionagi.cli.orchestrate import _validate_spec_fields
+from lionagi.cli.orchestrate import _FLOW_SPEC_FIELDS, _validate_spec_fields
 from lionagi.studio.services.playbooks import _check_spec_fields
 from lionagi.studio.services.schedules import _validate_flow_yaml_spec
 
@@ -36,6 +36,68 @@ ALL_SURFACES = (
     ("playbook", _check_spec_fields),
     ("schedule", _schedule_spec),
 )
+
+
+VALID_FIELD_VALUES = {
+    "agent": "test-profile",
+    "argument-hint": "[--mode MODE]",
+    "args": {"mode": {"type": "str"}},
+    "artifacts": {"expected": [{"id": "report", "path": "report.md"}]},
+    "bare": True,
+    "bypass": True,
+    "description": "Review a target",
+    "dry_run": False,
+    "effort": "high",
+    "max_agents": 0,
+    "max_ops": 0,
+    "model": "claude-code/opus-4-7",
+    "name": "repo-review",
+    "pack": "./routing.yaml",
+    "permission_mode": "acceptEdits",
+    "prompt": "Do the thing",
+    "reactive": "off",
+    "save": "./results",
+    "show_graph": True,
+    "team_attach": "existing-team",
+    "team_mode": "new-team",
+    "with_synthesis": True,
+    "workers": 1,
+    "yolo": True,
+}
+
+
+def test_every_declared_field_is_accepted_by_every_surface():
+    assert frozenset(VALID_FIELD_VALUES) == _FLOW_SPEC_FIELDS
+
+    for field, value in VALID_FIELD_VALUES.items():
+        errors = [validate({field: value}) for _, validate in ALL_SURFACES]
+        assert errors == [None] * len(ALL_SURFACES), (field, errors)
+
+
+def test_every_surface_rejects_an_unknown_field_with_the_same_error():
+    errors = [validate({"not_a_flow_field": True}) for _, validate in ALL_SURFACES]
+
+    assert all(error is not None for error in errors), errors
+    assert len(set(errors)) == 1, errors
+
+
+def test_every_surface_returns_the_same_field_error():
+    invalid_specs = (
+        {"workers": 33},
+        {"max_ops": 51},
+        {"effort": "impossible"},
+        {"with_synthesis": []},
+        {"bare": "true"},
+        {"prompt": 42},
+        {"save": 7},
+        {"model": 42},
+        {"artifacts": None},
+    )
+
+    for spec in invalid_specs:
+        errors = [validate(spec) for _, validate in ALL_SURFACES]
+        assert all(error is not None for error in errors), (spec, errors)
+        assert len(set(errors)) == 1, (spec, errors)
 
 
 def test_the_bound_is_far_from_anything_a_prompt_reaches():

--- a/tests/cli/orchestrate/test_spec_prompt_cap.py
+++ b/tests/cli/orchestrate/test_spec_prompt_cap.py
@@ -48,6 +48,7 @@ VALID_FIELD_VALUES = {
     "description": "Review a target",
     "dry_run": False,
     "effort": "high",
+    "links": [],
     "max_agents": 0,
     "max_ops": 0,
     "model": "claude-code/opus-4-7",
@@ -58,10 +59,12 @@ VALID_FIELD_VALUES = {
     "reactive": "off",
     "save": "./results",
     "show_graph": True,
+    "steps": {},
     "team_attach": "existing-team",
     "team_mode": "new-team",
     "with_synthesis": True,
     "workers": 1,
+    "use": {"models": {}},
     "yolo": True,
 }
 

--- a/tests/cli/test_schedule_quick_create.py
+++ b/tests/cli/test_schedule_quick_create.py
@@ -118,9 +118,7 @@ def test_quick_create_agent_prompt_file(temp_db_path, agent_profile):
 
 def test_quick_create_flow_cron_trigger(temp_db_path, agent_profile):
     flow_file = agent_profile / "flow.yaml"
-    flow_file.write_text(
-        "agents:\n  - id: a1\n    model: anthropic/claude-sonnet-5\n    prompt: hi\n"
-    )
+    flow_file.write_text("model: anthropic/claude-sonnet-5\nprompt: hi\n")
     rc = _run(
         "flow",
         [
@@ -139,7 +137,24 @@ def test_quick_create_flow_cron_trigger(temp_db_path, agent_profile):
     assert row["trigger_type"] == "cron"
     assert row["cron_expr"] == "0 2 * * *"
     assert row["resolved_timezone"] == "America/New_York"
-    assert "agents:" in row["action_flow_yaml"]
+    assert "prompt: hi" in row["action_flow_yaml"]
+
+
+def test_quick_create_flow_refuses_an_unknown_spec_field(temp_db_path, agent_profile):
+    """An invalid flow file is refused at creation, not at the first fire.
+
+    The companion above only shows a valid file is accepted, which a validator
+    that accepts everything would also pass. This is the arm that fails if the
+    field check stops running.
+    """
+    flow_file = agent_profile / "flow.yaml"
+    flow_file.write_text("agents:\n  - id: a1\n    prompt: hi\n")
+    rc = _run(
+        "flow",
+        ["broken-review", "--cron", "0 2 * * *", "--file", str(flow_file)],
+    )
+    assert rc != 0
+    assert asyncio.run(_get_or_none("broken-review")) is None
 
 
 def test_quick_create_playbook_every_trigger(temp_db_path, agent_profile):

--- a/tests/mcp/test_admission_too_many_positionals.py
+++ b/tests/mcp/test_admission_too_many_positionals.py
@@ -28,7 +28,7 @@ def submit_dir(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     books = tmp_path / ".lionagi" / "playbooks"
     books.mkdir(parents=True)
-    (books / "probe.playbook.yaml").write_text("name: probe\nprompt: summarize this\nnodes:\n")
+    (books / "probe.playbook.yaml").write_text("name: probe\nprompt: summarize this\n")
     return tmp_path
 
 

--- a/tests/mcp/test_admission_without_a_named_model.py
+++ b/tests/mcp/test_admission_without_a_named_model.py
@@ -246,7 +246,7 @@ def test_a_play_naming_only_a_playbook_reaches_the_spawn(spawned, submit_dir):
     is a complete submission."""
     books = submit_dir / ".lionagi" / "playbooks"
     books.mkdir(parents=True)
-    (books / "probe.playbook.yaml").write_text("name: probe\nprompt: summarize this\nnodes:\n")
+    (books / "probe.playbook.yaml").write_text("name: probe\nprompt: summarize this\n")
 
     answer = call(
         ops=[spawn_op("play.submit", {"playbook": "probe", "no_mcp_config": True}, "probe")]

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -455,6 +455,47 @@ def a_playbook(tmp_path, monkeypatch):
     return "remedy-fixture"
 
 
+@pytest.fixture
+def invalid_playbook(tmp_path, monkeypatch):
+    directory = tmp_path / ".lionagi" / "playbooks"
+    directory.mkdir(parents=True)
+    (directory / "invalid-spec.playbook.yaml").write_text(
+        json.dumps(
+            {
+                "name": "invalid-spec",
+                "model": "claude-code/opus-4-7",
+                "prompt": "do the work",
+                "max-ops": 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    return "invalid-spec"
+
+
+def test_play_submit_refuses_invalid_spec_before_job_creation(invalid_playbook, submitted):
+    qualified = call(help={"verb": "play.submit", "playbook": invalid_playbook})
+    answer = call(
+        ops=[
+            {
+                "op": "play.submit",
+                "args": {"playbook": invalid_playbook},
+                "schema_fingerprint": qualified["schema_fingerprint"],
+            }
+        ]
+    )
+
+    op = answer["ops"][0]
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "invalid_input"
+    assert "max_ops" in op["error"]["message"]
+    assert "[0, 50]" in op["error"]["message"]
+    assert "64" in op["error"]["message"]
+    assert "run_id" not in op
+    assert submitted == {}
+
+
 def test_a_refused_playbook_call_is_told_to_ask_help_for_that_playbook(a_playbook, submitted):
     """The remedy has to name the playbook, or a caller who re-reads it loops.
 

--- a/tests/mcp/test_spawn_mcp_snapshot_flow_fanout.py
+++ b/tests/mcp/test_spawn_mcp_snapshot_flow_fanout.py
@@ -215,9 +215,7 @@ def test_the_snapshot_is_reported_when_the_caller_says_nothing(
 
 _PLAYBOOK = """\
 name: probe
-nodes:
-  - id: n1
-    prompt: hello
+prompt: hello
 """
 
 


### PR DESCRIPTION
## Summary

- centralize playbook field names, dashed-key normalization, and static field validation for the CLI and Studio surfaces
- validate a resolved playbook before the MCP job engine is called
- add contract coverage for submit-time refusal and cross-surface validator parity

## Caller-visible behavior change

Previously, a playbook with a static spec error could make `play.submit` return a healthy-looking job record and `run_id`, then fail immediately in the child process. `play.submit` now returns an `invalid_input` error and creates no job, so callers receive no job id for a run that could never start.

## Validation placement

Submit-time validation now covers YAML/JSON parsing, mapping shape, dashed-key normalization, unknown top-level fields, field types and bounds, prompt size, artifact contracts, and declared argument schemas. The child process retains these checks for direct CLI use.

Checks that depend on invocation values or the child environment remain there: declared-argument coercion, prompt interpolation and assembled-prompt checks, option compatibility, save-path containment, and background-run setup.

## Validation

- affected CLI, Studio schedule, and MCP tests pass
- full `tests/mcp` passes with the MCP extra; one process-table test skips because the sandbox denies process enumeration
- all 56 discovered playbooks pass through the production loader and new validation: 10 examples, 10 built-ins, and 36 additional compatibility files
- the population run's `max-ops: 64` positive control is refused as expected
- shared module coverage: 90.91%
- Ruff format/lint and Pyright pass

Fixes #2914
Fixes #2955
