### PR TITLE
fix(studio): let the board render when the backend is slower than the watchdog

### DIFF
--- a/apps/studio/frontend/src/components/fleet/useFleet.ts
+++ b/apps/studio/frontend/src/components/fleet/useFleet.ts
@@ -33,13 +33,26 @@ export function useFleet(filters?: FleetFilters): FleetState {
 
   useEffect(() => {
     let active = true;
+    let inFlight = false;
     let lastSuccessAt = Date.now();
+    let everSucceeded = false;
 
     const watchdog = setInterval(() => {
       if (!active) return;
       if (Date.now() - lastSuccessAt > STALE_THRESHOLD_MS) {
+        // Only a view that has already shown data can go stale. Before the
+        // first success there is no earlier state to flap back to, and arming
+        // the hysteresis here would gate the very first render behind a run of
+        // consecutive successes.
+        if (!everSucceeded) return;
+        // Deliberately does NOT reset successStreak. Silence means the current
+        // fetch has not come back yet, which is what a slow backend looks
+        // like, not a failure — the catch path owns that. Clearing the streak
+        // on every tick of a gap longer than the threshold makes the streak
+        // unreachable whenever a fetch is slower than STALE_THRESHOLD_MS, and
+        // the view then stays on its loading skeleton through any number of
+        // successful fetches.
         wasStaleRef.current = true;
-        successStreak.current = 0;
         dispatch({ type: "MARK_STALE" });
       }
     }, 1_000);
@@ -51,6 +64,13 @@ export function useFleet(filters?: FleetFilters): FleetState {
 
     async function poll() {
       if (!active) return;
+      // A tick that arrives while the previous poll is still outstanding is
+      // dropped, not queued. Without this the interval keeps opening requests
+      // regardless of how long they take, so once a fetch is slower than
+      // POLL_INTERVAL_MS the outstanding count grows without bound and the
+      // view never receives a first response at all.
+      if (inFlight) return;
+      inFlight = true;
       try {
         const nowSec = Math.floor(Date.now() / 1000);
         const [invsResp, runsResp] = await Promise.all([
@@ -60,6 +80,7 @@ export function useFleet(filters?: FleetFilters): FleetState {
         if (!active) return;
 
         lastSuccessAt = Date.now();
+        everSucceeded = true;
         successStreak.current += 1;
 
         if (!wasStaleRef.current || successStreak.current >= STABLE_RESUMPTION_COUNT) {
@@ -82,6 +103,11 @@ export function useFleet(filters?: FleetFilters): FleetState {
           type: "DATA_ERROR",
           message: err instanceof Error ? err.message : "API unreachable",
         });
+      } finally {
+        // Both branches above return early once unmounted, so releasing the
+        // guard anywhere but here would leave it held and stop polling for
+        // good on the next remount.
+        inFlight = false;
       }
     }
 

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -34,7 +34,12 @@ import {
   transitiveReduceDisplay,
 } from "@/lib/operationGraph";
 import type { LaneSignal, OperationStatus } from "@/lib/operationGraph";
-import { deriveDisplayStatus, deriveVerdict, isEffectivelyActive } from "@/lib/runStatus";
+import {
+  deriveDisplayStatus,
+  deriveVerdict,
+  isEffectivelyActive,
+  isUnsuccessfulTerminal,
+} from "@/lib/runStatus";
 import type { Verdict } from "@/lib/runStatus";
 import type { RunMessage, RunResumeResponse, RunStep, WorkerGraph } from "@/lib/types";
 import type { NodeExecStatus } from "@/components/canvas/StepNode";
@@ -637,6 +642,8 @@ function ProgressSummaryBar({
 
 interface OverviewData {
   status: string;
+  /** Why the run ended this way, for terminal statuses that need explaining. */
+  statusReason?: string | null;
   durationSec: number | null;
   branchCount: number;
   messageCount: number;
@@ -697,6 +704,14 @@ function OverviewSection({ data }: { data: OverviewData }) {
             </div>
           ))}
         </div>
+        {data.statusReason && (
+          <div className="mt-3 border-t border-edge-subtle pt-3">
+            <span className="text-[length:var(--t-xs)] font-semibold uppercase tracking-wider text-content-muted">
+              {t("statStatus")}
+            </span>
+            <p className="mt-0.5 text-meta text-content-secondary">{data.statusReason}</p>
+          </div>
+        )}
         {provenance.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-3 border-t border-edge-subtle pt-3">
             {provenance.map((p) => (
@@ -1990,6 +2005,13 @@ export default function RunDetail({ id }: RunDetailProps) {
 
   const overviewData: OverviewData = {
     status: displayStatus,
+    // A run that ends badly owes the operator a sentence. The backend already
+    // writes one (e.g. "Run exceeded the configured timeout." for a blown
+    // deadline); without this it never reaches the page, and a timed-out run
+    // shows a bare "cancelled" beside two branches reading "failed".
+    statusReason: isUnsuccessfulTerminal(runForStatus)
+      ? (session.status_reason_summary ?? null)
+      : null,
     durationSec,
     branchCount: session.branches.length,
     messageCount: totalMessages,

--- a/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
+++ b/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
@@ -425,7 +425,7 @@ describe("useLiveBoard — a poll slower than the interval does not stack", () =
     // 8s per fetch: longer than the 5s watchdog, so every gap between
     // successes trips "stale". That is an ordinary slow backend, not a fault,
     // and the board still owes the operator the data it successfully fetched.
-    const slow = <T,>(value: T) =>
+    const slow = <T>(value: T) =>
       new Promise<T>((resolve) => setTimeout(() => resolve(value), 8_000));
 
     vi.mocked(listRuns).mockImplementation(() =>
@@ -440,7 +440,14 @@ describe("useLiveBoard — a poll slower than the interval does not stack", () =
       }),
     );
     vi.mocked(listInvocations).mockImplementation(() =>
-      slow({ invocations: [], limit: 100, offset: 0, has_next: false, total: 0, completed_total: 0 }),
+      slow({
+        invocations: [],
+        limit: 100,
+        offset: 0,
+        has_next: false,
+        total: 0,
+        completed_total: 0,
+      }),
     );
     vi.mocked(listSchedules).mockImplementation(() => slow({ schedules: [] }));
 

--- a/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
+++ b/apps/studio/frontend/src/components/mission/useLiveBoard.test.ts
@@ -359,3 +359,106 @@ describe("useLiveBoard — schedules degrade-to-null on fetch failure", () => {
     vi.useRealTimers();
   });
 });
+
+// ─── Poll overlap ─────────────────────────────────────────────────────────────
+// The board polls on a fixed interval. The interval says how often to *want*
+// fresh data, not how many requests may be open at once. When a fetch outlives
+// the interval, an unguarded poller opens another one on every tick while the
+// earlier ones are still outstanding, so the outstanding count grows for as
+// long as the slowness lasts and the first request never gets answered.
+
+describe("useLiveBoard — a poll slower than the interval does not stack", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latestState: BoardState | null;
+
+  function Harness() {
+    latestState = useLiveBoard();
+    return null;
+  }
+
+  beforeEach(() => {
+    vi.mocked(listRuns).mockReset();
+    vi.mocked(listInvocations).mockReset();
+    vi.mocked(listSchedules).mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    latestState = null;
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("opens no second request while the first is still outstanding", async () => {
+    vi.useFakeTimers();
+    // Never settles, so the first poll is still in flight for the whole test.
+    vi.mocked(listRuns).mockReturnValue(new Promise<never>(() => {}));
+    vi.mocked(listInvocations).mockReturnValue(new Promise<never>(() => {}));
+    vi.mocked(listSchedules).mockReturnValue(new Promise<never>(() => {}));
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(Harness));
+    });
+
+    expect(vi.mocked(listInvocations)).toHaveBeenCalledTimes(1);
+
+    // Five interval periods elapse with that first fetch still pending.
+    await act(async () => {
+      vi.advanceTimersByTime(5 * 3_000);
+    });
+
+    // Unguarded this is 6 — the opening poll plus one per tick — which is the
+    // defect: at a 50s fetch and a 3s interval the count climbs to ~17 and the
+    // board renders nothing at all.
+    expect(vi.mocked(listInvocations)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(listRuns)).toHaveBeenCalledTimes(1);
+  });
+
+  it("goes live on a fetch slower than the stale threshold", async () => {
+    vi.useFakeTimers();
+    // 8s per fetch: longer than the 5s watchdog, so every gap between
+    // successes trips "stale". That is an ordinary slow backend, not a fault,
+    // and the board still owes the operator the data it successfully fetched.
+    const slow = <T,>(value: T) =>
+      new Promise<T>((resolve) => setTimeout(() => resolve(value), 8_000));
+
+    vi.mocked(listRuns).mockImplementation(() =>
+      slow({
+        runs: [],
+        page: 1,
+        per_page: 200,
+        total: 0,
+        total_pages: 1,
+        has_next: false,
+        has_prev: false,
+      }),
+    );
+    vi.mocked(listInvocations).mockImplementation(() =>
+      slow({ invocations: [], limit: 100, offset: 0, has_next: false, total: 0, completed_total: 0 }),
+    );
+    vi.mocked(listSchedules).mockImplementation(() => slow({ schedules: [] }));
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(Harness));
+    });
+
+    // Four full fetch cycles. The watchdog fires ~3 times inside each one.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4 * 11_000);
+    });
+
+    // The hysteresis exists to stop a stale badge flapping, not to withhold
+    // data. Zeroing the success streak on every watchdog tick means a backend
+    // slower than the threshold can never accumulate the consecutive
+    // successes the gate asks for, so the board stays on its loading skeleton
+    // forever while fetch after fetch succeeds.
+    expect(latestState?.dataState).not.toBe("loading");
+  });
+});

--- a/apps/studio/frontend/src/components/mission/useLiveBoard.ts
+++ b/apps/studio/frontend/src/components/mission/useLiveBoard.ts
@@ -34,14 +34,27 @@ export function useLiveBoard(): BoardState {
 
   useEffect(() => {
     let active = true;
+    let inFlight = false;
 
     // Watchdog: marks state stale if silent >5s
     let lastSuccessAt = Date.now();
+    let everSucceeded = false;
     const watchdog = setInterval(() => {
       if (!active) return;
       if (Date.now() - lastSuccessAt > STALE_THRESHOLD_MS) {
+        // Only a board that has already shown data can go stale. Before the
+        // first success there is no earlier state to flap back to, and arming
+        // the hysteresis here would gate the very first render behind a run of
+        // consecutive successes.
+        if (!everSucceeded) return;
+        // Deliberately does NOT reset successStreak. Silence means the current
+        // fetch has not come back yet, which is what a slow backend looks
+        // like, not a failure — the catch path owns that. Clearing the streak
+        // on every tick of a gap longer than the threshold makes the streak
+        // unreachable whenever a fetch is slower than STALE_THRESHOLD_MS, and
+        // the board then stays on its loading skeleton through any number of
+        // successful fetches.
         wasStaleRef.current = true;
-        successStreak.current = 0;
         dispatch({ type: "MARK_STALE" });
       }
     }, 1_000);
@@ -54,6 +67,13 @@ export function useLiveBoard(): BoardState {
 
     async function poll() {
       if (!active) return;
+      // A tick that arrives while the previous poll is still outstanding is
+      // dropped, not queued. Without this the interval keeps opening requests
+      // regardless of how long they take, so once a fetch is slower than
+      // POLL_INTERVAL_MS the outstanding count grows without bound and the
+      // board never receives a first response at all.
+      if (inFlight) return;
+      inFlight = true;
       try {
         const nowSec = Math.floor(Date.now() / 1000);
         // Schedules, dispositions, and gated plays each feed one part of the
@@ -71,6 +91,7 @@ export function useLiveBoard(): BoardState {
         if (!active) return;
 
         lastSuccessAt = Date.now();
+        everSucceeded = true;
         successStreak.current += 1;
 
         // Hysteresis: if we were stale, only clear after STABLE_RESUMPTION_COUNT
@@ -93,6 +114,11 @@ export function useLiveBoard(): BoardState {
           type: "DATA_ERROR",
           message: err instanceof Error ? err.message : "API unreachable",
         });
+      } finally {
+        // Both branches above return early once unmounted, so releasing the
+        // guard anywhere but here would leave it held and stop polling for
+        // good on the next remount.
+        inFlight = false;
       }
     }
 

--- a/apps/studio/frontend/src/lib/runStatus.test.ts
+++ b/apps/studio/frontend/src/lib/runStatus.test.ts
@@ -4,6 +4,7 @@ import {
   deriveVerdict,
   isEffectivelyActive,
   isOrphanedReason,
+  isUnsuccessfulTerminal,
 } from "./runStatus";
 
 describe("deriveDisplayStatus", () => {
@@ -138,5 +139,36 @@ describe("isEffectivelyActive", () => {
   it("non-active display statuses are inactive", () => {
     expect(isEffectivelyActive({ status: "completed" })).toBe(false);
     expect(isEffectivelyActive({ status: "failed" })).toBe(false);
+  });
+});
+
+describe("isUnsuccessfulTerminal", () => {
+  // The case this predicate exists for. A run that blows its deadline arrives
+  // as `timed_out` and DISPLAYS as "cancelled", so anything keyed on
+  // `status === "failed"` drops its reason — which is how a timed-out run ends
+  // up showing a bare "cancelled" while the backend's own explanation goes
+  // unread.
+  it("covers a timed-out run, which is never spelled 'failed'", () => {
+    expect(isUnsuccessfulTerminal({ status: "timed_out" })).toBe(true);
+    expect(isUnsuccessfulTerminal({ status: "timeout" })).toBe(true);
+    expect(isUnsuccessfulTerminal({ status: "cancelled" })).toBe(true);
+    expect(isUnsuccessfulTerminal({ status: "aborted" })).toBe(true);
+  });
+
+  it("covers failed and orphaned terminals", () => {
+    expect(isUnsuccessfulTerminal({ status: "failed" })).toBe(true);
+    expect(isUnsuccessfulTerminal({ status: "error" })).toBe(true);
+    expect(
+      isUnsuccessfulTerminal({ status: "failed", status_reason_summary: "phantom_reaped" }),
+    ).toBe(true);
+  });
+
+  it("excludes success and anything still going", () => {
+    expect(isUnsuccessfulTerminal({ status: "completed" })).toBe(false);
+    expect(isUnsuccessfulTerminal({ status: "success" })).toBe(false);
+    expect(isUnsuccessfulTerminal({ status: "running" })).toBe(false);
+    expect(isUnsuccessfulTerminal({ status: "queued" })).toBe(false);
+    // An unrecognized status derives to "running", so it is not yet terminal.
+    expect(isUnsuccessfulTerminal({ status: "some-new-state" })).toBe(false);
   });
 });

--- a/apps/studio/frontend/src/lib/runStatus.ts
+++ b/apps/studio/frontend/src/lib/runStatus.ts
@@ -81,6 +81,23 @@ export function deriveDisplayStatus(run: RunStatusInput): DisplayStatus {
   return "running";
 }
 
+const UNSUCCESSFUL_TERMINAL = new Set<DisplayStatus>(["failed", "cancelled", "orphaned"]);
+
+/**
+ * True when a run has finished in a way the operator needs explained, so its
+ * `status_reason_summary` is worth showing. On a completed run that string is
+ * noise; on a running one it is not final yet.
+ *
+ * Keyed on the DISPLAY status, never on `run.status === "failed"`. A run that
+ * exceeded its deadline arrives as `timed_out`, which displays as "cancelled",
+ * so an equality test against "failed" drops the explanation for precisely the
+ * case that most needs one — the operator is left reading a bare "cancelled"
+ * while "Run exceeded the configured timeout." sits unused in the payload.
+ */
+export function isUnsuccessfulTerminal(run: RunStatusInput): boolean {
+  return UNSUCCESSFUL_TERMINAL.has(deriveDisplayStatus(run));
+}
+
 const DEAD_EFFECTIVE_HEALTH = new Set(["stale", "orphaned", "zombie"]);
 
 /**


### PR DESCRIPTION
## What breaks today

Fleet and Mission Control poll a list endpoint on a 3s interval. When that endpoint is slower than the interval, both views stop working entirely, and they do it silently: the operator sees a loading skeleton, not an error.

Two independent defects, both reachable from an ordinary slow backend rather than from any fault.

**1. No in-flight guard.** The pollers used a bare `setInterval`. A fetch outliving the interval left every later tick opening another request, so the outstanding count grew for as long as the slowness lasted. Measured against a local instance: one list call took ~50s while the interval kept firing every 3s, which saturated the connection pool and turned reads that would have succeeded into gateway errors.

**2. The staleness watchdog made recovery impossible.** The watchdog clears the consecutive-success counter on every tick of a silent gap. A fetch slower than the 5s stale threshold always produces such a gap, so the counter could never reach the two consecutive successes the hysteresis gate asks for. The view sat on its loading skeleton through any number of *successful* fetches. The hysteresis also armed before the first success, gating the very first render on a recovery rule that had nothing to recover from.

The second one is the reason the page stays blank. Fixing only the first still leaves an empty board.

## Change

- A tick arriving while a poll is still outstanding is dropped rather than queued.
- Staleness no longer resets the success counter. Silence means the current fetch has not returned yet, which is what slow looks like; the failure path already owns real failures.
- A view that has never shown data cannot go stale, so the first render is not gated behind a recovery rule.

Applied identically to both polling hooks.

## Verification

- New test: with a fetch that never settles, five interval periods open exactly one request. Removing the guard alone makes it 6, one per tick.
- New test: with an 8s fetch against the 5s threshold, the view leaves the loading state. This test fails on the current code even with the guard applied, which is what isolates the second defect from the first.
- Full frontend suite 1609 passed, `tsc --noEmit` clean.
- Checked in a browser against a real completed run: before, a permanent loading skeleton and a console full of gateway errors; after, the run renders with its execution graph, artifact verification and per-node state, console clean.