### PR TITLE
fix(state): stop writing an engine label into an imported session's role field

### DIFF
--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -516,7 +516,15 @@ async def mirror_session(
                 "name": name or "Codex session",
                 "status": status,
                 "invocation_kind": "agent",
-                "agent_name": "codex",
+                # No agent_name. It is a ROLE field -- the role a branch plays
+                # within a flow, per the column's own note in schema.sql -- and
+                # an imported desktop thread has no role. Writing the engine
+                # there put a wrong value at the definition site, and because
+                # the role tier sits ahead of the prompt tier in
+                # resolve_display_name, it also shadowed the informative
+                # prompt-derived name every imported row would otherwise show.
+                # The engine is not lost: it is already carried by provider and
+                # by source_kind below.
                 "source_kind": SOURCE_KIND,
                 "model": model,
                 "provider": provider,
@@ -561,7 +569,9 @@ async def mirror_session(
             "progression_id": bprog,
             "model": model,
             "provider": provider,
-            "agent_name": "codex",
+            # Same reasoning as the session row above: the branch of an
+            # imported thread plays no role either, and create_branch reads
+            # this key with .get(), so omitting it stores NULL.
         }
     )
 

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -132,6 +132,7 @@ SCHEMA_VERSION = "3"
 _SCHEMA_MIGRATION_LOCK_KEY = "lionagi.state.schema.migration"
 _DISPATCHED_AT_BACKFILL_KEY = "migration.dispatched_at_backfill"
 _ATTENTION_DISPOSITIONS_BACKFILL_KEY = "migration.attention_dispositions_backfill"
+_IMPORTED_ROLE_LABEL_BACKFILL_KEY = "migration.imported_role_label_backfill"
 
 
 class SchemaTooNewError(RuntimeError):
@@ -997,6 +998,7 @@ class StateDB:
             await self._backfill_attention_dispositions_once(conn)
             await self._reconcile_indexes(conn)
             await self._backfill_dispatched_at_once(conn)
+            await self._backfill_imported_role_label_once(conn)
             # Seed immutable reference rows; ON CONFLICT DO NOTHING is safe to
             # re-run on every open() because the rows are identity-stable.
             # The version row is the exception: the migrations above rewrite an
@@ -1122,6 +1124,48 @@ class StateDB:
                 "WHERE status = 'running' AND dispatched_at IS NULL "
                 "AND schedule_id IS NOT NULL"
             )
+        )
+
+    async def _backfill_imported_role_label_once(self, conn) -> None:
+        """Clear the engine label off imported rows' role field, exactly once."""
+        claimed = await conn.execute(
+            text(
+                "INSERT INTO schema_meta (key, value) VALUES (:key, '1') "
+                "ON CONFLICT (key) DO NOTHING"
+            ),
+            {"key": _IMPORTED_ROLE_LABEL_BACKFILL_KEY},
+        )
+        if claimed.rowcount:
+            await self._backfill_imported_role_label(conn)
+
+    async def _backfill_imported_role_label(self, conn) -> None:
+        """Null out ``agent_name`` on rows imported from a desktop transcript.
+
+        The mirror used to write the engine name into ``agent_name``, which is
+        a role field. Stopping that write only fixes imports from here on:
+        rows already in the store keep the engine label, and because the role
+        tier sits ahead of the prompt tier in ``resolve_display_name`` they
+        would keep rendering the engine forever while new imports rendered
+        their prompt. That split is worse than either state on its own,
+        because the surface looks fixed.
+
+        Scoped by ``source_kind``, not by the label's value. Selecting on
+        ``agent_name = 'codex'`` would be selecting on the symptom: a live
+        session legitimately running a role of that name would be caught by
+        it, whereas ``source_kind`` names the thing that actually makes the
+        field meaningless. Branch rows are reached through their session for
+        the same reason -- the branches table has no ``source_kind`` of its
+        own, so its rows are identified by the session they belong to rather
+        than by what they happen to contain.
+        """
+        await conn.execute(
+            text(
+                "UPDATE branches SET agent_name = NULL WHERE session_id IN "
+                "(SELECT id FROM sessions WHERE source_kind = 'imported_codex')"
+            )
+        )
+        await conn.execute(
+            text("UPDATE sessions SET agent_name = NULL WHERE source_kind = 'imported_codex'")
         )
 
     async def _backfill_attention_dispositions_once(self, conn) -> None:

