### PR TITLE
docs: trim inline prose in plugins/hooks/agent, add plugin-runtime.md

### DIFF
--- a/docs/internals/plugin-runtime.md
+++ b/docs/internals/plugin-runtime.md
@@ -1,0 +1,106 @@
+# Plugin trust and the external hook lifecycle
+
+A lionagi plugin is a directory bundle under `.lionagi/plugins/<name>/` carrying
+a `plugin.yaml` manifest. Nothing it declares — a tool, a hook, an agent
+profile, a playbook — runs until a human has explicitly trusted that exact
+content. This document covers how that trust is computed and stored, and how
+a trusted (or built-in) hook actually gets executed once approved.
+
+## Trust model
+
+Trust is content-pinned, not declaration-pinned. `compute_trust_hashes()`
+(`lionagi/plugins/trust.py`) hashes the canonical-JSON manifest plus every
+file the manifest declares — tool/provider targets, hook binaries, agent
+profile files, playbook files, pack data files. `trust_plugin()` persists
+those hashes; `trust_state()` recomputes them on every load and returns
+`CHANGED` the instant any one of them differs, `UNTRUSTED` if there's no
+record at all, `TRUSTED` only when every hash still matches. There is no
+partial trust — one changed file reverts the whole plugin.
+
+Trust records live in `~/.lionagi/settings.yaml`, always user-level, never
+project-level. A repository cannot self-trust a plugin it carries by
+committing a settings line; only the human on the machine approves. The
+record also pins the bundle's resolved directory path, which is what garbage
+collection checks for presence.
+
+`gc_trust_records()` prunes a trust record only when its bundle directory is
+confirmed gone — not when the manifest merely fails to parse. A `plugin.yaml`
+mid-edit or hit by a transient read error is not the same as uninstalled, and
+losing its trust record over a blip would force re-approval for no reason.
+The presence check also closes a resurrection path: without it, a stale
+record for a genuinely removed bundle would silently re-trust a different
+bundle that later reappears under the same name and happens to hash the same
+— exactly what content-pinning exists to prevent.
+
+`trust_plugin()` raises `FileNotFoundError` rather than trusting a partial
+bundle: if a declared capability file can't be read, there's nothing to pin
+a hash to, and trusting is pinning content — a bundle missing a file it
+declares can't be trusted.
+
+## Settings lock
+
+Every mutator that touches `~/.lionagi/settings.yaml` — GC, trust, plugin
+enable/disable — goes through `locked_user_settings()`
+(`lionagi/plugins/_user_settings.py`), a single exclusive POSIX lock (`flock`
+on POSIX, `msvcrt.locking` on Windows) held for the entire read-modify-write.
+That is the one choke point that makes concurrent writers safe: without it, a
+writer's stale in-memory snapshot could silently clobber another writer's
+change between its read and its write.
+
+The context manager yields the parsed settings dict for the caller to mutate
+in place, and writes back only if the dict actually changed — a no-op pass
+touches neither the file's mtime nor a concurrent reader. It opens the file
+with `O_CREAT` but deliberately never `O_TRUNC`: truncating before the lock is
+held could blow away content a racing creator already committed, so
+truncation only happens after the lock is acquired, immediately before the
+rewrite.
+
+`read_user_settings()` takes a shared lock for a point-in-time snapshot, safe
+against a concurrent writer's truncate-then-rewrite. `write_user_settings()`
+is an unconditional whole-file rewrite under an exclusive lock — safe as a
+standalone call, but its lock only spans the write itself, not any read that
+preceded it, so two independent read/write pairs built on top of it can still
+race each other. Anything that needs read-modify-write safety must use
+`locked_user_settings()`, not compose `read_user_settings()` +
+`write_user_settings()` itself.
+
+## Hook lifecycle
+
+An external hook (a plugin's declared `hooks_external:` entry, or a
+project/user-authored one) is a wire contract, not an in-process callback.
+`build_envelope()` (`lionagi/hooks/external.py`) serializes the event as JSON
+to the hook's stdin; `_execute_hook()` spawns the command, exchanges the
+envelope, and normalizes exit code + stdout into a `HookVerdict`: exit 0 with
+non-empty, non-truncated stdout is parsed as a decision; exit 2 denies with
+stderr as the reason; anything else (non-zero exit, spawn/IO error, timeout)
+is a hook failure — denied on a blocking event, logged and passed through on
+an advisory one. A truncated response is never parsed even if it looks
+complete, since the retained prefix could coincidentally read as a valid but
+wrong decision.
+
+Trust for an *imported* hook command (one carrying a non-empty `source`, e.g.
+`imported:claude`) is re-checked on every invocation, not cached from when
+the adapter was built: `_trust_status()` (ADR-0048 D7) requires a record in
+`trusted_hook_commands` whose argv hash, resolved executable path, and
+content digest all match the command as it resolves *right now*. A stale
+approval of `["./guard"]` does not carry over if the executable it resolves
+to — or that executable's bytes — changed since approval. This closes a gap
+where argv-only hashing would let a different repository's `./guard`, or a
+later PATH-resolved one, run under someone else's approval. The resolution,
+the trust-record match, and the private hash-verified copy that actually
+gets executed all come from one `_prepare_trusted_execution` call, so a swap
+between "approved" and "exec'd" can't win a race by re-resolving the command
+a second time. A project/user-authored command (no `source`) has no separate
+approval to bind against and always spawns directly in the resolving
+directory.
+
+Hook teardown is where lost events get reported. `MessagePersistRetryQueue`
+(`lionagi/hooks/_message_retry.py`) preserves message order while retrying
+failed atomic persistence; `flush_final()` makes one last attempt and, if
+messages still didn't make it, logs an error — `flush()` alone only returns
+`False`, which nothing here reads. Teardown reaches `flush_final()` more than
+once (the hook bus flushes on `SESSION_END`, and run teardown flushes again
+before reading completion evidence, unaware of each other), so the loss
+report is deduped by pending count: a repeated identical count is the same
+incident restated and stays quiet, a changed count is new information and
+gets logged again.

