### PR TITLE
fix(cli): point the daemon check at readiness so a serving daemon stops reading as down

### DIFF
--- a/lionagi/cli/doctor.py
+++ b/lionagi/cli/doctor.py
@@ -40,7 +40,11 @@ _CORE_DEPS: dict[str, str] = {
     "psutil": "psutil",
 }
 
-_STUDIO_HEALTH_URL_DEFAULT = "http://127.0.0.1:8765/api/admin/health"
+# The readiness probe, not the composite health report. The report walks the
+# recent session page, so its cost scales with stored message volume and it can
+# outlast any timeout worth setting here — pointing this check at it made a
+# daemon that was serving every other route read as unreachable.
+_STUDIO_READINESS_URL_DEFAULT = "http://127.0.0.1:8765/api/admin/readiness"
 
 _SYMBOLS = {"ok": "✓", "warn": "!", "fail": "✗", "unknown": "?"}
 
@@ -112,18 +116,56 @@ def _check_core_deps() -> dict[str, dict[str, str]]:
     return results
 
 
+def _readiness_verdict(target: str, body: bytes) -> dict[str, str]:
+    """Turn a readiness response body into a check result.
+
+    Kept separate from the request so the mapping can be exercised without a
+    server, and because the probe distinguishes three states on purpose:
+    collapsing them into one boolean is what let a stalled daemon keep
+    reporting itself healthy.
+    """
+    try:
+        payload = json.loads(body)
+        state = payload["status"]
+    except Exception as exc:  # noqa: BLE001 — malformed body, wrong endpoint, no status key
+        return _result(
+            "unknown",
+            f"Studio daemon answered at {target} but its readiness verdict could not "
+            f"be read ({type(exc).__name__}: {exc}) — treat the daemon as unverified.",
+        )
+
+    detail = payload.get("detail") or ""
+    if state == "healthy":
+        return _result("ok", f"Studio daemon ready at {target} ({detail})")
+    if state in ("slow", "unavailable"):
+        return _result(
+            "warn",
+            f"Studio daemon is up at {target} but its store is {state} ({detail}) — "
+            "scheduled/agent-spawn actions that route through it will be affected.",
+        )
+    return _result(
+        "unknown",
+        f"Studio daemon at {target} reported an unrecognised readiness status {state!r}.",
+    )
+
+
 def _check_studio_daemon(url: str | None = None, timeout: float = 1.5) -> dict[str, str]:
-    """Optional check — the Studio daemon is not required for `li agent`/`li o flow`."""
+    """Optional check — the Studio daemon is not required for `li agent`/`li o flow`.
+
+    The verdict comes from the response body, not the status code: readiness
+    answers 200 even when the store is unreachable, so a code-only check would
+    report a daemon that cannot serve anything as healthy.
+    """
     import urllib.error
     import urllib.request
 
-    target = url or _STUDIO_HEALTH_URL_DEFAULT
+    target = url or _STUDIO_READINESS_URL_DEFAULT
     try:
         req = urllib.request.Request(target, method="GET")  # noqa: S310
         with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
