### PR TITLE
fix(mirror): derive real session names instead of placeholders and banner leakage

### DIFF
--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -632,7 +632,10 @@ def _first_codex_prompt(records: list[dict[str, Any]]) -> str | None:
 
     for r in records:
         for m in messages_for_record(r, "probe", {}):
-            text = (m.content or {}).get("instruction") if isinstance(m.content, dict) else None
+            # The instruction text is a field on the content model. A mapping
+            # is what goes in to build one, never what comes back out, so
+            # reading this as a dict finds nothing for every rollout there is.
+            text = getattr(m.content, "instruction", None)
             if text:
                 return " ".join(str(text).split())
     return None

--- a/lionagi/state/session_naming.py
+++ b/lionagi/state/session_naming.py
@@ -30,7 +30,18 @@ _LEADING_BANNER_RE = re.compile(
 )
 _LEADING_MARKDOWN_RE = re.compile(r"^(?:-{2,}|#{1,6})\s*")
 _LEADING_LABEL_RE = re.compile(r"^[A-Za-z][A-Za-z0-9 _-]{0,24}:\s*")
-_STRIP_PATTERNS = (_LEADING_BANNER_RE, _LEADING_MARKDOWN_RE, _LEADING_LABEL_RE)
+# A prompt routed through a YAML document keeps the block-scalar indicator that
+# introduced it ("|" or "|-"), and it lands ahead of the banner, so it defeats
+# every pattern above and the whole banner survives into the display name.
+# Anchored to the indicator alone: a lone "|" is never the start of prose, but
+# text merely containing one often is.
+_LEADING_BLOCK_SCALAR_RE = re.compile(r"^\|[-+]?\s*")
+_STRIP_PATTERNS = (
+    _LEADING_BLOCK_SCALAR_RE,
+    _LEADING_BANNER_RE,
+    _LEADING_MARKDOWN_RE,
+    _LEADING_LABEL_RE,
+)
 _MAX_STRIP_PASSES = 6
 
 

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -1616,6 +1616,69 @@ async def test_orchestrated_rollout_is_never_mirrored(tmp_path):
         assert await _mirror_one_codex(db, path, state, {}) == 0
 
 
+async def test_an_imported_rollout_is_named_from_its_first_prompt(tmp_path):
+    """Every imported rollout was landing under the same generic name.
+
+    The name is derived by reading the instruction off a mirrored message, and
+    the message carries it on a content model rather than in a mapping. Asked
+    for a mapping key, the derivation found nothing for every rollout ever
+    imported and each one fell through to the fallback -- so a board of live
+    sessions showed one repeated title with nothing to tell them apart.
+
+    Driven through the whole mirror rather than the derivation alone: the two
+    halves each look right in isolation, and it is the seam between them that
+    carried the defect.
+    """
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-00000000000a"
+    path = tmp_path / "rollout-named.jsonl"
+    path.write_text(_codex_rollout_lines(uid, "Codex Desktop"))
+    state = _FileState(session_uid="")
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        assert await _mirror_one_codex(db, path, state, {}) > 0
+        session = await db.get_session(codex_sid(uid))
+
+    assert session is not None
+    assert session["name"] == "q", (
+        f"named {session['name']!r}; the first prompt never reached the name"
+    )
+
+
+async def test_a_rollout_with_no_real_prompt_keeps_the_generic_name(tmp_path):
+    """The arm that separates deriving the right name from deriving any name.
+
+    Codex opens some rollouts with an injected context block and no human turn
+    at all. Those carry nothing worth showing, so they are expected to keep the
+    fallback -- without this, a derivation that returned the injected block
+    would pass the test above while putting machine plumbing on the board.
+    """
+    import json as _json
+
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+
+    uid = "0199bbbb-0000-0000-0000-00000000000b"
+    lines = _codex_rollout_lines(uid, "Codex Desktop").splitlines()
+    injected = _json.loads(lines[1])
+    injected["payload"]["content"] = [{"text": "<environment_context>cwd=/x</environment_context>"}]
+    lines[1] = _json.dumps(injected)
+    path = tmp_path / "rollout-injected.jsonl"
+    path.write_text("".join(line + "\n" for line in lines))
+    state = _FileState(session_uid="")
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        await _mirror_one_codex(db, path, state, {})
+        session = await db.get_session(codex_sid(uid))
+
+    assert session is not None
+    assert session["name"] == "Codex session", (
+        f"named {session['name']!r}; an injected context block became the title"
+    )
+
+
 async def test_orchestrated_rollout_absorbs_an_earlier_import(tmp_path):
     """A row imported before this rule existed is removed the first time the
     mirror reclassifies its rollout, so old double entries heal on upgrade."""

