### PR TITLE
Stop the budget preamble from talking ops out of recording what they learned

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -400,6 +400,9 @@ budget is approximately {seconds} seconds (until {deadline_iso} UTC).
 - Prefer "good enough by the deadline" over "ideal but late".
 - If you find yourself >70% through your budget and still in research, \
 switch to writing the deliverable with what you have.
+- Recording what you learned is part of finishing, not research. Memory and \
+knowledge-base writes cost seconds, so the rule above is never a reason to \
+skip them.
 - You can check the current time: `date -Iseconds`.
 [/BUDGET]
 

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -30,6 +30,30 @@ def test_format_budget_preamble_contains_expected_fields():
     assert "200 seconds" in text
 
 
+def test_format_budget_preamble_exempts_persistence_from_the_deadline_rule():
+    """Measured on a real run: legs read recording what they learned as research.
+
+    The preamble tells an op to switch from research to the deliverable once it
+    is 70% through its budget. Three of four workers in one flow cited the budget
+    as the reason they skipped their memory and knowledge-base writes entirely —
+    which is a permanent loss for seconds of work, and it does not get better by
+    handing them a larger budget, since the same rule bites at the same point.
+
+    So the exemption has to be stated where the rule is, and this asserts both
+    halves are present together: dropping the exemption while keeping the rule
+    reproduces the behaviour it was written to stop.
+    """
+    text = _format_budget_preamble(
+        op_index=1,
+        num_ops=3,
+        op_budget_seconds=450,
+        deadline_epoch=time.time() + 900,
+    )
+    assert "still in research" in text, "the deadline rule this exempts is missing"
+    assert "part of finishing, not research" in text
+    assert "never a reason to skip" in text
+
+
 def test_format_budget_preamble_deadline_iso_format():
     deadline = time.time() + 600
     text = _format_budget_preamble(


### PR DESCRIPTION
## What

One line added to the per-op budget preamble, and a test that keeps it there.

## Why

The preamble already tells an op:

> If you find yourself >70% through your budget and still in research, switch to
> writing the deliverable with what you have.

Workers classify their memory and knowledge-base writes as research and drop
them. This is measured, not inferred: in one flow, three of the four workers
said so in their own output, each naming the budget as the reason.

The trade is bad in both directions. The writes cost seconds, so cutting them
buys almost no time. What is lost is permanent, because the next run starts
without anything this one learned. And it does not improve by handing the flow a
larger budget, since the rule bites at the same fraction of whatever it is
given — a worker with twice the time that spends it researching reaches the same
70% and makes the same cut.

## The change

```
- If you find yourself >70% through your budget and still in research,
  switch to writing the deliverable with what you have.
+ Recording what you learned is part of finishing, not research. Memory and
+ knowledge-base writes cost seconds, so the rule above is never a reason to
+ skip them.
- You can check the current time: `date -Iseconds`.
```

The exemption is stated where the rule is, so an op reading one reads the other.

## Tests

`test_format_budget_preamble_exempts_persistence_from_the_deadline_rule` asserts
both halves are present together — the rule and its exemption. Asserting the
exemption alone would pass in a preamble that had lost the rule it qualifies,
which is a different template than the one this reasons about.

Confirmed load-bearing: removing the exemption line while keeping the rule
reddens exactly that test and nothing else. `tests/cli/orchestrate/` passes.

## Scope

Prompt text only. No behaviour, no arithmetic, no scheduling. Whether a worker
then keeps its writes is a model decision this can influence but not enforce;
the intended follow-up evidence is a real flow observed after this lands.
