### PR TITLE
Size an op's budget by how many ops must run in sequence

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -409,11 +409,15 @@ switch to writing the deliverable with what you have.
 def critical_path_depth(dep_indices: list[list[int]]) -> int:
     """Longest dependency chain in the plan, in ops.
 
-    This is the number of ops that must run one after another, which is what
-    bounds the flow's wall clock. It is not the op count: ops with no path
-    between them run at the same time, since the executor's default
-    concurrency is the whole assignment list and only dependencies hold an op
-    back.
+    This is how many ops the *dependencies* force to run one after another,
+    which is not the op count: ops with no path between them are free to run at
+    the same time.
+
+    It is a lower bound on the flow's wall clock, not the bound. A concurrency
+    cap serializes ops this function calls parallel, and under `--max-concurrent
+    1` it says 1 for a plan that runs strictly in sequence. Callers sizing a
+    budget want the larger of the two — see `op_budget_share`, which is the
+    reason this returns a chain length rather than a duration.
 
     Dependencies point backwards (op i may only depend on ops before it), so a
     single forward pass is enough. Cycles are therefore not reachable here, and
@@ -430,18 +434,63 @@ def critical_path_depth(dep_indices: list[list[int]]) -> int:
     return max(depths)
 
 
-def op_budget_share(total_budget: int, dep_indices: list[list[int]], num_ops: int) -> int:
+def op_budget_share(
+    total_budget: int,
+    dep_indices: list[list[int]],
+    num_ops: int,
+    max_concurrent: int = 0,
+) -> int:
     """Seconds to offer one op out of the flow's total budget.
 
-    The divisor is the critical-path depth rather than the op count, for the
-    reason given on `critical_path_depth`. `num_ops` is the fallback for a plan
-    with no dependency information at all, where nothing can be said about what
-    overlaps.
+    Two things force ops to run one after another, and the divisor has to
+    respect both. Dependencies are one: `critical_path_depth`. The concurrency
+    cap is the other, and it is easy to forget because it is usually not set —
+    with `--max-concurrent 1` the executor serializes four independent ops that
+    the dependency graph says could all run at once. Taking only the depth
+    there would hand every one of them the whole budget, and the flow's own
+    deadline would expire partway through.
+
+    So the divisor is the larger of the two lower bounds on how many ops must
+    run in sequence: the longest dependency chain, and the number of scheduling
+    rounds the cap imposes. `max_concurrent <= 0` means unbounded, matching how
+    the executor reads it, in which case the rounds bound is 1 and the depth
+    decides alone. `num_ops` is the fallback for a plan carrying no dependency
+    information, where nothing can be said about what overlaps.
     """
-    divisor = critical_path_depth(dep_indices) or num_ops
+    conc = max_concurrent if max_concurrent > 0 else num_ops
+    rounds = math.ceil(num_ops / conc) if conc > 0 else num_ops
+    divisor = max(critical_path_depth(dep_indices) or num_ops, rounds)
     if divisor <= 0:
         return total_budget
     return int(total_budget / divisor)
+
+
+def _build_budget_preambles(
+    total_budget: int | None,
+    dep_indices: list[list[int]],
+    num_ops: int,
+    max_concurrent: int,
+    deadline_epoch: float,
+) -> dict[int, str]:
+    """The per-op budget preambles for one flow, keyed by op index.
+
+    Exists as its own function so the share an op is actually told can be
+    asserted directly. Tests that only call `op_budget_share` cannot see
+    whether the caller uses it, which is how the equal-split divisor survived
+    a suite that was green the whole time.
+    """
+    if not total_budget or num_ops <= 0:
+        return {}
+    share = op_budget_share(total_budget, dep_indices, num_ops, max_concurrent)
+    return {
+        i: _format_budget_preamble(
+            op_index=i + 1,
+            num_ops=num_ops,
+            op_budget_seconds=share,
+            deadline_epoch=deadline_epoch,
+        )
+        for i in range(num_ops)
+    }
 
 
 def _format_budget_preamble(
@@ -2841,29 +2890,20 @@ async def _run_flow_inner(
             if not worker_is_cli(env, ta.assignee, pool[i % len(pool)] if pool else None)
         )
 
-    budget_preambles: dict[int, str] = {}
-    if env.total_budget and assignments:
-        # Divide the budget by how many ops run *one after another*, not by how
-        # many there are. Independent ops run at the same time — the executor's
-        # default concurrency is the whole assignment list, so only
-        # dependencies serialize anything — and dividing by the op count told
-        # every op in a wide graph that it had a fraction of the wall clock it
-        # actually had. Ops then paced themselves against that smaller number
-        # and dropped whatever was not the deliverable, which in practice meant
-        # the parts that run last.
-        #
-        # For a straight chain the depth equals the op count and this changes
-        # nothing; it only ever widens the share for graphs that really do run
-        # work in parallel.
-        share = op_budget_share(env.total_budget, dep_indices, len(assignments))
-        deadline = time.time() + env.total_budget
-        for i in range(len(assignments)):
-            budget_preambles[i] = _format_budget_preamble(
-                op_index=i + 1,
-                num_ops=len(assignments),
-                op_budget_seconds=share,
-                deadline_epoch=deadline,
-            )
+    # Divide the budget by how many ops must run *one after another*, not by
+    # how many there are. Dividing by the op count told every op in a wide
+    # graph that it had a fraction of the wall clock it actually had, and ops
+    # pace themselves against that number and drop whatever is not the
+    # deliverable — which in practice means the parts that run last. Both
+    # things that serialize ops are accounted for there: dependencies, and the
+    # concurrency cap this run was given.
+    budget_preambles = _build_budget_preambles(
+        env.total_budget,
+        dep_indices,
+        len(assignments),
+        max_concurrent,
+        time.time() + (env.total_budget or 0),
+    )
 
     plan_result = _PlanResult(
         assignments=assignments,

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -415,9 +415,12 @@ def critical_path_depth(dep_indices: list[list[int]]) -> int:
 
     It is a lower bound on the flow's wall clock, not the bound. A concurrency
     cap serializes ops this function calls parallel, and under `--max-concurrent
-    1` it says 1 for a plan that runs strictly in sequence. Callers sizing a
-    budget want the larger of the two — see `op_budget_share`, which is the
-    reason this returns a chain length rather than a duration.
+    1` it says 1 for a plan that runs strictly in sequence.
+
+    Taking the larger of this and the cap's round count is *still* not the
+    answer, because the two interact — see `schedule_wave_count`, which is what
+    sizes a budget. This function is exact only when nothing caps concurrency,
+    which is the common case and why it is still worth computing directly.
 
     Dependencies point backwards (op i may only depend on ops before it), so a
     single forward pass is enough. Cycles are therefore not reachable here, and
@@ -434,6 +437,67 @@ def critical_path_depth(dep_indices: list[list[int]]) -> int:
     return max(depths)
 
 
+def schedule_wave_count(dep_indices: list[list[int]], num_ops: int, max_concurrent: int) -> int:
+    """How many ops actually end up running one after another.
+
+    Two things push ops into sequence — the dependency chain and the
+    concurrency cap — and it is tempting to take the larger of the two. That is
+    still wrong, because they interact: a dependency leaves capacity idle, and
+    the ops it blocks have to be picked up in some later pass. One root feeding
+    three dependents at `--max-concurrent 2` has a longest chain of 2 and needs
+    `ceil(4 / 2) = 2` full passes, so both bounds say 2. It runs in three: the
+    root alone, then two of its dependents, then the last one, which had
+    nowhere to go while the other two held both slots.
+
+    So walk the schedule instead of estimating it. Repeatedly take the ops
+    whose dependencies are all satisfied, admit up to `max_concurrent` of them,
+    and count the passes.
+
+    The executor admits ops one at a time as slots free rather than in strict
+    passes (`operations/flow.py` starts every op as a task against a shared
+    `CapacityLimiter`), so this counts passes that the real schedule can only
+    beat, never lose to, when ops take comparable time. For sizing a budget
+    that is the safe direction: an op told it has slightly less time finishes
+    inside the flow's deadline, while one told it has more overruns it.
+
+    `max_concurrent <= 0` means unbounded, matching how the executor reads it.
+    A plan whose dependency data does not describe its ops gets `num_ops`, the
+    assumption that nothing overlaps, since nothing can be said about what does.
+    """
+    if num_ops <= 0:
+        return 0
+    if len(dep_indices) != num_ops:
+        return num_ops
+    conc = max_concurrent if max_concurrent > 0 else num_ops
+
+    # Unbounded capacity admits every ready op, so each pass clears one level
+    # of the dependency graph and the pass count is exactly the longest chain.
+    # Worth taking directly: it is the common case and it is one linear scan.
+    if conc >= num_ops:
+        return critical_path_depth(dep_indices) or num_ops
+
+    done: set[int] = set()
+    waves = 0
+    while len(done) < num_ops:
+        ready = [
+            i
+            for i in range(num_ops)
+            if i not in done
+            # An index pointing outside the plan is ignored rather than treated
+            # as unsatisfiable, matching critical_path_depth: a malformed entry
+            # should not be able to stall a budget hint.
+            and all(d in done for d in dep_indices[i] if 0 <= d < num_ops)
+        ]
+        if not ready:
+            # Unreachable for well-formed plans, whose dependencies point
+            # backwards. Fall back to the no-overlap assumption rather than
+            # spinning.
+            return num_ops
+        done.update(ready[:conc])
+        waves += 1
+    return waves
+
+
 def op_budget_share(
     total_budget: int,
     dep_indices: list[list[int]],
@@ -442,24 +506,10 @@ def op_budget_share(
 ) -> int:
     """Seconds to offer one op out of the flow's total budget.
 
-    Two things force ops to run one after another, and the divisor has to
-    respect both. Dependencies are one: `critical_path_depth`. The concurrency
-    cap is the other, and it is easy to forget because it is usually not set —
-    with `--max-concurrent 1` the executor serializes four independent ops that
-    the dependency graph says could all run at once. Taking only the depth
-    there would hand every one of them the whole budget, and the flow's own
-    deadline would expire partway through.
-
-    So the divisor is the larger of the two lower bounds on how many ops must
-    run in sequence: the longest dependency chain, and the number of scheduling
-    rounds the cap imposes. `max_concurrent <= 0` means unbounded, matching how
-    the executor reads it, in which case the rounds bound is 1 and the depth
-    decides alone. `num_ops` is the fallback for a plan carrying no dependency
-    information, where nothing can be said about what overlaps.
+    Divided by how many ops run in sequence rather than how many there are —
+    see `schedule_wave_count`, which is where the subtlety lives.
     """
-    conc = max_concurrent if max_concurrent > 0 else num_ops
-    rounds = math.ceil(num_ops / conc) if conc > 0 else num_ops
-    divisor = max(critical_path_depth(dep_indices) or num_ops, rounds)
+    divisor = schedule_wave_count(dep_indices, num_ops, max_concurrent)
     if divisor <= 0:
         return total_budget
     return int(total_budget / divisor)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -406,6 +406,44 @@ switch to writing the deliverable with what you have.
 """
 
 
