### PR TITLE
fix(flow): answer a node that is already terminal when the flow reaches it

### DIFF
--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -60,6 +60,18 @@ GATE_VERDICT_KEY = "gate_verdict"
 GATE_VERDICT_REJECT = "reject"
 SKIP_REASON_UPSTREAM_GATE_REJECT = "upstream_gate_reject"
 
+# Lifecycle status to announce for an operation that is already terminal when
+# the flow reaches it -- a resumed run replaying work an earlier attempt
+# finished. CANCELLED and ABORTED are deliberately absent: neither has a
+# lifecycle signal of its own, and announcing either under one of these words
+# would assert an outcome that did not happen. They stay unannounced until they
+# have a signal to be announced as.
+_PRETERMINAL_ANNOUNCE_STATUS = {
+    EventStatus.COMPLETED: "completed",
+    EventStatus.FAILED: "failed",
+    EventStatus.SKIPPED: "skipped",
+}
+
 # Tracks which Operation a reactive task is running (per-task contextvar).
 _CURRENT_OP: contextvars.ContextVar = contextvars.ContextVar("reactive_current_op", default=None)
 
@@ -489,6 +501,21 @@ class DependencyAwareExecutor:
                 )
             if operation.id not in self.results and operation.response is not None:
                 self.results[operation.id] = operation.response
+
+            # Every node is announced "queued" before execution begins, so an
+            # operation that is already terminal on arrival has to be answered
+            # here. Returning without a terminal leaves it announced and never
+            # resolved, which reads as work still pending rather than work
+            # already done -- the misreading a resumed run produces for every
+            # operation an earlier attempt finished.
+            announce_status = _PRETERMINAL_ANNOUNCE_STATUS.get(operation.execution.status)
+            if announce_status is not None:
+                branch = self.operation_branches.get(operation.id, self.session.default_branch)
+                branch_name, name_is_fallback = self._branch_display_name(operation, branch)
+                self._emit_terminal_once(
+                    operation, branch_name, announce_status, 0.0, name_is_fallback
+                )
+
             self.completion_events[operation.id].set()
             return
 

--- a/tests/operations/test_flow_lifecycle_terminal.py
+++ b/tests/operations/test_flow_lifecycle_terminal.py
@@ -23,6 +23,7 @@ from lionagi.ln.concurrency import CapacityLimiter
 from lionagi.operations.flow import DependencyAwareExecutor
 from lionagi.operations.node import Operation
 from lionagi.protocols.graph.graph import Graph
+from lionagi.protocols.types import EventStatus
 from lionagi.session.session import Session
 
 
@@ -645,3 +646,117 @@ async def test_gate_skipped_node_projects_to_the_skipped_lane_on_the_signal_bus(
         f"gated node reached the signal bus as {[type(s).__name__ for s in for_gated]}"
     )
     assert lane_for(for_gated) == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# an operation already terminal on arrival must still be answered
