### PR TITLE
chore: strip issue references from comments and docstrings

### DIFF
--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -734,7 +734,7 @@ async def _teardown_common(
         )
         final_evidence_refs = escalated_evidence
 
-    # Gate-rejection backstop: a gate node rejected mid-DAG (issue #2860) and the
+    # Gate-rejection backstop: a gate node rejected mid-DAG and the
     # executor short-circuited its dependent subtree to skipped instead of running
     # those nodes against the rejected baseline. That is a correct, deliberate
     # stop, not a failure -- status stays "completed" -- but the reason code must

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -120,7 +120,7 @@ class _FileState:
     tool_names: dict[str, str] = field(default_factory=dict)
     project: str | None = None
     project_source: str | None = None
-    # Raw transcript cwd, the session's artifact root (issue #2848) -- unlike
+    # Raw transcript cwd, the session's artifact root -- unlike
     # `project`, never bucketed/fallen-back, just the directory as reported.
     cwd: str | None = None
     model: str | None = None
@@ -422,7 +422,7 @@ async def _attribute_idle(db, state: _FileState, cwd: str) -> None:
     Covers sessions mirrored before project/artifact-root attribution existed,
     which have no new events to trigger the normal (streamed-event) attribution
     path. The two backfills are independent: a row can already carry a project
