### PR TITLE
fix(studio): bound the stale-lock scan and take it off the event loop

### DIFF
--- a/lionagi/studio/services/admin.py
+++ b/lionagi/studio/services/admin.py
@@ -10,8 +10,9 @@ import sqlite3
 import subprocess
 import time
 import uuid
+from functools import partial
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 import anyio
 from fastapi import HTTPException, Query
@@ -347,13 +348,70 @@ _UNSEARCHED_DIRS: frozenset[str] = frozenset(
 )
 
 
+# How long all the walks in one scan may take, in total. Pruning lowered the
+# per-tree constant but nothing bounds the work: a session's artifacts_path is
+# routinely a whole project directory, and the tree under it is whatever the
+# user happens to keep there. Measured against the live store, a full pass over
+# the 3780 artifact roots that exist on disk took 76 seconds, of which four
+# roots -- each a top-level directory -- accounted for 70.
+#
+# A ceiling on the scan rather than on each root, because the cost is
+# concentrated: a per-root limit generous enough for a normal tree still admits
+# a hundred slow roots, while one shared ceiling is the number that actually
+# bounds the endpoint.
+_SCAN_BUDGET_SECONDS = 5.0
+
+# Directories walked between budget checks. The clock read is cheap but not
+# free, and checking every directory would spend a measurable fraction of the
+# budget measuring the budget.
+_BUDGET_CHECK_INTERVAL = 64
+
+
+class _ScanBudget:
+    """Wall-clock ceiling shared by every walk in a single scan.
+
+    Monotonic on purpose: a system clock adjustment mid-scan must not extend or
+    collapse the ceiling, and this deadline is never compared against the
+    ``cutoff`` timestamps, which are wall-clock by necessity.
+
+    The ceiling is read when a budget is built rather than defaulted in the
+    signature, so that retuning the module constant retunes the next scan. A
+    default argument would have bound the value at import and left the constant
+    looking like a knob that does nothing.
+    """
+
+    def __init__(self, seconds: float | None = None) -> None:
+        ceiling = _SCAN_BUDGET_SECONDS if seconds is None else seconds
+        self._deadline = time.monotonic() + ceiling
+        self.exhausted = False
+
+    def expired(self) -> bool:
+        if not self.exhausted and time.monotonic() >= self._deadline:
+            self.exhausted = True
+        return self.exhausted
+
+
+class _ScanResult(NamedTuple):
+    """What a lock scan found, and whether it finished looking.
+
+    ``truncated`` exists so that "did not finish" cannot be read as "found
+    nothing". Both states carry ``lock=None``, and collapsing them would make a
+    scan that ran out of budget report a clean bill of health -- the failure
+    biased toward looking safe, which is the direction that gets believed.
+    """
+
+    lock: Path | None
+    truncated: bool
+
+
 def _find_stale_lock(
     root: Path,
     *,
     cutoff: float,
-    cache: dict[tuple[str, float], Path | None] | None = None,
-) -> Path | None:
-    """Find a stale runtime lock under *root*, or None.
+    cache: dict[tuple[str, float], _ScanResult] | None = None,
+    budget: _ScanBudget | None = None,
+) -> _ScanResult:
+    """Find a stale runtime lock under *root*.
 
     Pass *cache* to share results across one scan. Sessions repeat their
     artifact roots heavily -- one root accounted for 152 of 500 recent sessions
