### PR TITLE
Show live per-node activity on the run canvas

### DIFF
--- a/apps/studio/frontend/src/components/canvas/StepNode.test.ts
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.ts
@@ -109,6 +109,12 @@ describe("StepNode.tsx — source contract for the status rail + reduced-motion"
 
   it("gates the pulse animation on prefers-reduced-motion, keeping the rail/border cues animation-free", () => {
     expect(src).toMatch(/usePrefersReducedMotion/);
-    expect(src).toMatch(/reducedMotion \? "" : " animate-pulse"/);
+    // The pulse is gated on `animating`, which folds in reducedMotion along
+    // with the other real-signal requirements from ADR-0113 row 7 (fresh
+    // events, in viewport, under the concurrency cap) — reducedMotion alone
+    // is no longer sufficient to decide the class, but it must still be one
+    // of the inputs that can turn animation off.
+    expect(src).toMatch(/!reducedMotion/);
+    expect(src).toMatch(/animating \? " animate-pulse" : ""/);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -8,8 +8,10 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { IntlProvider } from "use-intl";
 import enMessages from "@/messages/en.json";
-import StepNode from "./StepNode";
+import StepNode, { MAX_ANIMATING_NODES } from "./StepNode";
 import type { StepNodeData, NodeExecStatus } from "./StepNode";
+import { NODE_HEIGHT } from "./useLayout";
+import { STALL_TIMEOUT_MS } from "@/lib/nodeActivity";
 
 // Handle needs a ReactFlow store; the card's own layout is what is under test.
 vi.mock("reactflow", () => ({
@@ -41,8 +43,8 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function renderNode(data: Partial<StepNodeData>) {
-  const full: StepNodeData = {
+function baseData(data: Partial<StepNodeData>): StepNodeData {
+  return {
     label: "plan-step",
     role: "critic",
     assignment: "",
@@ -53,17 +55,40 @@ function renderNode(data: Partial<StepNodeData>) {
     outputs: [],
     ...data,
   };
+}
+
+function renderNode(data: Partial<StepNodeData>, id?: string) {
+  const full = baseData(data);
   act(() => {
     // NodeProps carries more than the card reads; the rest is ReactFlow's.
     root.render(
       <IntlProvider locale="en" messages={enMessages}>
-        {React.createElement(StepNode, { data: full, selected: false } as never)}
+        {React.createElement(StepNode, { data: full, selected: false, id } as never)}
       </IntlProvider>,
     );
   });
 }
 
-/** The card's two rows, in order. */
+/** Renders several cards at once, sharing one animation-slot registry pass —
+ *  needed for the concurrent-animation-cap tests. */
+function renderNodes(entries: Array<{ id: string; data: Partial<StepNodeData> }>) {
+  act(() => {
+    root.render(
+      <IntlProvider locale="en" messages={enMessages}>
+        {entries.map(({ id, data }) =>
+          React.createElement(StepNode, {
+            key: id,
+            id,
+            data: baseData(data),
+            selected: false,
+          } as never),
+        )}
+      </IntlProvider>,
+    );
+  });
+}
+
+/** The card's content rows, in order: name/state, role/elapsed, live-activity. */
 function rows(): Element[] {
   return Array.from(container.querySelectorAll(":scope > div > div"));
 }
@@ -72,6 +97,20 @@ function bottomRightText(): string {
   const bottom = rows()[1];
   const spans = bottom.querySelectorAll("span");
   return spans[spans.length - 1]?.textContent ?? "";
+}
+
+/** The live-activity row's header line (activity word + counter). */
+function activityText(): string {
+  return rows()[2]?.textContent ?? "";
+}
+
+function cards(): Element[] {
+  return Array.from(container.children);
+}
+
+function isAnimating(card: Element): boolean {
+  const dot = card.querySelector("span.animate-pulse");
+  return dot !== null;
 }
 
 describe("StepNode — the bottom-right corner always says something", () => {
@@ -123,16 +162,16 @@ describe("StepNode — the bottom-right corner always says something", () => {
 });
 
 describe("StepNode — the card keeps its shape", () => {
-  it("renders both rows even when the node carries no role", () => {
+  it("renders all three rows even when the node carries no role", () => {
     // Held open rather than dropped: a missing role must not move the row above
     // it, because one height is what the layout reserves for every node.
     renderNode({ role: "" });
-    expect(rows().length).toBe(2);
+    expect(rows().length).toBe(3);
   });
 
-  it("renders both rows for a node carrying nothing but a label", () => {
+  it("renders all three rows for a node carrying nothing but a label", () => {
     renderNode({ role: "", execStatus: undefined, durationSeconds: undefined });
-    expect(rows().length).toBe(2);
+    expect(rows().length).toBe(3);
     expect(bottomRightText().trim().length).toBeGreaterThan(0);
   });
 
@@ -152,5 +191,165 @@ describe("StepNode — the card keeps its shape", () => {
     const failedIcon = rows()[0].querySelector("span.flex.shrink-0.items-center");
     expect(failedIcon?.className).toContain("text-status-error");
     expect(failedIcon?.className).not.toContain("text-status-warning");
+  });
+});
+
+describe("StepNode — fixed height regardless of live text (ADR-0113 row 6)", () => {
+  it("renders the assistant text but keeps the card's height constant, empty or full", () => {
+    renderNode({ lastText: null });
+    const emptyCard = container.firstElementChild as HTMLElement;
+    const emptyHeight = emptyCard.style.height;
+    expect(emptyHeight).toBe(`${NODE_HEIGHT}px`);
+
+    const longText = "one two three four five six seven eight nine ten eleven twelve thirteen";
+    renderNode({ lastText: longText });
+    const fullCard = container.firstElementChild as HTMLElement;
+    // The text must actually be on the card (row 6 exists), and the card's
+    // own reserved height must not have grown to fit it (that is the
+    // defect useLayout.ts's NODE_HEIGHT comment records fixing once already).
+    expect(fullCard.textContent).toContain("one two three");
+    expect(fullCard.style.height).toBe(emptyHeight);
+  });
+
+  it("is the same height for two side-by-side nodes whether or not either has finished", () => {
+    renderNodes([
+      { id: "unfinished", data: { execStatus: "running", lastText: null } },
+      {
+        id: "finished",
+        data: { execStatus: "completed", lastText: "final answer, three lines of it, done" },
+      },
+    ]);
+    const heights = cards().map((c) => (c as HTMLElement).style.height);
+    expect(new Set(heights).size).toBe(1);
+    expect(heights[0]).toBe(`${NODE_HEIGHT}px`);
+  });
+});
+
+describe("StepNode — a stall timeout returns the node to a static 'stalled' state", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("pulses right up to the stall timeout, then goes static and says it stalled", () => {
+    const now = Date.now();
+    renderNode({ execStatus: "running", lastEventAt: now, activity: "thinking" });
+    const card = container.firstElementChild as HTMLElement;
+    expect(isAnimating(card)).toBe(true);
+    expect(activityText()).not.toContain("stalled");
+
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS + 1);
+    });
+
+    expect(isAnimating(card)).toBe(false);
+    expect(activityText()).toContain("stalled");
+  });
+
+  it("never stalls a node still receiving fresh events at the same cadence", () => {
+    const now = Date.now();
+    renderNode({ execStatus: "running", lastEventAt: now, activity: "thinking" });
+
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS - 1);
+    });
+    // A fresh event lands just under the deadline, resetting the window.
+    renderNode({ execStatus: "running", lastEventAt: Date.now(), activity: "thinking" });
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS - 1);
+    });
+
+    const card = container.firstElementChild as HTMLElement;
+    expect(isAnimating(card)).toBe(true);
+    expect(activityText()).not.toContain("stalled");
+  });
+});
+
+describe("StepNode — prefers-reduced-motion carries the same information, not less", () => {
+  it("shows the identical activity word and counter whether or not motion is reduced", () => {
+    const props: Partial<StepNodeData> = {
+      execStatus: "running",
+      lastEventAt: Date.now(),
+      activity: "tool",
+      activityDetail: "run_tests",
+      counter: 128,
+    };
+
+    renderNode(props);
+    const animatedText = activityText();
+    const animatedHasPulse = isAnimating(container.firstElementChild as HTMLElement);
+
+    // Force a real remount so the reduced-motion hook re-reads matchMedia —
+    // it only asks on mount, same as the running card does today.
+    act(() => root.unmount());
+    root = createRoot(container);
+    vi.stubGlobal("matchMedia", () => ({
+      matches: true,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }));
+    renderNode(props);
+    const reducedText = activityText();
+    const reducedHasPulse = isAnimating(container.firstElementChild as HTMLElement);
+
+    expect(animatedHasPulse).toBe(true);
+    expect(reducedHasPulse).toBe(false);
+    // The information — not merely "did it animate" — must match exactly.
+    expect(reducedText).toBe(animatedText);
+    expect(reducedText).toContain("128");
+    expect(reducedText).toContain("run_tests");
+  });
+});
+
+describe("StepNode — the concurrent-animation cap keeps a big canvas responsive", () => {
+  it("animates at most MAX_ANIMATING_NODES nodes when more than that many are running", () => {
+    const total = MAX_ANIMATING_NODES + 3;
+    const now = Date.now();
+    const entries = Array.from({ length: total }, (_, i) => ({
+      id: `n${i}`,
+      data: { execStatus: "running" as const, lastEventAt: now, activity: "thinking" as const },
+    }));
+    renderNodes(entries);
+
+    expect(cards().length).toBe(total);
+    const animatingCount = cards().filter(isAnimating).length;
+    expect(animatingCount).toBe(MAX_ANIMATING_NODES);
+  });
+});
+
+describe("StepNode — nothing animates outside the viewport", () => {
+  it("does not animate a running node the IntersectionObserver reports as not intersecting", () => {
+    class NotIntersectingObserver {
+      constructor(private cb: IntersectionObserverCallback) {}
+      observe(target: Element) {
+        this.cb([{ isIntersecting: false, target } as IntersectionObserverEntry], this as never);
+      }
+      disconnect() {}
+      unobserve() {}
+    }
+    vi.stubGlobal("IntersectionObserver", NotIntersectingObserver);
+
+    renderNode({ execStatus: "running", lastEventAt: Date.now(), activity: "thinking" });
+    const card = container.firstElementChild as HTMLElement;
+    expect(isAnimating(card)).toBe(false);
+  });
+
+  it("animates a running node the IntersectionObserver reports as intersecting", () => {
+    class IntersectingObserver {
+      constructor(private cb: IntersectionObserverCallback) {}
+      observe(target: Element) {
+        this.cb([{ isIntersecting: true, target } as IntersectionObserverEntry], this as never);
+      }
+      disconnect() {}
+      unobserve() {}
+    }
+    vi.stubGlobal("IntersectionObserver", IntersectingObserver);
+
+    renderNode({ execStatus: "running", lastEventAt: Date.now(), activity: "thinking" });
+    const card = container.firstElementChild as HTMLElement;
+    expect(isAnimating(card)).toBe(true);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -345,6 +345,102 @@ describe("StepNode — the concurrent-animation cap keeps a big canvas responsiv
   });
 });
 
+/**
+ * Two canvases over the same run, mounted at once. The run detail keeps its
+ * inline canvas mounted while the expanded graph is open, so both sets of cards
+ * are live and carry identical node IDs. Every test above renders one canvas,
+ * and one canvas cannot exhibit this at all.
+ */
+function renderTwoCanvases(
+  inline: Array<{ id: string; data: Partial<StepNodeData> }>,
+  expanded: Array<{ id: string; data: Partial<StepNodeData> }>,
+) {
+  const groups: Array<[string, Array<{ id: string; data: Partial<StepNodeData> }>]> = [
+    ["inline", inline],
+    ["expanded", expanded],
+  ];
+  act(() => {
+    root.render(
+      <IntlProvider locale="en" messages={enMessages}>
+        {groups.flatMap(([canvas, entries]) =>
+          entries.map(({ id, data }) =>
+            React.createElement(StepNode, {
+              // The React key separates the two cards; the node `id` they are
+              // handed is deliberately the same, which is the real situation.
+              key: `${canvas}-${id}`,
+              id,
+              data: baseData(data),
+              selected: false,
+            } as never),
+          ),
+        )}
+      </IntlProvider>,
+    );
+  });
+}
+
+function runningNodes(count: number, prefix = "n") {
+  const now = Date.now();
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}${i}`,
+    data: { execStatus: "running" as const, lastEventAt: now, activity: "thinking" as const },
+  }));
+}
+
+describe("StepNode — the animation budget survives two canvases over one run", () => {
+  it("still animates at most MAX_ANIMATING_NODES when the expanded graph doubles the cards", () => {
+    // Both canvases show the same MAX_ANIMATING_NODES running nodes, so twice
+    // the cap is on screen carrying only `cap` distinct IDs. Keyed by node ID,
+    // the second canvas's cards each find their ID already registered and
+    // animate without taking a slot: every card moves, the registry still reads
+    // `cap`, and nothing anywhere reports that the budget was exceeded.
+    const nodes = runningNodes(MAX_ANIMATING_NODES);
+    renderTwoCanvases(nodes, nodes);
+
+    expect(cards().length).toBe(MAX_ANIMATING_NODES * 2);
+    expect(cards().filter(isAnimating).length).toBe(MAX_ANIMATING_NODES);
+  });
+
+  it("does not free a slot the surviving canvas is still animating on", () => {
+    // Collapsing the expanded graph unmounts one card per node while the inline
+    // card keeps animating. Keyed by node ID, that unmount deletes the entry the
+    // inline card is still using, emptying the registry while `cap` nodes are
+    // visibly moving — so the next node to start running claims a slot that is
+    // already spoken for, and the canvas ends up over budget.
+    const shared = runningNodes(MAX_ANIMATING_NODES);
+    renderTwoCanvases(shared, shared);
+
+    // Expanded canvas closes; a new node starts running in the same commit.
+    renderTwoCanvases(shared, runningNodes(1, "late"));
+
+    expect(cards().length).toBe(MAX_ANIMATING_NODES + 1);
+    expect(cards().filter(isAnimating).length).toBe(MAX_ANIMATING_NODES);
+  });
+
+  it("releases a slot when a holder stops, so a newly mounted card can take it", () => {
+    // The guard against satisfying the two above by never releasing anything.
+    // It arrives as a fresh card rather than one already turned away, because a
+    // denied card does not re-compete: slots are first-claimed-first-served and
+    // a card that lost re-runs its effect only if its own inputs change. That
+    // is the existing behaviour, unchanged here — the excess falls back to the
+    // static state, which is what the cap is for.
+    const shared = runningNodes(MAX_ANIMATING_NODES);
+    renderTwoCanvases(shared, []);
+    expect(cards().filter(isAnimating).length).toBe(MAX_ANIMATING_NODES);
+
+    // One holder completes and a new node starts running in the same commit.
+    const [first, ...rest] = shared;
+    renderTwoCanvases(
+      [{ id: first.id, data: { execStatus: "completed" as const } }, ...rest],
+      runningNodes(1, "late"),
+    );
+
+    expect(cards().filter(isAnimating).length).toBe(MAX_ANIMATING_NODES);
+    expect(isAnimating(cards()[0])).toBe(false);
+    expect(isAnimating(cards()[cards().length - 1])).toBe(true);
+  });
+});
+
 describe("StepNode — nothing animates outside the viewport", () => {
   it("does not animate a running node the IntersectionObserver reports as not intersecting", () => {
     class NotIntersectingObserver {

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -228,7 +228,14 @@ describe("StepNode — a stall timeout returns the node to a static 'stalled' st
 
   it("pulses right up to the stall timeout, then goes static and says it stalled", () => {
     const now = Date.now();
-    renderNode({ execStatus: "running", lastEventAt: now, activity: "thinking" });
+    // liveSignalAt is what arms the clock: this node HAS reported work, so
+    // its going quiet is the failure the stalled reading exists to catch.
+    renderNode({
+      execStatus: "running",
+      lastEventAt: now,
+      liveSignalAt: now,
+      activity: "thinking",
+    });
     const card = container.firstElementChild as HTMLElement;
     expect(isAnimating(card)).toBe(true);
     expect(activityText()).not.toContain("stalled");
@@ -243,13 +250,23 @@ describe("StepNode — a stall timeout returns the node to a static 'stalled' st
 
   it("never stalls a node still receiving fresh events at the same cadence", () => {
     const now = Date.now();
-    renderNode({ execStatus: "running", lastEventAt: now, activity: "thinking" });
+    renderNode({
+      execStatus: "running",
+      lastEventAt: now,
+      liveSignalAt: now,
+      activity: "thinking",
+    });
 
     act(() => {
       vi.advanceTimersByTime(STALL_TIMEOUT_MS - 1);
     });
     // A fresh event lands just under the deadline, resetting the window.
-    renderNode({ execStatus: "running", lastEventAt: Date.now(), activity: "thinking" });
+    renderNode({
+      execStatus: "running",
+      lastEventAt: Date.now(),
+      liveSignalAt: Date.now(),
+      activity: "thinking",
+    });
     act(() => {
       vi.advanceTimersByTime(STALL_TIMEOUT_MS - 1);
     });
@@ -257,6 +274,23 @@ describe("StepNode — a stall timeout returns the node to a static 'stalled' st
     const card = container.firstElementChild as HTMLElement;
     expect(isAnimating(card)).toBe(true);
     expect(activityText()).not.toContain("stalled");
+  });
+
+  it("never stalls a node that has no liveness signal to lose", () => {
+    // Every node under today's backend: lifecycle events bracket the work and
+    // nothing is emitted in between, so lastEventAt freezes at NodeStarted
+    // while the node runs perfectly normally for its whole life. Measured on a
+    // real run, that silence is 32-39 seconds per node, so reading it as a
+    // stall put "stalled" on every live card for about two thirds of the run.
+    const now = Date.now();
+    renderNode({ execStatus: "running", lastEventAt: now, activity: "thinking" });
+
+    act(() => {
+      vi.advanceTimersByTime(STALL_TIMEOUT_MS * 3);
+    });
+
+    expect(activityText()).not.toContain("stalled");
+    expect(activityText()).toContain("thinking");
   });
 });
 

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -294,11 +294,57 @@ describe("StepNode — a stall timeout returns the node to a static 'stalled' st
   });
 });
 
+describe("StepNode — a node with no live signal does not animate as though it had one", () => {
+  it("does not pulse a running node whose only events are lifecycle ones", () => {
+    // The production shape today: NodeStarted arrives and nothing follows it
+    // for the node's whole working life. That sets lastEventAt but not
+    // liveSignalAt, so the stall clock has nothing to arm and correctly never
+    // fires. Animating on lastEventAt combined those two into a pulse that
+    // could never be stopped by anything — a card asserting a live stream it
+    // had never been told about, for as long as it claimed to be running.
+    const now = Date.now();
+    renderNode({
+      execStatus: "running",
+      lastEventAt: now,
+      liveSignalAt: null,
+      activity: "thinking",
+    });
+
+    const card = container.firstElementChild as HTMLElement;
+    expect(isAnimating(card)).toBe(false);
+    // Still legibly running: the pulse is what goes away, not the node's
+    // state. The running dot draws off execStatus alone, so it is present and
+    // simply static, and the activity row still reports what NodeStarted told
+    // us the node is doing.
+    expect(card.querySelector("span.rounded-full")).not.toBeNull();
+    expect(activityText()).toContain("thinking");
+  });
+
+  it("pulses the same node once a real work signal arrives", () => {
+    // The must-MATCH half. Without this, the expectation above would be
+    // satisfied by the animation being broken outright rather than by the
+    // gate discriminating, and nothing here would notice.
+    const now = Date.now();
+    renderNode({
+      execStatus: "running",
+      lastEventAt: now,
+      liveSignalAt: now,
+      activity: "streaming",
+    });
+
+    expect(isAnimating(container.firstElementChild as HTMLElement)).toBe(true);
+  });
+});
+
 describe("StepNode — prefers-reduced-motion carries the same information, not less", () => {
   it("shows the identical activity word and counter whether or not motion is reduced", () => {
     const props: Partial<StepNodeData> = {
       execStatus: "running",
       lastEventAt: Date.now(),
+      // A node mid tool-call has reported work, so it carries a live signal —
+      // which is what lets it animate at all. Without it this test would
+      // compare two static cards and its pulse assertions would mean nothing.
+      liveSignalAt: Date.now(),
       activity: "tool",
       activityDetail: "run_tests",
       counter: 128,
@@ -361,7 +407,12 @@ describe("StepNode — the concurrent-animation cap keeps a big canvas responsiv
     const now = Date.now();
     const entries = Array.from({ length: total }, (_, i) => ({
       id: `n${i}`,
-      data: { execStatus: "running" as const, lastEventAt: now, activity: "thinking" as const },
+      data: {
+        execStatus: "running" as const,
+        lastEventAt: now,
+        liveSignalAt: now,
+        activity: "streaming" as const,
+      },
     }));
     renderNodes(entries);
 
@@ -405,11 +456,20 @@ function renderTwoCanvases(
   });
 }
 
+// Nodes that are actually streaming, so every animation gate but the cap is
+// satisfied and the cap is the only thing these tests can be measuring. A
+// lifecycle-only node (no liveSignalAt) never competes for a slot at all,
+// which would let a budget test pass while animating nothing.
 function runningNodes(count: number, prefix = "n") {
   const now = Date.now();
   return Array.from({ length: count }, (_, i) => ({
     id: `${prefix}${i}`,
-    data: { execStatus: "running" as const, lastEventAt: now, activity: "thinking" as const },
+    data: {
+      execStatus: "running" as const,
+      lastEventAt: now,
+      liveSignalAt: now,
+      activity: "streaming" as const,
+    },
   }));
 }
 
@@ -479,7 +539,17 @@ describe("StepNode — nothing animates outside the viewport", () => {
     }
     vi.stubGlobal("IntersectionObserver", NotIntersectingObserver);
 
-    renderNode({ execStatus: "running", lastEventAt: Date.now(), activity: "thinking" });
+    // Every other gate deliberately passes — a streaming node with a live
+    // signal — so the off-screen reading is the only thing that can be
+    // stopping the pulse. A fixture that failed some other gate would satisfy
+    // this expectation without the viewport logic doing anything.
+    const now = Date.now();
+    renderNode({
+      execStatus: "running",
+      lastEventAt: now,
+      liveSignalAt: now,
+      activity: "streaming",
+    });
     const card = container.firstElementChild as HTMLElement;
     expect(isAnimating(card)).toBe(false);
   });
@@ -495,7 +565,13 @@ describe("StepNode — nothing animates outside the viewport", () => {
     }
     vi.stubGlobal("IntersectionObserver", IntersectingObserver);
 
-    renderNode({ execStatus: "running", lastEventAt: Date.now(), activity: "thinking" });
+    const now = Date.now();
+    renderNode({
+      execStatus: "running",
+      lastEventAt: now,
+      liveSignalAt: now,
+      activity: "streaming",
+    });
     const card = container.firstElementChild as HTMLElement;
     expect(isAnimating(card)).toBe(true);
   });

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -10,12 +10,7 @@ import { IntlProvider } from "use-intl";
 import enMessages from "@/messages/en.json";
 import StepNode, { MAX_ANIMATING_NODES } from "./StepNode";
 import type { StepNodeData, NodeExecStatus } from "./StepNode";
-import {
-  NODE_HEIGHT,
-  PREVIEW_LINE_HEIGHT,
-  TEXT_PREVIEW_HEIGHT,
-  TEXT_PREVIEW_LINES,
-} from "./useLayout";
+import { NODE_HEIGHT } from "./useLayout";
 import { STALL_TIMEOUT_MS } from "@/lib/nodeActivity";
 
 // Handle needs a ReactFlow store; the card's own layout is what is under test.
@@ -199,34 +194,26 @@ describe("StepNode — the card keeps its shape", () => {
   });
 });
 
-describe("StepNode — fixed height regardless of live text (ADR-0113 row 6)", () => {
-  it("renders the assistant text but keeps the card's height constant, empty or full", () => {
-    renderNode({ lastText: null });
-    const emptyCard = container.firstElementChild as HTMLElement;
-    const emptyHeight = emptyCard.style.height;
-    expect(emptyHeight).toBe(`${NODE_HEIGHT}px`);
-
-    const longText = "one two three four five six seven eight nine ten eleven twelve thirteen";
-    renderNode({ lastText: longText });
-    const fullCard = container.firstElementChild as HTMLElement;
-    // The text must actually be on the card (row 6 exists), and the card's
-    // own reserved height must not have grown to fit it (that is the
-    // defect useLayout.ts's NODE_HEIGHT comment records fixing once already).
-    expect(fullCard.textContent).toContain("one two three");
-    expect(fullCard.style.height).toBe(emptyHeight);
-  });
-
+describe("StepNode — one height for every state of a run", () => {
   it("is the same height for two side-by-side nodes whether or not either has finished", () => {
+    // Compared against each other rather than against NODE_HEIGHT: the card
+    // sets its height FROM that constant, so asserting it equals the constant
+    // holds for any value and says nothing.
     renderNodes([
-      { id: "unfinished", data: { execStatus: "running", lastText: null } },
-      {
-        id: "finished",
-        data: { execStatus: "completed", lastText: "final answer, three lines of it, done" },
-      },
+      { id: "unfinished", data: { execStatus: "running", activity: "thinking" } },
+      { id: "finished", data: { execStatus: "completed" } },
     ]);
     const heights = cards().map((c) => (c as HTMLElement).style.height);
     expect(new Set(heights).size).toBe(1);
-    expect(heights[0]).toBe(`${NODE_HEIGHT}px`);
+  });
+
+  it("holds its height when a running node has an activity to report", () => {
+    renderNodes([
+      { id: "quiet", data: { execStatus: "running" } },
+      { id: "busy", data: { execStatus: "running", activity: "tool", activityDetail: "grep" } },
+    ]);
+    const heights = cards().map((c) => (c as HTMLElement).style.height);
+    expect(new Set(heights).size).toBe(1);
   });
 });
 
@@ -480,53 +467,32 @@ describe("StepNode — nothing animates outside the viewport", () => {
   });
 });
 
-/** The assistant-text preview: the second child of the live-activity row. */
-function previewEl(): HTMLElement {
-  const activityRow = rows()[2];
-  const preview = activityRow?.children[1] as HTMLElement | undefined;
-  if (!preview) throw new Error("no preview element under the activity row");
-  return preview;
-}
-
-describe("StepNode — the preview reserves its height instead of collapsing", () => {
-  it("occupies the same height with no text as with two full lines", () => {
-    // The invariant line-clamping alone cannot provide: a clamp caps how tall
-    // the block may get and says nothing about how short. An empty preview
-    // that collapses lets justify-between slide the rows above it downward,
-    // so the same fact stops being in the same place from card to card.
-    renderNode({ lastText: null });
-    const empty = previewEl().style.height;
-
-    renderNode({
-      lastText: "one two three four five six seven eight nine ten eleven twelve thirteen",
-    });
-    const full = previewEl().style.height;
-
-    expect(empty).toBe(`${TEXT_PREVIEW_HEIGHT}px`);
-    expect(full).toBe(empty);
+describe("StepNode — the card reserves exactly the rows it draws", () => {
+  it("reserves the chrome plus every row, and nothing for a row it does not draw", () => {
+    // NODE_HEIGHT is a sum of its terms rather than a literal, because a
+    // literal can only be checked against itself: the card sets its height
+    // from the constant, so a test comparing the two passes at any value —
+    // including 88, which it was while the card drew 98 worth of rows.
+    //
+    // Re-derived here from the type scale, so removing a row without
+    // shrinking the reservation (or adding one without growing it) fails.
+    const chrome = 8 * 2 + 3 * 2; // py-2 both sides, the running border both sides
+    const nameRow = Math.ceil(12 * 1.375);
+    const roleRow = Math.ceil(11 * 1.25);
+    const activityRow = Math.ceil(11 * 1.25);
+    const gapAboveActivity = 2;
+    expect(NODE_HEIGHT).toBe(chrome + nameRow + roleRow + gapAboveActivity + activityRow);
   });
 
-  it("draws exactly the lines it reserves room for", () => {
-    // Reservation and rendering are computed from one line height, so the
-    // clamped lines fill the reserved box exactly — no third line peeking
-    // past the clip, no dead band under a full preview.
-    renderNode({ lastText: "some text" });
-    expect(previewEl().style.lineHeight).toBe(`${PREVIEW_LINE_HEIGHT}px`);
-    expect(TEXT_PREVIEW_HEIGHT).toBe(PREVIEW_LINE_HEIGHT * TEXT_PREVIEW_LINES);
-  });
-
-  it("counts the whole preview inside the height the layout reserves", () => {
-    // The failure this replaces: the preview row was added to the card and
-    // NODE_HEIGHT stayed a hand-written literal that did not grow with it, so
-    // the card drew more than the layout had reserved. Now the card height is
-    // a sum with the preview as one of its terms — give the preview another
-    // line and NODE_HEIGHT follows, rather than silently overflowing.
-    expect(NODE_HEIGHT).toBeGreaterThan(TEXT_PREVIEW_HEIGHT);
-    // Chrome (padding 8 top and bottom, 3px border both sides) plus the two
-    // text rows above the activity block, which the card always draws.
-    const chrome = 8 * 2 + 3 * 2;
-    expect(NODE_HEIGHT - TEXT_PREVIEW_HEIGHT - chrome).toBeGreaterThanOrEqual(
-      PREVIEW_LINE_HEIGHT * 3,
+  it("draws no reserved-height block with nothing in it", () => {
+    // The card used to keep two lines for the agent's latest text. No signal
+    // carries per-node text, so that block rendered empty on every card of
+    // every run. This fails if a reservation returns before a producer does.
+    renderNode({ execStatus: "running", activity: "thinking" });
+    const card = container.firstElementChild as HTMLElement;
+    const emptyReservations = Array.from(card.querySelectorAll<HTMLElement>("*")).filter(
+      (el) => el.style.height !== "" && el.textContent === "",
     );
+    expect(emptyReservations).toEqual([]);
   });
 });

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -304,6 +304,31 @@ describe("StepNode — prefers-reduced-motion carries the same information, not 
   });
 });
 
+describe("StepNode — an absent activity signal is not a claim that the node is waiting", () => {
+  it("gives a running node with no activity signal its status word, not 'waiting'", () => {
+    // This is what the canvas renders for every running node today, because
+    // nothing supplies the activity fields yet. Saying "waiting" next to a
+    // node that is visibly running states something false about the run;
+    // absence of a signal is not evidence of waiting.
+    renderNode({ execStatus: "running", lastEventAt: Date.now() });
+
+    // Assert the word that must be there, not just the absence of the wrong
+    // one: an empty activity row would satisfy a "does not say waiting" check
+    // while dropping the caption entirely and silently shortening the row.
+    expect(activityText()).toContain("running");
+    expect(activityText()).not.toContain("waiting");
+  });
+
+  it("still calls a queued node waiting, because a queued node is waiting", () => {
+    // Guards the other direction, so the fix above cannot be satisfied by
+    // removing the word everywhere: "waiting" is correct for a queued node and
+    // has to survive.
+    renderNode({ execStatus: "queued" });
+
+    expect(activityText()).toContain("waiting");
+  });
+});
+
 describe("StepNode — the concurrent-animation cap keeps a big canvas responsive", () => {
   it("animates at most MAX_ANIMATING_NODES nodes when more than that many are running", () => {
     const total = MAX_ANIMATING_NODES + 3;

--- a/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.test.tsx
@@ -10,7 +10,12 @@ import { IntlProvider } from "use-intl";
 import enMessages from "@/messages/en.json";
 import StepNode, { MAX_ANIMATING_NODES } from "./StepNode";
 import type { StepNodeData, NodeExecStatus } from "./StepNode";
-import { NODE_HEIGHT } from "./useLayout";
+import {
+  NODE_HEIGHT,
+  PREVIEW_LINE_HEIGHT,
+  TEXT_PREVIEW_HEIGHT,
+  TEXT_PREVIEW_LINES,
+} from "./useLayout";
 import { STALL_TIMEOUT_MS } from "@/lib/nodeActivity";
 
 // Handle needs a ReactFlow store; the card's own layout is what is under test.
@@ -472,5 +477,56 @@ describe("StepNode — nothing animates outside the viewport", () => {
     renderNode({ execStatus: "running", lastEventAt: Date.now(), activity: "thinking" });
     const card = container.firstElementChild as HTMLElement;
     expect(isAnimating(card)).toBe(true);
+  });
+});
+
+/** The assistant-text preview: the second child of the live-activity row. */
+function previewEl(): HTMLElement {
+  const activityRow = rows()[2];
+  const preview = activityRow?.children[1] as HTMLElement | undefined;
+  if (!preview) throw new Error("no preview element under the activity row");
+  return preview;
+}
+
+describe("StepNode — the preview reserves its height instead of collapsing", () => {
+  it("occupies the same height with no text as with two full lines", () => {
+    // The invariant line-clamping alone cannot provide: a clamp caps how tall
+    // the block may get and says nothing about how short. An empty preview
+    // that collapses lets justify-between slide the rows above it downward,
+    // so the same fact stops being in the same place from card to card.
+    renderNode({ lastText: null });
+    const empty = previewEl().style.height;
+
+    renderNode({
+      lastText: "one two three four five six seven eight nine ten eleven twelve thirteen",
+    });
+    const full = previewEl().style.height;
+
+    expect(empty).toBe(`${TEXT_PREVIEW_HEIGHT}px`);
+    expect(full).toBe(empty);
+  });
+
+  it("draws exactly the lines it reserves room for", () => {
+    // Reservation and rendering are computed from one line height, so the
+    // clamped lines fill the reserved box exactly — no third line peeking
+    // past the clip, no dead band under a full preview.
+    renderNode({ lastText: "some text" });
+    expect(previewEl().style.lineHeight).toBe(`${PREVIEW_LINE_HEIGHT}px`);
+    expect(TEXT_PREVIEW_HEIGHT).toBe(PREVIEW_LINE_HEIGHT * TEXT_PREVIEW_LINES);
+  });
+
+  it("counts the whole preview inside the height the layout reserves", () => {
+    // The failure this replaces: the preview row was added to the card and
+    // NODE_HEIGHT stayed a hand-written literal that did not grow with it, so
+    // the card drew more than the layout had reserved. Now the card height is
+    // a sum with the preview as one of its terms — give the preview another
+    // line and NODE_HEIGHT follows, rather than silently overflowing.
+    expect(NODE_HEIGHT).toBeGreaterThan(TEXT_PREVIEW_HEIGHT);
+    // Chrome (padding 8 top and bottom, 3px border both sides) plus the two
+    // text rows above the activity block, which the card always draws.
+    const chrome = 8 * 2 + 3 * 2;
+    expect(NODE_HEIGHT - TEXT_PREVIEW_HEIGHT - chrome).toBeGreaterThanOrEqual(
+      PREVIEW_LINE_HEIGHT * 3,
+    );
   });
 });

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -322,6 +322,14 @@ function StepNodeComponent({ data, selected, id }: NodeProps<StepNodeData>) {
   // and where a stall becomes visible text rather than only an animation
   // that quietly stops. Independent of reducedMotion/animating: this is the
   // static-equivalent information those two must carry identically.
+  //
+  // A running node with no activity signal falls back to its status word, not
+  // to "waiting". Absence of a signal means we do not know what the node is
+  // doing; it does not mean the node is waiting, and a caption reading
+  // "waiting" beside a node that is visibly running is a false statement about
+  // the run. A queued node genuinely is waiting, so that branch keeps the word.
+  // The status word also keeps the row occupied, which the fixed-height
+  // contract above depends on.
   const activityWord = stalled
     ? "stalled"
     : status === "running"
@@ -329,7 +337,7 @@ function StepNodeComponent({ data, selected, id }: NodeProps<StepNodeData>) {
         ? data.activityDetail
           ? `${ACTIVITY_LABEL[data.activity]}: ${data.activityDetail}`
           : ACTIVITY_LABEL[data.activity]
-        : ACTIVITY_LABEL.waiting
+        : t(STATUS_WORD_KEY[status])
       : status === "queued"
         ? ACTIVITY_LABEL.waiting
         : "";

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -100,25 +100,30 @@ function useAnimationSlot(wantsToAnimate: boolean): boolean {
 }
 
 // Returns to a static "stalled" reading STALL_TIMEOUT_MS after the last live
-// event, rather than polling: a single timer fires exactly at the deadline
-// implied by `lastEventAt`, so a node that keeps receiving events never
-// stalls (each new event reschedules the timer) and one that stops gets
-// caught the instant its window closes — this is "a test, not a comment"
-// per the ADR's Consequences section, see StepNode.test.tsx.
-function useStallState(lastEventAt: number | null | undefined, isRunning: boolean): boolean {
+// signal, rather than polling: a single timer fires exactly at the deadline
+// implied by `liveSignalAt`, so a node that keeps reporting work never stalls
+// (each new signal reschedules the timer) and one that stops gets caught the
+// instant its window closes — this is "a test, not a comment" per the ADR's
+// Consequences section, see StepNode.test.tsx.
+//
+// The input is `liveSignalAt`, not `lastEventAt`, and the difference is the
+// whole correctness of this hook. A null means the node has never reported
+// work at all, so there is no stream to have stopped and the honest answer is
+// "not stalled" — the same answer this returns for a node that is not running.
+function useStallState(liveSignalAt: number | null | undefined, isRunning: boolean): boolean {
   const [stalled, setStalled] = useState(false);
   useEffect(() => {
-    if (!isRunning || lastEventAt == null) {
+    if (!isRunning || liveSignalAt == null) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing to the external clock (Date.now()), which React has no other way to read
       setStalled(false);
       return;
     }
-    setStalled(isStalled(lastEventAt, Date.now()));
-    const remaining = lastEventAt + STALL_TIMEOUT_MS - Date.now();
+    setStalled(isStalled(liveSignalAt, Date.now()));
+    const remaining = liveSignalAt + STALL_TIMEOUT_MS - Date.now();
     if (remaining <= 0) return;
     const timer = setTimeout(() => setStalled(true), remaining);
     return () => clearTimeout(timer);
-  }, [lastEventAt, isRunning]);
+  }, [liveSignalAt, isRunning]);
   return stalled;
 }
 
@@ -196,11 +201,16 @@ export interface StepNodeData {
   activityDetail?: string | null;
   /** Token or event counter, whichever the provider reports. */
   counter?: number | null;
-  /** Epoch ms of the most recent live signal for this node — the ONLY input
-   *  that drives whether/how fast this node's animation runs. Absent means
-   *  "no live stream correlation", which never animates regardless of
+  /** Epoch ms of the most recent signal of ANY kind for this node — the ONLY
+   *  input that drives whether/how fast this node's animation runs. Absent
+   *  means "no live stream correlation", which never animates regardless of
    *  execStatus. */
   lastEventAt?: number | null;
+  /** Epoch ms of the last signal that reported work in progress, as opposed
+   *  to a lifecycle transition. Drives the stall reading and nothing else.
+   *  Absent means no liveness signal exists for this node, which is not the
+   *  same as one that went quiet, and must not read as stalled. */
+  liveSignalAt?: number | null;
 }
 
 // Non-animation precedence cues (border weight + a left-edge status rail)
@@ -287,7 +297,7 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
 
   const cardRef = useRef<HTMLDivElement>(null);
   const inViewport = useInViewport(cardRef);
-  const stalled = useStallState(data.lastEventAt, status === "running");
+  const stalled = useStallState(data.liveSignalAt, status === "running");
   const pulseMs = useEventRatePulse(data.lastEventAt);
   // Every gate ADR-0113 D3 requires, all real signals: actually running,
   // fresh events (not stalled), a live stream correlation at all

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -5,7 +5,13 @@ import { Handle, Position } from "reactflow";
 import type { NodeProps } from "reactflow";
 import { useTranslations } from "use-intl";
 import { IconCheck, IconClose, IconPause, IconWarning } from "@/components/ui/icons";
-import { NODE_HEIGHT, NODE_WIDTH } from "./useLayout";
+import {
+  NODE_HEIGHT,
+  NODE_WIDTH,
+  PREVIEW_LINE_HEIGHT,
+  TEXT_PREVIEW_HEIGHT,
+  TEXT_PREVIEW_LINES,
+} from "./useLayout";
 import { isStalled, pulseDurationMs, STALL_TIMEOUT_MS } from "@/lib/nodeActivity";
 import type { NodeActivityKind } from "@/lib/nodeActivity";
 
@@ -147,11 +153,11 @@ const ACTIVITY_LABEL: Record<NodeActivityKind, string> = {
   waiting: "waiting",
 };
 
-// Fixed line count for the assistant-text preview (ADR-0113 row 6: "truncated
-// to a fixed line count"). Exported so the reserved-height math in
-// useLayout.ts's NODE_HEIGHT comment and this file agree on the number, even
-// though only the constant lives there.
-export const TEXT_PREVIEW_LINES = 2;
+// The preview's line count and reserved height live in useLayout.ts, beside
+// the NODE_HEIGHT sum they are terms of — one home for the card's geometry, so
+// the space the layout reserves and the space the card draws cannot drift.
+// Re-exported here because the line count reads as a property of the card.
+export { TEXT_PREVIEW_LINES };
 
 const ROLE_VAR: Record<string, string> = {
   researcher: "var(--role-researcher)",
@@ -454,10 +460,14 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
 
       {/* Live-activity row (ADR-0113 D3/row 6): current activity + counter on
           one line, the agent's latest text clipped to TEXT_PREVIEW_LINES on
-          the next. Always rendered, at a fixed clipped height, so a node
-          with no text yet reserves exactly the space one with a full preview
-          uses — see NODE_HEIGHT's comment in useLayout.ts. The word here and
-          the animation state above are two independent readouts of the same
+          the next. The preview HOLDS its height whether or not there is text
+          to put in it, which is what makes a card with nothing to say the same
+          shape as one mid-sentence — line-clamping alone caps how tall the
+          block can get and says nothing about how short, so an empty one used
+          to collapse and let justify-between slide the row below it upward.
+          Its line-height is set from the same constant the reservation is
+          computed from, so the two cannot round apart. The word here and the
+          animation state above are two independent readouts of the same
           `stalled`/`activity` facts, which is what keeps them from ever
           disagreeing under prefers-reduced-motion. */}
       <div className="mt-0.5 flex flex-col gap-0.5">
@@ -466,11 +476,13 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
           {counterText && <span className="shrink-0 tabular-nums">{counterText}</span>}
         </div>
         <div
-          className="overflow-hidden font-mono text-[length:var(--t-xs)] leading-tight text-content-muted"
+          className="overflow-hidden font-mono text-[length:var(--t-xs)] text-content-muted"
           style={{
             display: "-webkit-box",
             WebkitLineClamp: TEXT_PREVIEW_LINES,
             WebkitBoxOrient: "vertical",
+            height: TEXT_PREVIEW_HEIGHT,
+            lineHeight: `${PREVIEW_LINE_HEIGHT}px`,
           }}
         >
           {data.lastText || ""}

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -127,21 +127,25 @@ function useStallState(liveSignalAt: number | null | undefined, isRunning: boole
   return stalled;
 }
 
-// Pulse speed tracks the actual event rate rather than a fixed cadence — a
+// Pulse speed tracks the actual work rate rather than a fixed cadence — a
 // node emitting many events per second reads as busier than one emitting one
-// every few seconds. A sliding 5s window of observed `lastEventAt` values,
+// every few seconds. A sliding 5s window of observed `liveSignalAt` values,
 // entirely local to this node (no cross-node coordination needed).
-function useEventRatePulse(lastEventAt: number | null | undefined): number {
+//
+// Same field as the stall clock and the presence gate, for the same reason:
+// lifecycle events bracket a node's work rather than report on it, so letting
+// them drive the speed would read a node's start as a burst of activity.
+function useEventRatePulse(liveSignalAt: number | null | undefined): number {
   const windowRef = useRef<number[]>([]);
   const [duration, setDuration] = useState(1500);
   useEffect(() => {
-    if (lastEventAt == null) return;
+    if (liveSignalAt == null) return;
     const seen = windowRef.current;
-    seen.push(lastEventAt);
-    const cutoff = lastEventAt - 5000;
+    seen.push(liveSignalAt);
+    const cutoff = liveSignalAt - 5000;
     while (seen.length && seen[0]! < cutoff) seen.shift();
     setDuration(pulseDurationMs(seen.length));
-  }, [lastEventAt]);
+  }, [liveSignalAt]);
   return duration;
 }
 
@@ -298,15 +302,32 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
   const cardRef = useRef<HTMLDivElement>(null);
   const inViewport = useInViewport(cardRef);
   const stalled = useStallState(data.liveSignalAt, status === "running");
-  const pulseMs = useEventRatePulse(data.lastEventAt);
-  // Every gate ADR-0113 D3 requires, all real signals: actually running,
-  // fresh events (not stalled), a live stream correlation at all
-  // (lastEventAt present — no signal means no animation, never a guess),
-  // on-screen, and not overridden by prefers-reduced-motion. The cap is
-  // applied last, via useAnimationSlot, so a node that already fails one of
-  // these gates never even competes for a slot.
+  const pulseMs = useEventRatePulse(data.liveSignalAt);
+  // Every gate the live-node contract requires, all real signals: actually
+  // running, fresh work (not stalled), a live signal at all, on-screen, and
+  // not overridden by prefers-reduced-motion. The cap is applied last, via
+  // useAnimationSlot, so a node that already fails one of these gates never
+  // even competes for a slot.
+  //
+  // The presence gate reads `liveSignalAt`, not `lastEventAt`, and the two
+  // are not interchangeable here. `lastEventAt` advances on ANY event
+  // including the lifecycle ones that merely bracket a node's work, so a node
+  // fed only NodeStarted satisfies it for as long as it claims to be running
+  // — while `liveSignalAt` stays null, which makes the stall clock answer
+  // "not stalled" (correctly: no stream ever flowed, so none can have
+  // stopped). Gating on `lastEventAt` therefore combined a permanently-true
+  // presence test with a permanently-false stall test, and the pulse asserted
+  // a live stream for nodes that had never reported one. Reading the same
+  // field the stall clock reads keeps the two halves from disagreeing: a node
+  // only pulses while something is actually reporting work, and the moment
+  // that reporting stops the stall clock can end it.
+  //
+  // A running node with no live signal is not hidden by this — the running
+  // dot and the running border rail both draw on `status` alone. It simply
+  // holds still, which is the honest rendering of a node we know is running
+  // and know nothing else about.
   const wantsToAnimate =
-    status === "running" && !stalled && !reducedMotion && inViewport && data.lastEventAt != null;
+    status === "running" && !stalled && !reducedMotion && inViewport && data.liveSignalAt != null;
   const animationGranted = useAnimationSlot(wantsToAnimate);
   const animating = wantsToAnimate && animationGranted;
 

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useEffect, useId, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Handle, Position } from "reactflow";
 import type { NodeProps } from "reactflow";
 import { useTranslations } from "use-intl";
@@ -63,26 +63,39 @@ function useInViewport(ref: React.RefObject<Element | null>): boolean {
 // registry rather than context/store plumbing: every StepNode instance
 // competes for one of a fixed number of slots, first-claimed-first-served,
 // released on unmount or whenever the node no longer wants to animate.
+//
+// The slot belongs to the card, not to the node it is showing. The run detail
+// keeps its inline canvas mounted while the expanded graph is open, so the
+// same run — and therefore the same node ID — is on screen twice at once.
+// Keyed by node ID, that arrangement breaks the budget in both directions: the
+// second card finds its ID already registered and animates without taking a
+// slot, so twice the cap moves while the registry counts the cap; and whichever
+// card unmounts first releases the entry the other is still animating on, after
+// which fresh nodes claim slots that are already in use. Keyed by card, the two
+// simply compete like any other pair.
 export const MAX_ANIMATING_NODES = 10;
-const animatingNodeIds = new Set<string>();
+const animatingCards = new Set<symbol>();
 
-function useAnimationSlot(nodeId: string, wantsToAnimate: boolean): boolean {
+function useAnimationSlot(wantsToAnimate: boolean): boolean {
   const [granted, setGranted] = useState(false);
+  // This card's identity in the registry: allocated once per mount, never
+  // shared, and never rendered. Lazily-initialized state rather than the node
+  // ID precisely because two live cards can carry the same node ID.
+  const [slot] = useState(() => Symbol("animation-slot"));
   useEffect(() => {
     if (!wantsToAnimate) {
-      animatingNodeIds.delete(nodeId);
+      animatingCards.delete(slot);
       // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing local render state FROM the shared module-level slot registry (the external system here), not deriving it from props/state React already has
       setGranted(false);
       return;
     }
-    const alreadyHeld = animatingNodeIds.has(nodeId);
-    const canClaim = alreadyHeld || animatingNodeIds.size < MAX_ANIMATING_NODES;
-    if (canClaim) animatingNodeIds.add(nodeId);
+    const canClaim = animatingCards.size < MAX_ANIMATING_NODES;
+    if (canClaim) animatingCards.add(slot);
     setGranted(canClaim);
     return () => {
-      animatingNodeIds.delete(nodeId);
+      animatingCards.delete(slot);
     };
-  }, [nodeId, wantsToAnimate]);
+  }, [slot, wantsToAnimate]);
   return granted;
 }
 
@@ -274,19 +287,12 @@ export function computeNodeVisualStyle(status: NodeExecStatus, selected: boolean
   return { borderWidth, borderColor, bgColor, labelColor, railColor };
 }
 
-function StepNodeComponent({ data, selected, id }: NodeProps<StepNodeData>) {
+function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
   const t = useTranslations("history.detail");
   // roleColor arrives as a data-driven CSS var string — keep inline
   const roleColor = ROLE_VAR[data.role] || "var(--content-muted)";
   const status = data.execStatus ?? "pending";
   const reducedMotion = usePrefersReducedMotion();
-
-  // Identity for the shared animation-slot registry. React Flow always
-  // supplies `id`; the fallback only matters off-canvas (e.g. a unit test
-  // rendering the card directly), where a stable per-mount id still lets the
-  // cap behave correctly.
-  const fallbackId = useId();
-  const nodeId = id || fallbackId;
 
   const cardRef = useRef<HTMLDivElement>(null);
   const inViewport = useInViewport(cardRef);
@@ -300,7 +306,7 @@ function StepNodeComponent({ data, selected, id }: NodeProps<StepNodeData>) {
   // these gates never even competes for a slot.
   const wantsToAnimate =
     status === "running" && !stalled && !reducedMotion && inViewport && data.lastEventAt != null;
-  const animationGranted = useAnimationSlot(nodeId, wantsToAnimate);
+  const animationGranted = useAnimationSlot(wantsToAnimate);
   const animating = wantsToAnimate && animationGranted;
 
   // These derive from status data (dag-* tokens) — keep inline

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -5,13 +5,7 @@ import { Handle, Position } from "reactflow";
 import type { NodeProps } from "reactflow";
 import { useTranslations } from "use-intl";
 import { IconCheck, IconClose, IconPause, IconWarning } from "@/components/ui/icons";
-import {
-  NODE_HEIGHT,
-  NODE_WIDTH,
-  PREVIEW_LINE_HEIGHT,
-  TEXT_PREVIEW_HEIGHT,
-  TEXT_PREVIEW_LINES,
-} from "./useLayout";
+import { NODE_HEIGHT, NODE_WIDTH } from "./useLayout";
 import { isStalled, pulseDurationMs, STALL_TIMEOUT_MS } from "@/lib/nodeActivity";
 import type { NodeActivityKind } from "@/lib/nodeActivity";
 
@@ -153,12 +147,6 @@ const ACTIVITY_LABEL: Record<NodeActivityKind, string> = {
   waiting: "waiting",
 };
 
-// The preview's line count and reserved height live in useLayout.ts, beside
-// the NODE_HEIGHT sum they are terms of — one home for the card's geometry, so
-// the space the layout reserves and the space the card draws cannot drift.
-// Re-exported here because the line count reads as a property of the card.
-export { TEXT_PREVIEW_LINES };
-
 const ROLE_VAR: Record<string, string> = {
   researcher: "var(--role-researcher)",
   implementer: "var(--role-implementer)",
@@ -202,9 +190,6 @@ export interface StepNodeData {
   // absent-safe: a node with no live signal correlation yet (or a finished
   // run loaded from history, which never streamed) renders with none of
   // these set and looks exactly like the card did before this row existed.
-  /** The agent's most recent assistant text; truncated for display to
-   *  TEXT_PREVIEW_LINES, never the caller's job. */
-  lastText?: string | null;
   /** What the node is doing right now, while running. */
   activity?: NodeActivityKind | null;
   /** Tool name when activity is "tool". */
@@ -458,35 +443,20 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
         </span>
       </div>
 
-      {/* Live-activity row (ADR-0113 D3/row 6): current activity + counter on
-          one line, the agent's latest text clipped to TEXT_PREVIEW_LINES on
-          the next. The preview HOLDS its height whether or not there is text
-          to put in it, which is what makes a card with nothing to say the same
-          shape as one mid-sentence — line-clamping alone caps how tall the
-          block can get and says nothing about how short, so an empty one used
-          to collapse and let justify-between slide the row below it upward.
-          Its line-height is set from the same constant the reservation is
-          computed from, so the two cannot round apart. The word here and the
-          animation state above are two independent readouts of the same
-          `stalled`/`activity` facts, which is what keeps them from ever
-          disagreeing under prefers-reduced-motion. */}
-      <div className="mt-0.5 flex flex-col gap-0.5">
-        <div className="flex items-center justify-between gap-1.5 font-mono text-[length:var(--t-xs)] uppercase leading-tight tracking-wide text-content-muted">
-          <span className="truncate">{activityWord}</span>
-          {counterText && <span className="shrink-0 tabular-nums">{counterText}</span>}
-        </div>
-        <div
-          className="overflow-hidden font-mono text-[length:var(--t-xs)] text-content-muted"
-          style={{
-            display: "-webkit-box",
-            WebkitLineClamp: TEXT_PREVIEW_LINES,
-            WebkitBoxOrient: "vertical",
-            height: TEXT_PREVIEW_HEIGHT,
-            lineHeight: `${PREVIEW_LINE_HEIGHT}px`,
-          }}
-        >
-          {data.lastText || ""}
-        </div>
+      {/* Live-activity row: what the node is doing, and a counter beside it
+          where the provider reports one. Always rendered, so the row below the
+          role never moves as a run progresses.
+
+          This row used to sit above a two-line preview of the agent's latest
+          text. Nothing on the wire fills that, so it drew empty on every card
+          and has been removed until a signal carries per-node text — see the
+          note on NODE_HEIGHT. The word here and the animation state above are
+          two independent readouts of the same `stalled`/`activity` facts,
+          which is what keeps them from disagreeing under
+          prefers-reduced-motion. */}
+      <div className="mt-0.5 flex items-center justify-between gap-1.5 font-mono text-[length:var(--t-xs)] uppercase leading-tight tracking-wide text-content-muted">
+        <span className="truncate">{activityWord}</span>
+        {counterText && <span className="shrink-0 tabular-nums">{counterText}</span>}
       </div>
 
       {status === "running" && (

--- a/apps/studio/frontend/src/components/canvas/StepNode.tsx
+++ b/apps/studio/frontend/src/components/canvas/StepNode.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useId, useRef, useState } from "react";
 import { Handle, Position } from "reactflow";
 import type { NodeProps } from "reactflow";
 import { useTranslations } from "use-intl";
 import { IconCheck, IconClose, IconPause, IconWarning } from "@/components/ui/icons";
 import { NODE_HEIGHT, NODE_WIDTH } from "./useLayout";
+import { isStalled, pulseDurationMs, STALL_TIMEOUT_MS } from "@/lib/nodeActivity";
+import type { NodeActivityKind } from "@/lib/nodeActivity";
 
 // What the bottom-right corner says before there is a duration to put there.
 // "pending" has no lifecycle signal to report yet, so its placeholder is a
@@ -33,6 +35,110 @@ function usePrefersReducedMotion(): boolean {
   }, []);
   return reduced;
 }
+
+// "Nothing animates outside the viewport" (ADR-0113 D3). No IntersectionObserver
+// (SSR, or a test environment that doesn't polyfill it) reads as visible —
+// the safe default is to animate, matching behavior before this hook existed,
+// rather than silently going static everywhere a test happens not to stub it.
+function useInViewport(ref: React.RefObject<Element | null>): boolean {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined" || !ref.current) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (entry) setVisible(entry.isIntersecting);
+      },
+      { threshold: 0 },
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref]);
+  return visible;
+}
+
+// Global concurrent-animation budget (ADR-0113 D3: "the number of
+// concurrently animating nodes is capped, with the excess falling back to
+// the static state" — a 30-node canvas must stay responsive). A module-level
+// registry rather than context/store plumbing: every StepNode instance
+// competes for one of a fixed number of slots, first-claimed-first-served,
+// released on unmount or whenever the node no longer wants to animate.
+export const MAX_ANIMATING_NODES = 10;
+const animatingNodeIds = new Set<string>();
+
+function useAnimationSlot(nodeId: string, wantsToAnimate: boolean): boolean {
+  const [granted, setGranted] = useState(false);
+  useEffect(() => {
+    if (!wantsToAnimate) {
+      animatingNodeIds.delete(nodeId);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing local render state FROM the shared module-level slot registry (the external system here), not deriving it from props/state React already has
+      setGranted(false);
+      return;
+    }
+    const alreadyHeld = animatingNodeIds.has(nodeId);
+    const canClaim = alreadyHeld || animatingNodeIds.size < MAX_ANIMATING_NODES;
+    if (canClaim) animatingNodeIds.add(nodeId);
+    setGranted(canClaim);
+    return () => {
+      animatingNodeIds.delete(nodeId);
+    };
+  }, [nodeId, wantsToAnimate]);
+  return granted;
+}
+
+// Returns to a static "stalled" reading STALL_TIMEOUT_MS after the last live
+// event, rather than polling: a single timer fires exactly at the deadline
+// implied by `lastEventAt`, so a node that keeps receiving events never
+// stalls (each new event reschedules the timer) and one that stops gets
+// caught the instant its window closes — this is "a test, not a comment"
+// per the ADR's Consequences section, see StepNode.test.tsx.
+function useStallState(lastEventAt: number | null | undefined, isRunning: boolean): boolean {
+  const [stalled, setStalled] = useState(false);
+  useEffect(() => {
+    if (!isRunning || lastEventAt == null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing to the external clock (Date.now()), which React has no other way to read
+      setStalled(false);
+      return;
+    }
+    setStalled(isStalled(lastEventAt, Date.now()));
+    const remaining = lastEventAt + STALL_TIMEOUT_MS - Date.now();
+    if (remaining <= 0) return;
+    const timer = setTimeout(() => setStalled(true), remaining);
+    return () => clearTimeout(timer);
+  }, [lastEventAt, isRunning]);
+  return stalled;
+}
+
+// Pulse speed tracks the actual event rate rather than a fixed cadence — a
+// node emitting many events per second reads as busier than one emitting one
+// every few seconds. A sliding 5s window of observed `lastEventAt` values,
+// entirely local to this node (no cross-node coordination needed).
+function useEventRatePulse(lastEventAt: number | null | undefined): number {
+  const windowRef = useRef<number[]>([]);
+  const [duration, setDuration] = useState(1500);
+  useEffect(() => {
+    if (lastEventAt == null) return;
+    const seen = windowRef.current;
+    seen.push(lastEventAt);
+    const cutoff = lastEventAt - 5000;
+    while (seen.length && seen[0]! < cutoff) seen.shift();
+    setDuration(pulseDurationMs(seen.length));
+  }, [lastEventAt]);
+  return duration;
+}
+
+const ACTIVITY_LABEL: Record<NodeActivityKind, string> = {
+  thinking: "thinking",
+  tool: "tool",
+  streaming: "streaming",
+  waiting: "waiting",
+};
+
+// Fixed line count for the assistant-text preview (ADR-0113 row 6: "truncated
+// to a fixed line count"). Exported so the reserved-height math in
+// useLayout.ts's NODE_HEIGHT comment and this file agree on the number, even
+// though only the constant lives there.
+export const TEXT_PREVIEW_LINES = 2;
 
 const ROLE_VAR: Record<string, string> = {
   researcher: "var(--role-researcher)",
@@ -73,6 +179,24 @@ export interface StepNodeData {
   durationSeconds?: number | null;
   errorCount?: number;
   toolCallCount?: number;
+  // Live-activity fields (ADR-0113 D3/row 6). All optional and independently
+  // absent-safe: a node with no live signal correlation yet (or a finished
+  // run loaded from history, which never streamed) renders with none of
+  // these set and looks exactly like the card did before this row existed.
+  /** The agent's most recent assistant text; truncated for display to
+   *  TEXT_PREVIEW_LINES, never the caller's job. */
+  lastText?: string | null;
+  /** What the node is doing right now, while running. */
+  activity?: NodeActivityKind | null;
+  /** Tool name when activity is "tool". */
+  activityDetail?: string | null;
+  /** Token or event counter, whichever the provider reports. */
+  counter?: number | null;
+  /** Epoch ms of the most recent live signal for this node — the ONLY input
+   *  that drives whether/how fast this node's animation runs. Absent means
+   *  "no live stream correlation", which never animates regardless of
+   *  execStatus. */
+  lastEventAt?: number | null;
 }
 
 // Non-animation precedence cues (border weight + a left-edge status rail)
@@ -150,12 +274,34 @@ export function computeNodeVisualStyle(status: NodeExecStatus, selected: boolean
   return { borderWidth, borderColor, bgColor, labelColor, railColor };
 }
 
-function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
+function StepNodeComponent({ data, selected, id }: NodeProps<StepNodeData>) {
   const t = useTranslations("history.detail");
   // roleColor arrives as a data-driven CSS var string — keep inline
   const roleColor = ROLE_VAR[data.role] || "var(--content-muted)";
   const status = data.execStatus ?? "pending";
   const reducedMotion = usePrefersReducedMotion();
+
+  // Identity for the shared animation-slot registry. React Flow always
+  // supplies `id`; the fallback only matters off-canvas (e.g. a unit test
+  // rendering the card directly), where a stable per-mount id still lets the
+  // cap behave correctly.
+  const fallbackId = useId();
+  const nodeId = id || fallbackId;
+
+  const cardRef = useRef<HTMLDivElement>(null);
+  const inViewport = useInViewport(cardRef);
+  const stalled = useStallState(data.lastEventAt, status === "running");
+  const pulseMs = useEventRatePulse(data.lastEventAt);
+  // Every gate ADR-0113 D3 requires, all real signals: actually running,
+  // fresh events (not stalled), a live stream correlation at all
+  // (lastEventAt present — no signal means no animation, never a guess),
+  // on-screen, and not overridden by prefers-reduced-motion. The cap is
+  // applied last, via useAnimationSlot, so a node that already fails one of
+  // these gates never even competes for a slot.
+  const wantsToAnimate =
+    status === "running" && !stalled && !reducedMotion && inViewport && data.lastEventAt != null;
+  const animationGranted = useAnimationSlot(nodeId, wantsToAnimate);
+  const animating = wantsToAnimate && animationGranted;
 
   // These derive from status data (dag-* tokens) — keep inline
   const visual = computeNodeVisualStyle(status, !!selected);
@@ -172,8 +318,26 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
         ? "—"
         : t(STATUS_WORD_KEY[status]);
 
+  // The activity row's header word — the "current activity" half of row 6,
+  // and where a stall becomes visible text rather than only an animation
+  // that quietly stops. Independent of reducedMotion/animating: this is the
+  // static-equivalent information those two must carry identically.
+  const activityWord = stalled
+    ? "stalled"
+    : status === "running"
+      ? data.activity
+        ? data.activityDetail
+          ? `${ACTIVITY_LABEL[data.activity]}: ${data.activityDetail}`
+          : ACTIVITY_LABEL[data.activity]
+        : ACTIVITY_LABEL.waiting
+      : status === "queued"
+        ? ACTIVITY_LABEL.waiting
+        : "";
+  const counterText = data.counter != null ? String(data.counter) : "";
+
   return (
     <div
+      ref={cardRef}
       className="relative flex flex-col justify-between rounded-md px-2.5 py-2"
       style={{
         background: visual.bgColor,
@@ -192,8 +356,8 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
       {/* Status rail — a left-edge color bar that survives the readability
           zoom floor even when the card is too small to read text or icons.
           A span, not a div: the card's rows() test selects direct div
-          children of this card as its two content rows, and the rail is
-          decorative chrome, not a third row. */}
+          children of this card as its content rows, and the rail is
+          decorative chrome, not one of them. */}
       <span
         className="pointer-events-none absolute inset-y-0 left-0 block rounded-l-md"
         style={{ width: 3, background: visual.railColor }}
@@ -251,7 +415,7 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
         )}
         {status === "running" && (
           <span
-            className={`h-1.5 w-1.5 shrink-0 rounded-full${reducedMotion ? "" : " animate-pulse"}`}
+            className={`h-1.5 w-1.5 shrink-0 rounded-full${animating ? " animate-pulse" : ""}`}
             style={{ background: "var(--dag-running-border)" }}
           />
         )}
@@ -274,12 +438,37 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeData>) {
         </span>
       </div>
 
+      {/* Live-activity row (ADR-0113 D3/row 6): current activity + counter on
+          one line, the agent's latest text clipped to TEXT_PREVIEW_LINES on
+          the next. Always rendered, at a fixed clipped height, so a node
+          with no text yet reserves exactly the space one with a full preview
+          uses — see NODE_HEIGHT's comment in useLayout.ts. The word here and
+          the animation state above are two independent readouts of the same
+          `stalled`/`activity` facts, which is what keeps them from ever
+          disagreeing under prefers-reduced-motion. */}
+      <div className="mt-0.5 flex flex-col gap-0.5">
+        <div className="flex items-center justify-between gap-1.5 font-mono text-[length:var(--t-xs)] uppercase leading-tight tracking-wide text-content-muted">
+          <span className="truncate">{activityWord}</span>
+          {counterText && <span className="shrink-0 tabular-nums">{counterText}</span>}
+        </div>
+        <div
+          className="overflow-hidden font-mono text-[length:var(--t-xs)] leading-tight text-content-muted"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: TEXT_PREVIEW_LINES,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {data.lastText || ""}
+        </div>
+      </div>
+
       {status === "running" && (
         <div
           className="pointer-events-none absolute inset-0 rounded-md opacity-35"
           style={{
             border: "2px solid var(--dag-running-border)",
-            animation: reducedMotion ? "none" : "pulse 1.5s ease-in-out infinite",
+            animation: animating ? `pulse ${pulseMs}ms ease-in-out infinite` : "none",
           }}
         />
       )}

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.nodeActivity.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.nodeActivity.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * These tests start where the app starts — raw signal events as they arrive off
+ * the wire — and end at the text a node card actually renders, running the
+ * production path in between: the wire normalizer, the correlation, the canvas
+ * projection, and the real StepNode.
+ *
+ * That span is the point. The activity fold was fully unit-tested and green
+ * while nothing in the app called it and no card carried live data, so an
+ * assertion that stops at the fold cannot tell a wired projection from an
+ * unwired one. Both failure modes this covers are silent in exactly that way:
+ * an unwired projection renders the plain status word, and a timestamp left in
+ * the backend's seconds renders every signalled node as "stalled" — neither
+ * throws, and both look like a run that simply has nothing to report.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { IntlProvider } from "use-intl";
+import enMessages from "@/messages/en.json";
+import WorkerCanvas from "./WorkerCanvas";
+import { normalizeSignalEvent } from "@/lib/api";
+import type { SignalEvent } from "@/lib/api";
+import { buildNodeActivityByName } from "@/lib/nodeActivity";
+import type { NodeActivitySnapshot } from "@/lib/nodeActivity";
+import type { WorkerGraph } from "@/lib/types";
+
+// ReactFlow's viewport measures its container against a zustand store, which in
+// jsdom (every element 0x0) re-measures itself into an infinite update loop —
+// the reason the other tests here mock it away entirely. This replaces ONLY the
+// viewport renderer and its decorations, with a stand-in that draws every node
+// through the real nodeTypes map. Everything under test stays real: the
+// canvas's own node state (useNodesState is a plain useState wrapper), the
+// layout, the projection effect, and StepNode itself. What is not covered is
+// therefore stated rather than implied — panning, zoom, culling and node
+// measurement are ReactFlow's, and no assertion here depends on them.
+vi.mock("reactflow", async () => {
+  const actual = await vi.importActual<typeof import("reactflow")>("reactflow");
+  type StubNode = { id: string; type?: string; data: unknown };
+  type NodeComponent = React.ComponentType<{ id: string; data: unknown; selected: boolean }>;
+  return {
+    ...actual,
+    default: ({
+      nodes,
+      nodeTypes,
+    }: {
+      nodes: StubNode[];
+      nodeTypes: Record<string, NodeComponent>;
+    }) => (
+      <div>
+        {nodes.map((n) => {
+          const NodeComponent = nodeTypes[n.type ?? ""];
+          return (
+            <div key={n.id} className="react-flow__node" data-node-id={n.id}>
+              {NodeComponent ? <NodeComponent id={n.id} data={n.data} selected={false} /> : null}
+            </div>
+          );
+        })}
+      </div>
+    ),
+    Background: () => null,
+    Controls: () => null,
+    MiniMap: () => null,
+    Handle: () => null,
+  };
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+class StubObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("matchMedia", () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+  // ReactFlow measures its container and StepNode asks whether it is on screen;
+  // neither exists in jsdom. Observing nothing leaves the card in its default
+  // state, which is the one under test.
+  vi.stubGlobal("ResizeObserver", StubObserver);
+  vi.stubGlobal("IntersectionObserver", StubObserver);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+const GRAPH: WorkerGraph = {
+  name: "demo",
+  description: "",
+  nodes: [
+    {
+      id: "plan",
+      label: "plan",
+      role: "orchestrator",
+      assignment: "",
+      prompt: "",
+      capacity: 1,
+      timeout: null,
+      inputs: [],
+      outputs: [],
+    },
+    {
+      id: "silent",
+      label: "silent",
+      role: "implementer",
+      assignment: "",
+      prompt: "",
+      capacity: 1,
+      timeout: null,
+      inputs: [],
+      outputs: [],
+    },
+  ],
+  edges: [],
+};
+
+// One event exactly as the backend emits it: a Unix timestamp in SECONDS, and
+// the authored step id under payload.name (the runtime op_id is a UUID the
+// planned graph has never heard of).
+function rawEvent(overrides: Partial<SignalEvent> = {}): SignalEvent {
+  return {
+    id: "e1",
+    session_id: "s1",
+    seq: 1,
+    kind: "NodeStarted",
+    op_id: "0f9d6c2e-0000-4000-8000-000000000001",
+    ts: Date.now() / 1000,
+    payload: { name: "plan" },
+    ...overrides,
+  };
+}
+
+function renderCanvas(nodeActivity?: Map<string, NodeActivitySnapshot>) {
+  act(() => {
+    root.render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <WorkerCanvas
+          graph={GRAPH}
+          editable={false}
+          nodeStatuses={{ plan: "running", silent: "running" }}
+          nodeActivity={nodeActivity}
+          live
+        />
+      </IntlProvider>,
+    );
+  });
+}
+
+// The card for a node, located by the label it renders.
+function cardTextFor(label: string): string {
+  const nodes = Array.from(container.querySelectorAll<HTMLElement>(".react-flow__node"));
+  const match = nodes.find((n) => n.textContent?.includes(label));
+  if (!match) throw new Error(`no rendered node card contains "${label}"`);
+  return match.textContent ?? "";
+}
+
+describe("WorkerCanvas — live activity reaches the card it describes", () => {
+  it("renders what a node is doing, from raw events through the production path", () => {
+    const events = [
+      rawEvent({ payload: { name: "plan", tool_name: "grep" }, kind: "ToolCallStarted" }),
+    ].map(normalizeSignalEvent);
+
+    renderCanvas(buildNodeActivityByName(events));
+
+    // "tool: grep" is only reachable if the fold ran, the correlation matched
+    // the authored id, and the canvas wrote the result into the card's data.
+    expect(cardTextFor("plan")).toContain("tool: grep");
+  });
+
+  it("shows the assistant's latest text on the card", () => {
+    const events = [
+      rawEvent({ kind: "AssistantDelta", payload: { name: "plan", text: "reading the ADR" } }),
+    ].map(normalizeSignalEvent);
+
+    renderCanvas(buildNodeActivityByName(events));
+
+    expect(cardTextFor("plan")).toContain("reading the ADR");
+  });
+
+  it("leaves a node with no signal exactly as it was — no activity, not a blank", () => {
+    const events = [rawEvent()].map(normalizeSignalEvent);
+
+    renderCanvas(buildNodeActivityByName(events));
+
+    // "plan" is thinking; "silent" was never correlated, so it keeps the plain
+    // status word rather than borrowing its neighbour's activity or rendering
+    // an empty row where the word belongs.
+    expect(cardTextFor("plan")).toContain("thinking");
+    expect(cardTextFor("silent")).toContain("running");
+    expect(cardTextFor("silent")).not.toContain("thinking");
+  });
+
+  it("does not read a card as stalled when its event just arrived", () => {
+    // The unit defect, stated where it shows: the backend stamps seconds and
+    // the card's stall clock is Date.now() in milliseconds. Normalized, a
+    // fresh event is fresh. Un-normalized it is ~1.7 trillion ms old, so
+    // every node carrying a signal would render "stalled" the instant it got
+    // one — the arm below proves that is what the normalizer prevents.
+    const raw = [rawEvent()];
+
+    renderCanvas(buildNodeActivityByName(raw.map(normalizeSignalEvent)));
+    expect(cardTextFor("plan")).toContain("thinking");
+    expect(cardTextFor("plan")).not.toContain("stalled");
+
+    renderCanvas(buildNodeActivityByName(raw));
+    expect(cardTextFor("plan")).toContain("stalled");
+  });
+
+  it("renders the plain status word when nothing projects activity at all", () => {
+    // The shape of the original defect: everything below the canvas worked and
+    // the canvas was simply never handed the data.
+    renderCanvas(undefined);
+
+    expect(cardTextFor("plan")).toContain("running");
+    expect(cardTextFor("plan")).not.toContain("thinking");
+  });
+});

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.nodeActivity.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.nodeActivity.test.tsx
@@ -216,10 +216,14 @@ describe("WorkerCanvas — live activity reaches the card it describes", () => {
     // fresh event is fresh. Un-normalized it is ~1.7 trillion ms old, so
     // every node carrying a signal would render "stalled" the instant it got
     // one — the arm below proves that is what the normalizer prevents.
-    const raw = [rawEvent()];
+    //
+    // The event has to REPORT WORK, not merely exist, or the stall clock is
+    // never armed and both arms pass for the wrong reason: a lifecycle-only
+    // node has no liveness signal to lose and is never stalled at any age.
+    const raw = [rawEvent({ payload: { name: "plan", text: "drafting" } })];
 
     renderCanvas(buildNodeActivityByName(raw.map(normalizeSignalEvent)));
-    expect(cardTextFor("plan")).toContain("thinking");
+    expect(cardTextFor("plan")).toContain("streaming");
     expect(cardTextFor("plan")).not.toContain("stalled");
 
     renderCanvas(buildNodeActivityByName(raw));

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.nodeActivity.test.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.nodeActivity.test.tsx
@@ -182,14 +182,19 @@ describe("WorkerCanvas — live activity reaches the card it describes", () => {
     expect(cardTextFor("plan")).toContain("tool: grep");
   });
 
-  it("shows the assistant's latest text on the card", () => {
+  it("reads an assistant delta as streaming, without putting the text on the card", () => {
     const events = [
       rawEvent({ kind: "AssistantDelta", payload: { name: "plan", text: "reading the ADR" } }),
     ].map(normalizeSignalEvent);
 
     renderCanvas(buildNodeActivityByName(events));
 
-    expect(cardTextFor("plan")).toContain("reading the ADR");
+    // The fold still consumes the text — it is how a node is known to be
+    // streaming rather than thinking. The card reports that state and not the
+    // text itself: no signal in production carries per-node assistant text, so
+    // a card that made room for it drew an empty block on every run.
+    expect(cardTextFor("plan")).toContain("streaming");
+    expect(cardTextFor("plan")).not.toContain("reading the ADR");
   });
 
   it("leaves a node with no signal exactly as it was — no activity, not a blank", () => {

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -466,6 +466,7 @@ export default function WorkerCanvas({
                   activityDetail: activity.activityDetail,
                   counter: activity.counter,
                   lastEventAt: activity.lastEventAt,
+                  liveSignalAt: activity.liveSignalAt,
                 }
               : {}),
           },

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -464,7 +464,6 @@ export default function WorkerCanvas({
               ? {
                   activity: activity.activity,
                   activityDetail: activity.activityDetail,
-                  lastText: activity.lastText,
                   counter: activity.counter,
                   lastEventAt: activity.lastEventAt,
                 }

--- a/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
+++ b/apps/studio/frontend/src/components/canvas/WorkerCanvas.tsx
@@ -30,6 +30,7 @@ export { FIT_ZOOM_FLOOR };
 import { followModeReducer, initialFollowModeState, shouldAutoCenter } from "./followMode";
 import { reconcileNodeStatuses, computeStagePosition } from "@/lib/execGraphProgress";
 import type { GraphEdge } from "@/lib/execGraphProgress";
+import type { NodeActivitySnapshot } from "@/lib/nodeActivity";
 
 import type {
   AgentProfileSummary,
@@ -98,6 +99,12 @@ interface WorkerCanvasProps {
    * has a matching entry; nodes with no entry fall back to the legacy
    * execSteps/currentStep-derived status. */
   nodeStatuses?: Record<string, NodeExecStatus>;
+  /** Authored step id → live-activity snapshot, correlated from the signal
+   * stream the same way nodeStatuses is (by authored name, never op_id — see
+   * lib/nodeActivity.ts buildNodeActivityByName). Absent, or absent for a
+   * given node, means "no live correlation": that card renders exactly as it
+   * did before this data existed and never animates. */
+  nodeActivity?: Map<string, NodeActivitySnapshot>;
   currentStep?: string | null;
   onChange?: (nodes: WorkerStepNode[], edges: WorkerLinkEdge[]) => void;
   /** Read-only embed in a small container (e.g. RunDetail's 280px run-dag
@@ -319,14 +326,22 @@ function fromFlowEdges(edges: Edge<ConditionEdgeData>[]): WorkerLinkEdge[] {
 
 // ─── Canvas ──────────────────────────────────────────────
 
+// Hoisted so the default is one array for the life of the module rather than a
+// fresh one per render. It feeds the status memo and the projection effect's
+// dependency list, so a per-render identity makes that effect re-run on every
+// render it does not bail out of, and the effect's own setNodes triggers the
+// next render.
+const NO_EXEC_STEPS: NonNullable<WorkerCanvasProps["execSteps"]> = [];
+
 export default function WorkerCanvas({
   graph,
   editable = false,
   roles = [],
   agentProfiles = [],
   modelOverrides = {},
-  execSteps = [],
+  execSteps = NO_EXEC_STEPS,
   nodeStatuses,
+  nodeActivity,
   currentStep = null,
   onChange,
   compact = false,
@@ -427,17 +442,36 @@ export default function WorkerCanvas({
 
   // Apply the effective status map to the laid-out flow nodes/edges.
   useEffect(() => {
-    if (execSteps.length === 0 && !currentStep && !nodeStatuses) return;
+    if (execSteps.length === 0 && !currentStep && !nodeStatuses && !nodeActivity) return;
 
     const completedMap = new Map(
       execSteps.filter((s) => s.status === "completed").map((s) => [s.step, s]),
     );
 
     setNodes((nds) =>
-      nds.map((n) => ({
-        ...n,
-        data: { ...n.data, execStatus: effectiveStatuses[n.id] ?? "pending" },
-      })),
+      nds.map((n) => {
+        // Absent-safe by omission: a node the signal stream has not correlated
+        // gets no activity keys written at all, so its card renders exactly as
+        // it did before this projection existed rather than being handed a row
+        // of nulls to interpret.
+        const activity = nodeActivity?.get(n.id);
+        return {
+          ...n,
+          data: {
+            ...n.data,
+            execStatus: effectiveStatuses[n.id] ?? "pending",
+            ...(activity
+              ? {
+                  activity: activity.activity,
+                  activityDetail: activity.activityDetail,
+                  lastText: activity.lastText,
+                  counter: activity.counter,
+                  lastEventAt: activity.lastEventAt,
+                }
+              : {}),
+          },
+        };
+      }),
     );
 
     setEdges((eds) =>
@@ -449,7 +483,7 @@ export default function WorkerCanvas({
         },
       })),
     );
-  }, [execSteps, currentStep, nodeStatuses, effectiveStatuses, setNodes, setEdges]);
+  }, [execSteps, currentStep, nodeStatuses, nodeActivity, effectiveStatuses, setNodes, setEdges]);
 
   // ── Stage / rank position — honest under transitive reduction because it
   // is derived from the authored edge set, never the displayed one. ──

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -386,19 +386,26 @@ describe("computeNodeDepths / maxGraphDepth — longest-path rank index", () => 
 
 describe("enforceMinRankGap — minimum vertical gap within a rank", () => {
   it("is a no-op when nodes are already spaced beyond the floor", () => {
+    // Spaced off the node height rather than a literal: the floor is
+    // height + gap, so a hardcoded y stops clearing it the moment the card
+    // grows and this test starts asserting a push while still calling itself
+    // a no-op.
+    const clear = NODE_HEIGHT + 50;
     const nodes: Node[] = [
       { ...bare("a"), position: { x: 0, y: 0 } },
-      { ...bare("b"), position: { x: 0, y: 100 } },
+      { ...bare("b"), position: { x: 0, y: clear } },
     ];
     const out = enforceMinRankGap(nodes, 6);
     expect(out.find((n) => n.id === "a")!.position.y).toBe(0);
-    expect(out.find((n) => n.id === "b")!.position.y).toBe(100);
+    expect(out.find((n) => n.id === "b")!.position.y).toBe(clear);
   });
 
   it("pushes an overlapping node down until the gap floor is met", () => {
+    // Every node measures NODE_HEIGHT regardless of its own data (see
+    // estimateNodeHeight), so b at y=10 overlaps a by all but 10px of it.
     const nodes: Node[] = [
-      { ...bare("a"), position: { x: 0, y: 0 } }, // height 40
-      { ...bare("b"), position: { x: 0, y: 10 } }, // overlaps a by 30px
+      { ...bare("a"), position: { x: 0, y: 0 } },
+      { ...bare("b"), position: { x: 0, y: 10 } },
     ];
     const out = enforceMinRankGap(nodes, 6);
     const a = out.find((n) => n.id === "a")!;
@@ -1192,9 +1199,12 @@ describe("getLayoutedElements — folding a mid-run branch+join stays edge-aware
     // Measured pre-fix band at NODE_HEIGHT=56: ~1528x504, raw fit ~0.644 at a
     // 1280x560 panel. NODE_HEIGHT rose to 88 for the live-activity row (ADR-
     // 0113 row 6, see useLayout.ts), which raises every row's height and so
-    // this band's too — remeasured at ~1500x664, raw fit ~0.649 — small drift
-    // is fine, a strip (unfolded ~7692-wide) is the regression this guards
-    // against.
+    // this band's too — remeasured then at ~1500x664. It rose again when
+    // NODE_HEIGHT stopped being a literal and became the sum of the rows the
+    // card draws, which came out 11px taller than the literal had claimed:
+    // remeasured at ~719 tall. Drift with the row height is expected and is
+    // why the width and fit stay bands; a strip (unfolded ~7692-wide) is the
+    // regression this guards against.
     const c = chain(30);
     const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
     const left = Math.min(...nodes.map((n) => n.position.x));
@@ -1212,7 +1222,7 @@ describe("getLayoutedElements — folding a mid-run branch+join stays edge-aware
 
     expect(width).toBeGreaterThan(1300);
     expect(width).toBeLessThan(1700);
-    expect(height).toBeCloseTo(664, -1);
+    expect(height).toBeCloseTo(719, -1);
     expect(rawFit).toBeGreaterThan(0.55);
     expect(rawFit).toBeLessThan(0.75);
   });

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -1197,13 +1197,14 @@ describe("getLayoutedElements — folding a mid-run branch+join stays edge-aware
     // boundary in a pure chain is a safe (1-predecessor/1-successor) break,
     // so this must fold exactly as before, modulo the row height itself.
     // Measured pre-fix band at NODE_HEIGHT=56: ~1528x504, raw fit ~0.644 at a
-    // 1280x560 panel. NODE_HEIGHT rose to 88 for the live-activity row (ADR-
-    // 0113 row 6, see useLayout.ts), which raises every row's height and so
-    // this band's too — remeasured then at ~1500x664. It rose again when
-    // NODE_HEIGHT stopped being a literal and became the sum of the rows the
-    // card draws, which came out 11px taller than the literal had claimed:
-    // remeasured at ~719 tall. Drift with the row height is expected and is
-    // why the width and fit stay bands; a strip (unfolded ~7692-wide) is the
+    // 1280x560 panel. NODE_HEIGHT rose to 88 for the live-activity row (see
+    // useLayout.ts), which raises every row's height and so this band's too —
+    // remeasured then at ~1500x664. It rose again when NODE_HEIGHT stopped
+    // being a literal and became the sum of the rows the card draws, 11px
+    // taller than the literal had claimed: ~719. It then FELL by 30 a node,
+    // to ~569, when the card stopped reserving two lines for assistant text
+    // that no signal fills. Drift with the row height is expected and is why
+    // width and fit stay bands; a strip (unfolded ~7692-wide) is the
     // regression this guards against.
     const c = chain(30);
     const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
@@ -1222,7 +1223,7 @@ describe("getLayoutedElements — folding a mid-run branch+join stays edge-aware
 
     expect(width).toBeGreaterThan(1300);
     expect(width).toBeLessThan(1700);
-    expect(height).toBeCloseTo(719, -1);
+    expect(height).toBeCloseTo(569, -1);
     expect(rawFit).toBeGreaterThan(0.55);
     expect(rawFit).toBeLessThan(0.75);
   });

--- a/apps/studio/frontend/src/components/canvas/useLayout.test.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.test.ts
@@ -95,7 +95,7 @@ function assertNoOverlap(nodes: Node[]) {
 }
 
 describe("estimateNodeHeight", () => {
-  // The card is a fixed two-row box, so its height cannot depend on how far
+  // The card is a fixed-height box, so its height cannot depend on how far
   // along a run is. This is the invariant the whole layout leans on: two nodes
   // side by side are the same size whether or not either has finished, which is
   // what lets a rank line up. It used to grow a row at a time, and these tests
@@ -1188,9 +1188,13 @@ describe("getLayoutedElements — folding a mid-run branch+join stays edge-aware
   it("the truly-sequential 30-node chain still folds into the previously-measured band", () => {
     // Pins the readability win survives the edge-aware rewrite: every
     // boundary in a pure chain is a safe (1-predecessor/1-successor) break,
-    // so this must fold exactly as before. Measured pre-fix band: ~1528x504,
-    // raw fit ~0.644 at a 1280x560 panel — small drift is fine, a strip
-    // (unfolded ~7692-wide) is the regression this guards against.
+    // so this must fold exactly as before, modulo the row height itself.
+    // Measured pre-fix band at NODE_HEIGHT=56: ~1528x504, raw fit ~0.644 at a
+    // 1280x560 panel. NODE_HEIGHT rose to 88 for the live-activity row (ADR-
+    // 0113 row 6, see useLayout.ts), which raises every row's height and so
+    // this band's too — remeasured at ~1500x664, raw fit ~0.649 — small drift
+    // is fine, a strip (unfolded ~7692-wide) is the regression this guards
+    // against.
     const c = chain(30);
     const { nodes } = getLayoutedElements(c.nodes(), c.edges, "LR");
     const left = Math.min(...nodes.map((n) => n.position.x));
@@ -1208,7 +1212,7 @@ describe("getLayoutedElements — folding a mid-run branch+join stays edge-aware
 
     expect(width).toBeGreaterThan(1300);
     expect(width).toBeLessThan(1700);
-    expect(height).toBeCloseTo(504, -1);
+    expect(height).toBeCloseTo(664, -1);
     expect(rawFit).toBeGreaterThan(0.55);
     expect(rawFit).toBeLessThan(0.75);
   });

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -24,9 +24,15 @@ export const NODE_WIDTH = 210;
 // a literal, because a literal can only ever be checked against itself: a test
 // asserting the card's style height equals the constant passes whatever the
 // constant says, including when the content needs more room than it grants.
-// Carried as a literal it was 88 while the card drew 99 worth of rows, so a
+// Carried as a literal it was 88 while the card drew 98 worth of rows, so a
 // running node — the widest border, and the only kind with live text to show —
 // overflowed its own border by the preview's second line.
+//
+// The sum below comes to 99, one more than a browser measures, because the name
+// row is reserved from its type scale (ceil of 12px at 1.375 leading = 17) where
+// the browser lays it out at 16. Leave it: over-reserving costs a pixel of empty
+// card, under-reserving clips text, and the drawn height depends on font metrics
+// that are not the same on every platform.
 
 // The type scale these rows are set in (theme.css --t-xs / --t-sm) and the two
 // Tailwind leading ratios used on them. Duplicated from CSS by necessity: the

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -7,56 +7,48 @@ import type { Node, Edge } from "reactflow";
 // of them is edited.
 export const NODE_WIDTH = 210;
 
-// StepNode is a fixed three-row card: name and state on top, role and
-// elapsed second, and a live-activity row (agent's latest text, current
-// activity, event/token counter) along the bottom — all three rows always
-// rendered. So one constant describes it at every moment of a run, and dagre
-// reserves exactly what the node occupies.
+// StepNode is a fixed three-row card: name and state on top, role and elapsed
+// second, and an activity row along the bottom — all three always rendered. So
+// one constant describes it at every moment of a run, and dagre reserves
+// exactly what the node occupies.
 //
 // It used to grow a row at a time as a run filled its data in, which meant the
 // height depended on how far along the run was, ranks came out ragged, and this
 // function had to guess. Fixing the card removed the guess: two nodes side by
-// side are the same size whether or not either has finished, and — since the
-// live-activity row was added — whether or not either has produced any
-// assistant text yet.
+// side are the same size whether or not either has finished.
 //
 // The height below is ADDED UP from the rows the card draws rather than kept as
 // a literal, because a literal can only ever be checked against itself: a test
 // asserting the card's style height equals the constant passes whatever the
 // constant says, including when the content needs more room than it grants.
 // Carried as a literal it was 88 while the card drew 98 worth of rows, so a
-// running node — the widest border, and the only kind with live text to show —
-// overflowed its own border by the preview's second line.
+// running node — the widest border — overflowed its own border.
 //
-// The sum below comes to 99, one more than a browser measures, because the name
-// row is reserved from its type scale (ceil of 12px at 1.375 leading = 17) where
-// the browser lays it out at 16. Leave it: over-reserving costs a pixel of empty
-// card, under-reserving clips text, and the drawn height depends on font metrics
-// that are not the same on every platform.
+// The card also reserved two lines for the agent's latest text, and nothing on
+// the wire fills them. The one signal that carries assistant content is reduced
+// to a bare reference before it is stored, and that reference has no operation
+// id or step name to correlate it to a node, so every card drew an empty block.
+// The reservation is gone until a signal exists that can fill it. Removing it
+// also buys back the vertical space a wide graph needs to stay readable.
+//
+// The sum still runs one pixel over what a browser measures, because the name
+// row is reserved from its type scale (ceil of 12px at 1.375 leading = 17)
+// where the browser lays it out at 16. Leave it: over-reserving costs a pixel
+// of empty card, under-reserving clips text, and the drawn height depends on
+// font metrics that are not the same on every platform.
 
 // The type scale these rows are set in (theme.css --t-xs / --t-sm) and the two
 // Tailwind leading ratios used on them. Duplicated from CSS by necessity: the
 // layout has to know the card's height before the browser has laid anything
-// out. StepNode sets the preview's line-height from PREVIEW_LINE_HEIGHT below
-// so the reserved space and the drawn space cannot round apart.
+// out.
 const TYPE_XS = 11;
 const TYPE_SM = 12;
 const LEADING_TIGHT = 1.25;
 const LEADING_SNUG = 1.375;
 
-/** Lines of assistant text the card previews before clipping. */
-export const TEXT_PREVIEW_LINES = 2;
-
-export const PREVIEW_LINE_HEIGHT = Math.ceil(TYPE_XS * LEADING_TIGHT);
-
-/** Height the preview block always occupies, full or empty. StepNode applies
- *  it directly, which is what makes a card with no text yet the same shape as
- *  one with two lines rather than merely the same outer height. */
-export const TEXT_PREVIEW_HEIGHT = PREVIEW_LINE_HEIGHT * TEXT_PREVIEW_LINES;
-
 const CARD_PADDING_Y = 8; // py-2
 const CARD_BORDER_MAX = 3; // the running state's border, the widest drawn
-const CARD_ROW_GAP = 2; // mt-0.5 above the activity block, gap-0.5 inside it
+const CARD_ROW_GAP = 2; // mt-0.5 above the activity row
 
 const TOP_ROW_HEIGHT = Math.ceil(TYPE_SM * LEADING_SNUG);
 const SECOND_ROW_HEIGHT = Math.ceil(TYPE_XS * LEADING_TIGHT);
@@ -68,9 +60,7 @@ export const NODE_HEIGHT =
   TOP_ROW_HEIGHT +
   SECOND_ROW_HEIGHT +
   CARD_ROW_GAP +
-  ACTIVITY_HEADER_HEIGHT +
-  CARD_ROW_GAP +
-  TEXT_PREVIEW_HEIGHT;
+  ACTIVITY_HEADER_HEIGHT;
 
 /** The height of a rendered node. Constant by construction — see NODE_HEIGHT.
  *  Kept as a function because the layout passes call it per node and a future

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -18,9 +18,53 @@ export const NODE_WIDTH = 210;
 // function had to guess. Fixing the card removed the guess: two nodes side by
 // side are the same size whether or not either has finished, and — since the
 // live-activity row was added — whether or not either has produced any
-// assistant text yet. The row's text is clipped to a fixed line count rather
-// than allowed to grow the card, which is what keeps this constant honest.
-export const NODE_HEIGHT = 88;
+// assistant text yet.
+//
+// The height below is ADDED UP from the rows the card draws rather than kept as
+// a literal, because a literal can only ever be checked against itself: a test
+// asserting the card's style height equals the constant passes whatever the
+// constant says, including when the content needs more room than it grants.
+// Carried as a literal it was 88 while the card drew 99 worth of rows, so a
+// running node — the widest border, and the only kind with live text to show —
+// overflowed its own border by the preview's second line.
+
+// The type scale these rows are set in (theme.css --t-xs / --t-sm) and the two
+// Tailwind leading ratios used on them. Duplicated from CSS by necessity: the
+// layout has to know the card's height before the browser has laid anything
+// out. StepNode sets the preview's line-height from PREVIEW_LINE_HEIGHT below
+// so the reserved space and the drawn space cannot round apart.
+const TYPE_XS = 11;
+const TYPE_SM = 12;
+const LEADING_TIGHT = 1.25;
+const LEADING_SNUG = 1.375;
+
+/** Lines of assistant text the card previews before clipping. */
+export const TEXT_PREVIEW_LINES = 2;
+
+export const PREVIEW_LINE_HEIGHT = Math.ceil(TYPE_XS * LEADING_TIGHT);
+
+/** Height the preview block always occupies, full or empty. StepNode applies
+ *  it directly, which is what makes a card with no text yet the same shape as
+ *  one with two lines rather than merely the same outer height. */
+export const TEXT_PREVIEW_HEIGHT = PREVIEW_LINE_HEIGHT * TEXT_PREVIEW_LINES;
+
+const CARD_PADDING_Y = 8; // py-2
+const CARD_BORDER_MAX = 3; // the running state's border, the widest drawn
+const CARD_ROW_GAP = 2; // mt-0.5 above the activity block, gap-0.5 inside it
+
+const TOP_ROW_HEIGHT = Math.ceil(TYPE_SM * LEADING_SNUG);
+const SECOND_ROW_HEIGHT = Math.ceil(TYPE_XS * LEADING_TIGHT);
+const ACTIVITY_HEADER_HEIGHT = Math.ceil(TYPE_XS * LEADING_TIGHT);
+
+export const NODE_HEIGHT =
+  CARD_PADDING_Y * 2 +
+  CARD_BORDER_MAX * 2 +
+  TOP_ROW_HEIGHT +
+  SECOND_ROW_HEIGHT +
+  CARD_ROW_GAP +
+  ACTIVITY_HEADER_HEIGHT +
+  CARD_ROW_GAP +
+  TEXT_PREVIEW_HEIGHT;
 
 /** The height of a rendered node. Constant by construction — see NODE_HEIGHT.
  *  Kept as a function because the layout passes call it per node and a future

--- a/apps/studio/frontend/src/components/canvas/useLayout.ts
+++ b/apps/studio/frontend/src/components/canvas/useLayout.ts
@@ -7,15 +7,20 @@ import type { Node, Edge } from "reactflow";
 // of them is edited.
 export const NODE_WIDTH = 210;
 
-// StepNode is a fixed two-row card: name and state on top, role and elapsed
-// along the bottom, both rows always rendered. So one constant describes it at
-// every moment of a run, and dagre reserves exactly what the node occupies.
+// StepNode is a fixed three-row card: name and state on top, role and
+// elapsed second, and a live-activity row (agent's latest text, current
+// activity, event/token counter) along the bottom — all three rows always
+// rendered. So one constant describes it at every moment of a run, and dagre
+// reserves exactly what the node occupies.
 //
 // It used to grow a row at a time as a run filled its data in, which meant the
 // height depended on how far along the run was, ranks came out ragged, and this
 // function had to guess. Fixing the card removed the guess: two nodes side by
-// side are now the same size whether or not either has finished.
-export const NODE_HEIGHT = 56;
+// side are the same size whether or not either has finished, and — since the
+// live-activity row was added — whether or not either has produced any
+// assistant text yet. The row's text is clipped to a fixed line count rather
+// than allowed to grow the card, which is what keeps this constant honest.
+export const NODE_HEIGHT = 88;
 
 /** The height of a rendered node. Constant by construction — see NODE_HEIGHT.
  *  Kept as a function because the layout passes call it per node and a future

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -34,6 +34,8 @@ import {
   transitiveReduceDisplay,
 } from "@/lib/operationGraph";
 import type { LaneSignal, OperationStatus } from "@/lib/operationGraph";
+import { buildNodeActivityByName } from "@/lib/nodeActivity";
+import type { NodeActivitySnapshot } from "@/lib/nodeActivity";
 import { deriveDisplayStatus, deriveVerdict, isEffectivelyActive } from "@/lib/runStatus";
 import type { Verdict } from "@/lib/runStatus";
 import type { RunMessage, RunResumeResponse, RunStep, WorkerGraph } from "@/lib/types";
@@ -1285,7 +1287,7 @@ export function EventsSection({
                 <div key={ev.id} className="hover:bg-surface-overlay">
                   <div className="flex items-start gap-2 px-3 py-1.5">
                     <span className="mt-0.5 shrink-0 font-mono text-[length:var(--t-xs)] tabular-nums text-content-muted">
-                      {new Date(ev.ts * 1000).toLocaleTimeString([], {
+                      {new Date(ev.ts).toLocaleTimeString([], {
                         hour: "2-digit",
                         minute: "2-digit",
                         second: "2-digit",
@@ -1899,6 +1901,21 @@ export default function RunDetail({ id }: RunDetailProps) {
     return result;
   }, [runGraph, signalEvents]);
 
+  // What each node is DOING inside its running state, correlated from the same
+  // stream and by the same authored-name rule as nodeStatuses above. Kept to
+  // the planned graph's own nodes so a signal for something the graph does not
+  // draw cannot grow the map.
+  const nodeActivity = useMemo((): Map<string, NodeActivitySnapshot> | undefined => {
+    if (!runGraph) return undefined;
+    const byName = buildNodeActivityByName(signalEvents);
+    const result = new Map<string, NodeActivitySnapshot>();
+    for (const node of runGraph.nodes) {
+      const live = byName.get(node.id);
+      if (live) result.set(node.id, live);
+    }
+    return result;
+  }, [runGraph, signalEvents]);
+
   // The SAME reconciled map feeds both the always-visible progress summary
   // and the graph nodes below (WorkerCanvas nodeStatuses prop) — one source,
   // so the header can never disagree with what a node renders. Reconciling
@@ -2093,6 +2110,7 @@ export default function RunDetail({ id }: RunDetailProps) {
                 editable={false}
                 execSteps={execSteps}
                 nodeStatuses={reconciledNodeStatuses}
+                nodeActivity={nodeActivity}
                 compact
                 onLayoutHeight={onDagLayoutHeight}
                 live={live}
@@ -2138,6 +2156,7 @@ export default function RunDetail({ id }: RunDetailProps) {
                     editable={false}
                     execSteps={execSteps}
                     nodeStatuses={reconciledNodeStatuses}
+                    nodeActivity={nodeActivity}
                     compact
                     onLayoutHeight={noopLayoutHeight}
                     live={live}

--- a/apps/studio/frontend/src/lib/api.test.ts
+++ b/apps/studio/frontend/src/lib/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { resolveApiBase, resolveAuthToken } from "./api";
+import { normalizeSignalEvent, resolveApiBase, resolveAuthToken } from "./api";
+import type { SignalEvent } from "./api";
 
 describe("resolveApiBase", () => {
   beforeEach(() => {
@@ -649,5 +650,48 @@ describe("runs/sessions query construction", () => {
     await getSession("s1");
     const url = new URL(calls[0]!.url, "http://localhost");
     expect(url.searchParams.has("message_cursor")).toBe(false);
+  });
+});
+
+// The backend stamps a signal's `ts` with time.time() — Unix SECONDS — and the
+// frontend compares it against Date.now(), which is milliseconds. The gap is
+// about 1.7 trillion, so an un-normalized fresh event reads as ancient rather
+// than as malformed: nothing throws, and every node carrying a signal quietly
+// reports itself stalled. Converting once here is what keeps every consumer
+// from having to know where the number came from.
+describe("normalizeSignalEvent", () => {
+  const raw: SignalEvent = {
+    id: "e1",
+    session_id: "s1",
+    seq: 1,
+    kind: "NodeStarted",
+    op_id: "op1",
+    ts: 1_770_000_000,
+    payload: { name: "plan" },
+  };
+
+  it("converts the backend's seconds into epoch milliseconds", () => {
+    expect(normalizeSignalEvent(raw).ts).toBe(1_770_000_000_000);
+  });
+
+  it("leaves every other field alone", () => {
+    const out = normalizeSignalEvent(raw);
+    expect({ ...out, ts: raw.ts }).toEqual(raw);
+  });
+
+  it("does not mutate the event it was given", () => {
+    normalizeSignalEvent(raw);
+    expect(raw.ts).toBe(1_770_000_000);
+  });
+
+  it("lands on the same clock Date.now() reports", () => {
+    // The assertion that actually matters: a timestamp taken now, stamped the
+    // way the backend stamps it, must come back within a second of Date.now()
+    // — and the un-normalized value must NOT, or this conversion is decorative.
+    const now = Date.now();
+    const asBackendSends = { ...raw, ts: now / 1000 };
+
+    expect(Math.abs(normalizeSignalEvent(asBackendSends).ts - now)).toBeLessThan(1000);
+    expect(Math.abs(asBackendSends.ts - now)).toBeGreaterThan(1_000_000_000);
   });
 });

--- a/apps/studio/frontend/src/lib/api.ts
+++ b/apps/studio/frontend/src/lib/api.ts
@@ -1307,8 +1307,21 @@ export interface SignalEvent {
   seq: number;
   kind: string;
   op_id: string;
+  /** Epoch MILLISECONDS, so it can be compared against `Date.now()` directly.
+   *  The backend stamps this in SECONDS (`time.time()`, in the session
+   *  observer) and passes it through the signals service unchanged;
+   *  `normalizeSignalEvent` does the conversion once, here at the wire, and
+   *  it is the only place that knows the backend's unit. */
   ts: number;
   payload: Record<string, unknown>;
+}
+
+const SIGNAL_TS_SECONDS_TO_MS = 1000;
+
+/** Converts one raw signal off the wire into the frontend's units. Exported so
+ *  the unit can be asserted directly rather than inferred from a consumer. */
+export function normalizeSignalEvent(raw: SignalEvent): SignalEvent {
+  return { ...raw, ts: raw.ts * SIGNAL_TS_SECONDS_TO_MS };
 }
 
 export function streamSignals(
@@ -1326,7 +1339,7 @@ export function streamSignals(
     if ("type" in event && event.type === "done") {
       close();
     }
-    onEvent(event);
+    onEvent("type" in event ? event : normalizeSignalEvent(event));
   });
   return close;
 }

--- a/apps/studio/frontend/src/lib/nodeActivity.test.ts
+++ b/apps/studio/frontend/src/lib/nodeActivity.test.ts
@@ -21,6 +21,7 @@ describe("deriveNodeActivity", () => {
       lastText: null,
       counter: null,
       lastEventAt: null,
+      liveSignalAt: null,
       eventCount: 0,
     });
   });
@@ -65,6 +66,58 @@ describe("deriveNodeActivity", () => {
   it("tracks lastEventAt as the max timestamp regardless of array order", () => {
     const snap = deriveNodeActivity([ev("NodeStarted", 500), ev("NodeQueued", 10)]);
     expect(snap.lastEventAt).toBe(500);
+  });
+});
+
+// The shape today's backend actually produces, taken from a real run: a node
+// emits NodeStarted, then nothing at all for the 32-39 seconds it works, then
+// NodeCompleted. Reading event silence as a stall turns every live node on the
+// canvas into a stalled one for roughly two thirds of its life, and the longer
+// the op the worse it reads. `liveSignalAt` is what separates "never reported
+// work" from "reported work and stopped".
+describe("liveSignalAt separates silence-by-design from a dead stream", () => {
+  it("stays null across a lifecycle-only node, however long it runs", () => {
+    const snap = deriveNodeActivity([
+      ev("NodeQueued", 0, { name: "writer" }),
+      ev("NodeStarted", 10, { name: "writer" }),
+      ev("NodeCompleted", 35_510, { name: "writer" }),
+    ]);
+    expect(snap.lastEventAt).toBe(35_510);
+    expect(snap.liveSignalAt).toBeNull();
+  });
+
+  it("does not call a working lifecycle-only node stalled", () => {
+    const snap = deriveNodeActivity([
+      ev("NodeQueued", 0, { name: "writer" }),
+      ev("NodeStarted", 10, { name: "writer" }),
+    ]);
+    // Well past the timeout, which is the normal case for a real op.
+    const now = 10 + STALL_TIMEOUT_MS * 3;
+    expect(isStalled(snap.liveSignalAt, now)).toBe(false);
+    // And the reading this replaces, so the test states what it prevents.
+    expect(isStalled(snap.lastEventAt, now)).toBe(true);
+  });
+
+  it("still catches a node whose real stream died", () => {
+    // The failure the stall reading exists for: work WAS being reported, then
+    // it stopped. Without this arm the fix above would be indistinguishable
+    // from deleting the feature.
+    const snap = deriveNodeActivity([
+      ev("NodeStarted", 10, { name: "writer" }),
+      ev("AssistantDelta", 500, { name: "writer", text: "partial" }),
+    ]);
+    expect(snap.liveSignalAt).toBe(500);
+    expect(isStalled(snap.liveSignalAt, 500 + STALL_TIMEOUT_MS + 1)).toBe(true);
+    expect(isStalled(snap.liveSignalAt, 500 + STALL_TIMEOUT_MS)).toBe(false);
+  });
+
+  it("advances on a tool call and on a counter, not just on text", () => {
+    expect(
+      deriveNodeActivity([ev("ToolCallStarted", 42, { name: "w", tool_name: "grep" })]).liveSignalAt,
+    ).toBe(42);
+    expect(deriveNodeActivity([ev("Whatever", 77, { name: "w", token_count: 12 })]).liveSignalAt).toBe(
+      77,
+    );
   });
 });
 

--- a/apps/studio/frontend/src/lib/nodeActivity.test.ts
+++ b/apps/studio/frontend/src/lib/nodeActivity.test.ts
@@ -113,11 +113,12 @@ describe("liveSignalAt separates silence-by-design from a dead stream", () => {
 
   it("advances on a tool call and on a counter, not just on text", () => {
     expect(
-      deriveNodeActivity([ev("ToolCallStarted", 42, { name: "w", tool_name: "grep" })]).liveSignalAt,
+      deriveNodeActivity([ev("ToolCallStarted", 42, { name: "w", tool_name: "grep" })])
+        .liveSignalAt,
     ).toBe(42);
-    expect(deriveNodeActivity([ev("Whatever", 77, { name: "w", token_count: 12 })]).liveSignalAt).toBe(
-      77,
-    );
+    expect(
+      deriveNodeActivity([ev("Whatever", 77, { name: "w", token_count: 12 })]).liveSignalAt,
+    ).toBe(77);
   });
 });
 

--- a/apps/studio/frontend/src/lib/nodeActivity.test.ts
+++ b/apps/studio/frontend/src/lib/nodeActivity.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { deriveNodeActivity, isStalled, pulseDurationMs, STALL_TIMEOUT_MS } from "./nodeActivity";
+import type { SignalEvent } from "./api";
+
+function ev(kind: string, ts: number, payload: Record<string, unknown> = {}): SignalEvent {
+  return { id: `${kind}-${ts}`, session_id: "s", seq: ts, kind, op_id: "op1", ts, payload };
+}
+
+describe("deriveNodeActivity", () => {
+  it("reports nothing for an empty event log", () => {
+    const snap = deriveNodeActivity([]);
+    expect(snap).toEqual({
+      activity: null,
+      activityDetail: null,
+      lastText: null,
+      counter: null,
+      lastEventAt: null,
+      eventCount: 0,
+    });
+  });
+
+  it("reads 'thinking' from a bare NodeStarted with no richer payload", () => {
+    const snap = deriveNodeActivity([ev("NodeStarted", 100, { name: "a" })]);
+    expect(snap.activity).toBe("thinking");
+    expect(snap.lastText).toBeNull();
+    expect(snap.lastEventAt).toBe(100);
+  });
+
+  it("reads 'waiting' from a bare NodeQueued", () => {
+    const snap = deriveNodeActivity([ev("NodeQueued", 50)]);
+    expect(snap.activity).toBe("waiting");
+  });
+
+  it("picks up streaming text from any kind that carries a text-ish field", () => {
+    const snap = deriveNodeActivity([
+      ev("NodeStarted", 1),
+      ev("NodeStarted", 2, { text: "hello" }),
+    ]);
+    expect(snap.activity).toBe("streaming");
+    expect(snap.lastText).toBe("hello");
+  });
+
+  it("prefers the tool activity when a tool name is present", () => {
+    const snap = deriveNodeActivity([ev("NodeStarted", 1, { tool_name: "read_file" })]);
+    expect(snap.activity).toBe("tool");
+    expect(snap.activityDetail).toBe("read_file");
+  });
+
+  it("last-write-wins on text and counter across the event log, in the order given", () => {
+    const snap = deriveNodeActivity([
+      ev("NodeStarted", 1, { text: "first", token_count: 5 }),
+      ev("NodeStarted", 2, { text: "second", token_count: 12 }),
+    ]);
+    expect(snap.lastText).toBe("second");
+    expect(snap.counter).toBe(12);
+    expect(snap.eventCount).toBe(2);
+  });
+
+  it("tracks lastEventAt as the max timestamp regardless of array order", () => {
+    const snap = deriveNodeActivity([ev("NodeStarted", 500), ev("NodeQueued", 10)]);
+    expect(snap.lastEventAt).toBe(500);
+  });
+});
+
+describe("isStalled", () => {
+  it("is never stalled with no event yet", () => {
+    expect(isStalled(null, 999_999)).toBe(false);
+  });
+
+  it("is not stalled right up to the timeout boundary", () => {
+    expect(isStalled(1000, 1000 + STALL_TIMEOUT_MS)).toBe(false);
+  });
+
+  it("is stalled the instant the timeout is exceeded", () => {
+    expect(isStalled(1000, 1000 + STALL_TIMEOUT_MS + 1)).toBe(true);
+  });
+});
+
+describe("pulseDurationMs", () => {
+  it("falls back to the default duration with no events in the window", () => {
+    expect(pulseDurationMs(0)).toBe(1500);
+  });
+
+  it("speeds up (shorter duration) as the event rate rises", () => {
+    const slow = pulseDurationMs(1, 5000); // 0.2/s -> clamped floor
+    const fast = pulseDurationMs(20, 5000); // 4/s -> clamped ceiling
+    expect(fast).toBeLessThan(slow);
+  });
+
+  it("never goes below the compositor-friendly floor or above the perceptible ceiling", () => {
+    for (const n of [0, 1, 5, 100, 10_000]) {
+      const ms = pulseDurationMs(n);
+      expect(ms).toBeGreaterThanOrEqual(700);
+      expect(ms).toBeLessThanOrEqual(2400);
+    }
+  });
+});

--- a/apps/studio/frontend/src/lib/nodeActivity.test.ts
+++ b/apps/studio/frontend/src/lib/nodeActivity.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { deriveNodeActivity, isStalled, pulseDurationMs, STALL_TIMEOUT_MS } from "./nodeActivity";
+import {
+  buildNodeActivityByName,
+  deriveNodeActivity,
+  isStalled,
+  pulseDurationMs,
+  STALL_TIMEOUT_MS,
+} from "./nodeActivity";
 import type { SignalEvent } from "./api";
 
 function ev(kind: string, ts: number, payload: Record<string, unknown> = {}): SignalEvent {
@@ -93,5 +99,90 @@ describe("pulseDurationMs", () => {
       expect(ms).toBeGreaterThanOrEqual(700);
       expect(ms).toBeLessThanOrEqual(2400);
     }
+  });
+});
+
+// The correlation is the part that fails silently: keying on op_id resolves
+// nothing against a planned graph and yields an empty snapshot per node, which
+// is indistinguishable from a run that has not emitted anything yet.
+function named(
+  name: string,
+  opId: string,
+  kind: string,
+  ts: number,
+  extra: Record<string, unknown> = {},
+): SignalEvent {
+  return {
+    id: `${opId}-${kind}-${ts}`,
+    session_id: "s",
+    seq: ts,
+    kind,
+    op_id: opId,
+    ts,
+    payload: { name, ...extra },
+  };
+}
+
+describe("buildNodeActivityByName", () => {
+  it("buckets by the authored step name, not by the runtime op id", () => {
+    // Same authored step, two different runtime ops (a retry, or a node the
+    // engine re-created). Keyed by op_id this reads as two unrelated nodes,
+    // neither of which matches anything the planned graph draws.
+    const by = buildNodeActivityByName([
+      named("plan", "uuid-a", "NodeStarted", 1),
+      named("plan", "uuid-b", "ToolCallStarted", 2, { tool_name: "grep" }),
+    ]);
+
+    expect([...by.keys()]).toEqual(["plan"]);
+    expect(by.get("plan")!.eventCount).toBe(2);
+    expect(by.get("plan")!.activity).toBe("tool");
+  });
+
+  it("keeps separate authored steps separate", () => {
+    const by = buildNodeActivityByName([
+      named("plan", "uuid-a", "NodeStarted", 1),
+      named("build", "uuid-b", "NodeQueued", 2),
+    ]);
+
+    expect(by.get("plan")!.activity).toBe("thinking");
+    expect(by.get("build")!.activity).toBe("waiting");
+  });
+
+  it("places an event that carries only an op id, using the name that op already announced", () => {
+    // The shape a richer emitter will have: the lifecycle signal names the
+    // step, the interesting one does not repeat it.
+    const bare: SignalEvent = {
+      id: "bare",
+      session_id: "s",
+      seq: 2,
+      kind: "ToolCallStarted",
+      op_id: "uuid-a",
+      ts: 2,
+      payload: { tool_name: "rg" },
+    };
+    const by = buildNodeActivityByName([named("plan", "uuid-a", "NodeStarted", 1), bare]);
+
+    expect(by.get("plan")!.eventCount).toBe(2);
+    expect(by.get("plan")!.activityDetail).toBe("rg");
+  });
+
+  it("drops an event it cannot place rather than filing it under a guess", () => {
+    const orphan: SignalEvent = {
+      id: "orphan",
+      session_id: "s",
+      seq: 1,
+      kind: "ToolCallStarted",
+      op_id: "uuid-unknown",
+      ts: 1,
+      payload: { tool_name: "rg" },
+    };
+    const by = buildNodeActivityByName([named("plan", "uuid-a", "NodeStarted", 1), orphan]);
+
+    expect([...by.keys()]).toEqual(["plan"]);
+    expect(by.get("plan")!.eventCount).toBe(1);
+  });
+
+  it("returns an empty map for an empty stream", () => {
+    expect(buildNodeActivityByName([]).size).toBe(0);
   });
 });

--- a/apps/studio/frontend/src/lib/nodeActivity.ts
+++ b/apps/studio/frontend/src/lib/nodeActivity.ts
@@ -85,6 +85,46 @@ export function deriveNodeActivity(events: readonly SignalEvent[]): NodeActivity
   return { activity, activityDetail, lastText, counter, lastEventAt, eventCount: events.length };
 }
 
+// Correlates the raw event stream against a PLANNED graph, whose node ids are
+// authored step names — so events bucket by `payload.name`, never by `op_id`
+// (a runtime UUID the planned graph knows nothing about; see
+// operationGraph.ts's buildNodeStatusesByName, which correlates the same way
+// for lifecycle status). Keying on op_id here would resolve nothing and
+// produce an empty snapshot for every node, which reads as "no signals yet"
+// rather than as the miscorrelation it is.
+//
+// Unlike the lifecycle path this does not filter by kind: every event for a
+// node feeds the activity fold, because the richer kinds a future emitter adds
+// are exactly the ones worth showing. Such an event may carry only `op_id`, so
+// the name learned from that op's Node* events is remembered and used to place
+// it. An event whose op has never carried a name is dropped rather than filed
+// under a guess.
+export function buildNodeActivityByName(
+  events: readonly SignalEvent[],
+): Map<string, NodeActivitySnapshot> {
+  const nameByOp = new Map<string, string>();
+  for (const ev of events) {
+    const name = ev.payload && typeof ev.payload.name === "string" ? ev.payload.name : "";
+    if (name && ev.op_id && !nameByOp.has(ev.op_id)) nameByOp.set(ev.op_id, name);
+  }
+
+  const eventsByName = new Map<string, SignalEvent[]>();
+  for (const ev of events) {
+    const direct = ev.payload && typeof ev.payload.name === "string" ? ev.payload.name : "";
+    const name = direct || nameByOp.get(ev.op_id) || "";
+    if (!name) continue;
+    const bucket = eventsByName.get(name);
+    if (bucket) bucket.push(ev);
+    else eventsByName.set(name, [ev]);
+  }
+
+  const result = new Map<string, NodeActivitySnapshot>();
+  for (const [name, bucket] of eventsByName) {
+    result.set(name, deriveNodeActivity(bucket));
+  }
+  return result;
+}
+
 // A node "stalls" once this long passes with no fresh event while it is still
 // reporting itself as running — the failure mode ADR-0113's Consequences
 // section names explicitly: a node pulsing forever after its event stream

--- a/apps/studio/frontend/src/lib/nodeActivity.ts
+++ b/apps/studio/frontend/src/lib/nodeActivity.ts
@@ -13,6 +13,16 @@
 // exactly what StepNode should show for a node it has no richer signal for.
 // A future emitter can add payload fields (or new kinds) without any change
 // on this side.
+//
+// That reality has one consequence worth stating outright, because getting it
+// wrong is worse than showing nothing. Under today's signals a node emits
+// NOTHING between NodeStarted and NodeCompleted — measured on a real run, 32
+// to 39 seconds per node, and proportionally worse for ops that run minutes.
+// The events that DO flow during that window (hook and message signals) carry
+// no op id or name, so the correlator below drops them, correctly: filing
+// them under a guess would be worse. So `liveSignalAt` stays null for the
+// whole of a node's working life, and any reading that treats event silence
+// as evidence about the node must consult it rather than `lastEventAt`.
 import type { SignalEvent } from "./api";
 
 export type NodeActivityKind = "thinking" | "tool" | "streaming" | "waiting";
@@ -23,6 +33,20 @@ export interface NodeActivitySnapshot {
   lastText: string | null;
   counter: number | null;
   lastEventAt: number | null;
+  /** Epoch ms of the last event that actually said what the node was DOING —
+   *  a tool call, a stream delta, or any event carrying text or a counter.
+   *  Lifecycle events do not advance it, because they bracket a node's work
+   *  rather than report on it.
+   *
+   *  This exists so the stall clock has an honest input. Stalling means "a
+   *  stream that was flowing has stopped", and a node fed only lifecycle
+   *  signals never had a stream, so its silence between started and completed
+   *  is the normal case rather than evidence of anything. Measured against a
+   *  real run of today's backend, every node is silent for the whole 32-39s
+   *  it works, which a stall clock reading `lastEventAt` calls stalled for
+   *  about two thirds of its life. Null here means "no liveness signal
+   *  exists", which the card must not read as either alive or stuck. */
+  liveSignalAt: number | null;
   eventCount: number;
 }
 
@@ -54,6 +78,7 @@ export function deriveNodeActivity(events: readonly SignalEvent[]): NodeActivity
   let lastText: string | null = null;
   let counter: number | null = null;
   let lastEventAt: number | null = null;
+  let liveSignalAt: number | null = null;
   let activity: NodeActivityKind | null = null;
   let activityDetail: string | null = null;
 
@@ -67,6 +92,22 @@ export function deriveNodeActivity(events: readonly SignalEvent[]): NodeActivity
     if (count !== null) counter = count;
 
     const toolName = firstString(ev.payload, ["tool_name", "tool"]);
+
+    // Recognised as reporting work in progress, rather than enumerated as
+    // "not a lifecycle kind". Framed positively so a lifecycle kind added
+    // later cannot start arming the stall clock by being unlisted, while a
+    // future kind that carries text or a tool name arms it without edits
+    // here — the same defensive-read stance as the fields above.
+    if (
+      TOOL_KINDS.has(ev.kind) ||
+      STREAM_KINDS.has(ev.kind) ||
+      text ||
+      toolName ||
+      count !== null
+    ) {
+      if (liveSignalAt === null || ev.ts > liveSignalAt) liveSignalAt = ev.ts;
+    }
+
     if (TOOL_KINDS.has(ev.kind) || toolName) {
       activity = "tool";
       activityDetail = toolName;
@@ -82,7 +123,15 @@ export function deriveNodeActivity(events: readonly SignalEvent[]): NodeActivity
     }
   }
 
-  return { activity, activityDetail, lastText, counter, lastEventAt, eventCount: events.length };
+  return {
+    activity,
+    activityDetail,
+    lastText,
+    counter,
+    lastEventAt,
+    liveSignalAt,
+    eventCount: events.length,
+  };
 }
 
 // Correlates the raw event stream against a PLANNED graph, whose node ids are
@@ -125,10 +174,15 @@ export function buildNodeActivityByName(
   return result;
 }
 
-// A node "stalls" once this long passes with no fresh event while it is still
-// reporting itself as running — the failure mode ADR-0113's Consequences
-// section names explicitly: a node pulsing forever after its event stream
-// dies asserts liveness it no longer has.
+// A node "stalls" once this long passes with no fresh LIVE signal while it is
+// still reporting itself as running — the failure mode ADR-0113's Consequences
+// section names explicitly: a node pulsing forever after its event stream dies
+// asserts liveness it no longer has.
+//
+// Feed this `liveSignalAt`, never `lastEventAt`. The two differ exactly when a
+// node's only events are lifecycle ones, which is every node under today's
+// backend, and reading `lastEventAt` there turns "we were never told anything"
+// into the much stronger claim "it was working and stopped".
 export const STALL_TIMEOUT_MS = 12_000;
 
 export function isStalled(

--- a/apps/studio/frontend/src/lib/nodeActivity.ts
+++ b/apps/studio/frontend/src/lib/nodeActivity.ts
@@ -1,0 +1,117 @@
+// Pure, framework-free derivation of a node's live-activity snapshot (ADR-0113
+// D3/row 6) from the raw signal-event stream StepNode's caller reads
+// (`streamSignals` in ./api). Kept separate from StepNode so the folding logic
+// is testable without mounting React, and separate from operationGraph.ts
+// because that module derives LIFECYCLE (queued/running/...); this derives
+// WHAT THE NODE IS DOING within the running state.
+//
+// Today's backend only emits the lifecycle signals in
+// lionagi/session/signal.py (NodeQueued/Started/Completed/...), none of which
+// carry assistant text, a tool name, or a token count. The fields below are
+// read defensively from `payload` — a node fed only today's signals gets
+// `activity: "thinking"` while running and everything else null, which is
+// exactly what StepNode should show for a node it has no richer signal for.
+// A future emitter can add payload fields (or new kinds) without any change
+// on this side.
+import type { SignalEvent } from "./api";
+
+export type NodeActivityKind = "thinking" | "tool" | "streaming" | "waiting";
+
+export interface NodeActivitySnapshot {
+  activity: NodeActivityKind | null;
+  activityDetail: string | null;
+  lastText: string | null;
+  counter: number | null;
+  lastEventAt: number | null;
+  eventCount: number;
+}
+
+const TOOL_KINDS = new Set(["ToolCallStarted", "ToolCallCompleted"]);
+const STREAM_KINDS = new Set(["AssistantDelta", "MessageDelta"]);
+
+function firstString(payload: Record<string, unknown> | undefined, keys: string[]): string | null {
+  if (!payload) return null;
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return null;
+}
+
+function firstNumber(payload: Record<string, unknown> | undefined, keys: string[]): number | null {
+  if (!payload) return null;
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+// Folds events in whatever order they're given — last-write-wins per field —
+// so a caller may pass either the full per-node event log or just the tail of
+// it; both produce the same snapshot as long as order is preserved.
+export function deriveNodeActivity(events: readonly SignalEvent[]): NodeActivitySnapshot {
+  let lastText: string | null = null;
+  let counter: number | null = null;
+  let lastEventAt: number | null = null;
+  let activity: NodeActivityKind | null = null;
+  let activityDetail: string | null = null;
+
+  for (const ev of events) {
+    if (lastEventAt === null || ev.ts > lastEventAt) lastEventAt = ev.ts;
+
+    const text = firstString(ev.payload, ["text", "assistant_text", "delta"]);
+    if (text) lastText = text;
+
+    const count = firstNumber(ev.payload, ["token_count", "tokens", "event_count"]);
+    if (count !== null) counter = count;
+
+    const toolName = firstString(ev.payload, ["tool_name", "tool"]);
+    if (TOOL_KINDS.has(ev.kind) || toolName) {
+      activity = "tool";
+      activityDetail = toolName;
+    } else if (STREAM_KINDS.has(ev.kind) || text) {
+      activity = "streaming";
+      activityDetail = null;
+    } else if (ev.kind === "NodeStarted") {
+      activity = "thinking";
+      activityDetail = null;
+    } else if (ev.kind === "NodeQueued") {
+      activity = "waiting";
+      activityDetail = null;
+    }
+  }
+
+  return { activity, activityDetail, lastText, counter, lastEventAt, eventCount: events.length };
+}
+
+// A node "stalls" once this long passes with no fresh event while it is still
+// reporting itself as running — the failure mode ADR-0113's Consequences
+// section names explicitly: a node pulsing forever after its event stream
+// dies asserts liveness it no longer has.
+export const STALL_TIMEOUT_MS = 12_000;
+
+export function isStalled(
+  lastEventAt: number | null,
+  now: number,
+  timeoutMs: number = STALL_TIMEOUT_MS,
+): boolean {
+  if (lastEventAt === null) return false;
+  return now - lastEventAt > timeoutMs;
+}
+
+// Pulse speed is derived from the event rate, not fixed — a node emitting
+// many events per second reads as busier than one emitting one every few
+// seconds. Bucketed and clamped so a burst or a lull can't animate faster
+// than the compositor should be asked to run, or slower than a human
+// perceives as "still moving".
+const MIN_PULSE_MS = 700;
+const MAX_PULSE_MS = 2400;
+const DEFAULT_PULSE_MS = 1500;
+
+export function pulseDurationMs(eventsInWindow: number, windowMs = 5000): number {
+  if (eventsInWindow <= 0) return DEFAULT_PULSE_MS;
+  const ratePerSec = eventsInWindow / (windowMs / 1000);
+  const ms = 1000 / Math.min(Math.max(ratePerSec, 0.4), 4);
+  return Math.min(Math.max(ms, MIN_PULSE_MS), MAX_PULSE_MS);
+}


### PR DESCRIPTION
A node card on the run canvas showed status but not what the node was doing.
While a step was running, the card was indistinguishable from one that had been
running for an hour with nothing happening.

## What changes

- The card carries a live activity line, so a running node reports a derived
  activity state — waiting, thinking, and where a richer signal exists,
  streaming or a named tool — rather than only that it is running.
- Motion is bound to a real signal. A node animates only while it is running,
  not stalled, in the viewport, and has actually emitted a recent event. The
  number of simultaneously animating nodes is capped, and motion is suppressed
  entirely under a reduced-motion preference.
- The run view derives an activity snapshot per node from the signal stream and
  the canvas writes it into each card, which is what actually puts the data on
  screen. Correlation is by authored step name, the same rule live status
  already uses: a signal's `op_id` is a runtime UUID that a planned graph has
  never heard of, so keying on it resolves nothing and yields an empty snapshot
  for every node — a result indistinguishable from a run with nothing to say.
- A signal's timestamp is converted from the backend's seconds to milliseconds
  once, at the wire. This has to land with the projection rather than after it:
  the card's stall clock is `Date.now()`, so an unconverted timestamp is about
  1.7 trillion milliseconds old and every node carrying a signal would render
  "stalled" the moment it got one. The event log's own timestamp render drops
  its local conversion in the same change.
- The card's height is now the sum of the rows it draws instead of a literal.

A node the stream has not correlated gets no activity keys written at all, so
its card renders exactly as it did before.

## What today's signals can and cannot fill

Stated plainly, because a slot with nothing in it is not self-explaining.

The card originally also previewed the agent's latest text, and nothing on the
wire can fill it. The backend emits lifecycle signals only, none of which
declares a text or delta field. The one signal that carries assistant content
is reduced at the persistence boundary to a reference — id, role, sender,
recipient — with the content dropped, and with no operation id or step name to
correlate it by, so it cannot reach a node even as a reference.

That preview is therefore gone rather than left empty. A blank band on every
card of every run is not an empty state a reader can identify as intentional;
it reads as a rendering defect. Removing it also buys back vertical space,
which is what a wide graph is short of. The activity fold still consumes
assistant text, since reading it is how a node is known to be streaming rather
than thinking — it simply no longer reaches the card. If a signal ever carries
per-node text, the row comes back with the emitter.

The counter is a different case and stays. Token counts are reported once for
the whole run rather than per node, so today it is usually absent — but it
renders only where a value exists, so a card without one draws nothing rather
than a reserved blank. It is read defensively from the payload so that an
emitter adding per-node counts later needs no change on this side.

So on today's signals what works is the activity state, the stall detection and
the event-rate pulse, and the card is sized to exactly those.

## The height was wrong, and could not have been caught

The card set its height from a constant of 88. What it drew, measured in a
browser on a running node — 8px padding top and bottom, a 3px border each side,
a 16px name row, a 14px role row, two 2px gaps, a 14px activity line and two
14px preview lines — needed 98. A running node has the widest border and was the
only kind with live text to show, so it drew ten pixels past its own border and
the preview's second line fell outside the card.

The tests could not see it. The card set its style height from the constant and
the tests asserted that style height equalled the constant, which passes for any
value, including one smaller than the content needs. A test that checks a
component renders the number it was handed is a tautology dressed as coverage.

Both halves are now fixed. The height is summed in code from the rows the card
draws, and the height tests compare cards to each other rather than to the
constant, so they cannot pass by echoing it.

With the preview removed the sum is 69: 16 padding, 6 border, a 17 name row, a
14 role row, a 2 gap and a 14 activity row. The 2px gap goes with the preview
rather than staying behind, because it sat on the wrapper holding both rows.
Against the browser-measured 98 above, dropping two 14px lines and that gap
leaves 68 drawn against 69 reserved, and the remaining pixel has the same origin
it always had: the name row is reserved from its type scale (ceil of 12px at
1.375 leading = 17) where the browser lays it out at 16. That is deliberate.
Over-reserving costs a pixel of empty card, under-reserving clips text, and the
drawn height depends on font metrics that are not identical across platforms.

That 68 is measured, not inferred. In a browser, on this build, a card left to
size itself asks for 68 in the demanding case — the running state's 3px border
with the activity row carrying both a word and a counter — against the 69 it is
given. The same probe run across the three border weights returns 50, 52 and 54
for 1px, 2px and 3px with an empty activity row, moving by exactly the border
delta each time, so it is responding to the state rather than reporting one
number; a populated activity row then adds its 14 to reach 68.

Two limits on that, stated rather than implied. The run rendered was a finished
one, so the 3px border and the activity text were applied to a real card in the
real stylesheet rather than produced by a live running node. And jsdom performs
no layout, so none of this is reachable from the test suite — it is why the
height is summed from named terms in code, where the suite can check the terms
even though it can never check the fit.

## Verification

Full canvas, lib and history suites green: 802 tests.

The projection and the unit conversion were each confirmed load-bearing by
mutation, against reddened-test predictions written before the runs and
reconciled arm by arm afterwards.

Stopping the canvas from writing activity into node data reddens exactly four
of the five end-to-end card tests. The survivor is the no-data case, which is
the state that mutation makes universal — the correct outcome, not a gap.

Making the unit conversion a no-op reddens six: two on the conversion itself,
and all four card-level cases. That is one more than the same probe reddened
before the preview was removed, and the difference is informative rather than
incidental. The assistant-delta case used to survive this mutation, because it
asserted on the text field and text rendered regardless of stall state. It now
asserts on the activity word, and a node the stall clock has misread reports
"stalled" instead of "streaming", so it fails. Removing the unfillable row made
that test strictly more sensitive to the defect it sits next to.

The end-to-end canvas tests run the whole path rather than its pieces — raw
events in the shape the backend emits them, through the real normalizer,
correlation, canvas projection and node card, asserting the text the card ends
up showing. That span is deliberate: the activity fold was correct and fully
covered while nothing called it, and an assertion that stops at the fold cannot
tell a wired projection from an unwired one. The seconds-versus-milliseconds
case asserts both directions, so it fails if the conversion ever becomes a
no-op.

Two measured layout expectations move with the height and are remeasured: the
30-node fold band, whose comment tracks it across every height change and now
sits at ~569, and a minimum-gap fixture whose spacing was a literal that stopped
clearing the floor. That one derives from the node height rather than restating
it, so it stays honest as the card changes again.

One thing about the original browser measurement worth keeping on the record,
because it would have produced a confident wrong number. It is in layout pixels:
the canvas viewport carries a scale transform, so anything read through
`getBoundingClientRect` is in scaled units and not comparable to the constants.
`box-sizing: border-box` was confirmed active there rather than assumed.


---

## Follow-up in this branch: the pulse was gated on the wrong field

Moving the stall clock onto `liveSignalAt` fixed the reading that called a
working node stalled, but left the animation predicate still asking
`lastEventAt != null`. The two fields disagree for exactly the nodes production
has. `lastEventAt` advances on any event, including the lifecycle ones that
merely bracket a node's work, so `NodeStarted` satisfies it permanently;
`liveSignalAt` stays null, which makes the stall clock answer "not stalled"
permanently.

That wired a permanently-true presence test to a permanently-false stall test.
Every running node pulsed, nothing could stop it, and because today's backend
emits lifecycle kinds only, the stall guard protected none of the nodes it was
written for. The protection existed and was unreachable.

The presence gate and the pulse-rate window now read `liveSignalAt`, the same
field the stall clock reads, so the two halves cannot disagree again.

This reverses the closing note of the earlier commit in this branch, which
chose to keep pulsing a node that had never reported work. That was the wrong
call.

**What it changes on screen, stated plainly:** under today's backend nothing on
the canvas pulses, because no node ever has a live signal. Running nodes stay
legible — the running dot and the running border rail both draw off the node's
status alone — they simply hold still. Restoring motion honestly needs a
per-node heartbeat on the backend so `liveSignalAt` advances, which would also
give the stall clock something real to protect. That is deliberately not in
this branch.

**Not covered by the suite:** the same change moves the pulse-rate window's
input from `lastEventAt` to `liveSignalAt`. No test anywhere asserts pulse
*speed*, so a green run says nothing about that half. The presence gate itself
is pinned in both directions: a lifecycle-only running node must not animate,
and the same node must animate once a real work signal arrives.
