### PR TITLE
fix(studio): make Operator execution root explicit

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -4,7 +4,7 @@
 #   docker build -f apps/studio/Dockerfile -t lion-studio .
 #
 # Run:
-#   docker run -p 8765:8765 -v ~/.lionagi:/root/.lionagi lion-studio
+#   docker run -p 8765:8765 -v ~/.lionagi:/root/.lionagi -v "$PWD:/workspace" lion-studio
 
 # ── Stage 1: Build frontend ──────────────────────────────────────────────────
 FROM node:22-alpine AS frontend-build
@@ -39,10 +39,13 @@ COPY .claude-plugin/ ./.claude-plugin/
 # Copy built frontend dist — uvicorn serves this via the SPA mount in app.py.
 COPY --from=frontend-build /build/dist ./apps/studio/frontend/dist
 
-VOLUME /root/.lionagi
+RUN mkdir -p /workspace
+
+VOLUME ["/root/.lionagi", "/workspace"]
 
 EXPOSE 8765
 
-ENV LIONAGI_STUDIO_FRONTEND_DIST=/app/apps/studio/frontend/dist
+ENV LIONAGI_STUDIO_FRONTEND_DIST=/app/apps/studio/frontend/dist \
+    LIONAGI_STUDIO_OPERATOR_CWD=/workspace
 
 CMD ["uvicorn", "lionagi.studio.app:app", "--host", "0.0.0.0", "--port", "8765"]

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -31,7 +31,7 @@ All variables are optional; defaults are shown.
 | `LIONAGI_STUDIO_PORT` | `8765` | FastAPI bind port |
 | `LIONAGI_STUDIO_AUTH_TOKEN` | *(unset)* | Bearer token for `/api/*` routes |
 | `LIONAGI_STUDIO_FRONTEND_DIST` | `apps/studio/frontend/dist` | Path to built SPA dist/ |
-| `LIONAGI_STUDIO_OPERATOR_CWD` | *(unset)* | Absolute execution root for Operator CLI providers |
+| `LIONAGI_STUDIO_OPERATOR_CWD` | user home (`/workspace` in Docker) | Absolute execution root for Operator CLI providers |
 | `LIONAGI_HOME` | `~/.lionagi` | Base LionAGI data directory (holds `state.db`) |
 | `LIONAGI_SHOWS_ROOT` | `~/khive-work/shows` | Show artifact root |
 | `CORS_ORIGINS` | `localhost:5173,localhost:3000` | Comma-separated allowed browser origins |
@@ -69,13 +69,19 @@ Operator uses the locally installed Claude Code CLI and its own authenticated
 session by default. The Studio extra does not install or sign in to Claude
 Code.
 
-Set `LIONAGI_STUDIO_OPERATOR_CWD` to an existing absolute directory to pin all
-Operator turns to one execution root. When it is unset, Operator uses the
-selected project's registered path. If neither path is usable, or if the
-explicit setting is invalid, the turn fails with a configuration error instead
-of inheriting whichever directory launched the Studio daemon. Browser-created
-conversations currently have no project selection, so configure this variable
-for normal Operator use in container deployments.
+The daemon freezes its Operator execution-root configuration at startup and
+logs both the resolved root and the rule that selected it. An explicit
+`LIONAGI_STUDIO_OPERATOR_CWD` wins; otherwise the shipped daemon-config default
+is the user's home directory. A project-bearing conversation uses that
+project's registered path when no environment override is set, while a normal
+browser-created conversation uses the frozen daemon default. An invalid
+explicit setting or selected project fails closed instead of falling through
+to another root or inheriting whichever directory launched the daemon.
+
+The Studio image explicitly sets the root to `/workspace`, not its application
+`WORKDIR /app`, and declares `/workspace` as a volume. Bind-mount the code the
+Operator should work on there, for example `-v "$PWD:/workspace"` when running
+the image directly.
 
 On a fresh machine:
 

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -31,6 +31,7 @@ All variables are optional; defaults are shown.
 | `LIONAGI_STUDIO_PORT` | `8765` | FastAPI bind port |
 | `LIONAGI_STUDIO_AUTH_TOKEN` | *(unset)* | Bearer token for `/api/*` routes |
 | `LIONAGI_STUDIO_FRONTEND_DIST` | `apps/studio/frontend/dist` | Path to built SPA dist/ |
+| `LIONAGI_STUDIO_OPERATOR_CWD` | *(unset)* | Absolute execution root for Operator CLI providers |
 | `LIONAGI_HOME` | `~/.lionagi` | Base LionAGI data directory (holds `state.db`) |
 | `LIONAGI_SHOWS_ROOT` | `~/khive-work/shows` | Show artifact root |
 | `CORS_ORIGINS` | `localhost:5173,localhost:3000` | Comma-separated allowed browser origins |
@@ -67,6 +68,14 @@ li studio --no-frontend
 Operator uses the locally installed Claude Code CLI and its own authenticated
 session by default. The Studio extra does not install or sign in to Claude
 Code.
