### PR TITLE
fix(studio): resolve session display names in the health report

### DIFF
--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -23,6 +23,7 @@ from lionagi.ln import now_utc
 from lionagi.state.db import ADMIN_TRANSITION_TARGETS as _ADMIN_TRANSITION_TARGETS
 from lionagi.state.db import state_db_known_absent
 from lionagi.state.reasons import RunReasons, SessionReasons, validate_reason_code
+from lionagi.state.session_naming import resolve_display_name
 
 from ..registry import studio_route
 from ._db import open_db as _open_db
@@ -498,10 +499,13 @@ async def health_report() -> dict[str, Any]:
             unhealthy.append(
                 {
                     "session_id": row["id"],
-                    "name": sess.get("name")
-                    or sess.get("playbook_name")
-                    or sess.get("agent_name")
-                    or "",
+                    # The same resolver every other surface reads through. The
+                    # stored `name` column can hold a raw prompt body, which
+                    # resolve_display_name demotes below the play, playbook and
+                    # agent-role tiers; reading the column directly published
+                    # those prompts here while the API and UI showed a clean
+                    # label for the very same session.
+                    "name": resolve_display_name(sess),
                     "health": health.value,
                     "status": status,
                     "invocation_kind": sess.get("invocation_kind"),

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -434,8 +434,15 @@ async def health_report() -> dict[str, Any]:
             WITH page AS (
                 SELECT id AS page_id FROM sessions ORDER BY updated_at DESC LIMIT ?
             )
+            -- show_play_name sits ABOVE playbook_name in the display-name
+            -- chain, so omitting it here does not fall back gracefully: the
+            -- resolver reads None and answers with the tier below, and a play
+            -- session is named one way here and another way in the API and
+            -- UI. Selecting a column short of what the resolver reads is the
+            -- same two-names-for-one-session defect, one layer down.
             SELECT s.id, s.name, s.status, s.invocation_kind, s.agent_name,
-                   s.playbook_name, s.started_at, s.ended_at, s.updated_at,
+                   s.playbook_name, s.show_play_name, s.started_at, s.ended_at,
+                   s.updated_at,
                    s.last_message_at, s.artifacts_path, s.node_metadata,
                    COALESCE(SUM(json_array_length(p.collection)), 0) AS message_count
             FROM page

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -689,3 +689,55 @@ def test_admin_transition_legacy_reason_backwards_compat(tmp_path, monkeypatch):
             assert row["status_reason_summary"] == "Legacy client cleanup"
 
     _run(_check())
+
+
+def test_admin_health_names_a_session_the_way_every_other_surface_does(tmp_path, monkeypatch):
+    """The health report must resolve a session's display name, not print the
+    stored column.
+
+    The `name` column can hold a raw prompt body. Every other surface reads it
+    through resolve_display_name, which ranks the play, playbook and agent-role
+    labels above it, so the API and the UI showed a clean label while this
+    endpoint published the prompt for the very same session.
+    """
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+    prompt_as_name = (
+        "|- You are a scheduled DRAFT-ONLY worker for the re-enrichment "
+        "campaign. Do not write to the graph."
+    )
+
+    async def _seed() -> None:
+        async with StateDB(db_path) as db:
+            pid = str(uuid.uuid4())
+            await db.create_progression(pid)
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": pid,
+                    "name": prompt_as_name,
+                    "status": "running",
+                    "started_at": time.time(),
+                }
+            )
+            await db.execute(
+                "UPDATE sessions SET agent_name = ? WHERE id = ?", ("claude-code", sid)
+            )
+
+    _run(_seed())
+
+    import lionagi.studio.services.admin as admin_mod
+
+    # No artifacts and no messages classify this ORPHANED, which is what puts
+    # it in the `unhealthy` list this test reads.
+    monkeypatch.setattr(admin_mod, "process_liveness", lambda *a, **k: False)
+
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    body = client.get("/api/admin/health").json()
+    rows = body["sessions"]["unhealthy"]
+    assert rows, "the seeded session never reached the unhealthy list"
+    row = next(r for r in rows if r["session_id"] == sid)
+
+    assert not row["name"].startswith("|-"), "the raw prompt body is being published"
+    assert "DRAFT-ONLY" not in row["name"]
+    assert row["name"].startswith("claude-code"), row["name"]

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -741,3 +741,59 @@ def test_admin_health_names_a_session_the_way_every_other_surface_does(tmp_path,
     assert not row["name"].startswith("|-"), "the raw prompt body is being published"
     assert "DRAFT-ONLY" not in row["name"]
     assert row["name"].startswith("claude-code"), row["name"]
+
+
+def test_admin_health_prefers_the_play_name_like_the_session_list_does(tmp_path, monkeypatch):
+    """The report must select every column the resolver ranks above the one it
+    already selects.
+
+    show_play_name sits ABOVE playbook_name in the display-name chain, so
+    omitting it from the report's own SELECT does not degrade gracefully: the
+    resolver reads None and answers with the tier below. The session list
+    selects it, so a play session was named by its play there and by its
+    playbook here -- the same two-names-for-one-session defect this endpoint
+    was fixed for, one layer down. Both names are clean labels, which is why
+    only a cross-surface comparison catches it.
+    """
+    db_path = tmp_path / "state.db"
+    sid = str(uuid.uuid4())
+
+    async def _seed() -> None:
+        async with StateDB(db_path) as db:
+            pid = str(uuid.uuid4())
+            await db.create_progression(pid)
+            await db.create_session(
+                {
+                    "id": sid,
+                    "progression_id": pid,
+                    "name": "some raw prompt body",
+                    "status": "running",
+                    "started_at": time.time(),
+                }
+            )
+            # Both tiers populated, and they differ. A row carrying only one
+            # of them cannot tell the two orderings apart.
+            await db.execute(
+                "UPDATE sessions SET show_play_name = ?, playbook_name = ? WHERE id = ?",
+                ("nightly-enrichment", "oss-feature", sid),
+            )
+
+    _run(_seed())
+
+    import lionagi.studio.services.admin as admin_mod
+
+    monkeypatch.setattr(admin_mod, "process_liveness", lambda *a, **k: False)
+
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    rows = client.get("/api/admin/health").json()["sessions"]["unhealthy"]
+    assert rows, "the seeded session never reached the unhealthy list"
+    health_name = next(r for r in rows if r["session_id"] == sid)["name"]
+
+    listed = client.get("/api/sessions").json()
+    entries = listed["sessions"] if isinstance(listed, dict) else listed
+    list_name = next(s for s in entries if s["id"] == sid)["name"]
+
+    assert health_name == list_name, (
+        f"health report says {health_name!r}, session list says {list_name!r}"
+    )
+    assert health_name == "nightly-enrichment"


### PR DESCRIPTION
## What

`/api/admin/health` built each row's name from the stored `name` column
directly. That column can hold a raw prompt body. Every other surface reads
it through `resolve_display_name`, which ranks the play name, playbook name
and agent-role label above it, and sanitizes the prompt if it does fall
through to that tier.

So a single session had two names at once:

| surface | name |
|---|---|
| `/api/sessions/{id}` and the UI | `claude-code · 8864 · 12:00` |
| `/api/admin/health` | `'Run exactly this command from … and report its output…` |

Some rows were worse, carrying a `LION_SYSTEM_MESSAGE` banner and the
opening of the system prompt, which is prompt content leaking onto an
operations surface.

## Scope

Display only. Nothing is written, and the stored column is untouched.

## Evidence

Measured against a live store: of 198 sessions in the report, **37** carried
a prompt body as their name. All 37 resolve to a clean label through the
shared resolver.

The new test seeds a session whose `name` is a prompt and whose `agent_name`
is set, then asserts the report returns the agent-role label. Reverting the
one line to the old expression makes it fail on the raw prompt.