--- a/lionagi/agent/gate.py
+++ b/lionagi/agent/gate.py
@@ -46,19 +46,14 @@ GateEvaluator = Callable[[str, str, dict], Awaitable[GateResult]]
 
 
 class ControlUnavailableError(PermissionError):
-    """A control could not reach a verdict about this call.
+    """A control could not reach a verdict — its own configuration is the
+    problem (missing escalation handler, unreachable backend, a rule set
+    that failed to load), not anything about the call. Still refuses the
+    call, since a control that cannot answer must not be read as approval.
 
-    Raised when the thing standing in the way is the control's own
-    configuration rather than anything about the call: no escalation handler
-    where a decision needs one, a backend that is not reachable, a rule set
-    that could not be loaded. The call is still refused, because a control
-    that cannot answer must not be read as an approval.
-
-    It subclasses ``PermissionError`` so that everything already failing
-    closed on that keeps doing so unchanged. What it adds is a way to tell
-    "your configuration cannot answer this" from "the answer is no", which
-    an operator acts on differently and which the two are otherwise
-    indistinguishable in.
+    Subclasses ``PermissionError`` so existing fail-closed handling is
+    unchanged; distinguishes "configuration cannot answer this" from "the
+    answer is no" for operators who act on the two differently.
     """
 
 

--- a/lionagi/hooks/_message_retry.py
+++ b/lionagi/hooks/_message_retry.py
@@ -61,30 +61,14 @@ class MessagePersistRetryQueue:
             return await self._drain_locked(force=True)
 
     async def flush_final(self) -> bool:
-        """Flush at teardown, and say so when events did not make it.
+        """Flush at teardown, and log-error when events did not make it — ``flush``
+        alone only returns ``False``, which no caller here reads.
 
-        ``flush`` reports failure only by returning ``False``, and that is the
-        whole of what the failing path says. The state log is deliberately quiet
-        when nothing changed, and a queue that has been failing long enough to
-        reach teardown is already in the state it would be transitioning to, so
-        the last attempt these events will ever get is exactly the attempt that
-        emits nothing. A caller that drops the return value is then told nothing
-        at all, by a queue that just lost their messages.
-
-        Losing them is an outcome rather than a state change, so it is reported
-        here whichever state the queue was already in. The count is included
-        because it is the part nobody can reconstruct afterwards: the events are
-        gone, and no later sweep has anything left to find.
-
-        Teardown reaches this more than once. The hook bus flushes on
-        ``SESSION_END`` and the run teardown flushes before it reads completion
-        evidence, and both traverse the same queues without either being able to
-        see the other. The repeated *attempt* is wanted — the store may have come
-        back between them, and the second call is a real last chance — so what is
-        suppressed is the repeated *report*: the same loss, restated, reads as
-        two separate incidents. A count that has changed is a different fact and
-        is reported again, and a flush that finally succeeds clears the marker so
-        a later loss is not swallowed as a repeat.
+        Teardown reaches this more than once (hook-bus ``SESSION_END`` and run
+        teardown both flush, unaware of each other), so the loss report is
+        deduped by pending count rather than re-logged every call: a repeated
+        identical count is the same incident restated, a changed count is new
+        information. See docs/internals/plugin-runtime.md#hook-lifecycle.
         """
         flushed = await self.flush()
         if flushed:

--- a/lionagi/hooks/external.py
+++ b/lionagi/hooks/external.py
@@ -341,16 +341,14 @@ def _prepare_trusted_execution(
 
 
 def _trust_status(command: list[str], *, source: str | None, cwd: str) -> tuple[bool, str]:
-    """Loader trust rule (ADR-0048 D7, content-pinned): an entry with no
-    ``source`` is project/user-authored and trusted as code; any non-empty
-    ``source`` (``imported:claude``, ``imported:codex``, ...) requires a
-    trust record in ``~/.lionagi/settings.yaml``'s ``trusted_hook_commands``
-    whose argv hash, resolved executable path, AND content digest all match
-    *command* as it resolves right now -- a prior approval of ``["./guard"]``
-    does NOT carry over if the executable it resolves to, or that
-    executable's bytes, have changed since approval (the flaw this closes:
-    argv-only hashing let a different repository's or a later PATH-resolved
-    ``./guard`` run under a stale approval).
+    """Loader trust rule (ADR-0048 D7, content-pinned): a ``source``-less entry
+    is project/user-authored and trusted as code; any non-empty ``source``
+    (``imported:claude``, ``imported:codex``, ...) requires a matching record
+    in ``trusted_hook_commands`` whose argv hash, resolved executable path,
+    AND content digest all match *command* as it resolves right now — a
+    stale approval does not carry over if the resolved executable or its
+    bytes changed (closes argv-only hashing letting a different repo's or a
+    later PATH-resolved same-argv command run under a stale approval).
 
     Returns ``(trusted, reason)``; *reason* is empty when trusted.
     """
@@ -750,18 +748,14 @@ def external_hook_adapter(
     blocking = event in BLOCKING_EVENTS
 
     async def _guarded_execute(envelope: dict[str, Any]) -> HookVerdict:
-        # Re-resolved every call, not cached from adapter construction: the
-        # executable a relative/PATH-searched command resolves to can change
-        # between approval and this exact invocation (D7 content pinning).
-        # For a source-having (imported) entry, resolution, the trust-record
-        # match, AND the private copy that gets exec'd all come from this
-        # ONE `_prepare_trusted_execution` call -- never a fresh
-        # re-resolution of `command[0]` that a swap between "approved" and
-        # "exec'd" could win a race against (see `_BoundExecutable`). A
-        # project/user-authored entry (source is falsy) has no separate
-        # approval to bind against; it always spawns in `resolved_cwd`,
-        # matching the directory it would have resolved a relative path
-        # against.
+        # Re-resolved every call, not cached: for a source-having (imported)
+        # entry, resolution, the trust-record match, and the private copy
+        # that gets exec'd all come from this ONE
+        # `_prepare_trusted_execution` call, never a fresh re-resolution of
+        # `command[0]` that a swap between "approved" and "exec'd" could win
+        # a race against (see `_BoundExecutable`, D7 content pinning). A
+        # source-less entry has no approval to bind against; it spawns
+        # directly in `resolved_cwd`.
         bound: _BoundExecutable | None = None
         if source:
             bound, reason = _prepare_trusted_execution(command, source=source, cwd=resolved_cwd)

--- a/lionagi/plugins/_user_settings.py
+++ b/lionagi/plugins/_user_settings.py
@@ -3,13 +3,9 @@
 """Read/write helper for the plugin-related blocks of ``~/.lionagi/settings.yaml``.
 
 Trust records and the enable/disable flag are both user-level, never
-project-level: a repository must not be able to self-trust a plugin it
-carries by committing a settings line — the human on the machine approves.
-
-Every mutator in this package (GC, trust, enable/disable) goes through
-``locked_user_settings()``, a single exclusive-``flock`` critical section
-held across the whole read-modify-write, so a concurrent writer's stale
-snapshot can never silently clobber another's write.
+project-level — a repository must not be able to self-trust a plugin it
+carries by committing a settings line. Every mutator here goes through
+``locked_user_settings()``. See docs/internals/plugin-runtime.md#settings-lock.
 """
 
 from __future__ import annotations
@@ -125,11 +121,9 @@ def locked_user_settings():
 
     Yields the parsed settings dict; mutate it in place. Written back only
     if it changed, so a no-op pass touches neither the file's mtime nor a
-    concurrent reader.
-
-    Opens with ``O_CREAT`` but never ``O_TRUNC``, since truncating before
-    the lock is held could blow away content a racing creator already
-    committed; truncation only happens below, after the lock is held.
+    concurrent reader. Opens with ``O_CREAT`` but never ``O_TRUNC`` — see
+    docs/internals/plugin-runtime.md#settings-lock for why truncating before
+    the lock is held is unsafe.
     """
     path = user_settings_path()
     ensure_lionagi_dir(path.parent)

--- a/lionagi/plugins/trust.py
+++ b/lionagi/plugins/trust.py
@@ -2,13 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Plugin trust: nothing executes before an explicit, content-pinned trust record.
 
-The trust record pins content, not just declaration, for every declared
-capability file — executable and consumed-as-instructions alike: the
-canonical-JSON manifest, plus every tool/provider target file, hook binary,
-agent profile file, playbook file, and pack data file the manifest declares.
-Any change to any of these reverts the plugin to ``changed`` and it stops
-loading until re-approved. Trust is recorded user-level
-(``~/.lionagi/settings.yaml``), never project-level.
+Content-pinned: any change to the manifest or a declared file reverts the
+plugin to ``changed`` and it stops loading until re-approved. Trust is
+recorded user-level (``~/.lionagi/settings.yaml``), never project-level.
+See docs/internals/plugin-runtime.md#trust-model for the full contract.
 """
 
 from __future__ import annotations
@@ -94,16 +91,11 @@ def _bundle_dir_present(bundle_path: str) -> bool:
 def gc_trust_records(discovered: list[DiscoveredPlugin]) -> list[str]:
     """Prune ``trusted_plugins`` entries whose bundle directory is confirmed gone.
 
-    Pruning is directory-presence, not manifest-parse-success: a plugin
-    whose ``plugin.yaml`` merely fails to parse right now (malformed edit in
-    progress, transient read error) is not the same as uninstalled, and its
-    trust record must survive untouched. Legacy records with no
-    ``bundle_path`` key fall back to a parsed-manifest-name check instead.
-
-    Not just tidiness: a lingering record for a genuinely-removed bundle
-    would silently trust a different bundle that later reappears under the
-    same name with content that happens to hash the same — the exact
-    resurrection content-pinning is meant to prevent.
+    Pruning is directory-presence, not manifest-parse-success — a plugin
+    whose manifest merely fails to parse right now is not "uninstalled".
+    Legacy records with no ``bundle_path`` key fall back to a
+    parsed-manifest-name check. See docs/internals/plugin-runtime.md#trust-model
+    for why presence (not parse success) is the bar.
 
     Returns the pruned names, sorted; never prunes silently. Idempotent.
     """


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 5 (+47 / -88, net -41)
- New documentation: 106 lines in docs/internals/plugin-runtime.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.