+
+Set `LIONAGI_STUDIO_OPERATOR_CWD` to an existing absolute directory to pin all
+Operator turns to one execution root. When it is unset, Operator uses the
+selected project's registered path. If neither path is usable, or if the
+explicit setting is invalid, the turn fails with a configuration error instead
+of inheriting whichever directory launched the Studio daemon. Browser-created
+conversations currently have no project selection, so configure this variable
+for normal Operator use in container deployments.
 
 On a fresh machine:
 

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -212,6 +212,47 @@ STUDIO_PORT: int = int(os.environ.get("LIONAGI_STUDIO_PORT", "8765"))
 HOST: str = os.environ.get("LIONAGI_STUDIO_HOST", "127.0.0.1")
 SHOWS_ROOT: Path = Path(os.environ.get("LIONAGI_SHOWS_ROOT", "~/khive-work/shows")).expanduser()
 
+OPERATOR_CWD_ENV_VAR = "LIONAGI_STUDIO_OPERATOR_CWD"
+OPERATOR_CWD_DEFAULT: Path = Path.home().resolve()
+OPERATOR_CWD_RULE_ENV = f"env:{OPERATOR_CWD_ENV_VAR}"
+OPERATOR_CWD_RULE_DEFAULT = "daemon-config-default:user-home"
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorExecutionRootResolution:
+    root: Path | None
+    rule: str
+    configured_value: str
+
+
+def _usable_operator_execution_root(value: str | Path) -> Path | None:
+    path = Path(value)
+    if not path.is_absolute() or not path.is_dir():
+        return None
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def resolve_operator_execution_root_config() -> OperatorExecutionRootResolution:
+    """Freeze the daemon-wide Operator root choice and its provenance."""
+    configured = os.environ.get(OPERATOR_CWD_ENV_VAR)
+    if configured is not None:
+        return OperatorExecutionRootResolution(
+            root=_usable_operator_execution_root(configured),
+            rule=OPERATOR_CWD_RULE_ENV,
+            configured_value=configured,
+        )
+
+    default = str(OPERATOR_CWD_DEFAULT)
+    return OperatorExecutionRootResolution(
+        root=_usable_operator_execution_root(default),
+        rule=OPERATOR_CWD_RULE_DEFAULT,
+        configured_value=default,
+    )
+
+
 _raw_origins = os.environ.get("CORS_ORIGINS", "")
 CORS_ORIGINS: list[str] = (
     [o.strip() for o in _raw_origins.split(",") if o.strip()]

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -12,6 +12,10 @@ from contextlib import suppress
 from dataclasses import replace
 from typing import Any
 
+from ..config import (
+    OperatorExecutionRootResolution,
+    resolve_operator_execution_root_config,
+)
 from .catalog import OperatorSelectionError, resolve_selection
 from .engine import (
     BranchOperatorEngine,
@@ -147,8 +151,24 @@ class OperatorCoordinator:
         self.command_executor = command_executor or _execute_application_command
         self._tasks: dict[str, asyncio.Task] = {}
         self._started = False
+        self._execution_root_resolution: OperatorExecutionRootResolution | None = None
 
     async def startup(self) -> list[str]:
+        resolution = resolve_operator_execution_root_config()
+        self._execution_root_resolution = resolution
+        if resolution.root is None:
+            _log.error(
+                "Studio Operator execution root unresolved at startup: "
+                "configured_value=%r rule=%s; Operator turns will refuse",
+                resolution.configured_value,
+                resolution.rule,
+            )
+        else:
+            _log.warning(
+                "Studio Operator execution root resolved at startup: root=%s rule=%s",
+                resolution.root,
+                resolution.rule,
+            )
         await self.store.ensure_schema()
         recovered = await self.store.recover_interrupted_turns()
         self._started = True
@@ -186,6 +206,7 @@ class OperatorCoordinator:
             )
         self._tasks.clear()
         self._started = False
+        self._execution_root_resolution = None
 
     async def create_conversation(
         self, *, project: str | None = None, title: str | None = None
@@ -333,7 +354,8 @@ class OperatorCoordinator:
                 else conversation_row.get("project")
             )
             execution_root = await resolve_operator_execution_root(
-                project if isinstance(project, str) else None
+                project if isinstance(project, str) else None,
+                self._execution_root_resolution,
             )
             selected_provider = conversation_row.get("provider")
             selected_model = conversation_row.get("providerModel")

--- a/lionagi/studio/operator/coordinator.py
+++ b/lionagi/studio/operator/coordinator.py
@@ -15,9 +15,11 @@ from typing import Any
 from .catalog import OperatorSelectionError, resolve_selection
 from .engine import (
     BranchOperatorEngine,
+    OperatorExecutionRootError,
     OperatorProviderUnavailableError,
     build_operator_branch,
     compile_operator_history,
+    resolve_operator_execution_root,
     resolve_operator_provider_model,
     write_resumable_operator_snapshot,
 )
@@ -324,6 +326,15 @@ class OperatorCoordinator:
                     await asyncio.sleep(0.05)
 
             conversation_row = await self.store.get_conversation(conversation_id)
+            context_project = turn_row["context"].get("project")
+            project = (
+                context_project
+                if isinstance(context_project, str) and context_project
+                else conversation_row.get("project")
+            )
+            execution_root = await resolve_operator_execution_root(
+                project if isinstance(project, str) else None
+            )
             selected_provider = conversation_row.get("provider")
             selected_model = conversation_row.get("providerModel")
             selected_effort = turn_row.get("effort")
@@ -363,7 +374,7 @@ class OperatorCoordinator:
                     resumed_session_id if isinstance(resumed_session_id, str) else None
                 ),
             )