--- a/lionagi/state/session_naming.py
+++ b/lionagi/state/session_naming.py
@@ -121,6 +121,40 @@ def _stripped(session_row: dict[str, Any], key: str) -> str:
     return str(value).strip() if value else ""
 
 
+# Stored names that identify nothing. Each is a default written when the writer
+# had nothing better: "Codex session" is the codex mirror's fallback at its
+# create path, "agent" is lionagi's default branch name. "session" and "flow"
+# are here on the strength of the stored data rather than a located writer, and
+# that is the weaker grounding of the four -- said plainly so the next reader
+# knows which entries to re-derive rather than trusting the list wholesale.
+#
+# Counted in one store: agent 11851, codex session 917, session 600, flow 273.
+# A title tier that accepts these renders a page of identical cards, which is
+# the complaint this guards against.
+#
+# Matched by VALUE, deliberately, rather than by reordering the tiers. A reorder
+# would re-rank every row that has both a stored name and a derivable prompt --
+# including the mirrored Claude rows and the live codex rows whose stored names
+# are real -- so it would change populations that have nothing wrong with them.
+# Keying on the value leaves every one of those exactly where it was.
+#
+# Compared case-folded because these are written by several call sites and the
+# casing is not guaranteed to agree between them.
+_UNINFORMATIVE_STORED_NAMES: frozenset[str] = frozenset(
+    {
+        "agent",
+        "session",
+        "flow",
+        "codex session",
+    }
+)
+
+
+def _is_uninformative(raw_name: str) -> bool:
+    """Whether a stored name is a placeholder rather than a description."""
+    return raw_name.casefold() in _UNINFORMATIVE_STORED_NAMES
+
+
 def resolve_display_name(session_row: dict[str, Any]) -> str:
     """Priority chain for a run's displayed name:
 
@@ -131,6 +165,11 @@ def resolve_display_name(session_row: dict[str, Any]) -> str:
     defensively via `.get()` so a future rename feature slots into the top of
     this chain without another reorder. Every other tier reads a field that
     is already computed or stored on the row.
+
+    The prompt-derived tier declines a stored name that is a known placeholder
+    (see `_UNINFORMATIVE_STORED_NAMES`) and falls through to the short id, so
+    that thousands of rows sharing one default value render as distinct cards
+    rather than as one repeated title. The order itself is unchanged.
     """
     user_label = _stripped(session_row, "user_label")
     if user_label:
@@ -155,7 +194,7 @@ def resolve_display_name(session_row: dict[str, Any]) -> str:
             return label
 
     raw_name = _stripped(session_row, "name")
-    if raw_name:
+    if raw_name and not _is_uninformative(raw_name):
         sanitized = sanitize_prompt_name(raw_name)
         if sanitized:
             return sanitized

--- a/tests/cli/test_mirror.py
+++ b/tests/cli/test_mirror.py
@@ -2873,3 +2873,43 @@ def test_grep_evidence_live_mirror_paths_call_bound_mirror_content() -> None:
         "cli/mirror.py does not thread the mirror bounding budget/source pointers "
         "into mirror_session()"
     )
