### PR TITLE
feat(mcp): expose team coordination verbs

### DIFF
--- a/docs/reference/mcp-server.md
+++ b/docs/reference/mcp-server.md
@@ -130,7 +130,7 @@ resolves that playbook's own declared arguments into the schema.
 
 ## The catalog
 
-40 verbs are reachable. Both tables in this section are checked against the
+44 verbs are reachable. Both tables in this section are checked against the
 registry by the test suite, so a verb added or withdrawn without updating them
 fails a test rather than going unnoticed. The registry is the authority; ask it
 directly with:
@@ -182,7 +182,11 @@ python -c "from lionagi.mcp import verbs as v; print(len(v.VERBS)); [print(n) fo
 | `state.ls` | Sessions in the lifecycle store with their branch and message counts. |
 | `state.stats` | Store and write-ahead-log size, per-table row counts, session status spread. |
 | `stats.runs` | Run counts and first/last timestamps, grouped by project/kind/agent/model/status. |
+| `team.create` | Create a new team with named members. |
 | `team.list` | Teams on disk with their members and message counts. |
+| `team.receive` | Read inbox messages. |
+| `team.send` | Send a message to team members. |
+| `team.show` | Show team details and messages. |
 
 <!-- mcp-catalog:available:end -->
 
@@ -194,7 +198,7 @@ against rather than a copy of it.
 
 ## Operations the surface does not offer
 
-Thirty further names are catalogued as **unavailable**, each with its
+Twenty-six further names are catalogued as **unavailable**, each with its
 reason. They are not omissions: a caller that asks what exists gets the name and
 why it cannot be called, which is a different answer from the name never having
 been considered. The right-hand column below abbreviates the reason; `help=true`
@@ -207,10 +211,6 @@ returns each one in full.
 | `casts` | The built-in roles and modes an agent can be composed from. | no machine result |
 | `orchestrate.ctl.status` | What a running flow's control plane reports about it. | no machine result |
 | `state.doctor` | Read-only inspection of the lifecycle store. | no machine result |
-| `team.create` | Messaging between agents working as a team. | no machine result |
-| `team.receive` | Messaging between agents working as a team. | no machine result |
-| `team.send` | Messaging between agents working as a team. | no machine result |
-| `team.show` | Messaging between agents working as a team. | no machine result |
 | `state.checkpoint` | Writes against the lifecycle store. | invalidating write |
 | `state.import` | Writes against the lifecycle store. | invalidating write |
 | `state.import-teams` | Writes against the lifecycle store. | invalidating write |

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -688,6 +688,156 @@ def _machine_list(argv: list[str]) -> dict[str, Any]:
     return _machine_list_data()
 
 
