### PR TITLE
docs(studio): correct the fitZoomFor minZoom comment, which named the wrong wiring

### DIFF
--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -57,10 +57,13 @@ export const MIN_INTERACTIVE_ZOOM = 0.2;
 // width and height under a SINGLE padding term, then clamp to [minZoom,
 // maxZoom], take the smaller axis). Exported so layout fixtures can assert
 // "this graph's fit zoom would clear the floor" without mounting ReactFlow.
-// minZoom defaults to FIT_ZOOM_FLOOR because that is the clamp WorkerCanvas
-// actually wires into <ReactFlow minZoom>/fitViewOptions below — callers that
-// need the pre-clamp raw arithmetic (e.g. to demonstrate why the clamp is
-// needed) can pass 0 explicitly.
+// minZoom defaults to FIT_ZOOM_FLOOR because that is the clamp on FITTING:
+// it is what the fitView call and fitViewOptions below pass. The two floors go
+// to different places and are not interchangeable — <ReactFlow minZoom> below
+// gets MIN_INTERACTIVE_ZOOM instead, so a viewer can deliberately zoom well
+// past the fit floor even though no automatic fit ever will. Callers that need
+// the pre-clamp raw arithmetic (e.g. to demonstrate why the clamp is needed)
+// can pass 0 explicitly.
 export function fitZoomFor(
   graphWidth: number,
   graphHeight: number,


### PR DESCRIPTION
The doc comment on `fitZoomFor` said its `minZoom` default is `FIT_ZOOM_FLOOR`
"because that is the clamp WorkerCanvas actually wires into `<ReactFlow minZoom>`
/fitViewOptions below". Half of that is wrong, and it is the half a reader
reasons from.

The wiring, as it stands in the file:

| Site | Floor passed |
|---|---|
| `fitView({...})` (imperative re-fit) | `FIT_ZOOM_FLOOR` (0.65) |
| `fitViewOptions={{...}}` (governs the init `fitView` prop) | `FIT_ZOOM_FLOOR` (0.65) |
| `<ReactFlow minZoom>` | `MIN_INTERACTIVE_ZOOM` (0.2) |

So `FIT_ZOOM_FLOOR` is the clamp on *fitting* and reaches both automatic fit
paths, but it is not what bounds interactive zoom. The two constants exist
precisely because they answer different questions, which the constants' own
comments a few lines above say clearly. The `fitZoomFor` comment collapsed them.

The consequence is not cosmetic. Anyone reasoning from that comment concludes a
viewer cannot get below 0.65, when in fact wheel, pinch, and the Controls widget
all reach 0.2 deliberately. Any rule written against "the zoom floor" then
targets a bound the viewport does not actually have.

Comment only. No behaviour change, and the constants are untouched.