-            run_branch = build_operator_branch(engine_turn)
+            run_branch = build_operator_branch(engine_turn, execution_root=execution_root)
             engine_turn = replace(engine_turn, runtime_branch=run_branch)
             from lionagi.cli import _runs as cli_runs
 
@@ -499,6 +510,18 @@ class OperatorCoordinator:
                 outcome="failed",
                 error={
                     "code": "provider_unavailable",
+                    "message": str(exc),
+                    "retryable": False,
+                },
+            )
+        except OperatorExecutionRootError as exc:
+            terminal_status = "failed"
+            terminal_exc = exc
+            await self.store.finish_turn(
+                request_id,
+                outcome="failed",
+                error={
+                    "code": "service_failure",
                     "message": str(exc),
                     "retryable": False,
                 },

--- a/lionagi/studio/operator/engine.py
+++ b/lionagi/studio/operator/engine.py
@@ -13,10 +13,13 @@ from collections.abc import Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .redact import redact_arguments
 from .types import OperatorEngineEvent, OperatorEngineTurn
+
+if TYPE_CHECKING:
+    from ..config import OperatorExecutionRootResolution
 
 _SYSTEM_PROMPT = """\
 You are the resident Operator for Lion Studio. Be concise and factual.
@@ -88,9 +91,6 @@ class OperatorProviderUnavailableError(RuntimeError):
 
 class OperatorExecutionRootError(ValueError):
     """The Operator has no explicit, usable directory for provider execution."""
-
-
-_OPERATOR_CWD_ENV = "LIONAGI_STUDIO_OPERATOR_CWD"
 
 
 @dataclass(frozen=True, slots=True)
@@ -508,40 +508,69 @@ class BranchOperatorEngine:
                 await task
 
 
-async def resolve_operator_execution_root(project: str | None) -> Path:
-    """Resolve a stable Operator workspace without inheriting the daemon cwd."""
+async def resolve_operator_execution_root(
+    project: str | None,
+    daemon_resolution: OperatorExecutionRootResolution | None,
+) -> Path:
+    """Resolve a turn from the daemon's frozen root choice or its project."""
+    from lionagi.studio.config import (
+        OPERATOR_CWD_ENV_VAR,
+        OPERATOR_CWD_RULE_DEFAULT,
+        OPERATOR_CWD_RULE_ENV,
+    )
     from lionagi.studio.scheduler.engine import _is_usable_execution_root
 
     daemon_cwd = Path.cwd().resolve()
-    configured = os.environ.get(_OPERATOR_CWD_ENV)
-    if configured is not None:
-        if _is_usable_execution_root(configured):
-            return Path(configured).resolve()
+    if daemon_resolution is None:
         raise OperatorExecutionRootError(
-            f"{_OPERATOR_CWD_ENV} is set to {configured!r}, which is not an "
-            "existing absolute directory. Refusing to run the Operator from "
+            "Studio Operator execution root was not resolved at daemon startup. "
+            "Refusing to resolve it from turn-time process state or to inherit "
             f"the Studio daemon working directory {str(daemon_cwd)!r}."
         )
 
-    project_path: str | None = None
-    if project:
+    if daemon_resolution.rule == OPERATOR_CWD_RULE_ENV:
+        if daemon_resolution.root is not None:
+            return daemon_resolution.root
+        raise OperatorExecutionRootError(
+            f"{OPERATOR_CWD_ENV_VAR} is set to "
+            f"{daemon_resolution.configured_value!r}, which is not an existing "
+            "absolute directory. Refusing to run the Operator from the Studio "
+            f"daemon working directory {str(daemon_cwd)!r}."
+        )
+
+    if daemon_resolution.rule != OPERATOR_CWD_RULE_DEFAULT:
+        raise OperatorExecutionRootError(
+            f"Studio Operator execution root startup rule "
+            f"{daemon_resolution.rule!r} is unknown. Refusing to inherit the "
+            f"Studio daemon working directory {str(daemon_cwd)!r}."
+        )
+
+    if project is not None:
         from lionagi.studio.services.projects import get_project
 
         project_row = await get_project(project)
-        if project_row is not None and isinstance(project_row.get("path"), str):
-            project_path = project_row["path"]
+        project_path = (
+            project_row.get("path")
+            if project_row is not None and isinstance(project_row.get("path"), str)
+            else None
+        )
         if project_path is not None and _is_usable_execution_root(project_path):
             return Path(project_path).resolve()
+        raise OperatorExecutionRootError(
+            f"Studio Operator project {project!r} has no usable registered "
+            "execution root. Refusing to replace that selected project with "
+            f"the daemon default {str(daemon_resolution.root)!r} or working "
+            f"directory {str(daemon_cwd)!r}."
+        )
 
-    project_detail = (
-        f"project {project!r} has no usable registered path"
-        if project
-        else "no project with a usable registered path was selected"
-    )
+    if daemon_resolution.root is not None:
+        return daemon_resolution.root
+
     raise OperatorExecutionRootError(
-        f"Studio Operator execution root is unavailable: {project_detail}, and "
-        f"{_OPERATOR_CWD_ENV} is unset. Set {_OPERATOR_CWD_ENV} to an existing "
-        "absolute directory. Refusing to inherit the Studio daemon working "
+        "Studio Operator's shipped daemon-config default "
+        f"{daemon_resolution.configured_value!r} is not an existing absolute "
+        f"directory. Set {OPERATOR_CWD_ENV_VAR} to an existing absolute "
+        "directory. Refusing to inherit the Studio daemon working "
         f"directory {str(daemon_cwd)!r}."
     )
 
@@ -668,7 +697,7 @@ def build_operator_branch(
 
         repo_kwarg = PROVIDER_REPO_KWARG.get(provider)
         if repo_kwarg is not None:
-            model_kwargs[repo_kwarg] = execution_root
+            model_kwargs[repo_kwarg] = str(execution_root)
     model_name = _apply_operator_effort(provider, model_name, turn.effort, model_kwargs)
     chat_model = iModel(provider=provider, model=model_name, **model_kwargs)
     # The conversation's own durable identity, so this turn's branch/session

--- a/lionagi/studio/operator/engine.py
+++ b/lionagi/studio/operator/engine.py
@@ -86,6 +86,13 @@ class OperatorProviderUnavailableError(RuntimeError):
     """The configured local Operator CLI is not installed."""
 
 
+class OperatorExecutionRootError(ValueError):
+    """The Operator has no explicit, usable directory for provider execution."""
+
+
+_OPERATOR_CWD_ENV = "LIONAGI_STUDIO_OPERATOR_CWD"
+
+
 @dataclass(frozen=True, slots=True)
 class CompiledOperatorHistory:
     """A bounded, replayable history plus its durable compilation receipt."""
@@ -501,6 +508,44 @@ class BranchOperatorEngine:
                 await task
 
 
+async def resolve_operator_execution_root(project: str | None) -> Path:
+    """Resolve a stable Operator workspace without inheriting the daemon cwd."""
+    from lionagi.studio.scheduler.engine import _is_usable_execution_root
+
+    daemon_cwd = Path.cwd().resolve()
+    configured = os.environ.get(_OPERATOR_CWD_ENV)
+    if configured is not None:
+        if _is_usable_execution_root(configured):
+            return Path(configured).resolve()
+        raise OperatorExecutionRootError(
+            f"{_OPERATOR_CWD_ENV} is set to {configured!r}, which is not an "
+            "existing absolute directory. Refusing to run the Operator from "
+            f"the Studio daemon working directory {str(daemon_cwd)!r}."
+        )
+
+    project_path: str | None = None
+    if project:
+        from lionagi.studio.services.projects import get_project
+
+        project_row = await get_project(project)
+        if project_row is not None and isinstance(project_row.get("path"), str):
+            project_path = project_row["path"]
+        if project_path is not None and _is_usable_execution_root(project_path):
+            return Path(project_path).resolve()
+
+    project_detail = (
+        f"project {project!r} has no usable registered path"
+        if project
+        else "no project with a usable registered path was selected"
+    )
+    raise OperatorExecutionRootError(
+        f"Studio Operator execution root is unavailable: {project_detail}, and "
+        f"{_OPERATOR_CWD_ENV} is unset. Set {_OPERATOR_CWD_ENV} to an existing "
+        "absolute directory. Refusing to inherit the Studio daemon working "
+        f"directory {str(daemon_cwd)!r}."
+    )
+
+
 def resolve_operator_provider_model(turn: OperatorEngineTurn) -> tuple[str, str]:
     """Resolve (provider, model) for a turn.
 
@@ -548,7 +593,11 @@ def _apply_operator_effort(
     return model_name
 
 
-def build_operator_branch(turn: OperatorEngineTurn):
+def build_operator_branch(
+    turn: OperatorEngineTurn,
+    *,
+    execution_root: Path | None = None,
+):
     """Build the real, permission-gated Branch used by a canonical turn run."""
     from lionagi.service.manager import iModel
     from lionagi.session.branch import Branch
@@ -614,6 +663,12 @@ def build_operator_branch(turn: OperatorEngineTurn):
             "api_key": "dummy",
             **({"resume": turn.provider_session_id} if turn.provider_session_id else {}),
         }
+    if execution_root is not None:
+        from lionagi.service.providers import PROVIDER_REPO_KWARG
+
+        repo_kwarg = PROVIDER_REPO_KWARG.get(provider)
+        if repo_kwarg is not None:
+            model_kwargs[repo_kwarg] = execution_root
     model_name = _apply_operator_effort(provider, model_name, turn.effort, model_kwargs)
     chat_model = iModel(provider=provider, model=model_name, **model_kwargs)
     # The conversation's own durable identity, so this turn's branch/session

--- a/tests/studio/test_operator_execution_root.py
+++ b/tests/studio/test_operator_execution_root.py
@@ -1,13 +1,13 @@
+import logging
 from pathlib import Path
 
 import pytest
 
+from lionagi.studio import config as studio_config
 from lionagi.studio.operator import coordinator as coordinator_mod
 from lionagi.studio.operator.coordinator import OperatorCoordinator
 from lionagi.studio.operator.engine import (
-    OperatorExecutionRootError,
     build_operator_branch,
-    resolve_operator_execution_root,
 )
 from lionagi.studio.operator.store import OperatorStore
 from lionagi.studio.operator.types import OperatorEngineTurn
@@ -15,6 +15,18 @@ from lionagi.studio.operator.types import OperatorEngineTurn
 
 async def _request_permission(*_args):
     raise AssertionError("branch construction cannot request permission")
+
+
+def _set_shipped_default(
+    monkeypatch: pytest.MonkeyPatch,
+    execution_root: Path,
+) -> None:
+    monkeypatch.setattr(
+        studio_config,
+        "OPERATOR_CWD_DEFAULT",
+        execution_root,
+        raising=False,
+    )
 
 
 def _turn(*, provider: str, model: str, store_path: Path) -> OperatorEngineTurn:
@@ -53,11 +65,87 @@ def test_operator_branch_forwards_the_resolved_execution_root(
     )
 
     configured = branch.chat_model.endpoint.config.kwargs["repo"]
+    assert isinstance(configured, str)
     assert Path(configured).resolve() == execution_root.resolve()
 
 
 @pytest.mark.asyncio
-async def test_operator_uses_configured_root_when_no_project_root_is_available(
+async def test_operator_uses_explicit_root_before_the_selected_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lionagi.studio.services import projects
+
+    daemon_cwd = tmp_path / "app"
+    execution_root = tmp_path / "operator-root"
+    project_root = tmp_path / "selected-project"
+    daemon_cwd.mkdir()
+    execution_root.mkdir()
+    project_root.mkdir()
+    monkeypatch.chdir(daemon_cwd)
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(execution_root))
+    captured: list[Path] = []
+
+    async def get_project(name: str):
+        assert name == "selected"
+        return {"name": name, "path": str(project_root)}
+
+    monkeypatch.setattr(projects, "get_project", get_project)
+
+    def stop_after_resolution(turn, *, execution_root: Path | None = None):
+        assert turn.context["space"] == "mission"
+        if execution_root is not None:
+            captured.append(execution_root)
+        raise RuntimeError("stop after execution-root resolution")
+
+    monkeypatch.setattr(coordinator_mod, "build_operator_branch", stop_after_resolution)
+    coordinator = OperatorCoordinator(store=OperatorStore(tmp_path / "state.db"))
+    try:
+        await coordinator.startup()
+        conversation_id = (await coordinator.create_conversation(project="selected"))[
+            "conversation"
+        ]["id"]
+        await coordinator.submit(
+            conversation_id,
+            instruction="inspect this project",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+        )
+    finally:
+        await coordinator.shutdown()
+
+    assert [path.resolve() for path in captured] == [execution_root.resolve()]
+    assert captured[0].resolve() != daemon_cwd.resolve()
+
+
+@pytest.mark.asyncio
+async def test_operator_startup_discloses_the_default_root_and_rule(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    execution_root = tmp_path / "operator-root"
+    execution_root.mkdir()
+    monkeypatch.delenv("LIONAGI_STUDIO_OPERATOR_CWD", raising=False)
+    _set_shipped_default(monkeypatch, execution_root)
+
+    coordinator = OperatorCoordinator(store=OperatorStore(tmp_path / "state.db"))
+    with caplog.at_level(logging.INFO, logger=coordinator_mod.__name__):
+        await coordinator.startup()
+    await coordinator.shutdown()
+
+    disclosures = [
+        record.getMessage()
+        for record in caplog.records
+        if "Studio Operator execution root resolved" in record.getMessage()
+    ]
+    assert len(disclosures) == 1
+    assert str(execution_root.resolve()) in disclosures[0]
+    assert "daemon-config-default:user-home" in disclosures[0]
+
+
+@pytest.mark.asyncio
+async def test_browser_shaped_projectless_turn_uses_the_startup_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -66,7 +154,8 @@ async def test_operator_uses_configured_root_when_no_project_root_is_available(
     daemon_cwd.mkdir()
     execution_root.mkdir()
     monkeypatch.chdir(daemon_cwd)
-    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(execution_root))
+    monkeypatch.delenv("LIONAGI_STUDIO_OPERATOR_CWD", raising=False)
+    _set_shipped_default(monkeypatch, execution_root)
     captured: list[Path] = []
 
     def stop_after_resolution(turn, *, execution_root: Path | None = None):
@@ -94,15 +183,56 @@ async def test_operator_uses_configured_root_when_no_project_root_is_available(
 
 
 @pytest.mark.asyncio
-async def test_operator_uses_the_selected_projects_registered_root_when_unset(
+async def test_operator_freezes_the_explicit_root_at_startup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from lionagi.studio.services import projects
+    startup_root = tmp_path / "startup-root"
+    later_root = tmp_path / "later-root"
+    startup_root.mkdir()
+    later_root.mkdir()
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(startup_root))
+    captured: list[Path] = []
 
+    def stop_after_resolution(_turn, *, execution_root: Path | None = None):
+        if execution_root is not None:
+            captured.append(execution_root)
+        raise RuntimeError("stop after execution-root resolution")
+
+    monkeypatch.setattr(coordinator_mod, "build_operator_branch", stop_after_resolution)
+    coordinator = OperatorCoordinator(store=OperatorStore(tmp_path / "state.db"))
+    try:
+        await coordinator.startup()
+        monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(later_root))
+        conversation_id = (await coordinator.create_conversation())["conversation"]["id"]
+        await coordinator.submit(
+            conversation_id,
+            instruction="inspect this project",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+        )
+    finally:
+        await coordinator.shutdown()
+
+    assert [path.resolve() for path in captured] == [startup_root.resolve()]
+
+
+@pytest.mark.asyncio
+async def test_api_created_project_conversation_keeps_its_registered_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lionagi.studio.operator.types import CreateConversationRequest
+    from lionagi.studio.services import projects
+    from lionagi.studio.services.operator import create_operator_conversation
+
+    default_root = tmp_path / "operator-default"
     project_root = tmp_path / "selected-project"
+    default_root.mkdir()
     project_root.mkdir()
     monkeypatch.delenv("LIONAGI_STUDIO_OPERATOR_CWD", raising=False)
+    _set_shipped_default(monkeypatch, default_root)
+    captured: list[Path] = []
 
     async def get_project(name: str):
         assert name == "selected"
@@ -110,48 +240,103 @@ async def test_operator_uses_the_selected_projects_registered_root_when_unset(
 
     monkeypatch.setattr(projects, "get_project", get_project)
 
-    resolved = await resolve_operator_execution_root("selected")
+    def stop_after_resolution(_turn, *, execution_root: Path | None = None):
+        if execution_root is not None:
+            captured.append(execution_root)
+        raise RuntimeError("stop after execution-root resolution")
 
-    assert resolved == project_root.resolve()
+    monkeypatch.setattr(coordinator_mod, "build_operator_branch", stop_after_resolution)
+    coordinator = OperatorCoordinator(store=OperatorStore(tmp_path / "state.db"))
+    monkeypatch.setattr(coordinator_mod, "_COORDINATOR", coordinator)
+    try:
+        await coordinator.startup()
+        conversation_id = (
+            await create_operator_conversation(CreateConversationRequest(project="selected"))
+        )["conversation"]["id"]
+        await coordinator.submit(
+            conversation_id,
+            instruction="inspect this project",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+        )
+    finally:
+        await coordinator.shutdown()
+
+    assert [path.resolve() for path in captured] == [project_root.resolve()]
+    assert captured[0].resolve() != default_root.resolve()
 
 
 @pytest.mark.asyncio
-async def test_invalid_configured_root_never_falls_back_to_a_project(
+async def test_selected_invalid_project_refuses_instead_of_using_the_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from lionagi.studio.services import projects
 
-    project_root = tmp_path / "selected-project"
-    project_root.mkdir()
-    configured = tmp_path / "missing-configured-root"
-    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(configured))
+    default_root = tmp_path / "operator-default"
+    default_root.mkdir()
+    monkeypatch.delenv("LIONAGI_STUDIO_OPERATOR_CWD", raising=False)
+    _set_shipped_default(monkeypatch, default_root)
 
-    async def get_project(_name: str):
-        return {"name": "selected", "path": str(project_root)}
+    async def get_project(name: str):
+        assert name == "selected"
+        return {"name": name, "path": str(tmp_path / "missing-project")}
 
     monkeypatch.setattr(projects, "get_project", get_project)
 
-    with pytest.raises(OperatorExecutionRootError, match=str(configured)):
-        await resolve_operator_execution_root("selected")
+    def unexpected_build(*_args, **_kwargs):
+        raise AssertionError("an invalid selected project must fail before branch construction")
+
+    monkeypatch.setattr(coordinator_mod, "build_operator_branch", unexpected_build)
+    coordinator = OperatorCoordinator(store=OperatorStore(tmp_path / "state.db"))
+    try:
+        await coordinator.startup()
+        conversation_id = (await coordinator.create_conversation(project="selected"))[
+            "conversation"
+        ]["id"]
+        await coordinator.submit(
+            conversation_id,
+            instruction="inspect this project",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+        )
+        frames = await coordinator.store.list_frames(conversation_id)
+    finally:
+        await coordinator.shutdown()
+
+    error = next(frame for frame in frames if frame["type"] == "error")["payload"]["error"]
+    assert error["code"] == "service_failure"
+    assert "project 'selected'" in error["message"]
+    assert str(default_root.resolve()) in error["message"]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("configured", [None, ".", "missing"])
-async def test_operator_refuses_an_unusable_execution_root_legibly(
+@pytest.mark.parametrize("configured", [".", "missing"])
+async def test_explicit_invalid_root_refuses_instead_of_using_the_default_or_project(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    configured: str | None,
+    configured: str,
 ) -> None:
+    from lionagi.studio.services import projects
+
     daemon_cwd = tmp_path / "app"
+    default_root = tmp_path / "operator-default"
+    project_root = tmp_path / "selected-project"
     daemon_cwd.mkdir()
+    default_root.mkdir()
+    project_root.mkdir()
     monkeypatch.chdir(daemon_cwd)
-    if configured is None:
-        monkeypatch.delenv("LIONAGI_STUDIO_OPERATOR_CWD", raising=False)
-    elif configured == "missing":
+    _set_shipped_default(monkeypatch, default_root)
+    if configured == "missing":
         monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(tmp_path / configured))
     else:
         monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", configured)
+
+    async def get_project(name: str):
+        assert name == "selected"
+        return {"name": name, "path": str(project_root)}
+
+    monkeypatch.setattr(projects, "get_project", get_project)
 
     def unexpected_build(*_args, **_kwargs):
         raise AssertionError("an unusable execution root must fail before branch construction")
@@ -160,7 +345,9 @@ async def test_operator_refuses_an_unusable_execution_root_legibly(
     coordinator = OperatorCoordinator(store=OperatorStore(tmp_path / "state.db"))
     try:
         await coordinator.startup()
-        conversation_id = (await coordinator.create_conversation())["conversation"]["id"]
+        conversation_id = (await coordinator.create_conversation(project="selected"))[
+            "conversation"
+        ]["id"]
         await coordinator.submit(
             conversation_id,
             instruction="inspect this project",
@@ -175,4 +362,6 @@ async def test_operator_refuses_an_unusable_execution_root_legibly(
     assert error["code"] == "service_failure"
     assert "LIONAGI_STUDIO_OPERATOR_CWD" in error["message"]
     assert str(daemon_cwd.resolve()) in error["message"]
+    assert str(default_root.resolve()) not in error["message"]
+    assert str(project_root.resolve()) not in error["message"]
     assert error["retryable"] is False

--- a/tests/studio/test_operator_execution_root.py
+++ b/tests/studio/test_operator_execution_root.py
@@ -1,0 +1,178 @@
+from pathlib import Path
+
+import pytest
+
+from lionagi.studio.operator import coordinator as coordinator_mod
+from lionagi.studio.operator.coordinator import OperatorCoordinator
+from lionagi.studio.operator.engine import (
+    OperatorExecutionRootError,
+    build_operator_branch,
+    resolve_operator_execution_root,
+)
+from lionagi.studio.operator.store import OperatorStore
+from lionagi.studio.operator.types import OperatorEngineTurn
+
+
+async def _request_permission(*_args):
+    raise AssertionError("branch construction cannot request permission")
+
+
+def _turn(*, provider: str, model: str, store_path: Path) -> OperatorEngineTurn:
+    return OperatorEngineTurn(
+        conversation_id="conversation",
+        request_id="request",
+        instruction="inspect the project",
+        context={},
+        history=(),
+        request_permission=_request_permission,
+        store_path=str(store_path),
+        provider=provider,
+        model=model,
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("claude_code", "sonnet"),
+        ("codex", "gpt-5.3-codex"),
+        ("gemini_code", "gemini-3.5-flash"),
+    ],
+)
+def test_operator_branch_forwards_the_resolved_execution_root(
+    tmp_path: Path,
+    provider: str,
+    model: str,
+) -> None:
+    execution_root = tmp_path / "operator-root"
+    execution_root.mkdir()
+
+    branch = build_operator_branch(
+        _turn(provider=provider, model=model, store_path=tmp_path / "state.db"),
+        execution_root=execution_root,
+    )
+
+    configured = branch.chat_model.endpoint.config.kwargs["repo"]
+    assert Path(configured).resolve() == execution_root.resolve()
+
+
+@pytest.mark.asyncio
+async def test_operator_uses_configured_root_when_no_project_root_is_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    daemon_cwd = tmp_path / "app"
+    execution_root = tmp_path / "operator-root"
+    daemon_cwd.mkdir()
+    execution_root.mkdir()
+    monkeypatch.chdir(daemon_cwd)
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(execution_root))
+    captured: list[Path] = []
+
+    def stop_after_resolution(turn, *, execution_root: Path | None = None):
+        assert turn.context["space"] == "mission"
+        if execution_root is not None:
+            captured.append(execution_root)
+        raise RuntimeError("stop after execution-root resolution")
+
+    monkeypatch.setattr(coordinator_mod, "build_operator_branch", stop_after_resolution)
+    coordinator = OperatorCoordinator(store=OperatorStore(tmp_path / "state.db"))
+    try:
+        await coordinator.startup()
+        conversation_id = (await coordinator.create_conversation())["conversation"]["id"]
+        await coordinator.submit(
+            conversation_id,
+            instruction="inspect this project",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+        )
+    finally:
+        await coordinator.shutdown()
+
+    assert [path.resolve() for path in captured] == [execution_root.resolve()]
+    assert captured[0].resolve() != daemon_cwd.resolve()
+
+
+@pytest.mark.asyncio
+async def test_operator_uses_the_selected_projects_registered_root_when_unset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lionagi.studio.services import projects
+
+    project_root = tmp_path / "selected-project"
+    project_root.mkdir()
+    monkeypatch.delenv("LIONAGI_STUDIO_OPERATOR_CWD", raising=False)
+
+    async def get_project(name: str):
+        assert name == "selected"
+        return {"name": name, "path": str(project_root)}
+
+    monkeypatch.setattr(projects, "get_project", get_project)
+
+    resolved = await resolve_operator_execution_root("selected")
+
+    assert resolved == project_root.resolve()
+
+
+@pytest.mark.asyncio
+async def test_invalid_configured_root_never_falls_back_to_a_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from lionagi.studio.services import projects
+
+    project_root = tmp_path / "selected-project"
+    project_root.mkdir()
+    configured = tmp_path / "missing-configured-root"
+    monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(configured))
+
+    async def get_project(_name: str):
+        return {"name": "selected", "path": str(project_root)}
+
+    monkeypatch.setattr(projects, "get_project", get_project)
+
+    with pytest.raises(OperatorExecutionRootError, match=str(configured)):
+        await resolve_operator_execution_root("selected")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("configured", [None, ".", "missing"])
+async def test_operator_refuses_an_unusable_execution_root_legibly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str | None,
+) -> None:
+    daemon_cwd = tmp_path / "app"
+    daemon_cwd.mkdir()
+    monkeypatch.chdir(daemon_cwd)
+    if configured is None:
+        monkeypatch.delenv("LIONAGI_STUDIO_OPERATOR_CWD", raising=False)
+    elif configured == "missing":
+        monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", str(tmp_path / configured))
+    else:
+        monkeypatch.setenv("LIONAGI_STUDIO_OPERATOR_CWD", configured)
+
+    def unexpected_build(*_args, **_kwargs):
+        raise AssertionError("an unusable execution root must fail before branch construction")
+
+    monkeypatch.setattr(coordinator_mod, "build_operator_branch", unexpected_build)
+    coordinator = OperatorCoordinator(store=OperatorStore(tmp_path / "state.db"))
+    try:
+        await coordinator.startup()
+        conversation_id = (await coordinator.create_conversation())["conversation"]["id"]
+        await coordinator.submit(
+            conversation_id,
+            instruction="inspect this project",
+            context={"space": "mission", "route": "/", "filters": {}},
+            expected_last_sequence=0,
+        )
+        frames = await coordinator.store.list_frames(conversation_id)
+    finally:
+        await coordinator.shutdown()
+
+    error = next(frame for frame in frames if frame["type"] == "error")["payload"]["error"]
+    assert error["code"] == "service_failure"
+    assert "LIONAGI_STUDIO_OPERATOR_CWD" in error["message"]
+    assert str(daemon_cwd.resolve()) in error["message"]
+    assert error["retryable"] is False


### PR DESCRIPTION
## Summary

- resolve and freeze the daemon-wide Operator execution-root configuration at Operator startup
- disclose the resolved root and the exact rule that chose it in the startup log
- keep explicit environment and selected-project failures fail-closed
- forward JSON-safe canonical root strings to Claude Code, Codex, and Gemini CLI providers
- give the Studio image an explicit `/workspace` execution root and volume

## Behavior change

Before this PR, CLI-backed Operator turns silently inherited the Studio daemon's process working directory. That made the launch directory an undocumented execution choice; in the image it happened to be `/app`.

Round 1 removed that silent inheritance. It accepted an explicit `LIONAGI_STUDIO_OPERATOR_CWD` or a selected project's registered path and otherwise refused. That was correct fail-closed behavior, but it left the normal browser-created conversation (which has no selected project) unable to run a turn when the environment variable was absent.

This round gives the daemon a real startup default rather than adding a turn-time fallback. At Operator startup it snapshots one configuration resolution:

1. `env:LIONAGI_STUDIO_OPERATOR_CWD`, when the variable is present; otherwise
2. `daemon-config-default:user-home`, the shipped daemon default.

The chosen absolute root and rule are logged together. A project-bearing conversation still uses its registered project root when there is no environment override. A projectless browser conversation uses the frozen daemon default. Nothing re-reads the environment or consults `Path.cwd()` to choose a root at turn time.

An explicit invalid environment value still lets the rest of Studio start but makes every Operator turn refuse. A selected-but-invalid project also refuses rather than being swallowed by the daemon default.

## Container

The image keeps `WORKDIR /app` for the installed application, but explicitly sets `LIONAGI_STUDIO_OPERATOR_CWD=/workspace`, creates and declares `/workspace` as a volume, and documents binding the intended code there (for example `-v "$PWD:/workspace"`). `/app` is never the Operator default.

## CI diagnosis

The Python 3.10 and 3.14 jobs had the identical 23 failing Operator tests. Their representative failures showed the new execution-root `service_failure` preempting the provider/model/proposal behavior each test intended to reach. `ci-gate` only aggregated those Python failures and `studio-e2e`; it was not a separate defect.

Once a valid root was supplied, a second masked issue appeared: provider `repo` kwargs held a `Path`, so resumable snapshot JSON raised `TypeError: Object of type PosixPath is not JSON serializable`. The root is now forwarded as a canonical string.

## Validation

- 138 affected Python tests pass across Operator lifecycle, model selection, protocol, and execution-root suites
- focused startup/default/HTTP replay pass: 12 tests
- Ruff check and format: pass
- Pyright: 0 errors (one pre-existing `OperatorFrameType` warning)
- Docker BuildKit `--check`: pass, no warnings
- frontend TypeScript build + Vite production build: pass
- local Playwright execution was attempted, but the managed macOS sandbox denied Chromium's Mach rendezvous before either requested spec executed (`bootstrap_check_in ... Permission denied (1100)`); no browser green is claimed here

Mutation arms were named before execution and reconciled individually. In particular, no-oping the coordinator's startup-root snapshot made the browser-shaped unit test capture no root and made the existing HTTP replay contract go red at `latestSequence == 3` instead of `>= 5`. Removing log provenance, swallowing invalid explicit config, replacing a selected project with the default, and forwarding a raw `Path` each made its dedicated test go red; every mutation was then restored.

## Pushed CI result

Commit `4614f8e4e8537b350400219e586fa887e6e75289` is green across the full required workflow:

- Python 3.10: 18,735 passed, 43 skipped, 3 expected xfails
- Python 3.14: 18,736 passed, 42 skipped, 3 expected xfails
- `studio-e2e`: 9 passed, including both previously failing Operator turn specs
- full Studio Docker image build: passed
- `ci-gate`: passed

Focused changed-line coverage for this round is 93% (44/47 lines).
