### PR TITLE
Date an op's deadline from when the timeout starts

### DIFF
--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -523,6 +523,14 @@ class OrchestrationEnv:
 
     # None = no budget configured; workers skip the BUDGET preamble.
     total_budget: int | None = None
+
+    # The wall-clock instant the run's timeout actually begins counting from,
+    # captured where that clock starts rather than derived later. Everything
+    # between the clock starting and an op being told its allowance — planning
+    # above all — is time already spent, and a deadline recomputed after it has
+    # been spent names an instant the run will never reach. None when no budget
+    # is configured, which is the same condition that skips the preamble.
+    budget_deadline_epoch: float | None = None
     _live_persist: dict | None = field(default=None, repr=False)
     _run_manifest: dict[str, Any] = field(default_factory=dict, repr=False)
     _name_counts: dict[str, int] = field(default_factory=dict)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -537,6 +537,16 @@ def _build_budget_preambles(
     the instant therefore means no preamble at all, since telling an op
     nothing is the honest failure and telling it a late deadline is not.
     """
+    if total_budget and num_ops > 0 and deadline_epoch is None:
+        # A budgeted run that got this far without an instant is a wiring
+        # error rather than a configuration: the limit will still be enforced
+        # on these ops, they just will not be told about it. Staying silent is
+        # right about the value and wrong about the event, so name the event
+        # once and still refuse to invent the value.
+        _warn(
+            "flow has a total budget but no recorded deadline instant; "
+            "its ops will be given no budget guidance"
+        )
     if not total_budget or num_ops <= 0 or deadline_epoch is None:
         return {}
     share = op_budget_share(total_budget, dep_indices, num_ops, max_concurrent)
@@ -2629,11 +2639,16 @@ async def _run_flow(
     result: str = ""
     try:
         if timeout:
-            # Fix the deadline here, where the clock it belongs to starts, and
-            # carry the instant rather than the duration. Deriving it later
-            # measures from whenever "later" happens to be, so every second
-            # spent planning pushed the deadline every op was told a second
-            # further out than the one this scope will actually enforce.
+            # Fix the deadline immediately before the scope whose clock it
+            # describes, and carry the instant rather than the duration.
+            # Deriving it later measures from whenever "later" happens to be,
+            # so every second spent planning pushed the deadline every op was
+            # told a second further out than the one this scope will actually
+            # enforce. Reading the clock just before entry rather than inside
+            # the scope leaves a gap of one context-manager entry, which makes
+            # the advertised deadline very slightly early; that is the safe
+            # direction, since an op told it has less time than the scope will
+            # allow finishes early instead of being cancelled mid-work.
             env.budget_deadline_epoch = time.time() + timeout
             with move_on_after(timeout) as cancel_scope:
                 result = await _run_flow_inner(model_spec, prompt, **inner_kw)

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -520,7 +520,7 @@ def _build_budget_preambles(
     dep_indices: list[list[int]],
     num_ops: int,
     max_concurrent: int,
-    deadline_epoch: float,
+    deadline_epoch: float | None,
 ) -> dict[int, str]:
     """The per-op budget preambles for one flow, keyed by op index.
 
@@ -528,8 +528,16 @@ def _build_budget_preambles(
     asserted directly. Tests that only call `op_budget_share` cannot see
     whether the caller uses it, which is how the equal-split divisor survived
     a suite that was green the whole time.
+
+    `deadline_epoch` is an instant the caller captured when the run's clock
+    started, not a duration to add to now. It is deliberately not defaulted:
+    the obvious fallback, `now + total_budget`, is wrong by however long the
+    run has already been going, and it is wrong silently and in the permissive
+    direction — every op would be told it has more time than it does. Missing
+    the instant therefore means no preamble at all, since telling an op
+    nothing is the honest failure and telling it a late deadline is not.
     """
-    if not total_budget or num_ops <= 0:
+    if not total_budget or num_ops <= 0 or deadline_epoch is None:
         return {}
     share = op_budget_share(total_budget, dep_indices, num_ops, max_concurrent)
     return {
@@ -2621,6 +2629,12 @@ async def _run_flow(
     result: str = ""
     try:
         if timeout:
+            # Fix the deadline here, where the clock it belongs to starts, and
+            # carry the instant rather than the duration. Deriving it later
+            # measures from whenever "later" happens to be, so every second
+            # spent planning pushed the deadline every op was told a second
+            # further out than the one this scope will actually enforce.
+            env.budget_deadline_epoch = time.time() + timeout
             with move_on_after(timeout) as cancel_scope:
                 result = await _run_flow_inner(model_spec, prompt, **inner_kw)
             if cancel_scope.cancelled_caught:
@@ -2952,7 +2966,7 @@ async def _run_flow_inner(
         dep_indices,
         len(assignments),
         max_concurrent,
-        time.time() + (env.total_budget or 0),
+        env.budget_deadline_epoch,
     )
 
     plan_result = _PlanResult(

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -168,6 +168,7 @@ def _make_resume_env(tmp_path: Path) -> SimpleNamespace:
         bare=True,
         effort=None,
         total_budget=None,
+        budget_deadline_epoch=None,
         team_data=None,
         team_attach=None,
         pack=None,

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -28,7 +28,15 @@ from lionagi.cli.orchestrate.flow import (
 # ── Shared stubs ──────────────────────────────────────────────────────────────
 
 
-def _make_env(tmp_path, *, bare=True, total_budget=None, team_data=None, live_persist=None):
+def _make_env(
+    tmp_path,
+    *,
+    bare=True,
+    total_budget=None,
+    budget_deadline_epoch=None,
+    team_data=None,
+    live_persist=None,
+):
     """Minimal OrchestrationEnv stub for phase tests."""
     name_counts: dict = {}
 
@@ -62,6 +70,7 @@ def _make_env(tmp_path, *, bare=True, total_budget=None, team_data=None, live_pe
         bare=bare,
         effort=None,
         total_budget=total_budget,
+        budget_deadline_epoch=budget_deadline_epoch,
         team_data=team_data,
         pack=None,
         verbose=False,

--- a/tests/cli/orchestrate/test_flow_planning.py
+++ b/tests/cli/orchestrate/test_flow_planning.py
@@ -76,6 +76,7 @@ def _env(tmp_path, orc) -> SimpleNamespace:
         bare=True,
         effort=None,
         total_budget=None,
+        budget_deadline_epoch=None,
         team_data=None,
         pack=None,
         session=SimpleNamespace(),

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -353,6 +353,29 @@ def test_no_preambles_without_a_captured_deadline_instant():
     assert _build_budget_preambles(600, [[], [0]], 2, 0, None) == {}
 
 
+def test_a_budgeted_run_without_an_instant_says_so(monkeypatch):
+    """Silent about the value, loud about the event.
+
+    Refusing to invent a deadline is right, but a budgeted run reaching this
+    point without one means the instant was never wired through, and the ops
+    are about to be held to a limit nobody told them about. That is worth a
+    line on stderr even though it is not worth a guess.
+    """
+    from lionagi.cli.orchestrate import flow as flow_mod
+
+    said: list[str] = []
+    monkeypatch.setattr(flow_mod, "_warn", lambda msg: said.append(msg))
+
+    assert flow_mod._build_budget_preambles(600, [[], [0]], 2, 0, None) == {}
+    assert said, "a budgeted run with no captured instant passed without a word"
+
+    # The quiet cases stay quiet: no budget means no budget guidance was ever
+    # owed, so warning there would train the reader to ignore the channel.
+    said.clear()
+    assert flow_mod._build_budget_preambles(None, [[], [0]], 2, 0, None) == {}
+    assert not said, f"warned about an unbudgeted run: {said}"
+
+
 def test_the_preamble_renders_the_instant_it_was_handed():
     """A fixed instant renders as itself, so a recomputed one is visible."""
     import datetime
@@ -397,6 +420,22 @@ def test_the_flow_hands_over_the_stored_instant_instead_of_deriving_one():
             "the call site is deriving a deadline from the current time again, which "
             "dates it from whenever planning happened to finish"
         )
+    # Reading the right field is not enough on its own: overwriting it here,
+    # after planning and just before the call, restores the defect while still
+    # satisfying every assertion above. Planning happens in this function, so
+    # the only safe number of writes to the field here is none.
+    rewritten = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Attribute) and target.attr == "budget_deadline_epoch"
+    ]
+    assert not rewritten, (
+        f"_run_flow_inner assigns budget_deadline_epoch at line(s) {rewritten}; the "
+        "instant belongs to the caller that opens the timeout scope, and re-dating "
+        "it here is the original defect wearing the fix's field name"
+    )
 
 
 def test_the_deadline_is_recorded_before_the_timeout_scope_opens():
@@ -431,7 +470,10 @@ def test_the_deadline_is_recorded_before_the_timeout_scope_opens():
     # function that no longer has a timeout scope at all.
     assert scope_opened, "no timeout scope in _run_flow — this test is aimed at the wrong function"
     assert recorded, "_run_flow must record the instant its timeout clock starts counting from"
-    assert min(recorded) < min(scope_opened), (
+    # Every write, not just the first: an early assignment followed by a later
+    # one leaves the earliest line where it was, so comparing minima would call
+    # a re-dated deadline correct.
+    assert max(recorded) < min(scope_opened), (
         "the deadline is recorded after the timeout scope opens, so it dates from "
         "later than the clock it is supposed to describe"
     )

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -338,6 +338,105 @@ def test_the_flow_builds_its_preambles_through_the_shared_helper():
     )
 
 
+# ── the deadline instant is captured, not recomputed ───────────────────────
+
+
+def test_no_preambles_without_a_captured_deadline_instant():
+    """A missing instant means no preamble, never a substitute one.
+
+    The obvious fallback is `now + total_budget`, and it is wrong by however
+    long the run has already been going. It is also wrong permissively: every
+    op would be told it has more time than the flow will actually give it,
+    which is the direction that produces overruns rather than early finishes.
+    Saying nothing is the honest failure here.
+    """
+    assert _build_budget_preambles(600, [[], [0]], 2, 0, None) == {}
+
+
+def test_the_preamble_renders_the_instant_it_was_handed():
+    """A fixed instant renders as itself, so a recomputed one is visible."""
+    import datetime
+
+    captured = 1786380000.0
+    expected = datetime.datetime.fromtimestamp(captured, tz=datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+    assert expected in _build_budget_preambles(600, [[], [0]], 2, 0, captured)[0]
+
+
+def test_the_flow_hands_over_the_stored_instant_instead_of_deriving_one():
+    """The call site must pass the recorded instant, not build one from now.
+
+    `_build_budget_preambles` cannot tell where its instant came from, so every
+    test above stays green if the call site goes back to `time.time() + budget`.
+    That is the defect exactly: the arithmetic was right and the moment it ran
+    was wrong, which no assertion about the arithmetic can see.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from lionagi.cli.orchestrate import flow as flow_mod
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(flow_mod._run_flow_inner)))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_build_budget_preambles"
+    ]
+    assert calls, "no call to _build_budget_preambles found — this test is looking at nothing"
+    for call in calls:
+        attrs = {n.attr for arg in call.args for n in ast.walk(arg) if isinstance(n, ast.Attribute)}
+        assert "budget_deadline_epoch" in attrs, (
+            "the deadline handed to the preamble builder must be the instant recorded "
+            "when the run's clock started, read off the environment"
+        )
+        assert "time" not in attrs, (
+            "the call site is deriving a deadline from the current time again, which "
+            "dates it from whenever planning happened to finish"
+        )
+
+
+def test_the_deadline_is_recorded_before_the_timeout_scope_opens():
+    """Where the instant is taken is the whole fix.
+
+    Taken after the scope opens, it is already late by everything that ran in
+    between, and what runs in between is the planning phase every flow pays
+    for before its first op exists.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from lionagi.cli.orchestrate import flow as flow_mod
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(flow_mod._run_flow)))
+    recorded = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Attribute) and target.attr == "budget_deadline_epoch"
+    ]
+    scope_opened = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "move_on_after"
+    ]
+    # Control: without this the ordering assertion below passes vacuously on a
+    # function that no longer has a timeout scope at all.
+    assert scope_opened, "no timeout scope in _run_flow — this test is aimed at the wrong function"
+    assert recorded, "_run_flow must record the instant its timeout clock starts counting from"
+    assert min(recorded) < min(scope_opened), (
+        "the deadline is recorded after the timeout scope opens, so it dates from "
+        "later than the clock it is supposed to describe"
+    )
+
+
 def test_no_budget_preamble_when_total_budget_none():
     """The total_budget None guard produces no preamble entries."""
     total_budget = None


### PR DESCRIPTION
A flow hands every op a `[BUDGET]` preamble naming the absolute instant its
allowance ends. That instant was computed inside the planning path as "now
plus the budget". The timeout it describes starts earlier, when the cancel
scope opens, and planning happens in between.

On a measured run, planning took 63 seconds before the first op existed. Every
op was therefore told a deadline 63 seconds later than the one the flow will
actually enforce, and an op that paces itself against that number is pacing
against a moment the run never reaches.

## The change

The instant is captured where the clock it belongs to starts, and carried on
the orchestration environment beside the budget it goes with. The preamble
builder now takes an instant rather than deriving one.

It has no fallback on purpose. The obvious default, `now + total_budget`, is
wrong by however long the run has already been going, and wrong permissively:
every op would believe it has more time than it will get, which is the
direction that produces overruns. A missing instant produces no preamble
rather than a late one.

## On the tests

The assertions about the arithmetic cannot see this defect. The builder has no
way to tell where its instant came from, so every existing budget test stays
green if the call site goes back to computing one from the current time. That
is the shape of the bug: the arithmetic was right and the moment it ran was
wrong.

So two of the new tests read the callers. One requires the stored instant to be
what gets passed; the other requires it to be recorded before the timeout scope
opens, with a control asserting the scope is still there so the ordering check
cannot pass against a function that no longer has one. Both were checked by
reversing the change each guards: each reddened exactly one test and nothing
else.

The environment stand-ins in the phase, planning and resume test helpers gain
the field next to `total_budget`, so they keep mirroring the real environment
instead of only the parts some current test happens to read.

## Known gap, not addressed here

An op spawned after planning still receives no budget preamble at all. The
planned path prefixes one per op index; the reactive spawn decorator returns
the request instruction and artifact text only, and the stored operation is
that instruction. This is unchanged by this PR and predates it. It does not
affect a flow with no reactive spawns, and it becomes real debt the moment
someone runs a reactive flow under a budget.

Three tests in `tests/cli/orchestrate/test_role_config.py` and
`test_role_roster.py` fail on `main` at the merge base and still fail here.
They are unrelated to this change and were confirmed failing on an untouched
checkout of `main` before this branch was cut.