### PR TITLE
fix(studio): report the store size against the threshold the backend already set

### DIFF
--- a/apps/studio/frontend/index.html
+++ b/apps/studio/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Lion Studio</title>
     <script>
       (function () {

--- a/apps/studio/frontend/src/components/shell/StatusFooter.test.tsx
+++ b/apps/studio/frontend/src/components/shell/StatusFooter.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * StatusFooter — the DB size reading.
+ *
+ * No @testing-library/react in this project; mounts via react-dom/client + act
+ * and stubs the api module, same pattern as NoDaemonGate.test.tsx.
+ *
+ * The backend decides whether the store is over its threshold and says so in
+ * `size_alert`. The footer rendered the size in the same muted grey either
+ * way, so a store many times over its limit was indistinguishable from a
+ * healthy one. Both arms are here: without the under-threshold arm, an
+ * implementation that always paints the warning passes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import StatusFooter from "./StatusFooter";
+import enMessages from "@/messages/en.json";
+
+const getStats = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  resolveApiBase: () => "http://127.0.0.1:8765",
+  getStats: (...args: unknown[]) => getStats(...args),
+}));
+
+const GB = 1024 * 1024 * 1024;
+const MB = 1024 * 1024;
+
+function statsWith(db: Record<string, unknown>) {
+  return {
+    playbooks: 0,
+    agents: 0,
+    runs: 0,
+    shows: 0,
+    skills: 0,
+    plugins: 0,
+    db: {
+      path: ".lionagi/state.db",
+      wal_bytes: 0,
+      connections_active: 0,
+      last_checkpoint_at: null,
+      ...db,
+    },
+  };
+}
+
+async function mountFooter(container: HTMLElement): Promise<Root> {
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <StatusFooter />
+      </IntlProvider>,
+    );
+  });
+  // let the health probe and the stats read settle
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return root;
+}
+
+/** The span carrying the DB reading, found by its rendered text. */
+function dbSpan(container: HTMLElement): HTMLElement {
+  const match = Array.from(container.querySelectorAll("span")).find((el) =>
+    /^DB\s/.test(el.textContent ?? ""),
+  );
+  if (!match) throw new Error("no DB reading rendered");
+  return match as HTMLElement;
+}
+
+describe("StatusFooter DB reading", () => {
+  let container: HTMLElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: true, status: 200 } as Response)),
+    );
+  });
+
+  afterEach(async () => {
+    if (root) await act(async () => root!.unmount());
+    root = null;
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("marks the reading when the backend says the store is over its threshold", async () => {
+    getStats.mockResolvedValue(
+      statsWith({
+        size_bytes: 8.47 * GB,
+        size_alert: true,
+        size_threshold_bytes: 500 * MB,
+      }),
+    );
+    root = await mountFooter(container);
+
+    const span = dbSpan(container);
+    expect(span.className).toContain("text-status-warning");
+    // Numbers only, so the reason survives in every locale.
+    expect(span.getAttribute("title")).toBe("8.5 GB / 500.0 MB");
+  });
+
+  it("leaves the reading unmarked when the store is under its threshold", async () => {
+    getStats.mockResolvedValue(
+      statsWith({
+        size_bytes: 120 * MB,
+        size_alert: false,
+        size_threshold_bytes: 500 * MB,
+      }),
+    );
+    root = await mountFooter(container);
+
+    const span = dbSpan(container);
+    expect(span.textContent).toContain("120.0 MB");
+    expect(span.className).not.toContain("text-status-warning");
+    expect(span.getAttribute("title")).toBeNull();
+  });
+
+  it("leaves the reading unmarked when the backend sends no verdict at all", async () => {
+    // An older daemon, or any response without the field. The footer must not
+    // invent a verdict by re-deriving the threshold on its own.
+    getStats.mockResolvedValue(statsWith({ size_bytes: 8.47 * GB }));
+    root = await mountFooter(container);
+
+    const span = dbSpan(container);
+    expect(span.className).not.toContain("text-status-warning");
+    expect(span.getAttribute("title")).toBeNull();
+  });
+});