@@ -362,34 +420,47 @@ def _find_stale_lock(
     and per-scan rather than module-level: a scan is a snapshot taken at one
     ``cutoff``, so results are consistent within it, while a process-lifetime
     cache would keep answering with a filesystem that has since moved on.
+
+    Pass *budget* to bound the whole scan. A truncated result is cached like any
+    other: within one scan the answer for a root does not improve by asking
+    again, and re-walking it would spend budget that is already gone.
     """
     key = (str(root), cutoff)
     if cache is not None and key in cache:
         return cache[key]
-    found = _walk_for_stale_lock(root, cutoff=cutoff)
+    found = _walk_for_stale_lock(root, cutoff=cutoff, budget=budget)
     if cache is not None:
         cache[key] = found
     return found
 
 
-def _walk_for_stale_lock(root: Path, *, cutoff: float) -> Path | None:
+def _walk_for_stale_lock(
+    root: Path, *, cutoff: float, budget: _ScanBudget | None = None
+) -> _ScanResult:
+    seen = 0
     try:
         for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
             # Prune in place, which is what stops os.walk descending. Assigning
             # a new list to the name instead would be a no-op it cannot report.
             dirnames[:] = [d for d in dirnames if d not in _UNSEARCHED_DIRS]
+            seen += 1
+            if budget is not None and seen % _BUDGET_CHECK_INTERVAL == 0 and budget.expired():
+                return _ScanResult(None, True)
             # One traversal answers for every name. A pass per name walks the
             # whole tree once per name, and the miss case walks all of them.
             for name in _RUNTIME_LOCK_NAMES & set(filenames):
                 lock = Path(dirpath) / name
                 try:
                     if lock.stat().st_mtime < cutoff:
-                        return lock
+                        return _ScanResult(lock, False)
                 except OSError:
                     pass
     except OSError:
         pass
-    return None
+    # An OSError partway through is a tree we could not finish reading, but the
+    # caller already treats an unreadable root as its own condition, so it stays
+    # a completed scan here rather than acquiring a second meaning.
+    return _ScanResult(None, False)
 
 
 def _classify_phantom(
@@ -398,7 +469,8 @@ def _classify_phantom(
     now: float,
     stale_seconds: float,
     ps_snapshot: str | None = None,
-    lock_cache: dict[tuple[str, float], Path | None] | None = None,
+    lock_cache: dict[tuple[str, float], _ScanResult] | None = None,
+    lock_budget: _ScanBudget | None = None,
 ) -> PhantomReason | None:
     ap = _artifacts_path(row)
     node_metadata = row["node_metadata"] if "node_metadata" in row.keys() else None
@@ -416,9 +488,18 @@ def _classify_phantom(
     if (
         ap
         and ap.exists()
-        and _find_stale_lock(ap, cutoff=now - stale_seconds, cache=lock_cache) is not None
+        and _find_stale_lock(
+            ap, cutoff=now - stale_seconds, cache=lock_cache, budget=lock_budget
+        ).lock
+        is not None
     ):
         return "stale_lock"
+    # A truncated scan lands here too, and that is deliberate rather than an
+    # oversight: every path to this point has already established the session is
+    # a phantom, so the unfinished walk costs the *reason* its precision, not the
+    # verdict its safety. Where truncation would change a verdict -- the health
+    # classifier, where "no stale lock" is what keeps a session out of ZOMBIE --
+    # it is reported instead of absorbed.
     return "process_dead"
 
 
@@ -443,16 +524,24 @@ async def list_phantom_sessions(*, stale_hours: float = 1.0) -> list[dict[str, A
     snapshot: str | None = None
     # One scan, one answer per artifact root: sessions repeat their roots
     # heavily, and the walk is the expensive part.
-    lock_cache: dict[tuple[str, float], Path | None] = {}
+    lock_cache: dict[tuple[str, float], _ScanResult] = {}
+    lock_budget = _ScanBudget()
     for row in rows:
         if snapshot is None:
             snapshot = _ps_snapshot()
-        reason = _classify_phantom(
-            row,
-            now=now,
-            stale_seconds=stale_seconds,
-            ps_snapshot=snapshot,
-            lock_cache=lock_cache,
+        # Classification stats an artifact tree and may walk it. Both are
+        # synchronous filesystem work, and this coroutine is the one serving
+        # every other request while it runs.
+        reason = await anyio.to_thread.run_sync(
+            partial(
+                _classify_phantom,
+                row,
+                now=now,
+                stale_seconds=stale_seconds,
+                ps_snapshot=snapshot,
+                lock_cache=lock_cache,
+                lock_budget=lock_budget,
+            )
         )
         if reason is not None:
             phantoms.append(
@@ -572,7 +661,9 @@ async def health_report() -> dict[str, Any]:
     snapshot: str | None = None
     # One scan, one answer per artifact root: sessions repeat their roots
     # heavily, and the walk is the expensive part.
-    lock_cache: dict[tuple[str, float], Path | None] = {}
+    lock_cache: dict[tuple[str, float], _ScanResult] = {}
+    lock_budget = _ScanBudget()
+    lock_scan_truncated = 0
 
     for row in rows:
         sess = {k: row[k] for k in row.keys()}
@@ -583,9 +674,28 @@ async def health_report() -> dict[str, Any]:
         has_stale_locks = False
         if artifacts is not None and artifacts.exists():
             cutoff = now - 3600
-            has_stale_locks = (
-                _find_stale_lock(artifacts, cutoff=cutoff, cache=lock_cache) is not None
-            )
+            key = (str(artifacts), cutoff)
+            if key in lock_cache:
+                # A repeat of a root already answered: no walk, so nothing to
+                # move off the loop. Most rows take this path.
+                scan = lock_cache[key]
+            else:
+                # The walk is synchronous filesystem work and this coroutine is
+                # the one serving every other request. Left inline it blocks the
+                # loop for as long as the traversal takes, which is how a static
+                # /health probe that touches nothing ended up timing out.
+                scan = await anyio.to_thread.run_sync(
+                    partial(
+                        _find_stale_lock,
+                        artifacts,
+                        cutoff=cutoff,
+                        cache=lock_cache,
+                        budget=lock_budget,
+                    )
+                )
+            has_stale_locks = scan.lock is not None
+            if scan.truncated:
+                lock_scan_truncated += 1
 
         if status == "running":
             if snapshot is None:
@@ -646,6 +756,14 @@ async def health_report() -> dict[str, Any]:
             "total": total_sessions,
             "scanned": scanned,
             "truncated": scanned < total_sessions,
+            # Sessions whose artifact tree was too large to finish searching
+            # within the scan's shared budget. Named apart from "truncated"
+            # above, which is about how many rows were looked at rather than
+            # how completely each one was examined. Non-zero means some of the
+            # health verdicts below rest on an unfinished search: a session can
+            # only be counted ZOMBIE when a stale lock is FOUND, so an
+            # unfinished search can understate that bucket, never inflate it.
+            "lock_scan_truncated": lock_scan_truncated,
             "by_status": dict(by_status),
             "by_health": dict(by_health),
             "unhealthy": unhealthy,
@@ -726,7 +844,8 @@ async def transition_sessions(
     txn_snapshot: str | None = None
     # One scan, one answer per artifact root: sessions repeat their roots
     # heavily, and the walk is the expensive part.
-    lock_cache: dict[tuple[str, float], Path | None] = {}
+    lock_cache: dict[tuple[str, float], _ScanResult] = {}
+    lock_budget = _ScanBudget()
 
     async with StateDB() as db:
         for sid in session_ids:
@@ -743,11 +862,23 @@ async def transition_sessions(
             _snap_updated = current.get("updated_at")
             artifacts = _artifacts_path(current)
             has_artifacts = artifacts is not None and artifacts.exists()
-            has_stale_locks = (
-                _find_stale_lock(artifacts, cutoff=now - 3600, cache=lock_cache) is not None
-                if artifacts is not None and artifacts.exists()
-                else False
-            )
+            has_stale_locks = False
+            if artifacts is not None and artifacts.exists():
+                # Offloaded for the same reason the other two scans are: this is
+                # a synchronous walk inside a coroutine that is also the daemon's
+                # only thread of service. The list of sessions is the caller's
+                # rather than the whole table, which bounds how many walks run
+                # but not how long any one of them holds the loop.
+                scan = await anyio.to_thread.run_sync(
+                    partial(
+                        _find_stale_lock,
+                        artifacts,
+                        cutoff=now - 3600,
+                        cache=lock_cache,
+                        budget=lock_budget,
+                    )
+                )
+                has_stale_locks = scan.lock is not None
             if txn_snapshot is None:
                 txn_snapshot = _ps_snapshot()
             process_alive = process_liveness(current, artifacts, txn_snapshot)
@@ -764,8 +895,21 @@ async def transition_sessions(
                     "Only unhealthy sessions may be force-transitioned."
                 )
 
-            phantom_reason = _classify_phantom(
-                current, now=now, stale_seconds=3600, ps_snapshot=txn_snapshot
+            # The second walk this session can provoke, and the one that used to
+            # escape every bound: without the cache it repeated the traversal
+            # just done above at the same cutoff, and without the budget it was
+            # not bounded at all. Passing both makes it a cache hit in the
+            # ordinary case; offloading covers the case where it is not.
+            phantom_reason = await anyio.to_thread.run_sync(
+                partial(
+                    _classify_phantom,
+                    current,
+                    now=now,
+                    stale_seconds=3600,
+                    ps_snapshot=txn_snapshot,
+                    lock_cache=lock_cache,
+                    lock_budget=lock_budget,
+                )
             )
             classifier_code = _resolve_session_health_reason_code(
                 phantom_reason=phantom_reason,

--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import subprocess
 import time
 import uuid
 from pathlib import Path
@@ -14,6 +16,7 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
 from lionagi.state.db import StateDB  # noqa: E402
+from lionagi.state.reasons import SessionReasons  # noqa: E402
 
 
 def _run(coro):
@@ -936,15 +939,15 @@ def test_a_lock_inside_a_dependency_tree_is_not_searched(tmp_path):
     _aged(buried / "job.lock", 7200)
 
     now = time.time()
-    assert (
-        admin_svc._find_stale_lock(tmp_path / "repo", cutoff=now - 3600) is None
-    ), "a lock inside node_modules was searched; the subtree should be skipped"
+    assert admin_svc._find_stale_lock(tmp_path / "repo", cutoff=now - 3600).lock is None, (
+        "a lock inside node_modules was searched; the subtree should be skipped"
+    )
 
     reachable = tmp_path / "repo" / "run-1"
     reachable.mkdir()
     _aged(reachable / "job.lock", 7200)
     found = admin_svc._find_stale_lock(tmp_path / "repo", cutoff=now - 3600)
-    assert found is not None and found.name == "job.lock", (
+    assert found.lock is not None and found.lock.name == "job.lock", (
         "the skip list swallowed a lock outside any skipped directory"
     )
 
@@ -969,18 +972,242 @@ def test_one_scan_answers_once_per_artifact_root(tmp_path):
     now = time.time()
     cutoff = now - 3600
 
-    cache: dict[tuple[str, float], Path | None] = {}
-    assert admin_svc._find_stale_lock(root, cutoff=cutoff, cache=cache) is None
+    cache: dict[tuple[str, float], admin_svc._ScanResult] = {}
+    assert admin_svc._find_stale_lock(root, cutoff=cutoff, cache=cache).lock is None
     assert len(cache) == 1, "the answer was not recorded, so the next call re-walks"
 
     _aged(root / "run-1" / "job.lock", 7200)
 
-    assert admin_svc._find_stale_lock(root, cutoff=cutoff, cache=cache) is None, (
+    assert admin_svc._find_stale_lock(root, cutoff=cutoff, cache=cache).lock is None, (
         "the cache was not consulted: the tree was walked a second time"
     )
-    assert (
-        admin_svc._find_stale_lock(root, cutoff=cutoff, cache={}) is not None
-    ), "a fresh cache must see the lock, or the first assertion proves nothing"
-    assert (
-        admin_svc._find_stale_lock(root, cutoff=cutoff) is not None
-    ), "omitting the cache must always walk"
+    assert admin_svc._find_stale_lock(root, cutoff=cutoff, cache={}).lock is not None, (
+        "a fresh cache must see the lock, or the first assertion proves nothing"
+    )
+    assert admin_svc._find_stale_lock(root, cutoff=cutoff).lock is not None, (
+        "omitting the cache must always walk"
+    )
+
+
+# How long a deliberately-blocked walk is held, how often the probe below takes
+# the loop's pulse, and how long a stall has to be before it counts as the loop
+# having been held. The tolerance sits well above scheduling jitter at this tick
+# rate and well below the block, so neither a loaded machine nor a marginal
+# improvement can decide the verdict.
+_BLOCK_SECONDS = 0.5
+_TICK_SECONDS = 0.005
+_STALL_TOLERANCE = 0.2
+
+
+async def _max_loop_stall(coro) -> float:
+    """Run *coro*, returning the longest the loop went without giving a turn.
+
+    Counting turns is not enough, and the difference is not academic: a
+    coroutine that is slow for legitimate reasons accumulates plenty of turns
+    around its blocking section, so the count comes out healthy whether or not
+    the blocking work was offloaded. An earlier version of this helper counted,
+    and one of the two endpoints below passed under a deliberately reintroduced
+    defect because of it.
+
+    The longest gap does not dilute with the coroutine's total length. It is
+    also the number another in-flight request actually experiences, which is
+    what the property is about.
+    """
+    worst = 0.0
+    last = time.perf_counter()
+    task = asyncio.ensure_future(coro)
+    while not task.done():
+        await asyncio.sleep(_TICK_SECONDS)
+        now = time.perf_counter()
+        worst = max(worst, now - last)
+        last = now
+    await task
+    return worst
+
+
+@pytest.mark.parametrize(
+    "endpoint", ["list_phantom_sessions", "health_report", "transition_sessions"]
+)
+def test_a_lock_scan_does_not_block_the_loop_that_serves_every_other_request(
+    tmp_path, monkeypatch, endpoint
+):
+    """The artifact walk runs off the event loop, so other requests keep moving.
+
+    This is the defect rather than a refinement of it. The walk is synchronous
+    filesystem work and the scan is a coroutine, so left inline it holds the
+    loop for the whole traversal and every other request queues behind it.
+    Measured on a running daemon before this change: a static health probe that
+    reads no session data timed out at five seconds while an admin scan was in
+    flight, and the scan itself ran past four minutes.
+
+    Two arms, because the passing one alone would prove nothing:
+
+    * the loop is never held for long while a walk is deliberately blocked, and
+    * a walk really ran. Without that, a scan that reached no row at all would
+      leave the loop idle and the first assertion would pass having measured an
+      empty population.
+
+    Every coroutine that walks is covered, rather than the one the defect was
+    first noticed in. They offload at separate call sites, so a guard on one of
+    them says nothing about the others, and an untested one is where a later
+    edit puts the walk back on the loop with everything still green.
+
+    The instrument's own sensitivity is established separately, by
+    ``test_the_tick_counter_would_have_caught_a_walk_left_on_the_loop``. A
+    counter that ticks whatever the subject does is not evidence.
+    """
+    import lionagi.state.db as state_db_mod
+    import lionagi.studio.services.admin as admin_svc
+
+    db_path = tmp_path / "state.db"
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    sid = str(uuid.uuid4())
+    # Stale and not observably alive, so classification gets as far as the walk.
+    _run(
+        _seed_running_session(
+            db_path,
+            sid,
+            artifacts_path=str(artifacts),
+            updated_at=time.time() - 7200,
+        )
+    )
+    # Two more fields, both needed to get the transition arm as far as its walk.
+    # ``last_message_at`` is stamped at creation and outranks ``updated_at`` in
+    # the health classifier, so a row aged only by ``updated_at`` still reads as
+    # active. And an unknown liveness classifies the result merely idle, which
+    # the transition endpoint refuses; a recorded pid that has already exited is
+    # what makes deadness conclusive.
+    exited = subprocess.Popen(["/usr/bin/true"])
+    exited.wait()
+
+    async def _age_and_record_dead_pid():
+        async with StateDB(db_path) as db:
+            await db.execute(
+                "UPDATE sessions SET last_message_at = ?, node_metadata = ? WHERE id = ?",
+                (time.time() - 7200, json.dumps({"pid": exited.pid}), sid),
+            )
+
+    _run(_age_and_record_dead_pid())
+    monkeypatch.setattr(state_db_mod, "DEFAULT_DB_PATH", db_path)
+
+    walked: list[Path] = []
+
+    def slow_walk(root, *, cutoff, budget=None):
+        walked.append(root)
+        time.sleep(_BLOCK_SECONDS)
+        return admin_svc._ScanResult(None, False)
+
+    monkeypatch.setattr(admin_svc, "_walk_for_stale_lock", slow_walk)
+
+    if endpoint == "transition_sessions":
+        subject = admin_svc.transition_sessions(
+            [sid],
+            target_status="failed",
+            reason_code=SessionReasons.HEALTH_PHANTOM_PROCESS_DEAD,
+        )
+    else:
+        subject = getattr(admin_svc, endpoint)()
+
+    stall = _run(_max_loop_stall(subject))
+
+    assert walked, (
+        "no walk ran, so the loop was free for reasons unrelated to this fix; "
+        "the stall below describes an empty population"
+    )
+    assert stall < _STALL_TOLERANCE, (
+        f"the loop was held for {stall:.3f}s during a {_BLOCK_SECONDS}s walk: "
+        "the scan is back on the event loop and other requests are queueing"
+    )
+
+
+def test_the_stall_probe_would_have_caught_a_walk_left_on_the_loop():
+    """The measurement above can fail, on a subject that has the defect.
+
+    A healthy subject looks the same under a working probe and a broken one, so
+    the passing test says something about the loop only if the same instrument
+    reports a stall on a coroutine that holds it. This is that subject: the
+    identical block, run inline.
+    """
+
+    async def holds_the_loop():
+        time.sleep(_BLOCK_SECONDS)
+
+    stall = _run(_max_loop_stall(holds_the_loop()))
+    assert stall >= _STALL_TOLERANCE, (
+        f"only {stall:.3f}s measured while the loop was deliberately held for "
+        f"{_BLOCK_SECONDS}s: the probe is not measuring loop availability"
+    )
+
+
+def test_a_scan_that_runs_out_of_time_says_so_instead_of_reporting_clean(tmp_path, monkeypatch):
+    """ "Out of budget" and "found nothing" are different answers.
+
+    Both carry ``lock=None``, so a caller reading only that field cannot tell
+    them apart and the one it would infer is "clean". That is the direction that
+    gets believed: a scan cut short would hand back a clean bill of health for a
+    tree it never finished reading.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    root = tmp_path / "repo"
+    (root / "run-1").mkdir(parents=True)
+    _aged(root / "run-1" / "job.lock", 7200)
+    cutoff = time.time() - 3600
+
+    # Check the budget on every directory, so the outcome does not depend on the
+    # order the filesystem happens to hand back.
+    monkeypatch.setattr(admin_svc, "_BUDGET_CHECK_INTERVAL", 1)
+
+    spent = admin_svc._ScanBudget(seconds=-1.0)
+    cut = admin_svc._walk_for_stale_lock(root, cutoff=cutoff, budget=spent)
+    assert cut == admin_svc._ScanResult(None, True)
+
+    # Control: the lock is there to be found, so the result above is about the
+    # budget rather than about an empty tree.
+    whole = admin_svc._walk_for_stale_lock(root, cutoff=cutoff, budget=admin_svc._ScanBudget())
+    assert whole.lock is not None and whole.truncated is False
+
+
+def test_health_counts_the_rows_whose_lock_scan_did_not_finish(tmp_path, monkeypatch):
+    """A truncated scan is reported, not folded into the clean answer.
+
+    Here truncation genuinely changes a verdict, which is why the health
+    classifier reports it where the phantom classifier absorbs it: a session
+    reaches the zombie bucket only when a stale lock is *found*, so an
+    unfinished search understates that bucket while looking exactly like a
+    finished one.
+
+    This is also where the ceiling is shown to bound the endpoint rather than
+    each row. Three rows on three distinct artifact roots -- distinct so the
+    per-scan cache cannot collapse them into one answer -- share a single spent
+    budget, and all three come back truncated. A per-row ceiling is not a bound
+    on the endpoint at all, because the row count is the thing that grows.
+    """
+    import lionagi.studio.services.admin as admin_svc
+
+    db_path = tmp_path / "state.db"
+    for i in range(3):
+        root = tmp_path / f"artifacts-{i}"
+        root.mkdir()
+        _run(
+            _seed_running_session(
+                db_path,
+                str(uuid.uuid4()),
+                artifacts_path=str(root),
+                updated_at=time.time(),
+            )
+        )
+
+    monkeypatch.setattr(admin_svc, "_SCAN_BUDGET_SECONDS", -1.0)
+    monkeypatch.setattr(admin_svc, "_BUDGET_CHECK_INTERVAL", 1)
+
+    client = _make_client(tmp_path, monkeypatch, db_path)
+    body = client.get("/api/admin/health").json()
+    sess = body["sessions"]
+
+    assert sess["total"] == 3, (
+        "the seeded population is not the one the scan saw; the count below "
+        "would be about some other set of rows"
+    )
+    assert sess["lock_scan_truncated"] == 3


### PR DESCRIPTION
Fixes #2999.

## What happens today

An artifact-tree walk runs synchronously inside the coroutines serving
`/api/admin/health`, the phantom listing, and the admin transition. For as long
as a walk takes, the daemon answers nothing at all — not just the endpoint that
started it.

Measured on a running daemon, comparing two commits:

| | `/health` | `/api/runs` | `/api/admin/health` |
|---|---|---|---|
| before the walk change | 200 in 0.096s | 0.43s | 8.1–16.8s |
| after | timeout at 5s | — | timeout at 260s |

`/health` reads no session data. It timed out because the loop was held.

Nothing bounded the walk, either. Pruning dependency directories lowered the
per-tree constant, but a session's `artifacts_path` is routinely a whole project
directory and the tree under it is whatever happens to be there. A full pass over
the 3780 artifact roots present on one machine took 76 seconds, of which four
top-level roots accounted for 70.

## Changes

- **Offload.** Every walking coroutine goes through `anyio.to_thread`, so the
  loop stays free while a scan runs.
- **Bound.** One `_ScanBudget` per scan, monotonic, shared by every walk in that
  scan. A ceiling per root would not bound the endpoint, because the row count is
  the thing that grows.
- **Report truncation.** Walks return `_ScanResult(lock, truncated)` rather than
  `Path | None`, so "ran out of budget" cannot be read as "found nothing". Both
  carry `lock=None`, and collapsing them would have a cut-short scan hand back a
  clean bill of health. `/api/admin/health` gains `lock_scan_truncated`: a session
  reaches the zombie bucket only when a lock is *found*, so an unfinished search
  understates that bucket while looking exactly like a finished one.

The transition path also classified phantoms with neither the cache nor the
budget, repeating the traversal it had just done at the same cutoff and running
it unbounded. It now shares both, which makes it a cache hit in the ordinary case.

## On the tests

The property test covers all three endpoints. It measures the longest gap the
loop goes without a turn rather than counting turns — a coroutine that is slow
for legitimate reasons accumulates turns around its blocking section, and an
earlier counting version of the probe passed on `health_report` under a
deliberately reintroduced defect because of it.

Each offload site was reverted one at a time; each reverts to a failure of
exactly its own parametrized arm and nothing else. A separate test points the
same probe at a coroutine that deliberately holds the loop, so a probe that
reported "responsive" unconditionally would not pass unnoticed.

Existing behaviour is unchanged: 311 tests pass across every module that touches
this service.