### PR TITLE
fix(studio): match the lock names lionagi writes, not every file ending in .lock

### DIFF
--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -282,14 +282,32 @@ def _artifacts_path(row: Any) -> Path | None:
     return None
 
 
+# The lock files lionagi itself creates under a run's artifact tree. A stale one
+# of these means a process died still holding a claim, which is the only thing
+# this evidence is meant to detect.
+#
+# Matching by the ``.lock`` suffix instead reads dependency lockfiles -- uv.lock,
+# poetry.lock, Cargo.lock -- as dead runs. Since a run's artifacts_path is
+# routinely a repository root, and the search below is recursive, a single
+# checked-in uv.lock marked every completed session in that repository a zombie:
+# the classifier's most severe level, fired by a file that says nothing about any
+# process. Match the names we write, not the extension anyone may use.
+#
+# The resume lock (``{digest}.lock``) is deliberately absent: it lives in
+# ``resume-locks/`` beside the state DB, never under an artifact root, so it is
+# unreachable from here by construction.
+_RUNTIME_LOCK_NAMES: frozenset[str] = frozenset({"job.lock", "finalize.lock"})
+
+
 def _find_stale_lock(root: Path, *, cutoff: float) -> Path | None:
     try:
-        for lock in root.glob("**/*.lock"):
-            try:
-                if lock.stat().st_mtime < cutoff:
-                    return lock
-            except OSError:
-                pass
+        for name in _RUNTIME_LOCK_NAMES:
+            for lock in root.glob(f"**/{name}"):
+                try:
+                    if lock.stat().st_mtime < cutoff:
+                        return lock
+                except OSError:
+                    pass
     except OSError:
         pass
     return None

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -210,12 +210,18 @@ def test_stale_session_live_recorded_pid_not_reaped(tmp_path):
 
 
 def test_stale_lock_gated_on_staleness(tmp_path):
-    """A stale lock file only counts as zombie evidence once the session itself is stale."""
+    """A stale lock file only counts as zombie evidence once the session itself is stale.
+
+    The lock is named ``job.lock`` because that is a name lionagi actually
+    writes. This test used to use ``session.lock``, which nothing creates, so it
+    passed on the strength of the suffix alone and would have kept passing for
+    any file at all ending in ``.lock``.
+    """
     import lionagi.studio.services.admin as admin_svc
 
     artifacts_dir = tmp_path / "artifacts"
     artifacts_dir.mkdir()
-    lock = artifacts_dir / "session.lock"
+    lock = artifacts_dir / "job.lock"
     lock.write_text("x")
     old_mtime = time.time() - 7200
     os.utime(lock, (old_mtime, old_mtime))
@@ -230,6 +236,95 @@ def test_stale_lock_gated_on_staleness(tmp_path):
         admin_svc._classify_phantom(fresh_row, now=now, stale_seconds=3600, ps_snapshot="") is None
     )
 