--- a/apps/studio/frontend/src/components/shell/StatusFooter.tsx
+++ b/apps/studio/frontend/src/components/shell/StatusFooter.tsx
@@ -45,6 +45,10 @@ export default function StatusFooter() {
   }, [apiBase]);
 
   const dbSize = stats?.db?.size_bytes;
+  // The backend already decides this against one threshold; re-deriving it
+  // here would be a second opinion that can disagree with /api/stats.
+  const dbOverThreshold = stats?.db?.size_alert === true;
+  const dbThreshold = stats?.db?.size_threshold_bytes;
   const version = import.meta.env.VITE_APP_VERSION as string | undefined;
 
   return (
@@ -72,7 +76,16 @@ export default function StatusFooter() {
       {dbSize !== undefined ? (
         <>
           <span className="text-edge-strong">·</span>
-          <span className="tabular-nums">
+          <span
+            className={dbOverThreshold ? "tabular-nums text-status-warning" : "tabular-nums"}
+            // Numbers only, so the reason for the colour survives without a
+            // translated string in all sixteen locales.
+            title={
+              dbOverThreshold && dbThreshold !== undefined
+                ? `${formatBytes(dbSize)} / ${formatBytes(dbThreshold)}`
+                : undefined
+            }
+          >
             {t("footer.db")} {formatBytes(dbSize)}
           </span>
         </>

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1821,6 +1821,8 @@ export interface AdminDoctorResponse {
   db_health: {
     size_bytes: number;
     wal_bytes: number;
+    size_alert?: boolean;
+    size_threshold_bytes?: number;
   };
   diagnostic_run_at: string;
 }
@@ -2001,6 +2003,10 @@ export interface DbStats {
   path: string;
   size_bytes: number;
   wal_bytes: number;
+  /** True once size_bytes reaches size_threshold_bytes. Computed by the
+   * backend so every surface applies one threshold rather than its own. */
+  size_alert?: boolean;
+  size_threshold_bytes?: number;
   connections_active: number;
   last_checkpoint_at: string | null;
   tables?: Record<string, number>;

--- a/apps/studio/frontend/src/routes/system.tsx
+++ b/apps/studio/frontend/src/routes/system.tsx
@@ -75,7 +75,20 @@ function HealthSection({ doctor }: { doctor: AdminDoctorResponse }) {
       </SectionHead>
       <div className="flex flex-wrap gap-x-6 gap-y-1 text-body text-content-secondary">
         <span>
-          <span className="font-mono text-content-primary">{formatBytes(h.size_bytes)}</span>{" "}
+          <span
+            className={
+              h.size_alert === true
+                ? "font-mono text-status-warning"
+                : "font-mono text-content-primary"
+            }
+            title={
+              h.size_alert === true && h.size_threshold_bytes !== undefined
+                ? `${formatBytes(h.size_bytes)} / ${formatBytes(h.size_threshold_bytes)}`
+                : undefined
+            }
+          >
+            {formatBytes(h.size_bytes)}
+          </span>{" "}
           {t("health.stateDbSuffix")}
         </span>
         <span>

--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -76,12 +76,24 @@ class TransitionBody(BaseModel):
     actor: str = Field(default="admin", max_length=64)
 
 
-def db_health() -> dict[str, int]:
+def db_health() -> dict[str, int | bool]:
+    from .db_maintenance import get_db_size_alert
+
     db_path = Path(store_path())
     size_bytes = db_path.stat().st_size if db_path.exists() else 0
     wal_path = db_path.parent / (db_path.name + "-wal")
     wal_bytes = wal_path.stat().st_size if wal_path.exists() else 0
-    return {"size_bytes": size_bytes, "wal_bytes": wal_bytes}
+    # The same threshold /api/stats applies, read through the same helper. A
+    # health payload that reports the size but not whether it is over the
+    # limit leaves every reader to re-derive the limit, and the health view
+    # that consumed this had no way to say "unhealthy" at all.
+    size_alert, size_threshold_bytes = get_db_size_alert(size_bytes)
+    return {
+        "size_bytes": size_bytes,
+        "wal_bytes": wal_bytes,
+        "size_alert": size_alert,
+        "size_threshold_bytes": size_threshold_bytes,
+    }
 
 
 # How long the store probe waits before calling the store slow. Well under any

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -116,14 +116,32 @@ def test_db_health_reports_only_numbers_it_can_actually_measure(tmp_path, monkey
     Pinning the whole key set, not just the absence of that one name, is
     deliberate: the defect was a duplicate, and the next duplicate will have a
     different name.
+
+    ``size_alert`` and ``size_threshold_bytes`` were added later and are named
+    here on purpose. The threshold is configuration, not a measurement, and it
+    is not derivable from anything else in the payload, so without it a reader
+    cannot say whether the store is over the limit at all. ``size_alert`` is
+    arithmetically derivable once the threshold is present, which is what makes
+    it worth stating anyway: the comparison is a policy the producer owns, and a
+    reader that re-implements it can drift from the server's own predicate
+    silently, in whichever direction the mistake runs. Both come from the same
+    helper ``/api/stats`` uses, so the two surfaces agree by construction rather
+    than by two consumers happening to compute the same thing.
+
+    The rule this test enforces is unchanged: no field that merely restates
+    another. A derived field earns its place only by carrying a decision, and
+    the reason has to be written down here.
     """
     from lionagi.studio.services.admin import db_health
 
     health = db_health()
 
-    assert set(health) == {"size_bytes", "wal_bytes"}, (
-        f"db_health grew a field; if it reports a real measurement, say so here: {health}"
-    )
+    assert set(health) == {
+        "size_bytes",
+        "wal_bytes",
+        "size_alert",
+        "size_threshold_bytes",
+    }, f"db_health grew a field; if it reports a real measurement, say so here: {health}"
 
 
 def test_admin_prune_selected_sessions(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_stats_db_health.py
+++ b/tests/apps_studio_server/test_stats_db_health.py
@@ -200,3 +200,59 @@ def test_invocation_list_bad_metadata_becomes_none(tmp_path, monkeypatch):
     assert matching[0]["node_metadata"] is None, (
         "parse failure on node_metadata must yield None in list endpoint"
     )
+
+
+# ---------------------------------------------------------------------------
+# the size alert is one decision, and both health surfaces report it
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_and_stats_agree_on_the_size_alert(tmp_path, monkeypatch):
+    """Both health surfaces must read the same threshold decision.
+
+    /api/stats already decided this. /api/admin/doctor reported the raw size
+    and nothing else, so the only way for a reader of the doctor payload to
+    know whether the store was over its limit was to re-derive the limit --
+    which is how a health view ends up unable to say "unhealthy" at all.
+    Asserting agreement rather than a fixed number is what keeps a second
+    copy of the threshold from being introduced later.
+    """
+    import lionagi.studio.config as studio_config
+
+    db_path = tmp_path / "state.db"
+    _run(_seed_two_sessions(db_path))
+    monkeypatch.setattr(studio_config, "DB_SIZE_ALERT_BYTES", 1)
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    stats_db = client.get("/api/stats").json()["db"]
+    doctor_db = client.get("/api/admin/doctor").json()["db_health"]
+
+    assert stats_db["size_alert"] is True
+    assert doctor_db["size_alert"] is True, (
+        "doctor must report the alert /api/stats already raised for the same store"
+    )
+    assert doctor_db["size_threshold_bytes"] == stats_db["size_threshold_bytes"]
+    assert doctor_db["size_bytes"] == stats_db["size_bytes"]
+
+
+def test_doctor_size_alert_is_false_below_the_threshold(tmp_path, monkeypatch):
+    """The other arm: a store under its limit must not be flagged.
+
+    Without this, an implementation that hardcodes the alert to True passes
+    the agreement test above -- and a hardcoded health signal is the exact
+    defect this pair exists to prevent.
+    """
+    import lionagi.studio.config as studio_config
+
+    db_path = tmp_path / "state.db"
+    _run(_seed_two_sessions(db_path))
+    monkeypatch.setattr(studio_config, "DB_SIZE_ALERT_BYTES", 10**12)
+    client = _make_client(tmp_path, monkeypatch, db_path)
+
+    stats_db = client.get("/api/stats").json()["db"]
+    doctor_db = client.get("/api/admin/doctor").json()["db_health"]
+
+    assert doctor_db["size_bytes"] > 0, "the store must be non-empty for this to mean anything"
+    assert stats_db["size_alert"] is False
+    assert doctor_db["size_alert"] is False
+    assert doctor_db["size_threshold_bytes"] == 10**12


### PR DESCRIPTION
## The defect

`/api/stats` decides whether the state DB is over its size threshold and returns that decision as `size_alert`. Nothing in the frontend referenced it, and the admin doctor payload did not carry it at all — `db_health()` returned the raw size and WAL size only.

The result is that both places showing the size render it in the same muted grey no matter what it says. A store many times over its limit is indistinguishable from a healthy one, and a reader wanting to know had to re-derive the limit for themselves.

Measured on one store while writing this:

| | |
|---|---|
| `size_bytes` | 9,091,936,256 (8.47 GiB) |
| `size_threshold_bytes` | 524,288,000 (500 MB) |
| `size_alert` | `true` |
| references to `size_alert` in the frontend | 0 |

## The fix

`db_health()` reports the alert through `get_db_size_alert`, the same helper `/api/stats` already calls, so the two endpoints cannot drift onto different thresholds. The footer and the System page mark the figure when the backend says it is over.

The reason for the marking rides in a `title` built from the two figures (`8.5 GB / 500.0 MB`). Numbers only, so it needs no new string in any of the sixteen locales, all of which are currently at exact key parity.

## On the tests

The backend pair asserts the two health surfaces **agree** rather than pinning a fixed number — pinning a number is what allows a second copy of the threshold to be introduced later without anything noticing.

The under-threshold arm is load-bearing for a specific reason: an implementation that hardcodes the alert to `true` passes the agreement test on its own, and a hardcoded health signal is the defect this is meant to prevent.

Verified by reverting `db_health()` to its previous return: exactly the two new tests fail and the other six stay green.

The footer tests cover three arms — over threshold, under threshold, and a response carrying no verdict at all (an older daemon). The last one exists so the frontend cannot start re-deriving the threshold on its own. Mutation-checked the same way: removing the conditional reddens the over-threshold arm and leaves the two absence arms green, which is what makes those two informative rather than vacuous.

## Scope

Deliberately not addressed: the System page's health badge is a literal, not derived from the payload. It sits in the section header and only renders once the doctor request has succeeded, so it reads as a reachability indicator that is vacuously true whenever visible. Making it a real health verdict is a design question about what that section claims, not a styling fix, and it would need new strings in all sixteen locales.

Gates: 1589 frontend tests across 72 files, 8 in the touched python suite, typecheck and eslint clean.

## Also here: the favicon the app already ships

Same shape as the above, which is why it rides along rather than getting its own PR. `public/favicon.svg` is in the repo and is copied into the build, and nothing ever referenced it — the string "favicon" appears nowhere in `src`, `index.html`, the vite config, or `package.json`. So every browser falls back to `/favicon.ico`, gets nothing, and renders a blank generic tab icon next to a finished asset sitting in the output directory.

One line in `index.html`. Verified against the build rather than assumed: `dist/index.html` carries the link and `dist/favicon.svg` is present at 779 bytes.
