### PR TITLE
docs(contracts): state the real rule for refreshing a public-surface baseline

### DIFF
--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -6,9 +6,37 @@ Each test loads the frozen baseline captured before any consolidation edit
 (``tests/contracts/data/*.json``, generated once by running the functions in
 ``_capture.py`` against the pre-consolidation worktree) and compares it,
 field for field, against a fresh capture of the live code. A delta here means
-an observable public surface changed; the manifest requires behavior
-preservation, so these baselines must never be refreshed to match a change —
-only to correct a capture bug.
+an observable public surface changed.
+
+A delta is therefore never routine, but it is not always wrong. Two cases:
+
+*Unintended* delta — a consolidation edit changed observable behavior it was
+supposed to preserve. Fix the code, not the baseline. This is the case the
+gate exists for and the common one.
+
+*Intended* delta — a change deliberately adds to or alters the public surface,
+and the baseline is now the stale description. Record it. Refusing to record
+an intended change does not preserve anything; it only leaves the gate red
+until someone refreshes the baseline anyway, with less care than this note
+asks for.
+
+Recording an intended delta requires all three, because a wholesale refresh is
+exactly how an unrelated regression gets laundered into the baseline:
+
+1. Regenerate to a scratch file and diff it against the committed baseline
+   *before* installing it. Read that diff as the change's own claim about its
+   surface, and confirm every line belongs to the intended change. This is the
+   step that catches a second, unnoticed delta riding along.
+2. Say in the commit message what moved and what did not — the counts that
+   changed, and the ones that stayed put.
+3. Where a count is also asserted as a literal in this file, update it by hand
+   and mutation-probe it: restore the old value, confirm the test goes red,
+   restore the new one. Those literals are a second, independent lock on facts
+   the JSON also carries; keep them hand-typed rather than derived from the
+   baseline, which would collapse two checks into one.
+
+A capture bug — where the baseline never described the code correctly — is
+fixed the same way and is not a third case.
 
 Two fields carry inherent host-state volatility and are excluded from the
 byte-for-byte comparison: the "agent status" specialized-CLI case includes a


### PR DESCRIPTION
The public-surface gate's note says its baselines "must never be refreshed to match a change — only to correct a capture bug."

Practice in this repo has never matched that. The MCP baseline was refreshed for a deliberate behaviour change, and a sibling baseline had a new route recorded in it on purpose. Both were the right call.

The gap is not carelessness. The rule has no way to express "this delta was intended". It was written for a consolidation programme, where by definition every delta is a regression, and it reads as absolute once you are outside that scope. A rule that correct work routinely has to violate stops being read, which costs more than the rule was ever worth — and it leaves the next person meeting the same forbidden-but-correct choice with nothing to go on.

So the note now says what to actually do:

- **Unintended delta** — a change altered behaviour it was meant to preserve. Fix the code. This is what the gate is for and the common case.
- **Intended delta** — the surface genuinely changed and the baseline is now the stale description. Record it.

And it states what recording costs, because a wholesale regenerate is precisely how an unrelated regression gets laundered into a baseline:

1. Regenerate to a scratch file and diff against the committed baseline **before** installing, reading that diff as the change's own claim about its surface.
2. Say in the commit which counts moved and which held.
3. Where a count is also a literal in the test file, update it by hand and mutation-probe it — restore the old value, confirm red, restore the new one.

Point 3 is also why those literals should stay hand-typed rather than derived from the baseline: they are a second independent lock on facts the JSON also carries, and deriving them would collapse two checks into one.

Docstring only. No test behaviour changes.