### PR TITLE
fix(orchestrate): attribute a worker build failure, and record a python notify adapter's

### DIFF
--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import traceback
 import uuid
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -277,4 +278,18 @@ async def deliver_flow_notify_now(
     except Exception:  # noqa: BLE001 -- a notifier failure must never affect the run
         logger.warning(
             "direct-path notify.on_terminal delivery failed for run %s", run.run_id, exc_info=True
+        )
+        # The exec adapter records every failure mode onto the run -- timeout,
+        # spawn failure, nonzero exit -- because outcome recording is threaded
+        # into it. A python adapter is handed back as the imported callable
+        # with nothing wrapping it, so a raise reached only the log line above
+        # and left nothing to query. That made the durability of "did my
+        # terminal notification go out?" depend on which adapter type happened
+        # to be configured, which is not a distinction any caller can be
+        # expected to know about. The traceback goes to the same owner-only
+        # file the exec adapter's stderr does, and for the same reason: it is
+        # free text that can carry a credential, so it is referenced by path
+        # and never placed in the outcome record itself.
+        record_notify_outcome_to_run(
+            run, ok=False, exit_code=None, stderr_text=traceback.format_exc()
         )

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -63,7 +63,7 @@ __all__ = (
     "resolve_worker_spec",
     "setup_orchestration",
     "build_worker_branch",
-    "WorkerBuildFailed",
+    "WorkerBuildError",
     "attribute_worker_build_failure",
     "make_help_coordinator",
     "TeamLifecycleCoordinator",
@@ -814,7 +814,7 @@ def worker_is_cli(
     return bool(getattr(build_imodel_from_spec(w_model), "is_cli", False))
 
 
-class WorkerBuildFailed(RuntimeError):
+class WorkerBuildError(RuntimeError):
     """One worker could not be built, naming which one.
 
     Building a worker resolves a model spec, a profile, an artifact directory
@@ -827,14 +827,11 @@ class WorkerBuildFailed(RuntimeError):
         self.agent_id = agent_id
         self.role = role
         super().__init__(
-            f"worker {agent_id!r} (role {role!r}) failed to build: "
-            f"{type(cause).__name__}: {cause}"
+            f"worker {agent_id!r} (role {role!r}) failed to build: {type(cause).__name__}: {cause}"
         )
 
 
-def attribute_worker_build_failure(
-    exc: BaseException, *, agent_id: str, role: str
-) -> None:
+def attribute_worker_build_failure(exc: BaseException, *, agent_id: str, role: str) -> None:
     """Raise an attributed error for a worker build failure, or return.
 
     Returns without raising when the exception already carries a terminal
@@ -848,7 +845,7 @@ def attribute_worker_build_failure(
 
     if classify_exception(exc) != "failed":
         return
-    raise WorkerBuildFailed(agent_id=agent_id, role=role, cause=exc) from exc
+    raise WorkerBuildError(agent_id=agent_id, role=role, cause=exc) from exc
 
 
 async def build_worker_branch(

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -63,6 +63,8 @@ __all__ = (
     "resolve_worker_spec",
     "setup_orchestration",
     "build_worker_branch",
+    "WorkerBuildFailed",
+    "attribute_worker_build_failure",
     "make_help_coordinator",
     "TeamLifecycleCoordinator",
     "make_team_lifecycle_coordinator",
@@ -810,6 +812,43 @@ def worker_is_cli(
     the per-worker build loop."""
     w_model, _, _ = _resolve_worker_model_spec(env, role, model_override)
     return bool(getattr(build_imodel_from_spec(w_model), "is_cli", False))
+
+
+class WorkerBuildFailed(RuntimeError):
+    """One worker could not be built, naming which one.
+
+    Building a worker resolves a model spec, a profile, an artifact directory
+    and any tool handoff, and any of those can fail for reasons specific to a
+    single role. Without attribution the whole orchestration ends on a generic
+    error and the operator is left to work out which of N workers it was about.
+    """
+
+    def __init__(self, *, agent_id: str, role: str, cause: BaseException) -> None:
+        self.agent_id = agent_id
+        self.role = role
+        super().__init__(
+            f"worker {agent_id!r} (role {role!r}) failed to build: "
+            f"{type(cause).__name__}: {cause}"
+        )
+
+
+def attribute_worker_build_failure(
+    exc: BaseException, *, agent_id: str, role: str
+) -> None:
+    """Raise an attributed error for a worker build failure, or return.
+
+    Returns without raising when the exception already carries a terminal
+    meaning of its own -- cancellation, timeout, interrupt -- so the caller's
+    bare ``raise`` propagates it untouched. Wrapping those would re-label them:
+    terminal status is decided by exception type, so an attributed cancellation
+    would be recorded as a failure, which is a worse trade than losing the
+    worker's name on a run that was deliberately stopped.
+    """
+    from .._util import classify_exception
+
+    if classify_exception(exc) != "failed":
+        return
+    raise WorkerBuildFailed(agent_id=agent_id, role=role, cause=exc) from exc
 
 
 async def build_worker_branch(

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -29,8 +29,8 @@ from ._common import (
 from ._notify import register_flow_notify_scope, unregister_flow_notify_scope
 from ._orchestration import (
     OrchestrationEnv,
-    available_roles,
     attribute_worker_build_failure,
+    available_roles,
     build_worker_branch,
     finalize_orchestration,
     parse_orchestrator_provider,

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -30,6 +30,7 @@ from ._notify import register_flow_notify_scope, unregister_flow_notify_scope
 from ._orchestration import (
     OrchestrationEnv,
     available_roles,
+    attribute_worker_build_failure,
     build_worker_branch,
     finalize_orchestration,
     parse_orchestrator_provider,
@@ -306,14 +307,18 @@ async def _run_fanout_inner(
     for i, ta in enumerate(assignments):
         model_override = pool[i % len(pool)] if pool else None
         wname = worker_names[i]
-        w_branch, w_model, _, messenger_bound = await build_worker_branch(
-            env,
-            agent_id=wname,
-            role=ta.assignee,
-            model_override=model_override,
-            explicit_name=wname,
-            modes=ta.modes or None,
-        )
+        try:
+            w_branch, w_model, _, messenger_bound = await build_worker_branch(
+                env,
+                agent_id=wname,
+                role=ta.assignee,
+                model_override=model_override,
+                explicit_name=wname,
+                modes=ta.modes or None,
+            )
+        except BaseException as exc:
+            attribute_worker_build_failure(exc, agent_id=wname, role=ta.assignee)
+            raise
         ctx = [{"overall_task": prompt}]
         # Attached-team history (if any) rides in operation context, not the
         # system prompt — see team_history_context's docstring for why.

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -45,8 +45,8 @@ from ._notify import register_flow_notify_scope, unregister_flow_notify_scope
 from ._orchestration import (
     EFFORT_MAP,
     OrchestrationEnv,
-    available_roles,
     attribute_worker_build_failure,
+    available_roles,
     build_worker_branch,
     finalize_orchestration,
     make_help_coordinator,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -46,6 +46,7 @@ from ._orchestration import (
     EFFORT_MAP,
     OrchestrationEnv,
     available_roles,
+    attribute_worker_build_failure,
     build_worker_branch,
     finalize_orchestration,
     make_help_coordinator,
@@ -744,16 +745,20 @@ async def _build_dag(
         env.expect_worker(agent_id)
 
     for i, ta in enumerate(assignments):
-        w_branch, w_model, w_profile, messenger_bound = await build_worker_branch(
-            env,
-            agent_id=agent_ids[i],
-            role=ta.assignee,
-            model_override=pool[i % len(pool)] if pool else None,
-            explicit_name=agent_ids[i],
-            grant_spawn=_may_spawn(ta.assignee),
-            spawn_assignees=spawn_assignees,
-            modes=ta.modes or None,
-        )
+        try:
+            w_branch, w_model, w_profile, messenger_bound = await build_worker_branch(
+                env,
+                agent_id=agent_ids[i],
+                role=ta.assignee,
+                model_override=pool[i % len(pool)] if pool else None,
+                explicit_name=agent_ids[i],
+                grant_spawn=_may_spawn(ta.assignee),
+                spawn_assignees=spawn_assignees,
+                modes=ta.modes or None,
+            )
+        except BaseException as exc:
+            attribute_worker_build_failure(exc, agent_id=agent_ids[i], role=ta.assignee)
+            raise
         worker_branches[agent_ids[i]] = w_branch
         worker_messenger_bound[agent_ids[i]] = messenger_bound
         worker_models.append(w_model)

--- a/tests/cli/orchestrate/test_notify_python_adapter_outcome.py
+++ b/tests/cli/orchestrate/test_notify_python_adapter_outcome.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Whether a terminal notification went out must not depend on adapter type.
+
+The exec adapter records every failure mode it has -- timeout, spawn failure,
+nonzero exit -- onto the run, so a caller can ask afterwards whether delivery
+succeeded. A python adapter is handed back as the imported callable with no
+outcome recording wrapped around it, so when it raised, the only trace was a log
+line. A caller cannot reasonably be expected to know that the answer is
+queryable for one spec shape and not the other.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from lionagi.cli._runs import RunDir
+from lionagi.cli.orchestrate._notify import deliver_flow_notify_now
+
+_ADAPTER_MODULE = "_lionagi_test_notify_adapter"
+
+
+def _install_adapter(monkeypatch: pytest.MonkeyPatch, fn) -> dict:
+    """Register an importable python adapter and return its resolver mapping."""
+    mod = types.ModuleType(_ADAPTER_MODULE)
+    mod.adapter = fn
+    monkeypatch.setitem(sys.modules, _ADAPTER_MODULE, mod)
+    # The mapping shape is what selects a python adapter. A bare string is
+    # always an exec command, so passing one here would exercise the exec path
+    # and pass for a reason that has nothing to do with this behaviour.
+    return {"adapter": {"kind": "python", "ref": f"{_ADAPTER_MODULE}:adapter"}}
+
+
+def _run(tmp_path: Path) -> RunDir:
+    state_root = tmp_path / "state"
+    artifact_root = state_root / "artifacts"
+    artifact_root.mkdir(parents=True)
+    return RunDir(run_id="r-1", state_root=state_root, artifact_root=artifact_root)
+
+
+async def _deliver(run: RunDir, override: dict) -> None:
+    await deliver_flow_notify_now(
+        override=override,
+        run=run,
+        entity_kind="session",
+        entity_id="sess-1",
+        invocation_id=None,
+        flow_kind="flow",
+        playbook=None,
+        save_dir=None,
+        cwd=str(run.state_root),
+        started_at=0.0,
+        terminal_status="completed",
+        reason_code="",
+        occurred_at=0.0,
+    )
+
+
+async def test_a_python_adapter_that_raises_leaves_a_durable_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A raise must be queryable afterwards, not only present in a log.
+
+    This is the arm that separates recording the failure from swallowing it: the
+    delivery already caught the exception and carried on, so nothing about the
+    run's success or its exit status changes either way. The only observable
+    difference is whether the outcome file exists.
+    """
+
+    def _boom(_envelope):
+        raise RuntimeError("adapter exploded")
+
+    run = _run(tmp_path)
+    await _deliver(run, _install_adapter(monkeypatch, _boom))
+
+    assert run.notify_outcome_path.exists(), (
+        "a python adapter raised and left nothing to query; "
+        "the same failure through an exec adapter is recorded"
+    )
+    outcome = json.loads(run.notify_outcome_path.read_text())
+    assert outcome["ok"] is False, outcome
+
+
+async def test_a_python_adapter_that_returns_is_not_recorded_as_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The success arm, without which the test above passes on a handler that
+    records failure unconditionally."""
+    delivered: list[object] = []
+
+    def _ok(envelope):
+        delivered.append(envelope)
+
+    run = _run(tmp_path)
+    await _deliver(run, _install_adapter(monkeypatch, _ok))
+
+    assert delivered, "the adapter was never called, so neither arm means anything"
+    if run.notify_outcome_path.exists():
+        outcome = json.loads(run.notify_outcome_path.read_text())
+        assert outcome["ok"] is not False, (
+            f"a successful python adapter was recorded as a failure: {outcome}"
+        )
+
+
+async def test_the_exception_text_is_not_placed_in_the_outcome_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Adapter output is free text that can carry a credential from any source,
+    so it is referenced by path and kept out of the record itself -- the same
+    rule the exec adapter's stderr already follows."""
+
+    def _boom(_envelope):
+        raise RuntimeError("token=sk-not-a-real-secret-abcdef")
+
+    run = _run(tmp_path)
+    await _deliver(run, _install_adapter(monkeypatch, _boom))
+
+    assert run.notify_outcome_path.exists()
+    raw = run.notify_outcome_path.read_text()
+    assert "sk-not-a-real-secret-abcdef" not in raw, (
+        f"exception text was written into the outcome record: {raw}"
+    )

--- a/tests/cli/orchestrate/test_worker_build_attribution.py
+++ b/tests/cli/orchestrate/test_worker_build_attribution.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""A worker that cannot be built says which worker it was.
+
+Building a worker resolves a model spec, a profile, an artifact directory and
+any tool handoff, and each of those can fail for reasons specific to one role.
+Unattributed, the whole orchestration ends on a generic error and the operator
+is left to work out which of N workers it was about.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lionagi._errors import TimeoutError as LionTimeoutError
+from lionagi.cli.orchestrate._orchestration import (
+    WorkerBuildFailed,
+    attribute_worker_build_failure,
+)
+
+
+def test_a_build_failure_names_the_worker_and_its_role():
+    original = RuntimeError("could not resolve model spec 'nope/nope'")
+
+    with pytest.raises(WorkerBuildFailed) as caught:
+        attribute_worker_build_failure(original, agent_id="researcher-2", role="assessor")
+
+    message = str(caught.value)
+    assert "researcher-2" in message, message
+    assert "assessor" in message, message
+    # The original survives as the cause rather than being replaced by a
+    # summary of itself: whatever it said about the underlying failure is the
+    # part that makes the attribution actionable.
+    assert caught.value.__cause__ is original
+    assert caught.value.agent_id == "researcher-2"
+    assert caught.value.role == "assessor"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        KeyboardInterrupt(),
+        LionTimeoutError("worker build exceeded its deadline"),
+        TimeoutError("worker build exceeded its deadline"),
+    ],
+    ids=["interrupt", "lion-timeout", "builtin-timeout"],
+)
+def test_an_exception_that_already_means_something_is_not_relabelled(exc):
+    """Attribution must not change what a run's terminal status will say.
+
+    Terminal status is decided by exception type, so wrapping a cancellation or
+    a timeout in a ``RuntimeError`` subclass would record a deliberately stopped
+    run as a failed one. This is the arm that separates "attributes build
+    failures" from "wraps everything it sees", and it is the only one that does:
+    the test above passes under either rule.
+
+    Returning without raising is the contract -- the caller re-raises the
+    original itself, so the exception reaching the classifier is untouched.
+    """
+    assert (
+        attribute_worker_build_failure(exc, agent_id="w-1", role="researcher") is None
+    ), f"{type(exc).__name__} was re-labelled; its terminal status would change"
+
+
+def test_the_guard_tracks_the_classifier_rather_than_a_second_list():
+    """Whatever the classifier treats as its own outcome is left alone.
+
+    Stated as a property rather than by example so the two cannot drift: if a
+    new exception type is ever given its own terminal status, this holds without
+    anyone remembering to add it here.
+    """
+    from lionagi.cli._util import classify_exception
+
+    for exc in (KeyboardInterrupt(), LionTimeoutError("x"), RuntimeError("x")):
+        relabelled = True
+        try:
+            attribute_worker_build_failure(exc, agent_id="w", role="r")
+            relabelled = False
+        except WorkerBuildFailed:
+            pass
+        assert relabelled == (classify_exception(exc) == "failed"), (
+            f"{type(exc).__name__} classifies as {classify_exception(exc)!r} "
+            f"but attribution {'wrapped' if relabelled else 'passed'} it"
+        )

--- a/tests/cli/orchestrate/test_worker_build_attribution.py
+++ b/tests/cli/orchestrate/test_worker_build_attribution.py
@@ -15,7 +15,7 @@ import pytest
 
 from lionagi._errors import TimeoutError as LionTimeoutError
 from lionagi.cli.orchestrate._orchestration import (
-    WorkerBuildFailed,
+    WorkerBuildError,
     attribute_worker_build_failure,
 )
 
@@ -23,7 +23,7 @@ from lionagi.cli.orchestrate._orchestration import (
 def test_a_build_failure_names_the_worker_and_its_role():
     original = RuntimeError("could not resolve model spec 'nope/nope'")
 
-    with pytest.raises(WorkerBuildFailed) as caught:
+    with pytest.raises(WorkerBuildError) as caught:
         attribute_worker_build_failure(original, agent_id="researcher-2", role="assessor")
 
     message = str(caught.value)
@@ -58,9 +58,9 @@ def test_an_exception_that_already_means_something_is_not_relabelled(exc):
     Returning without raising is the contract -- the caller re-raises the
     original itself, so the exception reaching the classifier is untouched.
     """
-    assert (
-        attribute_worker_build_failure(exc, agent_id="w-1", role="researcher") is None
-    ), f"{type(exc).__name__} was re-labelled; its terminal status would change"
+    assert attribute_worker_build_failure(exc, agent_id="w-1", role="researcher") is None, (
+        f"{type(exc).__name__} was re-labelled; its terminal status would change"
+    )
 
 
 def test_the_guard_tracks_the_classifier_rather_than_a_second_list():
@@ -77,7 +77,7 @@ def test_the_guard_tracks_the_classifier_rather_than_a_second_list():
         try:
             attribute_worker_build_failure(exc, agent_id="w", role="r")
             relabelled = False
-        except WorkerBuildFailed:
+        except WorkerBuildError:
             pass
         assert relabelled == (classify_exception(exc) == "failed"), (
             f"{type(exc).__name__} classifies as {classify_exception(exc)!r} "


### PR DESCRIPTION
Two independent fixes from external reports. Thanks to @ciprianmelian for both — the reports were specific enough to verify directly against source, and every claim in them held at current `main`.

Closes #2992. Closes #2993.

---

### #2992 — one worker's construction failure aborts the run without saying which worker

`build_worker_branch` has no exception handling and neither call site guarded it, so a single role's failure reached the generic terminal-status classifier and ended the orchestration on an error naming nothing.

Attribution now happens at both call sites, in flow and in fan-out.

One thing worth calling out that the report did not cover: attribution must **not** apply to every exception. Terminal status is decided by exception type, so wrapping a cancellation or timeout in a `RuntimeError` subclass would record a deliberately stopped run as a failed one. The guard asks the classifier itself whether an exception already carries an outcome of its own, so the two cannot drift if a type is ever given its own status. That property has its own test.

On the second half of the report: agreed that fail-fast may be the right default, and equally that it is not currently *chosen* — it is what falls out of an unguarded call. This change deliberately does not settle it, only makes the failure legible.

Attribution sits at the call sites rather than inside the builder because the builder is widely patched in tests, and moving the behaviour under its name would change what those patches stand in for.

### #2993 — a python notify adapter that raises leaves no durable record

Confirmed: `outcome_fn` is threaded only into the exec path, the python adapter is returned as the imported callable, and a raise reached only a `logger.warning`. Now recorded through the same path, so both adapter types leave the same trace. The traceback goes to the owner-only file the exec adapter's stderr already uses — free text can carry a credential from any source, so it is referenced by path and never placed in the outcome record. There is a test for that.

**A reachability correction, since it bounds what this actually fixes.** The only in-tree caller of this delivery path passes the command-line notify value, which is a string and therefore always resolves to an exec adapter. A python adapter reaches this path only through a mapping-shaped override. So this closes a genuine asymmetry rather than a failure reachable from the CLI today.

More usefully: the settings-configured registration path — which is how a python adapter is normally configured — calls `build_handler` with **no** outcome recorder at all, for *either* adapter type. That is a wider gap than the one reported and is not addressed here; it wants its own issue and its own decision about which registrations should be run-bound.

---

### Tests

New: 5 for build attribution, 3 for notify outcome. 39 pass across the touched suites, 86 across the suites that patch the worker builder.

Mutation, arms predicted before running and reconciled after:

- dropping the re-label guard reddens the three cancellation/timeout arms and the classifier-agreement property, and leaves the naming test green
- reverting the notify record to log-only reddens the raise arm and the redaction arm, and leaves the success arm green

Both restored byte-identical with the suites green afterwards.