+def _machine_create(argv: list[str]) -> dict[str, Any]:
+    """`li team create NAME --members A,B --machine`."""
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li team create")
+    parser.add_argument("name")
+    parser.add_argument("-m", "--members", required=True)
+    args = parse_machine_argv(parser, argv)
+
+    members = [m.strip() for m in args.members.split(",") if m.strip()]
+    if not members:
+        raise MachineError("invalid_input", "--members requires at least one name")
+
+    team_id = uuid4().hex[:12]
+    path = _teams_dir() / f"{team_id}.json"
+    created_at = now_utc().isoformat()
+    with _locked_team(team_id, create_path=path) as data:
+        data.update(
+            {
+                "id": team_id,
+                "name": args.name,
+                "members": members,
+                "messages": [],
+                "created_at": created_at,
+            }
+        )
+    return {
+        "id": team_id,
+        "name": args.name,
+        "members": members,
+        "created_at": created_at,
+        "path": str(path),
+    }
+
+
+def _machine_show(argv: list[str]) -> dict[str, Any]:
+    """`li team show TEAM --machine`."""
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li team show")
+    parser.add_argument("team")
+    args = parse_machine_argv(parser, argv)
+
+    try:
+        data = _load_team(args.team)
+    except FileNotFoundError as exc:
+        raise MachineError("not_found", str(exc)) from exc
+    except AmbiguousIdError as exc:
+        raise MachineError("invalid_input", str(exc)) from exc
+    return {"team": data}
+
+
+def _machine_send(argv: list[str]) -> dict[str, Any]:
+    """`li team send CONTENT --team T --to R --machine`."""
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li team send")
+    parser.add_argument("content")
+    parser.add_argument("--team", "-t", required=True)
+    parser.add_argument("--to", required=True)
+    parser.add_argument("--from", dest="sender", default=None)
+    parser.add_argument("--from-op", dest="from_op", default=None)
+    parser.add_argument(
+        "--kind", default=None, choices=(MESSAGE_KIND, DONE_KIND, FINISHED_KIND, WAKEUP_KIND)
+    )
+    parser.add_argument("--artifacts", default=None)
+    args = parse_machine_argv(parser, argv)
+
+    try:
+        with _locked_team(args.team) as data:
+            if not data:
+                raise MachineError("not_found", f"Team '{args.team}' is empty or missing")
+
+            sender = args.sender or "_cli"
+            if args.to.lower() == "all":
+                recipients = ["*"]
+            else:
+                recipients = [r.strip() for r in args.to.split(",") if r.strip()]
+
+            artifacts = None
+            if args.artifacts:
+                artifacts = [a.strip() for a in args.artifacts.split(",") if a.strip()]
+            msg = _build_message(
+                sender,
+                recipients,
+                args.content,
+                kind=args.kind or MESSAGE_KIND,
+                from_op=args.from_op,
+                artifacts=artifacts,
+            )
+            data.setdefault("messages", []).append(msg)
+            team_id = data.get("id", args.team)
+    except FileNotFoundError as exc:
+        raise MachineError("not_found", str(exc)) from exc
+    except AmbiguousIdError as exc:
+        raise MachineError("invalid_input", str(exc)) from exc
+
+    return {
+        "message_id": msg["id"],
+        "team_id": team_id,
+        "to": recipients,
+        "timestamp": msg["timestamp"],
+    }
+
+
+def _machine_receive(argv: list[str]) -> dict[str, Any]:
+    """`li team receive --team T [--as MEMBER] --machine`."""
+    from .machine import MachineError, machine_parser, parse_machine_argv
+
+    parser = machine_parser("li team receive")
+    parser.add_argument("--team", "-t", required=True)
+    parser.add_argument("--as", dest="member", default=None)
+    args = parse_machine_argv(parser, argv)
+    me = args.member
+
+    try:
+        with _locked_team(args.team) as data:
+            if not data:
+                raise MachineError("not_found", f"Team '{args.team}' is empty or missing")
+            team_id = data.get("id", args.team)
+
+            msgs = data.get("messages", [])
+            unread: list[dict] = []
+            for msg in msgs:
+                read_by = _read_by_map(msg.get("read_by"))
+                if me and me in read_by:
+                    continue
+                targets = msg["to"]
+                if targets == ["*"] or (me and me in targets) or not me:
+                    unread.append(msg)
+
+            now = now_utc().isoformat()
+            for msg in unread:
+                read_by = _read_by_map(msg.get("read_by"))
+                if me and me not in read_by:
+                    read_by[me] = now
+                    msg["read_by"] = read_by
+    except FileNotFoundError as exc:
+        raise MachineError("not_found", str(exc)) from exc
+    except AmbiguousIdError as exc:
+        raise MachineError("invalid_input", str(exc)) from exc
+
+    return {
+        "team_id": team_id,
+        "messages": unread,
+        "member": me,
+        "count": len(unread),
+    }
+
+
 def machine_result(argv: list[str]) -> dict[str, Any]:
     """`li team <sub> --machine`."""
     from .machine import machine_subcommand