+# ---------------------------------------------------------------------------
+
+
+def _one_op_graph(status):
+    """A single-node graph whose only operation is already terminal on arrival.
+
+    This is the shape a resumed run replays: work an earlier attempt finished
+    arrives carrying its outcome, so the executor short-circuits it.
+    """
+    op = Operation(operation="work", parameters={})
+    op.execution.status = status
+    graph = Graph()
+    graph.add_node(op)
+    return graph, op
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (EventStatus.COMPLETED, "completed"),
+        (EventStatus.FAILED, "failed"),
+        (EventStatus.SKIPPED, "skipped"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_preterminal_op_is_announced_with_its_own_outcome(status, expected):
+    """An operation that is already terminal when the flow reaches it gets a
+    terminal announcement carrying the outcome it actually holds.
+
+    Every node is announced "queued" up front, so short-circuiting without an
+    announcement leaves the node announced and never answered — it reads as
+    still-pending work forever. That is a different defect from announcing the
+    wrong word, and it is not fixed by adding vocabulary, because the emitter
+    on this path was never reached at all.
+    """
+    from lionagi.operations.flow import flow
+
+    async def work(**kw):  # pragma: no cover - a terminal op must not re-execute
+        raise AssertionError("an already-terminal operation must not run again")
+
+    session = _session_with_ops(work=work)
+    graph, op = _one_op_graph(status)
+    log = _ProgressLog()
+
+    await flow(session, graph, parallel=False, verbose=False, on_progress=log)
+
+    statuses = log.statuses_for(str(op.id))
+    assert statuses == ["queued", expected], (
+        f"a pre-{expected} operation was announced {statuses}; it must be "
+        f'answered with "{expected}" rather than left sitting at "queued"'
+    )
+
+
+@pytest.mark.asyncio
+async def test_preterminal_cancelled_is_deliberately_left_unannounced():
+    """CANCELLED is terminal but has no lifecycle signal of its own.
+
+    Announcing it as "failed" would assert an outcome that did not happen, and
+    inventing a word here would pre-empt an open design question about whether
+    cancelled, skipped and aborted stay distinct. So it is deliberately silent,
+    and this test exists so that silence stays a decision: if a NodeCancelled
+    signal is ever added, this test fails and points at the choice.
+    """
+    from lionagi.operations.flow import flow
+
+    async def work(**kw):  # pragma: no cover - a terminal op must not re-execute
+        raise AssertionError("an already-terminal operation must not run again")
+
+    session = _session_with_ops(work=work)
+    graph, op = _one_op_graph(EventStatus.CANCELLED)
+    log = _ProgressLog()
+
+    await flow(session, graph, parallel=False, verbose=False, on_progress=log)
+
+    statuses = log.statuses_for(str(op.id))
+    assert statuses == ["queued"], (
+        f"cancelled must not borrow another outcome's word, got {statuses}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_preterminal_completed_reaches_the_signal_bus_and_leaves_the_queued_lane():
+    """End-to-end over the surface the execution graph renders.
+
+    Asserting only on the raw callback would pass while the canvas still showed
+    the node waiting, so this follows the same path a viewer sees: through
+    ``flow_progress_signals`` to ``lane_for``.
+    """
+    from lionagi.engines.flow_signals import flow_progress_signals
+    from lionagi.operations.flow import flow
+    from lionagi.session.signal import NodeCompleted, lane_for
+
+    async def work(**kw):  # pragma: no cover - a terminal op must not re-execute
+        raise AssertionError("an already-terminal operation must not run again")
+
+    session = _session_with_ops(work=work)
+    graph, op = _one_op_graph(EventStatus.COMPLETED)
+
+    seen: list[object] = []
+    session.observe(NodeCompleted, handler=lambda s, _: seen.append(s))
+
+    async with flow_progress_signals(session, graph) as on_progress:
+        await flow(session, graph, parallel=False, verbose=False, on_progress=on_progress)
+
+    op_id = str(op.id)
+    for_op = [s for s in seen if getattr(s, "op_id", None) == op_id]
+    assert for_op, "a pre-completed node reached no terminal signal on the bus"
+    assert lane_for(for_op) == "succeeded", (
+        f"pre-completed node projected to {lane_for(for_op)!r}, not the succeeded lane"
+    )


### PR DESCRIPTION
An operation that is already terminal when the flow reaches it was announced and
then never answered, so the execution graph showed it waiting indefinitely.

### Mechanism

`DependencyAwareExecutor` announces every node `queued` up front, before any
execution begins (`lionagi/operations/flow.py:215-219`). `_execute_operation`
then short-circuits any operation whose `execution.status` is already terminal
and returns without emitting a terminal signal (`:479-493` before this change).
`COMPLETED`, `FAILED`, `SKIPPED`, `CANCELLED` and `ABORTED` are all members of
`Event._TERMINAL_STATUSES` (`lionagi/protocols/generic/event.py:225-233`).

The result is an announcement with no answer. A viewer reads that as work still
pending, which is a worse failure than a wrong colour: a wrong outcome is still
an outcome, while a node stuck at `queued` looks like a stalled run.

This is the state a **resumed run** produces for every operation an earlier
attempt already finished.

### Why it is not fixed by adding signal classes

This is a distinct cause from a missing vocabulary. Here the emitter is never
reached at all, so no amount of new signal kinds changes the outcome. Both
causes are described in #2967.

### Incidence

Aggregated over local run history (3526 runs, restricted to the 152 that reached
a run-level terminal, so in-flight runs cannot be miscounted): 271 nodes were
announced `queued` with no terminal signal, against 40 `NodeFailed` signals for
the entire corpus. 214 of those are in runs that ended cleanly rather than by
failure, so they are genuine non-executions and not the debris of crashed runs.
Per-run density is bimodal: 69% of runs have none at all, while 13 runs have
half or more of the graph left unresolved.

### Scope

`CANCELLED` and `ABORTED` are deliberately left unannounced. Neither has a
lifecycle signal of its own, and announcing either under `failed` would assert
an outcome that did not happen — the same aliasing defect fixed for skipped
nodes in #2971. A test pins that silence so it stays a decision rather than
becoming an oversight.

No new vocabulary is introduced, so no consumer changes are required:
`completed`, `failed` and `skipped` are already handled by every surface that
reads the lifecycle stream (checked across the graph builder, the progress
rollup, the VS Code run tree, the progress counters and both history views).

### Testing

Three parametrized cases cover the pre-terminal statuses that have a signal, one
pins the deliberate silence for cancelled, and one runs end to end through
`flow_progress_signals` to `lane_for` — the surface the canvas actually reads,
rather than the flow result, which already reported these correctly and is
therefore blind to this defect.

Emptying the status map reddens exactly the four tests that assert an
announcement and leaves the cancelled test green, confirming each is load-bearing
for the behaviour it names.

Green: 19 tests in the lifecycle file, plus `tests/operations/`, `tests/session/`
and the event-schema drift golden. One unrelated failure,
`test_to_df_conversion`, needs `pandas`, which is not installed here; it fails
identically on the parent branch.
