### PR TITLE
chore: use neutral values in test fixtures and comments

### DIFF
--- a/apps/studio/DESIGN-SYSTEM.md
+++ b/apps/studio/DESIGN-SYSTEM.md
@@ -255,7 +255,7 @@ options.export_dir, description`). Rules:
    Freeform step graphs, "join"/"debounce" nodes, and emission grants that
    `engine_defs` cannot persist are rejected fictions.
 2. **Topology is data, not drawing.** Each kind's pipeline lives in one
-   λ-reviewed catalog (`lib/designer/topology.ts`); the canvas auto-lays it
+   reviewed catalog (`lib/designer/topology.ts`); the canvas auto-lays it
    out. Users never wire engine edges by hand.
 3. **Nodes are information-dense, inline.** A node shows its stage name,
    role, resolved model (per-stage override or engine default), real

--- a/apps/studio/frontend/src/components/RunStepCard.files.test.tsx
+++ b/apps/studio/frontend/src/components/RunStepCard.files.test.tsx
@@ -25,8 +25,8 @@ function paths(command: string): string[] {
 
 describe("shell file extraction", () => {
   it("keeps rooted paths, including the ones a command only reads", () => {
-    expect(paths("cat /Users/lion/projects/atlas/INDEX.md")).toEqual([
-      "/Users/lion/projects/atlas/INDEX.md",
+    expect(paths("cat /Users/dev/projects/docs/INDEX.md")).toEqual([
+      "/Users/dev/projects/docs/INDEX.md",
     ]);
     expect(paths("uv run pytest ~/work/tests/test_flow.py")).toEqual(["~/work/tests/test_flow.py"]);
     // `./` and `../` are roots too; they normalise away, which is expected.
@@ -66,26 +66,26 @@ describe("shell file extraction", () => {
   it("rejects a wrapped script captured as one quoted token", () => {
     // The tokenizer returns the body of a quoted argument as a single word.
     // Before the root and segment rules, this whole script was one "file".
-    const wrapped = `/bin/zsh -lc '/usr/bin/find /Users/lion -name FINDINGS.md -mmin -60'`;
-    expect(paths(wrapped)).not.toContain("/usr/bin/find /Users/lion -name FINDINGS.md -mmin -60");
+    const wrapped = `/bin/zsh -lc '/usr/bin/find /Users/dev -name FINDINGS.md -mmin -60'`;
+    expect(paths(wrapped)).not.toContain("/usr/bin/find /Users/dev -name FINDINGS.md -mmin -60");
   });
 
   it("claims nothing at all for a path only visible inside a quoted wrapper", () => {
     // A known limit, asserted so it stays known. The tokenizer cannot see
     // inside a quoted argument, so the real path here is invisible. Listing
     // nothing is the correct outcome; listing the script was the defect.
-    const wrapped = `/bin/zsh -lc "cat /Users/lion/projects/notes/a.md"`;
+    const wrapped = `/bin/zsh -lc "cat /Users/dev/projects/notes/a.md"`;
     expect(paths(wrapped)).toEqual([]);
   });
 
   it("keeps paths whose directories are named in a non-Latin script", () => {
     // The segment check ran before the rooted check, so an ASCII-only class
-    // rejected these before the rooted rule could vouch for them — on a
-    // machine whose directories are routinely named in Chinese, that dropped
-    // real files. Rooted and rootless both, since widening the class fixes
+    // rejected these before the rooted rule could vouch for them. Wherever
+    // directories are routinely named outside Latin script, that dropped real
+    // files. Rooted and rootless both, since widening the class fixes
     // the rootless case too as long as the name still looks like a file.
-    expect(paths("cat /Users/lion/项目/main.py")).toEqual(["/Users/lion/项目/main.py"]);
-    expect(paths("cat /Users/lion/Café/notes.md")).toEqual(["/Users/lion/Café/notes.md"]);
+    expect(paths("cat /Users/dev/项目/main.py")).toEqual(["/Users/dev/项目/main.py"]);
+    expect(paths("cat /Users/dev/Café/notes.md")).toEqual(["/Users/dev/Café/notes.md"]);
     expect(paths("cat 文档/报告.md")).toEqual(["文档/报告.md"]);
   });
 
@@ -109,9 +109,9 @@ describe("shell file extraction", () => {
 
   it("rejects regex and shell fragments", () => {
     for (const frag of [
-      `rg "\\.busy\\b" /Users/lion/projects`,
+      `rg "\\.busy\\b" /Users/dev/projects`,
       `rg "read.transaction" .`,
-      `awk '/^##/ {print}' /Users/lion/x.md`,
+      `awk '/^##/ {print}' /Users/dev/x.md`,
     ]) {
       for (const p of paths(frag)) {
         expect(p.startsWith("/"), `${p} is not rooted`).toBe(true);

--- a/apps/studio/frontend/src/components/mission/Pulse.tsx
+++ b/apps/studio/frontend/src/components/mission/Pulse.tsx
@@ -77,11 +77,11 @@ export default function Pulse({ window: window_, onWindowChange }: Props) {
   const { data, error, loading } = usePulse(window_);
 
   // Recomputed from the dense per-bucket counts, not data.completion_rate —
-  // the server field's denominator still includes cancelled runs (Ocean
-  // 7/6: "31% completion" was an artifact of counting daemon-restart
-  // casualties as failures). This excludes cancelled entirely. It still
-  // cannot exclude orphaned/phantom-reaped failures from the failed count —
-  // that needs a backend reason-level breakdown (see sparkline.ts TODO).
+  // the server field's denominator still includes cancelled runs, so a
+  // reported "31% completion" turned out to be an artifact of counting
+  // daemon-restart casualties as failures. This excludes cancelled entirely.
+  // It still cannot exclude orphaned/phantom-reaped failures from the failed
+  // count — that needs a backend reason-level breakdown (see sparkline.ts TODO).
   const rate = data ? completionRateFromBuckets(data.buckets) : null;
   const ratePct = rate != null ? Math.round(rate * 100) : null;
   // "" marks a failure without a usable message — localize the fallback.

--- a/benchmarks/orchestration/suites/lionbench/test_schema.py
+++ b/benchmarks/orchestration/suites/lionbench/test_schema.py
@@ -36,7 +36,7 @@ def _make_instance(instance_id="lionagi__1843", subject="lionagi", validated=Tru
         gold_patch="diff --git a/src/x.py b/src/x.py\n",
         merged_at="2026-06-14T00:00:00Z",
         subject=subject,
-        provenance=Provenance(pr=1843, issue=1791, nominated_by="lambda:lionagi", why="regression"),
+        provenance=Provenance(pr=1843, issue=1791, nominated_by="maintainer", why="regression"),
     )
     if validated:
         inst.validation = Validation(gold_passes=True, null_fails=True, leak_review="pass")
@@ -104,7 +104,7 @@ def test_save_instance_redacts_validation_output_and_nominated_by_on_disk(tmp_pa
     assert on_disk["provenance"]["why"] == ""
     # in-memory instance is untouched -- redaction only applies at the write boundary
     assert inst.validation.gold_output != ""
-    assert inst.provenance.nominated_by == "lambda:lionagi"
+    assert inst.provenance.nominated_by == "maintainer"
     assert inst.provenance.why == "regression"
 
 

--- a/docs/_archive/v0/ADR-0085-flow-control-plane.md
+++ b/docs/_archive/v0/ADR-0085-flow-control-plane.md
@@ -284,7 +284,7 @@ running" with "you typo'd a flag".)
 Implementation is pure reads over existing tables (`sessions`,
 `invocations`, `session_signals`) plus `session_controls` from part 1.
 `li o ctl status` becomes an alias into the same renderer. This directly
-replaces the hand-rolled sqlite polls every λ writes today.
+replaces the hand-rolled sqlite polls every caller writes today.
 
 ### 7. Per-provider usage: `usage_events` + `li usage`
 
@@ -333,7 +333,7 @@ predictive routing is attempted.
 
 Problem: gemini quota is a daily window while codex/claude are weekly, so
 gemini-routed lanes (mirror, doc verification) die mid-fleet when the daily
-window exhausts, and every λ handles it ad hoc.
+window exhausts, and every caller handles it ad hoc.
 
 v1 is **reactive** fallback, configured as chains in settings
 (project overrides global, ADR-0060 resolution):

--- a/docs/adr/ADR-0066-li-mcp-v2-verb-surface.md
+++ b/docs/adr/ADR-0066-li-mcp-v2-verb-surface.md
@@ -45,7 +45,7 @@ against, and each of these had a consumer reading the silence a different way.
    "cancel the wait" and "cancel the work" were indistinguishable from the document. They
    are different operations and always were.
 3. **The result partitions the observed ids.** D6 named the pending list without saying
-   which ids qualify for it. That silence was read three different ways in one review round,
+   which ids qualify for it. That silence was read three different ways by three readers,
    which is how a reader-derived rule announces that it needs writing down. The partition is
    now stated outright.
 4. **A call carries a minimum duration when an id resolves nothing by waiting.** This is


### PR DESCRIPTION
Six small edits across a test fixture, a provenance fixture, two code comments, and two documents. Nothing here changes behaviour.

**Why.** A path-extraction test used absolute paths from one contributor's machine as its inputs. Those inputs carry no meaning for anyone else reading or running the suite, and they pin the file to a layout nobody else has. They now use a neutral home root. The non-Latin-script cases and the quoted-wrapper cases are preserved exactly, because those are the load-bearing coverage in that file and the point was never the specific path. A provenance fixture likewise used a specific identifier where the field is an unconstrained string.

The comments and documents keep their technical rationale in full. What they drop is shorthand and attribution that a reader of this repository cannot resolve, which made the surrounding explanation weaker rather than stronger.

**Verification.** Both touched test files pass: 7 and 10 respectively. Formatters and lint are a no-op on the result. No source module is modified, so no other suite is in scope.