### PR TITLE
perf(studio): stop re-walking the same artifact tree once per session

### DIFF
--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import subprocess
 import time
@@ -311,11 +312,76 @@ def _artifacts_path(row: Any) -> Path | None:
 # unreachable from here by construction.
 _RUNTIME_LOCK_NAMES: frozenset[str] = frozenset({"job.lock", "finalize.lock"})
 
+# Directory names never on the path to a run directory, and routinely holding
+# more files than everything else in the tree combined.
+#
+# The cost of skipping them is what makes matching by name affordable. Matching
+# by suffix was fast for the wrong reason: a repository root almost always has a
+# dependency lockfile near the top, so the search hit one immediately and
+# stopped. Searching for names we write means the common answer is "not here",
+# and reaching that answer costs a complete traversal. Measured on one machine,
+# an unpruned walk of a projects directory took 100 seconds, against three
+# milliseconds for the suffix match it replaced.
+_UNSEARCHED_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        ".venv",
+        "venv",
+        "site-packages",
+        "target",
+        "dist",
+        "build",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".next",
+        ".turbo",
+        ".gradle",
+        "DerivedData",
+    }
+)
 
-def _find_stale_lock(root: Path, *, cutoff: float) -> Path | None:
+
+def _find_stale_lock(
+    root: Path,
+    *,
+    cutoff: float,
+    cache: dict[tuple[str, float], Path | None] | None = None,
+) -> Path | None:
+    """Find a stale runtime lock under *root*, or None.
+
+    Pass *cache* to share results across one scan. Sessions repeat their
+    artifact roots heavily -- one root accounted for 152 of 500 recent sessions
+    on one machine -- and without a cache each of those repeats re-walks the
+    same tree to reach the same answer. The cache is deliberately caller-owned
+    and per-scan rather than module-level: a scan is a snapshot taken at one
+    ``cutoff``, so results are consistent within it, while a process-lifetime
+    cache would keep answering with a filesystem that has since moved on.
+    """
+    key = (str(root), cutoff)
+    if cache is not None and key in cache:
+        return cache[key]
+    found = _walk_for_stale_lock(root, cutoff=cutoff)
+    if cache is not None:
+        cache[key] = found
+    return found
+
+
+def _walk_for_stale_lock(root: Path, *, cutoff: float) -> Path | None:
     try:
-        for name in _RUNTIME_LOCK_NAMES:
-            for lock in root.glob(f"**/{name}"):
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            # Prune in place, which is what stops os.walk descending. Assigning
+            # a new list to the name instead would be a no-op it cannot report.
+            dirnames[:] = [d for d in dirnames if d not in _UNSEARCHED_DIRS]
+            # One traversal answers for every name. A pass per name walks the
+            # whole tree once per name, and the miss case walks all of them.
+            for name in _RUNTIME_LOCK_NAMES & set(filenames):
+                lock = Path(dirpath) / name
                 try:
                     if lock.stat().st_mtime < cutoff:
                         return lock
@@ -332,6 +398,7 @@ def _classify_phantom(
     now: float,
     stale_seconds: float,
     ps_snapshot: str | None = None,
+    lock_cache: dict[tuple[str, float], Path | None] | None = None,
 ) -> PhantomReason | None:
     ap = _artifacts_path(row)
     node_metadata = row["node_metadata"] if "node_metadata" in row.keys() else None
@@ -346,7 +413,11 @@ def _classify_phantom(
         return None
     if ap and not ap.exists():
         return "missing_artifacts"
-    if ap and ap.exists() and _find_stale_lock(ap, cutoff=now - stale_seconds) is not None:
+    if (
+        ap
+        and ap.exists()
+        and _find_stale_lock(ap, cutoff=now - stale_seconds, cache=lock_cache) is not None
+    ):
         return "stale_lock"
     return "process_dead"
 
@@ -370,10 +441,19 @@ async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, A
         )
         rows = await cur.fetchall()
     snapshot: str | None = None