-            if resp.status == 200:
-                return _result("ok", f"Studio daemon reachable at {target}")
-            return _result("warn", f"Studio daemon at {target} returned HTTP {resp.status}")
+            if resp.status != 200:
+                return _result("warn", f"Studio daemon at {target} returned HTTP {resp.status}")
+            body = resp.read()
     except Exception as exc:  # noqa: BLE001 — connection refused, timeout, DNS, etc.
         return _result(
             "warn",
@@ -131,6 +173,7 @@ def _check_studio_daemon(url: str | None = None, timeout: float = 1.5) -> dict[s
             "optional; scheduled/agent-spawn actions that route through it will fail "
             "until `li studio` is running.",
         )
+    return _readiness_verdict(target, body)
 
 
 def _check_lionagi_home(home: Path | None = None) -> dict[str, str]:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import pytest
 
 from lionagi.cli.doctor import (
+    _STUDIO_READINESS_URL_DEFAULT,
     _check_core_deps,
     _check_imports,
     _check_lionagi_home,
@@ -19,6 +20,7 @@ from lionagi.cli.doctor import (
     _check_studio_daemon,
     _check_version,
     _looks_editable,
+    _readiness_verdict,
     collect_checks,
     run_doctor,
 )
@@ -30,7 +32,7 @@ def _closed_port_url() -> str:
     sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
     sock.close()
-    return f"http://127.0.0.1:{port}/api/admin/health"
+    return f"http://127.0.0.1:{port}/api/admin/readiness"
 
 
 # ── _looks_editable ──────────────────────────────────────────────────────────
@@ -173,6 +175,52 @@ def test_check_studio_daemon_unreachable_is_warn_not_fail() -> None:
     result = _check_studio_daemon(url=url, timeout=0.5)
     assert result["status"] == "warn"
     assert url in result["detail"]
+
+
+def test_studio_default_target_is_readiness_not_the_composite_report() -> None:
+    """The composite report walks the recent session page, so its cost grows with
+    stored message volume and it can stop answering entirely while every other
+    route serves. Pointing this check back at it reports a working daemon as
+    unreachable, so the endpoint choice is pinned here deliberately."""
+    assert _STUDIO_READINESS_URL_DEFAULT.endswith("/api/admin/readiness")
+
+
+# ── _readiness_verdict ───────────────────────────────────────────────────────
+# Readiness answers 200 for all three of its states, so these assert the verdict
+# is taken from the body. A code-only check would pass every one of them.
+
+
+def test_readiness_verdict_healthy_is_ok() -> None:
+    body = json.dumps({"status": "healthy", "detail": "store answered"}).encode()
+    result = _readiness_verdict("http://x/api/admin/readiness", body)
+    assert result["status"] == "ok"
+    assert "store answered" in result["detail"]
+
+
+@pytest.mark.parametrize("state", ["slow", "unavailable"])
+def test_readiness_verdict_degraded_store_is_warn(state: str) -> None:
+    body = json.dumps({"status": state, "detail": "d"}).encode()
+    result = _readiness_verdict("http://x/api/admin/readiness", body)
+    assert result["status"] == "warn"
+    assert state in result["detail"]
+
+
+def test_readiness_verdict_malformed_body_is_unknown() -> None:
+    result = _readiness_verdict("http://x/api/admin/readiness", b"<html>not json</html>")
+    assert result["status"] == "unknown"
+
+
+def test_readiness_verdict_missing_status_key_is_unknown() -> None:
+    body = json.dumps({"detail": "no status field"}).encode()
+    result = _readiness_verdict("http://x/api/admin/readiness", body)
+    assert result["status"] == "unknown"
+
+
+def test_readiness_verdict_unrecognised_status_is_unknown() -> None:
+    """An unknown verdict has established nothing, so it must not read as a pass."""
+    body = json.dumps({"status": "brand-new-state"}).encode()
+    result = _readiness_verdict("http://x/api/admin/readiness", body)
+    assert result["status"] == "unknown"
 
 
 # ── _check_lionagi_home ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`li doctor` probed `/api/admin/health` to decide whether the Studio daemon was reachable. That endpoint is the composite session health report: it pages the most recently updated sessions and aggregates message counts across branches and progressions, so its cost scales with how much history the store holds. On a store that has grown, it can stop answering entirely while every other route on the daemon serves normally.

When that happens the check times out and reports the daemon unreachable, which is the opposite of true.

## Fix

The check now probes `/api/admin/readiness`, which runs a bounded indexed read against the store.

The result is taken from the response **body**, not the status code. Readiness answers 200 for all three of its states by design, so a status-code-only check would report a daemon whose store is unreachable as healthy, trading a false alarm for a false all-clear.

| readiness `status` | doctor result |
|---|---|
| `healthy` | ok |
| `slow` | warn |
| `unavailable` | warn |
| unparseable or unrecognised | unknown |

`unknown` is already treated as not-passing in this module, on the stated principle that a check which could not run has established nothing.

## Verification

Against a running daemon:

- before: `warn` — `Studio daemon unreachable at .../api/admin/health (TimeoutError: timed out)`
- after: `ok` — `Studio daemon ready at .../api/admin/readiness (store answered a bounded indexed read)`

`tests/cli/test_doctor.py` passes 27/27. The new tests were checked against deliberately broken versions of the code: making the result ignore the response body fails all six body-mapping tests, and pointing the constant back at the composite report fails only the test that pins the endpoint choice.