+
+
+async def test_an_imported_rollout_leaves_the_role_field_empty(tmp_path):
+    """`agent_name` is a role field, and an imported desktop thread has no role.
+
+    Writing the engine name there was wrong at the definition site, and it had
+    a visible consequence: the role tier sits ahead of the prompt tier in
+    `resolve_display_name`, so every imported row rendered the engine and
+    shadowed the informative prompt-derived name the mirror had just computed.
+
+    Both rows are asserted. The session and the branch each carried the label,
+    so checking only the session would pass while the branch kept it.
+    """
+    from lionagi.cli.mirror import _FileState, _mirror_one_codex
+    from lionagi.state.codex_mirror import session_db_id as codex_sid
+    from lionagi.state.session_naming import resolve_display_name
+
+    uid = "0199cccc-0000-0000-0000-00000000000b"
+    path = tmp_path / "rollout-role.jsonl"
+    path.write_text(_codex_rollout_lines(uid, "Codex Desktop"))
+    state = _FileState(session_uid="")
+
+    async with StateDB(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}") as db:
+        assert await _mirror_one_codex(db, path, state, {}) > 0
+        sid = codex_sid(uid)
+        session = await db.get_session(sid)
+        branches = await db.list_branches(sid)
+
+    assert session is not None
+    assert session["agent_name"] is None, (
+        f"session carries role {session['agent_name']!r}; the engine is in a role field"
+    )
+    assert branches, "no branch was mirrored, so the branch assertion below proves nothing"
+    for br in branches:
+        assert br["agent_name"] is None, (
+            f"branch carries role {br['agent_name']!r}; the session was cleared but its branch was not"
+        )
+
+    # The point of clearing the field: the prompt now reaches the display name.
+    assert resolve_display_name(dict(session)) == "q"

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -2114,3 +2114,107 @@ async def test_schedule_run_status_write_rejects_an_unlisted_extra_field(db):
 
     row = await db.get_schedule_run(run_id)
     assert row["status"] == "running"