--- a/tests/state/test_session_naming.py
+++ b/tests/state/test_session_naming.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from lionagi.state.session_naming import (
     DISPLAY_NAME_MAX_LEN,
     agent_role_label,
@@ -237,3 +239,37 @@ def test_blank_fields_are_treated_as_absent() -> None:
         "id": "abc123",
     }
     assert resolve_display_name(row) == "reviewer's genuine short name"
+
+
+def test_a_yaml_block_indicator_does_not_shield_the_banner() -> None:
+    """A prompt routed through a YAML document keeps the block-scalar indicator
+    that introduced it, and it lands ahead of the banner. Every strip pattern is
+    anchored at the start, so one stray "|-" left the entire system-message
+    banner in the display name -- on most of the rows on this machine, not a
+    rare shape.
+    """
+    out = sanitize_prompt_name("|- LION_SYSTEM_MESSAGE --- # Welcome to LIONAGI We are")
+    assert out is not None
+    assert not out.startswith("|"), out
+    assert "LION_SYSTEM_MESSAGE" not in out, out
+    assert "Welcome to LIONAGI" in out, out
+
+
+def test_a_bare_pipe_indicator_is_stripped_too() -> None:
+    out = sanitize_prompt_name("| # TASK - grade two answers to one question")
+    assert out == "TASK - grade two answers to one question", out
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "fix the graph fold so a long chain renders",
+        "a || b is the guard we want here",
+        "use the | operator to union the two sets",
+    ],
+    ids=["no-pipe", "pipe-inside", "pipe-as-subject"],
+)
+def test_prose_is_left_alone(raw: str) -> None:
+    """The arm that keeps the strip from over-reaching. Only a leading indicator
+    is noise; a pipe anywhere else is the text the reader asked to see."""
+    assert sanitize_prompt_name(raw) == raw


### PR DESCRIPTION
Two defects in how a session gets its stored display name. Both are on the same
surface, and fixing only one repeats the mistake of changing a path without its
mirror.

## 1. Every imported rollout got the same placeholder

Measured on a live store: **185 of 185** imported sessions created in the last
24 hours were named exactly `Codex session`.

The name is derived from the first real user turn:

```python
text = (m.content or {}).get("instruction") if isinstance(m.content, dict) else None
```

A mapping is what goes *in* to build the message content, never what comes back
out — the constructed message exposes it on a content model. The guard is false
for every message, so the derivation returns nothing and every session falls
through to the fallback. The derivation and the message model are each correct
in isolation; the defect is on the seam, which is why the tests drive the whole
mirror rather than the derivation alone.

## 2. A YAML block indicator shielded the system-message banner

`sanitize_prompt_name` strips a leading `LION_SYSTEM_MESSAGE` banner, but every
pattern is anchored at the start. A prompt routed through a YAML document keeps
the block-scalar indicator that introduced it, and it lands *ahead* of the
banner, so one stray `|-` left the whole banner in the name. **299 of 489**
sessions from the last day carry a pipe-prefixed or banner-leaking name.

## Verification

- Mutation control on each half, with the reddened arms predicted before running
  and reconciled arm by arm. Reverting half 1 fails with the exact production
  symptom (`named 'Codex session'`); reverting half 2 reddens the two banner
  arms and leaves the three prose arms green.
- Each half carries the arm that separates the right answer from any answer: a
  rollout opening with an injected context block and no human turn keeps the
  fallback, and prose containing a pipe anywhere but the start is left alone.
- 205 tests across the mirror suite, the codex state tests and the name-sanitiser
  tests pass.
- Checked against real transcripts: names now derive from the opening prompt.

## What this does NOT fix

Worth stating plainly, because the obvious reading of this PR is wrong. These
fix the **stored** name. The **rendered** name comes from `resolve_display_name`,
whose chain puts `agent_name` above the prompt-derived name — and an imported
rollout carries the literal `agent_name = "codex"`. So a card that reads
`codex · 01aa · 20:26` today still reads exactly that after this merges:

```
with today's stored name : codex · 01aa · 20:26
with the name this gives : codex · 01aa · 20:26
agent_name removed       : /goal work through at least 100 issues, cluster ...
```

That last line is the open question, and it is a design call rather than a bug
fix: `agent_name` is a *role* ("reviewer", "critic") for lionagi's own runs, and
an imported rollout has no role — the engine is already carried by `source_kind`
and `provider`. Whether to stop writing it, or to reorder the chain, is being
decided separately. This PR is a prerequisite either way: without it there is no
real name for the chain to fall through to.