### PR TITLE
Default the run detail to its graph, and give the run controls a reason

### DIFF
--- a/apps/studio/frontend/src/components/history/OperationGraphSection.tsx
+++ b/apps/studio/frontend/src/components/history/OperationGraphSection.tsx
@@ -32,12 +32,35 @@ const CONTINUATION_WIDTH = 1.25;
 
 // ── Node card ─────────────────────────────────────────────────────────────────
 
-function NodeCard({ node, live }: { node: OperationNode; live: boolean }) {
+function NodeCard({
+  node,
+  live,
+  onClick,
+}: {
+  node: OperationNode;
+  live: boolean;
+  onClick?: (nodeId: string) => void;
+}) {
   const isPulsing = live && node.status === "running";
+  const nodeId = node.name || node.opId;
 
   return (
     <div
-      className={`flex min-w-0 flex-col gap-1 rounded border border-edge border-l-2 bg-surface-raised px-2.5 py-2 shadow-card transition-opacity duration-150 ${STATUS_BORDER[node.status]}`}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      data-testid="op-graph-node"
+      onClick={onClick ? () => onClick(nodeId) : undefined}
+      onKeyDown={
+        onClick
+          ? (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onClick(nodeId);
+              }
+            }
+          : undefined
+      }
+      className={`flex min-w-0 flex-col gap-1 rounded border border-edge border-l-2 bg-surface-raised px-2.5 py-2 shadow-card transition-opacity duration-150 ${STATUS_BORDER[node.status]} ${onClick ? "cursor-pointer" : ""}`}
     >
       <div className="flex items-center gap-1.5">
         <span className="relative flex h-2 w-2 shrink-0">
@@ -126,9 +149,14 @@ export function computeLayers(
 export default function OperationGraphSection({
   state,
   live,
+  onNodeClick,
 }: {
   state: OperationGraphState;
   live: boolean;
+  /** ADR-0113 D6: selecting a runtime graph node resolves it to a branch,
+   * same as an authored-graph node click — the caller matches it, this
+   * component only reports which node was clicked. */
+  onNodeClick?: (nodeId: string) => void;
 }) {
   const { nodes, edges } = state;
 
@@ -141,7 +169,7 @@ export default function OperationGraphSection({
       <div className="flex flex-wrap gap-2">
         {nodes.map((n) => (
           <div key={n.opId} className="w-44">
-            <NodeCard node={n} live={live} />
+            <NodeCard node={n} live={live} onClick={onNodeClick} />
           </div>
         ))}
       </div>
@@ -233,7 +261,7 @@ export default function OperationGraphSection({
                 className="absolute"
                 style={{ left: x, top: y, width: colWidth, height: cardHeight }}
               >
-                <NodeCard node={node} live={live} />
+                <NodeCard node={node} live={live} onClick={onNodeClick} />
               </div>
             );
           }),

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -2294,7 +2294,7 @@ describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () =>
     };
   }
 
-  it("row 8: pause is shown and DISABLED, with its reason, on an agent run — never hidden", async () => {
+  it("row 8: pause is shown and DISABLED on an agent run — never hidden", async () => {
     const { container, unmount } = await mountRunDetail(sessionOf("agent"));
     try {
       const pauseButton = container.querySelector<HTMLButtonElement>(
@@ -2302,7 +2302,6 @@ describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () =>
       );
       expect(pauseButton).not.toBeNull();
       expect(pauseButton?.disabled).toBe(true);
-      expect(pauseButton?.title).toContain("no pause seam");
       // Resume is not a listed agent capability at all — not offered, not
       // just disabled.
       expect(container.querySelector('[data-testid="run-controls-resume"]')).toBeNull();
@@ -2311,26 +2310,52 @@ describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () =>
     }
   });
 
-  it("row 8: steer is offered and enabled on an agent run", async () => {
-    const { container, unmount } = await mountRunDetail(sessionOf("agent"));
+  // These three replace tests that asserted pause on a flow run and steer on
+  // an agent run were ENABLED. That expectation described a backend path that
+  // was never built: nothing in the operator's command set pauses a run,
+  // releases a pause gate, or delivers a steering message, and because the
+  // control dispatches a natural-language instruction, an unbacked verb does
+  // not fail cleanly — the nearest match to "stop this run" is cancel_run. A
+  // clickable button was the defect, not the fix.
+  it("every control is disabled while no command exists to carry its verb out", async () => {
+    const { container, unmount } = await mountRunDetail(sessionOf("flow"));
     try {
-      const steerButton = container.querySelector<HTMLButtonElement>(
-        '[data-testid="run-controls-steer"]',
-      );
-      expect(steerButton).not.toBeNull();
-      expect(steerButton?.disabled).toBe(false);
+      for (const verb of ["pause", "resume", "steer"]) {
+        const button = container.querySelector<HTMLButtonElement>(
+          `[data-testid="run-controls-${verb}"]`,
+        );
+        expect(button, `${verb} button missing`).not.toBeNull();
+        expect(button?.disabled, `${verb} button is clickable`).toBe(true);
+      }
     } finally {
       unmount();
     }
   });
 
-  it("pause is offered and enabled on a flow run", async () => {
+  it("states the refusal in text, not only in a tooltip", async () => {
     const { container, unmount } = await mountRunDetail(sessionOf("flow"));
     try {
-      const pauseButton = container.querySelector<HTMLButtonElement>(
-        '[data-testid="run-controls-pause"]',
+      const reason = container.querySelector(
+        '[data-testid="run-controls-reason-no-executable-path"]',
       );
-      expect(pauseButton?.disabled).toBe(false);
+      expect(reason).not.toBeNull();
+      expect(reason?.textContent).toBe("No command exists yet to carry this out.");
+    } finally {
+      unmount();
+    }
+  });
+
+  // The refusal that wins is the one that does not imply a working
+  // counterfactual: "steer instead" and "the run is not paused" both tell the
+  // reader another route works, and neither does.
+  it("does not advise steering as an alternative while steer is itself refused", async () => {
+    const { container, unmount } = await mountRunDetail(sessionOf("agent"));
+    try {
+      const panel = container.querySelector('[data-testid="run-controls"]');
+      expect(panel?.textContent).not.toContain("steer instead");
+      expect(
+        container.querySelector('[data-testid="run-controls-reason-no-executable-path"]'),
+      ).not.toBeNull();
     } finally {
       unmount();
     }

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -1932,3 +1932,405 @@ describe("history/RunDetail.tsx — the dag panel height policy is floor/grow-on
     expect(nextRun.height).toBe(DAG_MIN_HEIGHT);
   });
 });
+
+// ─── ADR-0113 rows 3 & 5: graph/list view — pure resolution logic ──────────
+
+describe("history/RunDetail.tsx — hasResolvableGraph (row 3: what counts as a real canvas)", () => {
+  const node = (id: string) => ({
+    id,
+    label: id,
+    role: "",
+    assignment: "",
+    prompt: "",
+    capacity: 1,
+    timeout: null,
+    inputs: [],
+    outputs: [],
+  });
+
+  it("a graph with edges is resolvable", async () => {
+    const { hasResolvableGraph } = await import("./RunDetail");
+    const graph = {
+      nodes: [node("A"), node("B")],
+      edges: [{ id: "e1", source: "A", target: "B", mode: "simple" as const }],
+    };
+    expect(hasResolvableGraph(graph, { nodes: [], edges: [] })).toBe(true);
+  });
+
+  it("a single node with no edges is NOT resolvable — a canvas with one node and no edges is not a canvas", async () => {
+    const { hasResolvableGraph } = await import("./RunDetail");
+    const graph = { nodes: [node("A")], edges: [] };
+    expect(hasResolvableGraph(graph, { nodes: [], edges: [] })).toBe(false);
+  });
+
+  it("several disconnected nodes with no edges are also not resolvable — same reasoning, not just the one-node case", async () => {
+    const { hasResolvableGraph } = await import("./RunDetail");
+    const graph = { nodes: [node("A"), node("B"), node("C")], edges: [] };
+    expect(hasResolvableGraph(graph, { nodes: [], edges: [] })).toBe(false);
+  });
+
+  it("falls through to a real-edged opGraph when the authored graph is edgeless (mirrors shouldRenderAuthoredGraph)", async () => {
+    const { hasResolvableGraph } = await import("./RunDetail");
+    const authoredEdgeless = { nodes: [node("A"), node("B")], edges: [] };
+    const opGraph = {
+      nodes: [{ id: "A" }, { id: "B" }],
+      edges: [{ id: "e1", source: "A", target: "B" }],
+    };
+    expect(hasResolvableGraph(authoredEdgeless, opGraph)).toBe(true);
+  });
+
+  it("no graph at all is not resolvable", async () => {
+    const { hasResolvableGraph } = await import("./RunDetail");
+    expect(hasResolvableGraph(null, { nodes: [], edges: [] })).toBe(false);
+  });
+});
+
+describe("history/RunDetail.tsx — resolveInitialView (row 5: the precedence rule)", () => {
+  it("defaults to graph when a resolvable graph exists and the reader has made no choice", async () => {
+    const { resolveInitialView } = await import("./RunDetail");
+    expect(
+      resolveInitialView({ urlView: null, storedPreference: null, hasResolvableGraph: true }),
+    ).toBe("graph");
+  });
+
+  it("defaults to list when there is no resolvable graph and the reader has made no choice", async () => {
+    const { resolveInitialView } = await import("./RunDetail");
+    expect(
+      resolveInitialView({ urlView: null, storedPreference: null, hasResolvableGraph: false }),
+    ).toBe("list");
+  });
+
+  // This is the precedence the brief calls out explicitly: "default is
+  // graph" and "preference is persisted" are in tension exactly once — a
+  // graph-having run whose reader has already chosen "list" — and the
+  // reader's choice must win. A regression that makes the default win
+  // again (e.g. checking hasResolvableGraph before storedPreference) fails
+  // this test.
+  it("a stored 'list' preference beats the graph default, even when a resolvable graph exists", () => {
+    return import("./RunDetail").then(({ resolveInitialView }) => {
+      expect(
+        resolveInitialView({
+          urlView: null,
+          storedPreference: "list",
+          hasResolvableGraph: true,
+        }),
+      ).toBe("list");
+    });
+  });
+
+  it("the URL view param outranks the stored preference (a pasted deep link reproduces what was shared)", async () => {
+    const { resolveInitialView } = await import("./RunDetail");
+    expect(
+      resolveInitialView({
+        urlView: "graph",
+        storedPreference: "list",
+        hasResolvableGraph: false,
+      }),
+    ).toBe("graph");
+  });
+});
+
+// ─── ADR-0113 rows 3, 5, 8, 9 — mounted behavior ────────────────────────────
+//
+// Reuses the mount pattern from the hidden-count-badge suite above
+// (getSession/streamSession/streamSignals/ResumeRun/WorkerCanvas mocked at
+// module scope): real RunDetail, real BranchesSection/RunStepCard, a fake
+// WorkerCanvas standing in for ReactFlow.
+
+describe("history/RunDetail.tsx — graph/list view toggle and cross-view selection, mounted", () => {
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    Element.prototype.scrollIntoView = vi.fn();
+    // localStorage is unavailable in this test runtime (jsdom under Node's
+    // experimental webstorage without a backing file) — RunDetail's own
+    // reads/writes already tolerate that (readStoredView/writeStoredView),
+    // so these tests exercise the URL query param instead, which jsdom does
+    // support. The stored-preference SIDE of the precedence rule is covered
+    // directly against resolveInitialView (pure function, above), which
+    // needs no browser storage at all.
+    window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const node = (id: string) => ({
+    id,
+    label: id,
+    role: "",
+    assignment: "",
+    prompt: "",
+    capacity: 1,
+    timeout: null,
+    inputs: [],
+    outputs: [],
+  });
+
+  const edgedGraph = {
+    name: "run",
+    description: "",
+    nodes: [node("A"), node("B")],
+    edges: [{ id: "e-ab", source: "A", target: "B", mode: "simple" as const }],
+  };
+
+  const singleNodeGraph = {
+    name: "run",
+    description: "",
+    nodes: [node("A")],
+    edges: [],
+  };
+
+  function sessionWithBranches(graph: unknown, invocationKind: string | null = null) {
+    return {
+      id: "run-mount-view",
+      name: "run-mount-view",
+      created_at: 0,
+      updated_at: 0,
+      status: "completed",
+      invocation_kind: invocationKind,
+      branches: [{ id: "branch-a", name: "A", created_at: 0, messages: [] }],
+      graph,
+    };
+  }
+
+  async function mountRunDetail(session: unknown) {
+    const [{ getSession }, { default: RunDetail }] = await Promise.all([
+      import("@/lib/api"),
+      import("./RunDetail"),
+    ]);
+    vi.mocked(getSession).mockResolvedValue(session as never);
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <RunDetail id="run-mount-view" />
+        </IntlProvider>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    return {
+      container,
+      unmount: () => {
+        act(() => root.unmount());
+        container.remove();
+      },
+    };
+  }
+
+  it("row 3: a run with edges opens on the graph", async () => {
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(edgedGraph));
+    try {
+      expect(container.querySelector('[data-testid="worker-canvas"]')).not.toBeNull();
+      expect(container.querySelector("#run-branches")).toBeNull();
+      const graphTab = container.querySelector('[data-testid="run-detail-view-graph"]');
+      expect(graphTab?.getAttribute("aria-selected")).toBe("true");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 3: a single-node run with no edges opens on the list", async () => {
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(singleNodeGraph));
+    try {
+      expect(container.querySelector('[data-testid="worker-canvas"]')).toBeNull();
+      expect(container.querySelector("#run-branches")).not.toBeNull();
+      const listTab = container.querySelector('[data-testid="run-detail-view-list"]');
+      expect(listTab?.getAttribute("aria-selected")).toBe("true");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 5: an explicit ?view=list in the URL beats the graph default for a run with edges", async () => {
+    window.history.replaceState(null, "", "/?view=list");
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(edgedGraph));
+    try {
+      expect(container.querySelector('[data-testid="worker-canvas"]')).toBeNull();
+      expect(container.querySelector("#run-branches")).not.toBeNull();
+      const listTab = container.querySelector('[data-testid="run-detail-view-list"]');
+      expect(listTab?.getAttribute("aria-selected")).toBe("true");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 5: clicking the List tab switches away from the graph, and Graph switches back", async () => {
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(edgedGraph));
+    try {
+      const listTab = container.querySelector<HTMLButtonElement>(
+        '[data-testid="run-detail-view-list"]',
+      );
+      await act(async () => {
+        listTab?.click();
+      });
+      expect(container.querySelector('[data-testid="worker-canvas"]')).toBeNull();
+      expect(container.querySelector("#run-branches")).not.toBeNull();
+
+      const graphTab = container.querySelector<HTMLButtonElement>(
+        '[data-testid="run-detail-view-graph"]',
+      );
+      await act(async () => {
+        graphTab?.click();
+      });
+      expect(container.querySelector('[data-testid="worker-canvas"]')).not.toBeNull();
+      expect(container.querySelector("#run-branches")).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 5: selection survives a view switch — selecting a step in the list, then switching to graph, keeps it as the selected node", async () => {
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(edgedGraph));
+    try {
+      const listTab = container.querySelector<HTMLButtonElement>(
+        '[data-testid="run-detail-view-list"]',
+      );
+      await act(async () => {
+        listTab?.click();
+      });
+      const expandButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-controls="step-A-body"]',
+      );
+      expect(expandButton).not.toBeNull();
+      // A session with this few branches auto-expands every step on load
+      // (see the session-load effect above), so the single step here starts
+      // already expanded — collapsing it first (a plain expand/collapse,
+      // not a selection) and then re-expanding it is what actually exercises
+      // "the reader opened this step," which is the act that selects it.
+      await act(async () => {
+        expandButton?.click();
+      });
+      await act(async () => {
+        expandButton?.click();
+      });
+      const selectedRow = document.getElementById("step-A")?.parentElement;
+      expect(selectedRow?.hasAttribute("data-selected")).toBe(true);
+
+      const graphTab = container.querySelector<HTMLButtonElement>(
+        '[data-testid="run-detail-view-graph"]',
+      );
+      await act(async () => {
+        graphTab?.click();
+      });
+      const indicator = container.querySelector('[data-testid="run-detail-selected-node"]');
+      expect(indicator?.textContent).toContain("A");
+    } finally {
+      unmount();
+    }
+  });
+});
+
+// ─── ADR-0113 rows 8 & 9 — run controls, mounted ────────────────────────────
+
+describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () => {
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const flatGraph = { name: "run", description: "", nodes: [], edges: [] };
+
+  function sessionOf(invocationKind: string | null) {
+    return {
+      id: "run-mount-controls",
+      name: "run-mount-controls",
+      created_at: 0,
+      updated_at: 0,
+      status: "running",
+      invocation_kind: invocationKind,
+      branches: [],
+      graph: flatGraph,
+    };
+  }
+
+  async function mountRunDetail(session: unknown) {
+    const [{ getSession }, { default: RunDetail }] = await Promise.all([
+      import("@/lib/api"),
+      import("./RunDetail"),
+    ]);
+    vi.mocked(getSession).mockResolvedValue(session as never);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <IntlProvider locale="en" messages={enMessages}>
+          <RunDetail id="run-mount-controls" />
+        </IntlProvider>,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    return {
+      container,
+      unmount: () => {
+        act(() => root.unmount());
+        container.remove();
+      },
+    };
+  }
+
+  it("row 8: pause is shown and DISABLED, with its reason, on an agent run — never hidden", async () => {
+    const { container, unmount } = await mountRunDetail(sessionOf("agent"));
+    try {
+      const pauseButton = container.querySelector<HTMLButtonElement>(
+        '[data-testid="run-controls-pause"]',
+      );
+      expect(pauseButton).not.toBeNull();
+      expect(pauseButton?.disabled).toBe(true);
+      expect(pauseButton?.title).toContain("no pause seam");
+      // Resume is not a listed agent capability at all — not offered, not
+      // just disabled.
+      expect(container.querySelector('[data-testid="run-controls-resume"]')).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 8: steer is offered and enabled on an agent run", async () => {
+    const { container, unmount } = await mountRunDetail(sessionOf("agent"));
+    try {
+      const steerButton = container.querySelector<HTMLButtonElement>(
+        '[data-testid="run-controls-steer"]',
+      );
+      expect(steerButton).not.toBeNull();
+      expect(steerButton?.disabled).toBe(false);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("pause is offered and enabled on a flow run", async () => {
+    const { container, unmount } = await mountRunDetail(sessionOf("flow"));
+    try {
+      const pauseButton = container.querySelector<HTMLButtonElement>(
+        '[data-testid="run-controls-pause"]',
+      );
+      expect(pauseButton?.disabled).toBe(false);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("no control panel renders for a kind the control poller does not drain (e.g. show-play)", async () => {
+    const { container, unmount } = await mountRunDetail(sessionOf("show-play"));
+    try {
+      expect(container.querySelector('[data-testid="run-controls"]')).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+});

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -553,6 +553,17 @@ describe("history/RunDetail.tsx — shouldRenderAuthoredGraph", () => {
     expect(src).toMatch(/edges:\s*resolveGraphEdges\(graph\.nodes,\s*graph\.edges\)/);
   });
 
+  // The progress counters are sentence-case labels ("Total", "Completed"); the
+  // graphNodeStatus* vocabulary is lowercase because it renders inside a node
+  // card ("done", "running"). The escalated counter borrowed the node-status
+  // key, so it rendered as the only lowercase label in the strip. Assert on the
+  // source because the counters carry no other behaviour to observe.
+  it("the escalated counter uses the progress label vocabulary, not the node-status one", () => {
+    const src = fs.readFileSync(path.join(HISTORY_DIR, "RunDetail.tsx"), "utf-8");
+    expect(src).toMatch(/\{t\("progressEscalated"\)\}\s*\{counts\.escalated\}/);
+    expect(src).not.toMatch(/\{t\("graphNodeStatusEscalated"\)\}\s*\{counts\.escalated\}/);
+  });
+
   it("omitted edges + no runtime edges renders the authored graph, and normalized edges survive a WorkerCanvas-style map", async () => {
     const { shouldRenderAuthoredGraph } = await import("./RunDetail");
     const persisted = { nodes: [{ id: "a" }, { id: "b" }] } as {

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -51,13 +51,22 @@ vi.mock("@/components/canvas/WorkerCanvas", () => ({
 }));
 
 // The control section renders only while some verb has a backing command.
-// This wrapper defaults to the real registry, so a test says nothing by
-// accident; the control tests below opt in to a backed registry, because the
-// shown-and-disabled contract they assert is what exists once a command type
-// lands, not what exists today.
+// Every wrapper below delegates to the real implementation, so a test says
+// nothing by accident; the control tests opt in to a backed registry, because
+// the shown-and-disabled contract they assert is what exists once a command
+// type lands, not what exists today. The run-swap test additionally overrides
+// applyExecutablePath and the two dispatch calls, because the state it is
+// about — a pause the user actually accepted — cannot be reached at all while
+// every verb is refused before it is offered.
 vi.mock("@/lib/runControls", async () => {
   const actual = await vi.importActual<typeof import("@/lib/runControls")>("@/lib/runControls");
-  return { ...actual, hasAnyExecutablePath: vi.fn(actual.hasAnyExecutablePath) };
+  return {
+    ...actual,
+    hasAnyExecutablePath: vi.fn(actual.hasAnyExecutablePath),
+    applyExecutablePath: vi.fn(actual.applyExecutablePath),
+    proposeRunControl: vi.fn(actual.proposeRunControl),
+    confirmRunControl: vi.fn(actual.confirmRunControl),
+  };
 });
 
 const HISTORY_DIR = path.resolve(__dirname);
@@ -539,11 +548,25 @@ describe("history/RunDetail.tsx — shouldRenderAuthoredGraph", () => {
     expect(shouldRenderAuthoredGraph(authoredMissingEdges, opGraphWithEdges)).toBe(false);
   });
 
-  it("a single-node authored graph is never considered edgeless (nothing to draw an edge between)", async () => {
+  // This assertion is inverted from what it first said, on purpose. It read
+  // "a single-node authored graph is never considered edgeless, because there
+  // is nothing to draw an edge between" — which is true of that snapshot on
+  // its own, and the wrong rule for deciding which source to draw from. Held
+  // as authoritative, a one-node snapshot sitting beside a runtime graph that
+  // does have an edge meant the real DAG was never rendered at all.
+  it("a single-node authored graph yields to a runtime graph that has edges", async () => {
     const { shouldRenderAuthoredGraph } = await import("./RunDetail");
     const singleNode = { nodes: [{ id: "a" }], edges: [] };
     const opGraphWithEdges = { edges: [{ source: "op-a", target: "op-b" }] };
-    expect(shouldRenderAuthoredGraph(singleNode, opGraphWithEdges)).toBe(true);
+    expect(shouldRenderAuthoredGraph(singleNode, opGraphWithEdges)).toBe(false);
+  });
+
+  // The other arm, which the inversion must not cost: with nothing to fall
+  // through to, the authored snapshot is still what renders.
+  it("a single-node authored graph still renders when the runtime graph has no edges either", async () => {
+    const { shouldRenderAuthoredGraph } = await import("./RunDetail");
+    const singleNode = { nodes: [{ id: "a" }], edges: [] };
+    expect(shouldRenderAuthoredGraph(singleNode, { edges: [] })).toBe(true);
   });
 
   it("null graph never renders as the authored DAG", async () => {
@@ -2000,6 +2023,20 @@ describe("history/RunDetail.tsx — hasResolvableGraph (row 3: what counts as a 
     expect(hasResolvableGraph(authoredEdgeless, opGraph)).toBe(true);
   });
 
+  // The one-node case takes the same fall-through. It used to be excluded,
+  // which meant an authored snapshot of a single node hid a runtime graph
+  // that had two nodes and an edge between them: canRenderGraph came back
+  // false and the run opened on the list with a real DAG sitting unrendered.
+  it("falls through to a real-edged opGraph even when the authored graph has exactly one node", async () => {
+    const { hasResolvableGraph } = await import("./RunDetail");
+    const authoredSingleNode = { nodes: [node("A")], edges: [] };
+    const opGraph = {
+      nodes: [{ id: "A" }, { id: "B" }],
+      edges: [{ id: "e1", source: "A", target: "B" }],
+    };
+    expect(hasResolvableGraph(authoredSingleNode, opGraph)).toBe(true);
+  });
+
   it("no graph at all is not resolvable", async () => {
     const { hasResolvableGraph } = await import("./RunDetail");
     expect(hasResolvableGraph(null, { nodes: [], edges: [] })).toBe(false);
@@ -2416,8 +2453,18 @@ describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () =>
     vi.mocked(hasAnyExecutablePath).mockReturnValue(true);
   });
 
-  afterEach(() => {
+  // Nothing in the vitest config resets mocks between tests, so the three
+  // wrappers the run-swap test overrides are put back to the real
+  // implementations here. Without this, one test's stand-in registry would
+  // silently become every later test's premise.
+  afterEach(async () => {
     vi.unstubAllGlobals();
+    const actual = await vi.importActual<typeof import("@/lib/runControls")>("@/lib/runControls");
+    const { applyExecutablePath, proposeRunControl, confirmRunControl } =
+      await import("@/lib/runControls");
+    vi.mocked(applyExecutablePath).mockImplementation(actual.applyExecutablePath);
+    vi.mocked(proposeRunControl).mockImplementation(actual.proposeRunControl);
+    vi.mocked(confirmRunControl).mockImplementation(actual.confirmRunControl);
   });
 
   const flatGraph = { name: "run", description: "", nodes: [], edges: [] };
@@ -2559,6 +2606,99 @@ describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () =>
       ).toBeNull();
     } finally {
       unmount();
+    }
+  });
+
+  // The pane is reused across runs: the id-change effect cleared session,
+  // graph, signals, and selection, and left the pause request behind, so run
+  // B derived its control state from a pause only run A had ever received.
+  // Once a command exists to carry the verb out, that is a resume dispatched
+  // against B's id for A's pause. No unit test of the phase function can see
+  // this — what is wrong is which state survives the swap — so the assertion
+  // has to be mounted and has to swap.
+  it("a pause accepted on one run does not carry into the next run shown in the same pane", async () => {
+    const [{ getSession }, { default: RunDetail }, controls] = await Promise.all([
+      import("@/lib/api"),
+      import("./RunDetail"),
+      import("@/lib/runControls"),
+    ]);
+
+    // Stands in for a registry with a backing command. Left real, every verb
+    // is refused before it is offered and the pause this test is about can
+    // never be accepted at all.
+    vi.mocked(controls.applyExecutablePath).mockImplementation((_verb, state) => state);
+    vi.mocked(controls.proposeRunControl).mockResolvedValue({
+      conversationId: "conv-run-swap",
+      proposal: {
+        id: "prop-run-swap",
+        commandType: "pause_run",
+        summary: "Pause the run",
+        commandHash: "hash-run-swap",
+        target: null,
+      },
+    } as never);
+    vi.mocked(controls.confirmRunControl).mockResolvedValue({} as never);
+    vi.mocked(getSession).mockImplementation((async (runId: string) => ({
+      id: runId,
+      name: runId,
+      created_at: 0,
+      updated_at: 0,
+      status: "running",
+      invocation_kind: "flow",
+      branches: [],
+      graph: flatGraph,
+    })) as never);
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const show = async (runId: string) => {
+      await act(async () => {
+        root.render(
+          <IntlProvider locale="en" messages={enMessages}>
+            <RunDetail id={runId} />
+          </IntlProvider>,
+        );
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+    const pauseLabel = () =>
+      container.querySelector('[data-testid="run-controls-pause"]')?.textContent;
+    const stillPausing = () =>
+      container.querySelector('[data-testid="run-controls-reason-still-pausing"]');
+
+    try {
+      await show("run-swap-a");
+      expect(pauseLabel()).toBe("Pause");
+      expect(stillPausing()).toBeNull();
+
+      // Accept a pause on run A through the surface — propose, then confirm —
+      // rather than by setting the state this test is about.
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('[data-testid="run-controls-pause"]')?.click();
+      });
+      const confirmYes = container.querySelector<HTMLButtonElement>(
+        '[data-testid="run-controls-confirm"] button',
+      );
+      expect(confirmYes, "no confirm dialog appeared after proposing a pause").not.toBeNull();
+      await act(async () => {
+        confirmYes?.click();
+      });
+      // This run has no authored graph and no signals yet, so nothing can say
+      // how much is still in flight: the phase is "pausing", never "paused".
+      expect(pauseLabel()).toBe("Pausing…");
+      expect(stillPausing()).not.toBeNull();
+
+      // Same pane, next run. Nothing about B was ever paused.
+      await show("run-swap-b");
+      expect(pauseLabel()).toBe("Pause");
+      expect(stillPausing()).toBeNull();
+    } finally {
+      act(() => root.unmount());
+      container.remove();
     }
   });
 });

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -50,6 +50,16 @@ vi.mock("@/components/canvas/WorkerCanvas", () => ({
   ),
 }));
 
+// The control section renders only while some verb has a backing command.
+// This wrapper defaults to the real registry, so a test says nothing by
+// accident; the control tests below opt in to a backed registry, because the
+// shown-and-disabled contract they assert is what exists once a command type
+// lands, not what exists today.
+vi.mock("@/lib/runControls", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/runControls")>("@/lib/runControls");
+  return { ...actual, hasAnyExecutablePath: vi.fn(actual.hasAnyExecutablePath) };
+});
+
 const HISTORY_DIR = path.resolve(__dirname);
 const mountedCards: Array<{ container: HTMLDivElement; root: Root }> = [];
 
@@ -2393,9 +2403,17 @@ describe("history/RunDetail.tsx — graph/list view toggle and cross-view select
 // ─── ADR-0113 rows 8 & 9 — run controls, mounted ────────────────────────────
 
 describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     Element.prototype.scrollIntoView = vi.fn();
+    // Everything in this block describes the surface as it behaves once some
+    // verb has a backing command. That is the state in which D4's rule
+    // applies: a verb the engine cannot carry out is shown and disabled with
+    // its reason, never hidden, so a deliberate constraint does not read as a
+    // missing feature. The separate case — no verb backed at all — is covered
+    // below, and is the only reason these need to opt in.
+    const { hasAnyExecutablePath } = await import("@/lib/runControls");
+    vi.mocked(hasAnyExecutablePath).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -2517,6 +2535,28 @@ describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () =>
     const { container, unmount } = await mountRunDetail(sessionOf("show-play"));
     try {
       expect(container.querySelector('[data-testid="run-controls"]')).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  // The state the surface is actually in today. Every verb above is disabled
+  // for want of a backing command, and a panel in which nothing can ever be
+  // clicked reads as a broken feature rather than an unbuilt one. So while no
+  // verb is backed the section is not rendered at all. This is scoped to that
+  // case and does not weaken the rule above: the moment one command type
+  // exists the section returns, and a verb the engine still cannot carry out
+  // goes back to being shown and disabled with its reason.
+  it("renders no control section at all while no verb has a backing command", async () => {
+    const { hasAnyExecutablePath } = await import("@/lib/runControls");
+    vi.mocked(hasAnyExecutablePath).mockReturnValue(false);
+    const { container, unmount } = await mountRunDetail(sessionOf("flow"));
+    try {
+      expect(container.querySelector('[data-testid="run-controls"]')).toBeNull();
+      // and specifically not the disabled-with-a-reason rendering
+      expect(
+        container.querySelector('[data-testid="run-controls-reason-no-executable-path"]'),
+      ).toBeNull();
     } finally {
       unmount();
     }

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -2147,13 +2147,17 @@ describe("history/RunDetail.tsx — graph/list view toggle and cross-view select
     }
   });
 
-  it("row 3: a single-node run with no edges opens on the list", async () => {
+  it("row 3: a single-node run with no edges opens on the list, and offers no graph tab to switch to — a graph with no edges is not a canvas worth exposing at all", async () => {
     const { container, unmount } = await mountRunDetail(sessionWithBranches(singleNodeGraph));
     try {
       expect(container.querySelector('[data-testid="worker-canvas"]')).toBeNull();
       expect(container.querySelector("#run-branches")).not.toBeNull();
-      const listTab = container.querySelector('[data-testid="run-detail-view-list"]');
-      expect(listTab?.getAttribute("aria-selected")).toBe("true");
+      // No view toggle at all — there is nothing to switch to. Before the
+      // resolved-graph consolidation, canRenderGraph (looser than
+      // hasResolvableGraph) still exposed a clickable Graph tab here, and
+      // selecting it rendered a single disconnected node with no edges.
+      expect(container.querySelector('[data-testid="run-detail-view-graph"]')).toBeNull();
+      expect(container.querySelector('[data-testid="run-detail-view-list"]')).toBeNull();
     } finally {
       unmount();
     }
@@ -2234,6 +2238,154 @@ describe("history/RunDetail.tsx — graph/list view toggle and cross-view select
       expect(indicator?.textContent).toContain("A");
     } finally {
       unmount();
+    }
+  });
+
+  it("row 3 (runtime path): an opGraph with nodes but no edges falls back to the list, same as an edgeless authored graph", async () => {
+    const { streamSignals } = await import("@/lib/api");
+    vi.mocked(streamSignals).mockImplementationOnce((_id, cb) => {
+      cb(sig({ id: "e1", op_id: "op-a", kind: "NodeStarted", payload: { name: "A" } }));
+      return () => {};
+    });
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(null));
+    try {
+      expect(container.querySelector('[data-testid="op-graph-node"]')).toBeNull();
+      expect(container.querySelector("#run-branches")).not.toBeNull();
+      expect(container.querySelector('[data-testid="run-detail-view-graph"]')).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 4 (authored path): selecting a node renders its detail card in place, in the graph view", async () => {
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(edgedGraph));
+    try {
+      // The mocked WorkerCanvas doesn't render ReactFlow's own node markup —
+      // handleDagPanelClick delegates on the raw DOM shape ReactFlow produces
+      // (`.react-flow__node[data-id]`), so a synthetic one exercises the same
+      // delegation the real graph relies on.
+      const canvas = container.querySelector('[data-testid="worker-canvas"]');
+      const panel = canvas?.parentElement;
+      expect(panel).not.toBeNull();
+      const fakeNode = document.createElement("div");
+      fakeNode.className = "react-flow__node";
+      fakeNode.dataset.id = "A";
+      panel!.appendChild(fakeNode);
+      await act(async () => {
+        fakeNode.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(document.getElementById("step-A")).not.toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 4 (runtime path): OperationGraphSection has a node click handler, and selecting a node renders its detail card in place", async () => {
+    const { streamSignals } = await import("@/lib/api");
+    vi.mocked(streamSignals).mockImplementationOnce((_id, cb) => {
+      cb(sig({ id: "e1", op_id: "op-a", kind: "NodeStarted", payload: { name: "A" } }));
+      cb(
+        sig({
+          id: "e2",
+          op_id: "op-b",
+          kind: "NodeStarted",
+          payload: { name: "B", parent_id: "op-a" },
+        }),
+      );
+      return () => {};
+    });
+    const session = {
+      ...sessionWithBranches(null),
+      branches: [{ id: "branch-b", name: "B", created_at: 0, messages: [] }],
+    };
+    const { container, unmount } = await mountRunDetail(session);
+    try {
+      // An opGraph with a real edge is a resolvable graph, so this defaults
+      // to the graph view without needing to click a tab.
+      const nodeCard = Array.from(
+        container.querySelectorAll<HTMLElement>('[data-testid="op-graph-node"]'),
+      ).find((el) => el.textContent?.includes("B"));
+      expect(nodeCard).toBeTruthy();
+      await act(async () => {
+        nodeCard?.click();
+      });
+      expect(document.getElementById("step-B")).not.toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 6 (D6 URL-addressability): a URL carrying a selected node restores that selection on load", async () => {
+    window.history.replaceState(null, "", "/?node=A");
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(edgedGraph));
+    try {
+      expect(document.getElementById("step-A")).not.toBeNull();
+      const indicator = container.querySelector('[data-testid="run-detail-selected-node"]');
+      expect(indicator?.textContent).toContain("A");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("coupled minor: changing the run id clears the previous run's selected node", async () => {
+    const [{ getSession }, { default: RunDetail }] = await Promise.all([
+      import("@/lib/api"),
+      import("./RunDetail"),
+    ]);
+    const runOne = sessionWithBranches(edgedGraph);
+    const runTwo = {
+      ...sessionWithBranches(edgedGraph),
+      id: "run-mount-view-2",
+      branches: [{ id: "branch-c", name: "C", created_at: 0, messages: [] }],
+    };
+    vi.mocked(getSession).mockImplementation(
+      async (id: string) => (id === "run-mount-view-2" ? runTwo : runOne) as never,
+    );
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          <IntlProvider locale="en" messages={enMessages}>
+            <RunDetail id="run-mount-view" />
+          </IntlProvider>,
+        );
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const canvas = container.querySelector('[data-testid="worker-canvas"]');
+      const panel = canvas?.parentElement;
+      const fakeNode = document.createElement("div");
+      fakeNode.className = "react-flow__node";
+      fakeNode.dataset.id = "A";
+      panel!.appendChild(fakeNode);
+      await act(async () => {
+        fakeNode.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(
+        container.querySelector('[data-testid="run-detail-selected-node"]')?.textContent,
+      ).toContain("A");
+
+      await act(async () => {
+        root.render(
+          <IntlProvider locale="en" messages={enMessages}>
+            <RunDetail id="run-mount-view-2" />
+          </IntlProvider>,
+        );
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelector('[data-testid="run-detail-selected-node"]')).toBeNull();
+    } finally {
+      act(() => root.unmount());
+      container.remove();
     }
   });
 });

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -129,7 +129,13 @@ export function shouldRenderAuthoredGraph(
 ): boolean {
   if (!graph) return false;
   const edgeCount = graph.edges?.length ?? 0;
-  const isEdgeless = graph.nodes.length >= 2 && edgeCount === 0;
+  // Node count deliberately does not enter this. The question is which SOURCE
+  // to draw from, not whether the authored graph is complete in itself. A
+  // one-node snapshot has nothing to draw an edge between, and that is the
+  // reason it should yield to a runtime graph that does have one rather than
+  // a reason to prefer it: treating it as authoritative rendered a real
+  // two-node runtime DAG as a flat list.
+  const isEdgeless = edgeCount === 0;
   return !(isEdgeless && opGraph.edges.length > 0);
 }
 
@@ -1823,6 +1829,12 @@ export default function RunDetail({ id }: RunDetailProps) {
     setDone(false);
     setError(null);
     setSignalEvents([]);
+    // The pause request is scoped to the run it was made on. The Fleet view
+    // keeps this component mounted and swaps `id`, so leaving it set let run
+    // B derive its pause phase from run A's request: B could show pausing or
+    // paused, disable its own Pause, and offer a Resume that would then send
+    // a command carrying B's run id even though only A was ever paused.
+    setPauseRequested(false);
     setLoadingOlder(false);
     loadingOlderRef.current = false;
     setOlderLoadFailed(false);
@@ -2345,6 +2357,20 @@ export default function RunDetail({ id }: RunDetailProps) {
     [runGraph, reconciledNodeStatuses],
   );
 
+  // What the soft-pause gate counts as still running. The authored graph is
+  // the preferred source, because it is the same count the progress bar and
+  // the canvas already show. But computeProgressCountsForGraph answers null
+  // for a run with no authored graph, and a run can be entirely runtime —
+  // real operations, real edges, no early_graph. Passing null on to the pause
+  // phase as zero would report "nothing left running" for exactly those runs,
+  // so fall through to the runtime operation graph, and answer null only when
+  // neither source can say anything at all.
+  const pauseRunningCount = useMemo((): number | null => {
+    if (progressCounts) return progressCounts.running;
+    if (opGraph.nodes.length === 0) return null;
+    return opGraph.nodes.filter((n) => n.status === "running").length;
+  }, [progressCounts, opGraph]);
+
   // Elapsed wall-clock ticks once a second only while the run is actually
   // live; a finished or not-yet-loaded run has nothing left to advance.
   const [elapsedNow, setElapsedNow] = useState<number>(() => Date.now() / 1000);
@@ -2418,7 +2444,7 @@ export default function RunDetail({ id }: RunDetailProps) {
   const runTerminal =
     displayStatus === "completed" || displayStatus === "failed" || displayStatus === "cancelled";
   const controlKind = controlKindFor(session.invocation_kind ?? null);
-  const pausePhase: PausePhase = derivePausePhase(pauseRequested, progressCounts?.running ?? 0);
+  const pausePhase: PausePhase = derivePausePhase(pauseRequested, pauseRunningCount);
 
   // ADR-0113 D1/D6: a graph with edges is the default view; anything with no
   // edges to draw (including "no graph at all") opens on the list.

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -36,7 +36,13 @@ import {
 import type { LaneSignal, OperationStatus } from "@/lib/operationGraph";
 import { deriveDisplayStatus, deriveVerdict, isEffectivelyActive } from "@/lib/runStatus";
 import type { Verdict } from "@/lib/runStatus";
-import type { RunMessage, RunResumeResponse, RunStep, WorkerGraph } from "@/lib/types";
+import type {
+  OperatorCommandProposal,
+  RunMessage,
+  RunResumeResponse,
+  RunStep,
+  WorkerGraph,
+} from "@/lib/types";
 import type { NodeExecStatus } from "@/components/canvas/StepNode";
 import {
   deriveProgressCounts,
@@ -45,6 +51,16 @@ import {
   reconcileNodeStatuses,
 } from "@/lib/execGraphProgress";
 import type { ProgressCounts } from "@/lib/execGraphProgress";
+import {
+  confirmRunControl,
+  controlKindFor,
+  derivePausePhase,
+  pauseControlState,
+  proposeRunControl,
+  resumeControlState,
+  steerControlState,
+} from "@/lib/runControls";
+import type { ControlKind, ControlReasonCode, ControlVerb, PausePhase } from "@/lib/runControls";
 
 const WorkerCanvas = lazy(() => import("@/components/canvas/WorkerCanvas"));
 
@@ -113,6 +129,70 @@ export function shouldRenderAuthoredGraph(
   const edgeCount = graph.edges?.length ?? 0;
   const isEdgeless = graph.nodes.length >= 2 && edgeCount === 0;
   return !(isEdgeless && opGraph.edges.length > 0);
+}
+
+// ── Graph/list view (ADR-0113 D1, D6) ───────────────────────────────────────
+
+export type RunDetailView = "graph" | "list";
+
+const RUN_DETAIL_VIEW_STORAGE_KEY = "studio.runDetail.view";
+const RUN_DETAIL_VIEW_QUERY_KEY = "view";
+
+// localStorage can throw (private-browsing quotas) or simply be absent from
+// a test/SSR environment's window shim — never let a preference read/write
+// take the page down.
+function readStoredView(): string | null {
+  try {
+    return window.localStorage.getItem(RUN_DETAIL_VIEW_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredView(next: RunDetailView): void {
+  try {
+    window.localStorage.setItem(RUN_DETAIL_VIEW_STORAGE_KEY, next);
+  } catch {
+    // Best-effort — the URL query param (also written by the caller) still
+    // carries the choice for this navigation even if persistence fails.
+  }
+}
+
+export function parseRunDetailView(value: string | null | undefined): RunDetailView | null {
+  return value === "graph" || value === "list" ? value : null;
+}
+
+// shouldRenderAuthoredGraph decides whether a graph CAN be drawn at all
+// (falling back to the runtime opGraph, or nothing). This decides whether
+// that graph is worth defaulting TO: a graph with no edges is a scatter of
+// boxes with nothing to say about concurrency or dependency, and per D1 "a
+// canvas with one node and no edges is not a canvas" — that reasoning holds
+// however many disconnected nodes there are, not just at exactly one.
+export function hasResolvableGraph(
+  runGraph: { nodes: unknown[]; edges: unknown[] | null | undefined } | null,
+  opGraph: { nodes: unknown[]; edges: unknown[] },
+): boolean {
+  if (runGraph && shouldRenderAuthoredGraph(runGraph, opGraph)) {
+    return (runGraph.edges?.length ?? 0) > 0;
+  }
+  return opGraph.nodes.length > 0 && opGraph.edges.length > 0;
+}
+
+// D6's precedence rule, made explicit: default is graph, but a user's own
+// choice — whether carried on the URL (a deep link someone pasted) or in
+// their stored preference — always wins over the default, on every load,
+// not just the first. The URL outranks the stored preference so a shared
+// link reproduces what was shared even if the recipient has their own
+// pinned preference. See RunDetail.test.tsx's precedence test: it fails
+// if the default is ever allowed to win over an explicit choice.
+export function resolveInitialView(input: {
+  urlView: RunDetailView | null;
+  storedPreference: RunDetailView | null;
+  hasResolvableGraph: boolean;
+}): RunDetailView {
+  if (input.urlView) return input.urlView;
+  if (input.storedPreference) return input.storedPreference;
+  return input.hasResolvableGraph ? "graph" : "list";
 }
 
 // The planner persists depends_on endpoints as 1-BASED STEP NUMBERS while
@@ -737,7 +817,7 @@ function BranchesSection({
   onLoadOlder,
   olderMessagesRemaining,
   loadingOlder,
-  highlightedStepKey,
+  selectedStepKey,
 }: {
   steps: RunStep[];
   live: boolean;
@@ -749,10 +829,11 @@ function BranchesSection({
   onLoadOlder?: () => void;
   olderMessagesRemaining?: number;
   loadingOlder?: boolean;
-  /** The step (RunStepCard) a graph-node drill-down just resolved to — ringed
-   * so the click's target is unmistakable. Cleared automatically after the
-   * pulse. */
-  highlightedStepKey?: string | null;
+  /** The step (RunStepCard) a graph-node drill-down resolved to, or that the
+   * reader opened directly in the list — ringed so the selection is
+   * unmistakable, and durable (ADR-0113 D6: selection survives a view
+   * switch), not a fading pulse. */
+  selectedStepKey?: string | null;
 }) {
   const t = useTranslations("history.detail");
   return (
@@ -777,9 +858,9 @@ function BranchesSection({
           steps.map((step) => (
             <div
               key={step.step}
-              data-highlighted={step.step === highlightedStepKey || undefined}
+              data-selected={step.step === selectedStepKey || undefined}
               className={
-                step.step === highlightedStepKey
+                step.step === selectedStepKey
                   ? "rounded ring-2 ring-accent ring-offset-2 ring-offset-surface-base transition-shadow"
                   : undefined
               }
@@ -1349,6 +1430,192 @@ export function EventsSection({
   );
 }
 
+// ── Run controls (ADR-0113 D4 / rows 8, 9) ──────────────────────────────────
+//
+// Pause/resume/steer never apply directly — every click proposes a command
+// through the ADR-0083 operator conversation, and nothing takes effect until
+// the reader explicitly confirms the proposal that comes back. That is the
+// same propose-then-confirm path every other operator command already rides;
+// this does not add a second one.
+
+type ControlDialog = {
+  verb: ControlVerb;
+  conversationId: string;
+  proposal: OperatorCommandProposal;
+};
+
+function RunControls({
+  runId,
+  kind,
+  runTerminal,
+  pausePhase,
+  onPauseAccepted,
+  onResumeAccepted,
+}: {
+  runId: string;
+  kind: ControlKind | null;
+  runTerminal: boolean;
+  pausePhase: PausePhase;
+  onPauseAccepted: () => void;
+  onResumeAccepted: () => void;
+}) {
+  const t = useTranslations("history.detail");
+  const [dialog, setDialog] = useState<ControlDialog | null>(null);
+  const [busy, setBusy] = useState<ControlVerb | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [steerOpen, setSteerOpen] = useState(false);
+  const [steerText, setSteerText] = useState("");
+
+  if (!kind) return null;
+
+  const pauseState = pauseControlState(kind, runTerminal, pausePhase);
+  const resumeState = resumeControlState(kind, runTerminal, pausePhase);
+  const steerState = steerControlState(kind, runTerminal);
+
+  async function propose(verb: ControlVerb, message?: string) {
+    setBusy(verb);
+    setError(null);
+    try {
+      const { conversationId, proposal } = await proposeRunControl(runId, kind!, verb, { message });
+      setDialog({ verb, conversationId, proposal });
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : t("controls.proposeFailed"));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function confirmDialog() {
+    if (!dialog) return;
+    setBusy(dialog.verb);
+    setError(null);
+    try {
+      await confirmRunControl(dialog.conversationId, dialog.proposal);
+      if (dialog.verb === "pause") onPauseAccepted();
+      else if (dialog.verb === "resume") onResumeAccepted();
+      else {
+        setSteerOpen(false);
+        setSteerText("");
+      }
+      setDialog(null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : t("controls.confirmFailed"));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const reasonText = (code: ControlReasonCode | null) =>
+    code ? t(`controls.reason.${code}`) : null;
+
+  return (
+    <div
+      data-testid="run-controls"
+      className="flex flex-col gap-2 rounded border border-edge bg-surface-raised p-2.5"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          data-testid="run-controls-pause"
+          disabled={pauseState.disabled || busy !== null}
+          title={reasonText(pauseState.reasonCode) ?? undefined}
+          onClick={() => void propose("pause")}
+          className="rounded border border-edge px-2 py-1 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {pausePhase === "pausing"
+            ? t("controls.pausePhasePausing")
+            : pausePhase === "paused"
+              ? t("controls.pausePhasePaused")
+              : t("controls.pause")}
+        </button>
+        {resumeState.offered && (
+          <button
+            type="button"
+            data-testid="run-controls-resume"
+            disabled={resumeState.disabled || busy !== null}
+            title={reasonText(resumeState.reasonCode) ?? undefined}
+            onClick={() => void propose("resume")}
+            className="rounded border border-edge px-2 py-1 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t("controls.resume")}
+          </button>
+        )}
+        {steerState.offered && (
+          <button
+            type="button"
+            data-testid="run-controls-steer"
+            disabled={steerState.disabled || busy !== null}
+            title={reasonText(steerState.reasonCode) ?? undefined}
+            onClick={() => setSteerOpen((v) => !v)}
+            className="rounded border border-edge px-2 py-1 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t("controls.steer")}
+          </button>
+        )}
+        {pauseState.disabled && pauseState.reasonCode && (
+          <span
+            data-testid="run-controls-pause-reason"
+            className="text-[length:var(--t-xs)] text-content-muted"
+          >
+            {reasonText(pauseState.reasonCode)}
+          </span>
+        )}
+      </div>
+
+      {steerOpen && steerState.offered && (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={steerText}
+            onChange={(event) => setSteerText(event.target.value)}
+            placeholder={t("controls.steerPlaceholder")}
+            className="focus-ring h-7 min-w-0 flex-1 rounded border border-edge bg-surface-base px-2 text-[length:var(--t-xs)] text-content-primary"
+          />
+          <button
+            type="button"
+            disabled={!steerText.trim() || busy !== null}
+            onClick={() => void propose("message", steerText)}
+            className="rounded border border-edge px-2 py-1 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t("controls.steerSend")}
+          </button>
+        </div>
+      )}
+
+      {dialog && (
+        <div
+          data-testid="run-controls-confirm"
+          className="flex flex-wrap items-center gap-2 rounded border border-edge bg-surface-overlay px-2 py-1.5 text-[length:var(--t-xs)] text-content-secondary"
+        >
+          <span>{t(`controls.confirm.${dialog.verb}`)}</span>
+          <button
+            type="button"
+            disabled={busy !== null}
+            onClick={() => void confirmDialog()}
+            className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50"
+          >
+            {t("controls.confirmYes")}
+          </button>
+          <button
+            type="button"
+            disabled={busy !== null}
+            onClick={() => setDialog(null)}
+            className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50"
+          >
+            {t("controls.confirmCancel")}
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <p role="alert" className="text-[length:var(--t-xs)] text-status-failure">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
 // ── Public component ──────────────────────────────────────────────────────────
 
 // Floor for the execution-graph panel — keeps a tiny pipeline from collapsing
@@ -1412,15 +1679,51 @@ export default function RunDetail({ id }: RunDetailProps) {
   const [error, setError] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const [expandedSteps, setExpandedSteps] = useState<Set<string>>(new Set());
-  // Graph-node drill-down: the branch a click resolved to (scrolled +
-  // highlighted below), or the node id a click found NO branch for (shown as
-  // an explicit not-started/no-branch state instead of a silent no-op).
-  const [highlightedStepKey, setHighlightedStepKey] = useState<string | null>(null);
+  // Cross-view selection (ADR-0113 D6): the step a graph-node click resolved
+  // to, or a list step the reader opened — either sets this, and it survives
+  // a graph/list toggle rather than fading, since selecting in one view and
+  // switching to the other is the whole point of D6's shared-selection
+  // contract. `unmatchedNodeId` covers a click that found NO branch (shown
+  // as an explicit not-started/no-branch state instead of a silent no-op).
+  const [selectedStepKey, setSelectedStepKey] = useState<string | null>(null);
   const [unmatchedNodeId, setUnmatchedNodeId] = useState<string | null>(null);
   // Full-width expand overlay for the execution graph — closed by its own
   // button or Escape; never by anything else, so a stray keypress elsewhere
   // can't dismiss it.
   const [graphExpanded, setGraphExpanded] = useState(false);
+  // ADR-0113 D6: the two raw sources resolveInitialView weighs against the
+  // default — the URL's `view` param (a pasted deep link) and the stored
+  // per-user preference — read once at mount (lazy useState initializers,
+  // never written again) rather than a ref, so reading them during render
+  // is safe. `userView` is a click during THIS session; once set it
+  // outranks both, same as a fresh choice always would.
+  const [initialUrlView] = useState<RunDetailView | null>(() =>
+    typeof window === "undefined"
+      ? null
+      : parseRunDetailView(
+          new URLSearchParams(window.location.search).get(RUN_DETAIL_VIEW_QUERY_KEY),
+        ),
+  );
+  const [initialStoredView] = useState<RunDetailView | null>(() =>
+    typeof window === "undefined" ? null : parseRunDetailView(readStoredView()),
+  );
+  const [userView, setUserView] = useState<RunDetailView | null>(null);
+  const handleSetView = useCallback((next: RunDetailView) => {
+    setUserView(next);
+    if (typeof window === "undefined") return;
+    writeStoredView(next);
+    const url = new URL(window.location.href);
+    url.searchParams.set(RUN_DETAIL_VIEW_QUERY_KEY, next);
+    window.history.replaceState(window.history.state, "", url);
+  }, []);
+  // ADR-0113 D4/row 9: whether THIS client has asked this run to pause.
+  // There is no session-level "paused"/"pausing" status column yet (only
+  // per-node NodeExecStatus models it) — the pause gate is enforced by the
+  // executor in-process and observed here only through node signals, so the
+  // request itself is tracked locally rather than re-derived from a status
+  // string that does not exist. A reload loses it, same as any other
+  // client-only UI state; see the report for the follow-up this implies.
+  const [pauseRequested, setPauseRequested] = useState(false);
   const [signalEvents, setSignalEvents] = useState<SignalEvent[]>([]);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const loadingOlderRef = useRef(false);
@@ -1603,6 +1906,11 @@ export default function RunDetail({ id }: RunDetailProps) {
     }
   }, [session]);
 
+  // Opening a step in the list is choosing to look at it — the same act
+  // that selecting its node in the graph performs, so it sets the same
+  // cross-view selection (ADR-0113 D6). Collapsing does not clear the
+  // selection: closing a card is not the same act as selecting a different
+  // one.
   const handleToggleExpand = useCallback((stepId: string, next: boolean) => {
     setExpandedSteps((prev) => {
       const updated = new Set(prev);
@@ -1610,6 +1918,7 @@ export default function RunDetail({ id }: RunDetailProps) {
       else updated.delete(stepId);
       return updated;
     });
+    if (next) setSelectedStepKey(stepId);
   }, []);
 
   // Graph-node drill-down. ReactFlow renders each node wrapper with a
@@ -1621,13 +1930,13 @@ export default function RunDetail({ id }: RunDetailProps) {
       const match = matchGraphNodeToBranch(nodeId, session?.branches ?? []);
       if (!match) {
         setUnmatchedNodeId(nodeId);
-        setHighlightedStepKey(null);
+        setSelectedStepKey(null);
         return;
       }
       setUnmatchedNodeId(null);
       const key = stepKeyForBranch(match);
       setExpandedSteps((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
-      setHighlightedStepKey(key);
+      setSelectedStepKey(key);
     },
     [session],
   );
@@ -1643,16 +1952,16 @@ export default function RunDetail({ id }: RunDetailProps) {
     [handleGraphNodeClick],
   );
 
-  // A finished drill-down highlight fades on its own rather than lingering
-  // until the next click — it is a "look here" pulse, not a persistent
-  // selection state.
+  // Scrolls the selected step into view whenever the selection changes AND
+  // the list is the visible view (the element only exists in the DOM then —
+  // in graph view this is a harmless no-op). Unlike the old drill-down
+  // pulse, the selection itself does not fade; only the scroll is one-shot
+  // per change.
   useEffect(() => {
-    if (!highlightedStepKey) return;
-    const el = document.getElementById(`step-${highlightedStepKey}`);
+    if (!selectedStepKey) return;
+    const el = document.getElementById(`step-${selectedStepKey}`);
     el?.scrollIntoView({ behavior: "smooth", block: "center" });
-    const timer = setTimeout(() => setHighlightedStepKey(null), 2500);
-    return () => clearTimeout(timer);
-  }, [highlightedStepKey]);
+  }, [selectedStepKey]);
 
   useEffect(() => {
     if (!graphExpanded) return;
@@ -1794,6 +2103,14 @@ export default function RunDetail({ id }: RunDetailProps) {
     },
     [id],
   );
+
+  // Confirming a pause proposal marks the request locally; derivePausePhase
+  // (above) turns that into "pausing" vs "paused" against the live running
+  // count, and confirming a resume clears it — a fresh pause() later
+  // installs its own gate, mirrored by allowing pauseRequested to be set
+  // again from idle.
+  const handlePauseAccepted = useCallback(() => setPauseRequested(true), []);
+  const handleResumeAccepted = useCallback(() => setPauseRequested(false), []);
 
   const sessionStatus = done ? "completed" : live ? "running" : "completed";
 
@@ -1987,6 +2304,27 @@ export default function RunDetail({ id }: RunDetailProps) {
     status_reason_summary: session.status_reason_summary,
   };
   const displayStatus = deriveDisplayStatus(runForStatus);
+  const runTerminal =
+    displayStatus === "completed" || displayStatus === "failed" || displayStatus === "cancelled";
+  const controlKind = controlKindFor(session.invocation_kind ?? null);
+  const pausePhase: PausePhase = derivePausePhase(pauseRequested, progressCounts?.running ?? 0);
+
+  // ADR-0113 D1/D6: a graph with edges is the default view; anything with no
+  // edges to draw (including "no graph at all") opens on the list.
+  // shouldRenderAuthoredGraph decides whether a graph CAN render at all —
+  // canRenderGraph mirrors that same branch so the toggle only offers a
+  // graph tab when there is a graph to show in it.
+  const canRenderGraph = Boolean(
+    (runGraph && shouldRenderAuthoredGraph(runGraph, opGraph)) || opGraph.nodes.length > 0,
+  );
+  const view: RunDetailView =
+    userView ??
+    resolveInitialView({
+      urlView: initialUrlView,
+      storedPreference: initialStoredView,
+      hasResolvableGraph: hasResolvableGraph(runGraph, opGraph),
+    });
+  const effectiveView: RunDetailView = canRenderGraph ? view : "list";
 
   const overviewData: OverviewData = {
     status: displayStatus,
@@ -2029,6 +2367,16 @@ export default function RunDetail({ id }: RunDetailProps) {
       </div>
 
       <OverviewSection data={overviewData} />
+      {controlKind && (
+        <RunControls
+          runId={session.id}
+          kind={controlKind}
+          runTerminal={runTerminal}
+          pausePhase={pausePhase}
+          onPauseAccepted={handlePauseAccepted}
+          onResumeAccepted={handleResumeAccepted}
+        />
+      )}
       <ResumeRun
         key={session.id}
         runId={session.id}
@@ -2043,7 +2391,51 @@ export default function RunDetail({ id }: RunDetailProps) {
         contract={session.artifact_contract_json}
         verification={session.artifact_verification_json}
       />
-      {runGraph && shouldRenderAuthoredGraph(runGraph, opGraph) ? (
+      {canRenderGraph && (
+        <div
+          role="tablist"
+          aria-label={t("viewToggleLabel")}
+          className="flex items-center gap-1 self-start rounded border border-edge bg-surface-raised p-0.5"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={effectiveView === "graph"}
+            data-testid="run-detail-view-graph"
+            onClick={() => handleSetView("graph")}
+            className={`rounded px-2 py-1 font-mono text-[length:var(--t-xs)] transition-colors ${
+              effectiveView === "graph"
+                ? "bg-surface-overlay text-content-primary"
+                : "text-content-muted hover:text-content-secondary"
+            }`}
+          >
+            {t("viewGraph")}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={effectiveView === "list"}
+            data-testid="run-detail-view-list"
+            onClick={() => handleSetView("list")}
+            className={`rounded px-2 py-1 font-mono text-[length:var(--t-xs)] transition-colors ${
+              effectiveView === "list"
+                ? "bg-surface-overlay text-content-primary"
+                : "text-content-muted hover:text-content-secondary"
+            }`}
+          >
+            {t("viewList")}
+          </button>
+          {selectedStepKey && effectiveView === "graph" && (
+            <span
+              data-testid="run-detail-selected-node"
+              className="ml-2 truncate font-mono text-[length:var(--t-xs)] text-content-muted"
+            >
+              {t("selectedNode", { node: selectedStepKey })}
+            </span>
+          )}
+        </div>
+      )}
+      {effectiveView === "graph" && runGraph && shouldRenderAuthoredGraph(runGraph, opGraph) ? (
         <div id="run-dag" className="w-full scroll-mt-4">
           <SectionHeader
             label={t("sectionExecutionGraph")}
@@ -2149,6 +2541,7 @@ export default function RunDetail({ id }: RunDetailProps) {
           )}
         </div>
       ) : (
+        effectiveView === "graph" &&
         opGraph.nodes.length > 0 && (
           <div id="run-dag" className="scroll-mt-4">
             <SectionHeader label={t("sectionExecutionGraph")} count={opGraph.nodes.length} />
@@ -2157,47 +2550,55 @@ export default function RunDetail({ id }: RunDetailProps) {
         )
       )}
       {/* Scroll-up trigger: reaching the top of the conversation loads the
-          next older page, same handler as the explicit button below. */}
+          next older page, same handler as the explicit button below. Kept
+          mounted regardless of view — an IntersectionObserver effect
+          attaches to it once, on session load (see sentinelMounted above),
+          and gating it on the list view would leave that effect watching a
+          ref that goes null whenever the reader starts on the graph. */}
       <div ref={olderSentinelRef} aria-hidden="true" className="h-px" />
-      {olderLoadFailed ? (
-        <div className="flex items-center gap-2 self-start rounded border border-edge bg-surface-raised px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary">
-          <span>{t("olderUnavailable")}</span>
-          <button
-            type="button"
-            onClick={handleReloadConversation}
-            disabled={loadingOlder}
-            className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50 disabled:opacity-50"
-          >
-            {t("reloadConversation")}
-          </button>
-        </div>
-      ) : (
-        hiddenOlderCount > 0 && (
-          <button
-            type="button"
-            onClick={handleLoadOlder}
-            disabled={loadingOlder}
-            className="self-start rounded border border-edge bg-surface-raised px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary disabled:opacity-50"
-          >
-            {loadingOlder
-              ? "…"
-              : `${t("loadOlder")} · ${t("olderRemaining", { count: hiddenOlderCount })}`}
-          </button>
-        )
+      {effectiveView === "list" && (
+        <>
+          {olderLoadFailed ? (
+            <div className="flex items-center gap-2 self-start rounded border border-edge bg-surface-raised px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary">
+              <span>{t("olderUnavailable")}</span>
+              <button
+                type="button"
+                onClick={handleReloadConversation}
+                disabled={loadingOlder}
+                className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50 disabled:opacity-50"
+              >
+                {t("reloadConversation")}
+              </button>
+            </div>
+          ) : (
+            hiddenOlderCount > 0 && (
+              <button
+                type="button"
+                onClick={handleLoadOlder}
+                disabled={loadingOlder}
+                className="self-start rounded border border-edge bg-surface-raised px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary transition-colors hover:border-accent/50 hover:text-content-primary disabled:opacity-50"
+              >
+                {loadingOlder
+                  ? "…"
+                  : `${t("loadOlder")} · ${t("olderRemaining", { count: hiddenOlderCount })}`}
+              </button>
+            )
+          )}
+          <BranchesSection
+            steps={steps}
+            live={live}
+            expandedSteps={expandedSteps}
+            onToggleExpand={handleToggleExpand}
+            runId={session.id}
+            artifactRoot={session.artifacts_path}
+            runFiles={runFiles}
+            onLoadOlder={handleLoadOlder}
+            olderMessagesRemaining={hiddenOlderCount}
+            loadingOlder={loadingOlder}
+            selectedStepKey={selectedStepKey}
+          />
+        </>
       )}
-      <BranchesSection
-        steps={steps}
-        live={live}
-        expandedSteps={expandedSteps}
-        onToggleExpand={handleToggleExpand}
-        runId={session.id}
-        artifactRoot={session.artifacts_path}
-        runFiles={runFiles}
-        onLoadOlder={handleLoadOlder}
-        olderMessagesRemaining={hiddenOlderCount}
-        loadingOlder={loadingOlder}
-        highlightedStepKey={highlightedStepKey}
-      />
       <ErrorsSection errors={errors} partial={partialWindow} gateOutcome={gateOutcome} />
       <FilesSection files={runFiles} partial={partialWindow} />
       <EventsSection events={signalEvents} live={live && !done} />

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/lib/execGraphProgress";
 import type { ProgressCounts } from "@/lib/execGraphProgress";
 import {
+  applyExecutablePath,
   confirmRunControl,
   controlKindFor,
   derivePausePhase,
@@ -1468,9 +1469,16 @@ function RunControls({
 
   if (!kind) return null;
 
-  const pauseState = pauseControlState(kind, runTerminal, pausePhase);
-  const resumeState = resumeControlState(kind, runTerminal, pausePhase);
-  const steerState = steerControlState(kind, runTerminal);
+  // applyExecutablePath layers the surface-wide refusal on top of the run's
+  // own state: no command exists that pauses a run, releases a pause gate, or
+  // delivers a steering message, so all three are shown and disabled rather
+  // than dispatching an instruction the operator has no tool for.
+  const pauseState = applyExecutablePath("pause", pauseControlState(kind, runTerminal, pausePhase));
+  const resumeState = applyExecutablePath(
+    "resume",
+    resumeControlState(kind, runTerminal, pausePhase),
+  );
+  const steerState = applyExecutablePath("message", steerControlState(kind, runTerminal));
 
   async function propose(verb: ControlVerb, message?: string) {
     setBusy(verb);
@@ -1490,7 +1498,11 @@ function RunControls({
     setBusy(dialog.verb);
     setError(null);
     try {
-      await confirmRunControl(dialog.conversationId, dialog.proposal);
+      // Binds the proposal to this verb and run, and reads the status the
+      // confirm call returns -- both throw rather than reporting a control as
+      // accepted when it was refused, rejected, or never applied. The local
+      // "accepted" callbacks below run only once the command actually landed.
+      await confirmRunControl(dialog.verb, runId, dialog.conversationId, dialog.proposal);
       if (dialog.verb === "pause") onPauseAccepted();
       else if (dialog.verb === "resume") onResumeAccepted();
       else {
@@ -1507,6 +1519,19 @@ function RunControls({
 
   const reasonText = (code: ControlReasonCode | null) =>
     code ? t(`controls.reason.${code}`) : null;
+
+  // Every offered-but-disabled control states its refusal in text, not only in
+  // a tooltip — a refusal the reader has to hover to discover is not a legible
+  // one. Deduplicated by code because the common case is several controls
+  // refusing for the same reason, and repeating one sentence three times reads
+  // as three separate problems.
+  const refusals = Array.from(
+    new Set(
+      [pauseState, resumeState, steerState]
+        .filter((state) => state.offered && state.disabled && state.reasonCode !== null)
+        .map((state) => state.reasonCode as ControlReasonCode),
+    ),
+  );
 
   return (
     <div
@@ -1552,14 +1577,15 @@ function RunControls({
             {t("controls.steer")}
           </button>
         )}
-        {pauseState.disabled && pauseState.reasonCode && (
+        {refusals.map((code) => (
           <span
-            data-testid="run-controls-pause-reason"
+            key={code}
+            data-testid={`run-controls-reason-${code}`}
             className="text-[length:var(--t-xs)] text-content-muted"
           >
-            {reasonText(pauseState.reasonCode)}
+            {reasonText(code)}
           </span>
-        )}
+        ))}
       </div>
 
       {steerOpen && steerState.offered && (
@@ -1585,25 +1611,50 @@ function RunControls({
       {dialog && (
         <div
           data-testid="run-controls-confirm"
-          className="flex flex-wrap items-center gap-2 rounded border border-edge bg-surface-overlay px-2 py-1.5 text-[length:var(--t-xs)] text-content-secondary"
+          className="flex flex-col gap-1 rounded border border-edge bg-surface-overlay px-2 py-1.5 text-[length:var(--t-xs)] text-content-secondary"
         >
-          <span>{t(`controls.confirm.${dialog.verb}`)}</span>
-          <button
-            type="button"
-            disabled={busy !== null}
-            onClick={() => void confirmDialog()}
-            className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50"
+          <div className="flex flex-wrap items-center gap-2">
+            <span>{t(`controls.confirm.${dialog.verb}`)}</span>
+            <button
+              type="button"
+              disabled={busy !== null}
+              onClick={() => void confirmDialog()}
+              className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50"
+            >
+              {t("controls.confirmYes")}
+            </button>
+            <button
+              type="button"
+              disabled={busy !== null}
+              onClick={() => setDialog(null)}
+              className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50"
+            >
+              {t("controls.confirmCancel")}
+            </button>
+          </div>
+          {/* What the proposal would actually do, read off the proposal rather
+              than off the verb that was asked for. The two can disagree: the
+              turn carries a natural-language instruction, so the command that
+              comes back is whichever one the operator model chose, and this
+              line is where a reader sees "Cancel run …" under "Confirm
+              pause?" instead of confirming it blind. Server-supplied text, so
+              it is rendered as-is rather than translated. */}
+          <div
+            data-testid="run-controls-confirm-proposal"
+            className="flex flex-wrap items-baseline gap-2 text-content-muted"
           >
-            {t("controls.confirmYes")}
-          </button>
-          <button
-            type="button"
-            disabled={busy !== null}
-            onClick={() => setDialog(null)}
-            className="rounded border border-edge px-2 py-0.5 text-content-primary transition-colors hover:border-accent/50"
-          >
-            {t("controls.confirmCancel")}
-          </button>
+            {dialog.proposal.commandType && (
+              <code data-testid="run-controls-confirm-command-type" className="font-mono">
+                {dialog.proposal.commandType}
+              </code>
+            )}
+            <span data-testid="run-controls-confirm-summary">{dialog.proposal.summary}</span>
+            {dialog.proposal.target && (
+              <span data-testid="run-controls-confirm-target" className="font-mono">
+                {dialog.proposal.target.kind} {dialog.proposal.target.id}
+              </span>
+            )}
+          </div>
         </div>
       )}
 

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -138,6 +138,7 @@ export type RunDetailView = "graph" | "list";
 
 const RUN_DETAIL_VIEW_STORAGE_KEY = "studio.runDetail.view";
 const RUN_DETAIL_VIEW_QUERY_KEY = "view";
+const RUN_DETAIL_NODE_QUERY_KEY = "node";
 
 // localStorage can throw (private-browsing quotas) or simply be absent from
 // a test/SSR environment's window shim — never let a preference read/write
@@ -1767,6 +1768,25 @@ export default function RunDetail({ id }: RunDetailProps) {
     url.searchParams.set(RUN_DETAIL_VIEW_QUERY_KEY, next);
     window.history.replaceState(window.history.state, "", url);
   }, []);
+  // ADR-0113 D6: the selected node is URL-addressable the same way `view`
+  // is — read once at mount (never re-read after) and restored against the
+  // first session load's branches. `initialNodeAppliedRef` bounds that
+  // restore to the run that was live when the component first mounted, so
+  // a later run swap (the Fleet view keeps this component mounted and only
+  // changes `id`) never re-applies a stale deep link onto the new run.
+  const [initialUrlNodeKey] = useState<string | null>(() =>
+    typeof window === "undefined"
+      ? null
+      : new URLSearchParams(window.location.search).get(RUN_DETAIL_NODE_QUERY_KEY),
+  );
+  const initialNodeAppliedRef = useRef(false);
+  const writeSelectedNodeToUrl = useCallback((key: string | null) => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (key) url.searchParams.set(RUN_DETAIL_NODE_QUERY_KEY, key);
+    else url.searchParams.delete(RUN_DETAIL_NODE_QUERY_KEY);
+    window.history.replaceState(window.history.state, "", url);
+  }, []);
   // ADR-0113 D4/row 9: whether THIS client has asked this run to pause.
   // There is no session-level "paused"/"pausing" status column yet (only
   // per-node NodeExecStatus models it) — the pause gate is enforced by the
@@ -1807,6 +1827,17 @@ export default function RunDetail({ id }: RunDetailProps) {
     setOlderLoadFailed(false);
     setOlderCursor(null);
     initialScrollDoneRef.current = false;
+    // The Fleet view keeps this component mounted and swaps `id` — the
+    // selection is scoped to the run it was made on, so a run switch must
+    // drop it rather than let it read as the new run's selection.
+    // `initialNodeAppliedRef` only flips true once the FIRST run's session
+    // has resolved (below), so this leaves the deep-link restore below
+    // untouched on that very first load.
+    if (initialNodeAppliedRef.current) {
+      setSelectedStepKey(null);
+      setUnmatchedNodeId(null);
+      writeSelectedNodeToUrl(null);
+    }
     getSession(id)
       .then((s) => {
         setSession(s);
@@ -1822,14 +1853,27 @@ export default function RunDetail({ id }: RunDetailProps) {
         ) {
           setDone(true);
         }
-        if (s.branches.length <= 3) {
-          setExpandedSteps(new Set(s.branches.map((b) => b.name || b.id.slice(0, 8))));
-        } else {
-          const first = s.branches[0];
-          if (first) {
-            setExpandedSteps(new Set([first.name || first.id.slice(0, 8)]));
+        const branchExpansion =
+          s.branches.length <= 3
+            ? new Set(s.branches.map((b) => b.name || b.id.slice(0, 8)))
+            : s.branches[0]
+              ? new Set([s.branches[0].name || s.branches[0].id.slice(0, 8)])
+              : null;
+        // Restore a deep-linked node selection against THIS run's branches,
+        // once only, ever — a later run swap must not reapply it (see the
+        // clear-on-id-change block above).
+        if (!initialNodeAppliedRef.current) {
+          initialNodeAppliedRef.current = true;
+          if (initialUrlNodeKey) {
+            const match = matchGraphNodeToBranch(initialUrlNodeKey, s.branches);
+            if (match) {
+              const key = stepKeyForBranch(match);
+              branchExpansion?.add(key);
+              setSelectedStepKey(key);
+            }
           }
         }
+        if (branchExpansion) setExpandedSteps(branchExpansion);
         const graph = (s as unknown as Record<string, unknown>).graph as
           | { nodes: WorkerGraph["nodes"]; edges?: WorkerGraph["edges"] | null }
           | null
@@ -1846,7 +1890,7 @@ export default function RunDetail({ id }: RunDetailProps) {
         }
       })
       .catch((e: unknown) => setError(String(e)));
-  }, [id]);
+  }, [id, initialUrlNodeKey, writeSelectedNodeToUrl]);
 
   useEffect(() => {
     if (!id || !resumeWatch || resumeWatch.run_id !== id) return;
@@ -1962,15 +2006,21 @@ export default function RunDetail({ id }: RunDetailProps) {
   // cross-view selection (ADR-0113 D6). Collapsing does not clear the
   // selection: closing a card is not the same act as selecting a different
   // one.
-  const handleToggleExpand = useCallback((stepId: string, next: boolean) => {
-    setExpandedSteps((prev) => {
-      const updated = new Set(prev);
-      if (next) updated.add(stepId);
-      else updated.delete(stepId);
-      return updated;
-    });
-    if (next) setSelectedStepKey(stepId);
-  }, []);
+  const handleToggleExpand = useCallback(
+    (stepId: string, next: boolean) => {
+      setExpandedSteps((prev) => {
+        const updated = new Set(prev);
+        if (next) updated.add(stepId);
+        else updated.delete(stepId);
+        return updated;
+      });
+      if (next) {
+        setSelectedStepKey(stepId);
+        writeSelectedNodeToUrl(stepId);
+      }
+    },
+    [writeSelectedNodeToUrl],
+  );
 
   // Graph-node drill-down. ReactFlow renders each node wrapper with a
   // `data-id` attribute (its own internals, not StepNode/WorkerCanvas
@@ -1982,14 +2032,16 @@ export default function RunDetail({ id }: RunDetailProps) {
       if (!match) {
         setUnmatchedNodeId(nodeId);
         setSelectedStepKey(null);
+        writeSelectedNodeToUrl(null);
         return;
       }
       setUnmatchedNodeId(null);
       const key = stepKeyForBranch(match);
       setExpandedSteps((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
       setSelectedStepKey(key);
+      writeSelectedNodeToUrl(key);
     },
-    [session],
+    [session, writeSelectedNodeToUrl],
   );
 
   const handleDagPanelClick = useCallback(
@@ -2174,6 +2226,13 @@ export default function RunDetail({ id }: RunDetailProps) {
   const steps = useMemo(
     () => (session ? buildRunSteps(session, sessionStatus, segments) : []),
     [session, sessionStatus, segments],
+  );
+  // ADR-0113 D1/D6: the graph view's in-place node detail is the SAME
+  // RunStepCard the list renders for the same step — no separate detail
+  // shape to keep in sync with it.
+  const selectedGraphStep = useMemo(
+    () => (selectedStepKey ? (steps.find((s) => s.step === selectedStepKey) ?? null) : null),
+    [steps, selectedStepKey],
   );
 
   // Run-wide known file surface (union across every step/agent branch) —
@@ -2362,18 +2421,18 @@ export default function RunDetail({ id }: RunDetailProps) {
 
   // ADR-0113 D1/D6: a graph with edges is the default view; anything with no
   // edges to draw (including "no graph at all") opens on the list.
-  // shouldRenderAuthoredGraph decides whether a graph CAN render at all —
-  // canRenderGraph mirrors that same branch so the toggle only offers a
-  // graph tab when there is a graph to show in it.
-  const canRenderGraph = Boolean(
-    (runGraph && shouldRenderAuthoredGraph(runGraph, opGraph)) || opGraph.nodes.length > 0,
-  );
+  // hasResolvableGraph is the single source of truth for "is there a graph
+  // worth rendering" — tab visibility, the default-view resolution below,
+  // and the render branch further down all gate on this SAME call, so they
+  // cannot disagree about a single-node or edgeless graph the way two
+  // separately-maintained predicates could.
+  const canRenderGraph = hasResolvableGraph(runGraph, opGraph);
   const view: RunDetailView =
     userView ??
     resolveInitialView({
       urlView: initialUrlView,
       storedPreference: initialStoredView,
-      hasResolvableGraph: hasResolvableGraph(runGraph, opGraph),
+      hasResolvableGraph: canRenderGraph,
     });
   const effectiveView: RunDetailView = canRenderGraph ? view : "list";
 
@@ -2509,15 +2568,6 @@ export default function RunDetail({ id }: RunDetailProps) {
           {progressCounts && (
             <ProgressSummaryBar counts={progressCounts} elapsedLabel={elapsedLabel} t={t} />
           )}
-          {unmatchedNodeId && (
-            <div
-              role="status"
-              data-testid="run-dag-unmatched-node"
-              className="mt-2 rounded border border-edge bg-surface-overlay px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary"
-            >
-              {t("nodeNoBranch", { node: unmatchedNodeId })}
-            </div>
-          )}
           {/* A fan-out of dozens of workers cannot be legible in the same
               280px that fits a five-step pipeline — the panel takes its height
               from the laid-out graph's bounding box so fitView has room to
@@ -2596,9 +2646,43 @@ export default function RunDetail({ id }: RunDetailProps) {
         opGraph.nodes.length > 0 && (
           <div id="run-dag" className="scroll-mt-4">
             <SectionHeader label={t("sectionExecutionGraph")} count={opGraph.nodes.length} />
-            <OperationGraphSection state={opGraph} live={live && !done} />
+            <OperationGraphSection
+              state={opGraph}
+              live={live && !done}
+              onNodeClick={handleGraphNodeClick}
+            />
           </div>
         )
+      )}
+      {/* ADR-0113 D1/D6: a node selected in EITHER graph path (authored via
+          handleDagPanelClick, runtime via OperationGraphSection's onNodeClick)
+          expands in place here — the same RunStepCard the list view shows for
+          that step, not a second detail shape. A click that resolved no
+          branch gets the same explicit no-branch state regardless of which
+          graph produced it. */}
+      {effectiveView === "graph" && unmatchedNodeId && (
+        <div
+          role="status"
+          data-testid="run-dag-unmatched-node"
+          className="mt-2 rounded border border-edge bg-surface-overlay px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary"
+        >
+          {t("nodeNoBranch", { node: unmatchedNodeId })}
+        </div>
+      )}
+      {effectiveView === "graph" && selectedGraphStep && (
+        <div className="mt-2 scroll-mt-4">
+          <RunStepCard
+            step={selectedGraphStep}
+            expanded
+            onToggleExpand={handleToggleExpand}
+            runId={session.id}
+            artifactRoot={session.artifacts_path}
+            runFiles={runFiles}
+            onLoadOlder={handleLoadOlder}
+            olderMessagesRemaining={hiddenOlderCount}
+            loadingOlder={loadingOlder}
+          />
+        </div>
       )}
       {/* Scroll-up trigger: reaching the top of the conversation loads the
           next older page, same handler as the explicit button below. Kept

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -56,6 +56,7 @@ import {
   confirmRunControl,
   controlKindFor,
   derivePausePhase,
+  hasAnyExecutablePath,
   pauseControlState,
   proposeRunControl,
   resumeControlState,
@@ -2477,7 +2478,7 @@ export default function RunDetail({ id }: RunDetailProps) {
       </div>
 
       <OverviewSection data={overviewData} />
-      {controlKind && (
+      {controlKind && hasAnyExecutablePath() && (
         <RunControls
           runId={session.id}
           kind={controlKind}

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -701,7 +701,7 @@ function ProgressSummaryBar({
         {t("progressFailed")} {counts.failed}
       </span>
       <span className={counts.escalated > 0 ? "font-semibold text-status-warning" : undefined}>
-        {t("graphNodeStatusEscalated")} {counts.escalated}
+        {t("progressEscalated")} {counts.escalated}
       </span>
       <span>
         {t("progressPending")} {pending}

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -202,8 +202,11 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 1058 leaves", () => {
-    expect(EN_LEAVES.size).toBe(1058);
+  // 1059 since the run controls gained a reason string for a verb with no
+  // backing command. Translated in all 16 locales rather than copied from
+  // English, so the identity-leak baseline below does not move.
+  it("en.json has 1059 leaves", () => {
+    expect(EN_LEAVES.size).toBe(1059);
   });
 
   it.each(LOCALES.map((l) => l.code))(

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -202,8 +202,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 1057 leaves", () => {
-    expect(EN_LEAVES.size).toBe(1057);
+  it("en.json has 1058 leaves", () => {
+    expect(EN_LEAVES.size).toBe(1058);
   });
 
   it.each(LOCALES.map((l) => l.code))(
@@ -268,6 +268,7 @@ describe("messages — a locale value byte-identical to English is a missed tran
     "history.detail.progressRunning",
     "history.detail.progressFailed",
     "history.detail.progressPending",
+    "history.detail.progressEscalated",
     "history.detail.progressElapsed",
     "history.detail.expandGraph",
     "history.detail.collapseGraph",

--- a/apps/studio/frontend/src/i18n/locales.test.ts
+++ b/apps/studio/frontend/src/i18n/locales.test.ts
@@ -202,8 +202,8 @@ describe("applyDocumentLocale — <html lang>/<html dir> wiring", () => {
 });
 
 describe("messages — leaf-key parity across all 16 locales", () => {
-  it("en.json has 1034 leaves", () => {
-    expect(EN_LEAVES.size).toBe(1034);
+  it("en.json has 1057 leaves", () => {
+    expect(EN_LEAVES.size).toBe(1057);
   });
 
   it.each(LOCALES.map((l) => l.code))(
@@ -306,11 +306,20 @@ describe("messages — a locale value byte-identical to English is a missed tran
   // fleet.agentRow.branchesTitle; one French value became identical on the
   // merits and is allow-listed above. A fourth, id, held the same English
   // text without ever matching byte-for-byte, so this number never saw it.
+  //
+  // Raised from 3143 to 3488 (+345 = 23 new leaves × 15 non-English locales)
+  // when ADR-0113's graph/list view toggle and pause/resume/steer run
+  // controls landed: every one of the 23 new history.detail leaves
+  // (viewGraph, viewList, viewToggleLabel, selectedNode, and the controls.*
+  // subtree) shipped with the English string copied into every locale as a
+  // placeholder rather than translated. This is real, attributed debt, not
+  // slipped in — a follow-up should translate these 23 keys per locale and
+  // lower this number back down by 345.
   it("pre-existing identity-leak count across all locales does not grow past its pinned baseline", () => {
     const total = LOCALES.map((l) => l.code)
       .filter((c) => c !== "en")
       .reduce((sum, code) => sum + findIdentityLeaks(code).length, 0);
-    expect(total).toBeLessThanOrEqual(3143);
+    expect(total).toBeLessThanOrEqual(3488);
   });
 });
 

--- a/apps/studio/frontend/src/lib/runControls.test.ts
+++ b/apps/studio/frontend/src/lib/runControls.test.ts
@@ -40,6 +40,11 @@ describe("lib/runControls — derivePausePhase (the pausing-vs-paused window)", 
   });
 });
 
+// The state machines below decide from the RUN's state. Whether a verb has a
+// command behind it at all is a separate fact about our command surface, and
+// applyExecutablePath (tested further down) layers it on top. Keeping them
+// apart is what lets these run-state rules stay reachable while every verb is
+// unbacked.
 describe("lib/runControls — pauseControlState", () => {
   it("is offered and enabled for a running flow with no pause requested", async () => {
     const { pauseControlState } = await import("./runControls");
@@ -148,6 +153,180 @@ describe("lib/runControls — steerControlState (row 8: steer offered on an agen
   });
 });
 
+describe("lib/runControls — hasExecutablePath / applyExecutablePath", () => {
+  // Tripwire. Every one of the operator's mutating commands is accounted for
+  // (prefill_schedule, launch_playbook, cancel_run, resume_run,
+  // rename_session) and none of them pauses a run, releases a pause gate, or
+  // delivers a steering message. When a backing command lands, its type goes
+  // into COMMAND_TYPES_BY_VERB, this test fails, and whoever added it is
+  // pointed straight at the refusals below that have to be revisited.
+  it("reports no executable path for any of the three verbs", async () => {
+    const { hasExecutablePath } = await import("./runControls");
+    expect(hasExecutablePath("pause")).toBe(false);
+    expect(hasExecutablePath("resume")).toBe(false);
+    expect(hasExecutablePath("message")).toBe(false);
+  });
+
+  it("disables an offered control and states the reason as no-executable-path", async () => {
+    const { applyExecutablePath } = await import("./runControls");
+    expect(
+      applyExecutablePath("pause", { offered: true, disabled: false, reasonCode: null }),
+    ).toEqual({ offered: true, disabled: true, reasonCode: "no-executable-path" });
+  });
+
+  // The run-state reason implies a counterfactual that is not true: "the run
+  // is not paused" tells the reader resume will work once it pauses. It will
+  // not, so this refusal has to win rather than defer to the more specific
+  // reason.
+  it("overrides a run-state reason that would imply the control works in another state", async () => {
+    const { applyExecutablePath, resumeControlState } = await import("./runControls");
+    const runState = resumeControlState("flow", false, "idle");
+    expect(runState.reasonCode).toBe("not-paused");
+    expect(applyExecutablePath("resume", runState).reasonCode).toBe("no-executable-path");
+  });
+
+  it("never turns an unoffered control into an offered one", async () => {
+    const { applyExecutablePath, resumeControlState } = await import("./runControls");
+    // Resume is not a listed agent capability — it is hidden, and a refusal
+    // about our command surface must not surface it.
+    expect(resumeControlState("agent", false, "idle").offered).toBe(false);
+    expect(applyExecutablePath("resume", resumeControlState("agent", false, "idle")).offered).toBe(
+      false,
+    );
+  });
+});
+
+describe("lib/runControls — assertProposalSatisfies binds the proposal to what was asked for", () => {
+  const proposalOf = (over: Record<string, unknown> = {}) =>
+    ({
+      id: "prop-1",
+      commandType: "pause",
+      command: { session_id: "run-abc123" },
+      commandHash: "hash-1",
+      risk: "mutate" as const,
+      summary: "Pause run-abc123",
+      idempotencyKey: "idem-1",
+      expiresAt: 0,
+      ...over,
+    }) as never;
+
+  // Every assertion here passes an explicit allow-set. With the real table
+  // empty, the command-type check refuses first for every input, so a test
+  // relying on the default would pass without the run-id rules below existing
+  // at all.
+  const ALLOWS_PAUSE = new Set(["pause"]);
+
+  it("accepts a proposal whose command type is allowed and whose target is this run", async () => {
+    const { assertProposalSatisfies } = await import("./runControls");
+    expect(() =>
+      assertProposalSatisfies(
+        "pause",
+        "run-abc123",
+        proposalOf({ target: { kind: "session", id: "run-abc123", version: "3" } }),
+        ALLOWS_PAUSE,
+      ),
+    ).not.toThrow();
+  });
+
+  // The substitution this whole check exists for: the turn asks in prose for
+  // a pause, and the nearest tool the operator has is cancel_run.
+  it("refuses a cancel proposal returned for a pause request", async () => {
+    const { assertProposalSatisfies, ControlProposalMismatch } = await import("./runControls");
+    expect(() =>
+      assertProposalSatisfies(
+        "pause",
+        "run-abc123",
+        proposalOf({ commandType: "cancel", summary: "Cancel run run-abc123" }),
+        ALLOWS_PAUSE,
+      ),
+    ).toThrow(ControlProposalMismatch);
+  });
+
+  it("refuses a proposal carrying no command type at all", async () => {
+    const { assertProposalSatisfies } = await import("./runControls");
+    // An older server omits commandType from the proposal frame. Unverifiable
+    // is not a match.
+    expect(() =>
+      assertProposalSatisfies(
+        "pause",
+        "run-abc123",
+        proposalOf({ commandType: undefined }),
+        ALLOWS_PAUSE,
+      ),
+    ).toThrow(/unknown/);
+  });
+
+  it("refuses a proposal that names no run at all", async () => {
+    const { assertProposalSatisfies } = await import("./runControls");
+    expect(() =>
+      assertProposalSatisfies("pause", "run-abc123", proposalOf({ command: {} }), ALLOWS_PAUSE),
+    ).toThrow(/does not name the run/);
+  });
+
+  it("refuses a proposal that targets a different run", async () => {
+    const { assertProposalSatisfies } = await import("./runControls");
+    expect(() =>
+      assertProposalSatisfies(
+        "pause",
+        "run-abc123",
+        proposalOf({ command: { session_id: "run-other" } }),
+        ALLOWS_PAUSE,
+      ),
+    ).toThrow(/run-other/);
+  });
+
+  it("refuses when target and command name different runs, even if one of them is this run", async () => {
+    const { assertProposalSatisfies } = await import("./runControls");
+    expect(() =>
+      assertProposalSatisfies(
+        "pause",
+        "run-abc123",
+        proposalOf({ target: { kind: "session", id: "run-other", version: "3" } }),
+        ALLOWS_PAUSE,
+      ),
+    ).toThrow(/run-other/);
+  });
+});
+
+describe("lib/runControls — assertCommandApplied reads the status the confirm call returns", () => {
+  it("passes only on succeeded", async () => {
+    const { assertCommandApplied } = await import("./runControls");
+    expect(() =>
+      assertCommandApplied("pause", { proposalId: "p", status: "succeeded" } as never),
+    ).not.toThrow();
+  });
+
+  // These arrive in a 200 body, not as a raised error, so a caller that only
+  // catches throws treats every one of them as an accepted control.
+  it.each(["failed", "conflict", "expired"] as const)("throws on %s", async (status) => {
+    const { assertCommandApplied } = await import("./runControls");
+    expect(() => assertCommandApplied("pause", { proposalId: "p", status } as never)).toThrow(
+      /was not applied/,
+    );
+  });
+
+  // Not a failure, but not success either: the command has not landed, and
+  // reporting it as accepted is what makes a control look applied while it is
+  // still in flight.
+  it("throws on executing, which is in-flight rather than applied", async () => {
+    const { assertCommandApplied } = await import("./runControls");
+    expect(() =>
+      assertCommandApplied("resume", { proposalId: "p", status: "executing" } as never),
+    ).toThrow(/was not applied/);
+  });
+
+  it("surfaces the server's own error message when it sends one", async () => {
+    const { assertCommandApplied } = await import("./runControls");
+    expect(() =>
+      assertCommandApplied("message", {
+        proposalId: "p",
+        status: "failed",
+        error: { code: "gone", message: "run already exited", retryable: false },
+      } as never),
+    ).toThrow(/run already exited/);
+  });
+});
+
 describe("lib/runControls — controlInstructionText", () => {
   it("names the run id explicitly so the operator does not have to disambiguate 'this run'", async () => {
     const { controlInstructionText } = await import("./runControls");
@@ -217,8 +396,13 @@ describe("lib/runControls — proposeRunControl / confirmRunControl route throug
     expect(result.conversationId).toBe("conv-1");
     expect(result.proposal.id).toBe("prop-1");
 
-    await confirmRunControl(result.conversationId, result.proposal);
-    expect(api.confirmOperatorProposal).toHaveBeenCalledWith("conv-1", "prop-1", "hash-1", null);
+    // This proposal carries no commandType, which is what a server predating
+    // the frame change sends. Confirming refuses and — the part that matters —
+    // never reaches the confirm endpoint, so nothing is applied.
+    await expect(
+      confirmRunControl("pause", "run-abc123", result.conversationId, result.proposal),
+    ).rejects.toThrow(/Refusing to confirm/);
+    expect(api.confirmOperatorProposal).not.toHaveBeenCalled();
   });
 
   it("rejects when the turn ends with an error frame instead of a proposal", async () => {

--- a/apps/studio/frontend/src/lib/runControls.test.ts
+++ b/apps/studio/frontend/src/lib/runControls.test.ts
@@ -17,6 +17,24 @@ describe("lib/runControls — controlKindFor", () => {
   });
 });
 
+describe("lib/runControls — hasAnyExecutablePath", () => {
+  // Deliberately unmocked. The run detail's decision to render no control
+  // section rests on this being false against the real registry; asserting it
+  // only through a mock would prove the wiring and say nothing about the fact.
+  it("is false today, because no verb has a backing command yet", async () => {
+    const { hasAnyExecutablePath } = await import("./runControls");
+    expect(hasAnyExecutablePath()).toBe(false);
+  });
+
+  it("agrees with the per-verb answer for every verb, so the two cannot drift", async () => {
+    const { hasAnyExecutablePath, hasExecutablePath } = await import("./runControls");
+    const verbs = ["pause", "resume", "message"] as const;
+    // Guards the aggregate against the case that matters: if it were ever
+    // hardcoded rather than derived, this is what would catch it.
+    expect(hasAnyExecutablePath()).toBe(verbs.some((v) => hasExecutablePath(v)));
+  });
+});
+
 describe("lib/runControls — derivePausePhase (the pausing-vs-paused window)", () => {
   it("reads idle when no pause has been requested, regardless of running count", async () => {
     const { derivePausePhase } = await import("./runControls");

--- a/apps/studio/frontend/src/lib/runControls.test.ts
+++ b/apps/studio/frontend/src/lib/runControls.test.ts
@@ -56,6 +56,16 @@ describe("lib/runControls — derivePausePhase (the pausing-vs-paused window)", 
     expect(derivePausePhase(true, 1)).toBe("pausing");
     expect(derivePausePhase(true, 0)).toBe("paused");
   });
+
+  it("holds at pausing when the running count is unknown, rather than reading unknown as zero", async () => {
+    const { derivePausePhase } = await import("./runControls");
+    // A run with no authored graph has nothing for the progress counter to
+    // count, so it answers null. Collapsing that to zero reported such runs
+    // as fully paused the instant the request was accepted, with operations
+    // still in flight, and offered Resume before the gate had drained.
+    expect(derivePausePhase(true, null)).toBe("pausing");
+    expect(derivePausePhase(false, null)).toBe("idle");
+  });
 });
 
 // The state machines below decide from the RUN's state. Whether a verb has a
@@ -452,5 +462,41 @@ describe("lib/runControls — proposeRunControl / confirmRunControl route throug
     await expect(
       proposeRunControl("run-xyz", "agent", "message", { message: "hi" }),
     ).rejects.toThrow("not allowed");
+  });
+
+  // The operator can accept the turn, answer in prose, and propose nothing.
+  // That used to leave the promise pending and the stream open until the
+  // 30-second timeout, so a refusal was reported to the reader as a stall.
+  // This test also fails by TIMING OUT if that regresses, since vitest's own
+  // per-test timeout is well under the 30 seconds the old path would take.
+  it("rejects immediately when a completed turn ends without proposing anything", async () => {
+    vi.doMock("@/lib/api", () => ({
+      createOperatorConversation: vi.fn().mockResolvedValue({ id: "conv-3" }),
+      submitOperatorTurn: vi.fn().mockResolvedValue({
+        conversationId: "conv-3",
+        requestId: "req-3",
+        acceptedSequence: 1,
+      }),
+      streamOperatorConversation: vi.fn((_conversationId, _after, handlers) => {
+        queueMicrotask(() =>
+          handlers.onFrame({
+            version: 1,
+            conversationId: "conv-3",
+            requestId: "req-3",
+            sequence: 2,
+            type: "done",
+            payload: { outcome: "completed" },
+            createdAt: Date.now(),
+          }),
+        );
+        return () => {};
+      }),
+      confirmOperatorProposal: vi.fn(),
+    }));
+
+    const { proposeRunControl } = await import("./runControls");
+    await expect(
+      proposeRunControl("run-xyz", "agent", "message", { message: "hi" }),
+    ).rejects.toThrow(/ended without a proposal \(completed\)/);
   });
 });

--- a/apps/studio/frontend/src/lib/runControls.test.ts
+++ b/apps/studio/frontend/src/lib/runControls.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+describe("lib/runControls — controlKindFor", () => {
+  it("recognizes flow, play, and agent", async () => {
+    const { controlKindFor } = await import("./runControls");
+    expect(controlKindFor("flow")).toBe("flow");
+    expect(controlKindFor("play")).toBe("play");
+    expect(controlKindFor("agent")).toBe("agent");
+  });
+
+  it("returns null for kinds the control poller does not drain (show-play, fanout, null)", async () => {
+    const { controlKindFor } = await import("./runControls");
+    expect(controlKindFor("show-play")).toBeNull();
+    expect(controlKindFor("fanout")).toBeNull();
+    expect(controlKindFor(null)).toBeNull();
+    expect(controlKindFor(undefined)).toBeNull();
+  });
+});
+
+describe("lib/runControls — derivePausePhase (the pausing-vs-paused window)", () => {
+  it("reads idle when no pause has been requested, regardless of running count", async () => {
+    const { derivePausePhase } = await import("./runControls");
+    expect(derivePausePhase(false, 3)).toBe("idle");
+    expect(derivePausePhase(false, 0)).toBe("idle");
+  });
+
+  it("reads pausing while a pause is requested and operations are still in flight", async () => {
+    const { derivePausePhase } = await import("./runControls");
+    expect(derivePausePhase(true, 1)).toBe("pausing");
+    expect(derivePausePhase(true, 4)).toBe("pausing");
+  });
+
+  it("crosses from pausing to paused exactly when the running count reaches zero", async () => {
+    const { derivePausePhase } = await import("./runControls");
+    // This is the window the ADR calls out: the request has been accepted
+    // but operations are still finishing. A naive `pauseRequested -> "paused"`
+    // implementation would fail this test by reading "paused" while running=1.
+    expect(derivePausePhase(true, 1)).toBe("pausing");
+    expect(derivePausePhase(true, 0)).toBe("paused");
+  });
+});
+
+describe("lib/runControls — pauseControlState", () => {
+  it("is offered and enabled for a running flow with no pause requested", async () => {
+    const { pauseControlState } = await import("./runControls");
+    expect(pauseControlState("flow", false, "idle")).toEqual({
+      offered: true,
+      disabled: false,
+      reasonCode: null,
+    });
+  });
+
+  it("is offered and enabled for a running play with no pause requested", async () => {
+    const { pauseControlState } = await import("./runControls");
+    expect(pauseControlState("play", false, "idle")).toEqual({
+      offered: true,
+      disabled: false,
+      reasonCode: null,
+    });
+  });
+
+  // D4 / row 8: an agent run cannot be paused, and the control must be SHOWN
+  // and DISABLED with the reason stated — never hidden.
+  it("is shown and disabled, with the no-pause-seam reason, for an agent run", async () => {
+    const { pauseControlState } = await import("./runControls");
+    const result = pauseControlState("agent", false, "idle");
+    expect(result.offered).toBe(true);
+    expect(result.disabled).toBe(true);
+    expect(result.reasonCode).toBe("agent-no-pause-seam");
+  });
+
+  it("stays shown and disabled for an agent run even on a terminal run (agent reason still applies)", async () => {
+    const { pauseControlState } = await import("./runControls");
+    const result = pauseControlState("agent", true, "idle");
+    expect(result.offered).toBe(true);
+    expect(result.disabled).toBe(true);
+  });
+
+  it("is disabled with a terminal reason once a flow run has ended", async () => {
+    const { pauseControlState } = await import("./runControls");
+    const result = pauseControlState("flow", true, "idle");
+    expect(result.disabled).toBe(true);
+    expect(result.reasonCode).toBe("run-terminal");
+  });
+
+  it("is disabled once a pause is already requested (pausing or paused)", async () => {
+    const { pauseControlState } = await import("./runControls");
+    expect(pauseControlState("flow", false, "pausing").disabled).toBe(true);
+    expect(pauseControlState("flow", false, "paused").disabled).toBe(true);
+  });
+});
+
+describe("lib/runControls — resumeControlState", () => {
+  it("is not offered at all for an agent run (resume is not a listed agent capability)", async () => {
+    const { resumeControlState } = await import("./runControls");
+    expect(resumeControlState("agent", false, "idle").offered).toBe(false);
+  });
+
+  it("is offered but disabled with not-paused when a flow is running normally", async () => {
+    const { resumeControlState } = await import("./runControls");
+    const result = resumeControlState("flow", false, "idle");
+    expect(result.offered).toBe(true);
+    expect(result.disabled).toBe(true);
+    expect(result.reasonCode).toBe("not-paused");
+  });
+
+  it("is offered but disabled while still pausing (gate not yet applied)", async () => {
+    const { resumeControlState } = await import("./runControls");
+    const result = resumeControlState("play", false, "pausing");
+    expect(result.disabled).toBe(true);
+    expect(result.reasonCode).toBe("still-pausing");
+  });
+
+  it("is offered and enabled once fully paused", async () => {
+    const { resumeControlState } = await import("./runControls");
+    expect(resumeControlState("play", false, "paused")).toEqual({
+      offered: true,
+      disabled: false,
+      reasonCode: null,
+    });
+  });
+
+  it("is disabled with a terminal reason for a terminal run even if paused", async () => {
+    const { resumeControlState } = await import("./runControls");
+    const result = resumeControlState("flow", true, "paused");
+    expect(result.disabled).toBe(true);
+    expect(result.reasonCode).toBe("run-terminal");
+  });
+});
+
+describe("lib/runControls — steerControlState (row 8: steer offered on an agent run)", () => {
+  it("is offered and enabled for flow, play, and agent runs alike", async () => {
+    const { steerControlState } = await import("./runControls");
+    for (const kind of ["flow", "play", "agent"] as const) {
+      expect(steerControlState(kind, false)).toEqual({
+        offered: true,
+        disabled: false,
+        reasonCode: null,
+      });
+    }
+  });
+
+  it("is disabled with a terminal reason once the run has ended", async () => {
+    const { steerControlState } = await import("./runControls");
+    const result = steerControlState("agent", true);
+    expect(result.disabled).toBe(true);
+    expect(result.reasonCode).toBe("run-terminal");
+  });
+});
+
+describe("lib/runControls — controlInstructionText", () => {
+  it("names the run id explicitly so the operator does not have to disambiguate 'this run'", async () => {
+    const { controlInstructionText } = await import("./runControls");
+    expect(controlInstructionText("flow", "pause", "run-abc123")).toContain("run-abc123");
+    expect(controlInstructionText("play", "resume", "run-abc123")).toContain("run-abc123");
+  });
+
+  it("carries the steer message text verbatim", async () => {
+    const { controlInstructionText } = await import("./runControls");
+    const text = controlInstructionText("agent", "message", "run-abc123", "check the test output");
+    expect(text).toContain("check the test output");
+    expect(text).toContain("run-abc123");
+  });
+});
+
+describe("lib/runControls — proposeRunControl / confirmRunControl route through the operator proposal path, not a bespoke endpoint", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("creates a conversation, submits a turn carrying the run id, and resolves with the proposal frame the turn produced", async () => {
+    vi.doMock("@/lib/api", () => ({
+      createOperatorConversation: vi.fn().mockResolvedValue({ id: "conv-1" }),
+      submitOperatorTurn: vi.fn().mockResolvedValue({
+        conversationId: "conv-1",
+        requestId: "req-1",
+        acceptedSequence: 1,
+      }),
+      streamOperatorConversation: vi.fn((_conversationId, _after, handlers) => {
+        queueMicrotask(() =>
+          handlers.onFrame({
+            version: 1,
+            conversationId: "conv-1",
+            requestId: "req-1",
+            sequence: 2,
+            type: "proposal",
+            payload: {
+              proposal: {
+                id: "prop-1",
+                command: { verb: "pause" },
+                commandHash: "hash-1",
+                risk: "mutate",
+                summary: "Pause run-abc123",
+                idempotencyKey: "idem-1",
+                expiresAt: Date.now() + 60_000,
+              },
+            },
+            createdAt: Date.now(),
+          }),
+        );
+        return () => {};
+      }),
+      confirmOperatorProposal: vi
+        .fn()
+        .mockResolvedValue({ proposalId: "prop-1", status: "succeeded" }),
+    }));
+
+    const { proposeRunControl, confirmRunControl } = await import("./runControls");
+    const api = await import("@/lib/api");
+
+    const result = await proposeRunControl("run-abc123", "flow", "pause");
+
+    expect(api.createOperatorConversation).toHaveBeenCalledTimes(1);
+    const turnArgs = vi.mocked(api.submitOperatorTurn).mock.calls[0];
+    expect(turnArgs[0]).toBe("conv-1");
+    expect(turnArgs[1].instruction).toContain("run-abc123");
+    expect(result.conversationId).toBe("conv-1");
+    expect(result.proposal.id).toBe("prop-1");
+
+    await confirmRunControl(result.conversationId, result.proposal);
+    expect(api.confirmOperatorProposal).toHaveBeenCalledWith("conv-1", "prop-1", "hash-1", null);
+  });
+
+  it("rejects when the turn ends with an error frame instead of a proposal", async () => {
+    vi.doMock("@/lib/api", () => ({
+      createOperatorConversation: vi.fn().mockResolvedValue({ id: "conv-2" }),
+      submitOperatorTurn: vi.fn().mockResolvedValue({
+        conversationId: "conv-2",
+        requestId: "req-2",
+        acceptedSequence: 1,
+      }),
+      streamOperatorConversation: vi.fn((_conversationId, _after, handlers) => {
+        queueMicrotask(() =>
+          handlers.onFrame({
+            version: 1,
+            conversationId: "conv-2",
+            requestId: "req-2",
+            sequence: 2,
+            type: "error",
+            payload: { error: { code: "refused", message: "not allowed", retryable: false } },
+            createdAt: Date.now(),
+          }),
+        );
+        return () => {};
+      }),
+      confirmOperatorProposal: vi.fn(),
+    }));
+
+    const { proposeRunControl } = await import("./runControls");
+    await expect(
+      proposeRunControl("run-xyz", "agent", "message", { message: "hi" }),
+    ).rejects.toThrow("not allowed");
+  });
+});

--- a/apps/studio/frontend/src/lib/runControls.ts
+++ b/apps/studio/frontend/src/lib/runControls.ts
@@ -49,7 +49,11 @@ export type ControlReasonCode =
   | "agent-no-pause-seam"
   | "already-pause-requested"
   | "not-paused"
-  | "still-pausing";
+  | "still-pausing"
+  /** No command exists that would carry this verb out, so the control is
+   * shown and refused rather than offered and unable to deliver. See
+   * COMMAND_TYPES_BY_VERB for which verbs are backed. */
+  | "no-executable-path";
 
 export interface ControlState {
   /** Whether the control renders at all. A kind this ADR does not cover
@@ -82,6 +86,34 @@ export type PausePhase = "idle" | "pausing" | "paused";
 export function derivePausePhase(pauseRequested: boolean, runningCount: number): PausePhase {
   if (!pauseRequested) return "idle";
   return runningCount > 0 ? "pausing" : "paused";
+}
+
+/** Whether any command exists that would actually carry this verb out. When
+ * none does, the control is refused before a conversation is ever opened —
+ * the propose step sends a natural-language instruction, so an unbacked verb
+ * does not fail cleanly, it comes back as some other command. Refusing early
+ * is what keeps that substitution from ever reaching a confirm dialog. */
+export function hasExecutablePath(verb: ControlVerb): boolean {
+  return COMMAND_TYPES_BY_VERB[verb].size > 0;
+}
+
+/** Layers the surface-wide fact that a verb has no backing command on top of
+ * whatever the run-state machine below decided.
+ *
+ * Deliberately separate from those state machines rather than folded into
+ * them. Two reasons. It keeps every run-state rule reachable and tested
+ * instead of shadowed by a refusal that currently fires first for every input.
+ * And it makes this refusal WIN over the run-state reasons, which is what the
+ * reader needs: "The run is not paused" on a resume button implies resume will
+ * work once the run pauses, and that is not true of a verb nothing can carry
+ * out. A verb the state machine did not offer at all stays unoffered — this
+ * disables controls, it never adds one.
+ *
+ * The moment a backing command's type is added to COMMAND_TYPES_BY_VERB this
+ * becomes a no-op and the specific run-state reason resurfaces on its own. */
+export function applyExecutablePath(verb: ControlVerb, state: ControlState): ControlState {
+  if (!state.offered || hasExecutablePath(verb)) return state;
+  return offeredState(true, "no-executable-path");
 }
 
 export function pauseControlState(
@@ -215,14 +247,126 @@ export async function proposeRunControl(
   return { conversationId: conversation.id, proposal };
 }
 
+/** Command types that legitimately satisfy each control verb.
+ *
+ * Every set is empty, and that is a finding rather than a placeholder. The
+ * operator's mutating command set is prefill_schedule, launch_playbook,
+ * cancel_run, resume_run and rename_session; none of them pauses a run,
+ * releases a pause gate, or delivers a steering message. `resume_run` is the
+ * trap: it carries command type "resume" and its own docstring says it is a
+ * distinct operation from un-pausing a paused run, so it matches this verb by
+ * name while doing something else.
+ *
+ * A control command therefore rides a natural-language instruction to a model
+ * that has no tool for it, and the nearest available match to "stop this run"
+ * is cancel_run. Until a backing command exists, every proposal returned for a
+ * control verb is the wrong command, and refusing it is the only correct
+ * outcome. Adding the backing command means adding its type here, and the
+ * checks below start passing without further change. */
+const COMMAND_TYPES_BY_VERB: Record<ControlVerb, ReadonlySet<string>> = {
+  pause: new Set(),
+  resume: new Set(),
+  message: new Set(),
+};
+
+/** A returned proposal does not match the control that was requested. Thrown
+ * before anything is confirmed, so the run is never mutated. */
+export class ControlProposalMismatch extends Error {
+  constructor(
+    readonly verb: ControlVerb,
+    readonly proposalCommandType: string,
+    reason: string,
+  ) {
+    super(reason);
+    this.name = "ControlProposalMismatch";
+  }
+}
+
+/** The run a proposal would actually act on, or null when it names none.
+ * `target.id` is the resource the store resolved; `command.session_id` is what
+ * the command itself carries. Either identifies the run, so a proposal is
+ * bound when one of them matches and neither names a different run. */
+function proposalRunIds(proposal: OperatorCommandProposal): string[] {
+  const ids: string[] = [];
+  if (proposal.target?.id) ids.push(proposal.target.id);
+  const fromCommand = proposal.command?.session_id;
+  if (typeof fromCommand === "string" && fromCommand) ids.push(fromCommand);
+  return ids;
+}
+
+/** Checks a returned proposal against the control that asked for it, throwing
+ * rather than returning a boolean so no caller can proceed by ignoring the
+ * result. The proposal arrives from a model round-trip, so neither its command
+ * nor its target is guaranteed to be what was requested — binding them here is
+ * what keeps "confirm pause" from executing some other mutation. */
+export function assertProposalSatisfies(
+  verb: ControlVerb,
+  runId: string,
+  proposal: OperatorCommandProposal,
+  /** The command types that satisfy `verb`. Defaults to the table above, which
+   * is empty for every verb today — meaning every call refuses at the first
+   * check, and a test asserting any of the later refusals would pass no matter
+   * what this function did with run ids. Passing a set explicitly is what keeps
+   * each rule here separately falsifiable, and is what a backing command's own
+   * tests use before its type is added to the table. */
+  allowed: ReadonlySet<string> = COMMAND_TYPES_BY_VERB[verb],
+): void {
+  const commandType = proposal.commandType ?? "";
+  if (!allowed.has(commandType)) {
+    throw new ControlProposalMismatch(
+      verb,
+      commandType,
+      `Refusing to confirm: asked to ${verb} this run, but the proposed command is "${commandType || "unknown"}".`,
+    );
+  }
+  const runIds = proposalRunIds(proposal);
+  if (runIds.length === 0) {
+    throw new ControlProposalMismatch(
+      verb,
+      commandType,
+      "Refusing to confirm: the proposed command does not name the run it would act on.",
+    );
+  }
+  const other = runIds.find((id) => id !== runId);
+  if (other) {
+    throw new ControlProposalMismatch(
+      verb,
+      commandType,
+      `Refusing to confirm: the proposed command targets run ${other}, not this run.`,
+    );
+  }
+}
+
+/** Throws unless the confirm call reported the command as actually applied.
+ *
+ * The status field is load-bearing: the API reports "failed", "conflict" and
+ * "expired" in a 200 body rather than by raising, so a caller that only
+ * catches thrown errors reports every one of those as an accepted control.
+ * "executing" is not success either — the command has not landed yet, and
+ * treating it as accepted is what makes a control look applied while it is
+ * still in flight. */
+export function assertCommandApplied(verb: ControlVerb, result: OperatorProposalResult): void {
+  if (result.status === "succeeded") return;
+  const detail = result.error?.message ?? result.status;
+  throw new Error(`The ${verb} command was not applied: ${detail}`);
+}
+
+/** Confirms a control proposal after binding it to the verb and run that were
+ * requested, and after reading the result the confirm call returns. Both
+ * checks throw rather than returning a value a caller can ignore. */
 export async function confirmRunControl(
+  verb: ControlVerb,
+  runId: string,
   conversationId: string,
   proposal: OperatorCommandProposal,
 ): Promise<OperatorProposalResult> {
-  return confirmOperatorProposal(
+  assertProposalSatisfies(verb, runId, proposal);
+  const result = await confirmOperatorProposal(
     conversationId,
     proposal.id,
     proposal.commandHash,
     proposal.target?.version ?? null,
   );
+  assertCommandApplied(verb, result);
+  return result;
 }

--- a/apps/studio/frontend/src/lib/runControls.ts
+++ b/apps/studio/frontend/src/lib/runControls.ts
@@ -82,9 +82,17 @@ export type PausePhase = "idle" | "pausing" | "paused";
 /** Pause is soft: a requested pause does not become "paused" until every
  * operation already admitted has finished. `runningCount` is the same
  * progress-counts.running the graph and progress bar already read, so this
- * can never disagree with what the canvas shows. */
-export function derivePausePhase(pauseRequested: boolean, runningCount: number): PausePhase {
+ * can never disagree with what the canvas shows.
+ *
+ * `null` means that count is UNKNOWN, which is not the same as zero and must
+ * not collapse into it. A run with no authored graph has nothing for the
+ * progress counter to count, so it would hand over zero and settle straight
+ * to "paused" while its operations are still in flight — offering Resume
+ * before the pause gate has drained anything. Unknown holds at "pausing"
+ * instead, the phase that claims nothing about what has finished. */
+export function derivePausePhase(pauseRequested: boolean, runningCount: number | null): PausePhase {
   if (!pauseRequested) return "idle";
+  if (runningCount === null) return "pausing";
   return runningCount > 0 ? "pausing" : "paused";
 }
 
@@ -228,13 +236,17 @@ function waitForProposal(
           close();
           reject(new Error((frame.payload as OperatorErrorPayload).error.message));
         } else if (frame.type === "done") {
+          // Reaching `done` at all means no proposal arrived: a proposal
+          // frame settles this promise in the branch above. The outcome only
+          // changes the wording, never whether this is a failure — a turn
+          // that completed normally and proposed nothing leaves just as
+          // little to confirm as one that errored. Waiting the outcome out
+          // reported it as a 30-second stall instead of the refusal it is.
           const outcome = (frame.payload as OperatorDonePayload).outcome;
-          if (outcome !== "completed") {
-            settled = true;
-            clearTimeout(timer);
-            close();
-            reject(new Error(`Command turn ended without a proposal (${outcome}).`));
-          }
+          settled = true;
+          clearTimeout(timer);
+          close();
+          reject(new Error(`Command turn ended without a proposal (${outcome}).`));
         }
       },
     });

--- a/apps/studio/frontend/src/lib/runControls.ts
+++ b/apps/studio/frontend/src/lib/runControls.ts
@@ -1,0 +1,228 @@
+/**
+ * Run control commands (pause / resume-gate / steer) for the run detail view.
+ *
+ * Mirrors the consumer-kind table in lionagi/cli/orchestrate/_control.py
+ * (`_CONSUMER_KINDS_BY_VERB`): a flow or play run drains all three verbs; an
+ * agent run drains only `message` (a steer lands as a warm continuation at
+ * the next turn boundary — there is no pause seam inside a single
+ * `operate()` call). Commands are never sent directly: they ride the
+ * ADR-0083 operator conversation → proposal → confirm path unchanged, so
+ * every control command gets the same audit trail as any other operator
+ * command.
+ */
+import {
+  confirmOperatorProposal,
+  createOperatorConversation,
+  submitOperatorTurn,
+  streamOperatorConversation,
+} from "@/lib/api";
+import type {
+  OperatorCommandProposal,
+  OperatorContextSnapshot,
+  OperatorDonePayload,
+  OperatorErrorPayload,
+  OperatorProposalPayload,
+  OperatorProposalResult,
+} from "@/lib/types";
+
+export type ControlKind = "flow" | "play" | "agent";
+export type ControlVerb = "pause" | "resume" | "message";
+
+const CONSUMER_KINDS_BY_VERB: Record<ControlVerb, ReadonlySet<ControlKind>> = {
+  pause: new Set(["flow", "play"]),
+  resume: new Set(["flow", "play"]),
+  message: new Set(["flow", "play", "agent"]),
+};
+
+/** session.invocation_kind → a kind the control poller recognizes, or null
+ * for a kind this ADR does not cover (e.g. show-play, fanout, a mirrored
+ * import) — the server enqueues nothing for those, so no control surface is
+ * offered rather than offering one that would be refused. */
+export function controlKindFor(invocationKind: string | null | undefined): ControlKind | null {
+  return invocationKind === "flow" || invocationKind === "play" || invocationKind === "agent"
+    ? invocationKind
+    : null;
+}
+
+export type ControlReasonCode =
+  | "run-terminal"
+  | "agent-no-pause-seam"
+  | "already-pause-requested"
+  | "not-paused"
+  | "still-pausing";
+
+export interface ControlState {
+  /** Whether the control renders at all. A kind this ADR does not cover
+   * (controlKindFor returned null, or resume/pause is not in the verb's
+   * consumer-kind set for this kind) is not offered — false here means
+   * "render nothing," never "render disabled." */
+  offered: boolean;
+  /** Offered but not clickable right now, with reasonCode explaining why.
+   * Per D4, an agent run's pause control is offered=true, disabled=true —
+   * shown, not hidden, so the engine constraint reads as deliberate. */
+  disabled: boolean;
+  reasonCode: ControlReasonCode | null;
+}
+
+function offeredState(
+  disabled: boolean,
+  reasonCode: ControlReasonCode | null = null,
+): ControlState {
+  return { offered: true, disabled, reasonCode };
+}
+
+const NOT_OFFERED: ControlState = { offered: false, disabled: true, reasonCode: null };
+
+export type PausePhase = "idle" | "pausing" | "paused";
+
+/** Pause is soft: a requested pause does not become "paused" until every
+ * operation already admitted has finished. `runningCount` is the same
+ * progress-counts.running the graph and progress bar already read, so this
+ * can never disagree with what the canvas shows. */
+export function derivePausePhase(pauseRequested: boolean, runningCount: number): PausePhase {
+  if (!pauseRequested) return "idle";
+  return runningCount > 0 ? "pausing" : "paused";
+}
+
+export function pauseControlState(
+  kind: ControlKind,
+  runTerminal: boolean,
+  pausePhase: PausePhase,
+): ControlState {
+  if (!CONSUMER_KINDS_BY_VERB.pause.has(kind)) {
+    // Only "agent" falls here among the three recognized kinds — this is the
+    // shown-and-disabled refusal D4 requires, not an omission.
+    return offeredState(true, "agent-no-pause-seam");
+  }
+  if (runTerminal) return offeredState(true, "run-terminal");
+  if (pausePhase !== "idle") return offeredState(true, "already-pause-requested");
+  return offeredState(false);
+}
+
+export function resumeControlState(
+  kind: ControlKind,
+  runTerminal: boolean,
+  pausePhase: PausePhase,
+): ControlState {
+  if (!CONSUMER_KINDS_BY_VERB.resume.has(kind)) return NOT_OFFERED;
+  if (runTerminal) return offeredState(true, "run-terminal");
+  if (pausePhase === "paused") return offeredState(false);
+  if (pausePhase === "pausing") return offeredState(true, "still-pausing");
+  return offeredState(true, "not-paused");
+}
+
+export function steerControlState(kind: ControlKind, runTerminal: boolean): ControlState {
+  if (!CONSUMER_KINDS_BY_VERB.message.has(kind)) return NOT_OFFERED;
+  if (runTerminal) return offeredState(true, "run-terminal");
+  return offeredState(false);
+}
+
+/** Deterministic instruction text sent as the operator turn — the run id is
+ * spelled out in the text itself so the operator model never has to
+ * disambiguate "this run" from page context alone. */
+export function controlInstructionText(
+  kind: ControlKind,
+  verb: ControlVerb,
+  runId: string,
+  message?: string,
+): string {
+  const label = kind === "agent" ? "agent run" : `${kind} run`;
+  if (verb === "pause") {
+    return `Pause the ${label} ${runId}. Let in-flight operations finish; do not start anything new.`;
+  }
+  if (verb === "resume") {
+    return `Resume the ${label} ${runId} by releasing its pause gate.`;
+  }
+  return `Deliver this message to the ${label} ${runId} as a steering continuation at the next turn boundary: ${(message ?? "").trim()}`;
+}
+
+function controlContext(runId: string): OperatorContextSnapshot {
+  return {
+    space: "history",
+    route: `/history?s=${encodeURIComponent(runId)}`,
+    selection: { s: runId },
+    filters: { s: runId },
+  };
+}
+
+export interface RunControlProposal {
+  conversationId: string;
+  proposal: OperatorCommandProposal;
+}
+
+/** Waits for the turn just submitted to produce a `proposal` frame. Rejects
+ * on an `error` frame, on a `done` frame with no proposal (nothing to
+ * confirm), or after `timeoutMs` with no signal at all. */
+function waitForProposal(
+  conversationId: string,
+  afterSequence: number,
+  timeoutMs = 30_000,
+): Promise<OperatorCommandProposal> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      close();
+      reject(new Error("Timed out waiting for a command proposal."));
+    }, timeoutMs);
+    const close = streamOperatorConversation(conversationId, Math.max(0, afterSequence - 1), {
+      onFrame: (frame) => {
+        if (settled) return;
+        if (frame.type === "proposal") {
+          settled = true;
+          clearTimeout(timer);
+          close();
+          resolve((frame.payload as OperatorProposalPayload).proposal);
+        } else if (frame.type === "error") {
+          settled = true;
+          clearTimeout(timer);
+          close();
+          reject(new Error((frame.payload as OperatorErrorPayload).error.message));
+        } else if (frame.type === "done") {
+          const outcome = (frame.payload as OperatorDonePayload).outcome;
+          if (outcome !== "completed") {
+            settled = true;
+            clearTimeout(timer);
+            close();
+            reject(new Error(`Command turn ended without a proposal (${outcome}).`));
+          }
+        }
+      },
+    });
+  });
+}
+
+/** Submits a control command through a fresh operator conversation and
+ * returns the proposal it produced — not yet applied. The caller confirms
+ * (confirmRunControl) or lets it expire; this never applies a command on its
+ * own, matching ADR-0083's propose-then-confirm safety contract. */
+export async function proposeRunControl(
+  runId: string,
+  kind: ControlKind,
+  verb: ControlVerb,
+  options?: { message?: string },
+): Promise<RunControlProposal> {
+  const conversation = await createOperatorConversation({
+    title: `${verb} · ${runId.slice(0, 8)}`,
+  });
+  const accepted = await submitOperatorTurn(conversation.id, {
+    instruction: controlInstructionText(kind, verb, runId, options?.message),
+    context: controlContext(runId),
+    expectedLastSequence: 0,
+  });
+  const proposal = await waitForProposal(conversation.id, accepted.acceptedSequence);
+  return { conversationId: conversation.id, proposal };
+}
+
+export async function confirmRunControl(
+  conversationId: string,
+  proposal: OperatorCommandProposal,
+): Promise<OperatorProposalResult> {
+  return confirmOperatorProposal(
+    conversationId,
+    proposal.id,
+    proposal.commandHash,
+    proposal.target?.version ?? null,
+  );
+}

--- a/apps/studio/frontend/src/lib/runControls.ts
+++ b/apps/studio/frontend/src/lib/runControls.ts
@@ -97,6 +97,22 @@ export function hasExecutablePath(verb: ControlVerb): boolean {
   return COMMAND_TYPES_BY_VERB[verb].size > 0;
 }
 
+/** Whether any control verb at all has a backing command.
+ *
+ * When none does, the run detail renders no control section rather than a
+ * section in which every control is disabled. A surface whose every verb
+ * refuses reads as a broken feature, while its absence reads as one not built
+ * yet, and only the second is true. The per-verb refusal above stays exactly
+ * as it is: it is what protects the mixed state, where some verbs are backed
+ * and others are not.
+ *
+ * The verb list comes from the registry itself rather than a second literal,
+ * so the two can never disagree, and the section reappears on its own the
+ * moment any command type lands. */
+export function hasAnyExecutablePath(): boolean {
+  return (Object.keys(COMMAND_TYPES_BY_VERB) as ControlVerb[]).some(hasExecutablePath);
+}
+
 /** Layers the surface-wide fact that a verb has no backing command on top of
  * whatever the run-state machine below decided.
  *

--- a/apps/studio/frontend/src/lib/types.ts
+++ b/apps/studio/frontend/src/lib/types.ts
@@ -599,6 +599,11 @@ export interface OperatorResourceVersion {
 
 export interface OperatorCommandProposal {
   id: string;
+  /** What the command would do, e.g. "cancel" or "rename_session". Optional
+   * because a client may still be talking to a server that predates the frame
+   * carrying it; a caller checking a proposal against its own request must
+   * treat the absent case as unverifiable rather than as a match. */
+  commandType?: string;
   command: Record<string, unknown>;
   commandHash: string;
   risk: "mutate" | "execute" | "admin";

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -491,7 +491,36 @@
       "expandGraph": "توسيع الرسم البياني للتنفيذ",
       "collapseGraph": "طي الرسم البياني للتنفيذ",
       "closeExpandedGraph": "إغلاق",
-      "nodeNoBranch": "لم يتم العثور على فرع لـ “{node}” — لم تبدأ هذه الخطوة بعد."
+      "nodeNoBranch": "لم يتم العثور على فرع لـ “{node}” — لم تبدأ هذه الخطوة بعد.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "قائمة السجل",
     "detailAria": "تفاصيل العنصر"

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "لا يوجد بعد أمر لتنفيذ هذا الإجراء."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/ar.json
+++ b/apps/studio/frontend/src/messages/ar.json
@@ -487,6 +487,7 @@
       "progressRunning": "قيد التشغيل",
       "progressFailed": "فشل",
       "progressPending": "قيد الانتظار",
+      "progressEscalated": "تم التصعيد",
       "progressElapsed": "الوقت المنقضي",
       "expandGraph": "توسيع الرسم البياني للتنفيذ",
       "collapseGraph": "طي الرسم البياني للتنفيذ",

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "এটি সম্পন্ন করার জন্য এখনও কোনো কমান্ড নেই।"
         }
       }
     },

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -491,7 +491,36 @@
       "expandGraph": "এক্সিকিউশন গ্রাফ প্রসারিত করুন",
       "collapseGraph": "এক্সিকিউশন গ্রাফ সংকুচিত করুন",
       "closeExpandedGraph": "বন্ধ করুন",
-      "nodeNoBranch": "“{node}”-এর জন্য কোনো ব্রাঞ্চ পাওয়া যায়নি — এই ধাপটি এখনও শুরু হয়নি।"
+      "nodeNoBranch": "“{node}”-এর জন্য কোনো ব্রাঞ্চ পাওয়া যায়নি — এই ধাপটি এখনও শুরু হয়নি।",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "হিস্ট্রি তালিকা",
     "detailAria": "আইটেমের বিস্তারিত"

--- a/apps/studio/frontend/src/messages/bn.json
+++ b/apps/studio/frontend/src/messages/bn.json
@@ -487,6 +487,7 @@
       "progressRunning": "চলমান",
       "progressFailed": "ব্যর্থ",
       "progressPending": "মুলতুবি",
+      "progressEscalated": "এস্কেলেটেড",
       "progressElapsed": "অতিবাহিত সময়",
       "expandGraph": "এক্সিকিউশন গ্রাফ প্রসারিত করুন",
       "collapseGraph": "এক্সিকিউশন গ্রাফ সংকুচিত করুন",

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "Es gibt noch keinen Befehl, der dies ausführen kann."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -491,7 +491,36 @@
       "expandGraph": "Ausführungsgraph erweitern",
       "collapseGraph": "Ausführungsgraph einklappen",
       "closeExpandedGraph": "Schließen",
-      "nodeNoBranch": "Kein Branch für „{node}“ gefunden — dieser Schritt hat noch nicht begonnen."
+      "nodeNoBranch": "Kein Branch für „{node}“ gefunden — dieser Schritt hat noch nicht begonnen.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "Verlaufsliste",
     "detailAria": "Elementdetails"

--- a/apps/studio/frontend/src/messages/de.json
+++ b/apps/studio/frontend/src/messages/de.json
@@ -487,6 +487,7 @@
       "progressRunning": "Läuft",
       "progressFailed": "Fehlgeschlagen",
       "progressPending": "Ausstehend",
+      "progressEscalated": "Eskaliert",
       "progressElapsed": "Verstrichen",
       "expandGraph": "Ausführungsgraph erweitern",
       "collapseGraph": "Ausführungsgraph einklappen",

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -491,7 +491,36 @@
       "expandGraph": "Expand execution graph",
       "collapseGraph": "Collapse execution graph",
       "closeExpandedGraph": "Close",
-      "nodeNoBranch": "No branch found for “{node}” — this step has not started."
+      "nodeNoBranch": "No branch found for “{node}” — this step has not started.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "History list",
     "detailAria": "Item detail"

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "No command exists yet to carry this out."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/en.json
+++ b/apps/studio/frontend/src/messages/en.json
@@ -487,6 +487,7 @@
       "progressRunning": "Running",
       "progressFailed": "Failed",
       "progressPending": "Pending",
+      "progressEscalated": "Escalated",
       "progressElapsed": "Elapsed",
       "expandGraph": "Expand execution graph",
       "collapseGraph": "Collapse execution graph",

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -491,7 +491,36 @@
       "expandGraph": "Expandir gráfico de ejecución",
       "collapseGraph": "Contraer gráfico de ejecución",
       "closeExpandedGraph": "Cerrar",
-      "nodeNoBranch": "No se encontró ninguna rama para «{node}» — este paso aún no ha comenzado."
+      "nodeNoBranch": "No se encontró ninguna rama para «{node}» — este paso aún no ha comenzado.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "Lista de historial",
     "detailAria": "Detalle del elemento"

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "Todavía no existe ningún comando que ejecute esta acción."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/es.json
+++ b/apps/studio/frontend/src/messages/es.json
@@ -487,6 +487,7 @@
       "progressRunning": "En ejecución",
       "progressFailed": "Fallido",
       "progressPending": "Pendiente",
+      "progressEscalated": "Escalado",
       "progressElapsed": "Transcurrido",
       "expandGraph": "Expandir gráfico de ejecución",
       "collapseGraph": "Contraer gráfico de ejecución",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "Aucune commande ne permet encore d'exécuter cette action."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -487,6 +487,7 @@
       "progressRunning": "En cours",
       "progressFailed": "Échoué",
       "progressPending": "En attente",
+      "progressEscalated": "Escaladé",
       "progressElapsed": "Écoulé",
       "expandGraph": "Développer le graphique d'exécution",
       "collapseGraph": "Réduire le graphique d'exécution",

--- a/apps/studio/frontend/src/messages/fr.json
+++ b/apps/studio/frontend/src/messages/fr.json
@@ -491,7 +491,36 @@
       "expandGraph": "Développer le graphique d'exécution",
       "collapseGraph": "Réduire le graphique d'exécution",
       "closeExpandedGraph": "Fermer",
-      "nodeNoBranch": "Aucune branche trouvée pour « {node} » — cette étape n'a pas encore commencé."
+      "nodeNoBranch": "Aucune branche trouvée pour « {node} » — cette étape n'a pas encore commencé.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "Liste d’historique",
     "detailAria": "Détail de l’élément"

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -487,6 +487,7 @@
       "progressRunning": "चल रहा है",
       "progressFailed": "विफल",
       "progressPending": "लंबित",
+      "progressEscalated": "एस्केलेटेड",
       "progressElapsed": "व्यतीत समय",
       "expandGraph": "निष्पादन ग्राफ विस्तृत करें",
       "collapseGraph": "निष्पादन ग्राफ संक्षिप्त करें",

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -491,7 +491,36 @@
       "expandGraph": "निष्पादन ग्राफ विस्तृत करें",
       "collapseGraph": "निष्पादन ग्राफ संक्षिप्त करें",
       "closeExpandedGraph": "बंद करें",
-      "nodeNoBranch": "“{node}” के लिए कोई शाखा नहीं मिली — यह चरण अभी शुरू नहीं हुआ है।"
+      "nodeNoBranch": "“{node}” के लिए कोई शाखा नहीं मिली — यह चरण अभी शुरू नहीं हुआ है।",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "इतिहास सूची",
     "detailAria": "आइटम विवरण"

--- a/apps/studio/frontend/src/messages/hi.json
+++ b/apps/studio/frontend/src/messages/hi.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "इसे पूरा करने के लिए अभी कोई कमांड मौजूद नहीं है।"
         }
       }
     },

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -487,6 +487,7 @@
       "progressRunning": "Berjalan",
       "progressFailed": "Gagal",
       "progressPending": "Tertunda",
+      "progressEscalated": "Dieskalasi",
       "progressElapsed": "Waktu berlalu",
       "expandGraph": "Perluas grafik eksekusi",
       "collapseGraph": "Ciutkan grafik eksekusi",

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -491,7 +491,36 @@
       "expandGraph": "Perluas grafik eksekusi",
       "collapseGraph": "Ciutkan grafik eksekusi",
       "closeExpandedGraph": "Tutup",
-      "nodeNoBranch": "Tidak ada cabang yang ditemukan untuk “{node}” — langkah ini belum dimulai."
+      "nodeNoBranch": "Tidak ada cabang yang ditemukan untuk “{node}” — langkah ini belum dimulai.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "Daftar riwayat",
     "detailAria": "Detail item"

--- a/apps/studio/frontend/src/messages/id.json
+++ b/apps/studio/frontend/src/messages/id.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "Belum ada perintah yang dapat menjalankan tindakan ini."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -491,7 +491,36 @@
       "expandGraph": "実行グラフを展開",
       "collapseGraph": "実行グラフを折りたたむ",
       "closeExpandedGraph": "閉じる",
-      "nodeNoBranch": "「{node}」のブランチが見つかりません — このステップはまだ開始されていません。"
+      "nodeNoBranch": "「{node}」のブランチが見つかりません — このステップはまだ開始されていません。",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "履歴一覧",
     "detailAria": "項目の詳細"

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -487,6 +487,7 @@
       "progressRunning": "実行中",
       "progressFailed": "失敗",
       "progressPending": "保留中",
+      "progressEscalated": "エスカレーション",
       "progressElapsed": "経過時間",
       "expandGraph": "実行グラフを展開",
       "collapseGraph": "実行グラフを折りたたむ",

--- a/apps/studio/frontend/src/messages/ja.json
+++ b/apps/studio/frontend/src/messages/ja.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "この操作を実行するコマンドはまだありません。"
         }
       }
     },

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "이 작업을 수행할 명령이 아직 없습니다."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -487,6 +487,7 @@
       "progressRunning": "실행 중",
       "progressFailed": "실패",
       "progressPending": "대기 중",
+      "progressEscalated": "에스컬레이션",
       "progressElapsed": "경과 시간",
       "expandGraph": "실행 그래프 펼치기",
       "collapseGraph": "실행 그래프 접기",

--- a/apps/studio/frontend/src/messages/ko.json
+++ b/apps/studio/frontend/src/messages/ko.json
@@ -491,7 +491,36 @@
       "expandGraph": "실행 그래프 펼치기",
       "collapseGraph": "실행 그래프 접기",
       "closeExpandedGraph": "닫기",
-      "nodeNoBranch": "“{node}”에 대한 브랜치를 찾을 수 없습니다 — 이 단계는 아직 시작되지 않았습니다."
+      "nodeNoBranch": "“{node}”에 대한 브랜치를 찾을 수 없습니다 — 이 단계는 아직 시작되지 않았습니다.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "기록 목록",
     "detailAria": "항목 세부 정보"

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -487,6 +487,7 @@
       "progressRunning": "Em execução",
       "progressFailed": "Falhou",
       "progressPending": "Pendente",
+      "progressEscalated": "Escalado",
       "progressElapsed": "Decorrido",
       "expandGraph": "Expandir gráfico de execução",
       "collapseGraph": "Recolher gráfico de execução",

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -491,7 +491,36 @@
       "expandGraph": "Expandir gráfico de execução",
       "collapseGraph": "Recolher gráfico de execução",
       "closeExpandedGraph": "Fechar",
-      "nodeNoBranch": "Nenhum branch encontrado para “{node}” — esta etapa ainda não começou."
+      "nodeNoBranch": "Nenhum branch encontrado para “{node}” — esta etapa ainda não começou.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "Lista do histórico",
     "detailAria": "Detalhes do item"

--- a/apps/studio/frontend/src/messages/pt-BR.json
+++ b/apps/studio/frontend/src/messages/pt-BR.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "Ainda não existe nenhum comando que execute esta ação."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "Пока нет команды, которая бы это выполнила."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -487,6 +487,7 @@
       "progressRunning": "Выполняется",
       "progressFailed": "Ошибка",
       "progressPending": "Ожидание",
+      "progressEscalated": "Эскалировано",
       "progressElapsed": "Прошло времени",
       "expandGraph": "Развернуть граф выполнения",
       "collapseGraph": "Свернуть граф выполнения",

--- a/apps/studio/frontend/src/messages/ru.json
+++ b/apps/studio/frontend/src/messages/ru.json
@@ -491,7 +491,36 @@
       "expandGraph": "Развернуть граф выполнения",
       "collapseGraph": "Свернуть граф выполнения",
       "closeExpandedGraph": "Закрыть",
-      "nodeNoBranch": "Ветка для «{node}» не найдена — этот шаг ещё не начался."
+      "nodeNoBranch": "Ветка для «{node}» не найдена — этот шаг ещё не начался.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "Список истории",
     "detailAria": "Сведения об элементе"

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "Bunu gerçekleştirecek bir komut henüz yok."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -487,6 +487,7 @@
       "progressRunning": "Çalışıyor",
       "progressFailed": "Başarısız",
       "progressPending": "Beklemede",
+      "progressEscalated": "Yükseltildi",
       "progressElapsed": "Geçen süre",
       "expandGraph": "Yürütme grafiğini genişlet",
       "collapseGraph": "Yürütme grafiğini daralt",

--- a/apps/studio/frontend/src/messages/tr.json
+++ b/apps/studio/frontend/src/messages/tr.json
@@ -491,7 +491,36 @@
       "expandGraph": "Yürütme grafiğini genişlet",
       "collapseGraph": "Yürütme grafiğini daralt",
       "closeExpandedGraph": "Kapat",
-      "nodeNoBranch": "“{node}” için dal bulunamadı — bu adım henüz başlamadı."
+      "nodeNoBranch": "“{node}” için dal bulunamadı — bu adım henüz başlamadı.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "geçmiş listesi",
     "detailAria": "öğe ayrıntısı"

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -491,7 +491,36 @@
       "expandGraph": "ایگزیکیوشن گراف پھیلائیں",
       "collapseGraph": "ایگزیکیوشن گراف سمیٹیں",
       "closeExpandedGraph": "بند کریں",
-      "nodeNoBranch": "“{node}” کے لیے کوئی برانچ نہیں ملی — یہ مرحلہ ابھی شروع نہیں ہوا۔"
+      "nodeNoBranch": "“{node}” کے لیے کوئی برانچ نہیں ملی — یہ مرحلہ ابھی شروع نہیں ہوا۔",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "ہسٹری فہرست",
     "detailAria": "آئٹم تفصیل"

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -487,6 +487,7 @@
       "progressRunning": "جاری",
       "progressFailed": "ناکام",
       "progressPending": "زیرِ التوا",
+      "progressEscalated": "بڑھایا گیا",
       "progressElapsed": "گزرا وقت",
       "expandGraph": "ایگزیکیوشن گراف پھیلائیں",
       "collapseGraph": "ایگزیکیوشن گراف سمیٹیں",

--- a/apps/studio/frontend/src/messages/ur.json
+++ b/apps/studio/frontend/src/messages/ur.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "اسے انجام دینے کے لیے ابھی کوئی کمانڈ موجود نہیں ہے۔"
         }
       }
     },

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -487,6 +487,7 @@
       "progressRunning": "Đang chạy",
       "progressFailed": "Thất bại",
       "progressPending": "Đang chờ",
+      "progressEscalated": "Đã leo thang",
       "progressElapsed": "Thời gian trôi qua",
       "expandGraph": "Mở rộng biểu đồ thực thi",
       "collapseGraph": "Thu gọn biểu đồ thực thi",

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -491,7 +491,36 @@
       "expandGraph": "Mở rộng biểu đồ thực thi",
       "collapseGraph": "Thu gọn biểu đồ thực thi",
       "closeExpandedGraph": "Đóng",
-      "nodeNoBranch": "Không tìm thấy nhánh cho “{node}” — bước này chưa bắt đầu."
+      "nodeNoBranch": "Không tìm thấy nhánh cho “{node}” — bước này chưa bắt đầu.",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "danh sách lịch sử",
     "detailAria": "chi tiết mục"

--- a/apps/studio/frontend/src/messages/vi.json
+++ b/apps/studio/frontend/src/messages/vi.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "Chưa có lệnh nào để thực hiện thao tác này."
         }
       }
     },

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -519,7 +519,8 @@
           "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
           "already-pause-requested": "A pause has already been requested.",
           "not-paused": "The run is not paused.",
-          "still-pausing": "Still finishing in-flight operations."
+          "still-pausing": "Still finishing in-flight operations.",
+          "no-executable-path": "目前还没有可以执行此操作的命令。"
         }
       }
     },

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -491,7 +491,36 @@
       "expandGraph": "展开执行图",
       "collapseGraph": "收起执行图",
       "closeExpandedGraph": "关闭",
-      "nodeNoBranch": "未找到“{node}”对应的分支 — 此步骤尚未开始。"
+      "nodeNoBranch": "未找到“{node}”对应的分支 — 此步骤尚未开始。",
+      "viewGraph": "Graph",
+      "viewList": "List",
+      "viewToggleLabel": "Graph or list view",
+      "selectedNode": "Selected: {node}",
+      "controls": {
+        "pause": "Pause",
+        "pausePhasePausing": "Pausing…",
+        "pausePhasePaused": "Paused",
+        "resume": "Resume gate",
+        "steer": "Steer",
+        "steerSend": "Send",
+        "steerPlaceholder": "Message to steer the run…",
+        "confirmYes": "Confirm",
+        "confirmCancel": "Cancel",
+        "proposeFailed": "Could not propose the command.",
+        "confirmFailed": "Could not confirm the command.",
+        "confirm": {
+          "pause": "Confirm pause?",
+          "resume": "Confirm resume?",
+          "message": "Confirm sending this message?"
+        },
+        "reason": {
+          "run-terminal": "This run has ended.",
+          "agent-no-pause-seam": "An agent run has no pause seam inside a single turn — steer instead.",
+          "already-pause-requested": "A pause has already been requested.",
+          "not-paused": "The run is not paused.",
+          "still-pausing": "Still finishing in-flight operations."
+        }
+      }
     },
     "masterAria": "历史列表",
     "detailAria": "条目详情"

--- a/apps/studio/frontend/src/messages/zh.json
+++ b/apps/studio/frontend/src/messages/zh.json
@@ -487,6 +487,7 @@
       "progressRunning": "运行中",
       "progressFailed": "失败",
       "progressPending": "待处理",
+      "progressEscalated": "已升级",
       "progressElapsed": "已用时间",
       "expandGraph": "展开执行图",
       "collapseGraph": "收起执行图",

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -1905,6 +1905,13 @@ WHERE request_id IN ({placeholders}) ORDER BY sequence ASC
             {
                 "proposal": {
                     "id": proposal_id,
+                    # The frame is the only view of a proposal a stream client
+                    # ever sees, so it has to carry what that client needs to
+                    # check the proposal against the request it made. Without
+                    # the type, a caller can confirm a proposal by id and hash
+                    # while having no way to tell what it would actually do.
+                    # Same key and value as the full row serialization.
+                    "commandType": command_type,
                     "command": command,
                     "commandHash": command_hash,
                     "risk": risk,

--- a/tests/apps_studio_server/test_operator_protocol.py
+++ b/tests/apps_studio_server/test_operator_protocol.py
@@ -515,6 +515,12 @@ async def test_application_mcp_launch_blocks_on_real_durable_human_proposal(tmp_
         "id": "daily-triage",
         "version": proposal["targetVersion"],
     }
+    # The frame is the only view of a proposal a stream client ever gets, so
+    # the row carrying commandType (asserted above) says nothing about whether
+    # the frame does. A client checking a returned proposal against the request
+    # it made needs the type here, and the two must agree.
+    assert proposal_frame["payload"]["proposal"]["commandType"] == "launch"
+    assert proposal_frame["payload"]["proposal"]["commandType"] == proposal["commandType"]
     assert "endpoint" not in proposal["command"]
     assert "command" not in proposal["command"]
 


### PR DESCRIPTION
Opening a run showed a list of steps first. For anything with structure, the
list is the wrong first answer: it cannot show what is waiting on what. The
graph is now the default view, with an explicit toggle back to the list for
cases where a flat reading is what you want.

## What changes

- The run detail opens on the graph, with a graph/list toggle and the current
  selection reflected in the view.
- A one-node authored snapshot no longer wins over a runtime graph that has
  edges. Node count does not decide which source to draw from; having an edge
  to draw does.
- Pause, resume and steer each carry the reason they are unavailable, as the
  control's title, and pause renders its reason inline as well. See the next
  section for when any of that is on screen.
- Pause is soft, so the phase holds at "pausing" until the running count says
  otherwise. An unknown count is not read as zero: a run with no authored
  graph has nothing for the progress counter to count, and reading that as
  zero claimed the run had drained while its operations were still in flight.
- Pause state belongs to the run it was requested on. Switching runs in the
  same pane no longer carries it across, which would otherwise mean a resume
  dispatched against a run that was never paused.
- An operator turn that ends without proposing a command is reported straight
  away, instead of after a 30-second timeout that read as a stall rather than
  the refusal it was.

## What is not on screen yet

No command type exists that pauses a run, releases a pause gate, or delivers a
steering message. While that is true of every verb, the control section is not
rendered at all, rather than rendered with three permanently dead buttons: a
surface where nothing can be clicked reads as a broken feature, while its
absence reads as one not built yet, and only the second is true. The per-verb
reasons described above are what appears the moment any single command type
lands, and the mixed state (some verbs backed, some not) is what they exist
for. The missing command types are tracked in #3030.

## Known limitation

The four strings introduced by the view toggle are not yet in the set that is
required to be translated, so they render in English in every locale. The rest
of the run detail is translated as normal. This is a gap in the required-string
list rather than in the translations themselves, and is tracked separately.

## Verification

Full frontend suite green at this head: 74 files, 1670 tests.

Each control and graph-source fix was checked by reverting it on its own and
confirming a test goes red: the run-swap guard is mounted and swaps the run id,
so it fails the way the defect presents rather than by construction.

Two test lines are removed. They invert a single assertion that had encoded the
one-node graph-source behaviour corrected here; the replacement asserts the
opposite, and a further case covers a multi-node edgeless graph so the
behaviour that was correct stays covered.
