### PR TITLE
fix(studio): let both redaction layers read a field name the same way

### DIFF
--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -24,7 +24,12 @@ import anyio
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from .cancel_run import CANCEL_RUN_DESCRIPTION, CancelRunInput, cancel_run
-from .redact import MESSAGE_BYTE_CAP, PER_ITEM_TEXT_CAP, scrub_text
+from .redact import (
+    MESSAGE_BYTE_CAP,
+    PER_ITEM_TEXT_CAP,
+    fold_field_name,
+    scrub_text,
+)
 from .rename_session import RENAME_SESSION_DESCRIPTION, RenameSessionInput, rename_session
 from .resume_run import RESUME_RUN_DESCRIPTION, ResumeRunInput, resume_run
 from .run_detail import RunDetailInput, run_detail
@@ -360,9 +365,24 @@ _SECRET_FIELD_MARKERS = (
     "private_key",
     "client_secret",
 )
-_FIELD_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
 _URL_FIELD_NAMES = frozenset(
-    {"url", "uri", "dsn", "store_url", "database_url", "db_url", "connection_url"}
+    {
+        "url",
+        "uri",
+        "dsn",
+        "store_url",
+        "database_url",
+        "db_url",
+        "connection_url",
+        # Compared after folding, so store-url and store.url are covered by the
+        # underscored spellings above. Concatenated spellings are not: they
+        # carry no separator to fold, and this is an exact-match set, so
+        # storeUrl has to be listed in its own right.
+        "storeurl",
+        "databaseurl",
+        "dburl",
+        "connectionurl",
+    }
 )
 _PATH_FIELD_NAMES = frozenset({"path", "directory", "cwd", "root"})
 _STORE_URL_RE = re.compile(
@@ -391,14 +411,7 @@ def _safe_text(value: str) -> str:
 
 
 def _secret_field(key: str) -> bool:
-    # Separators do not change which field a name refers to. HTTP headers
-    # arrive as X-API-Key, config files write api.key, and our own records
-    # write api_key; every marker below that contains an underscore would
-    # otherwise match only the last of those. Fold any run of non-alphanumeric
-    # characters to a single underscore so all the spellings compare equal.
-    # This can only widen what we redact, which is the safe direction for a
-    # rule whose job is to withhold.
-    lowered = _FIELD_SEPARATOR_RE.sub("_", key.lower())
+    lowered = fold_field_name(key)
     return lowered in {"auth", "authentication", "bearer"} or any(
         marker in lowered for marker in _SECRET_FIELD_MARKERS
     )
@@ -406,7 +419,7 @@ def _secret_field(key: str) -> bool:
 
 def _safe_content(value: Any, *, key: str = "") -> Any:
     """Recursively remove credentials, store URLs, and host filesystem layouts."""
-    if key.lower() in _URL_FIELD_NAMES or _secret_field(key):
+    if fold_field_name(key) in _URL_FIELD_NAMES or _secret_field(key):
         # Judge by field name only where the value could carry text. A number
         # is neither a credential nor a URL, and several counters we report
         # carry a marker in their name — input_tokens, output_tokens — so

--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -28,6 +28,7 @@ from .redact import (
     MESSAGE_BYTE_CAP,
     PER_ITEM_TEXT_CAP,
     fold_field_name,
+    is_secret_field_name,
     scrub_text,
 )
 from .rename_session import RENAME_SESSION_DESCRIPTION, RenameSessionInput, rename_session
@@ -352,19 +353,6 @@ _SESSION_DETAIL_DROP = frozenset(
 )
 _INVOCATION_DROP = frozenset({"node_metadata", "status_evidence_refs"})
 _ARTIFACT_DROP = frozenset({"file_path"})
-_SECRET_FIELD_MARKERS = (
-    "secret",
-    "token",
-    "password",
-    "passwd",
-    "api_key",
-    "apikey",
-    "credential",
-    "authorization",
-    "access_key",
-    "private_key",
-    "client_secret",
-)
 _URL_FIELD_NAMES = frozenset(
     {
         "url",
@@ -411,10 +399,7 @@ def _safe_text(value: str) -> str:
 
 
 def _secret_field(key: str) -> bool:
-    lowered = fold_field_name(key)
-    return lowered in {"auth", "authentication", "bearer"} or any(
-        marker in lowered for marker in _SECRET_FIELD_MARKERS
-    )
+    return is_secret_field_name(key)
 
 
 def _safe_content(value: Any, *, key: str = "") -> Any:
@@ -428,7 +413,7 @@ def _safe_content(value: Any, *, key: str = "") -> Any:
         # null-handling of secret fields unchanged.
         if not isinstance(value, (int, float, bool)):
             return "[redacted]"
-    if key.lower() in _PATH_FIELD_NAMES and isinstance(value, str):
+    if fold_field_name(key) in _PATH_FIELD_NAMES and isinstance(value, str):
         public_value = public_project(value)
         return _safe_text(public_value) if public_value is not None else None
     if isinstance(value, dict):

--- a/lionagi/studio/operator/redact.py
+++ b/lionagi/studio/operator/redact.py
@@ -267,15 +267,29 @@ def redact_scalar(key: str, value: Any) -> Any:
     return f"[{type(value).__name__}]"
 
 
-def redact_arguments(value: Any) -> Any:
+def redact_arguments(value: Any, *, parent_key: str = "") -> Any:
     """Recursively redact secret- and absolute-path-shaped values. Used on
     tool-call arguments and on artifact contract/verification payloads, the
     two places a new Operator read tool could otherwise widen exposure
-    beyond what the existing tools already show."""
+    beyond what the existing tools already show.
+
+    ``parent_key`` carries the field name a container arrived under, because a
+    credential name has to cover what is nested beneath it and not only a scalar
+    sitting directly on it. Without it the name was consulted for scalars alone,
+    so ``{"auth": "..."}`` was withheld while ``{"auth": {"value": "..."}}`` was
+    served — the same split, across two shapes, that sharing the field-name rule
+    had just closed across two layers. The session and artifact projection
+    already judges the name before descending into a container; this is that
+    same step, on this path.
+    """
+    if isinstance(value, (dict, list)) and is_secret_field_name(parent_key):
+        return "[redacted]"
     if isinstance(value, dict):
         return {
             key: (
-                redact_arguments(val) if isinstance(val, (dict, list)) else redact_scalar(key, val)
+                redact_arguments(val, parent_key=key)
+                if isinstance(val, (dict, list))
+                else redact_scalar(key, val)
             )
             for key, val in value.items()
         }

--- a/lionagi/studio/operator/redact.py
+++ b/lionagi/studio/operator/redact.py
@@ -114,10 +114,21 @@ _SECRET_KEY_MARKERS = (
     "authorization",
     "auth_token",
     "access_key",
+    "accesskey",
     "private_key",
+    "privatekey",
     "client_secret",
     "bearer",
 )
+# Multi-word markers are listed in both their separated and their run-together
+# spelling, because field names are folded to a single separator before the
+# comparison and a name written `accessKey` or `access-key` folds to
+# `accesskey`, which the separated spelling does not match. `api_key`/`apikey`
+# already worked this way; the other two names now follow it, and the
+# assignment pattern above already treats the same separators as optional.
+# Marker names whose folded form contains a shorter marker -- `authToken`
+# holds `token`, `clientSecret` holds `secret` -- are covered without a second
+# spelling.
 _SECRET_VALUE_PREFIXES = ("sk-", "ghp_", "gho_", "ghu_", "ghs_", "xox", "AKIA", "eyJ")
 
 

--- a/lionagi/studio/operator/redact.py
+++ b/lionagi/studio/operator/redact.py
@@ -189,8 +189,27 @@ def scrub_text(text: str, *, known_values: frozenset[str] | None = None) -> str:
     return text
 
 
+_FIELD_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
+
+
+def fold_field_name(key: str) -> str:
+    """Reduce a field name to the spelling the secret markers are written in.
+
+    Separators do not change which field a name refers to. HTTP headers arrive
+    as X-API-Key, config files write api.key, and our own records write
+    api_key, so every marker containing an underscore would otherwise match
+    only the last of those. Folding any run of non-alphanumeric characters to a
+    single underscore makes all the spellings compare equal.
+
+    This lives here, and not beside either caller, because both redaction
+    layers have to agree about it. When they disagreed, the same credential was
+    withheld on one path and served on the other.
+    """
+    return _FIELD_SEPARATOR_RE.sub("_", key.lower())
+
+
 def _is_secret_key(key: str) -> bool:
-    lowered = key.lower()
+    lowered = fold_field_name(key)
     return any(marker in lowered for marker in _SECRET_KEY_MARKERS)
 
 

--- a/lionagi/studio/operator/redact.py
+++ b/lionagi/studio/operator/redact.py
@@ -27,6 +27,8 @@ __all__ = (
     "ARTIFACT_BYTE_CAP",
     "public_project",
     "scrub_text",
+    "fold_field_name",
+    "is_secret_field_name",
     "known_secret_values",
     "redact_scalar",
     "redact_arguments",
@@ -208,9 +210,31 @@ def fold_field_name(key: str) -> str:
     return _FIELD_SEPARATOR_RE.sub("_", key.lower())
 
 
+# Names that mean a credential on their own but must not match as substrings.
+# "auth" inside "author" or "authorized_keys_count" is a different word, and
+# redacting those would delete data a caller legitimately reads, so these are
+# compared for equality against the folded name rather than searched for.
+_EXACT_SECRET_FIELD_NAMES = frozenset({"auth", "authentication", "bearer"})
+
+
+def is_secret_field_name(key: str) -> bool:
+    """Say whether a field name names a credential.
+
+    This is the whole rule, in one place, because two copies of it disagreed:
+    one carried the exact-match names above and the other did not, so a value
+    under an `auth` key was withheld on the session and artifact paths and
+    served on the tool-argument and manifest paths. Sharing the separator fold
+    alone was not enough — the vocabulary has to be shared too, or the same
+    class of gap simply moves to whichever name the two lists differ on.
+    """
+    folded = fold_field_name(key)
+    return folded in _EXACT_SECRET_FIELD_NAMES or any(
+        marker in folded for marker in _SECRET_KEY_MARKERS
+    )
+
+
 def _is_secret_key(key: str) -> bool:
-    lowered = fold_field_name(key)
-    return any(marker in lowered for marker in _SECRET_KEY_MARKERS)
+    return is_secret_field_name(key)
 
 
 def _looks_like_secret_value(value: str) -> bool:

--- a/tests/apps_studio_server/test_operator_invocation_and_artifact_reads.py
+++ b/tests/apps_studio_server/test_operator_invocation_and_artifact_reads.py
@@ -478,3 +478,90 @@ async def test_a_textual_secret_under_a_counter_shaped_name_is_still_redacted():
     projected = _safe_content({"token_count": UNSHAPED_SECRET})
 
     assert projected == {"token_count": "[redacted]"}
+
+
+# One name, written the several ways it actually arrives. Each entry is the
+# canonical spelling, whether that name names a secret, and the other spellings
+# of the same name. Non-secret rows are here so the agreement below cannot be
+# satisfied by a layer that simply answers False to everything.
+_ONE_NAME_MANY_SPELLINGS = [
+    ("api_key", True, ["api-key", "api.key", "api key", "API-KEY"]),
+    ("access_key", True, ["access-key", "access.key", "ACCESS KEY"]),
+    ("private_key", True, ["private-key", "private.key"]),
+    ("client_secret", True, ["client-secret", "client.secret"]),
+    ("db_password", True, ["db-password", "db password"]),
+    ("refresh_token", True, ["refresh-token", "refresh.token"]),
+    ("display_name", False, ["display-name", "display.name", "Display Name"]),
+    ("created_at", False, ["created-at", "created.at"]),
+]
+
+
+@pytest.mark.parametrize(
+    ("canonical", "alternative", "is_secret"),
+    [
+        (canonical, alternative, is_secret)
+        for canonical, is_secret, alternatives in _ONE_NAME_MANY_SPELLINGS
+        for alternative in alternatives
+    ],
+)
+async def test_both_field_name_rules_read_one_name_the_same_however_it_is_spelled(
+    canonical, alternative, is_secret
+):
+    """Two independent places decide whether a field name names a secret.
+
+    They are reached by different callers, so a name folded in one and not the
+    other means the same credential is withheld on one path and served on the
+    other. Pinning each rule separately cannot see that: both would be green
+    while they disagreed. This asserts the two answers together, for every
+    spelling, which is the property that actually has to hold.
+
+    The canonical spelling is asserted first so the agreement is not vacuous.
+    """
+    from lionagi.studio.operator import application_mcp, redact
+
+    assert redact._is_secret_key(canonical) is is_secret
+    assert application_mcp._secret_field(canonical) is is_secret
+
+    assert redact._is_secret_key(alternative) is is_secret
+    assert application_mcp._secret_field(alternative) is is_secret
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "url",
+        "uri",
+        "dsn",
+        "store_url",
+        "store-url",
+        "store.url",
+        "storeUrl",
+        "database_url",
+        "database-url",
+        "databaseUrl",
+        "db_url",
+        "db-url",
+        "dbUrl",
+        "connection_url",
+        "connection-url",
+        "connectionUrl",
+    ],
+)
+async def test_a_location_field_is_withheld_even_when_its_value_has_no_url_shape(key):
+    """Store locations are withheld by field name as well as by value shape.
+
+    Every other test that plants a store location also gives it a scheme, so
+    the pattern layer catches it and the name layer is never what makes the
+    assertion pass. Deleting the name check outright left the whole suite
+    green. A location that reaches us as bare text — a host, a path fragment,
+    an operator's note — has only this layer between it and the caller.
+    """
+    from lionagi.studio.operator.application_mcp import _safe_content
+
+    # Premise: this value survives under a name that matches nothing, so any
+    # redaction below is the work of the key and not of a pattern.
+    assert _safe_content({"note": UNSHAPED_SECRET}) == {"note": UNSHAPED_SECRET}
+
+    projected = _safe_content({key: UNSHAPED_SECRET})
+
+    assert projected == {key: "[redacted]"}

--- a/tests/apps_studio_server/test_operator_invocation_and_artifact_reads.py
+++ b/tests/apps_studio_server/test_operator_invocation_and_artifact_reads.py
@@ -481,7 +481,16 @@ async def test_a_textual_secret_under_a_counter_shaped_name_is_still_redacted():
 
 
 def _spellings(name: str) -> list[str]:
-    """The separator and case variants one field name arrives in."""
+    """The separator and case variants one field name arrives in.
+
+    The run-together and camelCase forms are the load-bearing ones. Every other
+    variant here keeps a separator, so the fold that precedes the comparison
+    collapses all of them back onto the underscored name and they match
+    whatever the rule's vocabulary happens to be. Only dropping the separator
+    changes the folded string, so a list without these two asserts agreement
+    over exactly the spellings that cannot disagree.
+    """
+    parts = name.split("_")
     variants = [
         name,
         name.replace("_", "-"),
@@ -489,6 +498,8 @@ def _spellings(name: str) -> list[str]:
         name.replace("_", " "),
         name.upper(),
         name.title(),
+        "".join(parts),
+        parts[0] + "".join(part.capitalize() for part in parts[1:]),
     ]
     return list(dict.fromkeys(variants))
 

--- a/tests/apps_studio_server/test_operator_invocation_and_artifact_reads.py
+++ b/tests/apps_studio_server/test_operator_invocation_and_artifact_reads.py
@@ -480,50 +480,91 @@ async def test_a_textual_secret_under_a_counter_shaped_name_is_still_redacted():
     assert projected == {"token_count": "[redacted]"}
 
 
-# One name, written the several ways it actually arrives. Each entry is the
-# canonical spelling, whether that name names a secret, and the other spellings
-# of the same name. Non-secret rows are here so the agreement below cannot be
-# satisfied by a layer that simply answers False to everything.
-_ONE_NAME_MANY_SPELLINGS = [
-    ("api_key", True, ["api-key", "api.key", "api key", "API-KEY"]),
-    ("access_key", True, ["access-key", "access.key", "ACCESS KEY"]),
-    ("private_key", True, ["private-key", "private.key"]),
-    ("client_secret", True, ["client-secret", "client.secret"]),
-    ("db_password", True, ["db-password", "db password"]),
-    ("refresh_token", True, ["refresh-token", "refresh.token"]),
-    ("display_name", False, ["display-name", "display.name", "Display Name"]),
-    ("created_at", False, ["created-at", "created.at"]),
+def _spellings(name: str) -> list[str]:
+    """The separator and case variants one field name arrives in."""
+    variants = [
+        name,
+        name.replace("_", "-"),
+        name.replace("_", "."),
+        name.replace("_", " "),
+        name.upper(),
+        name.title(),
+    ]
+    return list(dict.fromkeys(variants))
+
+
+def _every_name_the_secret_rule_knows() -> list[str]:
+    """Read the corpus out of the rule instead of writing it down again.
+
+    A hand-picked list can only hold names its author already believed both
+    layers agreed about. That is not a hypothetical: two layers disagreed about
+    `auth` while a test whose docstring claimed to assert their agreement was
+    green, because the name was in neither list the author had chosen. Deriving
+    the corpus means a name added to the vocabulary is covered by the same
+    commit that adds it.
+    """
+    from lionagi.studio.operator import redact
+
+    return sorted(set(redact._SECRET_KEY_MARKERS) | redact._EXACT_SECRET_FIELD_NAMES)
+
+
+# Names a caller legitimately reads that carry a secret marker as a substring.
+# `authors` is live on our own records, so withholding it deletes data rather
+# than protecting anything. This is the arm that fails a fix which closes a gap
+# by widening the substring markers instead of naming exact spellings.
+_NAMES_A_CALLER_NEEDS_TO_READ = [
+    "author",
+    "authors",
+    "author_name",
+    "authored_by",
+    "co_authors",
+    "oauth_client_id",
+    "unauthorized",
+    "authority",
+    "authorized_keys_count",
+    "display_name",
+    "created_at",
 ]
 
 
 @pytest.mark.parametrize(
-    ("canonical", "alternative", "is_secret"),
-    [
-        (canonical, alternative, is_secret)
-        for canonical, is_secret, alternatives in _ONE_NAME_MANY_SPELLINGS
-        for alternative in alternatives
-    ],
+    "spelling",
+    [spelling for name in _every_name_the_secret_rule_knows() for spelling in _spellings(name)],
 )
-async def test_both_field_name_rules_read_one_name_the_same_however_it_is_spelled(
-    canonical, alternative, is_secret
-):
-    """Two independent places decide whether a field name names a secret.
+async def test_every_name_the_secret_rule_knows_reads_the_same_on_both_paths(spelling):
+    """Two callers ask whether a field name names a secret, on different paths.
 
-    They are reached by different callers, so a name folded in one and not the
-    other means the same credential is withheld on one path and served on the
-    other. Pinning each rule separately cannot see that: both would be green
-    while they disagreed. This asserts the two answers together, for every
-    spelling, which is the property that actually has to hold.
+    A name one of them treats as a secret and the other does not means the same
+    credential is withheld on the session and artifact reads and served on the
+    tool-argument and manifest reads. Pinning each rule on its own cannot see
+    that — both stay green while they disagree — so this asserts the two answers
+    together, over every name the rule is written in and every spelling of each.
 
-    The canonical spelling is asserted first so the agreement is not vacuous.
+    The two now share one predicate, which makes the agreement structural rather
+    than coincidental. The assertion is still worth keeping: it is what reddens
+    if either caller grows its own copy of the rule again, which is how they
+    came apart the first time.
     """
     from lionagi.studio.operator import application_mcp, redact
 
-    assert redact._is_secret_key(canonical) is is_secret
-    assert application_mcp._secret_field(canonical) is is_secret
+    assert redact._is_secret_key(spelling) is True
+    assert application_mcp._secret_field(spelling) is True
 
-    assert redact._is_secret_key(alternative) is is_secret
-    assert application_mcp._secret_field(alternative) is is_secret
+
+@pytest.mark.parametrize("name", _NAMES_A_CALLER_NEEDS_TO_READ)
+async def test_a_name_that_merely_contains_a_marker_is_still_served(name):
+    """Withholding too much is a defect too, and a quieter one.
+
+    `auth` names a credential; `author` does not, and neither do `authors` or
+    `oauth_client_id`. A rule that closes the `auth` gap by searching for it as
+    a substring passes every test about credentials and silently empties fields
+    a caller reads, which is why the exact-match names are compared for equality
+    against the folded name rather than searched for inside it.
+    """
+    from lionagi.studio.operator import application_mcp, redact
+
+    assert redact._is_secret_key(name) is False
+    assert application_mcp._secret_field(name) is False
 
 
 @pytest.mark.parametrize(

--- a/tests/apps_studio_server/test_operator_registry_contract.py
+++ b/tests/apps_studio_server/test_operator_registry_contract.py
@@ -78,7 +78,23 @@ def test_newly_added_tools_are_all_registered():
 
 def test_registry_holds_no_unexpected_tool_names():
     expected = PRE_EXISTING_TOOL_NAMES | NEWLY_ADDED_TOOL_NAMES
-    assert set(application_mcp._TOOL_HANDLERS.keys()) == expected
+    registered = set(application_mcp._TOOL_HANDLERS.keys())
+
+    # Exact equality, deliberately. Tolerating extra names would give up the
+    # direction that matters most here, which is that nothing reaches the
+    # Operator's surface without someone naming it. The cost is that any
+    # branch adding a tool sees this fail while it is still correct, so the
+    # message says which case it is and what to do about it.
+    assert registered == expected, (
+        "The Operator tool registry no longer matches the names listed here.\n"
+        f"  registered but not listed: {sorted(registered - expected)}\n"
+        f"  listed but not registered: {sorted(expected - registered)}\n"
+        "A name in the first list means a tool was added. That is not a "
+        "failure on its own: confirm the tool is meant to be reachable, then "
+        "add its name to NEWLY_ADDED_TOOL_NAMES. A name in the second list "
+        "means a tool the Operator used to offer is gone, which withdraws a "
+        "capability and should be a decision rather than a side effect."
+    )
 
 
 class _WriteMethodTrap:

--- a/tests/apps_studio_server/test_operator_run_findings.py
+++ b/tests/apps_studio_server/test_operator_run_findings.py
@@ -365,6 +365,66 @@ async def test_run_findings_artifacts_kind(db_path):
     assert artifacts["artifactsPath"] == "artifacts"
 
 
+async def test_a_secret_nested_under_a_credential_name_is_withheld_on_both_read_paths(
+    db_path, monkeypatch
+):
+    """A credential field name has to cover what is stored underneath it.
+
+    The two read layers share one rule about which field names name a secret,
+    and the point of sharing it is that a caller cannot be served on one path
+    what it is denied on the other. Asking that rule directly cannot see this
+    gap: both layers agree `auth` names a credential, and one of them still
+    served the object stored under it, because only one consulted the name
+    before descending into a container. So this asks both public tools for the
+    same payload and requires the same answer of them.
+
+    The planted value is deliberately shapeless -- it has spaces, no known
+    prefix, and no header or assignment form -- so nothing except the field
+    name can withhold it. A secret that looked like one would pass here
+    whether the name was consulted or not.
+    """
+    import json
+
+    from lionagi.studio.operator.application_mcp import get_artifact
+    from lionagi.studio.operator.run_findings import run_findings
+    from lionagi.studio.services import invocations
+
+    nested = "correct horse battery staple"
+    payload = {
+        "auth": {"value": nested},
+        "credentials": [nested],
+        "steps": [{"api_key": {"header": nested}}],
+        "files": ["report.md"],
+    }
+
+    sid = str(uuid.uuid4())
+    await seed_session(
+        db_path,
+        session_id=sid,
+        status="completed",
+        artifact_contract_json=payload,
+        artifact_verification_json={"status": "ok"},
+    )
+
+    async def fake_get_artifact(_artifact_id, **_kwargs):
+        return {"id": "a-nested", "kind": "result", "name": "result", "content": payload}
+
+    monkeypatch.setattr(invocations, "get_artifact", fake_get_artifact)
+
+    findings = await run_findings({"run": sid, "kind": "artifacts"})
+    artifact = await get_artifact({"artifact_id": "a-nested"})
+
+    # Positive control: the value really is in the payload both tools read, so
+    # the two absence checks below are not vacuously true.
+    assert nested in json.dumps(payload)
+
+    assert nested not in json.dumps(findings)
+    assert nested not in json.dumps(artifact)
+    # And the ordinary field beside it is still served. Withholding too much is
+    # a defect too, and a quieter one.
+    assert findings["artifacts"]["contract"]["files"] == ["report.md"]
+
+
 async def test_run_findings_oversized_artifact_contract_is_capped(db_path):
     """A multi-megabyte artifact contract must not make the serialized
     response exceed the same aggregate bound every other findings section


### PR DESCRIPTION
## What

Two places decide whether a field name names a secret: `_is_secret_key` in
`redact.py` and `_secret_field` in `application_mcp.py`. Only the second folded
separators, so `X-API-Key` was withheld on one path and served on the other,
for the same field, depending on which caller got there. The fold moves into
`redact.py` as `fold_field_name` and both call it.

The comparison one line below `_secret_field` had the same gap: store locations
were matched against `_URL_FIELD_NAMES` on the raw lowercased key, so
`store-url` and `store.url` walked past it. That comparison folds too. Folding
cannot reach concatenated spellings — `storeUrl` has no separator to fold and
the set is exact-match — so those are listed in their own right.

Also: the tool-registry contract now says what to do when it fails. It asserts
exact equality against a hand-written list, so any branch that adds a tool sees
it go red while that branch is correct. Exact equality is still the right
contract — nothing else stops a tool reaching the Operator's surface unnamed —
but the failure should not be a puzzle, so it names which side the difference
is on.

## Why it is pinned this way

`test_both_field_name_rules_read_one_name_the_same_however_it_is_spelled`
asserts the two rules agree across spellings of one name, rather than pinning
each rule separately. Pinning them separately is what let them disagree: both
were green while one folded and the other did not.

Mutations run, with the reddened arms predicted before running and reconciled
after:

| mutation | predicted | observed |
|---|---|---|
| `redact._is_secret_key` stops folding (the pre-fix state, one layer only) | 11 agreement arms | **9** — `client-secret` and `client.secret` stay green because the bare marker `secret` matches them unfolded either way. Nothing else in the suite reddens, which is the point: without this test, un-folding one layer is silent. |
| the URL comparison stops folding | 5 | 5 (`store-url`, `store.url`, `database-url`, `db-url`, `connection-url`) |
| the concatenated URL spellings are removed | 4 | 4 (`storeUrl`, `databaseUrl`, `dbUrl`, `connectionUrl`) |
| registry list drops a registered name | message names it under "registered but not listed" | confirmed, and the two subset assertions beside it stay green |
| registry list adds an unregistered name | message names it under "listed but not registered" | confirmed |

The two `client_secret` rows do not discriminate, for the reason above. They
are kept because they still assert agreement, not because they carry the
mutation.

## Not in scope

Unicode and NFKC normalisation of field names. The fold handles ASCII
separators; a name spelled with a non-breaking hyphen or a fullwidth underscore
still misses. That is a real gap and wants its own change, since it needs a
decision about normalising before folding rather than a wider character class.

`tests/apps_studio_server` is green (1819 passed, 1 skipped).