### PR TITLE
Draw the run canvas ranks the rank function assigns

### DIFF
--- a/apps/studio/frontend/src/components/canvas/ConditionEdge.test.ts
+++ b/apps/studio/frontend/src/components/canvas/ConditionEdge.test.ts
@@ -11,10 +11,10 @@ describe("isLongRangeEdge — rank-distance routing threshold", () => {
   it("is short-range under the threshold", () => {
     expect(isLongRangeEdge(0)).toBe(false);
     expect(isLongRangeEdge(1)).toBe(false);
-    expect(isLongRangeEdge(2)).toBe(false);
   });
 
   it("is long-range at and beyond the threshold", () => {
+    expect(isLongRangeEdge(2)).toBe(true);
     expect(isLongRangeEdge(3)).toBe(true);
     expect(isLongRangeEdge(4)).toBe(true);
     expect(isLongRangeEdge(10)).toBe(true);

--- a/apps/studio/frontend/src/components/canvas/ConditionEdge.tsx
+++ b/apps/studio/frontend/src/components/canvas/ConditionEdge.tsx
@@ -7,8 +7,11 @@ import type { EdgeProps } from "reactflow";
 // A bezier between ranks that are far apart draws one long curve sweeping
 // across every intervening rank's cards — the "spaghetti" a deep chain reads
 // as. Past this rank distance, route with a rounded step instead: it hugs the
-// rank grid rather than cutting across it.
-const LONG_RANGE_RANK_DISTANCE = 3;
+// rank grid rather than cutting across it. Under ASAP ranking (ADR-0113 D2) a
+// 2-rank gap already means a result sat waiting for a rank's worth of other
+// work to finish, so that wait is worth reading off the edge rather than only
+// the 3+ case a dependency-ranked graph used to produce.
+const LONG_RANGE_RANK_DISTANCE = 2;
 const LONG_RANGE_BORDER_RADIUS = 12;
 const LONG_RANGE_OFFSET = 24;
 

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.test.ts
@@ -277,9 +277,11 @@ describe("WorkerCanvas.tsx — source contract for the readability floor clamp",
 });
 
 // ─── Rank-distance wiring — long-range edges know how far they span ──────────
-// ConditionEdge routes rank distance >= 3 edges as smooth-step instead of
-// bezier; it can only do that if WorkerCanvas stamps rankDistance onto edge
-// data after each layout pass, from useLayout's returned rank map.
+// ConditionEdge routes edges spanning at least LONG_RANGE_RANK_DISTANCE ranks
+// as smooth-step instead of bezier; it can only do that if WorkerCanvas stamps
+// rankDistance onto edge data after each layout pass, from useLayout's returned
+// rank map. The threshold is named rather than repeated here because it has
+// already moved once, and a number copied into a comment does not move with it.
 
 describe("WorkerCanvas.tsx — source contract for rank-distance edge data", () => {
   const CANVAS_DIR = path.resolve(__dirname);

--- a/apps/studio/frontend/src/components/canvas/useLayout.asapRank.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.asapRank.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Rank assignment is ours, not dagre's (ADR-0113 D2).
+ *
+ * A node's rank is its longest path from any source, so nodes that can start
+ * together share a rank. dagre keeps the jobs it is good at: ordering nodes
+ * within a rank to reduce crossings, and routing.
+ *
+ * The distinction these tests are built around: `computeNodeDepths` has always
+ * computed the right numbers, but it fed only rank separation and edge
+ * styling. dagre ranked the graph independently, and dagre optimizes total
+ * edge length rather than concurrency. So asserting on the rank function alone
+ * passes whether or not the canvas draws the ranks the function returned. The
+ * assertion has to be on the laid-out positions.
+ *
+ * The graph below is the one the decision was measured on: `a`, `b`, `c` have
+ * no dependencies; `d`, `e`, `f` depend on `a`; `g` depends on `d`, `e`, `f`;
+ * `h` depends on `b`, `c`, `g`. `b` and `c` start at the same moment as `a`,
+ * but their results are not consumed until `h`, so an edge-length optimizer
+ * pulls them rightward to sit beside `g` — drawing them as though they ran
+ * late. That is the specific false statement this replaces.
+ */
+import { describe, it, expect } from "vitest";
+import type { Node, Edge } from "reactflow";
+import { computeNodeDepths, getLayoutedElements } from "./useLayout";
+
+const ids = ["a", "b", "c", "d", "e", "f", "g", "h"] as const;
+
+const nodes: Node[] = ids.map((id) => ({
+  id,
+  position: { x: 0, y: 0 },
+  data: { label: id },
+}));
+
+const edges: Edge[] = (
+  [
+    ["a", "d"],
+    ["a", "e"],
+    ["a", "f"],
+    ["d", "g"],
+    ["e", "g"],
+    ["f", "g"],
+    ["b", "h"],
+    ["c", "h"],
+    ["g", "h"],
+  ] as [string, string][]
+).map(([source, target]) => ({ id: `${source}-${target}`, source, target }));
+
+/** Group node ids by the column they were actually drawn in. An LR layout
+ *  gives every node in a rank the same x, so distinct x values are the
+ *  columns, left to right. */
+function drawnColumns(laidOut: Node[]): string[][] {
+  const xById = new Map(laidOut.map((n) => [n.id, Math.round(n.position.x)]));
+  const columns = [...new Set(xById.values())].sort((p, q) => p - q);
+  return columns.map((x) =>
+    [...xById.entries()]
+      .filter(([, nodeX]) => nodeX === x)
+      .map(([id]) => id)
+      .sort(),
+  );
+}
+
+describe("canvas/useLayout.ts — rank assignment is ASAP", () => {
+  it("ranks every node at its longest path from a source", () => {
+    const ranks = computeNodeDepths(nodes, edges);
+
+    // Independent work shares rank 0 even when its result is consumed late.
+    expect(ranks.get("a")).toBe(0);
+    expect(ranks.get("b")).toBe(0);
+    expect(ranks.get("c")).toBe(0);
+
+    expect(ranks.get("d")).toBe(1);
+    expect(ranks.get("e")).toBe(1);
+    expect(ranks.get("f")).toBe(1);
+    expect(ranks.get("g")).toBe(2);
+    expect(ranks.get("h")).toBe(3);
+  });
+
+  // This is the one that discriminates. The assertion above passes against a
+  // canvas that ignores the rank function entirely.
+  it("draws nodes in the columns the rank function assigned", () => {
+    const { nodes: laidOut } = getLayoutedElements(nodes, edges, "LR");
+
+    expect(drawnColumns(laidOut)).toEqual([["a", "b", "c"], ["d", "e", "f"], ["g"], ["h"]]);
+  });
+
+  it("never draws a node in an earlier column than something it depends on", () => {
+    const { nodes: laidOut } = getLayoutedElements(nodes, edges, "LR");
+    const xById = new Map(laidOut.map((n) => [n.id, Math.round(n.position.x)]));
+
+    for (const edge of edges) {
+      const sourceX = xById.get(edge.source)!;
+      const targetX = xById.get(edge.target)!;
+      expect(
+        targetX,
+        `${edge.source} -> ${edge.target} runs backwards or sits in the same column`,
+      ).toBeGreaterThan(sourceX);
+    }
+  });
+
+  it("keeps a node with no edges at rank 0 rather than inventing a position for it", () => {
+    // An operation that entered the graph unattached depends on nothing, and
+    // the honest drawing says so. Placing it beside its apparent siblings
+    // would imply a relationship the graph does not carry.
+    const detached: Node = { id: "loose", position: { x: 0, y: 0 }, data: { label: "loose" } };
+    const ranks = computeNodeDepths([...nodes, detached], edges);
+
+    expect(ranks.get("loose")).toBe(0);
+  });
+});

--- a/apps/studio/frontend/src/components/canvas/useLayout.asapRank.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.asapRank.test.ts
@@ -97,13 +97,38 @@ describe("canvas/useLayout.ts — rank assignment is ASAP", () => {
     }
   });
 
-  it("keeps a node with no edges at rank 0 rather than inventing a position for it", () => {
+  it("draws a node with no edges in the first column rather than inventing a position for it", () => {
     // An operation that entered the graph unattached depends on nothing, and
     // the honest drawing says so. Placing it beside its apparent siblings
     // would imply a relationship the graph does not carry.
     const detached: Node = { id: "loose", position: { x: 0, y: 0 }, data: { label: "loose" } };
-    const ranks = computeNodeDepths([...nodes, detached], edges);
+    const withDetached = [...nodes, detached];
 
-    expect(ranks.get("loose")).toBe(0);
+    expect(computeNodeDepths(withDetached, edges).get("loose")).toBe(0);
+
+    // The rank assertion above is the non-discriminating half — it passes
+    // against a canvas that ignores the rank function entirely. The detached
+    // node has to be DRAWN in rank 0's column, beside the other work that
+    // depends on nothing.
+    const { nodes: laidOut } = getLayoutedElements(withDetached, edges, "LR");
+    expect(drawnColumns(laidOut)[0]).toEqual(["a", "b", "c", "loose"]);
+  });
+
+  it("lays out a graph whose edge names an endpoint that never arrived", () => {
+    // An edge can reference a node the graph never received — an escalation
+    // child whose parent is absent, for instance. Such an edge has no rank gap
+    // to pin, and the layout still has to draw the nodes it does have. Passing
+    // dagre an explicit `undefined` label for this edge crashes the whole
+    // layout, so this covers every node on the canvas, not just the dangling one.
+    const dangling: Edge[] = [...edges, { id: "ghost-h", source: "ghost", target: "h" }];
+
+    expect(() => getLayoutedElements(nodes, dangling, "LR")).not.toThrow();
+
+    const { nodes: laidOut } = getLayoutedElements(nodes, dangling, "LR");
+    expect(laidOut.map((n) => n.id).sort()).toEqual([...ids].sort());
+    for (const node of laidOut) {
+      expect(Number.isFinite(node.position.x), `${node.id} has no finite x`).toBe(true);
+      expect(Number.isFinite(node.position.y), `${node.id} has no finite y`).toBe(true);
+    }
   });
 });

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -444,6 +444,45 @@ describe("getLayoutedElements — exposes a rank map alongside the layout", () =
   });
 });
 
+describe("getLayoutedElements — an edge naming a node that never arrived", () => {
+  // Reachable in production, not a defensive case: the graph is assembled from
+  // a live event stream, so an edge can arrive before its endpoint does, or
+  // instead of it. computeNodeDepths already skips those edges, and the layout
+  // has to agree with it — graphlib's setEdge CREATES any endpoint it has not
+  // seen, so handing one over gives a rank and a slot to a node nothing draws.
+  const nodes: Node[] = [bare("a"), bare("b"), bare("c")];
+  const dangling: Edge[] = [{ id: "ghost-a", source: "ghost", target: "a" }];
+  const xOf = (laid: Node[], id: string) => laid.find((n) => n.id === id)!.position.x;
+
+  it("leaves the real node on the rank the rank map assigns it", () => {
+    const { nodes: laid, ranks } = getLayoutedElements(nodes, dangling, "LR");
+    expect(laid).toHaveLength(3);
+    // All three are roots once the dangling edge is ignored, so all three are
+    // rank 0 and share an x. The failure this guards against is positions that
+    // contradict the rank map returned beside them: the phantom source takes
+    // rank 0 and displaces "a" into the next rank, while its untouched
+    // siblings stay put.
+    expect(ranks.get("a")).toBe(0);
+    expect(ranks.get("b")).toBe(0);
+    expect(xOf(laid, "a")).toBe(xOf(laid, "b"));
+    expect(xOf(laid, "b")).toBe(xOf(laid, "c"));
+  });
+
+  it("does not invent a node for the endpoint that never arrived", () => {
+    const { nodes: laid } = getLayoutedElements(nodes, dangling, "LR");
+    expect(laid.map((n) => n.id).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("still ranks and spaces an edge whose endpoints both exist", () => {
+    // Control. Ignoring unresolved endpoints must not be satisfiable by
+    // ignoring every edge — a real edge still has to separate its endpoints.
+    const real: Edge[] = [{ id: "a-b", source: "a", target: "b" }];
+    const { nodes: laid, ranks } = getLayoutedElements(nodes, real, "LR");
+    expect(ranks.get("b")).toBe(1);
+    expect(xOf(laid, "b")).toBeGreaterThan(xOf(laid, "a"));
+  });
+});
+
 describe("getLayoutedElements — deep chain with global fan-in (readability fixture)", () => {
   // Modeled on the reported hairball shape: several independent roots, one
   // long implementer/tester chain hanging off the first root, every node

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -462,11 +462,19 @@ export function getLayoutedElements(
   for (const edge of edges) {
     const sourceRank = ranks.get(edge.source);
     const targetRank = ranks.get(edge.target);
-    const minlen =
-      sourceRank !== undefined && targetRank !== undefined
-        ? Math.max(1, targetRank - sourceRank)
-        : undefined;
-    g.setEdge(edge.source, edge.target, minlen !== undefined ? { minlen } : undefined);
+    if (sourceRank !== undefined && targetRank !== undefined) {
+      g.setEdge(edge.source, edge.target, { minlen: Math.max(1, targetRank - sourceRank) });
+      continue;
+    }
+    // An endpoint is missing from `ranks`, so there is no gap to pin. Call
+    // setEdge with no label at all rather than passing `undefined` for one:
+    // graphlib treats the two differently. Omitting the argument applies the
+    // default edge label set above, while an explicit `undefined` is stored as
+    // the label, and dagre dereferences that label while routing — it throws
+    // "Cannot set properties of undefined (setting 'points')" and takes the
+    // whole layout with it. An edge can name an endpoint that never arrived as
+    // a node, so this path is reachable rather than defensive.
+    g.setEdge(edge.source, edge.target);
   }
 
   dagre.layout(g);

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -445,10 +445,20 @@ export function getLayoutedElements(
   // whenever a node's result is consumed much later than it is produced (the
   // P2 case). Rather than fight that objective with a `ranker` option (the
   // ADR is explicit that no ranker choice changes the outcome), pin every
-  // edge's minlen to the exact ASAP rank gap between its endpoints. That
-  // leaves zero slack on every edge simultaneously, so the only feasible
-  // assignment left for any ranker to find is the ASAP one — dagre still
-  // does the ordering and routing, just not the ranking.
+  // edge's minlen to the exact ASAP rank gap between its endpoints. ASAP then
+  // satisfies every constraint with equality, so its total edge span equals
+  // the sum of the minlens, which is the lower bound any feasible assignment
+  // can reach — and reaching it requires every edge to be tight, which only
+  // ASAP is. dagre still does the ordering and routing, just not the ranking.
+  //
+  // Note what that argument rests on: ASAP is the unique MINIMUM-COST
+  // assignment here, not the unique feasible one. Slack-free constraints do
+  // not by themselves pin a solution — on the graph the decision was measured
+  // on, {b:1, h:4} with the rest unchanged satisfies all nine constraints at a
+  // total span of 15 against ASAP's 13. It loses on cost, not on legality. So
+  // this depends on the ranker minimizing total edge length, which every dagre
+  // ranker does. A future ranker with a different objective would need this
+  // revisited rather than trusted.
   for (const edge of edges) {
     const sourceRank = ranks.get(edge.source);
     const targetRank = ranks.get(edge.target);

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -438,8 +438,25 @@ export function getLayoutedElements(
   for (const node of nodes) {
     g.setNode(node.id, { width: NODE_WIDTH, height: estimateNodeHeight(node) });
   }
+  // Rank assignment is ours (ADR-0113 D2), not dagre's: `ranks` above already
+  // computed each node's ASAP depth. dagre's own rankers — network-simplex
+  // included, which is the untouched default here — minimize total edge
+  // length instead, which is a different objective and disagrees with ASAP
+  // whenever a node's result is consumed much later than it is produced (the
+  // P2 case). Rather than fight that objective with a `ranker` option (the
+  // ADR is explicit that no ranker choice changes the outcome), pin every
+  // edge's minlen to the exact ASAP rank gap between its endpoints. That
+  // leaves zero slack on every edge simultaneously, so the only feasible
+  // assignment left for any ranker to find is the ASAP one — dagre still
+  // does the ordering and routing, just not the ranking.
   for (const edge of edges) {
-    g.setEdge(edge.source, edge.target);
+    const sourceRank = ranks.get(edge.source);
+    const targetRank = ranks.get(edge.target);
+    const minlen =
+      sourceRank !== undefined && targetRank !== undefined
+        ? Math.max(1, targetRank - sourceRank)
+        : undefined;
+    g.setEdge(edge.source, edge.target, minlen !== undefined ? { minlen } : undefined);
   }
 
   dagre.layout(g);

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -466,15 +466,23 @@ export function getLayoutedElements(
       g.setEdge(edge.source, edge.target, { minlen: Math.max(1, targetRank - sourceRank) });
       continue;
     }
-    // An endpoint is missing from `ranks`, so there is no gap to pin. Call
-    // setEdge with no label at all rather than passing `undefined` for one:
-    // graphlib treats the two differently. Omitting the argument applies the
-    // default edge label set above, while an explicit `undefined` is stored as
-    // the label, and dagre dereferences that label while routing — it throws
-    // "Cannot set properties of undefined (setting 'points')" and takes the
-    // whole layout with it. An edge can name an endpoint that never arrived as
-    // a node, so this path is reachable rather than defensive.
-    g.setEdge(edge.source, edge.target);
+    // An endpoint is missing from `ranks`, which happens exactly when the edge
+    // names a node that never arrived: computeNodeDepths ranks every node it
+    // was given and skips edges pointing outside that set. Skip the edge here
+    // too, so the layout and the rank map describe the same graph.
+    //
+    // Handing it to dagre instead is worse than useless. graphlib's setEdge
+    // CREATES an endpoint it has not seen, so the absent node gets a rank and
+    // a slot of its own, and dagre pushes the real node that depends on it out
+    // of the rank this function just computed — positions contradicting the
+    // `ranks` map returned beside them, on behalf of a node nothing draws. It
+    // also costs real time at scale, since dagre lays out every phantom.
+    //
+    // If a future change does need one of these to reach dagre, call setEdge
+    // with no label rather than passing `undefined` for one: graphlib stores an
+    // explicit `undefined` AS the label, and dagre dereferences it while
+    // routing — "Cannot set properties of undefined (setting 'points')", which
+    // takes the whole layout down.
   }
 
   dagre.layout(g);


### PR DESCRIPTION
The run canvas computes each node's earliest possible start, then handed that
result to the layout engine only for spacing and edge styling. The engine still
ranked the graph by its own objective, so nodes that could start immediately
were drawn in later columns beside the work they do not depend on. The picture
made a false statement about the run.

## What changes

- Rank assignment is pinned to the computed earliest-start ranks by constraining
  each edge's minimum span to the exact rank gap. That leaves no slack on any
  edge, so the earliest-start assignment is the only one that reaches the
  minimum total edge length the engine optimises for. The ranks are fed in
  *before* crossing minimisation runs, so ordering is optimised against the real
  rank structure rather than against a rank assignment that gets discarded.
- An edge spanning two or more ranks is now styled as long-range. Previously the
  threshold was three, which predated this ranking change; a two-rank span is now
  an ordinary occurrence rather than a rare one. A one-rank edge is unchanged.
- An edge naming a node the graph never received is now left out of the layout
  entirely, matching what the rank function already did with it. Pinning a span
  needs both endpoints to have a rank, and these edges have only one.

## Edges to nodes that never arrived

The canvas builds its graph from a live event stream, so an edge can name a node
that has not arrived yet, or never arrives. Two separate faults came from
handing those edges to the layout engine anyway, and both are fixed here.

The first took the whole canvas down. With no rank gap to pin, the code passed
`undefined` where the edge label goes. The graph library treats that differently
from passing nothing: omitting the argument applies a default label, while an
explicit `undefined` is stored *as* the label and is later dereferenced during
routing, throwing `Cannot set properties of undefined (setting 'points')`. One
such edge failed the entire layout rather than just itself, so a run containing
an unattached operation rendered no canvas at all.

The second is why the edge is now skipped outright rather than passed with a
default label. The graph library creates any endpoint it has not already seen,
so the absent node received a rank and a column of its own, and the real node
depending on it was pushed out of the rank that had just been computed for it. A
graph of three roots and one such edge reported every node at rank 0 and then
drew one of them a full rank to the right of the other two: positions
contradicting the rank map returned beside them, on behalf of a node nothing
draws. It also spends layout time in proportion to how many absent endpoints
appear.

## Notes

Nodes reposition when the graph changes, without a transition. That is
deliberate: freezing a node at a stale column would reintroduce the same class
of false statement this change removes. Making the movement legible is a
separate concern with its own contract.

Two tests that asserted the rank function's output without ever laying the graph
out were strengthened to assert the drawn column instead. A test of the rank
function alone passes whether or not the canvas honours it, which is the gap
that let the original defect stand.

## Verification

`vitest run src/components/canvas/` — 203 passed across 7 files. Each behaviour
above is covered by a test that was red against the code preceding its fix and
green after, including the position assertion that discriminates the ranking
change and the three-root case that pins the unresolved-edge behaviour. Lint and
format clean.
