### PR TITLE
fix(flow): announce a gate-skipped node as skipped, not failed

### DIFF
--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -17,6 +17,7 @@ const STATUS_WORD_KEY: Record<Exclude<NodeExecStatus, "pending">, string> = {
   paused: "graphNodeStatusPaused",
   completed: "graphNodeStatusDone",
   failed: "graphNodeStatusFailed",
+  skipped: "graphNodeStatusSkipped",
   escalated: "graphNodeStatusEscalated",
 };
 
@@ -55,6 +56,7 @@ export type NodeExecStatus =
   | "paused"
   | "completed"
   | "failed"
+  | "skipped"
   | "escalated";
 
 export interface StepNodeData {
@@ -79,8 +81,11 @@ export interface StepNodeData {
 // border, brightest rail), completed/failed/warn are moderate and mutually
 // distinguishable by color alone (2px, distinct rail hue), pending/queued
 // recede (1px, no rail) so they never compete with completed work for
-// attention. Exported so StepNode.test.ts can assert the precedence
-// contract without mounting React Flow.
+// attention. skipped recedes with them by design: the node never ran, so it
+// is neither an error nor an achievement, and giving it a rail would spend
+// the reader's attention on the one part of the graph that did nothing.
+// Exported so StepNode.test.ts can assert the precedence contract without
+// mounting React Flow.
 export interface NodeVisualStyle {
   borderWidth: number;
   borderColor: string;

--- a/apps/studio/frontend/src/components/history/OperationGraphSection.tsx
+++ b/apps/studio/frontend/src/components/history/OperationGraphSection.tsx
@@ -9,6 +9,7 @@ const STATUS_BORDER: Record<OperationStatus, string> = {
   paused: "border-l-status-warning",
   succeeded: "border-l-status-success",
   failed: "border-l-status-error",
+  skipped: "border-l-content-muted",
   escalated: "border-l-status-warning",
 };
 
@@ -19,6 +20,7 @@ const STATUS_DOT: Record<OperationStatus, string> = {
   paused: "bg-status-warning",
   succeeded: "bg-status-success",
   failed: "bg-status-error",
+  skipped: "bg-content-muted",
   escalated: "bg-status-warning",
 };
 

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -1060,6 +1060,9 @@ const KIND_BADGE: Record<string, { label: string; tone: string }> = {
   NodeStarted: { label: "started", tone: "bg-status-running-bg text-status-running" },
   NodeCompleted: { label: "done", tone: "bg-status-success-bg text-status-success" },
   NodeFailed: { label: "failed", tone: "bg-status-error-bg text-status-error" },
+  // Muted, not an error tone: an edge condition passed this node over, which
+  // is the gate working rather than the step breaking.
+  NodeSkipped: { label: "skipped", tone: "bg-surface-overlay text-content-muted" },
   NodeAwaitingApproval: { label: "approval", tone: "bg-status-warning-bg text-status-warning" },
   NodeEscalated: { label: "escalated", tone: "bg-status-warning-bg text-status-warning" },
   GateDenied: { label: "gate-denied", tone: "bg-status-error-bg text-status-error" },
@@ -1090,6 +1093,7 @@ const LANE_TONE: Record<LaneState, string> = {
   paused: "bg-status-warning-bg text-status-warning",
   succeeded: "bg-status-success-bg text-status-success",
   failed: "bg-status-error-bg text-status-error",
+  skipped: "bg-surface-overlay text-content-muted",
   escalated: "bg-status-warning-bg text-status-warning",
 };
 

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -201,8 +201,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 1033 leaves", () => {
-    expect(EN_LEAVES.size).toBe(1033);
+  it("en.json has 1034 leaves", () => {
+    expect(EN_LEAVES.size).toBe(1034);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/lib/execGraphProgress.test.ts
+++ b/apps/studio/frontend/src/lib/execGraphProgress.test.ts
@@ -10,7 +10,7 @@ import {
 import { transitiveReduce } from "./operationGraph";
 import type { NodeExecStatus } from "@/components/canvas/StepNode";
 
-const ALL_EIGHT_STATES: NodeExecStatus[] = [
+const ALL_NINE_STATES: NodeExecStatus[] = [
   "pending",
   "queued",
   "running",
@@ -18,20 +18,21 @@ const ALL_EIGHT_STATES: NodeExecStatus[] = [
   "paused",
   "completed",
   "failed",
+  "skipped",
   "escalated",
 ];
 
 // ── deriveProgressCounts ────────────────────────────────────────────────────
 
 describe("deriveProgressCounts — summary counts from the canonical status source", () => {
-  it("buckets a mixed graph carrying every one of the 8 states", () => {
-    const nodeIds = ALL_EIGHT_STATES.map((_, i) => `n${i}`);
+  it("buckets a mixed graph carrying every one of the 9 states", () => {
+    const nodeIds = ALL_NINE_STATES.map((_, i) => `n${i}`);
     const statuses: Record<string, NodeExecStatus> = {};
-    ALL_EIGHT_STATES.forEach((s, i) => (statuses[`n${i}`] = s));
+    ALL_NINE_STATES.forEach((s, i) => (statuses[`n${i}`] = s));
 
     const counts = deriveProgressCounts(nodeIds, statuses);
 
-    expect(counts.total).toBe(8);
+    expect(counts.total).toBe(9);
     expect(counts.pending).toBe(1);
     expect(counts.queued).toBe(1);
     expect(counts.running).toBe(1);
@@ -39,14 +40,15 @@ describe("deriveProgressCounts — summary counts from the canonical status sour
     expect(counts.paused).toBe(1);
     expect(counts.completed).toBe(1);
     expect(counts.failed).toBe(1);
+    expect(counts.skipped).toBe(1);
     expect(counts.escalated).toBe(1);
     expect(counts.hasFailure).toBe(true);
   });
 
   it("sums every bucket back to total on a mixed graph", () => {
-    const nodeIds = ALL_EIGHT_STATES.map((_, i) => `n${i}`);
+    const nodeIds = ALL_NINE_STATES.map((_, i) => `n${i}`);
     const statuses: Record<string, NodeExecStatus> = {};
-    ALL_EIGHT_STATES.forEach((s, i) => (statuses[`n${i}`] = s));
+    ALL_NINE_STATES.forEach((s, i) => (statuses[`n${i}`] = s));
     const counts = deriveProgressCounts(nodeIds, statuses);
     const sum =
       counts.pending +
@@ -55,6 +57,7 @@ describe("deriveProgressCounts — summary counts from the canonical status sour
       counts.awaitingApproval +
       counts.paused +
       counts.completed +
+      counts.skipped +
       counts.escalated +
       counts.failed;
     expect(sum).toBe(counts.total);
@@ -70,6 +73,7 @@ describe("deriveProgressCounts — summary counts from the canonical status sour
       awaitingApproval: 0,
       paused: 0,
       completed: 0,
+      skipped: 0,
       escalated: 0,
       failed: 0,
       hasFailure: false,

--- a/apps/studio/frontend/src/lib/execGraphProgress.ts
+++ b/apps/studio/frontend/src/lib/execGraphProgress.ts
@@ -25,6 +25,7 @@ export interface ProgressCounts {
   awaitingApproval: number;
   paused: number;
   completed: number;
+  skipped: number;
   escalated: number;
   failed: number;
   hasFailure: boolean;
@@ -39,6 +40,7 @@ function emptyCounts(total = 0): ProgressCounts {
     awaitingApproval: 0,
     paused: 0,
     completed: 0,
+    skipped: 0,
     escalated: 0,
     failed: 0,
     hasFailure: false,
@@ -79,6 +81,12 @@ export function deriveProgressCounts(
       case "failed":
         counts.failed++;
         break;
+      // Counted in its own bucket, never folded into completed or failed: a
+      // status with no case here is counted in nothing, and the buckets stop
+      // summing to total.
+      case "skipped":
+        counts.skipped++;
+        break;
       case "escalated":
         counts.escalated++;
         break;
@@ -115,7 +123,7 @@ export function formatElapsed(seconds: number | null): string {
 
 // ── Descendant-terminal suppression + terminal-run collapse ────────────────
 
-const TERMINAL_STATUSES = new Set<NodeExecStatus>(["completed", "failed", "escalated"]);
+const TERMINAL_STATUSES = new Set<NodeExecStatus>(["completed", "failed", "skipped", "escalated"]);
 const NON_TERMINAL_ACTIVE_STATUSES = new Set<NodeExecStatus>([
   "queued",
   "running",

--- a/apps/studio/frontend/src/lib/operationGraph.ts
+++ b/apps/studio/frontend/src/lib/operationGraph.ts
@@ -9,6 +9,7 @@ export type OperationStatus =
   | "paused"
   | "succeeded"
   | "failed"
+  | "skipped"
   | "escalated";
 
 export interface OperationNode {
@@ -35,7 +36,7 @@ export interface OperationGraphState {
 
 // ── Status projection ─────────────────────────────────────────────────────────
 
-const TERMINAL = new Set<OperationStatus>(["succeeded", "failed", "escalated"]);
+const TERMINAL = new Set<OperationStatus>(["succeeded", "failed", "skipped", "escalated"]);
 
 const KIND_TO_STATE: Record<string, OperationStatus | undefined> = {
   NodeQueued: "queued",
@@ -44,6 +45,14 @@ const KIND_TO_STATE: Record<string, OperationStatus | undefined> = {
   NodePaused: "paused",
   NodeCompleted: "succeeded",
   NodeFailed: "failed",
+  // A node an edge condition passed over. Distinct from NodeFailed on
+  // purpose: it never ran, so presenting it as an error misreads a working
+  // gate as a broken step. Any kind missing from this map falls through the
+  // `if (!newState) continue` below and leaves the node at its initial
+  // "queued", so a backend signal added without a row here reads as a node
+  // that never finished -- which is why this mirrors _NODE_KIND_TO_STATE in
+  // lionagi/studio/operator/run_progress.py entry for entry.
+  NodeSkipped: "skipped",
   NodeEscalated: "escalated",
 };
 

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "متوقف مؤقتًا",
       "graphNodeStatusDone": "تم",
       "graphNodeStatusFailed": "فشل",
+      "graphNodeStatusSkipped": "تم التخطي",
       "graphNodeStatusEscalated": "تم التصعيد",
       "progressTotal": "الإجمالي",
       "progressCompleted": "مكتمل",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "স্থগিত",
       "graphNodeStatusDone": "সম্পন্ন",
       "graphNodeStatusFailed": "ব্যর্থ",
+      "graphNodeStatusSkipped": "এড়ানো",
       "graphNodeStatusEscalated": "এস্কেলেটেড",
       "progressTotal": "মোট",
       "progressCompleted": "সম্পন্ন",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "pausiert",
       "graphNodeStatusDone": "fertig",
       "graphNodeStatusFailed": "fehlgeschlagen",
+      "graphNodeStatusSkipped": "übersprungen",
       "graphNodeStatusEscalated": "eskaliert",
       "progressTotal": "Gesamt",
       "progressCompleted": "Abgeschlossen",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "paused",
       "graphNodeStatusDone": "done",
       "graphNodeStatusFailed": "failed",
+      "graphNodeStatusSkipped": "skipped",
       "graphNodeStatusEscalated": "escalated",
       "progressTotal": "Total",
       "progressCompleted": "Completed",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "pausado",
       "graphNodeStatusDone": "listo",
       "graphNodeStatusFailed": "fallido",
+      "graphNodeStatusSkipped": "omitido",
       "graphNodeStatusEscalated": "escalado",
       "progressTotal": "Total",
       "progressCompleted": "Completado",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "en pause",
       "graphNodeStatusDone": "terminé",
       "graphNodeStatusFailed": "échoué",
+      "graphNodeStatusSkipped": "ignoré",
       "graphNodeStatusEscalated": "escaladé",
       "progressTotal": "Total",
       "progressCompleted": "Terminé",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "रुका हुआ",
       "graphNodeStatusDone": "पूर्ण",
       "graphNodeStatusFailed": "विफल",
+      "graphNodeStatusSkipped": "छोड़ा गया",
       "graphNodeStatusEscalated": "एस्केलेटेड",
       "progressTotal": "कुल",
       "progressCompleted": "पूर्ण",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "dijeda",
       "graphNodeStatusDone": "selesai",
       "graphNodeStatusFailed": "gagal",
+      "graphNodeStatusSkipped": "dilewati",
       "graphNodeStatusEscalated": "dieskalasi",
       "progressTotal": "Total",
       "progressCompleted": "Selesai",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "一時停止",
       "graphNodeStatusDone": "完了",
       "graphNodeStatusFailed": "失敗",
+      "graphNodeStatusSkipped": "スキップ",
       "graphNodeStatusEscalated": "エスカレーション",
       "progressTotal": "合計",
       "progressCompleted": "完了",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "일시중지",
       "graphNodeStatusDone": "완료",
       "graphNodeStatusFailed": "실패",
+      "graphNodeStatusSkipped": "건너뜀",
       "graphNodeStatusEscalated": "에스컬레이션",
       "progressTotal": "전체",
       "progressCompleted": "완료",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "pausado",
       "graphNodeStatusDone": "concluído",
       "graphNodeStatusFailed": "falhou",
+      "graphNodeStatusSkipped": "ignorado",
       "graphNodeStatusEscalated": "escalado",
       "progressTotal": "Total",
       "progressCompleted": "Concluído",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "приостановлено",
       "graphNodeStatusDone": "готово",
       "graphNodeStatusFailed": "ошибка",
+      "graphNodeStatusSkipped": "пропущено",
       "graphNodeStatusEscalated": "эскалировано",
       "progressTotal": "Всего",
       "progressCompleted": "Завершено",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "duraklatıldı",
       "graphNodeStatusDone": "tamamlandı",
       "graphNodeStatusFailed": "başarısız",
+      "graphNodeStatusSkipped": "atlandı",
       "graphNodeStatusEscalated": "yükseltildi",
       "progressTotal": "Toplam",
       "progressCompleted": "Tamamlandı",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "موقوف",
       "graphNodeStatusDone": "مکمل",
       "graphNodeStatusFailed": "ناکام",
+      "graphNodeStatusSkipped": "چھوڑ دیا گیا",
       "graphNodeStatusEscalated": "بڑھایا گیا",
       "progressTotal": "کل",
       "progressCompleted": "مکمل",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "tạm dừng",
       "graphNodeStatusDone": "xong",
       "graphNodeStatusFailed": "thất bại",
+      "graphNodeStatusSkipped": "đã bỏ qua",
       "graphNodeStatusEscalated": "đã leo thang",
       "progressTotal": "Tổng",
       "progressCompleted": "Hoàn tất",

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -480,6 +480,7 @@
       "graphNodeStatusPaused": "已暂停",
       "graphNodeStatusDone": "完成",
       "graphNodeStatusFailed": "失败",
+      "graphNodeStatusSkipped": "已跳过",
       "graphNodeStatusEscalated": "已升级",
       "progressTotal": "总计",
       "progressCompleted": "已完成",

--- a/apps/vscode/src/api/types.ts
+++ b/apps/vscode/src/api/types.ts
@@ -97,6 +97,7 @@ export type NodeLifecycleState =
   | "paused"
   | "succeeded"
   | "failed"
+  | "skipped"
   | "escalated";
 
 /**

--- a/apps/vscode/src/runs/runTreeModel.ts
+++ b/apps/vscode/src/runs/runTreeModel.ts
@@ -46,12 +46,13 @@ export function createRunTreeState(): RunTreeState {
 const TERMINAL: ReadonlySet<NodeLifecycleState> = new Set([
   "succeeded",
   "failed",
+  "skipped",
   "escalated",
 ]);
 
 /**
  * Apply a single signal row to the state in-place (ascending seq order).
- * Mirrors lane_for() in lionagi/session/signal.py lines 183-219.
+ * Mirrors lane_for() and _signal_to_state() in lionagi/session/signal.py.
  */
 export function applySignalRow(state: RunTreeState, row: SignalRow): void {
   const kind = row.kind;
@@ -106,6 +107,12 @@ export function applySignalRow(state: RunTreeState, row: SignalRow): void {
       break;
     case "NodeFailed":
       newState = "failed";
+      break;
+    case "NodeSkipped":
+      // Terminal, but not an error: an edge condition passed the node over so
+      // it never ran. Without this case it falls to `default` and is dropped,
+      // leaving the node showing whatever it was before it was skipped.
+      newState = "skipped";
       break;
     case "NodeEscalated":
       // A soft ("fyi") help signal (route="notify") is informational only —

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -15,6 +15,7 @@ from lionagi.session.signal import (
     NodeCompleted,
     NodeFailed,
     NodeQueued,
+    NodeSkipped,
     NodeSpawned,
     NodeStarted,
 )
@@ -103,6 +104,14 @@ async def flow_progress_signals(
             )
         elif status == "failed":
             sig = NodeFailed(
+                op_id=op_id,
+                name=sig_name,
+                elapsed=elapsed,
+                parent_id=parent_id,
+                depends_on=depends_on,
+            )
+        elif status == "skipped":
+            sig = NodeSkipped(
                 op_id=op_id,
                 name=sig_name,
                 elapsed=elapsed,

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -523,7 +523,7 @@ class DependencyAwareExecutor:
 
                 branch = self.operation_branches.get(operation.id, self.session.default_branch)
                 branch_name, name_is_fallback = self._branch_display_name(operation, branch)
-                self._emit_terminal_once(operation, branch_name, "failed", 0.0, name_is_fallback)
+                self._emit_terminal_once(operation, branch_name, "skipped", 0.0, name_is_fallback)
 
                 self.completion_events[operation.id].set()
                 return

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -22,6 +22,7 @@ __all__ = (
     "NodeStarted",
     "NodeCompleted",
     "NodeFailed",
+    "NodeSkipped",
     "NodeQueued",
     "NodeAwaitingApproval",
     "NodeEscalated",
@@ -113,6 +114,23 @@ class NodeFailed(Signal):
     depends_on: list[str] = []
 
 
+class NodeSkipped(Signal):
+    """DAG node lifecycle: never ran, because an edge condition said not to.
+
+    A terminal outcome like NodeCompleted and NodeFailed, but not an error:
+    the node was deliberately passed over, so a reader must be able to tell it
+    apart from one that ran and raised. Why it was skipped is not carried here
+    -- the gate's reason code, id and name are already on the operation's
+    metadata and in its entry in the flow results.
+    """
+
+    op_id: str = ""
+    name: str = ""
+    elapsed: float = 0.0
+    parent_id: str | None = None
+    depends_on: list[str] = []
+
+
 class GateDenied(Signal):
     """Governance gate denied a proposed action."""
 
@@ -173,12 +191,22 @@ class NodePaused(Signal):
 
 # -- Lifecycle projection (ADR-0033) ------------------------------------------
 
-#: The seven canonical per-node lifecycle states.
+#: The eight canonical per-node lifecycle states.
 NodeLifecycleState = Literal[
-    "queued", "running", "awaiting_approval", "paused", "succeeded", "failed", "escalated"
+    "queued",
+    "running",
+    "awaiting_approval",
+    "paused",
+    "succeeded",
+    "failed",
+    "skipped",
+    "escalated",
 ]
 
-_TERMINAL: frozenset[str] = frozenset({"succeeded", "failed", "escalated"})
+#: Terminal lanes are sticky. "skipped" belongs here because a node passed over
+#: by an edge condition is finished, not waiting -- but it is deliberately kept
+#: distinct from "failed", which means the node ran and raised.
+_TERMINAL: frozenset[str] = frozenset({"succeeded", "failed", "skipped", "escalated"})
 
 
 def _signal_to_state(sig: Any) -> NodeLifecycleState | None:
@@ -195,6 +223,8 @@ def _signal_to_state(sig: Any) -> NodeLifecycleState | None:
         return "succeeded"
     if isinstance(sig, NodeFailed | RunFailed):
         return "failed"
+    if isinstance(sig, NodeSkipped):
+        return "skipped"
     if isinstance(sig, NodeEscalated):
         req = sig.escalation_request
         # Soft ("fyi") urgency is informational only, not terminal; only

--- a/lionagi/studio/operator/run_progress.py
+++ b/lionagi/studio/operator/run_progress.py
@@ -300,9 +300,10 @@ _NODE_KIND_TO_STATE: dict[str, str] = {
     "NodePaused": "paused",
     "NodeCompleted": "succeeded",
     "NodeFailed": "failed",
+    "NodeSkipped": "skipped",
     "NodeEscalated": "escalated",
 }
-_NODE_TERMINAL_STATES = frozenset({"succeeded", "failed", "escalated"})
+_NODE_TERMINAL_STATES = frozenset({"succeeded", "failed", "skipped", "escalated"})
 _NODE_STATE_BUCKET = {
     "queued": "pending",
     "running": "running",
@@ -310,6 +311,12 @@ _NODE_STATE_BUCKET = {
     "paused": "running",
     "succeeded": "completed",
     "failed": "failed",
+    # Settled, so it folds into "completed" rather than "pending": a skipped
+    # node will never run, and parking it in pending would leave a finished
+    # flow reporting outstanding work forever. It is not a failure either --
+    # the edge condition did what it was written to do. The separate
+    # skippedCount below keeps it from silently inflating the success figure.
+    "skipped": "completed",
     # The scalar API has four buckets that must sum to total. Keep the
     # per-node "escalated" outcome distinct while its aggregate waits for
     # follow-up in pending rather than inflating failure.
@@ -370,7 +377,7 @@ async def _dag_progress(session_id: str, graph: dict[str, Any]) -> dict[str, Any
     ]
     lanes = await _node_lanes_by_name(session_id)
 
-    completed = running = failed = pending = unknown = escalated = 0
+    completed = running = failed = pending = unknown = escalated = skipped = 0
     node_out: list[dict[str, Any]] = []
     for node in nodes:
         node_id = node["id"]
@@ -395,6 +402,8 @@ async def _dag_progress(session_id: str, graph: dict[str, Any]) -> dict[str, Any
             # and those ask for opposite responses.
             if lane == "escalated":
                 escalated += 1
+            elif lane == "skipped":
+                skipped += 1
         node_out.append(
             {
                 "id": node_id,
@@ -418,6 +427,10 @@ async def _dag_progress(session_id: str, graph: dict[str, Any]) -> dict[str, Any
         # non-zero is the field callers never wire up, because every run they
         # develop against lacks it.
         "escalatedCount": escalated,
+        # Same convention, and load-bearing for the same reason: without it a
+        # caller reading only the scalars cannot tell work that ran and
+        # succeeded from work an edge condition passed over.
+        "skippedCount": skipped,
         "nodes": node_out,
     }
 

--- a/tests/operations/test_flow_lifecycle_terminal.py
+++ b/tests/operations/test_flow_lifecycle_terminal.py
@@ -549,3 +549,99 @@ async def test_emit_terminal_once_is_idempotent_across_call_sites():
 
     op_id = str(op.id)
     assert log.statuses_for(op_id) == ["completed"]
+
+
+# ---------------------------------------------------------------------------
+# skipped is its own terminal outcome, not a failure
+# ---------------------------------------------------------------------------
+
+
+def _skip_graph():
+    """A two-node graph whose second node is gated off by a false edge condition."""
+    from lionagi.operations.node import Operation
+    from lionagi.protocols.graph.edge import Edge, EdgeCondition
+
+    class AlwaysFalseCondition(EdgeCondition):
+        async def apply(self, context: dict) -> bool:
+            return False
+
+    ran = Operation(operation="first", parameters={})
+    gated = Operation(operation="never", parameters={})
+    graph = Graph()
+    graph.add_node(ran)
+    graph.add_node(gated)
+    graph.add_edge(Edge(head=ran.id, tail=gated.id, condition=AlwaysFalseCondition()))
+    return graph, ran, gated
+
+
+@pytest.mark.asyncio
+async def test_gate_skipped_node_emits_skipped_not_failed_on_progress():
+    """The raw executor callback must announce a gated-off node as "skipped".
+
+    The rollup already told these apart (skipped_operations vs
+    failed_operations), but the on_progress stream did not: the skip path had
+    no "skipped" status to pass, so it passed "failed" and every consumer
+    reading the callback saw a deliberate skip as an error.
+    """
+    from lionagi.operations.flow import flow
+
+    async def first(**kw):
+        return "first ok"
+
+    async def never(**kw):  # pragma: no cover - the point is that it never runs
+        raise AssertionError("gated node must not execute")
+
+    session = _session_with_ops(first=first, never=never)
+    graph, _ran, gated = _skip_graph()
+    log = _ProgressLog()
+
+    result = await flow(session, graph, parallel=False, verbose=False, on_progress=log)
+
+    gated_id = str(gated.id)
+    statuses = log.statuses_for(gated_id)
+    assert "skipped" in statuses, f"gated node was never announced as skipped: {statuses}"
+    assert "failed" not in statuses, (
+        f"a node an edge condition passed over must not be announced as failed: {statuses}"
+    )
+    # The rollup and the callback must agree about the same node.
+    assert gated.id in result["skipped_operations"]
+    assert gated.id not in result["failed_operations"]
+
+
+@pytest.mark.asyncio
+async def test_gate_skipped_node_projects_to_the_skipped_lane_on_the_signal_bus():
+    """End-to-end over the surface the execution graph actually renders.
+
+    ``flow_progress_signals`` is the Studio-facing bridge, and ``lane_for`` is
+    the projection the canvas reads. A skipped node has to arrive as
+    NodeSkipped and project to the "skipped" lane -- asserting only on the
+    flow result would pass just as happily while the canvas painted the node
+    red, which is exactly how this defect survived.
+    """
+    from lionagi.engines.flow_signals import flow_progress_signals
+    from lionagi.operations.flow import flow
+    from lionagi.session.signal import NodeFailed, NodeSkipped, lane_for
+
+    async def first(**kw):
+        return "first ok"
+
+    async def never(**kw):  # pragma: no cover - the point is that it never runs
+        raise AssertionError("gated node must not execute")
+
+    session = _session_with_ops(first=first, never=never)
+    graph, _ran, gated = _skip_graph()
+
+    seen: list[object] = []
+    session.observe(NodeSkipped, handler=lambda s, _: seen.append(s))
+    session.observe(NodeFailed, handler=lambda s, _: seen.append(s))
+
+    async with flow_progress_signals(session, graph) as on_progress:
+        await flow(session, graph, parallel=False, verbose=False, on_progress=on_progress)
+
+    gated_id = str(gated.id)
+    for_gated = [s for s in seen if getattr(s, "op_id", None) == gated_id]
+    assert for_gated, "no terminal signal reached the bus for the gated node"
+    assert all(isinstance(s, NodeSkipped) for s in for_gated), (
+        f"gated node reached the signal bus as {[type(s).__name__ for s in for_gated]}"
+    )
+    assert lane_for(for_gated) == "skipped"

--- a/tests/protocols/test_event_schema_drift.py
+++ b/tests/protocols/test_event_schema_drift.py
@@ -47,6 +47,7 @@ from lionagi.session.signal import (
     NodeLifecycleState,
     NodePaused,
     NodeQueued,
+    NodeSkipped,
     NodeSpawned,
     NodeStarted,
     RunEnd,
@@ -73,6 +74,7 @@ EXPECTED_SIGNAL_EXPORTS = (
     "NodeStarted",
     "NodeCompleted",
     "NodeFailed",
+    "NodeSkipped",
     "NodeQueued",
     "NodeAwaitingApproval",
     "NodeEscalated",
@@ -187,6 +189,19 @@ EXPECTED_SIGNAL_FIELDS: dict[str, tuple[str, ...]] = {
         "parent_id",
         "schema_version",
     ),
+    "NodeSkipped": (
+        "created_at",
+        "data",
+        "depends_on",
+        "elapsed",
+        "emitter_role",
+        "id",
+        "metadata",
+        "name",
+        "op_id",
+        "parent_id",
+        "schema_version",
+    ),
     "NodeQueued": (
         "created_at",
         "data",
@@ -262,6 +277,7 @@ _SIGNAL_CLASSES: dict[str, type[Signal]] = {
     "NodeStarted": NodeStarted,
     "NodeCompleted": NodeCompleted,
     "NodeFailed": NodeFailed,
+    "NodeSkipped": NodeSkipped,
     "NodeQueued": NodeQueued,
     "NodeAwaitingApproval": NodeAwaitingApproval,
     "NodeEscalated": NodeEscalated,
@@ -453,10 +469,11 @@ EXPECTED_NODE_LIFECYCLE_STATES = (
     "paused",
     "succeeded",
     "failed",
+    "skipped",
     "escalated",
 )
 
-EXPECTED_NODE_LIFECYCLE_TERMINAL = frozenset({"succeeded", "failed", "escalated"})
+EXPECTED_NODE_LIFECYCLE_TERMINAL = frozenset({"succeeded", "failed", "skipped", "escalated"})
 
 
 def test_node_lifecycle_state_vocabulary_golden():

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -20,6 +20,7 @@ from lionagi.session.signal import (
     NodeFailed,
     NodePaused,
     NodeQueued,
+    NodeSkipped,
     NodeStarted,
     RunEnd,
     RunFailed,
@@ -444,11 +445,20 @@ async def test_reactive_injected_child_receives_node_queued():
 
 
 @pytest.mark.asyncio
-async def test_skipped_node_projects_to_failed_lane():
-    """A node skipped by an always-false edge condition emits NodeFailed → lane 'failed'.
+async def test_skipped_node_projects_to_skipped_lane():
+    """A node skipped by an always-false edge condition emits NodeSkipped → lane 'skipped'.
 
-    This is a regression guard: before the fix, the skip path did not call
-    on_progress, so the node stayed in 'queued' forever.
+    The guard this test has always carried is that the skip path reaches a
+    TERMINAL lane at all: before it existed, the skip path did not call
+    on_progress, so the node stayed in 'queued' forever. It originally asserted
+    'failed' because that was the only terminal value the signal vocabulary
+    offered, which made a working gate render as a broken step. NodeSkipped
+    gives the terminal outcome its own name; the original guard is unchanged
+    and stronger, since 'skipped' rules out both 'queued' and 'failed'.
+
+    Note the collector below must observe NodeSkipped explicitly. A consumer
+    that does not know the kind projects the node straight back to 'queued' --
+    the very failure this test was written to catch.
     """
     from lionagi.engines import Engine
     from lionagi.operations.node import Operation
@@ -476,7 +486,7 @@ async def test_skipped_node_projects_to_failed_lane():
         op_id = getattr(sig, "op_id", None) or "run"
         collected.setdefault(op_id, []).append(sig)
 
-    for sig_type in (NodeQueued, NodeStarted, NodeCompleted, NodeFailed):
+    for sig_type in (NodeQueued, NodeStarted, NodeCompleted, NodeFailed, NodeSkipped):
         session.observe(sig_type, handler=_capture)
 
     root = Operation(operation="root_op", parameters={})
@@ -497,8 +507,11 @@ async def test_skipped_node_projects_to_failed_lane():
     assert skipped_op_id in collected, (
         "No signals collected for the skipped op — on_progress was not called in the skip path"
     )
-    assert lane_for(collected[skipped_op_id]) == "failed", (
-        f"Skipped node must project to 'failed', got {lane_for(collected[skipped_op_id])}"
+    assert lane_for(collected[skipped_op_id]) == "skipped", (
+        f"Skipped node must project to 'skipped', got {lane_for(collected[skipped_op_id])}"
+    )
+    assert not any(isinstance(s, NodeFailed) for s in collected[skipped_op_id]), (
+        "a node an edge condition passed over must not emit NodeFailed"
     )
 
 
@@ -580,3 +593,25 @@ def test_session_package_exports_new_symbols():
         "lane_for",
     ):
         assert hasattr(sess, name), f"lionagi.session missing {name}"
+
+
+def test_lane_for_skipped():
+    """A gated-off node is terminal but not an error."""
+    assert (
+        lane_for([NodeQueued(op_id="a", name="a"), NodeSkipped(op_id="a", name="a")]) == "skipped"
+    )
+
+
+def test_lane_for_skipped_is_sticky():
+    """Terminal lanes are sticky: a stray later signal must not un-skip a node."""
+    assert (
+        lane_for([NodeSkipped(op_id="a", name="a"), NodeCompleted(op_id="a", name="a")])
+        == "skipped"
+    )
+
+
+def test_lane_for_skipped_resets_on_a_genuine_retry():
+    """...but an explicit re-queue/re-start does reset it, same as every other terminal."""
+    assert (
+        lane_for([NodeSkipped(op_id="a", name="a"), NodeStarted(op_id="a", name="a")]) == "running"
+    )


### PR DESCRIPTION
## What

A node short-circuited by an edge condition reached the lifecycle signal stream as `NodeFailed`, so the execution graph painted a deliberate skip in the error colour. A working gate read as a broken step.

The flow rollup already told the two apart (`skipped_operations` vs `failed_operations`) and `FlowEvent` already carried a `"skipped"` status. Only the signal layer had no such value, so the skip path in `flow.py` passed `"failed"` because that was the only terminal word available — `flow_signals.py` knew `queued`/`started`/`completed`/`failed` and silently returned on anything else.

## Why it touches so many files

`NodeSkipped` and the `"skipped"` lane land in every consumer in one change, and that is the point rather than incidental scope. Each of these maps discards a kind it does not recognise:

| Consumer | What an unknown kind does there |
|---|---|
| `operationGraph.ts` | `if (!newState) continue` — node stays at its initial `"queued"` |
| `runTreeModel.ts` | falls to `default:` and returns — node keeps its previous state |
| `run_progress.py` | `.get(kind)` returns `None` — node counts as `unknown` |
| `execGraphProgress.ts` | no `switch` case — counted in nothing, buckets stop summing to `total` |

Shipping the producer alone would have moved the defect rather than fixed it: instead of a red node you would get one stuck at queued forever.

## Changes

- **Lane** — `NodeSkipped` projects to `"skipped"`; terminal and sticky, distinct from `failed`
- **Producer** — the edge-condition skip path emits `"skipped"`
- **Consumers** — signal bridge, operator run-progress projection, canvas status projection and progress counts, VS Code run tree
- **Presentation** — skipped recedes (muted, no status rail) alongside pending/queued. It is neither an error nor an achievement, and a rail would spend the reader's attention on the part of the graph that did nothing
- **`run_progress`** gains `skippedCount`, and buckets skipped as *settled* rather than pending, so a finished flow stops reporting outstanding work
- **Locales** — the status word is added to all 16, which the leaf-key parity contract requires

## Scope

Skipped only. Cancelled and abandoned nodes also surface as failed — `_emit_abandoned_terminal` says so in its own docstring — but whether those warrant distinct treatments is an open design question, and answering it here would prejudge it.

`SIGNAL_SCHEMA_VERSION` is unchanged. It pins payload compatibility for a given signal, and no existing payload changed shape; the golden that guards it describes a bump as a breaking change, which an additive class is not.

## Tests

The gap was structural: the existing test asserting skipped/failed orthogonality only ever read the flow result and never installed an `on_progress` callback, so it was blind to the stream the graph renders. New coverage sits on that surface, end to end through `flow_progress_signals` to `lane_for`.

Confirmed load-bearing by reverting the producer to `"failed"`: both new tests fail, and the older rollup test stays green — which is precisely why it never caught this.

Green: 117 backend tests across the affected modules, 1566 studio frontend, 62 VS Code extension, plus typecheck and lint on both frontends. Five `tests/contracts` HTTP tests fail locally for want of `fastapi`; a control run on unmodified `main` reproduces the same five identically.

Closes #2971

### Scope: this fixes one of two paths

An operation only reaches the emission changed here if the flow evaluates its edge conditions
during this run. An operation that arrives *already* carrying a terminal `EventStatus` takes a
different route: `_execute_operation` returns early (`lionagi/operations/flow.py:479-493`) without
emitting any terminal signal. `SKIPPED` is a member of `Event._TERMINAL_STATUSES`
(`lionagi/protocols/generic/event.py:225-233`), so a pre-skipped operation — a resumed run
replaying work that was skipped on an earlier attempt — never reaches the line this PR corrects.

Because every node is announced `queued` up front and unconditionally
(`lionagi/operations/flow.py:215-219`), such a node is announced and then never resolved, and the
graph shows it waiting indefinitely. That symptom is tracked in #2967 and is not addressed here.
