### PR TITLE
docs(cli): trim inline prose in agent/mirror/state/_runs, extend cli.md

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -707,6 +707,21 @@ completion-trust check above has nothing to verify) but gave up mid-run via
 already made the run loud — an existing failure reason (including the artifact check above) is
 preserved untouched.
 
+**`_teardown_common` node-failure and gate-rejection backstops** — two more checks that run
+*before* the completion-trust gate and escalation backstop above, for the same reason: a DAG
+run whose nodes all failed, or whose dependent subtree was skipped after a gate rejection,
+typically produces no artifacts or commits either, so the trust gate would otherwise demote it
+to `completed_empty` before either backstop got a chance to apply. The node-failure backstop
+catches a DAG operation whose `invoke()` raised and was recorded `EventStatus.FAILED`, which
+folds into `completed_operations` alongside genuine completions and would otherwise never roll
+up into the run's own status. The gate-rejection backstop covers a gate node that rejected
+mid-DAG, whose dependent subtree the executor short-circuits to skipped rather than running
+against the rejected baseline — a correct, deliberate stop, not a failure, so status stays
+`completed` but the reason code must say so explicitly. Because it leaves status at
+`completed` instead of flipping to `failed` (unlike the other two backstops), it can't rely on
+the trust gate's own `final_status == "completed"` guard to skip it, and must run first so its
+evidence is already in place before that gate's no-evidence check runs.
+
 **`_teardown_common` pre_write_status snapshot** — the CAS-guard signal. Snapshot of the status
 this teardown itself observed when it started (before any status-changing write in this
 function) — this tells apart the two rejection causes in the CAS-miss/terminal-skip handling
@@ -759,6 +774,30 @@ already-open DB so every `Signal` emitted on this session's observer lands in
 under `status.py` above for the downstream consequence (usage metrics never recorded for those
 session kinds).
 
+**`_reopen_session_for_resume`** — a closing transition only announces itself when the status
+column actually changes. A resume adopts a session an earlier leg already left terminal, so
+writing that same terminal status again at the end is a no-op: the leg finishes silently and
+the job record never closes. This reopens the session to `running` first, restoring the
+invariant the rest of the system reads off that column (a session marked terminal is not
+currently executing), so the eventual re-close is a real transition. Reopening is the only
+sanctioned exit from a terminal status and carries an explicit override rather than a
+session-policy rule, so each reopening stays individually attributable instead of opening
+terminal-exit to every writer — finality is what the reapers, the teardown guard, and
+`li wait` all rest on.
+
+**`_reopen_session_for_resume` unresolved drain-declaration race** — when a resume does *not*
+reopen (the adopted row is still `running`), the row keeps whatever the earlier leg declared
+for whether its runner drains operator controls. Three states reach this point: explicit
+`True`, explicit `False`, and no declaration at all (a row written before the field existed,
+which refuses controls like `False` but means "nobody answered" rather than "no"). Only `True`
+is risky — if that leg is genuinely alive it's the right answer, but if it died without
+terminalizing, a stale `True` would admit a control for a drain that's gone, and a row reading
+`running` is the only evidence available either way; the stale-session doctor resolves it after
+the fact. This is left alone deliberately: writing the declaration here would be a
+read-modify-write against a row a live leg may be concurrently updating — the same race that
+once overwrote an exited leg's process markers with a live leg's — so the narrower failure mode
+(a `False`/undeclared row keeps refusing controls it could actually drain) is accepted instead.
+
 ## `mirror.py` — Claude transcript mirroring into StateDB
 
 **`_Lineage`** — cross-session conversation-lineage detection protocol. A continued
@@ -808,12 +847,71 @@ first-run startup, when the studio is creating the schema and checkpointing on a
 connection) is retried, not fatal. Opening it once outside the loop meant a single transient
 open error silently ended the in-process mirror for the whole life of the studio process.
 
