### PR TITLE
ci(lionrs): gate Rust workspace checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,7 @@ jobs:
       studio: ${{ steps.filter.outputs.studio }}
       adr: ${{ steps.filter.outputs.adr }}
       imports: ${{ steps.filter.outputs.imports }}
+      lionrs: ${{ steps.filter.outputs.lionrs }}
     steps:
     - uses: actions/checkout@v7
     - uses: dorny/paths-filter@v4
@@ -442,6 +443,9 @@ jobs:
             - 'lionagi/**'
             - 'pyproject.toml'
             - 'uv.lock'
+            - '.github/workflows/ci.yml'
+          lionrs:
+            - 'lionrs/**'
             - '.github/workflows/ci.yml'
 
   # Build the Studio image (Vite SPA + FastAPI single-origin) whenever its inputs
@@ -560,6 +564,26 @@ jobs:
           print(f"::notice::bare import loaded none of the {len(heavies)} guarded heavy modules")
           EOF
 
+  lionrs:
+    needs: changes
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.lionrs == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lionrs/crates
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+    - name: Lint
+      run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+    - name: Test
+      run: cargo test --workspace --all-features --locked
+
   vscode:
     runs-on: ubuntu-latest
     defaults:
@@ -595,13 +619,14 @@ jobs:
   # the event (PRs run a subset of Python versions) and a renamed leg would
   # strand PRs on a check that never reports. Fail-closed: every hard gate must
   # report success; a skipped, failed, or cancelled hard gate fails the aggregate.
-  # The conditional jobs (studio-docker, minimal-import, no-eager-heavies) may
+  # The conditional jobs (studio-docker, minimal-import, no-eager-heavies,
+  # lionrs) may
   # skip only when the changes path-filter job itself succeeded and reported
   # their inputs unchanged; any other skip, failure, or cancellation fails the
   # aggregate.
   ci-gate:
     if: ${{ always() }}
-    needs: [lint, core-install, docs, test, frontend, studio-e2e, changes, studio-docker, minimal-import, no-eager-heavies, vscode, marketplace]
+    needs: [lint, core-install, docs, test, frontend, studio-e2e, changes, studio-docker, minimal-import, no-eager-heavies, lionrs, vscode, marketplace]
     runs-on: ubuntu-latest
     steps:
     - name: Check aggregate result
@@ -638,6 +663,7 @@ jobs:
             "studio-docker": "studio",
             "minimal-import": "imports",
             "no-eager-heavies": "imports",
+            "lionrs": "lionrs",
         }
         for job, flag in conditional_gates.items():
             changed = needs["changes"].get("outputs", {}).get(flag)

--- a/lionrs/crates/lion-core/src/state/memory.rs
+++ b/lionrs/crates/lion-core/src/state/memory.rs
@@ -430,7 +430,7 @@ mod tests {
     #[test]
     fn test_linear_memory_empty() {
         let mem = LinearMemory::empty(1024);
-        assert_eq!(mem.bounds(), 1024);
+        assert_eq!(mem.bounds(), 1023);
         assert!(mem.is_empty());
     }
 

--- a/lionrs/crates/lion-core/src/state/memory.rs
+++ b/lionrs/crates/lion-core/src/state/memory.rs
@@ -430,7 +430,7 @@ mod tests {
     #[test]
     fn test_linear_memory_empty() {
         let mem = LinearMemory::empty(1024);
-        assert_eq!(mem.bounds(), 1023);
+        assert_eq!(mem.bounds(), 1024);
         assert!(mem.is_empty());
     }
 

--- a/lionrs/docs/adr/ADR-0001-lionrs-and-the-verified-core.md
+++ b/lionrs/docs/adr/ADR-0001-lionrs-and-the-verified-core.md
@@ -5,6 +5,12 @@
 - **Supersedes**: none
 - **Related**: lionagi ADR-0114 (executable flow definition and role capabilities)
 
+## Approval
+
+| Role | Decision | Date |
+|---|---|---|
+| Director | Approve | 2026-08-08 |
+
 ## Context
 
 lionagi is a Python package. This ADR opens a Rust tree inside the same repository and


### PR DESCRIPTION
## Summary

- add a path-filtered Rust workspace job for formatting, linting, and tests
- wire the conditional job into the aggregate CI gate
- record the ADR approval

## Gate demonstration

| State | Commit | `lionrs` | `ci-gate` | Run |
|---|---|---|---|---|
| Initial | `8f3da762` | success | success | [31291312288](https://github.com/ohdearquant/lionagi/actions/runs/31291312288) |
| Deliberate test break | `d73a12ed` | failure | failure | [31291787339](https://github.com/ohdearquant/lionagi/actions/runs/31291787339) |
| Restored | `7b9f56fb` | success | success | [31292384346](https://github.com/ohdearquant/lionagi/actions/runs/31292384346) |

The middle commit changed one deterministic `lion-core` assertion; the final commit reverted that change exactly.

Closes #2963