### PR TITLE
Graph tab gating, node selection on the canvas, and no run-control section while nothing backs it

### DIFF
--- a/apps/studio/frontend/src/components/history/OperationGraphSection.tsx
+++ b/apps/studio/frontend/src/components/history/OperationGraphSection.tsx
@@ -32,12 +32,35 @@ const CONTINUATION_WIDTH = 1.25;
 
 // ── Node card ─────────────────────────────────────────────────────────────────
 
-function NodeCard({ node, live }: { node: OperationNode; live: boolean }) {
+function NodeCard({
+  node,
+  live,
+  onClick,
+}: {
+  node: OperationNode;
+  live: boolean;
+  onClick?: (nodeId: string) => void;
+}) {
   const isPulsing = live && node.status === "running";
+  const nodeId = node.name || node.opId;
 
   return (
     <div
-      className={`flex min-w-0 flex-col gap-1 rounded border border-edge border-l-2 bg-surface-raised px-2.5 py-2 shadow-card transition-opacity duration-150 ${STATUS_BORDER[node.status]}`}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      data-testid="op-graph-node"
+      onClick={onClick ? () => onClick(nodeId) : undefined}
+      onKeyDown={
+        onClick
+          ? (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onClick(nodeId);
+              }
+            }
+          : undefined
+      }
+      className={`flex min-w-0 flex-col gap-1 rounded border border-edge border-l-2 bg-surface-raised px-2.5 py-2 shadow-card transition-opacity duration-150 ${STATUS_BORDER[node.status]} ${onClick ? "cursor-pointer" : ""}`}
     >
       <div className="flex items-center gap-1.5">
         <span className="relative flex h-2 w-2 shrink-0">
@@ -126,9 +149,14 @@ export function computeLayers(
 export default function OperationGraphSection({
   state,
   live,
+  onNodeClick,
 }: {
   state: OperationGraphState;
   live: boolean;
+  /** ADR-0113 D6: selecting a runtime graph node resolves it to a branch,
+   * same as an authored-graph node click — the caller matches it, this
+   * component only reports which node was clicked. */
+  onNodeClick?: (nodeId: string) => void;
 }) {
   const { nodes, edges } = state;
 
@@ -141,7 +169,7 @@ export default function OperationGraphSection({
       <div className="flex flex-wrap gap-2">
         {nodes.map((n) => (
           <div key={n.opId} className="w-44">
-            <NodeCard node={n} live={live} />
+            <NodeCard node={n} live={live} onClick={onNodeClick} />
           </div>
         ))}
       </div>
@@ -233,7 +261,7 @@ export default function OperationGraphSection({
                 className="absolute"
                 style={{ left: x, top: y, width: colWidth, height: cardHeight }}
               >
-                <NodeCard node={node} live={live} />
+                <NodeCard node={node} live={live} onClick={onNodeClick} />
               </div>
             );
           }),

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -50,6 +50,16 @@ vi.mock("@/components/canvas/WorkerCanvas", () => ({
   ),
 }));
 
+// The control section renders only while some verb has a backing command.
+// This wrapper defaults to the real registry, so a test says nothing by
+// accident; the control tests below opt in to a backed registry, because the
+// shown-and-disabled contract they assert is what exists once a command type
+// lands, not what exists today.
+vi.mock("@/lib/runControls", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/runControls")>("@/lib/runControls");
+  return { ...actual, hasAnyExecutablePath: vi.fn(actual.hasAnyExecutablePath) };
+});
+
 const HISTORY_DIR = path.resolve(__dirname);
 const mountedCards: Array<{ container: HTMLDivElement; root: Root }> = [];
 
@@ -2393,9 +2403,17 @@ describe("history/RunDetail.tsx — graph/list view toggle and cross-view select
 // ─── ADR-0113 rows 8 & 9 — run controls, mounted ────────────────────────────
 
 describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     Element.prototype.scrollIntoView = vi.fn();
+    // Everything in this block describes the surface as it behaves once some
+    // verb has a backing command. That is the state in which D4's rule
+    // applies: a verb the engine cannot carry out is shown and disabled with
+    // its reason, never hidden, so a deliberate constraint does not read as a
+    // missing feature. The separate case — no verb backed at all — is covered
+    // below, and is the only reason these need to opt in.
+    const { hasAnyExecutablePath } = await import("@/lib/runControls");
+    vi.mocked(hasAnyExecutablePath).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -2517,6 +2535,28 @@ describe("history/RunDetail.tsx — pause/resume/steer controls, mounted", () =>
     const { container, unmount } = await mountRunDetail(sessionOf("show-play"));
     try {
       expect(container.querySelector('[data-testid="run-controls"]')).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  // The state the surface is actually in today. Every verb above is disabled
+  // for want of a backing command, and a panel in which nothing can ever be
+  // clicked reads as a broken feature rather than an unbuilt one. So while no
+  // verb is backed the section is not rendered at all. This is scoped to that
+  // case and does not weaken the rule above: the moment one command type
+  // exists the section returns, and a verb the engine still cannot carry out
+  // goes back to being shown and disabled with its reason.
+  it("renders no control section at all while no verb has a backing command", async () => {
+    const { hasAnyExecutablePath } = await import("@/lib/runControls");
+    vi.mocked(hasAnyExecutablePath).mockReturnValue(false);
+    const { container, unmount } = await mountRunDetail(sessionOf("flow"));
+    try {
+      expect(container.querySelector('[data-testid="run-controls"]')).toBeNull();
+      // and specifically not the disabled-with-a-reason rendering
+      expect(
+        container.querySelector('[data-testid="run-controls-reason-no-executable-path"]'),
+      ).toBeNull();
     } finally {
       unmount();
     }

--- a/apps/studio/frontend/src/components/history/RunDetail.test.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.test.tsx
@@ -2147,13 +2147,17 @@ describe("history/RunDetail.tsx — graph/list view toggle and cross-view select
     }
   });
 
-  it("row 3: a single-node run with no edges opens on the list", async () => {
+  it("row 3: a single-node run with no edges opens on the list, and offers no graph tab to switch to — a graph with no edges is not a canvas worth exposing at all", async () => {
     const { container, unmount } = await mountRunDetail(sessionWithBranches(singleNodeGraph));
     try {
       expect(container.querySelector('[data-testid="worker-canvas"]')).toBeNull();
       expect(container.querySelector("#run-branches")).not.toBeNull();
-      const listTab = container.querySelector('[data-testid="run-detail-view-list"]');
-      expect(listTab?.getAttribute("aria-selected")).toBe("true");
+      // No view toggle at all — there is nothing to switch to. Before the
+      // resolved-graph consolidation, canRenderGraph (looser than
+      // hasResolvableGraph) still exposed a clickable Graph tab here, and
+      // selecting it rendered a single disconnected node with no edges.
+      expect(container.querySelector('[data-testid="run-detail-view-graph"]')).toBeNull();
+      expect(container.querySelector('[data-testid="run-detail-view-list"]')).toBeNull();
     } finally {
       unmount();
     }
@@ -2234,6 +2238,154 @@ describe("history/RunDetail.tsx — graph/list view toggle and cross-view select
       expect(indicator?.textContent).toContain("A");
     } finally {
       unmount();
+    }
+  });
+
+  it("row 3 (runtime path): an opGraph with nodes but no edges falls back to the list, same as an edgeless authored graph", async () => {
+    const { streamSignals } = await import("@/lib/api");
+    vi.mocked(streamSignals).mockImplementationOnce((_id, cb) => {
+      cb(sig({ id: "e1", op_id: "op-a", kind: "NodeStarted", payload: { name: "A" } }));
+      return () => {};
+    });
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(null));
+    try {
+      expect(container.querySelector('[data-testid="op-graph-node"]')).toBeNull();
+      expect(container.querySelector("#run-branches")).not.toBeNull();
+      expect(container.querySelector('[data-testid="run-detail-view-graph"]')).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 4 (authored path): selecting a node renders its detail card in place, in the graph view", async () => {
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(edgedGraph));
+    try {
+      // The mocked WorkerCanvas doesn't render ReactFlow's own node markup —
+      // handleDagPanelClick delegates on the raw DOM shape ReactFlow produces
+      // (`.react-flow__node[data-id]`), so a synthetic one exercises the same
+      // delegation the real graph relies on.
+      const canvas = container.querySelector('[data-testid="worker-canvas"]');
+      const panel = canvas?.parentElement;
+      expect(panel).not.toBeNull();
+      const fakeNode = document.createElement("div");
+      fakeNode.className = "react-flow__node";
+      fakeNode.dataset.id = "A";
+      panel!.appendChild(fakeNode);
+      await act(async () => {
+        fakeNode.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(document.getElementById("step-A")).not.toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 4 (runtime path): OperationGraphSection has a node click handler, and selecting a node renders its detail card in place", async () => {
+    const { streamSignals } = await import("@/lib/api");
+    vi.mocked(streamSignals).mockImplementationOnce((_id, cb) => {
+      cb(sig({ id: "e1", op_id: "op-a", kind: "NodeStarted", payload: { name: "A" } }));
+      cb(
+        sig({
+          id: "e2",
+          op_id: "op-b",
+          kind: "NodeStarted",
+          payload: { name: "B", parent_id: "op-a" },
+        }),
+      );
+      return () => {};
+    });
+    const session = {
+      ...sessionWithBranches(null),
+      branches: [{ id: "branch-b", name: "B", created_at: 0, messages: [] }],
+    };
+    const { container, unmount } = await mountRunDetail(session);
+    try {
+      // An opGraph with a real edge is a resolvable graph, so this defaults
+      // to the graph view without needing to click a tab.
+      const nodeCard = Array.from(
+        container.querySelectorAll<HTMLElement>('[data-testid="op-graph-node"]'),
+      ).find((el) => el.textContent?.includes("B"));
+      expect(nodeCard).toBeTruthy();
+      await act(async () => {
+        nodeCard?.click();
+      });
+      expect(document.getElementById("step-B")).not.toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("row 6 (D6 URL-addressability): a URL carrying a selected node restores that selection on load", async () => {
+    window.history.replaceState(null, "", "/?node=A");
+    const { container, unmount } = await mountRunDetail(sessionWithBranches(edgedGraph));
+    try {
+      expect(document.getElementById("step-A")).not.toBeNull();
+      const indicator = container.querySelector('[data-testid="run-detail-selected-node"]');
+      expect(indicator?.textContent).toContain("A");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("coupled minor: changing the run id clears the previous run's selected node", async () => {
+    const [{ getSession }, { default: RunDetail }] = await Promise.all([
+      import("@/lib/api"),
+      import("./RunDetail"),
+    ]);
+    const runOne = sessionWithBranches(edgedGraph);
+    const runTwo = {
+      ...sessionWithBranches(edgedGraph),
+      id: "run-mount-view-2",
+      branches: [{ id: "branch-c", name: "C", created_at: 0, messages: [] }],
+    };
+    vi.mocked(getSession).mockImplementation(
+      async (id: string) => (id === "run-mount-view-2" ? runTwo : runOne) as never,
+    );
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    try {
+      await act(async () => {
+        root.render(
+          <IntlProvider locale="en" messages={enMessages}>
+            <RunDetail id="run-mount-view" />
+          </IntlProvider>,
+        );
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const canvas = container.querySelector('[data-testid="worker-canvas"]');
+      const panel = canvas?.parentElement;
+      const fakeNode = document.createElement("div");
+      fakeNode.className = "react-flow__node";
+      fakeNode.dataset.id = "A";
+      panel!.appendChild(fakeNode);
+      await act(async () => {
+        fakeNode.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(
+        container.querySelector('[data-testid="run-detail-selected-node"]')?.textContent,
+      ).toContain("A");
+
+      await act(async () => {
+        root.render(
+          <IntlProvider locale="en" messages={enMessages}>
+            <RunDetail id="run-mount-view-2" />
+          </IntlProvider>,
+        );
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelector('[data-testid="run-detail-selected-node"]')).toBeNull();
+    } finally {
+      act(() => root.unmount());
+      container.remove();
     }
   });
 });

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -138,6 +138,7 @@ export type RunDetailView = "graph" | "list";
 
 const RUN_DETAIL_VIEW_STORAGE_KEY = "studio.runDetail.view";
 const RUN_DETAIL_VIEW_QUERY_KEY = "view";
+const RUN_DETAIL_NODE_QUERY_KEY = "node";
 
 // localStorage can throw (private-browsing quotas) or simply be absent from
 // a test/SSR environment's window shim — never let a preference read/write
@@ -1767,6 +1768,25 @@ export default function RunDetail({ id }: RunDetailProps) {
     url.searchParams.set(RUN_DETAIL_VIEW_QUERY_KEY, next);
     window.history.replaceState(window.history.state, "", url);
   }, []);
+  // ADR-0113 D6: the selected node is URL-addressable the same way `view`
+  // is — read once at mount (never re-read after) and restored against the
+  // first session load's branches. `initialNodeAppliedRef` bounds that
+  // restore to the run that was live when the component first mounted, so
+  // a later run swap (the Fleet view keeps this component mounted and only
+  // changes `id`) never re-applies a stale deep link onto the new run.
+  const [initialUrlNodeKey] = useState<string | null>(() =>
+    typeof window === "undefined"
+      ? null
+      : new URLSearchParams(window.location.search).get(RUN_DETAIL_NODE_QUERY_KEY),
+  );
+  const initialNodeAppliedRef = useRef(false);
+  const writeSelectedNodeToUrl = useCallback((key: string | null) => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (key) url.searchParams.set(RUN_DETAIL_NODE_QUERY_KEY, key);
+    else url.searchParams.delete(RUN_DETAIL_NODE_QUERY_KEY);
+    window.history.replaceState(window.history.state, "", url);
+  }, []);
   // ADR-0113 D4/row 9: whether THIS client has asked this run to pause.
   // There is no session-level "paused"/"pausing" status column yet (only
   // per-node NodeExecStatus models it) — the pause gate is enforced by the
@@ -1807,6 +1827,17 @@ export default function RunDetail({ id }: RunDetailProps) {
     setOlderLoadFailed(false);
     setOlderCursor(null);
     initialScrollDoneRef.current = false;
+    // The Fleet view keeps this component mounted and swaps `id` — the
+    // selection is scoped to the run it was made on, so a run switch must
+    // drop it rather than let it read as the new run's selection.
+    // `initialNodeAppliedRef` only flips true once the FIRST run's session
+    // has resolved (below), so this leaves the deep-link restore below
+    // untouched on that very first load.
+    if (initialNodeAppliedRef.current) {
+      setSelectedStepKey(null);
+      setUnmatchedNodeId(null);
+      writeSelectedNodeToUrl(null);
+    }
     getSession(id)
       .then((s) => {
         setSession(s);
@@ -1822,14 +1853,27 @@ export default function RunDetail({ id }: RunDetailProps) {
         ) {
           setDone(true);
         }
-        if (s.branches.length <= 3) {
-          setExpandedSteps(new Set(s.branches.map((b) => b.name || b.id.slice(0, 8))));
-        } else {
-          const first = s.branches[0];
-          if (first) {
-            setExpandedSteps(new Set([first.name || first.id.slice(0, 8)]));
+        const branchExpansion =
+          s.branches.length <= 3
+            ? new Set(s.branches.map((b) => b.name || b.id.slice(0, 8)))
+            : s.branches[0]
+              ? new Set([s.branches[0].name || s.branches[0].id.slice(0, 8)])
+              : null;
+        // Restore a deep-linked node selection against THIS run's branches,
+        // once only, ever — a later run swap must not reapply it (see the
+        // clear-on-id-change block above).
+        if (!initialNodeAppliedRef.current) {
+          initialNodeAppliedRef.current = true;
+          if (initialUrlNodeKey) {
+            const match = matchGraphNodeToBranch(initialUrlNodeKey, s.branches);
+            if (match) {
+              const key = stepKeyForBranch(match);
+              branchExpansion?.add(key);
+              setSelectedStepKey(key);
+            }
           }
         }
+        if (branchExpansion) setExpandedSteps(branchExpansion);
         const graph = (s as unknown as Record<string, unknown>).graph as
           | { nodes: WorkerGraph["nodes"]; edges?: WorkerGraph["edges"] | null }
           | null
@@ -1846,7 +1890,7 @@ export default function RunDetail({ id }: RunDetailProps) {
         }
       })
       .catch((e: unknown) => setError(String(e)));
-  }, [id]);
+  }, [id, initialUrlNodeKey, writeSelectedNodeToUrl]);
 
   useEffect(() => {
     if (!id || !resumeWatch || resumeWatch.run_id !== id) return;
@@ -1962,15 +2006,21 @@ export default function RunDetail({ id }: RunDetailProps) {
   // cross-view selection (ADR-0113 D6). Collapsing does not clear the
   // selection: closing a card is not the same act as selecting a different
   // one.
-  const handleToggleExpand = useCallback((stepId: string, next: boolean) => {
-    setExpandedSteps((prev) => {
-      const updated = new Set(prev);
-      if (next) updated.add(stepId);
-      else updated.delete(stepId);
-      return updated;
-    });
-    if (next) setSelectedStepKey(stepId);
-  }, []);
+  const handleToggleExpand = useCallback(
+    (stepId: string, next: boolean) => {
+      setExpandedSteps((prev) => {
+        const updated = new Set(prev);
+        if (next) updated.add(stepId);
+        else updated.delete(stepId);
+        return updated;
+      });
+      if (next) {
+        setSelectedStepKey(stepId);
+        writeSelectedNodeToUrl(stepId);
+      }
+    },
+    [writeSelectedNodeToUrl],
+  );
 
   // Graph-node drill-down. ReactFlow renders each node wrapper with a
   // `data-id` attribute (its own internals, not StepNode/WorkerCanvas
@@ -1982,14 +2032,16 @@ export default function RunDetail({ id }: RunDetailProps) {
       if (!match) {
         setUnmatchedNodeId(nodeId);
         setSelectedStepKey(null);
+        writeSelectedNodeToUrl(null);
         return;
       }
       setUnmatchedNodeId(null);
       const key = stepKeyForBranch(match);
       setExpandedSteps((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
       setSelectedStepKey(key);
+      writeSelectedNodeToUrl(key);
     },
-    [session],
+    [session, writeSelectedNodeToUrl],
   );
 
   const handleDagPanelClick = useCallback(
@@ -2174,6 +2226,13 @@ export default function RunDetail({ id }: RunDetailProps) {
   const steps = useMemo(
     () => (session ? buildRunSteps(session, sessionStatus, segments) : []),
     [session, sessionStatus, segments],
+  );
+  // ADR-0113 D1/D6: the graph view's in-place node detail is the SAME
+  // RunStepCard the list renders for the same step — no separate detail
+  // shape to keep in sync with it.
+  const selectedGraphStep = useMemo(
+    () => (selectedStepKey ? (steps.find((s) => s.step === selectedStepKey) ?? null) : null),
+    [steps, selectedStepKey],
   );
 
   // Run-wide known file surface (union across every step/agent branch) —
@@ -2362,18 +2421,18 @@ export default function RunDetail({ id }: RunDetailProps) {
 
   // ADR-0113 D1/D6: a graph with edges is the default view; anything with no
   // edges to draw (including "no graph at all") opens on the list.
-  // shouldRenderAuthoredGraph decides whether a graph CAN render at all —
-  // canRenderGraph mirrors that same branch so the toggle only offers a
-  // graph tab when there is a graph to show in it.
-  const canRenderGraph = Boolean(
-    (runGraph && shouldRenderAuthoredGraph(runGraph, opGraph)) || opGraph.nodes.length > 0,
-  );
+  // hasResolvableGraph is the single source of truth for "is there a graph
+  // worth rendering" — tab visibility, the default-view resolution below,
+  // and the render branch further down all gate on this SAME call, so they
+  // cannot disagree about a single-node or edgeless graph the way two
+  // separately-maintained predicates could.
+  const canRenderGraph = hasResolvableGraph(runGraph, opGraph);
   const view: RunDetailView =
     userView ??
     resolveInitialView({
       urlView: initialUrlView,
       storedPreference: initialStoredView,
-      hasResolvableGraph: hasResolvableGraph(runGraph, opGraph),
+      hasResolvableGraph: canRenderGraph,
     });
   const effectiveView: RunDetailView = canRenderGraph ? view : "list";
 
@@ -2509,15 +2568,6 @@ export default function RunDetail({ id }: RunDetailProps) {
           {progressCounts && (
             <ProgressSummaryBar counts={progressCounts} elapsedLabel={elapsedLabel} t={t} />
           )}
-          {unmatchedNodeId && (
-            <div
-              role="status"
-              data-testid="run-dag-unmatched-node"
-              className="mt-2 rounded border border-edge bg-surface-overlay px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary"
-            >
-              {t("nodeNoBranch", { node: unmatchedNodeId })}
-            </div>
-          )}
           {/* A fan-out of dozens of workers cannot be legible in the same
               280px that fits a five-step pipeline — the panel takes its height
               from the laid-out graph's bounding box so fitView has room to
@@ -2596,9 +2646,43 @@ export default function RunDetail({ id }: RunDetailProps) {
         opGraph.nodes.length > 0 && (
           <div id="run-dag" className="scroll-mt-4">
             <SectionHeader label={t("sectionExecutionGraph")} count={opGraph.nodes.length} />
-            <OperationGraphSection state={opGraph} live={live && !done} />
+            <OperationGraphSection
+              state={opGraph}
+              live={live && !done}
+              onNodeClick={handleGraphNodeClick}
+            />
           </div>
         )
+      )}
+      {/* ADR-0113 D1/D6: a node selected in EITHER graph path (authored via
+          handleDagPanelClick, runtime via OperationGraphSection's onNodeClick)
+          expands in place here — the same RunStepCard the list view shows for
+          that step, not a second detail shape. A click that resolved no
+          branch gets the same explicit no-branch state regardless of which
+          graph produced it. */}
+      {effectiveView === "graph" && unmatchedNodeId && (
+        <div
+          role="status"
+          data-testid="run-dag-unmatched-node"
+          className="mt-2 rounded border border-edge bg-surface-overlay px-3 py-1.5 font-mono text-[length:var(--t-xs)] text-content-secondary"
+        >
+          {t("nodeNoBranch", { node: unmatchedNodeId })}
+        </div>
+      )}
+      {effectiveView === "graph" && selectedGraphStep && (
+        <div className="mt-2 scroll-mt-4">
+          <RunStepCard
+            step={selectedGraphStep}
+            expanded
+            onToggleExpand={handleToggleExpand}
+            runId={session.id}
+            artifactRoot={session.artifacts_path}
+            runFiles={runFiles}
+            onLoadOlder={handleLoadOlder}
+            olderMessagesRemaining={hiddenOlderCount}
+            loadingOlder={loadingOlder}
+          />
+        </div>
       )}
       {/* Scroll-up trigger: reaching the top of the conversation loads the
           next older page, same handler as the explicit button below. Kept

--- a/apps/studio/frontend/src/components/history/RunDetail.tsx
+++ b/apps/studio/frontend/src/components/history/RunDetail.tsx
@@ -56,6 +56,7 @@ import {
   confirmRunControl,
   controlKindFor,
   derivePausePhase,
+  hasAnyExecutablePath,
   pauseControlState,
   proposeRunControl,
   resumeControlState,
@@ -2477,7 +2478,7 @@ export default function RunDetail({ id }: RunDetailProps) {
       </div>
 
       <OverviewSection data={overviewData} />
-      {controlKind && (
+      {controlKind && hasAnyExecutablePath() && (
         <RunControls
           runId={session.id}
           kind={controlKind}

--- a/apps/studio/frontend/src/lib/runControls.test.ts
+++ b/apps/studio/frontend/src/lib/runControls.test.ts
@@ -17,6 +17,24 @@ describe("lib/runControls — controlKindFor", () => {
   });
 });
 
+describe("lib/runControls — hasAnyExecutablePath", () => {
+  // Deliberately unmocked. The run detail's decision to render no control
+  // section rests on this being false against the real registry; asserting it
+  // only through a mock would prove the wiring and say nothing about the fact.
+  it("is false today, because no verb has a backing command yet", async () => {
+    const { hasAnyExecutablePath } = await import("./runControls");
+    expect(hasAnyExecutablePath()).toBe(false);
+  });
+
+  it("agrees with the per-verb answer for every verb, so the two cannot drift", async () => {
+    const { hasAnyExecutablePath, hasExecutablePath } = await import("./runControls");
+    const verbs = ["pause", "resume", "message"] as const;
+    // Guards the aggregate against the case that matters: if it were ever
+    // hardcoded rather than derived, this is what would catch it.
+    expect(hasAnyExecutablePath()).toBe(verbs.some((v) => hasExecutablePath(v)));
+  });
+});
+
 describe("lib/runControls — derivePausePhase (the pausing-vs-paused window)", () => {
   it("reads idle when no pause has been requested, regardless of running count", async () => {
     const { derivePausePhase } = await import("./runControls");

--- a/apps/studio/frontend/src/lib/runControls.ts
+++ b/apps/studio/frontend/src/lib/runControls.ts
@@ -97,6 +97,22 @@ export function hasExecutablePath(verb: ControlVerb): boolean {
   return COMMAND_TYPES_BY_VERB[verb].size > 0;
 }
 
+/** Whether any control verb at all has a backing command.
+ *
+ * When none does, the run detail renders no control section rather than a
+ * section in which every control is disabled. A surface whose every verb
+ * refuses reads as a broken feature, while its absence reads as one not built
+ * yet, and only the second is true. The per-verb refusal above stays exactly
+ * as it is: it is what protects the mixed state, where some verbs are backed
+ * and others are not.
+ *
+ * The verb list comes from the registry itself rather than a second literal,
+ * so the two can never disagree, and the section reappears on its own the
+ * moment any command type lands. */
+export function hasAnyExecutablePath(): boolean {
+  return (Object.keys(COMMAND_TYPES_BY_VERB) as ControlVerb[]).some(hasExecutablePath);
+}
+
 /** Layers the surface-wide fact that a verb has no backing command on top of
  * whatever the run-state machine below decided.
  *


### PR DESCRIPTION
Two follow-ups that sit on top of #3009, which this branch is based on. The diff
here is just the two commits; #3009 carries the rest and merges first.

## Graph tab visibility, node selection, and URL state

The run-detail graph/list toggle and its default view already agreed on what
counts as a real canvas (edges, not just nodes), but the toggle's own visibility
and render gate used a separate, looser check. A single-node graph, or a runtime
graph with nodes but no edges, still exposed a clickable graph tab that rendered
a meaningless scatter of boxes. Both now gate on the same resolved-graph check.

Selecting a node in the graph view previously did nothing visible: the
authored-graph click handler only updated hidden state and expanded a list row
that isn't mounted while the graph is showing, and the runtime execution-graph
view had no click handling at all. Both paths now expand the selected node's
detail, the same card the list view already renders for that step, in place
below the graph.

The selected node is carried in the URL the same way the graph/list choice
already is, so a deep link or a reload restores it. The run-detail pane can be
reused for a different run without remounting, so the selection is also cleared
whenever the run being viewed changes. A stale selection can no longer appear
attached to a new run.

## No run-control section while no verb has a backing command

The run detail offered pause, resume and steer controls in which every button
was disabled, because no command exists yet that would carry any of those verbs
out. A panel in which nothing can ever be clicked reads as a feature that is
broken rather than one that has not been built, so the section is left out
entirely while that is the case. The work to give those verbs real commands is
tracked in #3030.

This is scoped to the all-unbacked state and does not weaken the rule it sits
beside. Once any verb has a backing command the section returns, and a verb the
engine still cannot carry out goes back to being shown and disabled with its
reason stated, so a deliberate engine constraint (an agent run has no pause
seam) keeps reading as deliberate rather than as an omission.

The aggregate derives its verb list from the command registry itself instead of
repeating it, so the section reappears on its own once a command type lands and
the two cannot drift apart.

## Tests

The graph work adds coverage for the toggle gating on a nodes-but-no-edges
graph, for node selection expanding the detail card in both the authored and
runtime views, for the URL round-trip, and for the selection clearing when the
viewed run changes.

The control-section change is covered from both sides: the existing per-verb
tests opt into a registry that has a backing command, so the shown-and-disabled
rule is still asserted where it applies, and a new test pins the current
all-unbacked state to no section at all. A second test asserts the aggregate
agrees with the per-verb answer for every verb, so the two cannot drift.
