### PR TITLE
fix(studio): run_findings must say when it only loaded part of the run

### DIFF
--- a/lionagi/studio/operator/run_findings.py
+++ b/lionagi/studio/operator/run_findings.py
@@ -88,6 +88,25 @@ def _matches_agent_filter(branch: dict[str, Any], needle: str) -> bool:
     )
 
 
+def _message_totals(branches: list[dict[str, Any]]) -> tuple[int, int]:
+    """``(loaded, total)`` messages across ``branches``.
+
+    ``total`` is the session's own full-progression count per branch, which is
+    what makes an honest window flag possible: the carrier is called with
+    ``message_limit=PER_KIND_ITEM_CAP``, so ``branch["messages"]`` is already a
+    tail window and its length says nothing about what exists. A branch that
+    predates ``message_total`` reports its window length, which makes the
+    comparison say "nothing dropped" rather than inventing a number.
+    """
+    loaded = total = 0
+    for branch in branches:
+        window = len(branch.get("messages") or [])
+        loaded += window
+        reported = branch.get("message_total")
+        total += reported if isinstance(reported, int) and reported >= window else window
+    return loaded, total
+
+
 def _collect_messages(branches: list[dict[str, Any]]) -> dict[str, Any]:
     items: list[dict[str, Any]] = []
     for branch in branches:
@@ -104,8 +123,20 @@ def _collect_messages(branches: list[dict[str, Any]]) -> dict[str, Any]:
                     "timestamp": message.get("timestamp"),
                 }
             )
-    kept, truncated = cap_by_bytes(items, MESSAGE_BYTE_CAP)
-    return {"items": kept, "truncated": truncated}
+    kept, byte_truncated = cap_by_bytes(items, MESSAGE_BYTE_CAP)
+    loaded, total = _message_totals(branches)
+    # `truncated` used to report only the byte cap. That is the cap that almost
+    # never fires here -- fifty messages against a two-megabyte budget -- while
+    # the window above it fires constantly, so the flag read False on responses
+    # that had dropped most of the run. Report both, and carry the counts: for
+    # a reader deciding whether it has enough to answer from, "the last 50 of
+    # 48,123" and "truncated" are not the same information.
+    return {
+        "items": kept,
+        "truncated": byte_truncated or len(kept) < total,
+        "returned": len(kept),
+        "total": total,
+    }
 
 
 def _short_class(lion_class: str) -> str:
@@ -114,9 +145,19 @@ def _short_class(lion_class: str) -> str:
     return _short_lion_class(lion_class or "")
 
 
-def _derive_tool_calls(branches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _derive_tool_calls(branches: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
+    """``(calls, clipped)``, where ``clipped`` means calls were dropped here.
+
+    Two things drop tool calls, and they compose: the message window this runs
+    over (a call in a message that was never loaded cannot be derived) and the
+    per-branch cap below. Neither has a knowable denominator -- counting the
+    calls in messages we do not have is not something this can do -- so this
+    reports whether, not how many, and the caller says so rather than
+    publishing a total it would have to invent.
+    """
     from lionagi.studio.services.runs import _detect_status
 
+    clipped = False
     out: list[dict[str, Any]] = []
     for branch in branches:
         name, agent_name = _branch_label(branch)
@@ -131,6 +172,7 @@ def _derive_tool_calls(branches: list[dict[str, Any]]) -> list[dict[str, Any]]:
             for message in messages
             if _short_class(message.get("lion_class") or "") == "ActionRequest"
         ]
+        clipped = clipped or len(calls) > PER_KIND_ITEM_CAP
         for message in calls[-PER_KIND_ITEM_CAP:]:
             content = message.get("content") if isinstance(message.get("content"), dict) else {}
             function = content.get("function") or ""
@@ -160,19 +202,27 @@ def _derive_tool_calls(branches: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     "timestamp": message.get("timestamp"),
                 }
             )
-    return out
+    return out, clipped
 
 
-def _collect_tool_calls(tool_calls: list[dict[str, Any]]) -> dict[str, Any]:
-    kept, truncated = cap_by_bytes(tool_calls, MESSAGE_BYTE_CAP)
-    return {"items": kept, "truncated": truncated}
+def _collect_tool_calls(tool_calls: list[dict[str, Any]], clipped: bool) -> dict[str, Any]:
+    kept, byte_truncated = cap_by_bytes(tool_calls, MESSAGE_BYTE_CAP)
+    return {"items": kept, "truncated": byte_truncated or clipped or len(kept) < len(tool_calls)}
 
 
 def _collect_errors(
     session: dict[str, Any],
     branches: list[dict[str, Any]],
     tool_calls: list[dict[str, Any]],
+    partial: bool,
 ) -> dict[str, Any]:
+    """``partial`` is whether the evidence underneath was already incomplete.
+
+    It matters most for this section. Branch and session status rows are read
+    whole, so an errors list can look authoritative while the tool-call half of
+    it was derived from a fraction of the messages -- which is the reading that
+    turns "no errors found" into "no errors happened".
+    """
     items: list[dict[str, Any]] = [
         {
             "branch": call["branch"],
@@ -210,8 +260,8 @@ def _collect_errors(
                 "timestamp": session.get("ended_at"),
             }
         )
-    kept, truncated = cap_by_bytes(items, MESSAGE_BYTE_CAP)
-    return {"items": kept, "truncated": truncated}
+    kept, byte_truncated = cap_by_bytes(items, MESSAGE_BYTE_CAP)
+    return {"items": kept, "truncated": byte_truncated or partial or len(kept) < len(items)}
 
 
 def _collect_artifacts(session: dict[str, Any]) -> dict[str, Any]:
@@ -270,15 +320,23 @@ async def run_findings(arguments: dict[str, Any]) -> dict[str, Any]:
     wanted = {args.kind} if args.kind else {"messages", "tool_calls", "errors", "artifacts"}
 
     tool_calls: list[dict[str, Any]] | None = None
+    calls_clipped = False
     if "tool_calls" in wanted or "errors" in wanted:
-        tool_calls = _derive_tool_calls(branches)
+        tool_calls, calls_clipped = _derive_tool_calls(branches)
+
+    # The message window bounds every section derived from messages, not just
+    # the messages section, so it is computed once here and passed down.
+    loaded, total = _message_totals(branches)
+    window_dropped = loaded < total
 
     if "messages" in wanted:
         result["messages"] = _collect_messages(branches)
     if "tool_calls" in wanted:
-        result["toolCalls"] = _collect_tool_calls(tool_calls or [])
+        result["toolCalls"] = _collect_tool_calls(tool_calls or [], calls_clipped or window_dropped)
     if "errors" in wanted:
-        result["errors"] = _collect_errors(session, branches, tool_calls or [])
+        result["errors"] = _collect_errors(
+            session, branches, tool_calls or [], calls_clipped or window_dropped
+        )
     if "artifacts" in wanted:
         result["artifacts"] = _collect_artifacts(session)
 

--- a/tests/apps_studio_server/test_operator_run_findings.py
+++ b/tests/apps_studio_server/test_operator_run_findings.py
@@ -219,7 +219,7 @@ async def test_run_findings_zero_operations(db_path):
     result = await run_findings({"run": sid})
 
     assert result["found"] is True
-    assert result["messages"] == {"items": [], "truncated": False}
+    assert result["messages"] == {"items": [], "truncated": False, "returned": 0, "total": 0}
     assert result["toolCalls"] == {"items": [], "truncated": False}
     assert result["errors"] == {"items": [], "truncated": False}
     assert result["artifacts"] == {
@@ -779,3 +779,86 @@ async def test_run_findings_rejects_unknown_fields(db_path):
 
     with pytest.raises(ValidationError):
         RunFindingsInput.model_validate({"run": "x", "unexpected": True})
+
+
+async def test_run_findings_reports_the_message_window_it_did_not_load(db_path):
+    """A run bigger than the message window must say so.
+
+    The window is fifty messages; the byte cap the flag used to report is two
+    megabytes. Fifty messages never approach two megabytes, so the flag read
+    False on every response the window had trimmed -- and on this surface that
+    reads as "here is the run", not "here is the tail of it". Measured against
+    live data at the time this was written, 39% of branches were over the
+    window and the largest held 48,123 messages, of which the tool returned 50
+    and called the result complete.
+    """
+    from lionagi.studio.operator.redact import PER_KIND_ITEM_CAP
+    from lionagi.studio.operator.run_findings import run_findings
+
+    sid = str(uuid.uuid4())
+    bid = f"{sid}-b1"
+    await seed_session(db_path, session_id=sid, status="completed")
+    await seed_branch(db_path, branch_id=bid, session_id=sid, name="worker-1")
+
+    total_seeded = PER_KIND_ITEM_CAP + 10
+    for i in range(total_seeded):
+        await seed_text_message(
+            db_path,
+            branch_id=bid,
+            message_id=f"{bid}-m{i:03d}",
+            role="assistant",
+            content={"assistant_response": f"step {i}"},
+            timestamp=100.0 + i,
+        )
+
+    result = await run_findings({"run": sid})
+
+    messages = result["messages"]
+    assert messages["total"] == total_seeded
+    assert messages["returned"] == PER_KIND_ITEM_CAP
+    assert messages["truncated"] is True
+    # The counts are the point: "truncated" alone cannot tell a reader whether
+    # it is missing three messages or forty-eight thousand.
+    assert messages["returned"] < messages["total"]
+
+    # Everything derived from the same window inherits the incompleteness. An
+    # errors list is the dangerous one -- it reads as authoritative, and its
+    # tool-call half came from a fraction of the messages.
+    assert result["toolCalls"]["truncated"] is True
+    assert result["errors"]["truncated"] is True
+
+
+async def test_run_findings_does_not_claim_truncation_when_it_loaded_everything(db_path):
+    """Companion: the flag must stay False on a run that fits.
+
+    Without this the row above is satisfiable by hardcoding True, which is the
+    same defect in the other direction -- a surface that always warns tells a
+    reader nothing and gets ignored exactly when it matters.
+    """
+    from lionagi.studio.operator.run_findings import run_findings
+
+    sid = str(uuid.uuid4())
+    bid = f"{sid}-b1"
+    await seed_session(db_path, session_id=sid, status="completed")
+    await seed_branch(db_path, branch_id=bid, session_id=sid, name="worker-1")
+    for i in range(3):
+        await seed_text_message(
+            db_path,
+            branch_id=bid,
+            message_id=f"{bid}-m{i}",
+            role="assistant",
+            content={"assistant_response": f"step {i}"},
+            timestamp=100.0 + i,
+        )
+
+    result = await run_findings({"run": sid})
+
+    assert result["messages"] == {
+        "items": result["messages"]["items"],
+        "truncated": False,
+        "returned": 3,
+        "total": 3,
+    }
+    assert len(result["messages"]["items"]) == 3
+    assert result["toolCalls"]["truncated"] is False
+    assert result["errors"]["truncated"] is False


### PR DESCRIPTION
`run_findings` answered "what happened in this run" from the tail of the run and
said nothing about the rest.

## What was wrong

The messages section carried one truncation flag, and it reported the byte cap
only. Two caps sit above that byte cap, and the item window is the one that
actually fires: fifty messages against a two-megabyte budget essentially never
reaches the byte cap, so the flag read `false` on responses that had dropped
most of the run. On a tool whose whole job is telling a reader what a run
produced, `truncated: false` reads as "here is the run", not "here is the tail
of it".

Measured against live session data before the fix:

| | |
|---|---|
| branches sampled | 62 |
| branches over the 50-message window | 24 (39%) |
| largest branch | 48,123 messages |
| returned for that branch | 50, reported complete |

So the worst case answers from 0.1% of the evidence, confidently.

## What changed

- The messages flag reflects the window as well as the byte cap.
- The messages section carries `returned` and `total`. A flag cannot
  distinguish missing three messages from missing forty-eight thousand, and
  that difference decides whether a reader has enough to answer from.
- The sections derived from the same messages inherit the incompleteness. Tool
  calls are dropped both by the message window and by their own per-branch cap.
  Errors are the case that matters most: branch and session status rows are read
  whole, so the list looks authoritative while its tool-call half came from a
  fraction of the messages, which is what turns "no errors found" into "no
  errors happened".

Those two derived sections report *whether*, not *how many*. The denominator is
not knowable — counting tool calls inside messages that were never loaded is not
something this can do — and publishing a total it had to invent would be worse
than the flag it replaces.

## Checks

- 22 tests pass in the touched suite, including a row that seeds past the window
  and a companion that stays under it.
- Checked by mutation, arms named before running: reporting the byte cap alone
  fails the over-window row; hardcoding the flag true fails both the companion
  and the zero-operations row, so the fix cannot be satisfied by always warning;
  and stopping the derived sections from inheriting the window fails the
  over-window row on its tool-call and error assertions.
