### PR TITLE
fix(service): expose the served CLI model

### DIFF
--- a/docs/api/imodel.md
+++ b/docs/api/imodel.md
@@ -34,9 +34,14 @@ model = li.iModel(
 | `limit_tokens` | `int \| None` | `None` | Max tokens per rate-limit cycle |
 | `concurrency_limit` | `int \| None` | `None` | Max concurrent streams |
 | `streaming_process_func` | `Callable \| None` | `None` | Custom chunk processor for streaming responses |
-| `provider_metadata` | `dict \| None` | `None` | Auxiliary provider metadata; non-CLI session lookup reads its `session_id` key |
+| `provider_metadata` | `dict \| None` | `None` | Auxiliary provider metadata; see the keys below |
 | `hook_registry` | `HookRegistry \| dict \| None` | `HookRegistry()` | Pre/post invocation hooks |
 | `**kwargs` | — | — | Provider-specific config (e.g., `model="gpt-4o"`, `temperature=0.7`) |
+
+When a provider reports the model that actually served a request, `iModel`
+stores it in `provider_metadata["served_model"]`. The key remains absent when
+the provider does not report a model; it is never inferred from the requested
+`model` value. Non-CLI session lookup reads `provider_metadata["session_id"]`.
 
 ## Endpoint types
 

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -23,6 +23,7 @@ from .hooks import (
     global_hook_logger,
 )
 from .rate_limited_processor import RateLimitedAPIExecutor
+from .types import StreamChunk
 
 
 def _terminal_stream_error(api_call: APICalling) -> BaseException | None:
@@ -316,7 +317,28 @@ class iModel:  # noqa: N801
             return self.streaming_process_func(chunk)
         return processed
 
+    @staticmethod
+    def _reported_served_model(value: Any) -> str | None:
+        if isinstance(value, StreamChunk):
+            if value.type != "system":
+                return None
+            value = value.metadata
+        if not isinstance(value, dict):
+            return None
+
+        served_model = value.get("model")
+        if isinstance(served_model, str) and served_model.strip():
+            return served_model
+        return None
+
+    def _store_served_model(self, served_model: str | None) -> None:
+        if served_model is None:
+            self.provider_metadata.pop("served_model", None)
+        else:
+            self.provider_metadata["served_model"] = served_model
+
     async def stream(self, api_call=None, **kw) -> AsyncGenerator:
+        served_model = None
         if api_call is None:
             kw["stream"] = True
             api_call = await self.create_event(**kw)
@@ -330,6 +352,9 @@ class iModel:  # noqa: N801
                 stream_error = None
                 try:
                     async for i in api_call.stream():
+                        reported_model = self._reported_served_model(i)
+                        if reported_model is not None:
+                            served_model = reported_model
                         result = await self.process_chunk(i)
                         yield result if result is not None else i
                     # api_call.stream() captures a transport/provider failure as
@@ -341,6 +366,7 @@ class iModel:  # noqa: N801
                 except Exception as e:
                     raise ValueError(f"Failed to stream API call: {e}") from e
                 finally:
+                    self._store_served_model(served_model)
                     # Pop without yielding — yield-in-finally would swallow CancelledError
                     # during generator cleanup, breaking anyio.fail_after timeout enforcement.
                     self.executor.pile.pop(api_call.id, None)
@@ -350,12 +376,16 @@ class iModel:  # noqa: N801
             stream_error = None
             try:
                 async for i in api_call.stream():
+                    reported_model = self._reported_served_model(i)
+                    if reported_model is not None:
+                        served_model = reported_model
                     result = await self.process_chunk(i)
                     yield result if result is not None else i
                 stream_error = _terminal_stream_error(api_call)
             except Exception as e:
                 raise ValueError(f"Failed to stream API call: {e}") from e
             finally:
+                self._store_served_model(served_model)
                 self.executor.pile.pop(api_call.id, None)
             if stream_error is not None:
                 raise ValueError(f"Failed to stream API call: {stream_error}") from stream_error
@@ -386,17 +416,19 @@ class iModel:  # noqa: N801
                     pass
 
             completed_call = self.executor.pile.pop(api_call.id)
-            if (
-                isinstance(self.endpoint, AgenticEndpoint)
-                and completed_call
-                and completed_call.response
-            ):
-                response = completed_call.response
-                if isinstance(response, dict) and "session_id" in response:
+            response = completed_call.response if completed_call else None
+            self._store_served_model(self._reported_served_model(response))
+            if response:
+                if (
+                    isinstance(self.endpoint, AgenticEndpoint)
+                    and isinstance(response, dict)
+                    and "session_id" in response
+                ):
                     self.endpoint.session_id = response["session_id"]
 
             return completed_call
         except Exception as e:
+            self._store_served_model(None)
             raise ValueError(f"Failed to invoke API call: {e}") from e
 
     @property

--- a/tests/service/imodel/test_init.py
+++ b/tests/service/imodel/test_init.py
@@ -11,6 +11,7 @@ from lionagi.protocols.generic.event import EventStatus
 from lionagi.service.connections.api_calling import APICalling
 from lionagi.service.hooks import HookRegistry
 from lionagi.service.imodel import iModel
+from lionagi.service.types import StreamChunk
 
 
 class TestiModel:
@@ -135,6 +136,146 @@ class TestiModel:
                     chunks.append(chunk)
 
         assert len(chunks) >= 2  # Should have content chunks
+
+    @pytest.mark.asyncio
+    async def test_stream_stores_served_model_before_chunk_hook(self, base_imodel):
+        async def replace_system_chunk(_event, _chunk_type, _chunk, **_kw):
+            return {"handled": True}
+
+        base_imodel.hook_registry = HookRegistry(
+            stream_handlers={StreamChunk: replace_system_chunk}
+        )
+
+        async def mock_stream():
+            yield StreamChunk(
+                type="system",
+                metadata={"model": "provider-served-model", "session_id": "session-123"},
+            )
+
+        with patch.object(base_imodel.endpoint, "stream", return_value=mock_stream()):
+            chunks = [
+                chunk
+                async for chunk in base_imodel.stream(
+                    messages=[{"role": "user", "content": "Hello"}]
+                )
+            ]
+
+        assert chunks == [{"handled": True}]
+        assert base_imodel.provider_metadata["served_model"] == "provider-served-model"
+
+    @pytest.mark.asyncio
+    async def test_invoke_stores_and_serializes_served_model(self, base_imodel):
+        async def mock_call(*_args, **_kwargs):
+            return {"model": "provider-served-model", "response": "Hello"}
+
+        with patch.object(base_imodel.endpoint, "call", side_effect=mock_call):
+            await base_imodel.invoke(messages=[{"role": "user", "content": "Hello"}])
+
+        assert base_imodel.provider_metadata["served_model"] == "provider-served-model"
+        restored = iModel.from_dict(base_imodel.to_dict())
+        assert restored.provider_metadata["served_model"] == "provider-served-model"
+
+    @pytest.mark.asyncio
+    async def test_stream_clears_stale_served_model_when_provider_omits_it(self, base_imodel):
+        base_imodel.provider_metadata["served_model"] = "previous-served-model"
+
+        async def mock_stream():
+            yield StreamChunk(type="system", metadata={"session_id": "session-123"})
+
+        with patch.object(base_imodel.endpoint, "stream", return_value=mock_stream()):
+            chunks = [
+                chunk
+                async for chunk in base_imodel.stream(
+                    messages=[{"role": "user", "content": "Hello"}]
+                )
+            ]
+
+        assert len(chunks) == 1
+        assert "served_model" not in base_imodel.provider_metadata
+
+    @pytest.mark.asyncio
+    async def test_invoke_clears_stale_served_model_when_provider_omits_it(self, base_imodel):
+        base_imodel.provider_metadata["served_model"] = "previous-served-model"
+
+        async def mock_call(*_args, **_kwargs):
+            return {"response": "Hello"}
+
+        with patch.object(base_imodel.endpoint, "call", side_effect=mock_call):
+            await base_imodel.invoke(messages=[{"role": "user", "content": "Hello"}])
+
+        assert "served_model" not in base_imodel.provider_metadata
+
+    @pytest.mark.asyncio
+    async def test_concurrent_stream_uses_last_completed_provider_report(self, base_imodel):
+        release_unknown = asyncio.Event()
+        unknown_started = asyncio.Event()
+
+        async def mock_stream(request, **_kwargs):
+            content = request["messages"][0]["content"]
+            if content == "unknown":
+                unknown_started.set()
+                await release_unknown.wait()
+                yield StreamChunk(type="system", metadata={"session_id": "unknown"})
+                return
+            yield StreamChunk(type="system", metadata={"model": "provider-served-model"})
+
+        async def consume(content):
+            return [
+                chunk
+                async for chunk in base_imodel.stream(
+                    messages=[{"role": "user", "content": content}]
+                )
+            ]
+
+        with patch.object(base_imodel.endpoint, "stream", side_effect=mock_stream):
+            unknown_task = asyncio.create_task(consume("unknown"))
+            await unknown_started.wait()
+            await consume("reported")
+            assert base_imodel.provider_metadata["served_model"] == "provider-served-model"
+
+            release_unknown.set()
+            await unknown_task
+
+        assert "served_model" not in base_imodel.provider_metadata
+
+    @pytest.mark.asyncio
+    async def test_concurrent_invoke_uses_last_completed_provider_report(self, base_imodel):
+        release_unknown = asyncio.Event()
+        unknown_started = asyncio.Event()
+
+        async def mock_call(request, **_kwargs):
+            content = request["messages"][0]["content"]
+            if content == "unknown":
+                unknown_started.set()
+                await release_unknown.wait()
+                return {"response": "unknown"}
+            return {"model": "provider-served-model", "response": "reported"}
+
+        async def invoke(content):
+            return await base_imodel.invoke(messages=[{"role": "user", "content": content}])
+
+        with patch.object(base_imodel.endpoint, "call", side_effect=mock_call):
+            unknown_task = asyncio.create_task(invoke("unknown"))
+            await unknown_started.wait()
+            await invoke("reported")
+            assert base_imodel.provider_metadata["served_model"] == "provider-served-model"
+
+            release_unknown.set()
+            await unknown_task
+
+        assert "served_model" not in base_imodel.provider_metadata
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("reported_model", [None, "", "   "])
+    async def test_invoke_does_not_infer_missing_served_model(self, base_imodel, reported_model):
+        async def mock_call(*_args, **_kwargs):
+            return {"model": reported_model, "response": "Hello"}
+
+        with patch.object(base_imodel.endpoint, "call", side_effect=mock_call):
+            await base_imodel.invoke(messages=[{"role": "user", "content": "Hello"}])
+
+        assert base_imodel.model_name == "gpt-4.1-mini"
+        assert "served_model" not in base_imodel.provider_metadata
 
     def test_model_name_property(self, base_imodel):
         imodel = base_imodel


### PR DESCRIPTION
## Summary

- capture the non-empty model reported by CLI providers in `provider_metadata["served_model"]`
- publish stream provenance after processing completes so hooks and concurrent requests cannot leave stale metadata
- preserve the metadata through `iModel` serialization and document the contract without falling back to the requested model

Fixes #3070

## Testing

- `uv run pytest tests/service/imodel/test_init.py -q` (48 passed)
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=master uv run pytest` (19,208 passed, 12 skipped, 3 xfailed)
- `uv run pre-commit run --files lionagi/service/imodel.py tests/service/imodel/test_init.py docs/api/imodel.md`
- `uv build`
- `git diff --check`

Repository-wide `pre-commit -a` is currently blocked by pre-existing Ruff findings outside this diff and one existing Markdown finding in `ADR-0112`; all hooks pass on the changed files.

## AI assistance

Implementation and tests were prepared with OpenAI Codex, then independently reviewed against the current provider and concurrency contracts.
