### PR TITLE
docs(adr): advance shipped records and ratify the corpus's own lifecycle rules

### DIFF
--- a/docs/adr/ADR-0104-li-kill-detached-play-reaping-and-terminal-notify.md
+++ b/docs/adr/ADR-0104-li-kill-detached-play-reaping-and-terminal-notify.md
@@ -1,9 +1,10 @@
 # ADR-0104: `li kill` reaping of detached-play workers and terminal-notify on kill
 
 - **Status**: Accepted (2026-07-15), amended 2026-07-27 — see Amendment 1
-- **Kind**: Partially implemented. D1/D2 (play-worker reaping) shipped code that
-  cannot reach a worker; that code is removed and the guidance corrected. D3/D5
-  (terminal-notify on kill) are unaffected.
+- **Kind**: Aspirational (records the target state)
+- **Implementation-status**: partial — D3/D5 (terminal-notify on kill) are on main;
+  D1/D2 (play-worker reaping) shipped code that cannot reach a worker; that code is
+  removed and the guidance corrected (see Amendment 1)
 - **Area**: cli-surface
 - **Date**: 2026-07-13
 - **Relations**: extends ADR-0058 (unified lifecycle transition service, whose terminal-callback emit this ADR relies on); none superseded

--- a/docs/adr/ADR-0105-resumed-session-lifecycle-and-terminal-notification.md
+++ b/docs/adr/ADR-0105-resumed-session-lifecycle-and-terminal-notification.md
@@ -1,7 +1,9 @@
 # ADR-0105: Resumed session lifecycle and terminal notification
 
 - **Status**: Accepted (2026-07-25; implementation merged)
-- **Kind**: Implemented (the lifecycle and notification behavior specified here is on main)
+- **Kind**: Aspirational (records the target state)
+- **Implementation-status**: implemented (the lifecycle and notification behavior
+  specified here is on main)
 - **Area**: persistence-state
 - **Date**: 2026-07-24
 - **Relations**: extends ADR-0095

--- a/docs/adr/ADR-0110-deterministic-manifest-fanout.md
+++ b/docs/adr/ADR-0110-deterministic-manifest-fanout.md
@@ -1,7 +1,11 @@
 # ADR-0110: Deterministic manifest fan-out — legs from briefs, no planner
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-08-11; see Amendment 1)
 - **Kind**: Aspirational (records the target state)
