### PR TITLE
fix(fanout): treat a failed leg as a failure at every surface that reads it

### DIFF
--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -470,7 +470,13 @@ async def _run_fanout_inner(
 
     synthesis_result = None
     if with_synthesis and not contexts:
-        warn("Every worker failed; there is no output to synthesize.")
+        # An empty context means either "every worker failed" or "no worker ran
+        # at all". Only the first one has failures to report, so name the
+        # situation that actually happened.
+        if fanned_nodes:
+            warn("Every worker failed; there is no output to synthesize.")
+        else:
+            warn("No workers ran; there is no output to synthesize.")
     if with_synthesis and contexts:
         synth_spec = synthesis_model or model_spec
         synth_label = str(parse_model_spec(synth_spec))
@@ -492,7 +498,15 @@ async def _run_fanout_inner(
         t2 = time.monotonic()
         env.session.observe(NodeFailed, handler=_record_failed_op)
         try:
-            result3 = await env.session.flow(env.builder.get_graph(), verbose=env.verbose)
+            # Synthesis runs through the engine for the same reason the worker
+            # phase does: run_dag is what installs the node-lifecycle signal
+            # bridge, so a failed synthesis reaches the observer above. Calling
+            # session.flow directly emits no node signals at all, which leaves
+            # the observer silent and renders the failure as an empty response.
+            result3 = await eng_run.run_dag(
+                env.builder.get_graph(),
+                verbose=env.verbose,
+            )
         finally:
             env.session.observer.unobserve(_record_failed_op)
         t_synth = time.monotonic() - t2

--- a/lionagi/cli/orchestrate/fanout.py
+++ b/lionagi/cli/orchestrate/fanout.py
@@ -47,6 +47,14 @@ class FanoutPlanError(LionError):
     """Orchestrator failed to produce a usable plan."""
 
 
+# Rendered in place of a failed leg's output. Distinct from "(no response)",
+# which means the operation completed but returned nothing: a failed leg must
+# never read as a quiet success, and the synthesis context must be able to
+# exclude it rather than synthesize over a placeholder as if it were content.
+FAILED_WORKER_MARKER = "(worker failed: no output)"
+FAILED_SYNTHESIS_MARKER = "(synthesis failed: no output)"
+
+
 def _parse_worker_pool(workers_str: str | None, *, num_workers: int) -> list[str]:
     """Parse model overrides and report entries excluded by the assignment cap."""
     pool = [spec.strip() for spec in workers_str.split(",")] if workers_str else []
@@ -213,7 +221,11 @@ async def _run_fanout(
                 raise LionTimeoutError(msg)
         else:
             result = await _run_fanout_inner(model_spec, prompt, **inner_kw)
-        if _shared.get("artifact_failures"):
+        # Two distinct failure signals feed this decision: an operation that
+        # raised (op_failures) and a worker artifact that could not be written
+        # (artifact_failures). Either alone means the run did not deliver what
+        # it reported, so neither may resolve to "completed".
+        if _shared.get("artifact_failures") or _shared.get("op_failures"):
             _terminal_status = "failed"
     except BaseException as exc:
         _terminal_status = classify_exception(exc)
@@ -350,7 +362,22 @@ async def _run_fanout_inner(
     artifact_failures: dict[int, dict] = {}
 
     from lionagi.engines import PlanningEngine
-    from lionagi.session.signal import NodeCompleted
+    from lionagi.session.signal import NodeCompleted, NodeFailed
+
+    # Keyed by op_id so the same observer serves the fanned workers here and
+    # the synthesis node later. A failed op has no entry in operation_results,
+    # which is also what a completed-but-empty op looks like — this set is the
+    # only record that distinguishes the two.
+    failed_ops: set[str] = set()
+
+    def _record_failed_op(sig, _ctx) -> None:
+        failed_ops.add(sig.op_id)
+        worker_entry = node_workers.get(sig.op_id)
+        if worker_entry is not None:
+            worker_number, _ = worker_entry
+            warn(f"Worker {worker_number} failed after {sig.elapsed:.1f}s; its leg has no output.")
+        if _shared is not None:
+            _shared["op_failures"] = sorted(failed_ops)
 
     def _save_completed_worker(sig, _ctx) -> None:
         worker_entry = node_workers.get(sig.op_id)
@@ -386,6 +413,7 @@ async def _run_fanout_inner(
             _shared["saved_workers"] = [saved_workers[i] for i in sorted(saved_workers)]
 
     env.session.observe(NodeCompleted, handler=_save_completed_worker)
+    env.session.observe(NodeFailed, handler=_record_failed_op)
     eng_run = PlanningEngine().new_run(session=env.session)
     try:
         if env.exchange is not None:
@@ -409,14 +437,22 @@ async def _run_fanout_inner(
             )
     finally:
         env.session.observer.unobserve(_save_completed_worker)
+        env.session.observer.unobserve(_record_failed_op)
     t_fanout = time.monotonic() - t1
 
     op_results = result2.get("operation_results", {})
     worker_results: list[dict] = []
     contexts: list[str] = []
     for i, nid in enumerate(fanned_nodes):
-        res = op_results.get(nid)
-        response_text = str(res) if res is not None else "(no response)"
+        if str(nid) in failed_ops:
+            # A failed leg is rendered with its marker but kept out of the
+            # synthesis context: a placeholder read alongside real worker
+            # output would be synthesized as if it were content.
+            response_text = FAILED_WORKER_MARKER
+        else:
+            res = op_results.get(nid)
+            response_text = str(res) if res is not None else "(no response)"
+            contexts.append(response_text)
         worker_results.append(
             {
                 "worker": i + 1,
@@ -425,7 +461,6 @@ async def _run_fanout_inner(
                 "time_ms": t_fanout * 1000,
             }
         )
-        contexts.append(response_text)
 
     progress(f"Phase 2 done ({t_fanout:.1f}s).")
 
@@ -434,6 +469,8 @@ async def _run_fanout_inner(
         _shared["saved_workers"] = [saved_workers[i] for i in sorted(saved_workers)]
 
     synthesis_result = None
+    if with_synthesis and not contexts:
+        warn("Every worker failed; there is no output to synthesize.")
     if with_synthesis and contexts:
         synth_spec = synthesis_model or model_spec
         synth_label = str(parse_model_spec(synth_spec))
@@ -453,13 +490,21 @@ async def _run_fanout_inner(
         )
 
         t2 = time.monotonic()
-        result3 = await env.session.flow(env.builder.get_graph(), verbose=env.verbose)
+        env.session.observe(NodeFailed, handler=_record_failed_op)
+        try:
+            result3 = await env.session.flow(env.builder.get_graph(), verbose=env.verbose)
+        finally:
+            env.session.observer.unobserve(_record_failed_op)
         t_synth = time.monotonic() - t2
 
         synth_res = result3.get("operation_results", {}).get(synth_node)
+        if str(synth_node) in failed_ops:
+            synth_text = FAILED_SYNTHESIS_MARKER
+        else:
+            synth_text = str(synth_res) if synth_res is not None else "(no response)"
         synthesis_result = {
             "model": synth_label,
-            "response": str(synth_res) if synth_res is not None else "(no response)",
+            "response": synth_text,
             "time_ms": t_synth * 1000,
         }
 

--- a/tests/cli/orchestrate/test_fanout_failure_visibility.py
+++ b/tests/cli/orchestrate/test_fanout_failure_visibility.py
@@ -28,6 +28,7 @@ from lionagi.cli.orchestrate.fanout import (
 )
 from lionagi.engines import PlanningEngine
 from lionagi.operations.builder import OperationGraphBuilder
+from lionagi.protocols.types import EventStatus
 from lionagi.session.signal import NodeCompleted, NodeFailed
 
 
@@ -89,27 +90,48 @@ def _wire_fanout(monkeypatch, env, assignments, run_dag, warnings=None, progress
     return stop_persist
 
 
+def _completed(session, node, response, name="worker"):
+    """Leave a node the way a real run_dag leaves a finished one — terminal status
+    included, so a later pass over the same graph does not re-execute it."""
+    node.execution.status = EventStatus.COMPLETED
+    node.execution.response = response
+    return asyncio.create_task(
+        session.emit(NodeCompleted(op_id=str(node.id), name=name, elapsed=0.01))
+    )
+
+
+def _failed(session, node, name="worker"):
+    node.execution.status = EventStatus.FAILED
+    return asyncio.create_task(
+        session.emit(NodeFailed(op_id=str(node.id), name=name, elapsed=0.01))
+    )
+
+
 def _one_fails_one_completes(session):
-    """A run_dag stub: the first leg raises, the second completes normally."""
+    """A run_dag stub: on the worker pass the first leg fails and the second
+    completes. Synthesis goes through run_dag as well, so a second call gets the
+    graph with the synthesis node appended and completes that. ``passes`` records
+    one entry per call, which is how a test tells the two phases apart."""
+    passes: list = []
 
     async def run_dag(graph, **kwargs):
+        passes.append(graph)
         nodes = list(graph.internal_nodes.values())
-        operation_results = {}
-        emits = [
-            asyncio.create_task(
-                session.emit(NodeFailed(op_id=str(nodes[0].id), name="worker", elapsed=0.01))
-            )
-        ]
-        nodes[1].execution.response = "worker 2 result"
-        operation_results[nodes[1].id] = "worker 2 result"
-        emits.append(
-            asyncio.create_task(
-                session.emit(NodeCompleted(op_id=str(nodes[1].id), name="worker", elapsed=0.01))
-            )
+        if len(passes) == 1:
+            emits = [
+                _failed(session, nodes[0]),
+                _completed(session, nodes[1], "worker 2 result"),
+            ]
+            await asyncio.gather(*emits, return_exceptions=True)
+            return {"operation_results": {nodes[1].id: "worker 2 result"}}
+        synth = nodes[-1]
+        await asyncio.gather(
+            _completed(session, synth, "synthesis result", name="synthesis"),
+            return_exceptions=True,
         )
-        await asyncio.gather(*emits, return_exceptions=True)
-        return {"operation_results": operation_results}
+        return {"operation_results": {synth.id: "synthesis result"}}
 
+    run_dag.passes = passes
     return run_dag
 
 
@@ -145,7 +167,8 @@ async def test_a_failed_worker_is_excluded_from_the_synthesis_context(
         TaskAssignment(task="first", assignee="worker"),
         TaskAssignment(task="second", assignee="worker"),
     ]
-    _wire_fanout(monkeypatch, env, assignments, _one_fails_one_completes(session))
+    run_dag = _one_fails_one_completes(session)
+    _wire_fanout(monkeypatch, env, assignments, run_dag)
 
     added_contexts: list = []
     original_add = env.builder.add_operation
@@ -156,17 +179,14 @@ async def test_a_failed_worker_is_excluded_from_the_synthesis_context(
 
     monkeypatch.setattr(env.builder, "add_operation", capture_add)
 
-    async def fake_flow(self, graph, **kwargs):
-        return {"operation_results": {}}
-
-    monkeypatch.setattr(Session, "flow", fake_flow)
-
     await fanout_module._run_fanout("codex/model", "work", num_workers=2, with_synthesis=True)
 
     # The synthesis operation is added last; its context must carry the real
     # result and not the failed leg's marker.
     synthesis_context = added_contexts[-1]
     assert synthesis_context == ["worker 2 result"]
+    # Both phases execute through the engine, so synthesis is a second pass.
+    assert len(run_dag.passes) == 2
 
 
 async def test_all_workers_failed_skips_synthesis_and_says_why(
@@ -178,29 +198,27 @@ async def test_all_workers_failed_skips_synthesis_and_says_why(
         TaskAssignment(task="second", assignee="worker"),
     ]
 
+    passes: list = []
+
     async def run_dag(graph, **kwargs):
-        emits = [
-            asyncio.create_task(
-                session.emit(NodeFailed(op_id=str(node.id), name="worker", elapsed=0.01))
-            )
-            for node in graph.internal_nodes.values()
-        ]
+        passes.append(graph)
+        emits = [_failed(session, node) for node in graph.internal_nodes.values()]
         await asyncio.gather(*emits, return_exceptions=True)
         return {"operation_results": {}}
 
     warnings: list[str] = []
     _wire_fanout(monkeypatch, env, assignments, run_dag, warnings=warnings)
 
-    synth_flow = AsyncMock()
-    monkeypatch.setattr(Session, "flow", synth_flow)
-
     output, terminal_status = await fanout_module._run_fanout(
         "codex/model", "work", num_workers=2, with_synthesis=True
     )
 
     assert terminal_status == "failed"
-    synth_flow.assert_not_awaited()
-    assert any("no output to synthesize" in message for message in warnings)
+    # Synthesis is skipped, so the worker pass is the only pass. Counting passes
+    # is what makes this a real assertion: synthesis executes through the same
+    # run_dag seam as the workers, so a second pass would mean it ran anyway.
+    assert len(passes) == 1
+    assert any("Every worker failed" in message for message in warnings)
     assert output.count(FAILED_WORKER_MARKER) == 2
 
 
@@ -213,29 +231,34 @@ async def test_a_failed_synthesis_is_marked_as_failed_not_as_empty(
         TaskAssignment(task="second", assignee="worker"),
     ]
 
+    # The synthesis pass runs the real engine, so the failure signal this test
+    # reads is emitted by production code rather than injected here. Take the
+    # run before `new_run` is stubbed out for the worker pass.
+    real_run = PlanningEngine().new_run(session=session)
+    passes: list = []
+
     async def run_dag(graph, **kwargs):
+        passes.append(graph)
+        if len(passes) > 1:
+            return await real_run.run_dag(graph, **kwargs)
         operation_results = {}
         emits = []
         for number, node in enumerate(graph.internal_nodes.values(), start=1):
             response = f"worker {number} result"
-            node.execution.response = response
             operation_results[node.id] = response
-            emits.append(
-                asyncio.create_task(
-                    session.emit(NodeCompleted(op_id=str(node.id), name="worker", elapsed=0.01))
-                )
-            )
+            emits.append(_completed(session, node, response))
         await asyncio.gather(*emits, return_exceptions=True)
         return {"operation_results": operation_results}
 
     _wire_fanout(monkeypatch, env, assignments, run_dag)
 
-    async def failing_synthesis_flow(self, graph, **kwargs):
-        synthesis_node = list(graph.internal_nodes.values())[-1]
-        await session.emit(NodeFailed(op_id=str(synthesis_node.id), name="synthesis", elapsed=0.01))
-        return {"operation_results": {}}
+    # Fail the synthesis operation itself. Nothing here emits a signal: getting
+    # that outcome to the observer is the job of the engine's signal bridge,
+    # which is the thing under test.
+    async def failing_operate(self, *args, **kwargs):
+        raise RuntimeError("synthesis model unavailable")
 
-    monkeypatch.setattr(Session, "flow", failing_synthesis_flow)
+    monkeypatch.setattr(Branch, "operate", failing_operate)
 
     output, terminal_status = await fanout_module._run_fanout(
         "codex/model", "work", num_workers=2, with_synthesis=True
@@ -246,3 +269,6 @@ async def test_a_failed_synthesis_is_marked_as_failed_not_as_empty(
     assert terminal_status == "failed"
     assert FAILED_SYNTHESIS_MARKER in output
     assert "(no response)" not in output
+    # And it got there through the engine, whose signal bridge is the only thing
+    # that can carry a synthesis failure to the observer above.
+    assert len(passes) == 2

--- a/tests/cli/orchestrate/test_fanout_failure_visibility.py
+++ b/tests/cli/orchestrate/test_fanout_failure_visibility.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
+# SPDX-License-Identifier: Apache-2.0
+"""A fanout leg that fails is visible as a failure, everywhere it is read.
+
+Fan-out is the partial-failure-across-N-parallel-legs pattern, so a failed leg
+must be tellable apart from a quiet success at every surface that reads it: the
+run's terminal status, the per-worker render, and the synthesis context. Before
+this guard existed, the only signal feeding terminal status was an artifact
+write error, and a failed leg rendered with the same placeholder as an empty
+success — which a synthesis pass would then read as content.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lionagi import Branch, Session
+from lionagi.casts.emission import TaskAssignment
+from lionagi.cli._runs import RunDir
+from lionagi.cli.orchestrate import fanout as fanout_module
+from lionagi.cli.orchestrate._orchestration import OrchestrationEnv
+from lionagi.cli.orchestrate.fanout import (
+    FAILED_SYNTHESIS_MARKER,
+    FAILED_WORKER_MARKER,
+)
+from lionagi.engines import PlanningEngine
+from lionagi.operations.builder import OperationGraphBuilder
+from lionagi.session.signal import NodeCompleted, NodeFailed
+
+
+def _fanout_env(tmp_path) -> tuple[OrchestrationEnv, RunDir, Session]:
+    orchestrator = Branch(name="orchestrator")
+    session = Session(default_branch=orchestrator)
+    run = RunDir(
+        run_id="fanout-run",
+        state_root=tmp_path / "state",
+        artifact_root=tmp_path / "artifacts",
+    )
+    run.ensure_state_dirs()
+    run.ensure_artifact_root()
+    env = OrchestrationEnv(
+        run=run,
+        session=session,
+        orc_branch=orchestrator,
+        builder=OperationGraphBuilder(),
+        orc_profile=None,
+        orc_profile_name=None,
+        default_model_spec="codex/model",
+        bare=False,
+        effort=None,
+        theme=None,
+        yolo=False,
+        bypass=False,
+        verbose=False,
+        fast=False,
+        cwd=None,
+    )
+    return env, run, session
+
+
+def _wire_fanout(monkeypatch, env, assignments, run_dag, warnings=None, progress=None):
+    """Stub the orchestration seams around `_run_fanout` the way the artifact
+    durability tests do, leaving the code under test — signal observation,
+    result assembly, terminal-status resolution — real."""
+
+    async def build_worker(env, *, explicit_name, **kwargs):
+        branch = Branch(name=explicit_name)
+        env.session.include_branches(branch)
+        return branch, "codex/model", None, False
+
+    engine_run = type("EngineRunStub", (), {"run_dag": staticmethod(run_dag)})()
+    monkeypatch.setattr(fanout_module, "setup_orchestration", AsyncMock(return_value=env))
+    monkeypatch.setattr(fanout_module, "start_live_persist", AsyncMock())
+    stop_persist = AsyncMock(side_effect=lambda env, status: status)
+    monkeypatch.setattr(fanout_module, "stop_live_persist", stop_persist)
+    monkeypatch.setattr(fanout_module, "plan", AsyncMock(return_value=assignments))
+    monkeypatch.setattr(fanout_module, "available_roles", lambda: ["worker"])
+    monkeypatch.setattr(fanout_module, "role_roster", lambda model: "worker")
+    monkeypatch.setattr(fanout_module, "build_worker_branch", build_worker)
+    monkeypatch.setattr(fanout_module, "finalize_orchestration", lambda *args, **kwargs: None)
+    if warnings is not None:
+        monkeypatch.setattr(fanout_module, "warn", warnings.append, raising=False)
+    if progress is not None:
+        monkeypatch.setattr(fanout_module, "progress", progress.append)
+    monkeypatch.setattr(PlanningEngine, "new_run", lambda self, **kwargs: engine_run)
+    return stop_persist
+
+
+def _one_fails_one_completes(session):
+    """A run_dag stub: the first leg raises, the second completes normally."""
+
+    async def run_dag(graph, **kwargs):
+        nodes = list(graph.internal_nodes.values())
+        operation_results = {}
+        emits = [
+            asyncio.create_task(
+                session.emit(NodeFailed(op_id=str(nodes[0].id), name="worker", elapsed=0.01))
+            )
+        ]
+        nodes[1].execution.response = "worker 2 result"
+        operation_results[nodes[1].id] = "worker 2 result"
+        emits.append(
+            asyncio.create_task(
+                session.emit(NodeCompleted(op_id=str(nodes[1].id), name="worker", elapsed=0.01))
+            )
+        )
+        await asyncio.gather(*emits, return_exceptions=True)
+        return {"operation_results": operation_results}
+
+    return run_dag
+
+
+async def test_a_failed_worker_flips_terminal_status_and_renders_its_marker(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, run, session = _fanout_env(tmp_path)
+    assignments = [
+        TaskAssignment(task="first", assignee="worker"),
+        TaskAssignment(task="second", assignee="worker"),
+    ]
+    warnings: list[str] = []
+    stop_persist = _wire_fanout(
+        monkeypatch, env, assignments, _one_fails_one_completes(session), warnings=warnings
+    )
+
+    output, terminal_status = await fanout_module._run_fanout("codex/model", "work", num_workers=2)
+
+    # The failed leg is a failure at every surface: status, render, warning.
+    assert terminal_status == "failed"
+    stop_persist.assert_awaited_once_with(env, status="failed")
+    assert FAILED_WORKER_MARKER in output
+    assert "worker 2 result" in output
+    assert "(no response)" not in output
+    assert any("Worker 1 failed" in message for message in warnings)
+
+
+async def test_a_failed_worker_is_excluded_from_the_synthesis_context(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, run, session = _fanout_env(tmp_path)
+    assignments = [
+        TaskAssignment(task="first", assignee="worker"),
+        TaskAssignment(task="second", assignee="worker"),
+    ]
+    _wire_fanout(monkeypatch, env, assignments, _one_fails_one_completes(session))
+
+    added_contexts: list = []
+    original_add = env.builder.add_operation
+
+    def capture_add(operation, **kwargs):
+        added_contexts.append(kwargs.get("context"))
+        return original_add(operation, **kwargs)
+
+    monkeypatch.setattr(env.builder, "add_operation", capture_add)
+
+    async def fake_flow(self, graph, **kwargs):
+        return {"operation_results": {}}
+
+    monkeypatch.setattr(Session, "flow", fake_flow)
+
+    await fanout_module._run_fanout("codex/model", "work", num_workers=2, with_synthesis=True)
+
+    # The synthesis operation is added last; its context must carry the real
+    # result and not the failed leg's marker.
+    synthesis_context = added_contexts[-1]
+    assert synthesis_context == ["worker 2 result"]
+
+
+async def test_all_workers_failed_skips_synthesis_and_says_why(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, run, session = _fanout_env(tmp_path)
+    assignments = [
+        TaskAssignment(task="first", assignee="worker"),
+        TaskAssignment(task="second", assignee="worker"),
+    ]
+
+    async def run_dag(graph, **kwargs):
+        emits = [
+            asyncio.create_task(
+                session.emit(NodeFailed(op_id=str(node.id), name="worker", elapsed=0.01))
+            )
+            for node in graph.internal_nodes.values()
+        ]
+        await asyncio.gather(*emits, return_exceptions=True)
+        return {"operation_results": {}}
+
+    warnings: list[str] = []
+    _wire_fanout(monkeypatch, env, assignments, run_dag, warnings=warnings)
+
+    synth_flow = AsyncMock()
+    monkeypatch.setattr(Session, "flow", synth_flow)
+
+    output, terminal_status = await fanout_module._run_fanout(
+        "codex/model", "work", num_workers=2, with_synthesis=True
+    )
+
+    assert terminal_status == "failed"
+    synth_flow.assert_not_awaited()
+    assert any("no output to synthesize" in message for message in warnings)
+    assert output.count(FAILED_WORKER_MARKER) == 2
+
+
+async def test_a_failed_synthesis_is_marked_as_failed_not_as_empty(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    env, run, session = _fanout_env(tmp_path)
+    assignments = [
+        TaskAssignment(task="first", assignee="worker"),
+        TaskAssignment(task="second", assignee="worker"),
+    ]
+
+    async def run_dag(graph, **kwargs):
+        operation_results = {}
+        emits = []
+        for number, node in enumerate(graph.internal_nodes.values(), start=1):
+            response = f"worker {number} result"
+            node.execution.response = response
+            operation_results[node.id] = response
+            emits.append(
+                asyncio.create_task(
+                    session.emit(NodeCompleted(op_id=str(node.id), name="worker", elapsed=0.01))
+                )
+            )
+        await asyncio.gather(*emits, return_exceptions=True)
+        return {"operation_results": operation_results}
+
+    _wire_fanout(monkeypatch, env, assignments, run_dag)
+
+    async def failing_synthesis_flow(self, graph, **kwargs):
+        synthesis_node = list(graph.internal_nodes.values())[-1]
+        await session.emit(NodeFailed(op_id=str(synthesis_node.id), name="synthesis", elapsed=0.01))
+        return {"operation_results": {}}
+
+    monkeypatch.setattr(Session, "flow", failing_synthesis_flow)
+
+    output, terminal_status = await fanout_module._run_fanout(
+        "codex/model", "work", num_workers=2, with_synthesis=True
+    )
+
+    # The workers all succeeded; only the synthesis leg failed. The run must
+    # not read as completed, and the synthesis must not read as merely empty.
+    assert terminal_status == "failed"
+    assert FAILED_SYNTHESIS_MARKER in output
+    assert "(no response)" not in output


### PR DESCRIPTION
Closes #2991.

Implements the direction confirmed in the issue thread: fanout now observes `NodeFailed` the way flow does, an op-failure set feeds the terminal-status decision alongside `artifact_failures`, and failed legs carry a distinguishable marker so the synthesis context can exclude them rather than read a placeholder as real output.

### What changes

**A `NodeFailed` observer, registered next to the existing `NodeCompleted` one.** It records the failed op id, warns which worker failed, and shares the set with the terminal-status decision. The same handler is re-registered around the synthesis call so the synthesis node itself is covered — per the re-check in the issue thread, the `"(no response)"` placeholder also masked a failed synthesis.

**Terminal status.** `op_failures` now feeds the decision alongside `artifact_failures`. Before, the only signal feeding it was the `except OSError` around the artifact write, so an op-level failure could not flip status even in principle.

**Rendering and synthesis context.** A failed leg renders `(worker failed: no output)` — distinct from `(no response)`, which keeps meaning "completed but returned nothing" — and is excluded from the synthesis context. A failed synthesis renders `(synthesis failed: no output)`. When every worker failed, synthesis is skipped with an explicit warning instead of synthesizing over nothing (the existing `contexts` guard already short-circuits; the warning makes it a decision rather than silence).

**Synthesis runs through the engine.** The worker phase executes via the engine's `run_dag`, and `run_dag` is what installs the node-lifecycle signal bridge. Calling `session.flow` directly for the synthesis pass emits no node signals at all, so the observer registered around that call could never fire and a genuinely failed synthesis still rendered as `(no response)` with the run reporting `completed`. Both phases now go through the same engine run.

**One warning names the wrong situation.** An empty synthesis context can mean "every worker failed" or "no worker ran at all". Only the first has failures to report, so the two are now worded separately.

### Tests

`tests/cli/orchestrate/test_fanout_failure_visibility.py`, four cases built on the same harness as the artifact-durability tests:

- a failed worker flips terminal status, renders its marker, and warns;
- a failed worker is excluded from the synthesis context (the completed leg's real output is what synthesis sees);
- when every worker fails, synthesis is skipped with the reason stated, and status is failed;
- a failed synthesis is marked as failed, not as empty, and fails the run.

The synthesis case fails the operation itself and lets the engine emit the signal, rather than injecting the `NodeFailed` whose delivery is the thing under test. Reverting the engine routing turns that case red on its terminal-status assertion, which is the user-visible symptom: a run whose synthesis failed reporting `completed`.

Two assertions in the other cases counted on the synthesis pass being a distinct call surface, so they now count engine passes instead — otherwise they would have kept passing while asserting nothing.

AI-assisted (the report and fix were produced with Claude and re-verified by hand, same as the reports behind #2992/#2993).
