### PR TITLE
fix(studio): stop command prose being listed as files a run touched

### DIFF
--- a/apps/studio/frontend/src/components/RunStepCard.files.test.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.files.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The Files panel lists files, not every slash-bearing word in a command.
+ *
+ * The extractor used to accept any token containing a slash, or any token
+ * whose basename contained a dot. Command arguments are full of prose that
+ * passes both: DOIs, throughput units, ratios, and slash-separated lists of
+ * product names. Measured over five runs of four different agent shapes and
+ * ~800 shell commands, that rule produced 769 "files". Accepting a rooted
+ * path outright and asking a rootless one to look like a filename produced
+ * 139, and dropped nothing that existed on disk.
+ *
+ * Rootless paths are kept deliberately: they resolve against the emitting
+ * agent's artifact directory, so `analyst/disposition_table.md` is a real
+ * reference even though it names no root.
+ *
+ * The cases below are verbatim from that measurement, so a future loosening
+ * of the rule fails here rather than on the demo screen.
+ */
+import { describe, expect, it } from "vitest";
+import { pathFromArgs } from "./RunStepCard";
+
+function paths(command: string): string[] {
+  return pathFromArgs({ command }, "", "bash");
+}
+
+describe("shell file extraction", () => {
+  it("keeps rooted paths, including the ones a command only reads", () => {
+    expect(paths("cat /Users/lion/projects/atlas/INDEX.md")).toEqual([
+      "/Users/lion/projects/atlas/INDEX.md",
+    ]);
+    expect(paths("uv run pytest ~/work/tests/test_flow.py")).toEqual(["~/work/tests/test_flow.py"]);
+    // `./` and `../` are roots too; they normalise away, which is expected.
+    expect(paths("ruff check ./src/lionagi/config.py")).toEqual(["src/lionagi/config.py"]);
+  });
+
+  it("keeps a rootless path that names a real file, since it resolves against the agent dir", () => {
+    expect(paths("cat analyst/disposition_table.md")).toEqual(["analyst/disposition_table.md"]);
+    expect(paths("cat crates/khive-db/src/writer_task.rs")).toEqual([
+      "crates/khive-db/src/writer_task.rs",
+    ]);
+  });
+
+  it("rejects a rootless dotted word that is not a filename", () => {
+    // Only the extension gate separates these from the case above: they are
+    // rootless, they have a dot, and the old rule took both as files.
+    expect(paths("echo sqlite.org")).toEqual([]);
+    expect(paths("echo read.transaction")).toEqual([]);
+  });
+
+  it("rejects prose that merely contains a slash", () => {
+    // Every one of these appeared in the Files panel of a real run.
+    for (const prose of [
+      "echo 10.1145/502059.502057",
+      "echo Kingman/GI/G/1",
+      "echo Litestream/LiteFS/libSQL/rqlite/Bedrock",
+      "echo MB/s",
+      "echo I/O",
+      "echo 15/20",
+      "echo FULL/RESTART/TRUNCATE",
+      "echo admission/bounded",
+    ]) {
+      expect(paths(prose), `${prose} produced a file`).toEqual([]);
+    }
+  });
+
+  it("rejects a wrapped script captured as one quoted token", () => {
+    // The tokenizer returns the body of a quoted argument as a single word.
+    // Before the root and segment rules, this whole script was one "file".
+    const wrapped = `/bin/zsh -lc '/usr/bin/find /Users/lion -name FINDINGS.md -mmin -60'`;
+    expect(paths(wrapped)).not.toContain("/usr/bin/find /Users/lion -name FINDINGS.md -mmin -60");
+  });
+
+  it("claims nothing at all for a path only visible inside a quoted wrapper", () => {
+    // A known limit, asserted so it stays known. The tokenizer cannot see
+    // inside a quoted argument, so the real path here is invisible. Listing
+    // nothing is the correct outcome; listing the script was the defect.
+    const wrapped = `/bin/zsh -lc "cat /Users/lion/projects/notes/a.md"`;
+    expect(paths(wrapped)).toEqual([]);
+  });
+
+  it("rejects regex and shell fragments", () => {
+    for (const frag of [
+      `rg "\\.busy\\b" /Users/lion/projects`,
+      `rg "read.transaction" .`,
+      `awk '/^##/ {print}' /Users/lion/x.md`,
+    ]) {
+      for (const p of paths(frag)) {
+        expect(p.startsWith("/"), `${p} is not rooted`).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/studio/frontend/src/components/RunStepCard.files.test.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.files.test.tsx
@@ -78,6 +78,35 @@ describe("shell file extraction", () => {
     expect(paths(wrapped)).toEqual([]);
   });
 
+  it("keeps paths whose directories are named in a non-Latin script", () => {
+    // The segment check ran before the rooted check, so an ASCII-only class
+    // rejected these before the rooted rule could vouch for them — on a
+    // machine whose directories are routinely named in Chinese, that dropped
+    // real files. Rooted and rootless both, since widening the class fixes
+    // the rootless case too as long as the name still looks like a file.
+    expect(paths("cat /Users/lion/项目/main.py")).toEqual(["/Users/lion/项目/main.py"]);
+    expect(paths("cat /Users/lion/Café/notes.md")).toEqual(["/Users/lion/Café/notes.md"]);
+    expect(paths("cat 文档/报告.md")).toEqual(["文档/报告.md"]);
+  });
+
+  it("keeps the punctuation a filename is actually allowed to carry", () => {
+    // The charset edges, so a future tightening of the class fails here
+    // rather than silently dropping rows. Each of these characters is in the
+    // segment class on purpose.
+    expect(paths("cat /tmp/run-2026_08@v1.2+build~1/out.log")).toEqual([
+      "/tmp/run-2026_08@v1.2+build~1/out.log",
+    ]);
+  });
+
+  it("still rejects the punctuation that means the token is not a path", () => {
+    // The control for the two cases above: widening the class to every script
+    // must not dissolve it. Without this, replacing the class with something
+    // that matches anything passes both keep-arms.
+    for (const frag of ["run a=b/c.py", "echo 50%/hour", "note see p.12,/x.md"]) {
+      expect(paths(frag)).toEqual([]);
+    }
+  });
+
   it("rejects regex and shell fragments", () => {
     for (const frag of [
       `rg "\\.busy\\b" /Users/lion/projects`,

--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -212,6 +212,26 @@ function normalizeShellPath(path: string): string {
  * is all the heuristic below asks for. */
 const SHELL_GLOB_TOKEN = /[*?[\]{}]/;
 
+/** Characters no path we can render carries, but shell and regex fragments do.
+ * The tokenizer hands back the body of a quoted argument as ONE word, so a
+ * wrapped command (`/bin/zsh -lc '/usr/bin/find /Users/x -name y'`) arrives as
+ * a single token that begins with a slash and would otherwise be shown as a
+ * filename. Rejecting these, and requiring every segment to look like a name,
+ * is what separates a path from a script. */
+const SHELL_UNSAFE_IN_PATH = /[\\^$()|`"'#]/;
+const SHELL_PATH_SEGMENT = /^[A-Za-z0-9_.@+~-]+$/;
+
+/** Extensions that make a ROOTLESS token a filename rather than prose. A
+ * rooted path needs no such evidence; a bare `word/word` does, because that
+ * shape is overwhelmingly not a path. Kept deliberately broad — a miss costs
+ * one absent row, a false accept costs a wrong one on every run that mentions
+ * a ratio. */
+const KNOWN_FILE_EXTENSIONS = new Set(
+  `py js jsx ts tsx rs go java rb php sh bash zsh sql json yaml yml toml ini cfg
+   conf env md rst txt csv tsv log html css scss lock mjs cjs c h cpp hpp swift
+   kt lua r ipynb xml svg png jpg jpeg gif pdf`.split(/\s+/),
+);
+
 function shellFilePath(token: string): string | null {
   const path = token.replace(/[,:]+$/, "");
   if (!path || path.startsWith("-") || path.endsWith("/")) return null;
@@ -223,11 +243,17 @@ function shellFilePath(token: string): string | null {
   if (!basename || basename === "." || basename === "..") return null;
   if (SHELL_INTERPRETER_NAMES.has(basename.toLowerCase())) return null;
   if (/(?:^|\/)\.?venv\/bin\/[^/]+$/.test(normalized)) return null;
-  const looksLikeFile =
-    SHELL_FILE_NAMES.has(basename) ||
-    path.includes("/") ||
-    (basename.includes(".") && !basename.endsWith("."));
-  return looksLikeFile ? normalized : null;
+  if (SHELL_UNSAFE_IN_PATH.test(normalized)) return null;
+  if (!segments.every((segment) => SHELL_PATH_SEGMENT.test(segment))) return null;
+  // A slash alone is not evidence of a path. Command arguments are full of
+  // prose carrying one: DOIs (10.1145/502059.502057), rates (MB/s), ratios
+  // (15/20), and slash-separated lists of product names all parse as "has a
+  // slash, has a dot", which was the whole of the old test. A rooted path is
+  // self-evidently a path; a rootless one has to look like a filename.
+  if (normalized.startsWith("/") || /^(?:\.{1,2}|~)\//.test(path)) return normalized;
+  const extension = basename.includes(".") ? basename.split(".").at(-1)!.toLowerCase() : "";
+  if (SHELL_FILE_NAMES.has(basename) || KNOWN_FILE_EXTENSIONS.has(extension)) return normalized;
+  return null;
 }
 
 function shellFilePaths(command: string): string[] {

--- a/apps/studio/frontend/src/components/RunStepCard.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.tsx
@@ -219,7 +219,14 @@ const SHELL_GLOB_TOKEN = /[*?[\]{}]/;
  * filename. Rejecting these, and requiring every segment to look like a name,
  * is what separates a path from a script. */
 const SHELL_UNSAFE_IN_PATH = /[\\^$()|`"'#]/;
-const SHELL_PATH_SEGMENT = /^[A-Za-z0-9_.@+~-]+$/;
+// Letters, marks and digits from any script, not just ASCII. An ASCII-only
+// class rejects a real directory named 项目 or Café, and rejects it before the
+// rooted check below can vouch for it. Marks are in the set so a decomposed
+// accent (e + U+0301) is treated the same as its precomposed form. This class
+// is strictly wider than the ASCII one it replaces, so nothing that used to be
+// accepted can start being dropped; punctuation that is not part of a filename
+// (comma, equals, percent, colon) is still excluded.
+const SHELL_PATH_SEGMENT = /^[\p{L}\p{M}\p{N}_.@+~-]+$/u;
 
 /** Extensions that make a ROOTLESS token a filename rather than prose. A
  * rooted path needs no such evidence; a bare `word/word` does, because that


### PR DESCRIPTION
## What

The run detail Files panel lists the files a run touched. For shell tool
calls it derives them from the command text, and the test it used was
"contains a slash, or has a dot in its basename".

Command arguments are full of text that passes that: DOIs
(`10.1145/502059.502057`), throughput units (`MB/s`), ratios (`15/20`),
`I/O`, and slash-separated lists of product names. A quoted script also
arrives from the tokenizer as a single word, so a wrapped command showed
up as one very long filename.

## Change

- A rooted path (`/…`, `./…`, `../…`, `~/…`) is self-evidently a path and
  is taken as before.
- A rootless one now has to look like a filename: a known extension, or a
  known bare name. This keeps the references that resolve against an
  agent's own artifact directory, such as `analyst/disposition_table.md`.
- Tokens carrying shell or regex characters, and tokens whose segments are
  not name-shaped, are rejected.

## Evidence

Measured by replaying the extractor over stored tool-call arguments from
five runs of four different agent shapes, roughly 800 shell commands:

| | before | after |
|---|---|---|
| paths extracted | 769 | 139 |
| of those, present on disk | 44 | 44 |
| real paths dropped | — | 0 |

One run turned 86 commands into 227 "files", none of which existed.

New tests use the failing inputs verbatim. Each new rule was checked by
disabling it and confirming the matching test goes red.