+
+
+async def test_the_imported_role_backfill_clears_only_imported_rows(tmp_path):
+    """Stopping the write fixes future imports; rows already stored keep the
+    engine label unless something clears them, and because the role tier sits
+    ahead of the prompt tier in the name resolver they would render the engine
+    forever while new imports rendered their prompt.
+
+    The control is the point of this test. A live session is given the SAME
+    `agent_name` value the imported rows carry, so a backfill scoped to the
+    label rather than to `source_kind` passes every other assertion here and
+    fails only this one.
+    """
+    path = tmp_path / "state.db"
+    url = f"sqlite+aiosqlite:///{path}"
+    prog = uid()
+    imported_id, live_id, branch_id = uid(), uid(), uid()
+
+    async with StateDB(url) as db:
+        await db.create_progression(prog)
+        await db.create_session(
+            {
+                "id": imported_id,
+                "progression_id": prog,
+                "name": "imported",
+                "agent_name": "codex",
+                "invocation_kind": "agent",
+                "source_kind": "imported_codex",
+                "status": "completed",
+            }
+        )
+        await db.create_branch(
+            {
+                "id": branch_id,
+                "session_id": imported_id,
+                "progression_id": prog,
+                "agent_name": "codex",
+            }
+        )
+        # Control: a live row wearing the same label.
+        await db.create_session(
+            {
+                "id": live_id,
+                "progression_id": prog,
+                "name": "live",
+                "agent_name": "codex",
+                "invocation_kind": "agent",
+                "source_kind": "live",
+                "status": "completed",
+            }
+        )
+
+    # The first open already claimed the one-shot marker. Release it so the
+    # reopen below exercises the migration against rows that now exist -- which
+    # is the real upgrade order: rows first, migration after.
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("DELETE FROM schema_meta WHERE key = 'migration.imported_role_label_backfill'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    async with StateDB(url) as db:
+        imported = await db.get_session(imported_id)
+        live = await db.get_session(live_id)
+        branch = await db.get_branch(branch_id)
+
+    assert imported["agent_name"] is None, "imported session kept the engine label"
+    assert branch["agent_name"] is None, "imported session was cleared but its branch was not"
+    assert live["agent_name"] == "codex", (
+        "a LIVE row was cleared -- the backfill is selecting on the label instead of source_kind"
+    )
+
+
+async def test_the_imported_role_backfill_runs_only_once(tmp_path):
+    """A second open must not re-clear. The marker, not the data, is what makes
+    this one-shot: a row legitimately re-labelled after the migration would be
+    silently reverted on the next open if the guard were the data itself."""
+    path = tmp_path / "state.db"
+    url = f"sqlite+aiosqlite:///{path}"
+    prog, sid = uid(), uid()
+
+    async with StateDB(url) as db:
+        await db.create_progression(prog)
+        await db.create_session(
+            {
+                "id": sid,
+                "progression_id": prog,
+                "name": "imported",
+                "invocation_kind": "agent",
+                "source_kind": "imported_codex",
+                "status": "completed",
+            }
+        )
+
+    # Marker was claimed on the first open, so this label must survive.
+    async with StateDB(url) as db:
+        await db.update_session(sid, agent_name="re-labelled")
+
+    async with StateDB(url) as db:
+        again = await db.get_session(sid)
+    assert again["agent_name"] == "re-labelled", (
+        "the backfill ran a second time and reverted a post-migration write"
+    )

--- a/tests/state/test_session_naming.py
+++ b/tests/state/test_session_naming.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import pytest
 
 from lionagi.state.session_naming import (
+    _UNINFORMATIVE_STORED_NAMES,
     DISPLAY_NAME_MAX_LEN,
     agent_role_label,
     resolve_display_name,
@@ -273,3 +274,74 @@ def test_prose_is_left_alone(raw: str) -> None:
     """The arm that keeps the strip from over-reaching. Only a leading indicator
     is noise; a pipe anywhere else is the text the reader asked to see."""
     assert sanitize_prompt_name(raw) == raw
+
+
+# ── placeholder stored names ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("placeholder", sorted(_UNINFORMATIVE_STORED_NAMES))
+def test_a_placeholder_stored_name_does_not_become_the_title(placeholder: str) -> None:
+    """Every enumerated placeholder falls through to the id instead of winning.
+
+    These are defaults written when the writer had nothing better, and one
+    store held 11851 rows named "agent" and 917 named "Codex session". A tier
+    that accepts them renders that many identical cards, which is indenting the
+    same failure the id slice in ``agent_role_label`` was added to fix.
+
+    Parametrized over the set rather than spot-checking one member: the defect
+    is a value appearing thousands of times, so the population that matters is
+    the whole set, and a spot check cannot see a member that stops working.
+    """
+    row = {"id": "aaaabbbbccccddddeeee", "name": placeholder}
+    assert resolve_display_name(row) == "ccccddddeeee"
+
+
+@pytest.mark.parametrize("variant", ["Codex Session", "  codex session  ", "AGENT", "Flow"])
+def test_placeholders_are_matched_regardless_of_case_or_padding(variant: str) -> None:
+    """Written by several call sites, so the casing is not guaranteed to agree."""
+    row = {"id": "aaaabbbbccccddddeeee", "name": variant}
+    assert resolve_display_name(row) == "ccccddddeeee"
+
+
+@pytest.mark.parametrize(
+    "real",
+    [
+        "agentic workflow refactor",  # contains a placeholder as a prefix
+        "session recovery after a crash",  # starts with one
+        "rework the flow planner",  # contains one in the middle
+        "Codex session limits and how we hit them",  # starts with the longest one
+    ],
+)
+def test_a_name_that_merely_contains_a_placeholder_is_still_a_real_name(
+    real: str,
+) -> None:
+    """The match is on the whole value, and it has to stay that way.
+
+    A substring or prefix test would read every one of these as a placeholder
+    and throw away a perfectly good title. This is the arm that fails if the
+    check is ever "improved" into ``startswith`` or ``in``, which is the
+    natural-looking edit here.
+    """
+    assert resolve_display_name({"id": "aaaabbbbccccddddeeee", "name": real}) == real
+
+
+def test_a_role_label_still_outranks_a_placeholder_name() -> None:
+    """The tier order is untouched; only the prompt tier learned to decline.
+
+    A row carrying a role label never reaches the prompt tier, so it renders
+    exactly as it did before. This is the no-regression arm for the mirrored
+    rows, which all carry one.
+    """
+    row = {
+        "id": "aaaabbbbccccddddeeee",
+        "name": "Codex session",
+        "agent_name": "codex",
+        "started_at": 0.0,
+    }
+    assert resolve_display_name(row) == "codex · aaaa · 00:00"
+
+
+def test_a_real_stored_name_is_unaffected() -> None:
+    """The other no-regression arm: rows whose stored name says something."""
+    row = {"id": "aaaabbbbccccddddeeee", "name": "Refactor the auth module"}
+    assert resolve_display_name(row) == "Refactor the auth module"


### PR DESCRIPTION
`agent_name` is a role field. The schema says so at the column itself: it is
the role a branch plays within a flow ("r1", "critic"), not the name of the
thing that ran. An imported desktop thread has no role, so the transcript
mirror was writing a wrong value at the definition site.

That had a visible cost. The role tier sits ahead of the prompt tier in
`resolve_display_name`, so every imported row rendered the engine and shadowed
the prompt-derived name the mirror had just computed for it. Clearing the field
lets that name through. Nothing is lost: `provider` and `source_kind` already
record which engine produced the thread.

## What changed

- The mirror no longer writes the label, on **both** rows it used to. The
  session row and its branch row each carried it, so clearing only the session
  would have left the branch showing the engine.
- Existing rows are migrated once, on open, behind a durable marker.

## Why the migration is scoped by `source_kind`

Selecting on `agent_name = 'codex'` would be selecting on the symptom. A live
session legitimately running a role of that name would be caught by it, whereas
`source_kind` names the thing that actually makes the field meaningless. Branch
rows are reached through their session for the same reason: the branches table
has no `source_kind` of its own, so its rows are identified by the session they
belong to rather than by what they happen to contain.

Stopping the write without the migration would fix new imports while stored rows
kept the engine label forever. That split is worse than either state alone,
because the surface looks fixed.

## Tests

Three added, each with a mutation control run before submitting:

- An imported rollout leaves the role field empty on the session **and** the
  branch, and the row then resolves to its prompt-derived name. Restoring the
  label on only the branch reddens only the branch assertion, so that arm is
  not dead weight.
- The migration clears imported rows and **leaves a live row wearing the same
  label alone**. Re-scoping the migration to the label instead of
  `source_kind` reddens exactly this control and nothing else.
- The migration runs once: a row re-labelled after it has run is not reverted on
  the next open.

Worth noting that no test covered this behaviour before, which is why nothing
reddened when the write was removed. The two pre-existing `agent_name`
assertions belong to the other mirror, which is untouched here.

## Placeholder stored names

Clearing the role field sends these rows to the prompt-derived tier, which reads
the stored `name`. For a large share of them that column holds the mirror's own
create-path fallback, "Codex session". On its own, the change above would have
traded one repeated title for another.

`resolve_display_name` now declines a stored name that is a known placeholder
and falls through to the short id, which is distinct per row.

The set is matched by value, deliberately, rather than by reordering the tiers.
A reorder would re-rank every row that has both a stored name and a derivable
prompt, including the rows whose stored names are real, so it would move
populations that have nothing wrong with them. Keying on the value leaves all of
those exactly where they were. Measured against one store before and after: rows
carrying a real stored name are unchanged, rows from the other mirror are
unchanged, and a page that had rendered one repeated title renders distinct
cards.

Two of the four entries are traced to a specific writer; the other two rest on
the stored data alone. The comment at the constant says which is which, so the
next reader knows what to re-derive rather than trusting the list wholesale.

Mutation controls, reconciled arm by arm rather than by failure count: removing
the guard reddens the eight placeholder assertions and nothing else, and
loosening the exact match into a substring test reddens exactly the four arms
asserting that a real name which merely *contains* a placeholder word survives.

## Scope

The write change and the migration touch only rows with `source_kind =
'imported_codex'`. The other transcript mirror writes its own engine name on
rows that are not marked as imported; that is a larger and separate question and
is deliberately not addressed here.

The placeholder guard is **not** scoped that way, and it should not be: it is a
property of the stored value, so a row from any source whose name is one of
those four placeholders falls through for the same reason. That is what the
before/after measurement above was checking.