+- **Implementation-status**: partial — the manifest schema v1 loader (#2808) and the
+  quiescence proof before publishing a round complete (#2814) are on main
+  (`lionagi/cli/orchestrate/_manifest.py`, `_quiescence.py`, `_checkpoint.py`,
+  `_round_records.py`); remaining clauses have not been re-verified clause by clause
 - **Area**: orchestration
 - **Date**: 2026-08-03
 - **Relations**: extends ADR-0106 (machine result contract — D6 here names one
@@ -12,6 +16,19 @@
   identity-verified reads and its rule that only positive evidence of a gone
   process admits a terminal transition are what D3's reaper path is built on,
   and D3's finalization claim decides which of them a late arrival still owes)
+
+## Amendment 1 (2026-08-11) — the record catches up with the code
+
+This ADR was authored `Proposed` on 2026-08-03 and its core implementation merged the
+same day: the manifest schema v1 loader landed in #2808 (2026-08-03) and the
+quiescence gate — proving a manifest round quiet before publishing it complete — landed
+in #2814 (2026-08-04). The modules named by D1 exist on main
+(`lionagi/cli/orchestrate/_manifest.py`, `_quiescence.py`, `_checkpoint.py`,
+`_round_records.py`). The status flip to Accepted records that the decision has been
+in effect since then; it changes nothing in the decision text. Clauses beyond the
+D1 core have not been re-verified individually — the `Implementation-status` header
+field says `partial` for that reason and should be advanced as each clause is
+confirmed shipped.
 
 ## Context
 

--- a/docs/adr/ADR-0113-execution-graph-as-primary-run-canvas.md
+++ b/docs/adr/ADR-0113-execution-graph-as-primary-run-canvas.md
@@ -1,12 +1,32 @@
 # ADR-0113: The execution graph as the primary run canvas
 
-- **Status**: Proposed
+- **Status**: Accepted for D1-D4 and D6 (2026-08-11; see Amendment 1). D5 remains
+  Proposed — it depends on a flow definition format that does not exist yet (#2836)
 - **Kind**: Aspirational
+- **Implementation-status**: partial — D2 (ASAP ranks, dagre within ranks) and D3
+  (live node state on the node) are on main with tests; D1/D6 are shipping through
+  the current-vs-ideal delta table below, which is the live work list; D4's resume
+  verb is on main, pause and steer are not; D5 is not started
 - **Area**: studio
 - **Date**: 2026-08-08
 - **Relations**: extends ADR-0080 (six-space cockpit IA — this decides the primary surface
   *inside* a run, not the top-level taxonomy), extends ADR-0083 (operator-command protocol
   — the control verbs here ride its proposal and audit machinery)
+
+## Amendment 1 (2026-08-11) — partial landing, recorded per clause
+
+Implementation began the week this record was authored, so the Context section's
+present-tense description of a step-list-primary run detail is now historical: it is
+retained as the state the decision was made against, not a description of main. What
+has landed, with the evidence: live per-node activity on the run canvas (#3008,
+`WorkerCanvas` node-activity handling), lifecycle signals kept under one name per
+operation, the board rendering guarded against a slow backend (#3022), and the
+ASAP-rank layout with in-rank dagre ordering (`useLayout` and its rank tests). The
+run-detail resume verb exists (`resumeRun` in the Studio client API); pause and steer
+do not yet. D5 stays Proposed: as this record itself states, the executable flow
+definition format it depends on does not exist, and ADR-0114 is the design attempt at
+it. The delta table at the foot of this document remains the authoritative list of
+what D1/D6 still owe.
 
 ## Context
 

--- a/docs/adr/ADR-0114-executable-flow-definition-and-role-capabilities.md
+++ b/docs/adr/ADR-0114-executable-flow-definition-and-role-capabilities.md
@@ -1,11 +1,15 @@
 # ADR-0114: An executable flow definition, and roles whose declared capabilities are real
 
 - **Status**: Proposed
+- **Kind**: Aspirational (records the target state)
+- **Implementation-status**: not-started (no implementation commits identified as of
+  2026-08-11; ADR-0113 D5 is blocked on the format this record designs)
+- **Area**: cli-orchestration
 - **Date**: 2026-08-08
-- **Supersedes**: none
-- **Related**: ADR-0113 (execution graph as the primary run canvas), #2836 (deterministic YAML
-  pipeline interface), #2928 (REJECT-to-replan and the refusal budget), #2929 (role instance
-  naming at the spawn boundary), #2924 (escalation children enter the DAG with no edges)
+- **Relations**: supersedes none; related to ADR-0113 (execution graph as the primary run
+  canvas), #2836 (deterministic YAML pipeline interface), #2928 (REJECT-to-replan and the
+  refusal budget), #2929 (role instance naming at the spawn boundary), #2924 (escalation
+  children enter the DAG with no edges)
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,21 @@ Each ADR follows `TEMPLATE.md` and is exactly one of two kinds:
 A gap between a retrospective truth and an aspirational target is an issue, never a blurred
 document.
 
+Kind describes what the document is and never changes as code lands. How much of a decided
+target has actually shipped is recorded in the separate, mutable `Implementation-status`
+header field (see `TEMPLATE.md`), updated as implementation progresses without a formal
+amendment.
+
+## Status lifecycle
+
+An ADR is authored `Proposed`. The flip to `Accepted` has an owner and a trigger: **the PR
+that merges the ADR's first dependent implementation also flips its status**, and whoever
+merges that PR owns the flip. When an implementation has already merged while the record
+still reads `Proposed`, the correction is an immediate docs follow-up, not a debt to
+accumulate. Decisions inside one ADR are separable: where only some decision clauses have
+shipped or one clause is blocked on an external dependency, the status line says so
+per-clause and `Implementation-status` names what landed and what remains.
+
 ## Architecture-quality figures (κ and τ)
 
 Several ADRs report two figures in their Consequences sections. κ is a coupling density:
@@ -50,6 +65,10 @@ ADR-0104 is a documented numbering exception for the same reason: it declares `c
 but carries a number far outside that block (0062-0067), which was allocated before the
 per-area scheme was applied to it. It is indexed under cli-surface and keeps its number, so
 inbound references stay valid.
+
+Numbers 0096-0103 belong to no area block and are reserved but unused: they fall between the
+end of the block regime (0095) and the start of the sequential regime (0104), and no document
+will be created to fill them.
 
 From ADR-0104 onward, numbers are in practice allocated **sequentially** rather than from the
 area block, and each such record is indexed under the area it declares. This is a description
@@ -91,6 +110,8 @@ its area block.
 - [ADR-0013](ADR-0013-built-in-tool-provider-and-branch-binding.md) — Built-in tool provider and
   Branch binding
 - 0014-0015 — unused (intentional gaps)
+- [ADR-0112](ADR-0112-mcp-tool-registration-naming-and-collisions.md) — MCP tool registration
+  naming and collision behavior (sequential number; see Numbering)
 
 ### session-branch (0016-0020)
 
@@ -133,6 +154,10 @@ its area block.
   queue
 - [ADR-0038](ADR-0038-escalation-tier-routing.md) — Escalation tier routing
 - 0039-0040 — unused (intentional gaps)
+- [ADR-0110](ADR-0110-deterministic-manifest-fanout.md) — Deterministic manifest fan-out —
+  legs from briefs, no planner (sequential number; see Numbering)
+- [ADR-0111](ADR-0111-run-base-ref-provenance-and-preconditions.md) — A run records the code
+  it was reasoning about, and can refuse to start (sequential number; see Numbering)
 
 ### agent-roles (0041-0046)
 
@@ -212,6 +237,8 @@ its area block.
 - [ADR-0073](ADR-0073-fixed-workflow-definition-execution.md) — Fixed workflow-definition
   execution
 - 0074-0075 — unused (intentional gaps)
+- [ADR-0108](ADR-0108-agent-run-steering-at-turn-end.md) — Agent-run steering at the turn-end
+  boundary (sequential number; see Numbering)
 
 ### studio (0076-0085)
 
@@ -230,6 +257,8 @@ its area block.
 - [ADR-0082](ADR-0082-vscode-studio-observability-client.md) — VS Code Studio observability client
 - [ADR-0083](ADR-0083-studio-operator-command-protocol.md) — Studio operator-command protocol
 - 0084-0085 — unused (intentional gaps)
+- [ADR-0113](ADR-0113-execution-graph-as-primary-run-canvas.md) — The execution graph as the
+  primary run canvas (sequential number; see Numbering)
 
 ### governance (0086-0089)
 
@@ -255,6 +284,18 @@ its area block.
   supersedes ADR-0060)
 - [ADR-0088](ADR-0088-plugin-system.md) — Plugin system (directory-bundle manifest with
   lazy activation; number from the adjacent free gap — the substrates block is exhausted)
+
+### cli-orchestration (sequential numbers only)
+
+Ratified 2026-08-11 as the seventeenth area: the CLI orchestration surface — `li o flow` /
+`li o fanout`, playbooks and flow definitions, orchestration guidance packs. It postdates
+the block regime, so it holds no number block; its records carry sequential numbers (≥0104).
+
+- [ADR-0114](ADR-0114-executable-flow-definition-and-role-capabilities.md) — An executable
+  flow definition, and roles whose declared capabilities are real (sequential number; see
+  Numbering)
+- [ADR-0115](ADR-0115-orchestration-guidance-as-an-enforced-pack.md) — Orchestration
+  guidance as an enforced pack (sequential number; see Numbering)
 
 Remaining areas land here as their records are accepted.
 

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -3,11 +3,18 @@
 - **Status**: Proposed | Accepted | Superseded by ADR-NNNN
 - **Kind**: Retrospective (records what IS) | Aspirational (records the target state)
   — never both in one document; a delta between a retrospective truth and an
-  aspirational target is an ISSUE, not a section that blurs the two.
-- **Area**: <exactly one of the 16 ratified areas: core-data-model,
+  aspirational target is an ISSUE, not a section that blurs the two. Kind describes
+  what the document IS and never changes as code lands; implementation state lives
+  in the separate field below.
+- **Implementation-status**: not-started | partial (name what landed and what
+  remains, per decision clause) | implemented — optional for Retrospective records
+  (they describe shipped code by definition), required for Aspirational ones.
+  Orthogonal to both Status and Kind, and mutable: update it as code lands, without
+  a formal amendment.
+- **Area**: <exactly one of the 17 ratified areas: core-data-model,
   messages-context, actions-tools, session-branch, operations, service-providers,
   orchestration, agent-roles, hooks, utilities, persistence-state, cli-surface,
-  scheduling-control-plane, studio, governance, substrates>
+  scheduling-control-plane, studio, governance, substrates, cli-orchestration>
 - **Date**: YYYY-MM-DD
 - **Relations**: supersedes v0-NNNN[, v0-NNNN…] | extends ADR-NNNN | none
   — every v0 ADR referenced gets an explicit disposition in the corpus index:


### PR DESCRIPTION
An audit of the ADR corpus against the code found one systematic gap: records are authored `Proposed` and never advanced once their implementation merges. This PR fixes the instances found and adds the rule that prevents recurrence. No decision text changes anywhere; every edit is header fields, amendments, or index/README text.

## Record corrections

- **ADR-0110** (deterministic manifest fan-out): `Proposed` → `Accepted` with Amendment 1. The manifest schema v1 loader (#2808) and the round-quiescence gate (#2814) merged the same week the record was authored; the modules D1 names exist on main.
- **ADR-0113** (execution graph as primary run canvas): per-clause status with Amendment 1. D2 (ASAP ranks) and D3 (live node state, #3008) are on main with tests; D1/D6 are shipping through the record's own delta table; D5 stays `Proposed` — the flow definition format it depends on does not exist yet (#2836, designed by ADR-0114).
- **ADR-0114**: gains the template's missing `Kind` and `Area` headers and its `Relations` field (content unchanged, folded from `Supersedes`/`Related`).

## Corpus rules (TEMPLATE.md / README.md)

- **`Implementation-status` header field**: implementation state moves out of `Kind` into a separate, mutable field. `Kind` stays a two-value description of what the document is; how much of a decided target has shipped is orthogonal and changes over time. ADR-0104/0105, which had improvised status values inside `Kind`, now conform.
- **Status lifecycle**: the `Proposed` → `Accepted` flip now has an owner and a trigger — the PR that merges the ADR's first dependent implementation flips the status, and whoever merges it owns the flip.
- **`cli-orchestration` ratified as the seventeenth area** (sequential numbers only; it postdates the block regime). ADR-0115's declared area is now legitimate and ADR-0114 is indexed under it.
- **Numbering**: 0096-0103 documented as the reserved gap between the block regime (≤0095) and the sequential regime (≥0104).
- **Index completeness**: ADR-0108 and 0110-0115 had never received index rows; added under their declared areas.

`scripts/check_adr_status_sets.py` passes on the branch.