-## `state.py` — `li state doctor`
+**`_peek_codex_head` rollout classification** — classifies a Codex rollout's first line without
+consuming the tail, into `"meta"` (parsed session_meta header), `"headerless"` (a complete
+first line that isn't one), or `"torn"` (the line is still being written, or unreadable).
+Completeness is decided by the trailing newline BEFORE any parse attempt: rollouts are
+append-only JSONL, so a line without its newline may still be arriving even if the bytes so far
+happen to parse; a newline-terminated line that fails to parse is permanently corrupt and
+settles as headerless. `_mirror_one_codex` defers on `"torn"` rather than reading the file under
+the path-stem identity, since the header's real UID could arrive next pass and split one
+rollout into two sessions.
+
+**`_mirror_one_codex` orchestrated-rollout absorption** — a rollout whose header names an
+originator in `SKIPPED_ORIGINATORS` (an orchestrator's own run, e.g. a lionagi agent leg)
+already has a session under the agent's name, so importing the rollout too would double it.
+`_mirror_one_codex` absorbs whatever an older mirror version may have imported, under either id
+the file was ever keyed by (a pre-header path-stem fallback, and the header's real UID), then
+marks the file `orchestrated` and never reads it again. State only commits once both absorption
+calls return, so a failed attempt leaves exactly what the next pass needs to retry.
+
+**`_absorb_backfill`** — a process-wide, provenance-driven counterpart to the per-file
+absorption above: it reads recorded session provenance rather than the rollout tree, so it also
+reaches rows whose backing files fall outside the current sweep window. Returns whether the
+sweep completed cleanly; `mirror_forever`/`_run` only stand down (stop calling it) on `True` —
+one bad pass must not retire the backfill for the process's whole lifetime. Errors are logged,
+never raised, since reconciliation must never take the mirror down.
+
+## `state.py` — `li state` inspect/prune/migrate state.db
 
 **`_doctor` per-row sweep** — the per-row repair sweep goes through the single guarded write
 path (ADR-0035): `expected_statuses={"running"}` re-asserts the CAS the old bulk `UPDATE` did
 inline, and routes the sweep through `update_status()` so it gets a `reason_code` + a
 `status_transitions` audit row instead of a raw column write.
+
+**`_doctor` session age vs process age** — a stale-`running` session isn't necessarily a dead
+process: a branch picked up again keeps its session's original `started_at` while the process
+serving it is new. The sweep checks the process itself (via the same PID-identity check the
+stale-kill sweep uses, not a second weaker rule) before calling a row stuck. A PID that's alive
+isn't proof either — the OS can hand a dead session's PID to an unrelated live process — so an
+"unverifiable" identity check result is skipped (leaves the row for a later pass) while a
+"zombie" result (process exited, not yet reaped) is swept.
+
+**`_collect_message_breakdown`** — messages by role and by age, the two axes a retention
+decision needs. A bare row count can't say whether pruning reclaims anything; the age histogram
+makes that visible before a prune runs. It reports counts only, never a content-size sum:
+summing `LENGTH(content)` over the messages table is the one query here with no useful index
+(measured ~57s against 1.68M rows, vs under 2s for everything else) — the reclaim command that
+actually touches those rows reports their size directly instead.
+
+**`_prune_candidates` / `_null_content_candidates`** — both re-run their operation's own
+selection predicate outside the operation's transaction, and print the recount beside the
+result as a cross-check: after a real run it must read zero, after a `--dry-run` preview it
+must match what the preview reported. Running inside the same transaction would read the
+operation's own uncommitted rows and agree by construction, so it deliberately runs outside it.
+
+**`_null_content`** — replaces old message *bodies* with a size-preserving marker; it exists
+because `li state prune` can't reach this content. Prune selects and deletes **sessions**, but
+message bytes live on **messages**, and a message any surviving progression still references is
+kept regardless of its own age — so a store can be almost entirely message content, have every
+message inside prune's keep-window, and give prune nothing to delete. `--dry-run` performs the
+real `UPDATE` and rolls it back rather than estimating, which makes a preview a **write** that
+holds the same lock for the same duration as the real operation, not a cheap read.
+
+**`_prune` / `_null_content` preview mechanics** — both route their dry-run through a
+`_PreviewOnlyError` raised after the real statements ran inside the transaction: the exception
+carries the real counts out and forces the transaction to unwind instead of commit, so a preview
+number can never drift from what the real operation would have measured.
 
 ## `monitor.py` — `li monitor` (dashboard + `li monitor run` wait primitive)
 

--- a/lionagi/cli/_runs.py
+++ b/lionagi/cli/_runs.py
@@ -305,9 +305,6 @@ def allocate_run(
     return run
 
 
-# ── Branch lookup (canonical + legacy fallback) ─────────────────────────
-
-
 def _branch_dirs() -> list[tuple[str | None, Path, str]]:
     """Every directory that can hold a branch file, with its run id and suffix.
 
@@ -365,9 +362,6 @@ def find_branch(branch_id: str) -> tuple[str | None, Path]:
     raise FileNotFoundError(f"No branch log found for id {branch_id!r}")
 
 
-# ── Last-branch pointer (with legacy schema compat) ─────────────────────
-
-
 def load_last_branch() -> tuple[str | None, str]:
     """Read the last-branch pointer; returns (run_id, branch_id), run_id=None for pre-run-scoped schema."""
     if not _LAST_BRANCH_POINTER.exists():
@@ -407,9 +401,6 @@ def save_last_branch_pointer(run_id: str, branch_id: str) -> None:
         )
 
 
-# ── Introspection ───────────────────────────────────────────────────────
-
-
 def list_runs(limit: int | None = None) -> list[RunDir]:
     """Return all runs under RUNS_ROOT, newest first (by mtime)."""
     if not RUNS_ROOT.exists():
@@ -433,8 +424,6 @@ def list_runs(limit: int | None = None) -> list[RunDir]:
         out.append(RunDir(run_id=d.name, state_root=d, artifact_root=artifact_root))
     return out
 
-
-# ── Live-persist lifecycle (absorbed from _persist.py) ──────────────────────
 
 _log = logging.getLogger("lionagi.cli")
 
@@ -695,17 +684,13 @@ async def _teardown_common(
                 str(entry.get("id", "")) for entry in missing
             ]
 
-    # Node-failure backstop: a DAG operation's invoke() raised
-    # and the executor recorded EventStatus.FAILED for it, but that per-node
-    # failure was folded into completed_operations right alongside genuine
-    # completions and never rolled up into the run's own status -- a run
-    # whose terminal (or any other) node died could still read as an
-    # ordinary clean completion. See lionagi/operations/flow.py's
-    # failed_operations tracking and _execute_dag's evidence collection.
-    # Runs before the completion-trust gate below: a run whose nodes all
-    # failed typically produces no artifacts or commits either, so the gate
-    # would otherwise demote it to "completed_empty" first and this failure
-    # evidence would never see a status that reflects it.
+    # Node-failure backstop: a DAG operation's invoke() can raise and be
+    # recorded EventStatus.FAILED while still folding into
+    # completed_operations alongside genuine completions, so a run whose
+    # terminal (or any) node died could otherwise read as a clean completion.
+    # Runs before the completion-trust gate below, since a fully-failed run
+    # usually has no artifacts/commits either and would otherwise be demoted
+    # to "completed_empty" before this evidence had a chance to apply.
     if failed_operation_evidence and final_status == "completed":
         from lionagi.state.reasons import RunReasons
 
@@ -717,11 +702,9 @@ async def _teardown_common(
         )
         final_evidence_refs = failed_operation_evidence
 
-    # Escalation backstop: a leg that gave up mid-run via EscalationRequest without
-    # an artifact contract must not read as a clean completion. Also runs ahead of
-    # the completion-trust gate for the same reason as the node-failure backstop
-    # above -- an escalated run with no evidence must not be demoted to
-    # "completed_empty" before this check has a chance to run.
+    # Escalation backstop: a leg that gave up mid-run via EscalationRequest with
+    # no artifact contract must not read as a clean completion. Same ordering
+    # reason as the node-failure backstop above.
     if escalated_evidence and final_status == "completed":
         from lionagi.state.reasons import RunReasons
 
@@ -734,18 +717,14 @@ async def _teardown_common(
         )
         final_evidence_refs = escalated_evidence
 
-    # Gate-rejection backstop: a gate node rejected mid-DAG (issue #2860) and the
-    # executor short-circuited its dependent subtree to skipped instead of running
-    # those nodes against the rejected baseline. That is a correct, deliberate
-    # stop, not a failure -- status stays "completed" -- but the reason code must
-    # say so explicitly rather than reading identically to a clean pass. Runs
-    # before the completion-trust gate below, alongside the node-failure and
-    # escalation backstops: a gate-rejected run typically produces no artifacts
-    # or commits either (the rejected subtree never ran), and unlike those two
-    # backstops this one deliberately leaves final_status at "completed" instead
-    # of flipping to "failed" -- so it cannot rely on the trust gate's own
-    # `final_status == "completed"` guard to skip it and must run first so its
-    # evidence is in place before that gate's no-evidence check runs.
+    # Gate-rejection backstop: a gate node rejected mid-DAG and the executor
+    # short-circuited its dependent subtree to skipped instead of running those
+    # nodes against the rejected baseline. That's a correct, deliberate stop,
+    # not a failure -- status stays "completed" -- but the reason code must say
+    # so explicitly. Runs before the completion-trust gate for the same reason
+    # as the other two backstops, and unlike them leaves final_status at
+    # "completed" rather than flipping to "failed", so it must run first to
+    # place its evidence before the gate's no-evidence check.
     if gate_rejected_evidence and final_status == "completed":
         from lionagi.state.reasons import RunReasons
 
@@ -1221,20 +1200,17 @@ async def _reopen_session_for_resume(
 ) -> bool:
     """Return a resumed session to ``running`` so its next close is a real change.
 
-    A session's closing transition only announces itself when the status
-    actually changes. A resume adopts a session an earlier leg already took
-    terminal, so writing that same terminal status at the end is not a change:
-    the leg finishes without announcing anything, the completion notice never
-    arrives, and the job record never closes. Reopening first restores the
-    invariant the rest of the system reads off this column, which is that a
-    session marked terminal is not currently executing.
+    A closing transition only announces itself when the status actually
+    changes. A resume adopts a session an earlier leg already took terminal,
+    so writing that same terminal status at the end is a no-op: the leg
+    finishes silently and the job record never closes. Reopening first
+    restores the invariant the rest of the system reads off this column --
+    that a session marked terminal is not currently executing.
 
-    Reopening is the only sanctioned exit from a terminal status, so it carries
-    an override. That is not a formality to satisfy the guard: it is what makes
-    each reopening attributable. Declaring a terminal-to-running edge in the
-    session policy would have satisfied the guard too, and would have permitted
-    terminal exit for every writer in the system, while finality is exactly what
-    the reapers, the teardown guard and ``li wait`` all rest on.
+    Reopening is the only sanctioned exit from a terminal status and carries
+    an explicit override rather than a session-policy rule, so each reopening
+    stays attributable and terminal exit isn't opened to every writer --
+    finality is what the reapers, the teardown guard, and ``li wait`` all rest on.
     """
     from lionagi.cli.kill import current_pid_markers
     from lionagi.state.db import SESSION_TERMINAL_STATUSES
@@ -1406,31 +1382,23 @@ async def setup_agent_persist(
             # markers. Nothing to do here for a row that was terminal.
             #
             # A resume that did NOT reopen adopts a row still reading running,
-            # and that row keeps whatever the earlier leg declared. Three
-            # representations reach here, not two: explicit True, explicit
-            # False, and no declaration at all on a row written before this
-            # field existed. The last one refuses like False at the admission
-            # gate, but it is a third state and not a spelling of the second —
-            # it means nobody ever answered the question, where False means a
-            # runner answered no.
+            # keeping whatever the earlier leg declared. Three states reach
+            # here: explicit True, explicit False, and no declaration (a row
+            # written before this field existed) -- the last refuses like
+            # False at the admission gate but means "nobody answered", not "no".
             #
-            # Of the three, only True is not benign. If that leg is genuinely
-            # alive, its declaration is the right answer: it is the one a
-            # control would reach. If it died without terminalizing, the row
-            # outlives it, and a declaration of True then admits a control for
-            # a drain that is gone. Nothing here can tell those apart — a row
-            # reading running is the only evidence available, and it is exactly
-            # the evidence a dead leg leaves behind. The stale-session doctor is
-            # what resolves it, after the fact.
+            # Only True is risky: if that leg is genuinely alive it's the right
+            # answer, but if it died without terminalizing, a stale True admits
+            # a control for a drain that's gone -- and a row reading running is
+            # the only evidence available either way. The stale-session doctor
+            # resolves it after the fact.
             #
-            # So this path is not made correct by leaving it alone; it is left
-            # alone because the alternative is worse. Writing the declaration
-            # here would mean a read-modify-write against a row a live leg may
-            # be updating, which is how the exited leg's process markers got
-            # restored over the live leg's once already. The narrower cost is
-            # the other direction: a row reading False, or carrying no
-            # declaration at all, keeps refusing controls even though this leg
-            # would drain them.
+            # This path is left alone deliberately, not because it's correct:
+            # writing the declaration here would be a read-modify-write against
+            # a row a live leg may be updating, the same race that once
+            # restored an exited leg's process markers over a live leg's.
+            # The narrower cost -- a row reading False or undeclared keeps
+            # refusing controls it could actually drain -- is the safer one.
         else:
             session_prog_id = str(uuid.uuid4())
             branch_prog_id = str(uuid.uuid4())

--- a/lionagi/cli/agent.py
+++ b/lionagi/cli/agent.py
@@ -523,21 +523,16 @@ async def _tombstone_pending_steers(live: dict | None) -> None:
 
     A steer enqueued while the run was live but never drained must not sit
     pending forever. Best-effort: a failure here logs and leaves the row
-    visibly pending — the status surface independently renders a pending
-    control on a terminal run as never-landed, so the operator still sees
-    the truth.
+    visibly pending, since the status surface independently renders a pending
+    control on a terminal run as never-landed.
 
-    Only rows no consumer ever claimed are tombstoned, and that is enforced at
-    the write rather than read off the snapshot. A claimed row belongs to the
-    leg that took it, which may be another leg still inside its provider call,
-    or one that died between the claim and the apply. Rejecting either would
-    assert that the message was not delivered, which nothing here knows; the row
-    stays visible as claimed, carrying its owner and its age, for an operator to
-    resolve. Called after the run's teardown, so a control admitted against a
-    still-running session is normally already committed and visible to the read
-    below, and one arriving later is refused at the writer; the terminal check
-    at the top of this function is what makes that hold when teardown failed to
-    persist the transition it was asked for.
+    Only rows no consumer ever claimed are tombstoned, enforced at the write
+    rather than read off the snapshot -- a claimed row belongs to whichever
+    leg took it (still in its provider call, or dead between claim and apply),
+    and rejecting it would assert non-delivery that nothing here actually
+    knows, so it stays visible as claimed for an operator to resolve. Called
+    after teardown, so the terminal check at the top is what makes this hold
+    even when teardown failed to persist the transition it was asked for.
     """
     if not live or not live.get("session_id"):
         return
@@ -995,16 +990,14 @@ async def _run_agent(
     # invocation records are finalized externally and would never fire. Deferred
     # auto-resume legs unregister without firing; the recursed leg registers anew.
     #
-    # Persistence setup failing leaves no session entity to fire a terminal
-    # transition on, so the registered path below (register_flow_notify_scope)
-    # cannot be used. That used to mean the notice was silently unreachable;
-    # this run now delivers it itself once its own terminal status is known,
-    # in the `finally` block below (see `deliver_flow_notify_now`) — same
-    # resolution, same payload, run directly instead of registered for a
+    # If persistence setup failed there's no session entity to fire a terminal
+    # transition on, so register_flow_notify_scope can't be used -- this run
+    # instead delivers the notice itself once its own terminal status is known,
+    # in the `finally` block below (see `deliver_flow_notify_now`): same
+    # resolution and payload, run directly instead of registered for a
     # transition that will never happen. The refusal record this run can still
-    # write applies only once delivery is actually attempted and genuinely
-    # cannot be completed (nothing configured to run, or the config itself is
-    # unusable), never merely because persistence failed.
+    # write applies only when delivery is actually attempted and genuinely
+    # can't complete, never merely because persistence failed.
     _notify_scope_name: str | None = None
     _notify_session_id = live.get("session_id") if live else None
     if notify and _notify_session_id is not None:
@@ -1061,19 +1054,16 @@ async def _run_agent(
         """Send this run's one terminal notice on the no-persistence route.
 
         No session entity ever existed for this run, so the registered path
-        was never reached and nothing else will ever deliver for it. Which
-        makes *when* this is called the whole question: it reads
-        ``_terminal_status`` at call time, and a status is not this run's
-        answer until every later line that can still change it has run.
+        was never reached and nothing else will ever deliver for it. *When*
+        this is called is the whole question: it reads ``_terminal_status`` at
+        call time, so it must run only after every line that can still change
+        that status has run.
 
-        Shielded, because the guarantee it exists to provide is that a
-        terminal notice arrives, and the caller is a teardown path where a
-        cancellation is exactly what is expected to arrive.
-
-        Idempotent by flag rather than by the caller being careful: it is
-        reached from a ``finally`` and from the ordinary tail, and those two
-        overlap on nothing today, which is the sort of thing that stays true
-        only until someone adds a branch.
+        Shielded, since a cancellation is exactly what's expected from the
+        teardown path that calls this, and the guarantee this exists to
+        provide is that a terminal notice arrives regardless. Idempotent by
+        flag (reached from both a ``finally`` and the ordinary tail) rather
+        than by relying on those two call sites never overlapping.
         """
         nonlocal _direct_notice_sent
 
@@ -1244,35 +1234,27 @@ async def _run_agent(
                 defer_terminal=will_auto_resume,
                 **telemetry_kw,
             )
-            # Terminal-race tombstone, ordered after the teardown above rather
-            # than before it (skipped when auto-resume keeps the run alive — the
-            # resumed leg's drain will consume the steer). When that teardown
-            # does persist the terminal transition, this ordering is what leaves
-            # no gap for a control to slip through: the writer admits one only
-            # while the session reads 'running', so a control that got in is
-            # committed before the transition and is therefore visible to the
-            # sweep below, and one arriving after it is refused at the writer
-            # instead of landing on a terminal run with nobody left to consume
-            # it. Teardown can also fail and return the requested status without
-            # having written it, which is why the sweep re-reads the stored
-            # session and declines a non-terminal one rather than trusting the
-            # call order.
-            # That ordering also means the handle in `live` is gone by now:
-            # teardown closes it in its own `finally`. The sweep is given a
-            # fresh one rather than the corpse, because a sweep that fails on a
-            # closed engine fails into its own must-not-raise catch, which turns
-            # the entire tombstone path into one log line on every run while the
-            # rows it exists to close stay pending forever. The connection is
-            # opened here rather than inside the sweep so callers that hand it a
-            # handle of their own, including the tests, keep doing so.
-            # Opening it is inside the same best-effort boundary as the sweep,
-            # not outside it. The sweep swallows its own failures on purpose so
-            # a finished run is not turned into an error by bookkeeping, and
-            # acquiring the connection can fail for exactly the reasons the
-            # sweep already tolerates: another writer holding the lock, a busy
-            # timeout, a migration. StateDB re-raises out of __aenter__, so an
-            # unguarded `async with` here would escape this teardown and report
-            # an infrastructure exception for a run that actually completed.
+            # Terminal-race tombstone, ordered after the teardown above (skipped
+            # when auto-resume keeps the run alive -- the resumed leg's drain
+            # consumes the steer instead). This ordering leaves no gap for a
+            # control to slip through: the writer admits one only while the
+            # session reads 'running', so anything admitted lands before the
+            # transition and is visible to the sweep below, while anything
+            # arriving later is refused at the writer. Teardown can also fail
+            # and return the requested status without writing it, so the sweep
+            # re-reads the stored session and declines a non-terminal one
+            # rather than trusting call order.
+            #
+            # The `live` handle is closed by teardown's own `finally` by this
+            # point, so the sweep gets a fresh connection rather than the
+            # corpse -- a sweep that fails on a closed engine would otherwise
+            # turn this whole tombstone path into one log line while the rows
+            # it exists to close stay pending forever. Opened here (not inside
+            # the sweep) so callers supplying their own handle, including
+            # tests, keep doing so; it's still inside the sweep's must-not-raise
+            # boundary, since StateDB re-raises out of __aenter__ and an
+            # unguarded `async with` here would turn a completed run into a
+            # reported infrastructure exception.
             if not will_auto_resume and live:
                 from lionagi.state.db import StateDB
 

--- a/lionagi/cli/mirror.py
+++ b/lionagi/cli/mirror.py
@@ -27,12 +27,8 @@ CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
 
 
 def _display_path(path: Path) -> str:
-    """Render a path under the home directory as ~/... for display.
-
-    Help text is the same on every machine this way. Printing the expanded
-    absolute path puts the running user's home directory into --help output,
-    which differs per machine and ends up in anything that captures it.
-    """
+    """Render a path under the home directory as ~/... so --help output doesn't
+    embed the running user's absolute home directory."""
     try:
         return f"~/{path.relative_to(Path.home())}"
     except ValueError:
@@ -120,8 +116,8 @@ class _FileState:
     tool_names: dict[str, str] = field(default_factory=dict)
     project: str | None = None
     project_source: str | None = None
-    # Raw transcript cwd, the session's artifact root (issue #2848) -- unlike
-    # `project`, never bucketed/fallen-back, just the directory as reported.
+    # Raw transcript cwd, the session's artifact root -- unlike `project`,
+    # never bucketed/fallen-back, just the directory as reported.
     cwd: str | None = None
     model: str | None = None
     name: str | None = None
@@ -149,10 +145,7 @@ class _FileState:
 @dataclass
 class _Lineage:
     """Cross-session conversation-lineage detector, kept across poll passes.
-
-    Indexes each file's leaf uuid; when a file's root parent resolves to a
-    different session's leaf (a continuation via ``parentUuid``), records the link.
-    """
+    See docs/internals/cli.md#mirror.py."""
 
     leaf_owner: dict[str, str] = field(default_factory=dict)  # event uuid -> session_uid
     pending: dict[str, str] = field(default_factory=dict)  # child session_uid -> parent uuid
@@ -220,10 +213,9 @@ def _resolve_project_for_mirror(cwd: str) -> tuple[str, str]:
 
 
 def _load_states() -> dict[str, _FileState]:
-    # Persist tool_names, leaf_uuid and the current codex turn alongside the byte
-    # offset so a restart resumes without losing state that otherwise lives only in
-    # process memory. Dropping the turn would leave every message written after a
-    # restart unattributed until the next turn_context happens to arrive.
+    # offsets.json persisted-state contract: see docs/internals/cli.md#mirror.py.
+    # Dropping `turn` would leave messages written after a restart unattributed
+    # until the next turn_context arrives.
     try:
         raw = json.loads(_OFFSETS_PATH.read_text())
     except (FileNotFoundError, json.JSONDecodeError):
@@ -255,12 +247,10 @@ def _save_states(states: dict[str, _FileState]) -> None:
         }
         for key, st in states.items()
     }
-    # Only the byte offset is this module's own arithmetic. The session uid, the
-    # leaf uuid and the tool-name map are copied out of a transcript another
-    # program wrote, through a json.loads that accepts NaN and Infinity, and none
-    # of them is coerced to str on the way in. So a token no strict reader accepts
-    # can reach this file, and once here it round-trips through the equally
-    # permissive read above and never leaves. Refuse at the write instead.
+    # The session uid, leaf uuid, and tool-name map are copied out of a transcript
+    # another program wrote via a json.loads that accepts NaN/Infinity and never
+    # coerces to str. Refuse those tokens at the write instead of letting them
+    # round-trip forever through the equally permissive read above.
     raise_if_non_finite(payload)
     tmp = _OFFSETS_PATH.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload))
@@ -311,18 +301,12 @@ def _read_new_events(
     """Read complete JSONL lines past the cursor.
 
     Returns ``(events, sources, new_offset, unreadable)``. ``sources`` is the
-    per-event ``(byte_offset, byte_count, sha256)`` of each raw line, in the
-    same order as ``events`` — the basis for a resolvable mirror source pointer
-    (see ``_mirror_common.bound_mirror_content``).
-
-    The cursor is NOT advanced here — the caller only commits it after the batch
-    is durably mirrored, so a write failure re-reads the same lines next pass.
-
-    ``unreadable`` counts lines that were not JSON, or were JSON but not a record
-    object. It is reported rather than folded into the events count because a line
-    that could not be read is not a line deliberately not mirrored, and a consumer
-    comparing what a file held against what landed needs the difference between a
-    damaged corpus and an uninteresting one.
+    per-event ``(byte_offset, byte_count, sha256)`` of each raw line, same order
+    as ``events`` — basis for a resolvable mirror source pointer (see
+    ``_mirror_common.bound_mirror_content``). ``unreadable`` (lines that weren't
+    JSON, or weren't a record object) is reported separately from the events
+    count so a consumer can tell a damaged corpus from an uninteresting one.
+    Cursor-advance contract: see docs/internals/cli.md#mirror.py.
     """
     size = path.stat().st_size
     if state.offset > size:  # file truncated/rotated — re-read from the top.
@@ -387,10 +371,8 @@ def _derive_metadata(state: _FileState, events: list[dict[str, Any]]) -> None:
 
 
 def _peek_head(path: Path) -> tuple[str, str | None]:
-    """Recover (sessionId, cwd) from a transcript's head without consuming the tail.
-
-    Needed for idle files after a restart, which have no new events to derive these from.
-    """
+    """Recover (sessionId, cwd) from a transcript's head without consuming the
+    tail. See docs/internals/cli.md#mirror.py."""
     uid = ""
     cwd: str | None = None
     try:
@@ -418,13 +400,9 @@ def _peek_head(path: Path) -> tuple[str, str | None]:
 
 async def _attribute_idle(db, state: _FileState, cwd: str) -> None:
     """Attribute an idle/already-read transcript and backfill its session row.
-
-    Covers sessions mirrored before project/artifact-root attribution existed,
-    which have no new events to trigger the normal (streamed-event) attribution
-    path. The two backfills are independent: a row can already carry a project
-    from an earlier mirror pass while still missing artifacts_path (issue #2848's
-    dominant case), so each is only (re)written when actually missing.
-    """
+    See docs/internals/cli.md#mirror.py. Project and artifacts_path backfill
+    independently — a row can already carry one while missing the other, so
+    each is (re)written only when actually missing."""
     from lionagi.state.claude_mirror import session_db_id
 
     state.project, state.project_source = _resolve_project_for_mirror(cwd)
@@ -447,12 +425,10 @@ async def _attribute_idle_codex(db, state: _FileState) -> None:
     """Backfill artifacts_path for an already-read Codex rollout.
 
     ``_mirror_one_codex`` recovers ``cwd`` from the rollout header on the
-    head-check pass, but if the file has no new records that same pass (its
-    offset was restored at EOF, e.g. after a restart), it returns before ever
-    calling ``mirror_session`` — the only place ``set_session_provenance``
-    normally runs for an existing row. Without this, such a row's
-    artifacts_path stays NULL forever, even though the header supplied it.
-    """
+    head-check pass, but if that same pass has no new records (offset restored
+    at EOF, e.g. after a restart) it returns before ever calling
+    ``mirror_session`` — the only other place ``set_session_provenance`` runs.
+    Without this, such a row's artifacts_path stays NULL forever."""
     from lionagi.state.codex_mirror import session_db_id
 
     if not state.session_uid or not state.cwd:
@@ -500,8 +476,8 @@ async def _mirror_one(db, path: Path, state: _FileState, lineage: _Lineage) -> i
     lineage.note_head(state, events)
     lineage.note_leaf(state, events)
 
-    # Always created/kept running; the session-level idle sweep (after the whole
-    # pass) is what flips it to completed.
+    # Always kept "running"; the session-level idle sweep after the whole pass
+    # flips it to completed.
     written = await mirror_session(
         db,
         session_uid=state.session_uid,
@@ -552,12 +528,10 @@ async def _one_pass(db, root: Path, states, offsets, *, since, live_window, line
                 if not state.session_uid:
                     state.session_uid = uid
                 if state.project is None and not state.attr_peeked:
-                    # Set the flag only after a successful backfill (mirrors
-                    # the codex_provenance_peeked fix below): _one_pass's
-                    # per-transcript exception handler swallows a failure
-                    # here, and a flag set beforehand would then suppress
-                    # every later retry for the process lifetime of this
-                    # in-memory state.
+                    # Flag set only after a successful backfill: this loop's
+                    # exception handler swallows failures here, and a flag set
+                    # beforehand would suppress every later retry for this
+                    # process's lifetime.
                     if cwd:
                         await _attribute_idle(db, state, cwd)
                     state.attr_peeked = True
@@ -585,11 +559,9 @@ def _peek_codex_head(path: Path) -> tuple[str, dict[str, Any] | None]:
     ``("headerless", None)`` for a complete first line that is not one, and
     ``("torn", None)`` when the line is still being written or unreadable.
     Completeness is decided by the trailing newline BEFORE any parse attempt:
-    rollouts are append-only JSONL, so a line without its newline is still
-    arriving and defers even when the bytes so far happen to parse — later
-    appends can extend or corrupt it. A newline-terminated line that cannot
-    parse is permanently corrupt and settles as headerless; the normal reader
-    accounts for the bad line.
+    rollouts are append-only JSONL, so a line without its newline may still be
+    arriving even if the bytes so far happen to parse. A newline-terminated
+    line that fails to parse is permanently corrupt and settles as headerless.
     """
     from lionagi.state.codex_mirror import session_meta
 
@@ -657,34 +629,25 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
     if not state.head_checked:
         head_status, meta = _peek_codex_head(path)
         if head_status == "torn":
-            # The first line is still being written (or unreadable), so the
-            # rollout's identity is unknown. Mirroring waits along with the
-            # classification: writing records now would key them under the path
-            # stem while the header's real UID arrives next pass, splitting one
-            # rollout into two sessions — and committing head_checked would let
-            # an orchestrated rollout slip past the skip forever.
+            # Identity unknown while the header line is still arriving.
+            # Mirroring waits with the classification: writing records now would
+            # key them under the path stem while the real UID arrives next pass,
+            # splitting one rollout into two sessions, and committing
+            # head_checked would let an orchestrated rollout skip past forever.
             return 0
         if meta and meta.get("originator") in SKIPPED_ORIGINATORS:
-            # An orchestrator's own run (e.g. a lionagi agent leg) — its
-            # session already exists under the agent's name; importing the
-            # rollout too is the double entry. Absorb what an older version
-            # may have imported (under either id this file was ever keyed
-            # by), then never read this file again.
+            # An orchestrator's own run (e.g. a lionagi agent leg) already has a
+            # session under the agent's name; importing the rollout too would
+            # double it. Absorb whatever an older version may have imported
+            # under either id this file was ever keyed by, then never read it
+            # again. State fields commit only once both absorptions return, so
+            # a failed attempt leaves exactly what the next pass needs to
+            # retry: see docs/internals/cli.md#mirror.py.
             prior_uid = state.session_uid  # a stem fallback from a pre-header pass
             resolved_uid = meta["rollout_uid"] or path.stem
             await absorb_orchestrated_session(db, resolved_uid)
             if prior_uid and prior_uid != resolved_uid:
                 await absorb_orchestrated_session(db, prior_uid)
-            # Nothing is committed to the state until both absorptions return,
-            # so a failed attempt leaves exactly what the next one needs to
-            # repeat it. Committing head_checked would stop the header being
-            # re-read, and the rollout would then be mirrored after all —
-            # the same failure the torn-header branch above declines to cause.
-            # Committing orchestrated would retire the file with a row nobody
-            # ever tore down. Overwriting session_uid would lose the stem the
-            # second absorption call needs. Absorption fails for an ordinary
-            # reason now that a contended teardown gives up rather than waiting,
-            # so this path carries real traffic.
             state.session_uid = resolved_uid
             state.head_checked = True
             state.orchestrated = True
@@ -702,10 +665,7 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
     if not records:
         state.offset = new_offset
         if state.cwd and not state.codex_provenance_peeked:
-            # Set the flag only after a successful backfill: _codex_pass's
-            # per-rollout exception handler swallows a failure here, and a
-            # flag set beforehand would then suppress every later retry for
-            # the process lifetime of this in-memory state.
+            # Flag set only after success, same reasoning as _one_pass above.
             await _attribute_idle_codex(db, state)
             state.codex_provenance_peeked = True
         return 0
@@ -749,12 +709,10 @@ async def _mirror_one_codex(db, path: Path, state: _FileState, threads: dict[str
         state.created = True
         progress(f"  mirror: {state.name or state.session_uid[:8]} (+{written} msgs)")
     elif not written and records and not state.barren_reported:
-        # A file the mirror read in full and produced nothing from is a finding, not
-        # a quiet skip: without this it is indistinguishable from a file not yet
-        # reached. The durable half is the session row the writer keeps for such a
-        # file; this only surfaces it in the run that saw it. Measured cause on the
-        # local corpus: 6 of 29,652 rollouts (all 2025-09-01/02) predate the
-        # enveloped record format and match no record type this mirror reads.
+        # A file read in full but mirrored nothing is a finding, not a quiet
+        # skip — without this it's indistinguishable from a file not yet
+        # reached. Known cause: rollouts predating the enveloped record format
+        # match no record type this mirror reads.
         state.barren_reported = True
         warn(
             f"{path.name}: read {sum(tally.seen.values())} record(s), mirrored none "
@@ -795,13 +753,12 @@ async def _codex_pass(db, root: Path, states, offsets, *, since, live_window, th
 async def _absorb_backfill(db) -> bool:
     """Remove previously-imported rows for orchestrator-spawned rollouts.
 
-    It reads recorded provenance rather than the rollout tree, so it also
-    reaches rows whose files fall outside the sweep window; per-file absorption
-    in ``_mirror_one_codex`` covers the rest. Returns whether the sweep
-    completed cleanly — a caller that runs this once per process must only
-    stand down on True, else one bad pass would retire the backfill for the
-    process lifetime. Errors are logged, never raised: reconciliation must not
-    keep the mirror down.
+    Reads recorded provenance rather than the rollout tree, so it also reaches
+    rows whose files fall outside the sweep window (per-file absorption in
+    ``_mirror_one_codex`` covers the rest). Returns whether the sweep completed
+    cleanly — a caller that runs this once per process must only stand down on
+    True, else one bad pass retires the backfill for the process lifetime.
+    Errors are logged, never raised: reconciliation must not keep the mirror down.
     """
     from lionagi.state.codex_mirror import absorb_orchestrated_backfill
 
@@ -831,11 +788,10 @@ async def mirror_forever(
     """Tail recent transcripts into StateDB until ``stop`` is set.
 
     ``source`` selects which transcript trees to read ("claude", "codex", or
-    "both") and defaults to claude alone. A caller that scopes ``root`` has
-    scoped the mirror, and must not silently acquire an unscoped codex tree
-    under the home directory; asking for codex is therefore explicit.
-
-    Studio's in-process entry point; ``li mirror`` keeps its own loop in ``_run``.
+    "both") and defaults to claude alone — a caller that scopes ``root`` must
+    not silently also acquire an unscoped codex tree under the home directory,
+    so codex is opt-in. Studio's in-process entry point; ``li mirror`` keeps
+    its own loop in ``_run``. See docs/internals/cli.md#mirror.py.
     """
     from lionagi.state.db import StateDB
 
@@ -854,7 +810,7 @@ async def mirror_forever(
     lineage = _Lineage()
     threads: dict[str, str] = {}
     _seed_lineage(lineage, states)
-    # The connection lives inside the supervise loop so a failure to open it (e.g. a
+    # Connection lives inside the supervise loop so a failed open (e.g. a
     # locked/half-migrated state.db at studio startup) is retried, not fatal.
     backfilled = False
     while not stop.is_set():
@@ -914,8 +870,8 @@ async def _run(args: argparse.Namespace) -> int:
         if getattr(args, "codex_root", None)
         else CODEX_SESSIONS_DIR
     )
-    # A requested source whose tree is missing drops out with a warning; only when
-    # nothing requested is readable is there no work to do at all.
+    # A requested source whose tree is missing drops out with a warning; only
+    # when nothing requested is readable is there no work to do.
     if want_claude and not root.exists():
         warn(f"no Claude projects directory at {root}")
         want_claude = False
@@ -937,9 +893,8 @@ async def _run(args: argparse.Namespace) -> int:
     hint(f"li mirror: {mode} over {trees}")
 
     async with StateDB() as db:
-        # Retried every pass until one sweep completes cleanly, same as the
-        # studio's mirror_forever — a transient failure on the first attempt
-        # must not retire the backfill for the process lifetime.
+        # Retried every pass until one sweep completes cleanly (see
+        # _absorb_backfill), same as studio's mirror_forever.
         backfilled = not want_codex
         while True:
             if not backfilled:

--- a/lionagi/cli/state.py
+++ b/lionagi/cli/state.py
@@ -49,9 +49,6 @@ __all__ = [
 ]
 
 
-# ── run/team import helpers ───────────────────────────────────────────────────
-
-
 def _mtime_as_float(path: Path) -> float:
     try:
         return path.stat().st_mtime
@@ -295,9 +292,6 @@ async def _import_one_run(
     return 1, total_branches, total_messages
 
 
-# ── DB maintenance helpers ────────────────────────────────────────────────────
-
-
 def _format_bytes(n: int) -> str:
     for unit in ("B", "KiB", "MiB", "GiB"):
         if n < 1024:
@@ -492,17 +486,11 @@ def _db_sizes() -> dict[str, Any]:
 async def _collect_message_breakdown(db: Any) -> dict[str, Any]:
     """Messages by role and by age — the two axes a retention decision is made on.
 
-    A total row count cannot say whether a retention setting is able to reclaim
-    anything. A store whose oldest message is newer than the prune's keep-window
-    frees nothing at any ``--keep-days`` the prune accepts, and reports success
-    while doing it. The age histogram is what makes that readable before the
-    prune runs rather than after it has run and changed nothing.
-
-    Counts only. Summing content size is the one query here no index can serve
-    (57s against 1.68M rows, versus under 2s for everything else), and the
-    command that reclaims that content reports the size of the exact population
-    it is about to touch — which is the same number, measured where the decision
-    is actually taken.
+    A total row count can't say whether a retention setting reclaims anything;
+    the age histogram makes that readable before a prune runs rather than
+    after. Counts only, no content-size sum: that query is unindexable here
+    (measured 57s against 1.68M rows, vs under 2s for everything else) — the
+    prune command reports the size of its own touched population instead.
     """
     import time as _time
 
@@ -651,12 +639,10 @@ async def _print_stats() -> None:
         print("  oldest          (no messages)")
     else:
         print(f"  oldest       {oldest:>10.1f}d")
-        # Said about MESSAGES, deliberately, and not about the prune as a whole.
-        # Message lifetime and session lifetime are independent here: `li state
-        # prune` selects by session age and then frees only messages nothing
-        # surviving still references, so it can delete thousands of old sessions
-        # and free no message rows at all. Since messages hold nearly all the
-        # bytes, "sessions deleted" is not a claim about space.
+        # About MESSAGES, not the prune as a whole: `li state prune` selects by
+        # session age and frees only messages nothing surviving still
+        # references, so it can delete thousands of sessions and free no
+        # message rows at all.
         print("  (messages only — prune selects by SESSION age, see prune's own output)")
     print()
 
@@ -701,18 +687,12 @@ _PRUNE_VICTIMS = (
 
 
 async def _prune_candidates(*, keep_days: int, keep_n: int) -> dict[str, Any]:
-    """Recount what the prune's own predicate selects, and how old the oldest session is.
-
-    Printed beside the prune's result so the command cannot report an outcome
-    nothing contradicts. A single number is undetectable when it is wrong; a
-    pair is not. After a real run this must read zero, and after a preview it
-    must equal the count the preview reported, so either disagreement is visible
-    without anyone querying anything.
-
-    The age is here because of the failure this was built for: a keep-window
-    wider than the whole store selects nothing, so the prune deletes nothing and
-    says so in the words of a success. Beside the oldest session's age that
-    sentence stops being ambiguous.
+    """Recount what the prune's own predicate selects, and how old the oldest
+    session is. Printed beside the prune's result as a cross-check: after a
+    real run this must read zero, after a preview it must match the count the
+    preview reported. The age guards against a keep-window wider than the
+    whole store, which selects nothing and would otherwise report a no-op
+    prune as an unqualified success.
     """
     import time as _time
 
@@ -751,12 +731,10 @@ async def _prune_candidates(*, keep_days: int, keep_n: int) -> dict[str, Any]:
 
 
 class _PreviewOnlyError(Exception):
-    """Signals the end of a preview so its transaction unwinds instead of committing.
-
-    A preview has to answer "how many rows would this free", and the only answer
-    that cannot drift from the real one is the real one. The preview therefore
-    runs the prune and then refuses to commit it, carrying the counts out with it.
-    """
+    """Signals the end of a preview so its transaction unwinds instead of
+    committing. The preview runs the real prune statements and refuses to
+    commit them, carrying the real counts out via this exception, so the
+    reported "would free" number can't drift from the real one."""
 
     def __init__(self, counts: dict[str, int]) -> None:
         super().__init__("preview complete")
@@ -934,12 +912,9 @@ async def _prune(
 
 
 # Which message bodies the reclaim replaces, written once so the operation and
-# the recount below cannot describe different populations. Two copies of this
-# drifting apart would make the pair agree while counting different rows, which
-# is worse than printing no check at all.
-#
-# The already-reclaimed exclusion is what makes a second run of the same command
-# a no-op instead of a marker rewrite that reports work it did not do.
+# the recount below can't describe different populations. The already-reclaimed
+# exclusion makes a second run of the same command a no-op rather than a
+# marker rewrite reporting work it didn't do.
 _NULL_CONTENT_TARGETS = (
     "FROM messages "
     "WHERE created_at < :cutoff "
@@ -969,15 +944,10 @@ async def _null_content_candidates(
     roles: tuple[str, ...],
 ) -> dict[str, Any]:
     """Recount what the reclaim's own predicate still selects, and their size.
-
-    Printed beside the result so the command cannot report an outcome nothing
-    contradicts. After a real run this has to read zero; after a preview it has
-    to equal what the preview reported. A single number is undetectable when it
-    is wrong, and a pair is not.
-
-    Runs outside the operation's transaction deliberately: inside it, it would
-    be reading the same uncommitted rows the operation just wrote and would
-    agree with it by construction.
+    Printed beside the result as a cross-check: after a real run must read
+    zero, after a preview must match what the preview reported. Runs outside
+    the operation's transaction deliberately — inside it, it would read the
+    same uncommitted rows the operation just wrote and agree by construction.
     """
     import time as _time
 
@@ -1025,21 +995,16 @@ async def _null_content(
 ) -> dict[str, int]:
     """Replace old message bodies with a marker, keeping every row and reference.
 
-    This exists because the prune cannot reach these bytes. The prune selects
-    SESSIONS; the bytes live on MESSAGES; and a message some surviving
-    progression still names is kept whatever its age. So a store can be almost
-    entirely message content, have every message inside a keep-window, and give
-    a prune nothing to delete.
+    Exists because the prune can't reach these bytes: the prune selects
+    sessions, the bytes live on messages, and a message some surviving
+    progression still names is kept whatever its age. Only the body is
+    dropped; a marker recording that a body was there and how large it was
+    takes its place, so the row stays legible instead of reading as an empty
+    turn.
 
-    The row, its id, its role, its timestamp and its place in every progression
-    all survive. What is dropped is the body, and in its place goes a value that
-    says a body was there and how large it was, so the removal stays legible
-    instead of reading as a turn that produced nothing.
-
-    ``dry_run`` performs the update and rolls it back, so the reported numbers
-    are measurements of the operation rather than an estimate of it. That makes
-    a preview a WRITE that takes the same lock for the same duration -- it is
-    not a read, and on a large store it is not a quick one.
+    ``dry_run`` performs the update and rolls it back, so reported numbers are
+    measurements, not estimates — a preview is therefore a WRITE taking the
+    same lock for the same duration, not a quick read.
     """
     import time as _time
 
@@ -1057,12 +1022,11 @@ async def _null_content(
     async with StateDB() as db:
         try:
             async with db._tx() as conn:
-                # The batch is pinned to a scratch table before anything is
-                # written, because both measurements have to be about the same
-                # rows and the predicate stops selecting them the moment the
-                # update lands. It also keeps the after-size away from markers
-                # an earlier run left behind, which the predicate excludes but a
-                # sum over "rows carrying a marker" would quietly re-include.
+                # Batch pinned to a scratch table before any write: both
+                # measurements must be about the same rows, and the predicate
+                # stops selecting them the moment the update lands. Also keeps
+                # the after-size from re-including markers an earlier run left
+                # behind, which the predicate excludes but a raw sum wouldn't.
                 await conn.execute(text("DROP TABLE IF EXISTS null_content_batch"))
                 await conn.execute(
                     text("CREATE TEMPORARY TABLE null_content_batch (id TEXT PRIMARY KEY)")
@@ -1088,27 +1052,21 @@ async def _null_content(
                 target_count = int(measured["n"])
                 bytes_before = int(measured["b"])
 
-                # The marker is built in SQL rather than in Python so that
-                # LENGTH(content) is evaluated against each row as it is
-                # overwritten. That makes original_bytes the row's OWN size in a
-                # single statement -- the alternative, one marker computed here
-                # and written everywhere, records a batch average under a
-                # per-row name.
+                # Marker built in SQL, not Python, so LENGTH(content) evaluates
+                # against each row as it's overwritten -- original_bytes is the
+                # row's OWN size, not a batch average recorded under a per-row
+                # name. pruned_content_sql() takes no argument, so the
+                # interpolated expression is a module constant; :at is bound.
                 await conn.execute(
                     text(
-                        # noqa on the interpolation: pruned_content_sql() takes
-                        # no argument here, so the expression is a constant of
-                        # this module's making and the only value crossing the
-                        # boundary is :at, which is bound.
                         f"UPDATE messages SET content = {pruned_content_sql()} "  # noqa: S608
                         "WHERE id IN (SELECT id FROM null_content_batch)"
                     ),
                     {"at": now},
                 )
 
-                # Read back inside the same transaction: what the markers
-                # actually occupy. SQLite wrote them and is the only authority
-                # on how much of it is there.
+                # Read back inside the same transaction what the markers
+                # actually occupy -- SQLite wrote them and is the only authority.
                 bytes_after = int(
                     (
                         (
@@ -1180,11 +1138,9 @@ async def _doctor(
             if started is not None and started >= cutoff:
                 skipped += 1
                 continue
-            # Age answers "how long since this session first started", which is
-            # the same question as "how long has this process been running" only
-            # for a session that ran once. A branch picked up again keeps the
-            # start time of the session while the process is new, so the command
-            # asks the process itself before calling anything stuck.
+            # Session age isn't process age: a branch picked up again keeps the
+            # session's original start time while its process is new, so the
+            # sweep checks the process itself before calling anything stuck.
             entity = dict(row)
             meta = entity.get("node_metadata")
             if isinstance(meta, str):
@@ -1195,11 +1151,9 @@ async def _doctor(
             entity["node_metadata"] = meta if isinstance(meta, dict) else None
             pid = _read_pid_from_entity(entity)
             if pid is not None and pid_alive(pid):
-                # A live PID is not by itself proof: the OS can hand a dead
-                # session's number to an unrelated process, which would protect
-                # a genuinely stuck row for as long as that process lives. The
-                # stale-kill sweep already answers this, so it answers it here
-                # too rather than a second, weaker rule being written.
+                # A live PID alone isn't proof: the OS can hand a dead session's
+                # number to an unrelated process. Reuse the same identity check
+                # the stale-kill sweep uses rather than write a second, weaker rule.
                 raw_ct = (entity["node_metadata"] or {}).get("pid_create_time")
                 try:
                     expected_create_time = float(raw_ct) if raw_ct is not None else None
@@ -1211,11 +1165,10 @@ async def _doctor(
                     expected_session_id=row["id"],
                     expected_create_time=expected_create_time,
                 )
-                # "unverifiable" means the process could not be inspected, not
-                # that it is gone; skipping it leaves a row for the next run
-                # rather than reaping one out from under a worker. "zombie" is
-                # the opposite: the process has exited and is only waiting to
-                # be reaped, so the row is stale and belongs in the sweep.
+                # "unverifiable" means inspection failed, not that the process
+                # is gone -- skip it rather than reap a row out from under a
+                # live worker. "zombie" means the process exited and is only
+                # waiting to be reaped, so that row belongs in the sweep.
                 if verdict in ("ours", "unverifiable"):
                     skipped += 1
                     continue
@@ -1243,9 +1196,6 @@ async def _doctor(
                     swept_count += 1
 
         return {"running": total, "swept": swept_count, "skipped": skipped}
-
-
-# ── _import_runs / _import_teams ─────────────────────────────────────────────
 
 
 async def _import_runs() -> dict[str, int]:
@@ -1418,9 +1368,6 @@ async def _import_teams() -> dict[str, int]:
                     await conn.execute(msg_stmt, mrow)
 
     return counts
-
-
-# ── CLI parser + runner ───────────────────────────────────────────────────────
 
 
 def add_state_subparser(subparsers: argparse._SubParsersAction) -> None:
@@ -1722,14 +1669,12 @@ def run_state(args: argparse.Namespace) -> int:
             print("  oldest session: (none)")
         else:
             print(f"  oldest session: {age:.1f}d")
-            # Gated on the operation's own count, not on the age alone. The same
-            # comparison means two opposite things depending on when it is read:
-            # before the prune it says the window reaches nothing, after a
-            # successful one it says the prune WORKED and every survivor is
-            # inside the window. Ungated it prints "this reclaimed nothing"
-            # directly beneath "deleted 2000 session(s)", and tells an operator
-            # to lower the window -- advice that deletes more, on the one path
-            # where nothing was wrong.
+            # Gated on the operation's own count, not age alone: the same
+            # age-vs-window comparison means "window reaches nothing" before a
+            # prune but "it worked, every survivor is in-window" after one.
+            # Ungated, it would print "this reclaimed nothing" beneath "deleted
+            # 2000 session(s)" and suggest lowering the window when nothing was
+            # wrong.
             if result["sessions"] == 0 and age < args.keep_days:
                 print(
                     f"  NOTHING IS OLDER THAN --keep-days {args.keep_days}, so this "
@@ -1792,9 +1737,6 @@ def run_state(args: argparse.Namespace) -> int:
         return 0
 
     return 1
-
-
-# ── machine result ────────────────────────────────────────────────────────────
 
 
 async def _machine_ls_data(*, limit: int, status: str | None) -> dict[str, Any]:


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 4 (+224 / -377, net -153)
- New documentation: 99 lines in docs/internals/cli.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.