-    from an earlier mirror pass while still missing artifacts_path (issue #2848's
+    from an earlier mirror pass while still missing artifacts_path (the
     dominant case), so each is only (re)written when actually missing.
     """
     from lionagi.state.claude_mirror import session_db_id

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -2033,7 +2033,7 @@ async def _execute_dag(
         prior_failed_evidence = getattr(env, "_failed_operation_evidence", None) or []
         env._failed_operation_evidence = [*prior_failed_evidence, *lost_spawn_evidence]
 
-    # Gate-reject evidence (issue #2860): a mid-DAG gate node returned a
+    # Gate-reject evidence: a mid-DAG gate node returned a
     # REJECT verdict and the executor short-circuited its dependent subtree
     # to skipped rather than let it run against the rejected baseline. This
     # names the rejecting gate(s), not the (possibly many) skipped

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 UNLIMITED_CONCURRENCY = int(os.environ.get("LIONAGI_MAX_CONCURRENCY", "10000"))
 
-# Gate-reject contract (issue #2860). A playbook-authored node opts into gate
+# Gate-reject contract. A playbook-authored node opts into gate
 # semantics by setting ``operation.metadata["is_gate"] = True`` (e.g. via
 # ``OperationGraphBuilder.add_operation(..., is_gate=True)``). Once that node
 # completes, its result is inspected for a top-level ``"gate_verdict"`` key;

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -236,7 +236,7 @@ async def mirror_session(
     write, for callers with no live transcript file behind the events.
 
     ``cwd`` is the transcript's own working directory -- the CLI's artifact root
-    (issue #2848) -- written to ``artifacts_path`` on create, and backfilled on an
+    -- written to ``artifacts_path`` on create, and backfilled on an
     existing row that lacks one without ever overwriting one that is already set.
     """
     sid = session_db_id(session_uid)

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -3383,7 +3383,7 @@ class StateDB:
 
         ``artifacts_path`` is written via ``COALESCE`` rather than a plain
         assignment: a mirrored CLI session's artifact root is its transcript's
-        ``cwd``, a weaker signal than a launcher-set root (issue #2848), so a
+        ``cwd``, a weaker signal than a launcher-set root, so a
         later, more precise write must never be clobbered by an earlier guess.
         """
         sets: list[str] = []

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -66,7 +66,7 @@ class RunReasons:
     COMPLETED_EMPTY_NO_EVIDENCE = "run.completed_empty.no_evidence"
     # DAG's own result stands even when a post-completion finalize step raised
     COMPLETED_FINALIZE_ERROR = "run.completed.finalize_error"
-    # a gate node rejected mid-DAG (issue #2860) and its dependent subtree was
+    # a gate node rejected mid-DAG and its dependent subtree was
     # short-circuited to skipped rather than run against the rejected
     # baseline -- the run genuinely completed, so status stays "completed",
     # but the reason distinguishes it from a clean pass
@@ -76,11 +76,11 @@ class RunReasons:
     FAILED_ARTIFACT_WRITE = "run.failed.artifact_write"
     TIMED_OUT_DEADLINE = "run.timed_out.deadline"
     ABORTED_USER = "run.aborted.user"
-    CANCELLED_SIGINT = "run.cancelled.sigint"  # issue #1055
+    CANCELLED_SIGINT = "run.cancelled.sigint"
     CANCELLED_SIGTERM = "run.cancelled.sigterm"  # externally delivered SIGTERM (exit 143)
     CANCELLED_SYSTEM = "run.cancelled.system"
     CANCELLED_ORCHESTRATOR = "run.cancelled.orchestrator"
-    # `li kill` — Phase 2 reason codes (issue #1094)
+    # `li kill` reason codes
     CANCELLED_MANUAL_KILL = "run.cancelled.manual_kill"
     CANCELLED_FORCE_KILL = "run.cancelled.force_kill"
     CANCELLED_STALE_AUTO = "run.cancelled.stale_auto"

--- a/lionagi/studio/services/invocations.py
+++ b/lionagi/studio/services/invocations.py
@@ -26,7 +26,7 @@ def _invocation_health(
 ) -> tuple[str, float | None]:
     """Worst-of health verdict + latest activity timestamp across an
     invocation's child sessions, reusing the session health classifier
-    (ADR-0057) rather than a second vocabulary (issue #2851). "unknown"
+    (ADR-0057) rather than a second vocabulary. "unknown"
     when the invocation has no child sessions yet — liveness genuinely
     cannot be determined, never silently defaulted to "healthy"."""
     if not sessions:
@@ -112,7 +112,7 @@ async def list_invocations(
                     "schedule_run_exit_code": r.get("schedule_run_exit_code"),
                     "schedule_run_error_detail": r.get("schedule_run_error_detail"),
                     # ADR-0057 health verdict + last-activity, derived from child
-                    # sessions (issue #2851) — same vocabulary runs already use.
+                    # sessions — same vocabulary runs already use.
                     "health": health,
                     "last_activity_at": last_activity_at,
                 }

--- a/lionagi/studio/services/lifecycle.py
+++ b/lionagi/studio/services/lifecycle.py
@@ -117,7 +117,7 @@ async def reap_stale_invocations(
                     # atomic UPDATE as the status transition — a winning CAS
                     # followed by a separate update_invocation() call could
                     # leave status="timed_out" with ended_at never patched if
-                    # that second write failed (issue #2844). Preserving a
+                    # that second write failed. Preserving a
                     # pre-existing ended_at (rather than overwriting it) is
                     # still decided off this same pre-write snapshot.
                     transitioned = await db.update_status(

--- a/lionagi/studio/services/runs.py
+++ b/lionagi/studio/services/runs.py
@@ -554,7 +554,7 @@ async def list_runs(
 
 def _status_ended_at_mismatch(run: dict[str, Any]) -> bool:
     """A row reporting ``status="running"`` alongside a non-null ``ended_at``
-    is the exact write-path defect from issue #2844: two fields describing
+    is the write-path defect this guards against: two fields describing
     the same lifecycle event that disagree about it. Scoped to this one
     direction (not the reverse, a terminal row with a null ``ended_at``)
     because that population includes legitimate pre-existing rows -- rows
@@ -584,7 +584,7 @@ def paginate_runs(
         "has_prev": page > 1,
         # Recomputed on every page fetch, not read from a stored flag, so a
         # future divergence between status and ended_at is visible without
-        # anyone querying for it (issue #2844).
+        # anyone querying for it.
         "status_ended_at_mismatches": sum(1 for r in page_runs if _status_ended_at_mismatch(r)),
     }
 


### PR DESCRIPTION
The repo convention (documented in the contributor guidance) bans tracking references in committed source: comments and docstrings describe what the code does and why, and tracker numbers belong in commit messages and PR descriptions. A sweep found twelve surviving sites across ten files.

Each edit removes only the reference; the explanation it sat in stays. `grep -rnE '(issue|PR) #[0-9]' --include='*.py' lionagi/` now returns nothing, and the broader reference-class sweep is also clean.

Executable code is unchanged: every touched file passes a docstring-stripped AST-equality check against main (same guardrail as the earlier comment-relocation pass).