### PR TITLE
fix(studio): count a running orchestration that formed no group

### DIFF
--- a/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.test.ts
@@ -375,6 +375,63 @@ describe("fleetReducer — counts strip", () => {
     expect(s.counts.agents).toBe(1);
   });
 
+  it("counts a running play that carries no invocation_id — it forms no group", () => {
+    // The regression this guards: plays, fanouts and flows never populate
+    // invocation_id, so they group under nothing and the strip read zero while
+    // the run was visibly listed as active underneath it.
+    const s = dispatchOk(
+      initialFleetState(),
+      [],
+      [makeRun({ run_id: "p1", status: "running", invocation_kind: "play" })],
+    );
+    expect(s.counts.orchestrations).toBe(1);
+  });
+
+  it.each(["play", "fanout", "flow"])("counts an ungrouped %s run", (kind) => {
+    const s = dispatchOk(
+      initialFleetState(),
+      [],
+      [makeRun({ run_id: "x1", status: "running", invocation_kind: kind })],
+    );
+    expect(s.counts.orchestrations).toBe(1);
+  });
+
+  it("does not double count a play that DID join an invocation group", () => {
+    const s = dispatchOk(
+      initialFleetState(),
+      [makeInvocation({ id: "i1", status: "running", skill: "a" })],
+      [
+        makeRun({
+          run_id: "p1",
+          status: "running",
+          invocation_kind: "play",
+          invocation_id: "i1",
+        }),
+      ],
+    );
+    // One orchestration, evidenced twice. The group wins; the run is not added.
+    expect(s.counts.orchestrations).toBe(1);
+  });
+
+  it("does not count a terminal play run", () => {
+    const s = dispatchOk(
+      initialFleetState(),
+      [],
+      [makeRun({ run_id: "p1", status: "completed", invocation_kind: "play" })],
+    );
+    expect(s.counts.orchestrations).toBe(0);
+  });
+
+  it("counts an agent-kind run as an agent, never as an orchestration", () => {
+    const s = dispatchOk(
+      initialFleetState(),
+      [],
+      [makeRun({ run_id: "a1", status: "running", invocation_kind: "agent" })],
+    );
+    expect(s.counts.orchestrations).toBe(0);
+    expect(s.counts.agents).toBe(1);
+  });
+
   it("counts attention items — gated invocation (active, non-terminal)", () => {
     const nowSec = 2_000_000;
     const s = dispatchOk(

--- a/apps/studio/frontend/src/components/fleet/fleetReducer.ts
+++ b/apps/studio/frontend/src/components/fleet/fleetReducer.ts
@@ -339,8 +339,33 @@ export function createHistoryPager(
   };
 }
 
-function deriveCounts(units: OrgUnit[]): FleetCounts {
-  const orchestrations = units.filter((u) => u.id !== "__direct__").length;
+const ORCHESTRATION_KINDS = new Set(["play", "fanout", "flow"]);
+
+/**
+ * An orchestration is counted once, from whichever evidence exists for it.
+ *
+ * A group is the better evidence, but a group only forms when a run carries
+ * invocation_id, and that field is populated on the `li invoke` path alone. A
+ * play, fanout or flow never sets it, so it formed no group and was invisible
+ * here: the strip read zero orchestrations while one was visibly running in the
+ * list directly below it. Counting those runs closes that gap without inventing
+ * a parentage link that does not exist — it makes the number honest, not the
+ * tree. Their workers stay ungrouped, because rendering them as affiliated
+ * would be the same falsehood moved somewhere harder to notice.
+ *
+ * Runs already inside a group are excluded so this stays a union rather than a
+ * double count. Once real parentage exists, every orchestration forms a group,
+ * the second term goes to zero, and this reduces to the group count on its own.
+ */
+function deriveCounts(units: OrgUnit[], runs: RunSummary[]): FleetCounts {
+  const groups = units.filter((u) => u.id !== "__direct__");
+  const grouped = new Set(groups.flatMap((u) => u.agents.map((a) => a.id)));
+  const ungroupedOrchestrations = runs.filter(
+    (r) =>
+      isActive(r) && ORCHESTRATION_KINDS.has(r.invocation_kind ?? "") && !grouped.has(r.run_id),
+  ).length;
+
+  const orchestrations = groups.length + ungroupedOrchestrations;
   const agents = units.reduce((n, u) => n + u.agents.length, 0);
   const attention = units.reduce((n, u) => {
     if (u.id === "__direct__") return n + u.agents.filter((a) => needsAttention(a)).length;
@@ -375,7 +400,7 @@ export function fleetReducer(state: FleetState, action: FleetAction): FleetState
       const { invocations, runs, runsHasNext, nowSec, project, projectNull, search } = action;
       const scoped = isScopeActive(project, projectNull, search);
       const orgUnits = buildOrgUnits(invocations, runs, nowSec, scoped, runsHasNext);
-      const counts = deriveCounts(orgUnits);
+      const counts = deriveCounts(orgUnits, runs);
       return {
         ...state,
         nowSec,


### PR DESCRIPTION
## The defect

The Fleet view could report **0 orchestrations active** while a play was listed as
running directly beneath it, in the same viewport.

The count was derived from invocation groups alone. A group only forms when a run
carries `invocation_id`, and that field is populated on the `li invoke` path. A play,
fanout or flow started any other way carries none, forms no group, and so was counted
zero times despite being active and visible.

## The fix

The count becomes a union of two sources:

- invocation groups, as before
- active orchestration-kind runs (`play`, `fanout`, `flow`) that did not land in a group

Runs already inside a group are excluded from the second term, so the two sources
cannot double count. When runs carry real parentage, every orchestration forms a group,
the second term goes to zero, and the expression reduces to the group count on its own.
That property is asserted in the tests rather than left as an intention.

## What is deliberately unchanged

The grouping. Workers of an ungrouped orchestration still render as unaffiliated,
because attaching them without a parentage link would relocate the same inaccuracy
somewhere harder to notice. This corrects the number, not the tree.

## Tests

`fleetReducer.test.ts` gains 7 cases:

- the regression itself: one running play, no invocation, count is 1 and not 0
- all three orchestration kinds, parameterised
- a grouped orchestration is not counted twice
- a terminal run of an orchestration kind is not counted as active
- an `agent`-kind run is not counted as an orchestration

The existing suite pinning the `li invoke` path (two invocations, zero runs, expects two)
passes unchanged, which is the regression a straight swap of the count source would have
shipped.