### PR TITLE
Tell each op the deadline its own share implies

### DIFF
--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -392,10 +392,33 @@ async def _finalize_applied(db, control_id: str, claim: str | None = None) -> st
     return _CONTROL_UNSTAMPED
 
 
+# An op is told two numbers, and they have to agree. The share is per wave;
+# the flow's end is not. Handing every op "N seconds (until <flow end>)" put a
+# wave-1 op in a plan three waves deep in front of a sentence whose two halves
+# were three times apart, and the >70%-switch-to-writing rule keys off the
+# share, so it started drafting when it had used a third of the time it really
+# had. Which number an op paced against came down to which half it believed.
+_BUDGET_OPENING_WAVED = """\
+You are op {op_index} of {num_ops} in this flow, in wave {wave} of {waves}. \
+Your share of the total budget is approximately {seconds} seconds, which on \
+this plan runs until {op_deadline_iso} UTC. The flow as a whole ends at \
+{deadline_iso} UTC; that later time is not your deadline."""
+
+# When a concurrency cap forces more ops into sequence than the dependency
+# chain does, an op's wave stops being a property of the plan: it depends on
+# who finishes first, which is not known when this text is written. Saying so
+# is better than naming a wave that the schedule may not honour, because an op
+# handed a deadline it starts out already past has no good move.
+_BUDGET_OPENING_QUEUED = """\
+You are op {op_index} of {num_ops} in this flow. Your share of the total \
+budget is approximately {seconds} seconds, counted from when you start; ops \
+queue for capacity in this run, so when that is cannot be known in advance. \
+The flow as a whole ends at {deadline_iso} UTC; that is the flow's deadline, \
+not yours."""
+
 _BUDGET_PREAMBLE_TEMPLATE = """\
 [BUDGET]
-You are op {op_index} of {num_ops} in this flow. Your share of the total \
-budget is approximately {seconds} seconds (until {deadline_iso} UTC).
+{opening}
 - Pace your reasoning accordingly.
 - Prefer "good enough by the deadline" over "ideal but late".
 - If you find yourself >70% through your budget and still in research, \
@@ -407,6 +430,30 @@ skip them.
 [/BUDGET]
 
 """
+
+
+def dependency_depths(dep_indices: list[list[int]]) -> list[int]:
+    """How far down the dependency chain each op sits, one-based, per op.
+
+    An op's depth is the wave it can first run in when nothing caps
+    concurrency: everything at depth 1 starts together, depth 2 waits for one
+    of them, and so on.
+
+    Dependencies point backwards (op i may only depend on ops before it), so a
+    single forward pass is enough. Cycles are therefore not reachable here, and
+    an entry pointing outside the plan is ignored rather than raising: a bad
+    index should not be able to take down a run over a budget hint.
+
+    The longest chain and the per-op depths come from one traversal on purpose.
+    They are the same walk, and two copies of it would be free to disagree
+    about a plan while each looked right on its own tests.
+    """
+    depths = [1] * len(dep_indices)
+    for i, deps in enumerate(dep_indices):
+        for j in deps:
+            if 0 <= j < i:
+                depths[i] = max(depths[i], depths[j] + 1)
+    return depths
 
 
 def critical_path_depth(dep_indices: list[list[int]]) -> int:
@@ -424,20 +471,10 @@ def critical_path_depth(dep_indices: list[list[int]]) -> int:
     together with what the cap forces. This function is exact only when nothing
     caps concurrency, which is the common case and why it is still worth
     computing directly.
