### PR TITLE
fix(codex): grant linked worktree git mutation paths

### DIFF
--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -137,8 +137,8 @@ def toml_override_value(value: Any) -> str:
     raise TypeError(f"Unsupported codex `-c` override value type: {type(value)!r}")
 
 
-def _linked_worktree_git_dir(cwd: Path) -> Path | None:
-    """Return a linked worktree's private Git directory, if *cwd* is in one."""
+def _linked_worktree_git_writable_roots(cwd: Path) -> tuple[Path, ...]:
+    """Return the narrow Git write roots needed by a linked worktree."""
     resolved_cwd = cwd.resolve()
     try:
         result = subprocess.run(
@@ -149,17 +149,21 @@ def _linked_worktree_git_dir(cwd: Path) -> Path | None:
             timeout=5,
         )
     except (OSError, subprocess.SubprocessError):
-        return None
+        return ()
     paths = result.stdout.splitlines()
     if result.returncode != 0 or len(paths) != 2 or not all(paths):
-        return None
+        return ()
 
     def _resolve(value: str) -> Path:
         path = Path(value)
         return path.resolve() if path.is_absolute() else (resolved_cwd / path).resolve()
 
     git_dir, common_dir = map(_resolve, paths)
-    return git_dir if git_dir != common_dir else None
+    if git_dir == common_dir:
+        return ()
+
+    common_roots = (common_dir / "objects", common_dir / "refs", common_dir / "logs")
+    return (git_dir, *(path for path in common_roots if path.is_dir()))
 
 
 # --------------------------------------------------------------------------- request model
@@ -551,9 +555,9 @@ class CodexCodeRequest(BaseModel):
 
         args.extend(self._build_declarative_args())
 
-        linked_git_dir = _linked_worktree_git_dir(cwd)
-        if linked_git_dir is not None and str(linked_git_dir) not in (self.add_dir or []):
-            args.extend(["--add-dir", str(linked_git_dir)])
+        for git_root in _linked_worktree_git_writable_roots(cwd):
+            if str(git_root) not in (self.add_dir or []):
+                args.extend(["--add-dir", str(git_root)])
 
         # Approval & sandbox: mutually exclusive hierarchy
         if self.bypass_approvals:

--- a/tests/providers/openai/codex/test_sandbox_writable_roots.py
+++ b/tests/providers/openai/codex/test_sandbox_writable_roots.py
@@ -29,6 +29,11 @@ def _add_dir_values(args: list[str]) -> list[str]:
     return [args[index + 1] for index, value in enumerate(args) if value == "--add-dir"]
 
 
+def _is_reachable(path: Path, roots: list[Path]) -> bool:
+    resolved = path.resolve()
+    return any(resolved == root or resolved.is_relative_to(root) for root in roots)
+
+
 def _git_checkouts(tmp_path: Path) -> tuple[Path, Path]:
     ordinary = tmp_path / "ordinary"
     linked = tmp_path / "linked"
@@ -45,16 +50,19 @@ def _git_checkouts(tmp_path: Path) -> tuple[Path, Path]:
         "-qm",
         "initial",
     )
-    _git(ordinary, "worktree", "add", "--detach", "-q", str(linked))
+    _git(ordinary, "worktree", "add", "-b", "linked-worker", "-q", str(linked))
     return ordinary, linked
 
 
-def test_linked_worktree_grants_exact_per_worktree_git_directory(tmp_path):
+def test_linked_worktree_grants_git_mutation_paths_without_common_directory(tmp_path):
     ordinary, linked = _git_checkouts(tmp_path)
     configured_root = tmp_path / "configured-root"
     configured_root.mkdir()
     git_dir = _resolve_git_path(linked, _git(linked, "rev-parse", "--git-dir"))
     common_dir = _resolve_git_path(linked, _git(linked, "rev-parse", "--git-common-dir"))
+    object_store = common_dir / "objects"
+    refs = common_dir / "refs"
+    logs = common_dir / "logs"
 
     args = CodexCodeRequest(
         prompt="work",
@@ -66,7 +74,12 @@ def test_linked_worktree_grants_exact_per_worktree_git_directory(tmp_path):
     ).as_cmd_args()
 
     assert git_dir != common_dir
-    assert _add_dir_values(args) == [str(git_dir)]
+    grant_roots = [Path(value).resolve() for value in _add_dir_values(args)]
+    assert _is_reachable(object_store, grant_roots)
+    assert grant_roots == [git_dir, object_store, refs, logs]
+    assert not _is_reachable(common_dir / "config", grant_roots)
+    assert not _is_reachable(common_dir / "hooks", grant_roots)
+    assert not _is_reachable(common_dir / "packed-refs", grant_roots)
     configured_override = (
         "sandbox_workspace_write.writable_roots="
         f"{toml_override_value([str(configured_root.resolve())])}"


### PR DESCRIPTION
Closes #2960.\n\nA sandboxed worker running in a linked worktree now receives four narrowly scoped Git write roots: its private worktree metadata directory and the shared repository's objects, refs, and logs directories. Those roots are the paths Git actually writes while staging, committing, and updating remote-tracking refs during push.\n\nCapability change: the worker can now create shared Git objects and mutate shared loose refs and reflogs. It still cannot write the common Git directory itself, repository config, hooks, packed-refs, or other common-root metadata. Updating a ref that is also packed can emit a non-fatal packed-refs cleanup warning; Git writes the new loose ref and the commit succeeds.\n\nThe automatic roots remain repeatable --add-dir values, so configured writable roots are preserved.\n\nTests cover:\n- explicit reachability of the linked worktree's shared object store\n- the exact narrow automatic root set and exclusions for config, hooks, and packed-refs\n- no automatic Git grant for an ordinary checkout\n- a mutation check showing the linked-worktree arm fails under the previous private-directory-only behavior while the ordinary-checkout arm remains green\n\nValidation:\n- env -u VIRTUAL_ENV uv run pytest -q tests/providers/openai/codex\n- env -u VIRTUAL_ENV uv run ruff check lionagi/providers/openai/codex.py tests/providers/openai/codex/test_sandbox_writable_roots.py\n- env -u VIRTUAL_ENV uv run ruff format --check lionagi/providers/openai/codex.py tests/providers/openai/codex/test_sandbox_writable_roots.py\n- env -u VIRTUAL_ENV uv run pyright lionagi/providers/openai/codex.py tests/providers/openai/codex/test_sandbox_writable_roots.py