+    # One scan, one answer per artifact root: sessions repeat their roots
+    # heavily, and the walk is the expensive part.
+    lock_cache: dict[tuple[str, float], Path | None] = {}
     for row in rows:
         if snapshot is None:
             snapshot = _ps_snapshot()
-        reason = _classify_phantom(row, now=now, stale_seconds=stale_seconds, ps_snapshot=snapshot)
+        reason = _classify_phantom(
+            row,
+            now=now,
+            stale_seconds=stale_seconds,
+            ps_snapshot=snapshot,
+            lock_cache=lock_cache,
+        )
         if reason is not None:
             phantoms.append(
                 {
@@ -490,6 +570,9 @@ async def health_report() -> dict[str, Any]:
     by_health: Counter[str] = Counter()
     unhealthy: list[dict[str, Any]] = []
     snapshot: str | None = None
+    # One scan, one answer per artifact root: sessions repeat their roots
+    # heavily, and the walk is the expensive part.
+    lock_cache: dict[tuple[str, float], Path | None] = {}
 
     for row in rows:
         sess = {k: row[k] for k in row.keys()}
@@ -500,7 +583,9 @@ async def health_report() -> dict[str, Any]:
         has_stale_locks = False
         if artifacts is not None and artifacts.exists():
             cutoff = now - 3600
-            has_stale_locks = _find_stale_lock(artifacts, cutoff=cutoff) is not None
+            has_stale_locks = (
+                _find_stale_lock(artifacts, cutoff=cutoff, cache=lock_cache) is not None
+            )
 
         if status == "running":
             if snapshot is None:
@@ -639,6 +724,9 @@ async def transition_sessions(
     skipped: list[dict[str, str]] = []
     now = time.time()
     txn_snapshot: str | None = None
+    # One scan, one answer per artifact root: sessions repeat their roots
+    # heavily, and the walk is the expensive part.
+    lock_cache: dict[tuple[str, float], Path | None] = {}
 
     async with StateDB() as db:
         for sid in session_ids:
@@ -656,7 +744,7 @@ async def transition_sessions(
             artifacts = _artifacts_path(current)
             has_artifacts = artifacts is not None and artifacts.exists()
             has_stale_locks = (
-                _find_stale_lock(artifacts, cutoff=now - 3600) is not None
+                _find_stale_lock(artifacts, cutoff=now - 3600, cache=lock_cache) is not None
                 if artifacts is not None and artifacts.exists()
                 else False
             )

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -910,3 +910,77 @@ def test_admin_health_prefers_the_play_name_like_the_session_list_does(tmp_path,
         f"health report says {health_name!r}, session list says {list_name!r}"
     )
     assert health_name == "nightly-enrichment"
+
+
+def test_a_lock_inside_a_dependency_tree_is_not_searched(tmp_path):
+    """A runtime lock buried in ``node_modules`` must not be found, and the same
+    lock outside it must be.
+
+    Both halves are the test. Only the pair separates "the walk skips dependency
+    trees" from "the walk found nothing here anyway", and it is the second half
+    that fails if the skip list is ever widened until it excludes real ground.
+
+    The skip list is what makes matching by name affordable. Matching by suffix
+    was fast for the wrong reason: a repository root nearly always has a
+    dependency lockfile near the top, so the search hit one at once and stopped.
+    Searching for the names we write means the usual answer is "not here", and
+    reaching it costs a full traversal -- measured at 100 seconds for one
+    projects directory, against 3 milliseconds for the suffix match. Nothing
+    lionagi writes puts a run directory inside ``node_modules``, so the subtree
+    is cost with no evidence in it.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    buried = tmp_path / "repo" / "node_modules" / "pkg"
+    buried.mkdir(parents=True)
+    _aged(buried / "job.lock", 7200)
+
+    now = time.time()
+    assert (
+        admin_svc._find_stale_lock(tmp_path / "repo", cutoff=now - 3600) is None
+    ), "a lock inside node_modules was searched; the subtree should be skipped"
+
+    reachable = tmp_path / "repo" / "run-1"
+    reachable.mkdir()
+    _aged(reachable / "job.lock", 7200)
+    found = admin_svc._find_stale_lock(tmp_path / "repo", cutoff=now - 3600)
+    assert found is not None and found.name == "job.lock", (
+        "the skip list swallowed a lock outside any skipped directory"
+    )
+
+
+def test_one_scan_answers_once_per_artifact_root(tmp_path):
+    """Within a single scan, a root already answered is not walked again.
+
+    Proven by changing the filesystem between the two calls: a cache that is
+    genuinely consulted keeps returning the first answer, while a fresh cache
+    sees the new lock. Asserting only that two calls agree would pass whether or
+    not the cache is read, since without it both walks reach the same tree.
+
+    This is the difference that matters at scale rather than a micro-optimisation.
+    Sessions repeat their artifact roots heavily -- one root accounted for 152 of
+    500 recent sessions on one machine -- and uncached, that root is re-walked
+    152 times in one pass to produce one answer.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    root = tmp_path / "repo"
+    (root / "run-1").mkdir(parents=True)
+    now = time.time()
+    cutoff = now - 3600
+
+    cache: dict[tuple[str, float], Path | None] = {}
+    assert admin_svc._find_stale_lock(root, cutoff=cutoff, cache=cache) is None
+    assert len(cache) == 1, "the answer was not recorded, so the next call re-walks"
+
+    _aged(root / "run-1" / "job.lock", 7200)
+
+    assert admin_svc._find_stale_lock(root, cutoff=cutoff, cache=cache) is None, (
+        "the cache was not consulted: the tree was walked a second time"
+    )
+    assert (
+        admin_svc._find_stale_lock(root, cutoff=cutoff, cache={}) is not None
+    ), "a fresh cache must see the lock, or the first assertion proves nothing"
+    assert (
+        admin_svc._find_stale_lock(root, cutoff=cutoff) is not None
+    ), "omitting the cache must always walk"


### PR DESCRIPTION
## What

The session-health scan looks for lock files under each session's artifact root. Matching those files by the names lionagi writes (`job.lock`, `finalize.lock`) is correct, and it is also far more expensive than the suffix match it replaced — for a reason that is easy to miss.

A `**/*.lock` search on a repository root almost always hit a dependency lockfile near the top and stopped immediately. It was fast because it was wrong. Searching for the names we actually write means the usual answer is "not present", and reaching that answer costs a full traversal — repeated once per name.

## Measured

Twelve artifact roots taken from recent sessions on one machine:

| | total |
|---|---|
| as shipped | 156.0s |
| walk once, skip dependency and build trees | 27.1s |

The worst single root, a directory holding many checkouts, went from 100.5s to 13.8s.

Then the repetition, which is the larger effect. The 500 most recently updated sessions cover 227 distinct artifact roots, and one root accounts for **153** of them. At 3.7s per walk that single root costs 569 seconds per scan to produce one answer.

| over those 500 sessions | total |
|---|---|
| pruned, no cache | 673.2s |
| pruned, one answer per root per scan | 45.7s |

## How

- One traversal answers for every lock name, instead of one traversal per name.
- Skip subtrees that cannot contain a run directory: version-control metadata, dependency installs, build and cache output.
- An optional caller-owned cache, shared across one scan. It is deliberately not process-lifetime: a scan is a snapshot at a single cutoff, so one answer per root is consistent within it, whereas a longer-lived cache would answer from a filesystem that had moved on.

Default is unchanged for any caller that does not pass a cache.

## Tests

Two new cases, each written so it fails without the change:

- a stale `job.lock` inside `node_modules` must not be found, **and** the same lock outside it must be. Only the pair distinguishes "the walk skips dependency trees" from "there was nothing to find"; the second half is what fails if the skip list is ever widened over real ground.
- a root already answered keeps its answer when a lock appears beneath it mid-scan, while a fresh cache sees the new lock. Asserting only that two calls agree would pass whether or not the cache is ever read.

32 pass. Mutation: emptying the skip set reddens the first and only the first; making the cache write-only reddens the second and only the second. Both restored byte-identical, suite green after each.