### PR TITLE
chore(deps): raise the gitpython floor to 3.1.58

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,14 +347,21 @@ constraint-dependencies = [
     "requests>=2.33.0",     # CVE: insecure temp file reuse in extract_zipped_paths
     "pygments>=2.20.0",     # CVE: ReDoS in GUID regex
     "lxml>=6.1.0",          # CVE-2026-41066: XXE via default iterparse / ETCompatXMLParser config
-    "gitpython>=3.1.57",    # CVE: RCE via config_writer + path traversal in reference APIs; then a
+    "gitpython>=3.1.58",    # CVE: RCE via config_writer + path traversal in reference APIs; then a
                             # run of option-injection escapes -- long-option abbreviation, joined and
                             # single-character short options, and unguarded options in archive(),
                             # ls_remote(), iter_commits() and blame() -- plus env-var exfiltration
                             # through expandvars() on clone_from()/create_remote() URLs,
                             # unguarded option forwarding in IndexFile.checkout() and
                             # TagReference.create(), and an unsafe_git_archive_options
-                            # denylist that omitted --add-file / --add-virtual-file
+                            # denylist that omitted --add-file / --add-virtual-file. 3.1.58 closes a
+                            # further run of the same shape: an OPTION-name injection through
+                            # git-config that forges core.sshCommand / core.hooksPath, unguarded
+                            # option forwarding in Repo.init (--template) and in
+                            # IndexFile.from_tree/reset/merge_tree, a short-option guard bypass via
+                            # split_single_char_options=False, --pathspec-from-file in
+                            # IndexFile.remove() and Head.checkout(), and submodule names in
+                            # .gitmodules that escape the working tree
     "pymdown-extensions>=11.0.0",  # CVE: path traversal in the b64 extension lets an <img src> read
                             # files outside base_path
     "setuptools>=83.0.0",   # CVE: MANIFEST.in exclusion bypass in sdist via Unicode NFC/NFD

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ constraints = [
     { name = "authlib", specifier = ">=1.6.11" },
     { name = "cairosvg", specifier = ">=2.9.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
-    { name = "gitpython", specifier = ">=3.1.57" },
+    { name = "gitpython", specifier = ">=3.1.58" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -2197,14 +2197,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.57"
+version = "3.1.58"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Six advisories stand against gitpython 3.1.57, five of them high, and 3.1.58 is
the first patched release for all six. They are more of the option-injection
family the existing note in `pyproject.toml` already tracks:

- config OPTION-name injection forging `core.sshCommand` / `core.hooksPath`
- unguarded option forwarding in `Repo.init` (`--template`) and in
  `IndexFile.from_tree` / `reset` / `merge_tree`
- short-option guard bypass via `split_single_char_options=False`
- arbitrary file read through `--pathspec-from-file` in `IndexFile.remove()`
  and `Head.checkout()`
- submodule names in `.gitmodules` that escape the working tree

**Reachability:** nothing under `lionagi/` imports the package. It arrives
through `mkdocs-git-committers-plugin-2` and
`mkdocs-git-revision-date-localized-plugin`, so the exposure is the
documentation build, not the shipped library. The floor moves anyway because
the fix is one line and the alternative is carrying six open advisories on a
public repository to save it.

**Scope of the lock change:** resolved with the upgrade pinned to that one
package rather than re-running across the graph. `uv.lock` moves gitpython and
nothing else — 4 insertions, 4 deletions, all version and hash lines.