@@ -695,12 +845,14 @@ def machine_result(argv: list[str]) -> dict[str, Any]:
     return machine_subcommand(
         "team",
         argv,
-        {"list": _machine_list, "ls": _machine_list},
-        without_seam={
-            "create": "it writes a new team file",
-            "show": "it prints a team's messages for a human reader",
-            "send": "it appends a message to a team file",
-            "receive": "it marks the messages it returns as read, which is a write",
-            "recv": "it marks the messages it returns as read, which is a write",
+        {
+            "list": _machine_list,
+            "ls": _machine_list,
+            "create": _machine_create,
+            "show": _machine_show,
+            "send": _machine_send,
+            "receive": _machine_receive,
+            "recv": _machine_receive,
         },
+        without_seam={},
     )

--- a/lionagi/cli/team.py
+++ b/lionagi/cli/team.py
@@ -693,8 +693,8 @@ def _machine_create(argv: list[str]) -> dict[str, Any]:
     from .machine import MachineError, machine_parser, parse_machine_argv
 
     parser = machine_parser("li team create")
-    parser.add_argument("name")
-    parser.add_argument("-m", "--members", required=True)
+    parser.add_argument("name", help="Display name for the new team")
+    parser.add_argument("-m", "--members", required=True, help="Comma-separated member names")
     args = parse_machine_argv(parser, argv)
 
     members = [m.strip() for m in args.members.split(",") if m.strip()]
@@ -728,7 +728,7 @@ def _machine_show(argv: list[str]) -> dict[str, Any]:
     from .machine import MachineError, machine_parser, parse_machine_argv
 
     parser = machine_parser("li team show")
-    parser.add_argument("team")
+    parser.add_argument("team", help="Team id (or unambiguous prefix)")
     args = parse_machine_argv(parser, argv)
 
     try:
@@ -745,15 +745,27 @@ def _machine_send(argv: list[str]) -> dict[str, Any]:
     from .machine import MachineError, machine_parser, parse_machine_argv
 
     parser = machine_parser("li team send")
-    parser.add_argument("content")
-    parser.add_argument("--team", "-t", required=True)
-    parser.add_argument("--to", required=True)
-    parser.add_argument("--from", dest="sender", default=None)
-    parser.add_argument("--from-op", dest="from_op", default=None)
+    parser.add_argument("content", help="Message body")
+    parser.add_argument("--team", "-t", required=True, help="Team id (or unambiguous prefix)")
+    parser.add_argument("--to", required=True, help="Recipients: comma-separated names, or 'all'")
     parser.add_argument(
-        "--kind", default=None, choices=(MESSAGE_KIND, DONE_KIND, FINISHED_KIND, WAKEUP_KIND)
+        "--from", dest="sender", default=None, help="Sender name recorded on the message"
     )
-    parser.add_argument("--artifacts", default=None)
+    parser.add_argument(
+        "--from-op",
+        dest="from_op",
+        default=None,
+        help="Originating op id, for tracing the emitting turn",
+    )
+    parser.add_argument(
+        "--kind",
+        default=None,
+        choices=(MESSAGE_KIND, DONE_KIND, FINISHED_KIND, WAKEUP_KIND),
+        help="Message kind; 'done'/'finished' signal completion",
+    )
+    parser.add_argument(
+        "--artifacts", default=None, help="Comma-separated artifact paths to attach"
+    )
     args = parse_machine_argv(parser, argv)
 
     try:
@@ -798,8 +810,10 @@ def _machine_receive(argv: list[str]) -> dict[str, Any]:
     from .machine import MachineError, machine_parser, parse_machine_argv
 
     parser = machine_parser("li team receive")
-    parser.add_argument("--team", "-t", required=True)
-    parser.add_argument("--as", dest="member", default=None)
+    parser.add_argument("--team", "-t", required=True, help="Team id (or unambiguous prefix)")
+    parser.add_argument(
+        "--as", dest="member", default=None, help="Read as this member; marks their messages read"
+    )
     args = parse_machine_argv(parser, argv)
     me = args.member
 

--- a/lionagi/mcp/verbs.py
+++ b/lionagi/mcp/verbs.py
@@ -744,6 +744,34 @@ _REGISTERED: tuple[Verb, ...] = (
         admits=(),
     ),
     Verb(
+        name="team.create",
+        summary="Create a new team with named members.",
+        executor="machine",
+        cli_path="team create",
+        admits=("name", "members"),
+    ),
+    Verb(
+        name="team.show",
+        summary="Show team details and messages.",
+        executor="machine",
+        cli_path="team show",
+        admits=("team",),
+    ),
+    Verb(
+        name="team.send",
+        summary="Send a message to team members.",
+        executor="machine",
+        cli_path="team send",
+        admits=("content", "team", "to", "sender", "from_op", "kind", "artifacts"),
+    ),
+    Verb(
+        name="team.receive",
+        summary="Read inbox messages.",
+        executor="machine",
+        cli_path="team receive",
+        admits=("team", "member"),
+    ),
+    Verb(
         name="plugin.info",
         summary="One plugin's version, trust state, and everything its manifest declares.",
         executor="machine",
@@ -819,11 +847,6 @@ ABSENT: tuple[AbsentVerb, ...] = (
             "it reports one schedule run, which schedule.runs already returns in a machine result"
         ),
         cli_path="schedule run",
-    ),
-    *_absent(
-        "team",
-        ("create", "show", "send", "receive"),
-        "Messaging between agents working as a team.",
     ),
     *_absent(
         "state",

--- a/tests/cli/test_team_lifecycle.py
+++ b/tests/cli/test_team_lifecycle.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -516,3 +517,123 @@ class TestConcurrentWrites:
         assert read_count > 0
         data = team._load_team(team_id)
         assert len(data["messages"]) == 20 * len(workers)
+
+
+# ── machine result: create / show / send / receive ──────────────────────────
+
+
+class TestMachineResult:
+    def test_create_writes_a_team_and_returns_its_record(self):
+        from lionagi.cli.machine import validate_envelope
+
+        data = team.machine_result(["create", "Squad", "--members", "alice, bob"])
+        validate_envelope({"ok": True, "contract_version": 1, "data": data, "error": None})
+        assert data["name"] == "Squad"
+        assert data["members"] == ["alice", "bob"]
+        assert data["created_at"]
+        on_disk = json.loads(Path(data["path"]).read_text())
+        assert on_disk["id"] == data["id"]
+        assert on_disk["messages"] == []
+
+    def test_create_with_no_members_is_invalid_input(self):
+        from lionagi.cli.machine import MachineError
+
+        with pytest.raises(MachineError) as exc:
+            team.machine_result(["create", "Squad", "--members", " , ,"])
+        assert exc.value.kind == "invalid_input"
+
+    def test_create_missing_required_flag_is_invalid_input(self):
+        from lionagi.cli.machine import MachineError
+
+        with pytest.raises(MachineError) as exc:
+            team.machine_result(["create", "Squad"])
+        assert exc.value.kind == "invalid_input"
+
+    def test_show_returns_the_full_team_including_messages(self):
+        created = team.machine_result(["create", "Squad", "--members", "alice,bob"])
+        team.machine_result(
+            ["send", "hi", "--team", created["id"], "--to", "all", "--from", "alice"]
+        )
+        shown = team.machine_result(["show", created["id"]])
+        assert shown["team"]["id"] == created["id"]
+        assert [m["content"] for m in shown["team"]["messages"]] == ["hi"]
+
+    def test_show_of_unknown_team_is_not_found(self):
+        from lionagi.cli.machine import MachineError
+
+        with pytest.raises(MachineError) as exc:
+            team.machine_result(["show", "no-such-team"])
+        assert exc.value.kind == "not_found"
+
+    def test_send_returns_message_id_team_id_recipients_and_timestamp(self):
+        created = team.machine_result(["create", "Squad", "--members", "alice,bob"])
+        sent = team.machine_result(
+            ["send", "hi", "--team", created["id"], "--to", "bob", "--from", "alice"]
+        )
+        assert sent["team_id"] == created["id"]
+        assert sent["to"] == ["bob"]
+        assert sent["message_id"]
+        assert sent["timestamp"]
+
+    def test_send_broadcast_recipient_is_the_star_marker(self):
+        created = team.machine_result(["create", "Squad", "--members", "alice,bob"])
+        sent = team.machine_result(
+            ["send", "hi all", "--team", created["id"], "--to", "all", "--from", "alice"]
+        )
+        assert sent["to"] == ["*"]
+
+    def test_send_to_a_missing_team_is_not_found(self):
+        from lionagi.cli.machine import MachineError
+
+        with pytest.raises(MachineError) as exc:
+            team.machine_result(["send", "hi", "--team", "no-such-team", "--to", "all"])
+        assert exc.value.kind == "not_found"
+
+    def test_receive_as_a_member_marks_only_their_mail_read_and_returns_the_count(self):
+        created = team.machine_result(["create", "Squad", "--members", "alice,bob"])
+        team.machine_result(
+            ["send", "hi", "--team", created["id"], "--to", "all", "--from", "alice"]
+        )
+        first = team.machine_result(["receive", "--team", created["id"], "--as", "bob"])
+        assert first["count"] == 1
+        assert first["member"] == "bob"
+        assert [m["content"] for m in first["messages"]] == ["hi"]
+
+        second = team.machine_result(["receive", "--team", created["id"], "--as", "bob"])
+        assert second["count"] == 0
+
+    def test_receive_without_member_dumps_everything_and_marks_nothing_read(self):
+        created = team.machine_result(["create", "Squad", "--members", "alice,bob"])
+        team.machine_result(
+            ["send", "hi", "--team", created["id"], "--to", "all", "--from", "alice"]
+        )
+        first = team.machine_result(["receive", "--team", created["id"]])
+        assert first["member"] is None
+        assert first["count"] == 1
+
+        second = team.machine_result(["receive", "--team", created["id"]])
+        assert second["count"] == 1, "no member name means nothing is ever marked read"
+
+    def test_recv_alias_reaches_the_same_handler_as_receive(self):
+        created = team.machine_result(["create", "Squad", "--members", "alice,bob"])
+        team.machine_result(
+            ["send", "hi", "--team", created["id"], "--to", "all", "--from", "alice"]
+        )
+        via_recv = team.machine_result(["recv", "--team", created["id"], "--as", "bob"])
+        assert via_recv["count"] == 1
+
+    def test_receive_from_a_missing_team_is_not_found(self):
+        from lionagi.cli.machine import MachineError
+
+        with pytest.raises(MachineError) as exc:
+            team.machine_result(["receive", "--team", "no-such-team"])
+        assert exc.value.kind == "not_found"
+
+    def test_an_unknown_team_subcommand_is_invalid_input_not_unavailable(self):
+        """Every `li team` subcommand now has a machine seam, so nothing on this
+        command should still answer through the `without_seam` unavailable path."""
+        from lionagi.cli.machine import MachineError
+
+        with pytest.raises(MachineError) as exc:
+            team.machine_result(["not-a-subcommand"])
+        assert exc.value.kind == "invalid_input"

--- a/tests/contracts/data/mcp.json
+++ b/tests/contracts/data/mcp.json
@@ -79,7 +79,7 @@
   "available_path_count": 75,
   "catalog": {
     "verb_count": 70,
-    "available_count": 40,
+    "available_count": 44,
     "max_ops": 8,
     "verb_names": [
       "agent.submit",
@@ -193,7 +193,11 @@
       "state.ls",
       "state.stats",
       "stats.runs",
-      "team.list"
+      "team.create",
+      "team.list",
+      "team.receive",
+      "team.send",
+      "team.show"
     ]
   },
   "projections": {
@@ -2925,33 +2929,9 @@
       "summary": "The Studio server.",
       "reason": "it runs for as long as the process lives rather than returning a result, so it is a process to start, not a call to make",
       "cli_path": "studio start"
-    },
-    {
-      "name": "team.create",
-      "summary": "Messaging between agents working as a team.",
-      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
-      "cli_path": "team create"
-    },
-    {
-      "name": "team.receive",
-      "summary": "Messaging between agents working as a team.",
-      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
-      "cli_path": "team receive"
-    },
-    {
-      "name": "team.send",
-      "summary": "Messaging between agents working as a team.",
-      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
-      "cli_path": "team send"
-    },
-    {
-      "name": "team.show",
-      "summary": "Messaging between agents working as a team.",
-      "reason": "the CLI path emits no versioned machine result (`li <path> --machine`), so there is nothing to return that is not scraped console text",
-      "cli_path": "team show"
     }
   ],
-  "absent_verb_count": 30,
+  "absent_verb_count": 26,
   "errors": [
     {
       "input": "",

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -412,7 +412,7 @@ def test_mcp_aliases_derived_from_live_seed_table():
 
 def test_mcp_absent_verbs_are_captured_in_full():
     live = _capture.capture_mcp()
-    assert live["absent_verb_count"] == 30
+    assert live["absent_verb_count"] == 26
     by_name = {v["name"]: v for v in live["absent_verbs"]}
     assert "mirror" in by_name
     assert "casts" in by_name

--- a/tests/mcp/test_catalog_coverage.py
+++ b/tests/mcp/test_catalog_coverage.py
@@ -210,3 +210,19 @@ def test_every_absence_states_a_reason_and_a_path(absent):
     assert len(absent.reason) > 40, (
         f"{absent.name} reason is too short to be one: {absent.reason!r}"
     )
+
+
+@pytest.mark.parametrize("verb", ["team.create", "team.show", "team.send", "team.receive"])
+def test_team_write_verbs_are_registered_not_absent(verb):
+    """Pinned the way the bug this catalog exists to prevent would break it.
+
+    These four used to be `AbsentVerb`s with the no-machine-seam reason —
+    `team.py` had no versioned machine result to give them. Once it does, the
+    catalog has to actually say so: a caller reading `available: false` here
+    would still be told to fall back to a filesystem path a sandboxed worker
+    cannot reach.
+    """
+    assert verb in VERBS, f"{verb} is still absent from the catalog"
+    assert verb not in {absent.name for absent in ABSENT}
+    assert VERBS[verb].executor == "machine"
+    assert VERBS[verb].cli_path == verb.replace("team.", "team ")

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -597,6 +597,45 @@ def test_a_machine_verb_returns_the_contract_envelope_it_was_given():
     assert result["data"]["implementation"] == "lionagi"
 
 
+def test_team_send_and_receive_round_trip_through_the_dispatcher(tmp_path, monkeypatch):
+    # `team.send`/`team.receive` used to be `AbsentVerb`s with no machine seam;
+    # this is the round trip that seam now has to carry, through the same
+    # `request()` entry point every op goes through — not the CLI directly.
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    created = call(ops=[{"op": "team.create", "args": {"name": "Squad", "members": "a,b"}}])
+    assert created["ops"][0]["ok"] is True
+    team_id = created["ops"][0]["result"]["data"]["id"]
+
+    sent = call(ops=[{"op": "team.send", "args": {"content": "hi", "team": team_id, "to": "all"}}])
+    assert sent["ops"][0]["ok"] is True
+    assert sent["ops"][0]["result"]["data"]["team_id"] == team_id
+
+    received = call(ops=[{"op": "team.receive", "args": {"team": team_id, "member": "a"}}])
+    assert received["ops"][0]["ok"] is True
+    assert [m["content"] for m in received["ops"][0]["result"]["data"]["messages"]] == ["hi"]
+
+
+def test_team_send_to_an_unknown_team_is_a_not_found_error_via_the_dispatcher(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    answer = call(
+        ops=[{"op": "team.send", "args": {"content": "hi", "team": "no-such-team", "to": "all"}}]
+    )
+    assert answer["ops"][0]["ok"] is False
+    assert answer["ops"][0]["error"]["kind"] == "not_found"
+
+
+def test_team_create_with_bad_input_is_refused_before_ever_spawning_the_cli(tmp_path, monkeypatch):
+    # Closed argument validation catches this before `_run_machine` spawns a
+    # subprocess at all — the schema admits only `name`/`members`.
+    monkeypatch.setenv("LIONAGI_HOME", str(tmp_path))
+    answer = call(ops=[{"op": "team.create", "args": {"name": "Squad"}}])
+    assert answer["ops"][0]["ok"] is False
+    assert answer["ops"][0]["error"]["kind"] == "invalid_input"
+    assert "missing required parameter 'members'" in answer["ops"][0]["error"]["message"]
+
+
 def test_a_machine_verb_that_writes_no_result_is_an_explicit_error(monkeypatch):
     # Absent output must never read as an empty success: a caller that treats it
     # as one concludes the command answered and found nothing.

--- a/tests/mcp/test_machine_observability.py
+++ b/tests/mcp/test_machine_observability.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
 
 import pytest
@@ -111,6 +112,140 @@ def test_no_team_directory_at_all_is_a_definitive_zero(home):
     teams = run_op("team.list")["result"]["data"]["teams"]
     assert teams["available"] is True
     assert teams["value"] == []
+
+
+# ── team.create / show / send / receive, through the real subprocess ────────
+
+
+def test_team_create_show_send_receive_round_trip_through_the_real_command(home):
+    created = run_op("team.create", {"name": "Squad", "members": "alice,bob"})
+    assert created["ok"] is True
+    data = created["result"]["data"]
+    assert data["name"] == "Squad"
+    assert data["members"] == ["alice", "bob"]
+    team_id = data["id"]
+
+    sent = run_op("team.send", {"content": "hi", "team": team_id, "to": "bob", "sender": "alice"})
+    assert sent["ok"] is True
+    assert sent["result"]["data"]["team_id"] == team_id
+    assert sent["result"]["data"]["to"] == ["bob"]
+
+    received = run_op("team.receive", {"team": team_id, "member": "bob"})
+    assert received["ok"] is True
+    payload = received["result"]["data"]
+    assert payload["count"] == 1
+    assert [m["content"] for m in payload["messages"]] == ["hi"]
+
+    shown = run_op("team.show", {"team": team_id})
+    assert shown["ok"] is True
+    assert shown["result"]["data"]["team"]["id"] == team_id
+    assert len(shown["result"]["data"]["team"]["messages"]) == 1
+
+
+@pytest.mark.parametrize(
+    ("verb", "args"),
+    [
+        ("team.show", {"team": "no-such-team"}),
+        ("team.send", {"content": "hi", "team": "no-such-team", "to": "all"}),
+        ("team.receive", {"team": "no-such-team"}),
+    ],
+)
+def test_a_team_verb_against_a_missing_team_is_not_found(home, verb, args):
+    op = run_op(verb, args)
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "not_found"
+
+
+def test_team_create_with_no_members_is_invalid_input(home):
+    op = run_op("team.create", {"name": "Squad", "members": " , "})
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "invalid_input"
+
+
+def test_team_create_missing_required_parameter_is_refused_before_the_subprocess_runs(home):
+    op = run_op("team.create", {"members": "alice"})
+    assert op["ok"] is False
+    assert op["error"]["kind"] == "invalid_input"
+    assert "missing required parameter 'name'" in op["error"]["message"]
+
+
+def test_every_team_envelope_matches_the_versioned_contract(home):
+    created = run_op("team.create", {"name": "Squad", "members": "alice,bob"})
+    assert created["result"]["contract_version"] == 1
+    team_id = created["result"]["data"]["id"]
+    for verb, args in (
+        ("team.show", {"team": team_id}),
+        ("team.send", {"content": "hi", "team": team_id, "to": "all"}),
+        ("team.receive", {"team": team_id}),
+    ):
+        op = run_op(verb, args)
+        assert op["ok"] is True, op
+        assert op["result"]["contract_version"] == 1
+
+
+# ── proof: MCP transport delivers when the caller has no direct FS access ───
+
+
+def test_mcp_transport_delivers_when_the_calling_process_denies_direct_filesystem_access(
+    home, tmp_path
+):
+    """The sandbox failure this MCP transport exists to fix, reproduced directly.
+
+    `denied_home` stands in for a sandboxed worker's own restricted view of
+    `~/.lionagi`: a `workspace-write`-style sandbox denies a process direct
+    filesystem access to a path outside its grant, which `chmod` reproduces
+    here — a subprocess pointed at `denied_home` cannot even create the
+    `teams/` directory. That subprocess is the same command a sandboxed
+    worker would shell out to directly (the original bug).
+
+    The MCP dispatcher path below never touches `denied_home` at all:
+    `dispatch.request()` runs in this test process, using the `home`
+    fixture's own `LIONAGI_HOME` — exactly as the real MCP server does, since
+    it is a separate, unsandboxed process from the worker and never inherits
+    the worker's sandbox. That process separation, not a shared filesystem
+    grant, is what lets the message through.
+    """
+    denied_home = tmp_path / "denied-home"
+    denied_home.mkdir()
+    denied_home.chmod(0o555)
+    try:
+        probe = denied_home / "probe"
+        try:
+            probe.mkdir()
+        except OSError:
+            pass
+        else:
+            probe.rmdir()
+            pytest.skip(
+                "this process can write under a mode-555 directory (likely running as "
+                "root), so denying direct access cannot be demonstrated here"
+            )
+
+        denied = subprocess.run(
+            [*config.li_command(), "team", "create", "T", "--members", "a,b", "--machine"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, "LIONAGI_HOME": str(denied_home)},
+        )
+    finally:
+        denied_home.chmod(0o755)
+
+    envelope = json.loads(denied.stdout)
+    assert envelope["ok"] is False
+    assert envelope["error"]["kind"] == "internal"
+
+    created = run_op("team.create", {"name": "Squad", "members": "alice,bob"})
+    assert created["ok"] is True
+    team_id = created["result"]["data"]["id"]
+
+    sent = run_op("team.send", {"content": "hi", "team": team_id, "to": "all", "sender": "alice"})
+    assert sent["ok"] is True
+    assert sent["result"]["data"]["team_id"] == team_id
+
+    received = run_op("team.receive", {"team": team_id, "member": "bob"})
+    assert received["ok"] is True
+    assert [m["content"] for m in received["result"]["data"]["messages"]] == ["hi"]
 
 
 # ── the rows a seeded store actually holds ───────────────────────────────────
@@ -228,7 +363,7 @@ def test_the_listing_that_prunes_trust_never_runs_from_this_surface(home):
 
 @pytest.mark.parametrize(
     ("command", "sub"),
-    [("state", "prune"), ("team", "send"), ("invoke", "start")],
+    [("state", "prune"), ("state", "checkpoint"), ("invoke", "start")],
 )
 def test_a_subcommand_that_writes_says_so_instead_of_running(home, command, sub):
     done = li(command, sub, "--machine")

--- a/tests/mcp/test_privilege_fence.py
+++ b/tests/mcp/test_privilege_fence.py
@@ -78,6 +78,15 @@ REVIEWED_PATHS = frozenset(
         "state stats",
         "stats runs",
         "team list",
+        # Team coordination read/write. Reviewed together: all four act only on
+        # the team store under the server's own home, take a closed argument
+        # set matching the CLI flags, and exist so filesystem-sandboxed workers
+        # can coordinate through the unsandboxed server instead of being
+        # refused at open() on the team file.
+        "team create",
+        "team show",
+        "team send",
+        "team receive",
     }
 )
 


### PR DESCRIPTION
## Summary

- add versioned machine results for team create, show, send, and receive
- register those four operations on the MCP catalog and document their schemas
- add the reviewed command paths to the privilege fence
- preserve the current orchestration flow and stall-detection implementation unchanged

The available `team.*` catalog surface moves from 1 verb to 5 verbs.

## Verification

- 385 focused team and MCP tests passed
- 140 focused orchestration, flow-phase, and heartbeat tests passed
- end-to-end MCP create/send/show/receive/list round trip passed
- Ruff lint and format checks passed
- Pyright reported 0 errors
- scoped MCP verb coverage: 97.14%