+def critical_path_depth(dep_indices: list[list[int]]) -> int:
+    """Longest dependency chain in the plan, in ops.
+
+    This is the number of ops that must run one after another, which is what
+    bounds the flow's wall clock. It is not the op count: ops with no path
+    between them run at the same time, since the executor's default
+    concurrency is the whole assignment list and only dependencies hold an op
+    back.
+
+    Dependencies point backwards (op i may only depend on ops before it), so a
+    single forward pass is enough. Cycles are therefore not reachable here, and
+    an entry pointing outside the plan is ignored rather than raising: a bad
+    index should not be able to take down a run over a budget hint.
+    """
+    if not dep_indices:
+        return 0
+    depths = [1] * len(dep_indices)
+    for i, deps in enumerate(dep_indices):
+        for j in deps:
+            if 0 <= j < i:
+                depths[i] = max(depths[i], depths[j] + 1)
+    return max(depths)
+
+
+def op_budget_share(total_budget: int, dep_indices: list[list[int]], num_ops: int) -> int:
+    """Seconds to offer one op out of the flow's total budget.
+
+    The divisor is the critical-path depth rather than the op count, for the
+    reason given on `critical_path_depth`. `num_ops` is the fallback for a plan
+    with no dependency information at all, where nothing can be said about what
+    overlaps.
+    """
+    divisor = critical_path_depth(dep_indices) or num_ops
+    if divisor <= 0:
+        return total_budget
+    return int(total_budget / divisor)
+
+
 def _format_budget_preamble(
     op_index: int,
     num_ops: int,
@@ -2805,7 +2843,19 @@ async def _run_flow_inner(
 
     budget_preambles: dict[int, str] = {}
     if env.total_budget and assignments:
-        share = int(env.total_budget / len(assignments))
+        # Divide the budget by how many ops run *one after another*, not by how
+        # many there are. Independent ops run at the same time — the executor's
+        # default concurrency is the whole assignment list, so only
+        # dependencies serialize anything — and dividing by the op count told
+        # every op in a wide graph that it had a fraction of the wall clock it
+        # actually had. Ops then paced themselves against that smaller number
+        # and dropped whatever was not the deliverable, which in practice meant
+        # the parts that run last.
+        #
+        # For a straight chain the depth equals the op count and this changes
+        # nothing; it only ever widens the share for graphs that really do run
+        # work in parallel.
+        share = op_budget_share(env.total_budget, dep_indices, len(assignments))
         deadline = time.time() + env.total_budget
         for i in range(len(assignments)):
             budget_preambles[i] = _format_budget_preamble(

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -417,10 +417,10 @@ def critical_path_depth(dep_indices: list[list[int]]) -> int:
     cap serializes ops this function calls parallel, and under `--max-concurrent
     1` it says 1 for a plan that runs strictly in sequence.
 
-    Taking the larger of this and the cap's round count is *still* not the
-    answer, because the two interact — see `schedule_wave_count`, which is what
-    sizes a budget. This function is exact only when nothing caps concurrency,
-    which is the common case and why it is still worth computing directly.
+    What actually sizes a budget is `max_sequential_depth`, which takes this
+    together with what the cap forces. This function is exact only when nothing
+    caps concurrency, which is the common case and why it is still worth
+    computing directly.
 
     Dependencies point backwards (op i may only depend on ops before it), so a
     single forward pass is enough. Cycles are therefore not reachable here, and
@@ -437,35 +437,32 @@ def critical_path_depth(dep_indices: list[list[int]]) -> int:
     return max(depths)
 
 
-def schedule_wave_count(dep_indices: list[list[int]], num_ops: int, max_concurrent: int) -> int:
-    """How many ops actually end up running one after another.
+def max_sequential_depth(dep_indices: list[list[int]], num_ops: int, max_concurrent: int) -> int:
+    """The most ops that can end up running one after another.
 
-    Two things push ops into sequence — the dependency chain and the
-    concurrency cap — and it is tempting to take the larger of the two. That is
-    still wrong, because they interact: a dependency leaves capacity idle, and
-    the ops it blocks have to be picked up in some later pass. One root feeding
-    three dependents at `--max-concurrent 2` has a longest chain of 2 and needs
-    `ceil(4 / 2) = 2` full passes, so both bounds say 2. It runs in three: the
-    root alone, then two of its dependents, then the last one, which had
-    nowhere to go while the other two held both slots.
+    This number divides the flow's budget, so its error has a direction:
+    counting too few hands every op more time than the flow can afford and the
+    flow overruns its deadline, while counting too many only means an op is
+    told it has slightly less time than it might have had. That asymmetry is
+    what makes this an upper bound rather than an estimate.
 
-    So walk the schedule instead of estimating it. Keep a queue of ops whose
-    dependencies are satisfied, admit up to `max_concurrent` from the front of
-    it, and count the passes.
+    It has to be a bound, because the quantity it describes depends on how long
+    each op runs and a budget is computed before any of them have. An earlier
+    version simulated the schedule directly — a queue of ready ops, admitting
+    `max_concurrent` at a time, counting passes. That models one schedule, the
+    one where every op takes about as long as every other, and the executor
+    runs a great many. Give four ops a cap of two and let the second one run
+    six times longer than the rest, and the other three serialize behind it in
+    a chain of three where the simulation counted two. Unequal durations are
+    the normal case, not the corner, so the equal-duration schedule is the
+    wrong thing to be exact about.
 
-    The queue is the point, and it has to be a queue rather than a set. The
-    executor starts every op as a task that waits for its dependencies and
-    then queues for a shared `CapacityLimiter` (`operations/flow.py`), which
-    hands slots out in arrival order. An op that has just become ready
-    therefore waits behind ops that were already queued, and taking whichever
-    ops are ready — ignoring how long each has waited — counts a schedule the
-    executor cannot actually run, one pass short on shapes where a dependency
-    chain competes with independent work.
-
-    Getting that wrong has a direction. This number divides the flow's budget,
-    so counting too few passes hands every op more time than the flow can
-    afford and the flow overruns its deadline, while counting too many only
-    means an op is told it has slightly less time than it might have had.
+    Two things force ops into sequence and the bound is the worse of them.
+    Dependencies force a chain that no amount of capacity can shorten. Capacity
+    forces the rest: any run of ops executing strictly one after another can
+    contain at most one op from a set that started together, so it is bounded
+    by one plus however many ops are not in that first admitted batch. Neither
+    can exceed the everything-serializes case of one op at a time.
 
     `max_concurrent <= 0` means unbounded, matching how the executor reads it.
     A plan whose dependency data does not describe its ops gets `num_ops`, the
@@ -483,48 +480,19 @@ def schedule_wave_count(dep_indices: list[list[int]], num_ops: int, max_concurre
     if conc >= num_ops:
         return critical_path_depth(dep_indices) or num_ops
 
-    def _plan_deps(i: int) -> list[int]:
-        # An index pointing outside the plan is ignored rather than treated as
-        # unsatisfiable, matching critical_path_depth: a malformed entry should
-        # not be able to stall a budget hint.
-        return [d for d in dep_indices[i] if 0 <= d < num_ops]
-
-    # Slots go out in arrival order. Every op is started as a task, waits for
-    # its dependencies, and only then queues for the shared limiter, so an op
-    # whose dependency has just cleared joins BEHIND ops that have been waiting
-    # for a slot all along and cannot overtake them.
+    # Two things can force ops into sequence, and the answer is the worse of
+    # them.
     #
-    # Admitting whichever ops are ready, ignoring how long each has waited,
-    # lets the dependency chain skip that backlog. Six ops at a cap of two — a
-    # chain of three beside three independent ops — comes out at three passes
-    # that way, where the executor runs four: the middle of the chain becomes
-    # ready while two independents are still queued, waits behind them, and
-    # pushes its own dependent a pass later. Undercounting is the one direction
-    # a budget divisor must not go, because it hands every op more time than
-    # the flow can afford and the flow overruns its deadline.
-    queued: set[int] = set()
-    queue: list[int] = []
-
-    def _enqueue_newly_ready(done: set[int]) -> None:
-        for i in range(num_ops):
-            if i not in queued and all(d in done for d in _plan_deps(i)):
-                queue.append(i)
-                queued.add(i)
-
-    done: set[int] = set()
-    _enqueue_newly_ready(done)
-    waves = 0
-    while len(done) < num_ops:
-        if not queue:
-            # Unreachable for well-formed plans, whose dependencies point
-            # backwards. Fall back to the no-overlap assumption rather than
-            # spinning.
-            return num_ops
-        done.update(queue[:conc])
-        del queue[:conc]
-        waves += 1
-        _enqueue_newly_ready(done)
-    return waves
+    # Dependencies force a chain no amount of capacity can shorten.
+    #
+    # Capacity forces the rest. When ops are ready the executor admits
+    # `conc` of them at once, and a run of ops that execute strictly one
+    # after another can contain at most ONE op out of any set that started
+    # together — so such a run is at most one of that first batch plus every
+    # op outside it, `num_ops - conc + 1`.
+    #
+    # Nothing can exceed `num_ops`, which is the everything-serializes case.
+    return min(num_ops, max(critical_path_depth(dep_indices), num_ops - conc + 1))
 
 
 def op_budget_share(
@@ -535,10 +503,10 @@ def op_budget_share(
 ) -> int:
     """Seconds to offer one op out of the flow's total budget.
 
-    Divided by how many ops run in sequence rather than how many there are —
-    see `schedule_wave_count`, which is where the subtlety lives.
+    Divided by how many ops can run in sequence rather than how many there are —
+    see `max_sequential_depth`, which is where the subtlety lives.
     """
-    divisor = schedule_wave_count(dep_indices, num_ops, max_concurrent)
+    divisor = max_sequential_depth(dep_indices, num_ops, max_concurrent)
     if divisor <= 0:
         return total_budget
     return int(total_budget / divisor)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -449,16 +449,23 @@ def schedule_wave_count(dep_indices: list[list[int]], num_ops: int, max_concurre
     root alone, then two of its dependents, then the last one, which had
     nowhere to go while the other two held both slots.
 
-    So walk the schedule instead of estimating it. Repeatedly take the ops
-    whose dependencies are all satisfied, admit up to `max_concurrent` of them,
-    and count the passes.
+    So walk the schedule instead of estimating it. Keep a queue of ops whose
+    dependencies are satisfied, admit up to `max_concurrent` from the front of
+    it, and count the passes.
 
-    The executor admits ops one at a time as slots free rather than in strict
-    passes (`operations/flow.py` starts every op as a task against a shared
-    `CapacityLimiter`), so this counts passes that the real schedule can only
-    beat, never lose to, when ops take comparable time. For sizing a budget
-    that is the safe direction: an op told it has slightly less time finishes
-    inside the flow's deadline, while one told it has more overruns it.
+    The queue is the point, and it has to be a queue rather than a set. The
+    executor starts every op as a task that waits for its dependencies and
+    then queues for a shared `CapacityLimiter` (`operations/flow.py`), which
+    hands slots out in arrival order. An op that has just become ready
+    therefore waits behind ops that were already queued, and taking whichever
+    ops are ready — ignoring how long each has waited — counts a schedule the
+    executor cannot actually run, one pass short on shapes where a dependency
+    chain competes with independent work.
+
+    Getting that wrong has a direction. This number divides the flow's budget,
+    so counting too few passes hands every op more time than the flow can
+    afford and the flow overruns its deadline, while counting too many only
+    means an op is told it has slightly less time than it might have had.
 
     `max_concurrent <= 0` means unbounded, matching how the executor reads it.
     A plan whose dependency data does not describe its ops gets `num_ops`, the
@@ -476,25 +483,47 @@ def schedule_wave_count(dep_indices: list[list[int]], num_ops: int, max_concurre
     if conc >= num_ops:
         return critical_path_depth(dep_indices) or num_ops
 
+    def _plan_deps(i: int) -> list[int]:
+        # An index pointing outside the plan is ignored rather than treated as
+        # unsatisfiable, matching critical_path_depth: a malformed entry should
+        # not be able to stall a budget hint.
+        return [d for d in dep_indices[i] if 0 <= d < num_ops]
+
+    # Slots go out in arrival order. Every op is started as a task, waits for
+    # its dependencies, and only then queues for the shared limiter, so an op
+    # whose dependency has just cleared joins BEHIND ops that have been waiting
+    # for a slot all along and cannot overtake them.
+    #
+    # Admitting whichever ops are ready, ignoring how long each has waited,
+    # lets the dependency chain skip that backlog. Six ops at a cap of two — a
+    # chain of three beside three independent ops — comes out at three passes
+    # that way, where the executor runs four: the middle of the chain becomes
+    # ready while two independents are still queued, waits behind them, and
+    # pushes its own dependent a pass later. Undercounting is the one direction
+    # a budget divisor must not go, because it hands every op more time than
+    # the flow can afford and the flow overruns its deadline.
+    queued: set[int] = set()
+    queue: list[int] = []
+
+    def _enqueue_newly_ready(done: set[int]) -> None:
+        for i in range(num_ops):
+            if i not in queued and all(d in done for d in _plan_deps(i)):
+                queue.append(i)
+                queued.add(i)
+
     done: set[int] = set()
+    _enqueue_newly_ready(done)
     waves = 0
     while len(done) < num_ops:
-        ready = [
-            i
-            for i in range(num_ops)
-            if i not in done
-            # An index pointing outside the plan is ignored rather than treated
-            # as unsatisfiable, matching critical_path_depth: a malformed entry
-            # should not be able to stall a budget hint.
-            and all(d in done for d in dep_indices[i] if 0 <= d < num_ops)
-        ]
-        if not ready:
+        if not queue:
             # Unreachable for well-formed plans, whose dependencies point
             # backwards. Fall back to the no-overlap assumption rather than
             # spinning.
             return num_ops
-        done.update(ready[:conc])
+        done.update(queue[:conc])
+        del queue[:conc]
         waves += 1
+        _enqueue_newly_ready(done)
     return waves
 
 

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -16,8 +16,8 @@ from lionagi.cli.orchestrate.flow import (
     _build_budget_preambles,
     _format_budget_preamble,
     critical_path_depth,
+    max_sequential_depth,
     op_budget_share,
-    schedule_wave_count,
 )
 
 # ── _format_budget_preamble ────────────────────────────────────────────────
@@ -127,31 +127,42 @@ def test_share_falls_back_to_the_op_count_without_dependency_data():
 # independent ops one after another, and a share computed from depth 1 hands
 # each of them the whole wall clock, so the first two spend the deadline and
 # the rest are cancelled part-written.
+#
+# What the cap contributes is not a count of batches. Once `conc` ops are in
+# flight together, a sequence of ops that run strictly one after another can
+# pick up at most one of them, so it reaches at most `num_ops - conc + 1`. The
+# ops that lose the race for a slot do not have to resume in step with each
+# other, and any test phrased in rounds of equal length is asserting a schedule
+# rather than a bound.
 
 
-def test_share_counts_scheduling_rounds_when_a_cap_serializes_independent_ops():
+def test_share_counts_every_op_when_a_cap_of_one_serializes_them_all():
     # Four independent ops, cap of 1: the graph permits full overlap, the cap
-    # permits none. Four rounds, so 900s / 4.
+    # permits none, so all four run in sequence and each gets 900s / 4.
     assert op_budget_share(900, [[], [], [], []], 4, 1) == 225
 
 
-def test_share_counts_partial_rounds_under_a_cap_that_allows_some_overlap():
-    # Cap of 2 over four independent ops is two rounds, not four.
-    assert op_budget_share(900, [[], [], [], []], 4, 2) == 450
+def test_share_counts_the_ops_that_can_queue_behind_one_slow_op():
+    # Four independent ops at a cap of 2. Two start together, and a sequence
+    # can hold only one of those two, so the reachable depth is 3 rather than
+    # the two equal-length rounds an even schedule would show: one op finishes
+    # early, another takes its slot, that one finishes, a third takes it.
+    assert op_budget_share(900, [[], [], [], []], 4, 2) == 300
 
 
-def test_share_rounds_a_partial_final_batch_up():
-    # Three ops at a cap of 2 still needs two rounds: one pair, then a single.
+def test_share_over_a_cap_leaving_one_op_to_follow():
+    # Three ops at a cap of 2: two start together, one waits, so at most two
+    # run in sequence.
     assert op_budget_share(900, [[], [], []], 3, 2) == 450
 
 
-def test_share_takes_the_dependency_chain_when_it_is_longer_than_the_rounds():
-    # A 3-chain under a cap of 3: rounds is 1, so depth decides. The cap being
-    # present must not shorten a share the dependencies already justify.
+def test_share_takes_the_dependency_chain_when_it_is_longer():
+    # A 3-chain under a cap of 3: capacity forces nothing, so depth decides.
+    # The cap being present must not shorten a share the dependencies justify.
     assert op_budget_share(900, [[], [0], [1]], 3, 3) == 300
 
 
-def test_share_takes_the_rounds_when_they_exceed_the_dependency_chain():
+def test_share_takes_the_cap_when_it_forces_more_than_the_dependency_chain():
     # Fan-in: depth 2, but a cap of 1 forces all four into sequence.
     assert op_budget_share(900, [[], [], [], [0, 1, 2]], 4, 1) == 225
 
@@ -167,17 +178,20 @@ def test_share_treats_a_non_positive_cap_as_unbounded():
 # ── Where the two bounds interact ───────────────────────────────────────────
 #
 # A dependency does not only lengthen the chain, it idles capacity while it is
-# unsatisfied, and the ops it blocks have to be picked up in some later pass.
-# Neither bound sees that, so neither does the larger of the two.
+# unsatisfied, and the ops it blocks have to be picked up later. Counting
+# batches of `conc` ops misses that, because it assumes every slot is busy in
+# every batch. Counting the ops that can queue behind a single occupied slot
+# does not.
 
 
-def test_a_dependency_idles_capacity_so_neither_bound_sees_the_third_wave():
-    # One root, three dependents, two slots. The root runs alone (one slot idle
-    # because nothing else is ready), then two dependents, then the last.
+def test_a_dependency_idles_capacity_and_the_batch_count_cannot_see_it():
+    # One root, three dependents, two slots. The root runs alone because
+    # nothing else is ready, and its dependents follow it.
     deps = [[], [0], [0], [0]]
-    assert schedule_wave_count(deps, 4, 2) == 3
-    # Both bounds say 2, so max() of them cannot reach 3. This is the whole
-    # finding: the counterexample is invisible to either bound alone.
+    assert max_sequential_depth(deps, 4, 2) == 3
+    # Neither the chain nor a count of full batches reaches 3, which is why
+    # the divisor is neither of them. The batch count is the shape of the
+    # bound this file used to assert, kept here as the thing that undercounts.
     assert critical_path_depth(deps) == 2
     assert math.ceil(4 / 2) == 2
 
@@ -188,42 +202,45 @@ def test_the_share_for_that_schedule_fits_inside_the_deadline():
     assert op_budget_share(900, [[], [0], [0], [0]], 4, 2) == 300
 
 
-def test_a_diamond_under_a_cap_counts_the_pass_its_join_needs():
+def test_a_diamond_under_a_cap_counts_the_stage_its_join_needs():
     # root → two middles → join. The join cannot start until both middles are
-    # done, so it gets a pass of its own however wide the cap is.
-    assert schedule_wave_count([[], [0], [0], [1, 2]], 4, 2) == 3
+    # done, so it follows them however wide the cap is.
+    assert max_sequential_depth([[], [0], [0], [1, 2]], 4, 2) == 3
 
 
-def test_a_wide_layer_splits_across_passes_under_a_narrow_cap():
-    # A root feeding five dependents at a cap of 2: root, then three passes of
-    # two, two, one.
-    assert schedule_wave_count([[], [0], [0], [0], [0], [0]], 6, 2) == 4
+def test_a_wide_layer_queues_behind_a_narrow_cap():
+    # A root feeding five dependents at a cap of 2. Once the root is done, two
+    # dependents start together and a sequence can hold only one of them, so
+    # four of the five can end up nose to tail behind the root.
+    assert max_sequential_depth([[], [0], [0], [0], [0], [0]], 6, 2) == 5
 
 
 def test_an_uncapped_schedule_is_exactly_the_dependency_depth():
-    # With capacity for everyone each pass clears one level, which is the
-    # cheaper short-circuit the function takes.
+    # With capacity for everyone, only the dependencies serialize anything,
+    # which is the cheaper short-circuit the function takes.
     deps = [[], [0], [1]]
-    assert schedule_wave_count(deps, 3, 0) == critical_path_depth(deps) == 3
-    assert schedule_wave_count([[], [], []], 3, 0) == 1
+    assert max_sequential_depth(deps, 3, 0) == critical_path_depth(deps) == 3
+    assert max_sequential_depth([[], [], []], 3, 0) == 1
 
 
 def test_a_plan_whose_dependency_data_does_not_match_its_ops_assumes_no_overlap():
     # Nothing can be said about what overlaps, so every op is assumed serial.
-    assert schedule_wave_count([[], [0]], 4, 2) == 4
-    assert schedule_wave_count([], 3, 2) == 3
+    assert max_sequential_depth([[], [0]], 4, 2) == 4
+    assert max_sequential_depth([], 3, 2) == 3
 
 
 def test_a_dependency_pointing_outside_the_plan_does_not_stall_the_count():
     # Matches critical_path_depth's tolerance: a malformed index is ignored
     # rather than treated as a dependency that can never be satisfied. All four
-    # ops are ready immediately, so the cap alone decides — a stall would give
-    # the no-overlap fallback of 4 instead.
-    assert schedule_wave_count([[], [9], [-1], []], 4, 2) == 2
+    # ops are ready immediately, so the cap alone decides, giving the same 3 as
+    # four genuinely independent ops — a stall would give the no-overlap
+    # fallback of 4 instead.
+    assert max_sequential_depth([[], [9], [-1], []], 4, 2) == 3
+    assert max_sequential_depth([[], [], [], []], 4, 2) == 3
 
 
-def test_an_empty_plan_has_no_waves():
-    assert schedule_wave_count([], 0, 2) == 0
+def test_an_empty_plan_has_no_depth():
+    assert max_sequential_depth([], 0, 2) == 0
 
 
 # ── The share an op is actually told ────────────────────────────────────────

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for flow budget propagation: _format_budget_preamble, equal-split arithmetic, and OrchestrationEnv.total_budget wiring."""
+"""Tests for flow budget propagation: _format_budget_preamble, the critical-path share arithmetic, and OrchestrationEnv.total_budget wiring."""
 
 from __future__ import annotations
 
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from lionagi.cli.orchestrate.flow import _format_budget_preamble
+from lionagi.cli.orchestrate.flow import (
+    _format_budget_preamble,
+    critical_path_depth,
+    op_budget_share,
+)
 
 # ── _format_budget_preamble ────────────────────────────────────────────────
 
@@ -56,20 +60,62 @@ def test_format_budget_preamble_index_and_count():
     assert "60 seconds" in text
 
 
-# ── Budget split (equal share across assignments) ──────────────────────────
+# ── Critical-path depth ────────────────────────────────────────────────────
+#
+# These call the shipped functions rather than a copy of their arithmetic. The
+# previous version of this section defined its own `_equal_split` helper and
+# asserted against that, so it agreed with itself no matter what the flow did.
 
 
-def _equal_split(n: int, total_budget: int) -> int:
-    """Replicate the per-assignment share from _run_flow_inner."""
-    return int(total_budget / n)
+def test_depth_of_a_straight_chain_is_the_op_count():
+    # 1 → 2 → 3: nothing overlaps, so every op is on the critical path.
+    assert critical_path_depth([[], [0], [1]]) == 3
 
 
-def test_equal_split_3_assignments():
-    assert _equal_split(3, 600) == 200
+def test_depth_of_independent_ops_is_one():
+    # No edges at all: the ops run together, so the chain is one op long.
+    assert critical_path_depth([[], [], [], []]) == 1
 
 
-def test_equal_split_rounds_down():
-    assert _equal_split(3, 700) == 233
+def test_depth_of_a_fan_in_counts_the_longest_chain_only():
+    # Three producers in parallel feeding one consumer — the shape the run
+    # canvas draws for a writer fan-in. Four ops, but only two run in sequence.
+    assert critical_path_depth([[], [], [], [0, 1, 2]]) == 2
+
+
+def test_depth_takes_the_longest_of_two_unequal_branches():
+    # 0 → 1 → 2 alongside a lone 3, both feeding 4.
+    assert critical_path_depth([[], [0], [1], [], [2, 3]]) == 4
+
+
+def test_depth_of_an_empty_plan_is_zero():
+    assert critical_path_depth([]) == 0
+
+
+def test_depth_ignores_a_dependency_pointing_outside_the_plan():
+    # A malformed index must not raise: this only sizes a hint in a prompt.
+    assert critical_path_depth([[], [7]]) == 1
+
+
+def test_share_divides_by_chain_length_not_op_count():
+    # The case that motivated the change: 4 ops, 900s, three of them parallel.
+    # By op count each op is told 225s; two of those four ops actually run in
+    # sequence, so the honest figure is 450s.
+    assert op_budget_share(900, [[], [], [], [0, 1, 2]], 4) == 450
+
+
+def test_share_is_unchanged_for_a_straight_chain():
+    # The no-op guarantee: where nothing overlaps, this must not hand out more
+    # time than dividing by the op count did.
+    assert op_budget_share(600, [[], [0], [1]], 3) == 200
+
+
+def test_share_rounds_down():
+    assert op_budget_share(700, [[], [0], [1]], 3) == 233
+
+
+def test_share_falls_back_to_the_op_count_without_dependency_data():
+    assert op_budget_share(600, [], 3) == 200
 
 
 def test_no_budget_preamble_when_total_budget_none():

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from lionagi.cli.orchestrate.flow import (
+    _build_budget_preambles,
     _format_budget_preamble,
     critical_path_depth,
     op_budget_share,
@@ -116,6 +117,120 @@ def test_share_rounds_down():
 
 def test_share_falls_back_to_the_op_count_without_dependency_data():
     assert op_budget_share(600, [], 3) == 200
+
+
+# ── The concurrency cap serializes ops the dependency graph says are parallel ──
+#
+# Depth alone is not a lower bound on makespan. `--max-concurrent 1` runs four
+# independent ops one after another, and a share computed from depth 1 hands
+# each of them the whole wall clock, so the first two spend the deadline and
+# the rest are cancelled part-written.
+
+
+def test_share_counts_scheduling_rounds_when_a_cap_serializes_independent_ops():
+    # Four independent ops, cap of 1: the graph permits full overlap, the cap
+    # permits none. Four rounds, so 900s / 4.
+    assert op_budget_share(900, [[], [], [], []], 4, 1) == 225
+
+
+def test_share_counts_partial_rounds_under_a_cap_that_allows_some_overlap():
+    # Cap of 2 over four independent ops is two rounds, not four.
+    assert op_budget_share(900, [[], [], [], []], 4, 2) == 450
+
+
+def test_share_rounds_a_partial_final_batch_up():
+    # Three ops at a cap of 2 still needs two rounds: one pair, then a single.
+    assert op_budget_share(900, [[], [], []], 3, 2) == 450
+
+
+def test_share_takes_the_dependency_chain_when_it_is_longer_than_the_rounds():
+    # A 3-chain under a cap of 3: rounds is 1, so depth decides. The cap being
+    # present must not shorten a share the dependencies already justify.
+    assert op_budget_share(900, [[], [0], [1]], 3, 3) == 300
+
+
+def test_share_takes_the_rounds_when_they_exceed_the_dependency_chain():
+    # Fan-in: depth 2, but a cap of 1 forces all four into sequence.
+    assert op_budget_share(900, [[], [], [], [0, 1, 2]], 4, 1) == 225
+
+
+def test_share_treats_a_non_positive_cap_as_unbounded():
+    # 0 is how the executor spells "no limit" (flow.py's `conc` fallback), so
+    # depth decides and the pre-cap answer is preserved. This is the arm that
+    # keeps the default path honest: every caller that passes no cap lands here.
+    assert op_budget_share(900, [[], [], [], [0, 1, 2]], 4, 0) == 450
+    assert op_budget_share(900, [[], [], [], [0, 1, 2]], 4) == 450
+
+
+# ── The share an op is actually told ────────────────────────────────────────
+#
+# `op_budget_share` being right says nothing about whether the flow uses it.
+# The equal-split divisor this PR removes survived a green suite for exactly
+# that reason: every test called the arithmetic directly, and the call site
+# went unread. These go through the function that builds the preamble text.
+
+
+def _seconds_in(preamble: str) -> int:
+    m = re.search(r"(\d+) seconds", preamble)
+    assert m, f"no budget figure in preamble: {preamble!r}"
+    return int(m.group(1))
+
+
+def test_preamble_carries_the_critical_path_share_not_the_equal_split():
+    # Three producers into one consumer, 900s. Equal split would say 225.
+    preambles = _build_budget_preambles(900, [[], [], [], [0, 1, 2]], 4, 0, time.time() + 900)
+    assert set(preambles) == {0, 1, 2, 3}
+    assert {_seconds_in(t) for t in preambles.values()} == {450}
+
+
+def test_preamble_reflects_the_concurrency_cap():
+    preambles = _build_budget_preambles(900, [[], [], [], []], 4, 1, time.time() + 900)
+    assert {_seconds_in(t) for t in preambles.values()} == {225}
+
+
+def test_preamble_numbers_the_ops_from_one():
+    preambles = _build_budget_preambles(600, [[], [0], [1]], 3, 0, time.time() + 600)
+    assert "op 1 of 3" in preambles[0]
+    assert "op 3 of 3" in preambles[2]
+
+
+def test_no_preambles_without_a_total_budget():
+    assert _build_budget_preambles(None, [[], []], 2, 0, time.time()) == {}
+    assert _build_budget_preambles(0, [[], []], 2, 0, time.time()) == {}
+
+
+def test_no_preambles_for_an_empty_plan():
+    assert _build_budget_preambles(900, [], 0, 0, time.time() + 900) == {}
+
+
+def test_the_flow_builds_its_preambles_through_the_shared_helper():
+    """The flow's own call site must not do this arithmetic itself.
+
+    The three tests above pin `_build_budget_preambles`, which pins nothing
+    about whether `_run_flow_inner` calls it — restoring an inline equal split
+    there leaves all of them green. That is the gap that let the original
+    divisor ship. Read the function's AST and require the call.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from lionagi.cli.orchestrate import flow as flow_mod
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(flow_mod._run_flow_inner)))
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "_build_budget_preambles" in called, (
+        "_run_flow_inner must build budget preambles through the shared helper, "
+        "so the divisor it uses is the one the tests above pin"
+    )
+    assert "_format_budget_preamble" not in called, (
+        "_run_flow_inner formats preambles inline again, which puts the divisor "
+        "back out of reach of every test in this file"
+    )
 
 
 def test_no_budget_preamble_when_total_budget_none():

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -16,6 +17,7 @@ from lionagi.cli.orchestrate.flow import (
     _format_budget_preamble,
     critical_path_depth,
     op_budget_share,
+    schedule_wave_count,
 )
 
 # ── _format_budget_preamble ────────────────────────────────────────────────
@@ -160,6 +162,68 @@ def test_share_treats_a_non_positive_cap_as_unbounded():
     # keeps the default path honest: every caller that passes no cap lands here.
     assert op_budget_share(900, [[], [], [], [0, 1, 2]], 4, 0) == 450
     assert op_budget_share(900, [[], [], [], [0, 1, 2]], 4) == 450
+
+
+# ── Where the two bounds interact ───────────────────────────────────────────
+#
+# A dependency does not only lengthen the chain, it idles capacity while it is
+# unsatisfied, and the ops it blocks have to be picked up in some later pass.
+# Neither bound sees that, so neither does the larger of the two.
+
+
+def test_a_dependency_idles_capacity_so_neither_bound_sees_the_third_wave():
+    # One root, three dependents, two slots. The root runs alone (one slot idle
+    # because nothing else is ready), then two dependents, then the last.
+    deps = [[], [0], [0], [0]]
+    assert schedule_wave_count(deps, 4, 2) == 3
+    # Both bounds say 2, so max() of them cannot reach 3. This is the whole
+    # finding: the counterexample is invisible to either bound alone.
+    assert critical_path_depth(deps) == 2
+    assert math.ceil(4 / 2) == 2
+
+
+def test_the_share_for_that_schedule_fits_inside_the_deadline():
+    # The bug this replaces handed each op 450 of 900 seconds for a schedule
+    # that runs three deep, so a flow could spend 1350 against a 900 budget.
+    assert op_budget_share(900, [[], [0], [0], [0]], 4, 2) == 300
+
+
+def test_a_diamond_under_a_cap_counts_the_pass_its_join_needs():
+    # root → two middles → join. The join cannot start until both middles are
+    # done, so it gets a pass of its own however wide the cap is.
+    assert schedule_wave_count([[], [0], [0], [1, 2]], 4, 2) == 3
+
+
+def test_a_wide_layer_splits_across_passes_under_a_narrow_cap():
+    # A root feeding five dependents at a cap of 2: root, then three passes of
+    # two, two, one.
+    assert schedule_wave_count([[], [0], [0], [0], [0], [0]], 6, 2) == 4
+
+
+def test_an_uncapped_schedule_is_exactly_the_dependency_depth():
+    # With capacity for everyone each pass clears one level, which is the
+    # cheaper short-circuit the function takes.
+    deps = [[], [0], [1]]
+    assert schedule_wave_count(deps, 3, 0) == critical_path_depth(deps) == 3
+    assert schedule_wave_count([[], [], []], 3, 0) == 1
+
+
+def test_a_plan_whose_dependency_data_does_not_match_its_ops_assumes_no_overlap():
+    # Nothing can be said about what overlaps, so every op is assumed serial.
+    assert schedule_wave_count([[], [0]], 4, 2) == 4
+    assert schedule_wave_count([], 3, 2) == 3
+
+
+def test_a_dependency_pointing_outside_the_plan_does_not_stall_the_count():
+    # Matches critical_path_depth's tolerance: a malformed index is ignored
+    # rather than treated as a dependency that can never be satisfied. All four
+    # ops are ready immediately, so the cap alone decides — a stall would give
+    # the no-overlap fallback of 4 instead.
+    assert schedule_wave_count([[], [9], [-1], []], 4, 2) == 2
+
+
+def test_an_empty_plan_has_no_waves():
+    assert schedule_wave_count([], 0, 2) == 0
 
 
 # ── The share an op is actually told ────────────────────────────────────────

--- a/tests/cli/orchestrate/test_flowop_budget_vs_executor.py
+++ b/tests/cli/orchestrate/test_flowop_budget_vs_executor.py
@@ -4,24 +4,53 @@
 """Does the budget's divisor cover every schedule the executor can produce?
 
 `op_budget_share` divides a flow's total budget by `max_sequential_depth`, so a
-divisor that lands BELOW the number of ops the executor actually runs in
-sequence hands every op more time than the flow can afford, and the flow
-overruns its deadline. Every other test of that function checks its arithmetic
+divisor that lands BELOW what the executor actually consumes hands every op more
+time than the flow can afford, and the flow overruns its deadline with later ops
+cancelled part-written. Every other test of that function checks its arithmetic
 against a hand-computed number, which cannot see whether the executor agrees.
 These run the executor.
 
-The scheduling here is real: the same `flow()` entry point production uses.
-Only the work inside an op belongs to the test, and how long that work takes is
-the whole point. An earlier version of this file slept a FIXED amount in every
-op, which held the equal-duration assumption the divisor used to be built on,
-so it agreed with a divisor that undercounted five of these eight shapes and
-read as coverage while doing it. Durations here are deliberately unequal, and
-each shape is swept with the slow op in every admission position, because a
-long-running op holding a slot is what makes the ops behind it serialize.
+The scheduling here is real: the same `flow()` entry point production uses. Only
+the work inside an op belongs to the test, and how long that work takes is the
+whole point. An earlier version slept a FIXED amount in every op, which held the
+equal-duration assumption the divisor used to be built on, so it agreed with a
+divisor that undercounted and read as coverage while doing it. Durations here
+are deliberately unequal, and each shape is swept with the long op in every
+admission position, because a long-running op holding a slot is what makes the
+ops behind it serialize.
 
-The depth is then read off the recorded spans as a longest chain of
-non-overlapping ops, which is what the divisor means and which does not vary
-with how heavy the executor's per-op overhead happens to be.
+WHAT IS MEASURED, AND WHY IT CHANGED
+------------------------------------
+Every op sleeps exactly one budget unit in the primary pattern, so elapsed
+wall clock divided by that unit is literally the number of op-budgets the flow
+consumed. That is the quantity the divisor bounds: the flow overruns precisely
+when consumption exceeds the divisor.
+
+This replaces an earlier reading that took the longest chain of non-overlapping
+spans. That quantity is not the same one, and it is wrong in BOTH directions:
+
+  it OVER-counts   two ops separated by an idle gap are non-overlapping while
+                   consuming no budget in between, so a chain across a gap that
+                   some third op owns reads as extra stages that cost nothing.
+                   Measured: deps [[], [0], [0], [1], [2]] under a cap of 3 with
+                   one slow op reads a chain of 4, while the same shape with
+                   every op at a full budget consumes 3.
+
+  it UNDER-counts  two ops overlapping by half consume one and a half budgets
+                   at a chain length of 1.
+
+Because the span reading over-counts, it would have failed this suite on shapes
+that do not overrun — a false alarm waiting for a future author, in a test whose
+whole job is to be believed.
+
+THE INSTRUMENT PRICES ITSELF
+----------------------------
+A straight chain consumes exactly one budget per op by construction, so it
+measures this machine's per-op executor overhead in the same units everything
+else is reported in. The work unit has to stay well above that overhead: at
+0.15s the ~5ms per-op cost perturbs which ops get admitted together, so the
+instrument changes the schedule it is measuring and readings move by a whole
+budget between runs. At the unit below, readings sit within 0.06 of an integer.
 """
 
 import asyncio
@@ -38,69 +67,66 @@ from lionagi.protocols.graph.edge import Edge
 from lionagi.protocols.graph.graph import Graph
 from lionagi.session.session import Session
 
-# Long enough that scheduling overhead is a rounding error against it, short
-# enough that a dozen stages stay quick.
-WORK = 0.05
+# One op-budget. Large enough that per-op executor overhead is a rounding error
+# against it (see the module docstring: at half this, it is not).
+BUDGET = 0.30
 
-# The two work lengths the sweep hands out. The gap between them has to be
-# wide enough that a slow op is still holding its slot after several fast ops
-# have come and gone, since that queueing is the effect being measured; an
-# order of magnitude does it, and leaves the ordering robust on a loaded
-# machine.
-FAST, SLOW = 0.02, 0.22
+# The short work length in the unequal-duration patterns. An op is free to
+# finish early; the budget only promises it will not run longer.
+SHORT = BUDGET / 8
+
+# Readings land within ~0.06 of an integer on an idle machine. This absorbs
+# executor overhead and ordinary load without absorbing a whole extra op.
+TOLERANCE = 0.35
 
 
-def _duration_patterns(num_ops: int) -> list[list[float]]:
-    """One slow op in each admission position, plus an all-fast control.
+def _duration_patterns(num_ops: int) -> list[tuple[str, list[float]]]:
+    """Patterns obeying the only thing a per-op budget promises: no op exceeds it.
 
-    Which op is slow decides how much serializing happens, and the answer is
-    not the same for every position, so the shape is only swept once every
-    position has been tried. The all-fast row is the schedule the old fixed
-    sleep produced, kept so its result stays visible next to the others.
+    The all-at-budget row is the case where every op actually spends what it was
+    given, and it is the worst of these for every shape measured. The others put
+    a single full-length op in each admission position with the rest short, which
+    is what makes a slot-holder stagger the ops behind it — the effect a fixed
+    sleep in every op cannot produce.
     """
-    patterns = [[FAST] * num_ops]
-    for slow_at in range(num_ops):
-        patterns.append([SLOW if i == slow_at else FAST for i in range(num_ops)])
+    patterns = [("all at budget", [BUDGET] * num_ops)]
+    for long_at in range(num_ops):
+        patterns.append(
+            (
+                f"only admission {long_at} at budget",
+                [BUDGET if i == long_at else SHORT for i in range(num_ops)],
+            )
+        )
     return patterns
 
 
-def _sequential_depth(spans: list[tuple[float, float]]) -> int:
-    """Longest run of ops that executed strictly one after another.
+async def _measure(
+    dep_indices: list[list[int]],
+    num_ops: int,
+    max_concurrent: int,
+    durations: list[float] | None = None,
+    attempts: int = 3,
+) -> tuple[float, int]:
+    """Run the shape several times and keep the LOWEST consumption.
 
-    This is the quantity the budget divisor bounds — the function under test
-    opens by calling itself "the most ops that can end up running one after
-    another". Read off the spans as a longest-path, it is independent of
-    how long an op takes and of the executor's per-op overhead. Dividing the
-    elapsed time by the sleep instead would count that overhead as extra
-    stages: a four-op chain measures seven that way, because ~37ms of setup
-    per op is most of a 50ms work unit.
+    Contention — other tests on the same machine, or a parallel test runner —
+    can only push two ops that would have overlapped apart, which inflates a
+    reading. Nothing makes a flow consume less than it really does. So the
+    smallest reading is the truest one, and a busy machine cannot manufacture
+    either a coverage failure or a changed-behaviour failure out of noise.
+
+    Peak concurrency is taken as the MAXIMUM across attempts, since a cap breach
+    is a breach whenever it happens.
     """
-    ordered = sorted(spans)
-    depths: list[int] = []
-    best = 0
-    for i, (start_i, _end_i) in enumerate(ordered):
-        depth = 1
-        for j in range(i):
-            _start_j, end_j = ordered[j]
-            if end_j <= start_i:
-                depth = max(depth, depths[j] + 1)
-        depths.append(depth)
-        best = max(best, depth)
-    return best
-
-
-def _peak_concurrency(spans: list[tuple[float, float]]) -> int:
-    """Most ops in flight at once, by sweeping the start/end edges."""
-    edges: list[tuple[float, int]] = []
-    for start, end in spans:
-        edges.append((start, 1))
-        edges.append((end, -1))
-    edges.sort()
-    peak = current = 0
-    for _t, delta in edges:
-        current += delta
-        peak = max(peak, current)
-    return peak
+    best = float("inf")
+    peak = 0
+    for _ in range(attempts):
+        consumed, attempt_peak = await _run_real_flow(
+            dep_indices, num_ops, max_concurrent, durations
+        )
+        best = min(best, consumed)
+        peak = max(peak, attempt_peak)
+    return best, peak
 
 
 async def _run_real_flow(
@@ -108,13 +134,18 @@ async def _run_real_flow(
     num_ops: int,
     max_concurrent: int,
     durations: list[float] | None = None,
-) -> tuple[int, int]:
-    """Execute this shape on the real executor; return (stages, peak concurrency).
+) -> tuple[float, int]:
+    """Execute this shape on the real executor; return (budgets consumed, peak).
 
-    `durations` assigns work lengths in the order ops are admitted rather than
-    by op index, because the point of a slow op is that it occupies a slot,
-    and which op holds a slot is a scheduling outcome rather than a property
-    of the graph. Omitted, every op takes the same fixed `WORK`.
+    `durations` assigns work lengths in the order ops are admitted rather than by
+    op index, because the point of a long op is that it occupies a slot, and
+    which op holds a slot is a scheduling outcome rather than a property of the
+    graph.
+
+    Peak concurrency comes from a counter incremented and decremented inside the
+    work itself, so it reports ops genuinely in flight. Deriving it from span
+    arithmetic instead reports a transient breach at a phase boundary, where one
+    op's recorded end and the next op's recorded start differ by microseconds.
     """
     graph = Graph()
     ops = []
@@ -127,23 +158,27 @@ async def _run_real_flow(
             # head runs before tail, so the dependency is the head.
             graph.add_edge(Edge(head=ops[d].id, tail=ops[i].id))
 
-    spans: list[tuple[float, float]] = []
+    finished_at: list[float] = []
     t0 = time.monotonic()
     admitted = 0
+    in_flight = 0
+    peak = 0
 
     async def work(**_kwargs):
-        nonlocal admitted
-        length = WORK if durations is None else durations[admitted % len(durations)]
+        nonlocal admitted, in_flight, peak
+        length = BUDGET if durations is None else durations[admitted % len(durations)]
         admitted += 1
-        start = time.monotonic() - t0
+        in_flight += 1
+        peak = max(peak, in_flight)
         await asyncio.sleep(length)
-        spans.append((start, time.monotonic() - t0))
+        in_flight -= 1
+        finished_at.append(time.monotonic() - t0)
         return "ok"
 
-    # An op that waits on a dependency is run against a CLONE of the branch,
-    # so the clone has to route to the same work function. Without this only
-    # the dependency-free ops execute, and a stage count taken from that
-    # partial run flatters the model instead of testing it.
+    # An op that waits on a dependency is run against a CLONE of the branch, so
+    # the clone has to route to the same work function. Without this only the
+    # dependency-free ops execute, and a reading taken from that partial run
+    # flatters the model instead of testing it.
     def _wire(b):
         b.id = str(uuid4())
         b.chat = AsyncMock(side_effect=work)
@@ -164,113 +199,112 @@ async def _run_real_flow(
 
     result = await flow(session, graph, max_concurrent=max_concurrent, verbose=False)
 
-    # Two independent channels agreeing that the whole graph ran: the
-    # executor's own tally, and the work actually performed. A stage count
-    # derived from a partial run is meaningless, and it fails toward the
-    # model looking correct.
+    # Two independent channels agreeing that the whole graph ran: the executor's
+    # own tally, and the work actually performed. A reading derived from a
+    # partial run is meaningless, and it fails toward the model looking correct.
     completed = len(result["completed_operations"])
     assert completed == num_ops, f"executor completed {completed} of {num_ops} ops"
-    assert len(spans) == num_ops, f"work ran for {len(spans)} of {num_ops} ops"
+    assert len(finished_at) == num_ops, f"work ran for {len(finished_at)} of {num_ops} ops"
 
-    return _sequential_depth(spans), _peak_concurrency(spans)
+    return max(finished_at) / BUDGET, peak
 
 
 # --- Instrument controls -------------------------------------------------
 #
-# Both of these have a stage count that is true by construction rather than by
-# measurement. If either misreads, the timing instrument is not fit to judge
-# anything below it and a disagreement further down would be an artefact.
+# Both have an answer that is true by construction rather than by measurement.
+# If either misreads, the timing instrument is not fit to judge anything below
+# it and a disagreement further down would be an artefact.
 
 
 @pytest.mark.asyncio
-async def test_a_straight_chain_measures_one_stage_per_op():
-    stages, peak = await _run_real_flow([[], [0], [1], [2]], 4, 2)
-    assert stages == 4
+async def test_a_straight_chain_consumes_one_budget_per_op():
+    """Also prices this machine's overhead, in the units everything else uses."""
+    consumed, peak = await _measure([[], [0], [1], [2]], 4, 2)
     assert peak == 1  # a chain can never overlap, whatever the cap allows
+    assert consumed == pytest.approx(4, abs=TOLERANCE), (
+        f"a four-op chain consumed {consumed:.2f} budgets where it must consume 4. "
+        f"Per-op overhead is {(consumed - 4) / 4:.3f} budgets, which is too much of "
+        f"a {BUDGET}s unit for any reading below to mean anything."
+    )
 
 
 @pytest.mark.asyncio
 async def test_independent_ops_fill_the_cap_and_no_more():
-    # Equal durations, so this shape runs as two clean pairs. The sweep below
-    # gets the same four ops to three deep by making one of them slow, which
-    # is the difference a fixed sleep cannot show.
-    stages, peak = await _run_real_flow([[], [], [], []], 4, 2)
-    assert stages == 2
+    consumed, peak = await _measure([[], [], [], []], 4, 2)
     assert peak == 2
+    assert consumed == pytest.approx(2, abs=TOLERANCE)
 
 
 # --- The claim -----------------------------------------------------------
 #
-# `expected` is not derived from the function. It is the depth the executor was
-# measured reaching on that shape, written down so a change to the divisor has
-# to argue with a number rather than silently redefine what it is compared
-# against. A test that asked only "does the divisor cover what we just
-# measured" would follow the divisor wherever it went.
+# Neither pinned number is derived from the function under test. `divisor` is
+# what the function returns today and `consumed` is what the executor was
+# measured spending, so a change to either has to argue with a number rather
+# than silently redefine what it is compared against.
+#
+# The two are NOT equal on every shape, and that is the design rather than a
+# defect: the divisor is an upper bound, and overcounting only makes per-op
+# budgets conservative while undercounting makes a flow overrun its own
+# deadline. Where a shape carries slack, the capacity term bounds a
+# serialization that this shape's dependencies never actually force. Pinning
+# both columns is what keeps the bound honest — a divisor loosened toward the
+# op count reddens the first column, and it cannot be excused by the second.
 
 SWEEP_SHAPES = [
-    # (name, dep_indices, num_ops, max_concurrent, expected depth)
-    ("four independent ops", [[], [], [], []], 4, 2, 3),
-    ("a straight chain of four", [[], [0], [1], [2]], 4, 2, 4),
-    ("three independent ops and one dependent", [[], [], [], [0]], 4, 2, 3),
-    ("one root feeding three dependents", [[], [0], [0], [0]], 4, 2, 3),
-    ("a chain whose ops sort last", [[], [], [], [2], [3]], 5, 2, 4),
-    ("a chain competing with independent work", [[], [], [0], [], [], [2]], 6, 2, 5),
-    ("two chains sharing a cap of two", [[], [0], [], [2], [1], [3]], 6, 2, 5),
-    ("a wide fan-in behind a narrow cap", [[], [], [], [], [0, 1, 2, 3]], 5, 2, 4),
+    # (name, dep_indices, num_ops, max_concurrent, divisor, budgets consumed)
+    ("four independent ops", [[], [], [], []], 4, 2, 3, 2),
+    ("a straight chain of four", [[], [0], [1], [2]], 4, 2, 4, 4),
+    ("three independent ops and one dependent", [[], [], [], [0]], 4, 2, 3, 2),
+    ("one root feeding three dependents", [[], [0], [0], [0]], 4, 2, 3, 3),
+    ("a chain whose ops sort last", [[], [], [], [2], [3]], 5, 2, 4, 4),
+    ("a chain competing with independent work", [[], [], [0], [], [], [2]], 6, 2, 5, 4),
+    ("two chains sharing a cap of two", [[], [0], [], [2], [1], [3]], 6, 2, 5, 3),
+    ("a wide fan-in behind a narrow cap", [[], [], [], [], [0, 1, 2, 3]], 5, 2, 4, 3),
+    # Staggered unlocks: each of two mid-layer ops releases a different
+    # dependent. With one op long and the rest short the ops finish in an order
+    # that looks like a four-deep chain, which is what a span-based reading
+    # counted; at a full budget each the flow consumes three.
+    ("staggered unlocks under a cap of three", [[], [0], [0], [1], [2]], 5, 3, 3, 3),
 ]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("name,deps,num_ops,cap,expected", SWEEP_SHAPES)
-async def test_the_divisor_covers_the_worst_schedule_without_being_looser(
-    name, deps, num_ops, cap, expected
+@pytest.mark.parametrize("name,deps,num_ops,cap,divisor,consumed", SWEEP_SHAPES)
+async def test_the_divisor_covers_every_schedule_this_shape_can_produce(
+    name, deps, num_ops, cap, divisor, consumed
 ):
-    """Two properties, and they fail in opposite directions.
+    """COVERAGE is the property that matters in production.
 
-    COVERAGE is the one that matters in production: a divisor below the depth
-    the executor reaches hands every op more time than the flow can afford, and
-    the flow overruns its own deadline with later ops cancelled part-written.
-
-    TIGHTNESS keeps the first property from being satisfied trivially.
-    Returning the op count always covers, and always shrinks every op's budget
-    to the serial worst case, so this pins the divisor to the depth actually
-    reachable rather than to a safe constant.
-
-    Every duration pattern runs twice and the lower depth is kept. Load on the
-    machine can only push apart two ops that would otherwise have overlapped,
-    which inflates a depth; nothing makes a depth read low. So the smaller
-    reading is the truer one, and a busy machine cannot manufacture either a
-    coverage failure or a tightness failure out of noise.
+    A divisor below what the executor consumes hands every op more time than the
+    flow can afford. The sweep runs every duration pattern in which no op exceeds
+    its budget — the only thing a per-op budget promises — and takes the worst.
     """
-    divisor = max_sequential_depth(deps, num_ops, cap)
-    assert divisor == expected, (
-        f"{name}: the divisor is now {divisor} where this shape was measured at "
-        f"{expected}. If the executor's behaviour changed, re-measure and update "
-        f"`expected`; if it did not, the divisor has moved away from reality."
+    actual_divisor = max_sequential_depth(deps, num_ops, cap)
+    assert actual_divisor == divisor, (
+        f"{name}: the divisor is now {actual_divisor} where it was {divisor}. If "
+        f"this is a deliberate change, the measured consumption below ({consumed}) "
+        f"says whether it is still a bound: at least that, or flows of this shape "
+        f"overrun their deadline."
     )
 
-    per_pattern: list[int] = []
-    for durations in _duration_patterns(num_ops):
-        attempts = []
-        for _attempt in range(2):
-            stages, peak = await _run_real_flow(deps, num_ops, cap, durations)
-            assert peak <= cap, (
-                f"{name}: {peak} ops in flight under a cap of {cap} — the cap was "
-                f"not enforced, so this run says nothing about sequencing"
-            )
-            attempts.append(stages)
-        per_pattern.append(min(attempts))
+    worst = 0.0
+    worst_pattern = ""
+    for pattern_name, durations in _duration_patterns(num_ops):
+        budgets, peak = await _measure(deps, num_ops, cap, durations, attempts=2)
+        assert peak <= cap, (
+            f"{name}: {peak} ops in flight under a cap of {cap} — the cap was not "
+            f"enforced, so this run says nothing about sequencing"
+        )
+        if budgets > worst:
+            worst, worst_pattern = budgets, pattern_name
 
-    worst = max(per_pattern)
-    assert worst <= divisor, (
-        f"{name}: the executor ran {worst} ops in sequence (per duration pattern: "
-        f"{per_pattern}) where the divisor is {divisor}. Each op is handed "
-        f"total/{divisor} seconds, so a flow of this shape overruns its deadline "
-        f"by {worst - divisor} ops' worth of budget."
+    assert worst <= divisor + TOLERANCE, (
+        f"{name}: the executor consumed {worst:.2f} op-budgets under '{worst_pattern}' "
+        f"where the divisor is {divisor}. Each op is handed total/{divisor} seconds, "
+        f"so a flow of this shape overruns its deadline."
     )
-    assert worst == divisor, (
-        f"{name}: the divisor is {divisor} but no duration pattern got the "
-        f"executor past {worst} (per pattern: {per_pattern}). The budget is being "
-        f"divided by more stages than this shape can produce, so every op is told "
-        f"it has less time than it really has."
+    assert worst == pytest.approx(consumed, abs=TOLERANCE), (
+        f"{name}: the executor consumed {worst:.2f} op-budgets under '{worst_pattern}' "
+        f"where this shape was measured at {consumed}. The scheduler's behaviour on "
+        f"this shape has changed; re-measure before touching the divisor."
     )

--- a/tests/cli/orchestrate/test_flowop_budget_vs_executor.py
+++ b/tests/cli/orchestrate/test_flowop_budget_vs_executor.py
@@ -1,23 +1,27 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Does the budget's scheduling model promise more parallelism than the executor delivers?
+"""Does the budget's divisor cover every schedule the executor can produce?
 
-`op_budget_share` divides a flow's total budget by `schedule_wave_count`, so a
-count that lands BELOW the number of stages the executor actually runs hands
-every op more time than the flow can afford, and the flow overruns its
-deadline. `schedule_wave_count` documents the opposite direction: the real
-schedule "can only beat, never lose to" its count when ops take comparable
-time. Every other test of that function checks its arithmetic against a
-hand-computed number, which cannot see whether the executor agrees. These run
-the executor.
+`op_budget_share` divides a flow's total budget by `max_sequential_depth`, so a
+divisor that lands BELOW the number of ops the executor actually runs in
+sequence hands every op more time than the flow can afford, and the flow
+overruns its deadline. Every other test of that function checks its arithmetic
+against a hand-computed number, which cannot see whether the executor agrees.
+These run the executor.
 
-The scheduling here is real — the same `flow()` entry point production uses.
-Only the work inside an op belongs to the test: a fixed sleep, so the
-equal-duration precondition the claim names actually holds. The stage count is
-then read off the recorded spans as a longest chain of non-overlapping ops,
-which is what the divisor means and which does not vary with how heavy the
-executor's per-op overhead happens to be.
+The scheduling here is real: the same `flow()` entry point production uses.
+Only the work inside an op belongs to the test, and how long that work takes is
+the whole point. An earlier version of this file slept a FIXED amount in every
+op, which held the equal-duration assumption the divisor used to be built on,
+so it agreed with a divisor that undercounted five of these eight shapes and
+read as coverage while doing it. Durations here are deliberately unequal, and
+each shape is swept with the slow op in every admission position, because a
+long-running op holding a slot is what makes the ops behind it serialize.
+
+The depth is then read off the recorded spans as a longest chain of
+non-overlapping ops, which is what the divisor means and which does not vary
+with how heavy the executor's per-op overhead happens to be.
 """
 
 import asyncio
@@ -27,7 +31,7 @@ from uuid import uuid4
 
 import pytest
 
-from lionagi.cli.orchestrate.flow import schedule_wave_count
+from lionagi.cli.orchestrate.flow import max_sequential_depth
 from lionagi.operations.flow import flow
 from lionagi.operations.node import Operation
 from lionagi.protocols.graph.edge import Edge
@@ -38,13 +42,34 @@ from lionagi.session.session import Session
 # enough that a dozen stages stay quick.
 WORK = 0.05
 
+# The two work lengths the sweep hands out. The gap between them has to be
+# wide enough that a slow op is still holding its slot after several fast ops
+# have come and gone, since that queueing is the effect being measured; an
+# order of magnitude does it, and leaves the ordering robust on a loaded
+# machine.
+FAST, SLOW = 0.02, 0.22
+
+
+def _duration_patterns(num_ops: int) -> list[list[float]]:
+    """One slow op in each admission position, plus an all-fast control.
+
+    Which op is slow decides how much serializing happens, and the answer is
+    not the same for every position, so the shape is only swept once every
+    position has been tried. The all-fast row is the schedule the old fixed
+    sleep produced, kept so its result stays visible next to the others.
+    """
+    patterns = [[FAST] * num_ops]
+    for slow_at in range(num_ops):
+        patterns.append([SLOW if i == slow_at else FAST for i in range(num_ops)])
+    return patterns
+
 
 def _sequential_depth(spans: list[tuple[float, float]]) -> int:
     """Longest run of ops that executed strictly one after another.
 
-    This is the quantity the budget divisor is supposed to be — the function
-    under test opens by calling it "how many ops actually end up running one
-    after another". Read off the spans as a longest-path, it is independent of
+    This is the quantity the budget divisor bounds — the function under test
+    opens by calling itself "the most ops that can end up running one after
+    another". Read off the spans as a longest-path, it is independent of
     how long an op takes and of the executor's per-op overhead. Dividing the
     elapsed time by the sleep instead would count that overhead as extra
     stages: a four-op chain measures seven that way, because ~37ms of setup
@@ -79,9 +104,18 @@ def _peak_concurrency(spans: list[tuple[float, float]]) -> int:
 
 
 async def _run_real_flow(
-    dep_indices: list[list[int]], num_ops: int, max_concurrent: int
+    dep_indices: list[list[int]],
+    num_ops: int,
+    max_concurrent: int,
+    durations: list[float] | None = None,
 ) -> tuple[int, int]:
-    """Execute this shape on the real executor; return (stages, peak concurrency)."""
+    """Execute this shape on the real executor; return (stages, peak concurrency).
+
+    `durations` assigns work lengths in the order ops are admitted rather than
+    by op index, because the point of a slow op is that it occupies a slot,
+    and which op holds a slot is a scheduling outcome rather than a property
+    of the graph. Omitted, every op takes the same fixed `WORK`.
+    """
     graph = Graph()
     ops = []
     for i in range(num_ops):
@@ -95,10 +129,14 @@ async def _run_real_flow(
 
     spans: list[tuple[float, float]] = []
     t0 = time.monotonic()
+    admitted = 0
 
     async def work(**_kwargs):
+        nonlocal admitted
+        length = WORK if durations is None else durations[admitted % len(durations)]
+        admitted += 1
         start = time.monotonic() - t0
-        await asyncio.sleep(WORK)
+        await asyncio.sleep(length)
         spans.append((start, time.monotonic() - t0))
         return "ok"
 
@@ -153,49 +191,86 @@ async def test_a_straight_chain_measures_one_stage_per_op():
 
 @pytest.mark.asyncio
 async def test_independent_ops_fill_the_cap_and_no_more():
+    # Equal durations, so this shape runs as two clean pairs. The sweep below
+    # gets the same four ops to three deep by making one of them slow, which
+    # is the difference a fixed sleep cannot show.
     stages, peak = await _run_real_flow([[], [], [], []], 4, 2)
     assert stages == 2
     assert peak == 2
 
 
 # --- The claim -----------------------------------------------------------
+#
+# `expected` is not derived from the function. It is the depth the executor was
+# measured reaching on that shape, written down so a change to the divisor has
+# to argue with a number rather than silently redefine what it is compared
+# against. A test that asked only "does the divisor cover what we just
+# measured" would follow the divisor wherever it went.
 
-SHAPES = [
-    # (name, dep_indices, num_ops, max_concurrent)
-    ("one root feeding three dependents", [[], [0], [0], [0]], 4, 2),
-    ("a chain whose ops sort last", [[], [], [], [2], [3]], 5, 2),
-    ("a chain competing with independent work", [[], [], [0], [], [], [2]], 6, 2),
-    ("two chains sharing a cap of two", [[], [0], [], [2], [1], [3]], 6, 2),
-    ("a wide fan-in behind a narrow cap", [[], [], [], [], [0, 1, 2, 3]], 5, 2),
+SWEEP_SHAPES = [
+    # (name, dep_indices, num_ops, max_concurrent, expected depth)
+    ("four independent ops", [[], [], [], []], 4, 2, 3),
+    ("a straight chain of four", [[], [0], [1], [2]], 4, 2, 4),
+    ("three independent ops and one dependent", [[], [], [], [0]], 4, 2, 3),
+    ("one root feeding three dependents", [[], [0], [0], [0]], 4, 2, 3),
+    ("a chain whose ops sort last", [[], [], [], [2], [3]], 5, 2, 4),
+    ("a chain competing with independent work", [[], [], [0], [], [], [2]], 6, 2, 5),
+    ("two chains sharing a cap of two", [[], [0], [], [2], [1], [3]], 6, 2, 5),
+    ("a wide fan-in behind a narrow cap", [[], [], [], [], [0, 1, 2, 3]], 5, 2, 4),
 ]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("name,deps,num_ops,cap", SHAPES)
-async def test_the_model_never_promises_more_parallelism_than_the_executor_delivers(
-    name, deps, num_ops, cap
+@pytest.mark.parametrize("name,deps,num_ops,cap,expected", SWEEP_SHAPES)
+async def test_the_divisor_covers_the_worst_schedule_without_being_looser(
+    name, deps, num_ops, cap, expected
 ):
-    """The budget divisor must not come in under the executor's real stage count.
+    """Two properties, and they fail in opposite directions.
 
-    Measured on the best of three runs. A run that happens to be slowed by
-    other load inflates its stage count, so taking the fastest keeps a busy
-    machine from manufacturing a failure — and a model that undercounts even
-    the executor's best schedule has undercounted.
+    COVERAGE is the one that matters in production: a divisor below the depth
+    the executor reaches hands every op more time than the flow can afford, and
+    the flow overruns its own deadline with later ops cancelled part-written.
+
+    TIGHTNESS keeps the first property from being satisfied trivially.
+    Returning the op count always covers, and always shrinks every op's budget
+    to the serial worst case, so this pins the divisor to the depth actually
+    reachable rather than to a safe constant.
+
+    Every duration pattern runs twice and the lower depth is kept. Load on the
+    machine can only push apart two ops that would otherwise have overlapped,
+    which inflates a depth; nothing makes a depth read low. So the smaller
+    reading is the truer one, and a busy machine cannot manufacture either a
+    coverage failure or a tightness failure out of noise.
     """
-    model = schedule_wave_count(deps, num_ops, cap)
+    divisor = max_sequential_depth(deps, num_ops, cap)
+    assert divisor == expected, (
+        f"{name}: the divisor is now {divisor} where this shape was measured at "
+        f"{expected}. If the executor's behaviour changed, re-measure and update "
+        f"`expected`; if it did not, the divisor has moved away from reality."
+    )
 
-    observed = []
-    for _attempt in range(3):
-        stages, peak = await _run_real_flow(deps, num_ops, cap)
-        assert peak <= cap, (
-            f"{name}: {peak} ops in flight under a cap of {cap} — the cap was not "
-            f"enforced, so elapsed time says nothing about how many stages ran"
-        )
-        observed.append(stages)
+    per_pattern: list[int] = []
+    for durations in _duration_patterns(num_ops):
+        attempts = []
+        for _attempt in range(2):
+            stages, peak = await _run_real_flow(deps, num_ops, cap, durations)
+            assert peak <= cap, (
+                f"{name}: {peak} ops in flight under a cap of {cap} — the cap was "
+                f"not enforced, so this run says nothing about sequencing"
+            )
+            attempts.append(stages)
+        per_pattern.append(min(attempts))
 
-    best = min(observed)
-    assert best <= model, (
-        f"{name}: the executor needed {best} stages (runs: {observed}) where the "
-        f"model budgeted for {model}. Each op is handed total/{model} seconds, so "
-        f"a flow of this shape overruns its deadline by {best - model} stages."
+    worst = max(per_pattern)
+    assert worst <= divisor, (
+        f"{name}: the executor ran {worst} ops in sequence (per duration pattern: "
+        f"{per_pattern}) where the divisor is {divisor}. Each op is handed "
+        f"total/{divisor} seconds, so a flow of this shape overruns its deadline "
+        f"by {worst - divisor} ops' worth of budget."
+    )
+    assert worst == divisor, (
+        f"{name}: the divisor is {divisor} but no duration pattern got the "
+        f"executor past {worst} (per pattern: {per_pattern}). The budget is being "
+        f"divided by more stages than this shape can produce, so every op is told "
+        f"it has less time than it really has."
     )

--- a/tests/cli/orchestrate/test_flowop_budget_vs_executor.py
+++ b/tests/cli/orchestrate/test_flowop_budget_vs_executor.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Does the budget's scheduling model promise more parallelism than the executor delivers?
+
+`op_budget_share` divides a flow's total budget by `schedule_wave_count`, so a
+count that lands BELOW the number of stages the executor actually runs hands
+every op more time than the flow can afford, and the flow overruns its
+deadline. `schedule_wave_count` documents the opposite direction: the real
+schedule "can only beat, never lose to" its count when ops take comparable
+time. Every other test of that function checks its arithmetic against a
+hand-computed number, which cannot see whether the executor agrees. These run
+the executor.
+
+The scheduling here is real — the same `flow()` entry point production uses.
+Only the work inside an op belongs to the test: a fixed sleep, so the
+equal-duration precondition the claim names actually holds. The stage count is
+then read off the recorded spans as a longest chain of non-overlapping ops,
+which is what the divisor means and which does not vary with how heavy the
+executor's per-op overhead happens to be.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from lionagi.cli.orchestrate.flow import schedule_wave_count
+from lionagi.operations.flow import flow
+from lionagi.operations.node import Operation
+from lionagi.protocols.graph.edge import Edge
+from lionagi.protocols.graph.graph import Graph
+from lionagi.session.session import Session
+
+# Long enough that scheduling overhead is a rounding error against it, short
+# enough that a dozen stages stay quick.
+WORK = 0.05
+
+
+def _sequential_depth(spans: list[tuple[float, float]]) -> int:
+    """Longest run of ops that executed strictly one after another.
+
+    This is the quantity the budget divisor is supposed to be — the function
+    under test opens by calling it "how many ops actually end up running one
+    after another". Read off the spans as a longest-path, it is independent of
+    how long an op takes and of the executor's per-op overhead. Dividing the
+    elapsed time by the sleep instead would count that overhead as extra
+    stages: a four-op chain measures seven that way, because ~37ms of setup
+    per op is most of a 50ms work unit.
+    """
+    ordered = sorted(spans)
+    depths: list[int] = []
+    best = 0
+    for i, (start_i, _end_i) in enumerate(ordered):
+        depth = 1
+        for j in range(i):
+            _start_j, end_j = ordered[j]
+            if end_j <= start_i:
+                depth = max(depth, depths[j] + 1)
+        depths.append(depth)
+        best = max(best, depth)
+    return best
+
+
+def _peak_concurrency(spans: list[tuple[float, float]]) -> int:
+    """Most ops in flight at once, by sweeping the start/end edges."""
+    edges: list[tuple[float, int]] = []
+    for start, end in spans:
+        edges.append((start, 1))
+        edges.append((end, -1))
+    edges.sort()
+    peak = current = 0
+    for _t, delta in edges:
+        current += delta
+        peak = max(peak, current)
+    return peak
+
+
+async def _run_real_flow(
+    dep_indices: list[list[int]], num_ops: int, max_concurrent: int
+) -> tuple[int, int]:
+    """Execute this shape on the real executor; return (stages, peak concurrency)."""
+    graph = Graph()
+    ops = []
+    for i in range(num_ops):
+        op = Operation(operation="chat", parameters={"idx": i})
+        graph.add_node(op)
+        ops.append(op)
+    for i, deps in enumerate(dep_indices):
+        for d in deps:
+            # head runs before tail, so the dependency is the head.
+            graph.add_edge(Edge(head=ops[d].id, tail=ops[i].id))
+
+    spans: list[tuple[float, float]] = []
+    t0 = time.monotonic()
+
+    async def work(**_kwargs):
+        start = time.monotonic() - t0
+        await asyncio.sleep(WORK)
+        spans.append((start, time.monotonic() - t0))
+        return "ok"
+
+    # An op that waits on a dependency is run against a CLONE of the branch,
+    # so the clone has to route to the same work function. Without this only
+    # the dependency-free ops execute, and a stage count taken from that
+    # partial run flatters the model instead of testing it.
+    def _wire(b):
+        b.id = str(uuid4())
+        b.chat = AsyncMock(side_effect=work)
+        b.get_operation = MagicMock(
+            side_effect=lambda operation: b.chat if operation == "chat" else None
+        )
+        b.clone = MagicMock(side_effect=lambda sender=None: _wire(MagicMock()))
+        b._message_manager = MagicMock()
+        b._message_manager.pile = MagicMock()
+        b._message_manager.pile.clear = MagicMock()
+        return b
+
+    branch = _wire(MagicMock())
+
+    session = Session()
+    session.branches.include(branch)
+    session.default_branch = branch
+
+    result = await flow(session, graph, max_concurrent=max_concurrent, verbose=False)
+
+    # Two independent channels agreeing that the whole graph ran: the
+    # executor's own tally, and the work actually performed. A stage count
+    # derived from a partial run is meaningless, and it fails toward the
+    # model looking correct.
+    completed = len(result["completed_operations"])
+    assert completed == num_ops, f"executor completed {completed} of {num_ops} ops"
+    assert len(spans) == num_ops, f"work ran for {len(spans)} of {num_ops} ops"
+
+    return _sequential_depth(spans), _peak_concurrency(spans)
+
+
+# --- Instrument controls -------------------------------------------------
+#
+# Both of these have a stage count that is true by construction rather than by
+# measurement. If either misreads, the timing instrument is not fit to judge
+# anything below it and a disagreement further down would be an artefact.
+
+
+@pytest.mark.asyncio
+async def test_a_straight_chain_measures_one_stage_per_op():
+    stages, peak = await _run_real_flow([[], [0], [1], [2]], 4, 2)
+    assert stages == 4
+    assert peak == 1  # a chain can never overlap, whatever the cap allows
+
+
+@pytest.mark.asyncio
+async def test_independent_ops_fill_the_cap_and_no_more():
+    stages, peak = await _run_real_flow([[], [], [], []], 4, 2)
+    assert stages == 2
+    assert peak == 2
+
+
+# --- The claim -----------------------------------------------------------
+
+SHAPES = [
+    # (name, dep_indices, num_ops, max_concurrent)
+    ("one root feeding three dependents", [[], [0], [0], [0]], 4, 2),
+    ("a chain whose ops sort last", [[], [], [], [2], [3]], 5, 2),
+    ("a chain competing with independent work", [[], [], [0], [], [], [2]], 6, 2),
+    ("two chains sharing a cap of two", [[], [0], [], [2], [1], [3]], 6, 2),
+    ("a wide fan-in behind a narrow cap", [[], [], [], [], [0, 1, 2, 3]], 5, 2),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name,deps,num_ops,cap", SHAPES)
+async def test_the_model_never_promises_more_parallelism_than_the_executor_delivers(
+    name, deps, num_ops, cap
+):
+    """The budget divisor must not come in under the executor's real stage count.
+
+    Measured on the best of three runs. A run that happens to be slowed by
+    other load inflates its stage count, so taking the fastest keeps a busy
+    machine from manufacturing a failure — and a model that undercounts even
+    the executor's best schedule has undercounted.
+    """
+    model = schedule_wave_count(deps, num_ops, cap)
+
+    observed = []
+    for _attempt in range(3):
+        stages, peak = await _run_real_flow(deps, num_ops, cap)
+        assert peak <= cap, (
+            f"{name}: {peak} ops in flight under a cap of {cap} — the cap was not "
+            f"enforced, so elapsed time says nothing about how many stages ran"
+        )
+        observed.append(stages)
+
+    best = min(observed)
+    assert best <= model, (
+        f"{name}: the executor needed {best} stages (runs: {observed}) where the "
+        f"model budgeted for {model}. Each op is handed total/{model} seconds, so "
+        f"a flow of this shape overruns its deadline by {best - model} stages."
+    )


### PR DESCRIPTION
A flow tells each op roughly how many seconds it has, so the op can pace itself.
That figure came from dividing the flow's total budget by the number of ops,
which is only right if every op runs one after another. In a wide graph they do
not, so every op was told it had a fraction of the wall clock it actually had.

Three producers feeding one consumer is four ops, but only two of them run in
sequence: against a 900 second budget each op was told 225 seconds when 450 was
available.

That figure is not harmless, because the preamble carrying it also says to
prefer "good enough by the deadline" and to stop researching past 70% of
budget. An op that believes it has half its real time drops whatever is not the
deliverable, and the things that run at the very end of an op are the first to
go.

## The direction of the error, which decides everything else

This number is a divisor, so being wrong in one direction is not like being
wrong in the other.

Counting **too few** ops in sequence hands every op more time than the flow can
afford. The flow overruns its own deadline and the later work is cancelled
part-written, which is the failure the budget exists to prevent.

Counting **too many** tells an op it has somewhat less time than it might have
had. It paces itself more conservatively and finishes.

So this is an **upper bound, chosen to be loose in the safe direction**, and
ties break toward the larger divisor deliberately. A later change that tightens
it for its own sake is moving toward the failing direction and needs to argue
for that, which is why the tests now assert tightness against the executor
rather than leaving it to taste.

## The change

Divide by the most ops that can end up running one after another. Two things
push ops into sequence, and the answer is the worse of them:

- **Dependencies** force a chain no amount of capacity can shorten.
- **Capacity** forces the rest. When ops are ready the executor admits
  `max_concurrent` of them at once, and a run of ops executing strictly one
  after another can contain at most *one* op out of any set that started
  together — so such a run is at most one of that first batch plus every op
  outside it, `num_ops - max_concurrent + 1`.

Neither can exceed `num_ops`, the everything-serializes case.

`critical_path_depth` stays as the exact short-circuit for the uncapped case:
with capacity for everyone, only dependencies serialize anything, so the answer
*is* the longest chain. That is the common case and a single linear scan.

The function is renamed to `max_sequential_depth`. It no longer counts waves,
and the old name was the model this replaces.

## Four wrong answers on the way here

This branch arrived at the bound by getting it wrong four times, and each wrong
answer is worth stating because each one looked right and had green tests.

**Dividing by the dependency chain alone.** The premise was that the only thing
serializing two ops is a dependency between them. `--max-concurrent 1` runs four
independent ops strictly one after another while the chain is still one op long,
so each would have been handed the flow's entire wall clock.

**Taking the larger of the chain and `ceil(num_ops / max_concurrent)`.** The two
interact rather than compete: a dependency does not only lengthen the chain, it
*idles capacity*, and the ops it blocks get picked up later. One root feeding
three dependents at a cap of 2 has a chain of 2 and needs `ceil(4 / 2) = 2` full
batches, so both bounds say 2 and so does the larger of them. It runs three
deep. Taking the max of two lower bounds yields a lower bound, not the answer.

**Simulating the schedule as passes.** Repeatedly take the ops whose
dependencies are satisfied, admit up to `max_concurrent`, count the passes. This
is exact — for one schedule. It assumes every op takes about as long as every
other, and the executor runs a great many schedules where they do not.

**Simulating it as a queue.** Same walk, but admitting from the front of a
FIFO queue, because the executor's shared `CapacityLimiter` hands slots out in
arrival order and an op whose dependency just cleared cannot overtake ops that
have been queued all along. More faithful, and still a simulation of one
schedule.

The fourth is where the approach itself gives out. The quantity being computed
depends on **how long each op runs**, and a budget is computed before any of
them have run. Give four ops a cap of two and let one of them run ten times
longer than the rest: the other three serialize behind it three deep, where
every simulation above counts two. Unequal durations are the normal case rather
than the corner, so the equal-duration schedule is the wrong thing to be exact
about. A duration-agnostic function cannot compute a duration-dependent
quantity, which is why this is now a bound and not an estimate.

## What the old suite could not see

The acceptance file runs the real `flow()` executor rather than a model of it,
which is what caught the third and fourth wrong answers. But every op in it
slept a **fixed** amount, and that fixed sleep is precisely the equal-duration
assumption the divisor was built on. The harness held the one condition under
which the divisor was correct, so it agreed with it — and read as coverage
while doing so.

Swept adversarially with unequal durations, the previous divisor undercounts
**five of the eight shapes the file then had**, and three of those five were shapes
the suite already had and passed.

So the harness changed, not just the case list. Durations are now unequal, and
each shape is swept with the slow op in every admission position, since which
op is slow decides how much serializing happens and the answer is not the same
for every position.

## Tests

`critical_path_depth` and `op_budget_share` are covered directly: straight
chain, fully independent ops, fan-in, two unequal branches, empty plan, and a
dependency index pointing outside the plan (ignored rather than raising — this
only sizes a hint in a prompt and should not be able to end a run).

`max_sequential_depth` covers the shape neither bound can see alone (one root,
three dependents, cap 2) and asserts alongside it that the chain is 2 and
`ceil(4 / 2)` is 2, so the test states *why* a batch count cannot reach 3 rather
than just disagreeing with it. Then a diamond whose join must follow both
middles, a wide layer queueing behind a narrow cap, the uncapped case agreeing
exactly with the chain length, mismatched dependency data, an out-of-range index
that must not stall the count, and an empty plan.

Against the real executor, all nine shapes now assert two things about the same
measured number.

What is measured changed in this branch, and that is the substantive part. The
sweep used to read a shape's cost as the longest chain of non-overlapping spans.
That is not the quantity the divisor bounds, and it is wrong in both directions:
two ops separated by an idle gap that some third op owns are non-overlapping
while consuming nothing in between, and two ops overlapping by half consume one
and a half budgets at a chain length of one. Concretely, `[[], [0], [0], [1],
[2]]` under a cap of three reads a chain of four when one op is slow, while the
same shape with every op at a full budget consumes three — so the old reading
would have failed this suite on a flow that does not overrun.

Every op now sleeps exactly one budget unit, so elapsed wall clock in those units
is literally how many budgets the flow spent, and coverage becomes the exact
question of whether it can overrun.

- **Coverage** — consumption never exceeds the divisor. This is the production
  property.
- **The pinned pair** — each shape writes down both what the divisor returns and
  what the executor was measured spending, so a change has to argue with a number
  rather than silently redefine what it is compared against.

Several shapes carry slack between the two columns, and that is the design rather
than a defect: the capacity term bounds a serialization those shapes' dependencies
never actually force, and overcounting only makes budgets conservative. An earlier
revision asserted the two were equal, which held only because it compared against
the span reading; under the quantity that matters the equality is false, and
pinning both columns is what keeps a loosened divisor from passing.

Confirmed load-bearing by mutation: loosening the divisor to `num_ops` reddens
eight of nine, and dropping the capacity term to leave only the dependency chain
reddens seven of nine. The survivors are the right ones in each case — the
straight chain under the first, where `num_ops` genuinely is the answer, and the
chain plus the staggered shape under the second, where dependencies alone bound
the schedule.

The instrument prices itself: a straight chain consumes one budget per op by
construction, so it reports this machine's per-op executor overhead in the same
units, and fails loudly if that overhead is too large for any reading below it to
mean anything. The work unit is 0.30s because at half that the per-op cost
perturbs which ops get admitted together, moving readings by a whole budget
between runs. Peak concurrency comes from a counter inside the work rather than
from span arithmetic, which reported a transient cap breach at phase boundaries
where one op's recorded end and the next op's recorded start differ by
microseconds.

Preamble construction lives in `_build_budget_preambles` so the share an op is
actually told can be asserted rather than only the arithmetic that computes it.
That distinction matters here: with the share tested alone, restoring an equal
split at the call site left the whole suite green, because nothing read the
caller. A check on `_run_flow_inner`'s syntax tree now fails if the arithmetic
moves back out of the helper.

Two notes on what this deliberately does not model:

- A plan whose dependency list does not describe its ops falls back to
  `num_ops`, the assumption that nothing overlaps, rather than to a number
  derived from data that does not match. Conservative in the same direction.
  Both construction paths keep the two in step, so it is a guard rather than a
  live path.
- The preambles are built once from the planned ops, so an op added later by a
  reactive spawn is told nothing about the budget rather than a figure computed
  without it. Unchanged here, and the safe direction, but it does mean a heavily
  reactive flow paces only the ops it planned.

Verified: `tests/cli/orchestrate/` passes with the `[mcp]` extra installed.
Without it, four tests in three files this branch does not touch fail with
`ImportError: FastMCP not installed`; installing the extra clears all four, so
they are environmental rather than introduced here.