-
-    Dependencies point backwards (op i may only depend on ops before it), so a
-    single forward pass is enough. Cycles are therefore not reachable here, and
-    an entry pointing outside the plan is ignored rather than raising: a bad
-    index should not be able to take down a run over a budget hint.
     """
     if not dep_indices:
         return 0
-    depths = [1] * len(dep_indices)
-    for i, deps in enumerate(dep_indices):
-        for j in deps:
-            if 0 <= j < i:
-                depths[i] = max(depths[i], depths[j] + 1)
-    return max(depths)
+    return max(dependency_depths(dep_indices))
 
 
 def max_sequential_depth(dep_indices: list[list[int]], num_ops: int, max_concurrent: int) -> int:
@@ -532,12 +569,26 @@ def _build_budget_preambles(
     if not total_budget or num_ops <= 0:
         return {}
     share = op_budget_share(total_budget, dep_indices, num_ops, max_concurrent)
+    waves = max_sequential_depth(dep_indices, num_ops, max_concurrent)
+
+    # An op's wave is a property of the plan only while the dependency chain is
+    # what forces ops into sequence. Once a concurrency cap forces more than the
+    # chain does, where an op lands depends on who finishes first, so there is
+    # no wave to name and the preamble says so instead of guessing one.
+    depths: list[int] = []
+    if len(dep_indices) == num_ops and waves > 0 and waves == critical_path_depth(dep_indices):
+        depths = dependency_depths(dep_indices)
+
+    flow_start = deadline_epoch - total_budget
     return {
         i: _format_budget_preamble(
             op_index=i + 1,
             num_ops=num_ops,
             op_budget_seconds=share,
             deadline_epoch=deadline_epoch,
+            wave=depths[i] if depths else None,
+            waves=waves if depths else None,
+            op_deadline_epoch=(flow_start + depths[i] * share) if depths else None,
         )
         for i in range(num_ops)
     }
@@ -548,17 +599,35 @@ def _format_budget_preamble(
     num_ops: int,
     op_budget_seconds: int,
     deadline_epoch: float,
+    wave: int | None = None,
+    waves: int | None = None,
+    op_deadline_epoch: float | None = None,
 ) -> str:
+    """One op's budget preamble.
+
+    Without a wave the opening states the share alone and names the flow's end
+    as the flow's, since that is all that can be said honestly. That is also
+    the safe default for a caller that has no schedule to hand over.
+    """
     import datetime
 
-    deadline_dt = datetime.datetime.fromtimestamp(deadline_epoch, tz=datetime.timezone.utc)
-    deadline_iso = deadline_dt.strftime("%Y-%m-%dT%H:%M:%S")
-    return _BUDGET_PREAMBLE_TEMPLATE.format(
+    def _iso(epoch: float) -> str:
+        dt = datetime.datetime.fromtimestamp(epoch, tz=datetime.timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+    deadline_iso = _iso(deadline_epoch)
+    waved = wave is not None and waves is not None and op_deadline_epoch is not None
+    template = _BUDGET_OPENING_WAVED if waved else _BUDGET_OPENING_QUEUED
+    opening = template.format(
         op_index=op_index,
         num_ops=num_ops,
         seconds=op_budget_seconds,
         deadline_iso=deadline_iso,
+        wave=wave,
+        waves=waves,
+        op_deadline_iso=_iso(op_deadline_epoch) if op_deadline_epoch is not None else "",
     )
+    return _BUDGET_PREAMBLE_TEMPLATE.format(opening=opening)
 
 
 async def _resolve_invocation_terminal_flow(

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -16,6 +16,7 @@ from lionagi.cli.orchestrate.flow import (
     _build_budget_preambles,
     _format_budget_preamble,
     critical_path_depth,
+    dependency_depths,
     max_sequential_depth,
     op_budget_share,
 )
@@ -297,6 +298,112 @@ def test_preamble_numbers_the_ops_from_one():
     preambles = _build_budget_preambles(600, [[], [0], [1]], 3, 0, time.time() + 600)
     assert "op 1 of 3" in preambles[0]
     assert "op 3 of 3" in preambles[2]
+
+
+# ── The share and the deadline have to describe the same thing ─────────────
+#
+# Measured on a real 9-op run: every op got the identical sentence, "your share
+# is approximately 1800 seconds (until 15:31:32 UTC)", while the run began at
+# 13:59:57. For a wave-1 op those two halves are 1800s and 5400s apart — the
+# same sentence naming a budget and a deadline three times its size. The
+# >70%-switch-to-writing rule keys off the share, so a wave-1 op begins drafting
+# a third of the way into the time it actually has.
+#
+# These fix the arithmetic in the text, so they compute against a pinned epoch
+# rather than `time.time()`: a test that recomputes the expected instant the
+# same way the code does would agree with any answer the code gave.
+
+_EPOCH = 1_786_000_000.0  # a fixed instant, so the expected strings are literals
+
+
+def _deadlines_in(preamble: str) -> list[str]:
+    return re.findall(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", preamble)
+
+
+def test_a_first_wave_op_is_given_its_own_waves_deadline_not_the_flows():
+    """The defect, stated directly: 1800s and an instant 5400s away.
+
+    Three waves of 1800s each. The first op's own deadline must land one share
+    in, and the flow's end must still be present but named as the flow's.
+    """
+    flow_end = _EPOCH + 5400
+    preambles = _build_budget_preambles(5400, [[], [], [0, 1], [2]], 4, 0, flow_end)
+    first = preambles[0]
+
+    assert _seconds_in(first) == 1800
+    assert "wave 1 of 3" in first
+    # _EPOCH + 1800, not _EPOCH + 5400.
+    assert "runs until 2026-08-06T07:36:40 UTC" in first
+    assert "flow as a whole ends at 2026-08-06T08:36:40 UTC" in first
+    assert "that later time is not your deadline" in first
+
+
+def test_each_wave_gets_a_different_deadline():
+    """Under the old text every preamble was identical but for the op number.
+
+    So this is the assertion that separates the two versions: three waves must
+    produce three distinct op deadlines, and ops sharing a wave must share one.
+    """
+    flow_end = _EPOCH + 5400
+    p = _build_budget_preambles(5400, [[], [], [0, 1], [2]], 4, 0, flow_end)
+    own = [_deadlines_in(p[i])[0] for i in range(4)]
+
+    assert own[0] == own[1], "ops 1 and 2 are both in wave 1"
+    assert len({own[0], own[2], own[3]}) == 3, f"waves collapsed to one deadline: {own}"
+    assert own[0] < own[2] < own[3], f"later waves must fall later: {own}"
+
+
+def test_the_last_waves_deadline_is_the_flows_deadline():
+    """The chain of per-wave deadlines has to end where the flow does.
+
+    If it landed short, the final op would be told to finish before the flow
+    needs it; if it overran, the wave deadlines would promise time the flow has
+    already spent.
+    """
+    flow_end = _EPOCH + 5400
+    p = _build_budget_preambles(5400, [[], [], [0, 1], [2]], 4, 0, flow_end)
+    own, flow = _deadlines_in(p[3])
+    assert own == flow == "2026-08-06T08:36:40"
+
+
+def test_a_capped_run_names_no_wave_because_it_has_none_to_name():
+    """A cap forcing more sequence than the chain makes the wave unknowable.
+
+    Four independent ops through one slot run one after another, but which op
+    goes when depends on nothing in the plan. Naming a wave here would hand
+    three of the four a deadline they start out already past, so the text says
+    the share is counted from the start it cannot predict.
+    """
+    flow_end = _EPOCH + 900
+    p = _build_budget_preambles(900, [[], [], [], []], 4, 1, flow_end)
+    text = p[0]
+
+    assert "wave" not in text.split("[/BUDGET]")[0].split("- Pace")[0]
+    assert "counted from when you start" in text
+    assert "that is the flow's deadline, not yours" in text
+    assert _deadlines_in(text) == ["2026-08-06T07:21:40"], (
+        "a run with no derivable wave should name one instant, the flow's"
+    )
+
+
+def test_an_uncapped_plan_still_names_waves_when_the_cap_is_slack():
+    """The guard keys on whether the cap BINDS, not on whether one was given.
+
+    A cap of four over a four-op plan changes no schedule, so the waves are
+    still the plan's and must still be named. A guard written as "any cap at
+    all" would silence them here.
+    """
+    p = _build_budget_preambles(900, [[], [0], [1]], 3, 4, _EPOCH + 900)
+    assert "wave 1 of 3" in p[0]
+    assert "wave 3 of 3" in p[2]
+
+
+def test_dependency_depths_places_each_op_in_its_own_wave():
+    # Two roots, a join, then a tail: depths 1, 1, 2, 3.
+    assert dependency_depths([[], [], [0, 1], [2]]) == [1, 1, 2, 3]
+    # Unequal branches: the join takes the longer one.
+    assert dependency_depths([[], [0], [1], [0], [2, 3]]) == [1, 2, 3, 2, 4]
+    assert dependency_depths([]) == []
 
 
 def test_no_preambles_without_a_total_budget():


### PR DESCRIPTION
A flow divides its budget by how many ops must run one after another, so the
share is per wave. The deadline in the same sentence was the whole flow's.
Every op got the identical pair.

Measured on a real nine-op run, three waves deep, 5400s total:

> `Your share of the total budget is approximately 1800 seconds (until
> 2026-08-10T15:31:32 UTC)`

The run started at 13:59:57. For a first-wave op those two halves are 1800
seconds and 5400 seconds — the same sentence naming a budget and a deadline
three times its size. The bullet directly below it says to stop researching
and start writing at 70% of budget, and that rule keys off the share, so a
first-wave op begins drafting a third of the way into the time it has. A
last-wave op reading the instant instead has no share-based margin left.
Which number an op paces against comes down to which half it believes.

## What changes

The deadline is now computed per wave, like the share already was. An op is
told which wave it is in and the instant that wave's share runs out, and the
flow's own end is named separately as the flow's:

> `You are op 1 of 4 in this flow, in wave 1 of 3. Your share of the total
> budget is approximately 1800 seconds, which on this plan runs until
> 14:31:32 UTC. The flow as a whole ends at 15:31:32 UTC; that later time is
> not your deadline.`

The chain of wave deadlines ends exactly where the flow does.

## Where a wave cannot be named

When a concurrency cap forces more ops into sequence than the dependency chain
does, an op's wave stops being a property of the plan — it depends on who
finishes first, which is not known when the text is written. Naming a wave
there would hand most ops a deadline they start out already past, and an op in
that position has no good move. So the preamble says the share is counted from
the start it cannot predict, and names the flow's end as the flow's.

The guard keys on whether the cap *binds*, not on whether one was given: a cap
of four over a four-op plan changes no schedule, so the waves are still the
plan's and are still named.

## Notes

Per-op depths and the longest chain now come from one traversal. They are the
same walk, and two copies would be free to disagree about a plan while each
looked right on its own tests.

Tests compute against a pinned epoch rather than the wall clock: a test that
recomputed the expected instant the same way the source does would agree with
whatever answer the source gave.

Three mutations, each with its reddened arms predicted before running and
matched after:

| mutation | predicted red | observed |
|---|---|---|
| never derive a wave | 4 | 4 |
| drop the binding-cap guard | 1 (the capped-run test) | 1 |
| point the op deadline at the flow's end (the defect above) | 2, last-wave stays green | 2, last-wave green |