+    stale_row = {
+        "id": str(uuid.uuid4()),
+        "updated_at": now - 7200,
+        "artifacts_path": str(artifacts_dir),
+    }
+    assert (
+        admin_svc._classify_phantom(stale_row, now=now, stale_seconds=3600, ps_snapshot="")
+        == "stale_lock"
+    )
+
+
+def _aged(path, seconds_ago: float) -> None:
+    path.write_text("x")
+    when = time.time() - seconds_ago
+    os.utime(path, (when, when))
+
+
+def test_dependency_lockfile_is_not_evidence_of_a_dead_process(tmp_path):
+    """A stale ``uv.lock`` alone must classify as nothing.
+
+    This is the arm that separates the two rules, and it is the only one that
+    does. Under a ``**/*.lock`` suffix match this row is ``stale_lock``; under a
+    match on the names lionagi writes it is ``None``. Every other lock test here
+    scores the same under both rules, so none of them can catch a regression to
+    the suffix match.
+
+    It is not hypothetical. A run's ``artifacts_path`` is routinely a repository
+    root and the search is recursive, so one checked-in ``uv.lock`` classified
+    every completed session in that repository as a zombie.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    artifacts_dir = tmp_path / "repo"
+    artifacts_dir.mkdir()
+    _aged(artifacts_dir / "uv.lock", 7200)
+
+    now = time.time()
+    stale_row = {
+        "id": str(uuid.uuid4()),
+        "updated_at": now - 7200,
+        "artifacts_path": str(artifacts_dir),
+    }
+    assert (
+        admin_svc._classify_phantom(stale_row, now=now, stale_seconds=3600, ps_snapshot="")
+        != "stale_lock"
+    )
+
+
+def test_dependency_lockfile_does_not_mask_a_real_runtime_lock(tmp_path):
+    """A ``uv.lock`` sitting beside a genuine stale ``job.lock`` still classifies.
+
+    Without this, a fix could pass the arm above by giving up whenever a
+    dependency lockfile is present, which would suppress the true positives the
+    evidence exists to find.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    artifacts_dir = tmp_path / "repo"
+    artifacts_dir.mkdir()
+    _aged(artifacts_dir / "uv.lock", 7200)
+    _aged(artifacts_dir / "job.lock", 7200)
+
+    now = time.time()
+    stale_row = {
+        "id": str(uuid.uuid4()),
+        "updated_at": now - 7200,
+        "artifacts_path": str(artifacts_dir),
+    }
+    assert (
+        admin_svc._classify_phantom(stale_row, now=now, stale_seconds=3600, ps_snapshot="")
+        == "stale_lock"
+    )
+
+
+def test_finalize_lock_is_also_runtime_evidence(tmp_path):
+    """``finalize.lock`` is the other name lionagi writes under a run tree.
+
+    Named explicitly so a fix that hardcodes only ``job.lock`` fails here rather
+    than silently narrowing the evidence to one of the two real locks.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    artifacts_dir = tmp_path / "repo"
+    artifacts_dir.mkdir()
+    nested = artifacts_dir / "run-1"
+    nested.mkdir()
+    _aged(nested / "finalize.lock", 7200)
+
+    now = time.time()
     stale_row = {
         "id": str(uuid.uuid4()),
         "updated_at": now - 7200,


### PR DESCRIPTION
## The defect

Session health classifies a terminal session as `ZOMBIE` on exactly one signal: a stale lock file under the run's artifact tree, meaning a process died still holding a claim. `ZOMBIE` is the most severe level in `HEALTH_SEVERITY`, so it drives the worst colour on any health view.

The search matched the `.lock` **suffix**, recursively, and a run's `artifacts_path` is routinely a repository root. So it matched `uv.lock`, `poetry.lock`, `Cargo.lock` — dependency lockfiles, which say nothing about any process.

Measured on one store before the fix:

| | |
|---|---|
| sessions scanned (the health scan limit) | 500 |
| classified `zombie` | 190 |
| of those, `status='completed'` | 190 (all of them) |
| distinct lock files responsible | 13, every one a `uv.lock` |
| attributable to a single `uv.lock` | 163 |
| age of that file | 1.9 hours |

Every classification was a correctly-completed session. The count also climbs on its own: it went 190 → 193 → 198 over about fifteen minutes of ordinary use, because each newly-completed session inherits the same verdict, and it re-reddens within an hour of running `uv lock` anywhere in the tree.

## The fix

Match the lock names lionagi actually writes under an artifact tree, rather than the extension anyone may use:

- `job.lock` — the per-run mutation lock
- `finalize.lock` — the finalize claim, written into the run directory

The resume lock (`{digest}.lock`) is deliberately excluded: it lives in `resume-locks/` beside the state database, never under an artifact root, so it is unreachable from this search by construction. That is stated in a comment so the omission does not read as an oversight.

## On the tests

The existing staleness test used a lock named `session.lock`. Nothing in the codebase creates that file, so the test passed on the strength of the suffix alone and would have kept passing for any file at all ending in `.lock`. It now uses a real name.

Three cases are added, and only one of them is load-bearing:

- **a stale `uv.lock` alone is not evidence** — this is the only case that scores *differently* under the old rule and the new one, so it is the only one that can catch a regression back to suffix matching. Verified by reverting the predicate: it is the single test that fails, and the other lock tests stay green, which is precisely why they cannot serve as the guard.
- **a `uv.lock` beside a genuine stale `job.lock` still classifies** — without it, a fix could pass the case above by bailing out whenever a dependency lockfile is present, suppressing the true positives this evidence exists to find.
- **`finalize.lock` is matched too** — so a fix that hardcodes only `job.lock` fails here instead of silently narrowing the evidence to one of the two real locks.

## Scope

`_find_stale_lock` has four call sites and they all share the predicate, so the phantom-session classification (`stale_lock` reason) is corrected by the same change.

Not addressed here: `artifacts_path` pointing at a repository root is what makes the recursive search span an entire checkout in the first place. That is a broader question about artifact roots and is left alone deliberately.

53 tests pass across the touched suites.
