### PR TITLE
docs(cli/orchestrate): trim inline prose to docs/internals/cli.md

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -219,6 +219,81 @@ posting a coordinator-authored `wakeup` signal are side effects: the
 quiescence read, which is what prevents the same round from being
 double-injected.
 
+### `flow.py` — dividing a time budget across a DAG
+
+When a flow run carries a total time budget, each op needs to be told its own
+share of it — and that share has to be a bound computed before any op has
+run, not a measurement of how long ops actually take.
+
+`critical_path_depth(dep_indices)` is the longest dependency chain in the
+plan, in ops — how many ops the *dependencies alone* force to run one after
+another. It's a lower bound on wall-clock, not the bound: a concurrency cap
+can serialize ops this function considers parallel — under
+`--max-concurrent 1` it still reports the dependency-only depth even though
+the run is forced fully sequential, which is why `max_sequential_depth`
+below, not this function, is what actually sizes a budget. Dependencies
+point only backwards (op *i* may depend
+only on ops before it), so a single forward pass suffices; an out-of-range
+dependency index is ignored rather than raising, since a bad index in a
+budget hint shouldn't be able to take down a run.
+
+`max_sequential_depth(dep_indices, num_ops, max_concurrent)` is what actually
+sizes the budget. It has to be an upper bound rather than an estimate,
+because a simulated schedule (a ready-queue admitting `max_concurrent` ops at
+a time) only models the equal-duration case — give four ops a cap of two and
+let one of them run six times longer than the rest, and the other three
+serialize behind it into a chain of three, while a duration-blind simulation
+would have counted two. Unequal op durations are the normal case, not the
+corner, so exactness on the equal-duration schedule is the wrong thing to
+optimize for. Being a bound also fixes the error's direction: undercounting
+hands every op *more* time than the flow can actually afford and the flow
+overruns its deadline; overcounting only tells an op it has slightly less
+time than it might have had.
+
+Two things force ops into sequence, and the bound is the worse of the two:
+dependencies force a chain no capacity can shorten, and capacity forces the
+rest — a run of ops executing strictly one after another can contain at most
+one op from any set that started together, bounding it at
+`num_ops - max_concurrent + 1`. Neither can exceed `num_ops` (the
+everything-serializes case). `max_concurrent <= 0` reads as unbounded,
+matching how the executor itself interprets it; a plan whose dependency data
+doesn't describe all its ops falls back to `num_ops` (assume nothing
+overlaps, since nothing more can be said).
+
+`op_budget_share` divides the total budget by `max_sequential_depth`, not by
+`num_ops` — that's the whole point of computing the depth bound rather than
+just counting ops.
+
+`_build_budget_preambles` needs `deadline_epoch` — the instant the run's
+clock started, captured by the caller — and deliberately has no default for
+it. The obvious fallback, `now + total_budget`, would be wrong by however
+long the run has already been going, and wrong in the permissive direction
+(every op told it has more time than it actually does). Missing the instant
+therefore means no preamble at all: telling an op nothing is an honest
+failure, telling it a late deadline is not. A budgeted run that reaches this
+function with no deadline instant is a wiring error, not a configuration
+choice — the budget is still enforced on these ops, they're just never told
+about it, so this case logs a warning and returns no preambles rather than
+inventing a value.
+
+**`_hand_mcp_servers`** — a caller-named MCP server set is applied to every
+worker whose provider has a transport for it; a worker whose provider has
+none is warned about, naming the worker (`label`) since a run's workers can
+resolve different providers. `{}` (an explicit empty set) and `None` (no set
+at all) are different requests: `{}` means "apply no servers" and is applied
+as the whole set; `None` means there's nothing to hand over and the model
+keeps whatever it already had.
+
+**`collect_worker_artifacts`** — the worker roster comes from the artifact
+directories the run actually handed out, not a scan for non-empty ones, so a
+worker that wrote nothing is still a `reported` entry with empty `files`
+rather than being silently absent. A worker the run expected but that never
+registered a directory is emitted as `unregistered` rather than dropped
+(otherwise that failure looks identical to "the run just had fewer
+workers"). Per-entry `status`: `unreadable` (traversal raised), `missing`
+(the registered path is gone), `unregistered` (expected, no directory ever
+recorded), `reported` (looked, `files` is what was there).
+
 ### `flow.py` — reactive DAG orchestrator (`li o flow`)
 
 Artifact contract has two write classes to `artifact_contract_json`: `_build_dag`
@@ -252,6 +327,149 @@ spawns from a prior checkpoint generation, not just what the live executor
 spawned this generation — otherwise a resume that reconstructs every spawned
 node as already-terminal would report `n_spawned=0` and silently skip the
 `with_synthesis`-or-`n_spawned` gate in `_run_flow_inner`.
+
+### `_round_records.py` / `_quiescence.py` — proving a manifest round is idle
+
+A manifest round dispatches independent legs as subprocesses, each in its own
+process group. Two questions need durable, disk-based answers, because the
+observer that eventually has to answer them — a reaper, a cooperative
+finalizer — may share nothing with the process that ran the round: which
+process groups belong to this round, and are they still holding a live
+member.
+
+**`_round_records.py` answers the first question.** Two files per round:
+`{run_dir}/legs/{label}.json` records what one leg was dispatched with and
+how it ended; `{run_dir}/round.json` records the round summary. The dispatch
+half of a leg record — the leg's `pgid` and `pid_create_time` (the start time
+of the process that led it) — is written at spawn, before the leg can do
+anything. This ordering matters: a group id read only after the leg exits can
+by then belong to a different process the kernel has reissued that number to;
+pairing it with the start time is how a later reader tells "this run's group"
+from "some stranger who now has that number." A leg record missing
+`pid_create_time` carries no identity and must be excluded from a sweep
+entirely, not treated as a present-but-unpinned group. Every write lands by
+temp-file-plus-atomic-rename, and a writer that finds an already-`COMPLETE`
+leg record leaves it alone — first writer to complete a leg wins, and
+`recorded_by` names the winner. `round.json` starts as
+`round_state: pending_harvest` at spawn and is flipped to `complete` only as
+finalization's last act, so a terminal read at any point before that, by any
+writer, observes "pending" rather than something that looks silently done.
+
+`control_group_domain()` builds the sweep's domain by reading every leg
+record from disk (never a live runner's memory) and keeping only groups whose
+record carries both a `pgid` and a `pid_create_time`. A record missing either
+is counted as `unpinned` and excluded from the domain — a sweep cannot
+certify a group it was never told about, and a bare number pretending to be a
+domain is worse than an admitted gap. `ControlGroupDomain.complete` is false
+whenever anything was unpinned or unreadable, and a sweep over an incomplete
+domain must report `unproven`, never `quiet`.
+
+**`_quiescence.py` answers the second question** — is every recorded group
+empty — via `sweep_quiet()`. It classifies each group as `QUIET` (no live
+member), `BUSY` (a live member was pinned), or `UNPROVEN` (the process-table
+scan of that group didn't complete), then rolls the whole sweep into one
+verdict by a fixed precedence: `BUSY` beats `UNPROVEN` beats an incomplete
+domain beats `NO_DOMAIN` beats `QUIET`. An unread member is indistinguishable
+from an absent one, so scan-incompleteness is checked before the emptiness
+test even runs — a partial scan that happens to see nothing must never read
+as quiet.
+
+Two invariants matter when interpreting a `Quiescence`:
+
+- **Where the observer sits.** A reaper belongs to no recorded group, so its
+  predicate is absolute emptiness. A cooperative finalizer runs inside the
+  runner's own group and must exempt exactly its own pid via
+  `exempt_pgid`/`observer_pid` — nothing else. Passing an `exempt_pgid` the
+  observer isn't actually in would wrongly exempt that pid from a group it
+  doesn't lead.
+- **Group ids are not stable identities.** `getpgid(pid) != pgid` is the only
+  thing a scan reads, so a process that calls `setpgid(0, 0)` to leave its
+  recorded group — not limited to processes that call `setsid`, a narrower
+  class an earlier version of this doc named — becomes invisible to every
+  group-based check here, and no amount of re-scanning fixes it. A member
+  forked during the sweep can likewise be missed; identification and signal
+  are two syscalls, so a group observed empty was empty at the moment it was
+  read, not necessarily afterward.
+
+`enforce_quiet()` is the close-time counterpart. It signals only groups
+`sweep_quiet` pinned as `BUSY` — never `UNPROVEN`, since an incomplete scan
+says a member *may* exist but never who, and signalling on that risks hitting
+whatever process now holds a recycled pgid. For a group the observer sits
+outside, it kills the whole group (`kill_group_now`, which also catches a
+member that appeared after the scan); for the observer's own group it signals
+its pinned members individually and skips itself, since killing that group
+would kill the observer before it can publish a result. Sending a signal is
+not the verdict: `enforce_quiet` waits up to `settle` seconds
+(`_wait_for_delivery`) and then re-sweeps — the second sweep (`after`) is
+what a caller must trust, not the fact that something was signalled.
+`already_quiet` separately records whether anything needed signalling at
+all, so a caller can tell "the round genuinely finished clean" from "the
+round leaked and this had to clean up after it," even though both end in the
+same `QUIET` verdict.
+
+### `_control.py` — `li o ctl pause|resume|msg`
+
+Pure writers: resolve the target session and insert one row into
+`session_controls`, without waiting for it to apply. Two live consumers read
+that table: the poller in `flow.py`'s `_execute_dag` (flow/play runs) and the
+turn-end drain in `cli/agent.py` (agent runs). Only context-mode `msg` is
+supported today — the poller appends the message to shared flow context for
+operations not yet rendered; operation-mode messages are not (ADR-0069 D1,
+D3). `li o ctl status <id>` is how a caller checks whether an enqueued
+control actually landed.
+
+**Admission gating.** `pause`/`resume` are only accepted for `flow`/`play`
+sessions; `message` is additionally accepted for `agent` sessions. Within
+`agent`-kind sessions, `run_id` alone is not proof that something will drain
+the control — several producers stamp a `run_id` on the sessions they create
+without running the turn-end drain that would consume it. The authoritative
+signal is a `drains_controls` flag the runner declares in `node_metadata`
+when the session starts; its absence is read as `False` on purpose, since a
+runner that never declared draining is exactly the case admission must
+refuse. One exception is grandfathered deliberately: a pre-existing CLI
+agent-run session row that predates the `drains_controls` declaration is
+still admitted, because it does have a real turn-end drain. The precise set
+of session shapes/transitions this covers is intentionally not enumerated in
+prose — every attempt drifted out of date — see the resume cases in
+`tests/cli/test_agent_steer.py` for the executable version of that contract.
+
+The running-session check and the `session_controls` insert are two separate
+statements; a session can go terminal between them. The insert re-checks the
+running condition so it — not the earlier read — is what decides admission,
+avoiding a control queued against a run whose consumer has already exited.
+
+Landing time is a property of the consumer, not the verb: a flow/play poller
+renders queued context before the next op (~2s poll interval), while an
+agent leg only drains at its next turn boundary, which can be far later than
+2s into a long provider call.
+
+### `_finalize.py` — the exclusive claim over closing a manifest round
+
+Three different processes can arrive at the same round wanting to finish it:
+the runner itself at teardown, a reaper acting on a kill request, and a
+reaper sweeping up an orphan. Only one may act, and the primitive deciding
+that is a non-blocking `flock` on `{run_dir}/finalize.lock`. The kernel ties
+the lock's lifetime to the holding process, so a dead holder's claim vanishes
+with it — takeover *is* acquisition, and there is no stale-lock repair path
+because there is no separate repair path at all.
+
+Two properties matter:
+
+- **The descriptor must never reach a spawned leg.** A lock a leg inherited
+  would keep a dead runner's claim alive from inside a living child. Since
+  PEP 446, every descriptor Python opens is non-inheritable by default, so
+  the explicit `O_CLOEXEC` here is a statement of the requirement, not what
+  actually enforces it — the way to lose the property is to mark the
+  descriptor inheritable, which is what the module's test pins.
+- **The claim decides nothing by itself.** Every claimant arrives because of
+  something it observed *before* acquiring the lock, and the gap between
+  observing and acquiring is exactly where a live holder can finish,
+  publish, exit, and release the lock — turning what the claimant saw into
+  stale information. So the first act under the claim is always a re-read;
+  disposition comes only from that fresh read, never from what motivated the
+  attempt. This is why the module's functions take readers as arguments
+  rather than pre-observed state — there's no parameter through which a
+  caller could hand in what it saw earlier and have that trusted.
 
 ## `team.py` — `li team` persistent messaging (inbox pattern)
 

--- a/lionagi/cli/orchestrate/__init__.py
+++ b/lionagi/cli/orchestrate/__init__.py
@@ -374,18 +374,12 @@ def _interpolate_prompt(template: str, positional: str | None, playbook_args: di
 def _check_assembled_prompt(prompt: str) -> str | None:
     """Measure the prompt that will run, not the one it was written from.
 
-    A spec's prompt field is checked when the file is read, but that is a
-    template: the caller's positional and the playbook's arguments are
-    substituted into it afterwards, and either can make the result far longer
-    than the text that passed. A caller that names no spec at all skips the
-    file check outright. Both forms arrive here holding the finished text,
-    which is the only version that reaches a run.
-
-    Same bound as the spec field, deliberately: the number exists to refuse a
-    file that is not a prompt, and it sits far enough out that template plus
-    arguments together stay well under it. A second, larger bound here would
-    mean the assembled prompt could pass while the template it came from could
-    not, which is the asymmetry this check is closing.
+    A spec's prompt field is checked at file-read time, but that's a
+    template — substituting the caller's positional and the playbook's
+    arguments afterward can make the result far longer than the text that
+    passed. Uses the same length bound as the spec-field check, deliberately:
+    a larger bound here would let an assembled prompt pass while the
+    template it came from would not have.
     """
     if len(prompt) > MAX_SPEC_PROMPT_CHARS:
         return (

--- a/lionagi/cli/orchestrate/_checkpoint.py
+++ b/lionagi/cli/orchestrate/_checkpoint.py
@@ -101,20 +101,17 @@ class CheckpointWriter:
     ) -> None:
         """Record one reactively spawned node's outcome, keyed by its own node id.
 
-        Spawned nodes never share the `ops` keyspace: a spawned child's branch
-        can carry a name identical to a planned agent_id's, which would
-        silently overwrite the planned entry if keyed the same way.
-
-        operation/assignee/instruction/parent_id/spawn_id (CHECKPOINT_VERSION 2)
-        are what resume needs to reconstruct the node into a fresh graph.
-        spawn_id must be restored alongside assignee, never alone — the
-        finalize-time scan raises if an assignee-bearing node lacks one. A
-        checkpoint predating this field set carries entries without
-        `operation`; resume refuses only the affected node(s), not the run.
-
-        context is the node's `parameters["context"]` (e.g. a team round's
-        `prior_team_messages`) — distinct from `instruction`, which for a team
-        round is generic boilerplate. None when there's no context payload.
+        Kept out of the `ops` keyspace so a spawned child's branch name can't
+        collide with and silently overwrite a planned `agent_id` entry.
+        `operation`/`assignee`/`instruction`/`parent_id`/`spawn_id`
+        (CHECKPOINT_VERSION 2) are what resume needs to rebuild the node into
+        a fresh graph; `spawn_id` must accompany `assignee` (the finalize-time
+        scan raises if one appears without the other) — a checkpoint
+        predating this field set has entries with no `operation`, and resume
+        refuses only those nodes, not the whole run. `context` is the node's
+        `parameters["context"]` (e.g. a team round's `prior_team_messages`),
+        distinct from `instruction` (generic boilerplate for a team round);
+        `None` when there's no context payload.
         """
         async with self._lock:
             entry = {

--- a/lionagi/cli/orchestrate/_control.py
+++ b/lionagi/cli/orchestrate/_control.py
@@ -4,14 +4,9 @@
 
 Pure writers: resolve the target session (id/invocation id/play id/run id,
 same shapes `li o ctl status` accepts) and insert one row into
-session_controls. They do not wait for the control to apply — the poller in
-cli/orchestrate/flow.py `_execute_dag` (flow/play) and the turn-end drain in
-cli/agent.py (agent) are the consumers; use `li o ctl status <id>` to check
-whether it landed.
-
-Only context-mode `msg` is currently supported: the poller appends the message
-to shared flow context for operations not yet rendered. Operation-mode messages
-are unsupported. See ADR-0069 D1 and D3.
+session_controls; do not wait for it to apply. See
+``docs/internals/cli.md`` (`_control.py`) for consumer wiring and admission
+gating.
 """
 
 from __future__ import annotations
@@ -118,37 +113,9 @@ async def _enqueue_control_inner(
                 "deliver the steer",
                 EXIT_UNKNOWN,
             )
-        # Owning a run is not the same as consuming controls. The check above
-        # uses run_id as a proxy for "a lionagi runner owns this", and that
-        # proxy held only while the CLI agent runner was the sole caller that
-        # stamped one. Other callers persist through the same path, write the
-        # same kind, and supply their own run_id, so they pass that check while
-        # having no drain at all — the control would be admitted, never
-        # delivered, and never closed. Ask about the capability instead, and
-        # let the runner declare it when it starts the session.
-        #
-        # This refuses one row that used to be admitted and deserved to be: a
-        # CLI agent leg whose session row predates the declaration. It has a
-        # run_id and a real turn-end drain, and its control would have landed.
-        # That is deliberate and it is not a migration that was skipped.
-        #
-        # Which transitions replace an absent declaration, and when that
-        # refusal ends, are not described here on purpose: every attempt to
-        # state it in prose has been wrong, in a different way each time, while
-        # the meaning below has held. Read the resume cases in
-        # tests/cli/test_agent_steer.py instead. They are where that behaviour
-        # is stated in a form that fails when it stops being true, which a
-        # comment cannot do; they are not a claim that every transition is
-        # covered.
-        #
-        # Absence is still the right reading. Fields that happen to differ
-        # between producers are not capability: the embedded runner's run_id
-        # carries a distinguishing prefix today, but a naming convention is not
-        # a contract, and keying admission on the shape of an id is the same
-        # move as keying it on the presence of one — the proxy this check
-        # exists to retire. There is no field on a pre-existing row that says
-        # what the runner will DO, and inventing one from a prefix would
-        # re-admit the orphaned controls as soon as a producer renamed a run.
+        # run_id is not proof of a drain consumer — see docs/internals/cli.md
+        # (`_control.py`) for why `drains_controls` is the authoritative check
+        # and which session is grandfathered around it.
         if kind == "agent" and not _runner_drains_controls(session):
             return (
                 f"session {session_id[:8]} is run by something that does not "

--- a/lionagi/cli/orchestrate/_finalize.py
+++ b/lionagi/cli/orchestrate/_finalize.py
@@ -2,30 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """The exclusive claim a finalizer holds while it closes out a manifest round.
 
-Three different processes can arrive at the same round wanting to finish it: the
-runner itself at teardown, a reaper acting on a kill request, and a reaper
-sweeping up an orphan. Only one may act, and the primitive that decides is an
-``flock`` on ``{run_dir}/finalize.lock``, taken non-blocking. The kernel ties the
-lock's lifetime to the holding process, so a dead holder's claim vanishes with it
-and takeover IS acquisition — there is no stale-lock repair path for two
-claimants to race on, because there is no repair path at all.
-
-Two properties are the whole point of this module:
-
-- **The descriptor must not reach a spawned leg.** A lock a leg inherited would
-  keep a dead runner's claim alive from inside a living child, and the claim
-  would outlive the only process that knew what it was for. What actually
-  provides this is the interpreter: since PEP 446 every descriptor Python opens
-  is non-inheritable, so ``O_CLOEXEC`` below is a statement of the requirement
-  rather than the thing that meets it. The way to lose the property is to mark
-  the descriptor inheritable, which is what the test pins.
-- **The claim decides nothing.** Every claimant arrives because of something it
-  observed BEFORE acquiring, and the gap between observing and acquiring is
-  exactly where a live holder finishes, publishes, exits, and releases the lock
-  whose availability the claimant is about to read as confirmation. So the first
-  act under the claim is a re-read, and the disposition comes only from that.
-  This module takes readers rather than state for that reason: there is no
-  parameter through which a caller could hand in what it saw earlier.
+Non-blocking ``flock`` on ``{run_dir}/finalize.lock``; a dead holder's claim
+vanishes with it (takeover IS acquisition — no stale-lock repair path). The
+descriptor must never reach a spawned leg (``O_CLOEXEC``), and the claim
+itself decides nothing — every claimant re-reads state after acquiring
+rather than trusting what it observed before. See ``docs/internals/cli.md``
+(`_finalize.py`) for why both properties are load-bearing.
 """
 
 from __future__ import annotations

--- a/lionagi/cli/orchestrate/_notify.py
+++ b/lionagi/cli/orchestrate/_notify.py
@@ -279,17 +279,12 @@ async def deliver_flow_notify_now(
         logger.warning(
             "direct-path notify.on_terminal delivery failed for run %s", run.run_id, exc_info=True
         )
-        # The exec adapter records every failure mode onto the run -- timeout,
-        # spawn failure, nonzero exit -- because outcome recording is threaded
-        # into it. A python adapter is handed back as the imported callable
-        # with nothing wrapping it, so a raise reached only the log line above
-        # and left nothing to query. That made the durability of "did my
-        # terminal notification go out?" depend on which adapter type happened
-        # to be configured, which is not a distinction any caller can be
-        # expected to know about. The traceback goes to the same owner-only
-        # file the exec adapter's stderr does, and for the same reason: it is
-        # free text that can carry a credential, so it is referenced by path
-        # and never placed in the outcome record itself.
+        # A python adapter's raise otherwise reaches only the log line above,
+        # leaving nothing queryable — unlike the exec adapter, which records
+        # every failure mode as part of outcome recording. Recorded here too
+        # so durability doesn't depend on adapter type. Traceback goes to the
+        # same owner-only file the exec adapter's stderr does (free text can
+        # carry a credential), referenced by path, never inlined.
         record_notify_outcome_to_run(
             run, ok=False, exit_code=None, stderr_text=traceback.format_exc()
         )

--- a/lionagi/cli/orchestrate/_orchestration.py
+++ b/lionagi/cli/orchestrate/_orchestration.py
@@ -574,20 +574,9 @@ class OrchestrationEnv:
 def _hand_mcp_servers(imodel, servers: dict | None, *, label: str) -> None:
     """Give one worker's model the run's server set, or say it could not be given.
 
-    A caller who named a set for this run gets that set applied to every worker
-    whose provider has a transport for one, and is told about every worker whose
-    provider has none. Which providers those are is not decided here — the
-    request is where the set lands, so the function that writes it is the one
-    that answers whether it landed.
-
-    An empty set and no set are different requests. ``{}`` is the caller having
-    asked for no servers, so it is applied as the whole set rather than as
-    nothing to add. ``None`` is there being nothing to hand over, and the model
-    keeps whatever it would have used.
-
-    *label* names the worker, because a run's workers can resolve different
-    providers and a caller reading the warning needs to know which leg lost
-    what.
+    ``{}`` (apply no servers) and ``None`` (nothing to hand over, keep
+    whatever the model already had) are different requests. See
+    ``docs/internals/cli.md`` (`_orchestration.py`).
     """
     if servers is None:
         return
@@ -1247,23 +1236,11 @@ def make_team_lifecycle_coordinator(
 def collect_worker_artifacts(env: OrchestrationEnv) -> list[dict]:
     """List what each worker actually wrote, one entry per worker the run expected.
 
-    The roster comes from the directories the run handed out, not a scan for
-    non-empty ones, so a worker that wrote nothing is still an entry (empty
-    ``files``) rather than an absence. A worker the run expected but never
-    registered a directory for is emitted as ``unregistered`` rather than
-    dropped, since that failure looks identical to "fewer workers" if omitted.
-
-    ``status`` per entry:
-
-    ``unreadable``
-        traversal raised — could not look.
-    ``missing``
-        the registered path is gone (removed after registration, not a worker
-        declining to write).
-    ``unregistered``
-        expected but no directory was ever recorded.
-    ``reported``
-        looked, and ``files`` is what was there, empty or not.
+    ``status``: ``unreadable`` (traversal raised), ``missing`` (registered
+    path gone), ``unregistered`` (expected, no directory recorded),
+    ``reported`` (looked, ``files`` is what was there). See
+    ``docs/internals/cli.md`` (`_orchestration.py`) for why every expected
+    worker gets an entry rather than being dropped when empty/absent.
     """
     entries: list[dict] = []
     registered = env.worker_artifact_dirs

--- a/lionagi/cli/orchestrate/_quiescence.py
+++ b/lionagi/cli/orchestrate/_quiescence.py
@@ -1,43 +1,17 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Proving that nothing a manifest round started is still running.
+"""Prove that nothing a manifest round started is still running.
 
-``round_state: complete`` is a claim that the round's work is over, and it is
-published only after this sweep has observed every recorded control group
-empty. The domain is read from the run directory rather than from a live
-process's memory, so a reaper that shared nothing with a dead runner sweeps
-exactly what the runner would have swept.
+``round_state: complete`` is published only after this sweep has observed
+every recorded control group empty. The domain is read from the run
+directory, never from a live process's memory, so a reaper sharing nothing
+with a dead runner sweeps exactly what the runner would have.
 
-Three things about the predicate are load-bearing, and all three are the sort
-that fail toward reassuring if left implicit:
-
-- **Where the observer sits.** A reaper belongs to no recorded group, so its
-  predicate is absolute emptiness. A cooperative finalizer is a member of the
-  runner's own group, so its predicate exempts exactly itself and nothing else.
-  A predicate that forgets its own observer fails toward unsatisfiable; one
-  that assumes it is outside when it is inside certifies a group holding the
-  observer as empty.
-- **Who joins the domain.** The groups come from each leg record's spawn-time
-  capture, written on the record's first write. That is the mechanism that
-  populates the set, and it is named here because a sweep over a domain nobody
-  joined is indistinguishable from a clean sweep. So an incomplete domain is
-  never quiet, however quiet its groups are.
-- **An unfinished measurement is not an answer.** A scan that could not read
-  the process table, or a member whose identity could not be pinned, leaves the
-  scan incomplete. That is reported as its own verdict and never as emptiness.
-
-What this cannot close, stated rather than papered over: a descendant that
-leaves its leg's recorded process GROUP keeps running outside every group
-here, and leaving the group is all it takes — ``setpgid(0, 0)`` is enough and
-stays in the same session, so this is not confined to the descendants that
-call ``setsid``, which is the narrower class an earlier wording of this
-paragraph named. Membership is the only thing read (``getpgid(pid) != pgid``),
-so nothing group-based can see a process that has left, and no change here
-would fix it. A member that forks during the sweep can likewise leave a child
-the verification pass never saw; and identification and signal are two
-syscalls, so a group observed empty was empty when it was read. The round
-record is what a consumer reads, and writes that land after the sweep simply
-miss the round.
+Known blind spot: a descendant that leaves its leg's recorded process group
+(``setpgid(0, 0)`` — not limited to ``setsid`` callers) keeps running outside
+every group this module can see, and no rescan fixes it. See
+``docs/internals/cli.md`` (`_round_records.py` / `_quiescence.py`) for the
+full verdict precedence and observer-exemption rules.
 """
 
 from __future__ import annotations
@@ -130,15 +104,11 @@ def sweep_quiet(
 ) -> Quiescence:
     """Observe every recorded control group and say whether the round is quiet.
 
-    ``exempt_pgid`` names the one group the observer belongs to, which is the
-    cooperative finalizer's case: it is running inside the runner's group, so
-    that group holds the observer and the predicate there admits the observer's
-    own pid and nothing else. A reaper passes None, belongs to no recorded
-    group, and gets absolute emptiness everywhere.
-
-    Passing an ``exempt_pgid`` the observer is NOT in would exempt a pid from a
-    group it does not lead, so the exemption applies only to the observer's own
-    pid inside that one group; every other pid in it is a member.
+    ``exempt_pgid`` names the one group the observer itself belongs to (the
+    cooperative-finalizer case); the predicate there admits only the
+    observer's own pid, nothing else. A reaper passes None and gets absolute
+    emptiness everywhere. Passing an ``exempt_pgid`` the observer is NOT in
+    would wrongly exempt that pid from a group it doesn't lead.
     """
     observer_pid = os.getpid() if observer_pid is None else observer_pid
     domain = control_group_domain(run_dir)
@@ -222,36 +192,14 @@ def enforce_quiet(
 ) -> QuietEnforcement:
     """End what a round's recorded groups still hold, then re-observe.
 
-    The close-time counterpart to :func:`sweep_quiet`. A leg that ended normally
-    leaves its group empty and this changes nothing; a straggler still inside one
-    is ended at round close rather than tolerated into the harvest window, where
-    it could still be writing the files about to be collected.
-
-    Four properties, each of which fails toward reassuring if left implicit.
-
-    **It signals only on positive evidence.** A group is ended only where the
-    sweep pinned a live member in it. That evidence is also what makes the group
-    id safe to use: a process group id is not reissued while the group still has
-    members, so a group that answers with members is the one whose id was
-    recorded. On the other side, an incomplete scan says an unread member may
-    exist, never who is there — signalling on that reaches whatever now holds a
-    recycled id. So UNPROVEN is left alone and reported, not swept.
-
-    **The mechanism follows the observer's position, and the rule does not
-    change with it.** For a group the observer is outside, the whole group is
-    killed, which also reaches a member that appeared after the scan. The
-    observer's own group cannot be killed that way without ending the observer,
-    which still has to publish, so there its pinned members are signalled
-    individually and it is skipped. Same predicate, two mechanisms.
-
-    **Sending a signal is not ending a process.** The second sweep is the
-    verdict. ``settle`` bounds how long delivery is given; a group still holding
-    a member after it is BUSY, and the round is not quiet.
-
-    **Making it quiet and finding it quiet are different facts**, and
-    ``already_quiet`` keeps them apart. A close that had to kill something is
-    reporting that the round leaked, which a reader should be able to see even
-    though the outcome is the same word.
+    Close-time counterpart to :func:`sweep_quiet`. Only signals groups pinned
+    BUSY (never UNPROVEN — an incomplete scan never tells who's there, so
+    signalling could hit a recycled pgid). Kills the whole group when the
+    observer sits outside it; signals its own pinned members individually,
+    skipping itself, when it doesn't (killing its own group would end the
+    observer before it can publish). The returned ``after`` sweep is the
+    verdict — sending a signal isn't the same as a process having ended.
+    See ``docs/internals/cli.md`` for the full rationale.
     """
     observer_pid = os.getpid() if observer_pid is None else observer_pid
     before = sweep_quiet(
@@ -343,19 +291,10 @@ def _holds_a_member(
 ) -> bool:
     """Whether *pgid* still holds a member the quiet predicate would count.
 
-    An incomplete scan answers True, so the wait continues rather than releasing
-    on a reading that could not see everyone. The benefit is confined to a
-    transiently unreadable process table, where waiting lets the next poll
-    reach a readable one and converge to QUIET instead of settling for
-    UNPROVEN. Where the table stays unreadable this only spends the settle
-    budget: the sweep that follows answers UNPROVEN either way, because it is
-    the verdict and this is not.
-
-    That confinement is also why no test here pins this direction. A mutant
-    that releases early survives the suite, which is a gap in the tests rather
-    than a defence of the mutant: constructing the transient case means
-    controlling how many reads fail, and a test whose apparatus decides the
-    timing decides the outcome.
+    An incomplete scan answers True, so the wait keeps polling instead of
+    releasing on a reading that couldn't see everyone — this only spends the
+    ``settle`` budget if the process table stays unreadable; the sweep that
+    follows is the actual verdict either way.
     """
     members, complete = live_group_members(pgid, marker_var=marker_var)
     if not complete:

--- a/lionagi/cli/orchestrate/_round_records.py
+++ b/lionagi/cli/orchestrate/_round_records.py
@@ -2,25 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Durable per-leg and per-round records for a manifest round.
 
-Two files answer two different questions, and both are written where a reader
-that shares nothing with the runner can find them:
-
-- ``{run_dir}/legs/{label}.json`` — what one leg was dispatched with, and how
-  it ended. The dispatch half is written at spawn, before the leg can do
-  anything, because it carries the leg's process group: the quiescence sweep
-  that a reaper performs reads its control domain from these files, never from
-  a live runner's memory, so a reaper that shared nothing with a dead runner
-  sweeps the same groups the runner would have.
-- ``{run_dir}/round.json`` — the round summary. Written at spawn with
-  ``round_state: pending_harvest`` and flipped to ``complete`` as the last act
-  of finalization, so a terminal status published by ANY writer at ANY point,
-  including one that knows nothing about manifest rounds, is observably
-  pending rather than silently incomplete.
-
-Every write lands by temp-file-plus-atomic-rename, and a writer that finds a
-COMPLETE leg record already present leaves it alone. First write wins, and
-``recorded_by`` names the winner, so even a mis-sequenced writer cannot
-produce two competing accounts of one leg.
+``{run_dir}/legs/{label}.json`` records what one leg was dispatched with and
+how it ended; ``{run_dir}/round.json`` records the round summary
+(``pending_harvest`` at spawn, flipped to ``complete`` as finalization's last
+act). Every write is temp-file-plus-atomic-rename, and first write wins for a
+COMPLETE leg record. See ``docs/internals/cli.md`` (`_round_records.py` /
+`_quiescence.py`) for why the dispatch half is written before the leg runs
+and what a reaper reconstructs from these files alone.
 """
 
 from __future__ import annotations
@@ -87,14 +75,11 @@ RECORDED_BY_ORPHAN_REAPER = "orphan-reaper"
 class LegDispatch:
     """The facts that exist before a leg can produce anything.
 
-    ``pgid`` is the leg's own process group and ``pid_create_time`` is when the
-    process leading it started, both read at spawn. That pairing is the reason
-    this record is written before the leg runs rather than at its end: a group
-    read after the leg is reaped can resolve to a stranger's, a sweep over a
-    domain nobody joined is indistinguishable from a clean sweep, and the start
-    time is the only thing that tells those two cases apart. A record whose
-    ``pid_create_time`` is None carries no identity, and a sweep must refuse to
-    signal on it rather than fall back to the bare group.
+    ``pgid`` (the leg's process group) and ``pid_create_time`` (when the
+    leading process started) are both read at spawn, before the leg runs —
+    a group id read later can belong to a different process the kernel has
+    since reissued it to. A record with ``pid_create_time is None`` carries
+    no identity; a sweep must refuse to signal on it.
     """
 
     label: str
@@ -261,17 +246,12 @@ class ControlGroupDomain:
 def control_group_domain(run_dir: Path | str) -> ControlGroupDomain:
     """Process groups a quiescence sweep must observe empty, read from disk.
 
-    Read from the run directory rather than from any live process's memory, so
-    a reaper that shared nothing with a dead runner sweeps the same domain the
-    runner would have.
-
-    A group is only included when the record also carries the start time of the
-    process that led it. Without that, the group id names whatever the kernel
-    has since put at that number, and observing it "not empty" would report a
-    stranger as this run's straggler while observing it empty would certify
-    nothing. Such a record contributes nothing to the domain, and it is counted
-    rather than dropped: a sweep cannot certify a group it was never told about,
-    and it must not pretend a bare number is a domain.
+    Read from the run directory, never a live process's memory. A group is
+    only included when its record also carries the start time of the process
+    that led it — otherwise the group id may name whatever the kernel has
+    since reissued it to, and observing it either empty or not would report a
+    false result. Such a record is counted as ``unpinned`` rather than
+    silently dropped, so a sweep never pretends a bare number is a domain.
     """
     groups: list[int] = []
     unpinned = 0

--- a/lionagi/cli/orchestrate/flow.py
+++ b/lionagi/cli/orchestrate/flow.py
@@ -410,25 +410,11 @@ skip them.
 
 
 def critical_path_depth(dep_indices: list[list[int]]) -> int:
-    """Longest dependency chain in the plan, in ops.
-
-    This is how many ops the *dependencies* force to run one after another,
-    which is not the op count: ops with no path between them are free to run at
-    the same time.
-
-    It is a lower bound on the flow's wall clock, not the bound. A concurrency
-    cap serializes ops this function calls parallel, and under `--max-concurrent
-    1` it says 1 for a plan that runs strictly in sequence.
-
-    What actually sizes a budget is `max_sequential_depth`, which takes this
-    together with what the cap forces. This function is exact only when nothing
-    caps concurrency, which is the common case and why it is still worth
-    computing directly.
-
-    Dependencies point backwards (op i may only depend on ops before it), so a
-    single forward pass is enough. Cycles are therefore not reachable here, and
-    an entry pointing outside the plan is ignored rather than raising: a bad
-    index should not be able to take down a run over a budget hint.
+    """Longest dependency chain in the plan, in ops — a lower bound on wall
+    clock, not the bound `max_sequential_depth` computes. See
+    ``docs/internals/cli.md`` (`flow.py` — dividing a time budget across a
+    DAG). Dependencies point only backwards, so a single forward pass
+    suffices; an out-of-range entry is ignored rather than raising.
     """
     if not dep_indices:
         return 0
@@ -443,33 +429,15 @@ def critical_path_depth(dep_indices: list[list[int]]) -> int:
 def max_sequential_depth(dep_indices: list[list[int]], num_ops: int, max_concurrent: int) -> int:
     """The most ops that can end up running one after another.
 
-    This number divides the flow's budget, so its error has a direction:
-    counting too few hands every op more time than the flow can afford and the
-    flow overruns its deadline, while counting too many only means an op is
-    told it has slightly less time than it might have had. That asymmetry is
-    what makes this an upper bound rather than an estimate.
+    An upper bound, not an estimate — the error must undercount never, since
+    undercounting hands every op more time than the flow can afford. See
+    ``docs/internals/cli.md`` (`flow.py` — dividing a time budget across a
+    DAG) for why a simulated schedule is wrong and how the two forcing
+    mechanisms (dependencies, capacity) combine.
 
-    It has to be a bound, because the quantity it describes depends on how long
-    each op runs and a budget is computed before any of them have. An earlier
-    version simulated the schedule directly — a queue of ready ops, admitting
-    `max_concurrent` at a time, counting passes. That models one schedule, the
-    one where every op takes about as long as every other, and the executor
-    runs a great many. Give four ops a cap of two and let the second one run
-    six times longer than the rest, and the other three serialize behind it in
-    a chain of three where the simulation counted two. Unequal durations are
-    the normal case, not the corner, so the equal-duration schedule is the
-    wrong thing to be exact about.
-
-    Two things force ops into sequence and the bound is the worse of them.
-    Dependencies force a chain that no amount of capacity can shorten. Capacity
-    forces the rest: any run of ops executing strictly one after another can
-    contain at most one op from a set that started together, so it is bounded
-    by one plus however many ops are not in that first admitted batch. Neither
-    can exceed the everything-serializes case of one op at a time.
-
-    `max_concurrent <= 0` means unbounded, matching how the executor reads it.
-    A plan whose dependency data does not describe its ops gets `num_ops`, the
-    assumption that nothing overlaps, since nothing can be said about what does.
+    `max_concurrent <= 0` means unbounded, matching how the executor reads
+    it. A plan whose dependency data does not describe its ops gets
+    `num_ops` (assume nothing overlaps).
     """
     if num_ops <= 0:
         return 0
@@ -477,24 +445,13 @@ def max_sequential_depth(dep_indices: list[list[int]], num_ops: int, max_concurr
         return num_ops
     conc = max_concurrent if max_concurrent > 0 else num_ops
 
-    # Unbounded capacity admits every ready op, so each pass clears one level
-    # of the dependency graph and the pass count is exactly the longest chain.
-    # Worth taking directly: it is the common case and it is one linear scan.
+    # Unbounded capacity: each pass clears one level of the dependency graph,
+    # so the pass count is exactly the longest chain.
     if conc >= num_ops:
         return critical_path_depth(dep_indices) or num_ops
 
-    # Two things can force ops into sequence, and the answer is the worse of
-    # them.
-    #
-    # Dependencies force a chain no amount of capacity can shorten.
-    #
-    # Capacity forces the rest. When ops are ready the executor admits
-    # `conc` of them at once, and a run of ops that execute strictly one
-    # after another can contain at most ONE op out of any set that started
-    # together — so such a run is at most one of that first batch plus every
-    # op outside it, `num_ops - conc + 1`.
-    #
-    # Nothing can exceed `num_ops`, which is the everything-serializes case.
+    # Worse of: the dependency chain, and capacity's forced remainder
+    # (num_ops - conc + 1), capped at the everything-serializes case.
     return min(num_ops, max(critical_path_depth(dep_indices), num_ops - conc + 1))
 
 
@@ -524,25 +481,12 @@ def _build_budget_preambles(
 ) -> dict[int, str]:
     """The per-op budget preambles for one flow, keyed by op index.
 
-    Exists as its own function so the share an op is actually told can be
-    asserted directly. Tests that only call `op_budget_share` cannot see
-    whether the caller uses it, which is how the equal-split divisor survived
-    a suite that was green the whole time.
-
     `deadline_epoch` is an instant the caller captured when the run's clock
-    started, not a duration to add to now. It is deliberately not defaulted:
-    the obvious fallback, `now + total_budget`, is wrong by however long the
-    run has already been going, and it is wrong silently and in the permissive
-    direction — every op would be told it has more time than it does. Missing
-    the instant therefore means no preamble at all, since telling an op
-    nothing is the honest failure and telling it a late deadline is not.
+    started, not a duration to add to now, and is deliberately not defaulted
+    (see ``docs/internals/cli.md`` — the obvious `now + total_budget`
+    fallback is silently wrong). Missing it means no preamble at all.
     """
     if total_budget and num_ops > 0 and deadline_epoch is None:
-        # A budgeted run that got this far without an instant is a wiring
-        # error rather than a configuration: the limit will still be enforced
-        # on these ops, they just will not be told about it. Staying silent is
-        # right about the value and wrong about the event, so name the event
-        # once and still refuse to invent the value.
         _warn(
             "flow has a total budget but no recorded deadline instant; "
             "its ops will be given no budget guidance"
@@ -828,19 +772,13 @@ class _ExecResult:
 def _deps_from_built_graph(builder, label_by_node: dict[str, str]) -> dict[str, list[str]]:
     """Read each node's incoming edges out of the graph the executor walks.
 
-    A dependency list re-derived from what the planner declared is a statement
-    about the *input* to the build step, not an observation of its *output*:
-    the builder can add or omit edges, the executor waits on every incoming
-    edge whatever its label, and nothing downstream would notice the two
-    disagreeing. Reading the graph makes the reported structure and the
-    executed one the same object.
-
-    `label_by_node` names the nodes a reader already has a name for — plan
-    steps, by their 1-based ordinal, matching how deps have always been shown.
-    A head outside it is a node that has no plan ordinal because it did not
-    exist at plan time; it is named by the spawn id stamped on it (the same id
-    its own result record carries), falling back to the raw node id so an edge
-    is never dropped for want of a name.
+    Reads the graph itself, not the planner's declared deps, so the reported
+    structure and the executed one are the same object — a re-derivation from
+    what was declared could silently drift from what the builder actually
+    wired. `label_by_node` names plan-time nodes by their 1-based ordinal; a
+    head outside it (a node with no plan ordinal, spawned after plan time) is
+    named by its stamped `spawn_id`, falling back to the raw node id so an
+    edge is never dropped for want of a name.
     """
     graph = builder.get_graph()
     nodes = getattr(graph, "internal_nodes", None)
@@ -1872,30 +1810,23 @@ async def _execute_dag(
                     await _drain_escalation_links_bounded()
                 else:
                     # Bounded by _ESCALATION_LINK_RETRIES * _ESCALATION_LINK_RETRY_INTERVAL
-                    # (a few seconds worst case) in the happy path — the outer
-                    # db/session teardown (teardown_persist) only runs after this
-                    # function returns, so draining here, not firing untracked, is
-                    # what keeps a late retry from writing into a store this run
-                    # has already closed.
+                    # (a few seconds worst case); draining here rather than
+                    # firing untracked keeps a late retry from writing into a
+                    # store teardown_persist is about to close.
                     #
-                    # A cancellation can also land on *this* task after
-                    # run_dag() already returned — the CancelScope shield above
-                    # only stops anyio-mediated cancellation, not a direct
-                    # cancel() on this task — so _dag_cancelled stays False and
-                    # this is the await that would otherwise take it. gather()
-                    # only settles its own cancellation once every child
-                    # actually finishes, so a link task that swallows the one
-                    # cancel it's handed (or blocks past it) would leave a bare
-                    # `await gather(...)` parked here forever — asyncio.shield
-                    # lets this await raise promptly instead of waiting on the
-                    # children, which keep running in the background for
-                    # _drain_escalation_links_bounded() to actually finish off.
-                    # Re-raise afterward so the caller still observes the
-                    # cancellation — unless the try body already raised a real
-                    # exception, in which case that exception is what the
-                    # caller was waiting on and must win; a cancellation that
-                    # only landed during this teardown drain must not silently
-                    # replace it.
+                    # A cancellation can land on *this* task after run_dag()
+                    # already returned (the CancelScope shield above only
+                    # stops anyio-mediated cancellation, not a direct
+                    # cancel()), so _dag_cancelled stays False and this await
+                    # would otherwise absorb it. asyncio.shield lets this
+                    # await raise promptly instead of blocking on gather()
+                    # until every child settles (a link task that swallows or
+                    # outlives its own cancel would otherwise park this await
+                    # forever) — the children keep running in the background
+                    # for _drain_escalation_links_bounded() to finish off.
+                    # Re-raised below unless the try body already raised a
+                    # real exception, which must win over a cancellation that
+                    # only landed during this teardown drain.
                     _in_flight_exc = sys.exc_info()[1]
                     try:
                         with contextlib.suppress(Exception):
@@ -1978,21 +1909,13 @@ async def _execute_dag(
         prior_failed_evidence = getattr(env, "_failed_operation_evidence", None) or []
         env._failed_operation_evidence = [*prior_failed_evidence, *failed_evidence]
 
-    # Lost-node evidence: a node in the fixed initial plan (node_ids /
-    # assignments, indexed 1:1) whose result never landed in
-    # operation_results at all -- distinct from a node that ran and failed
-    # (already caught above) or was legitimately never meant to run. Every
-    # other accounted-for fate is excluded explicitly: an edge-condition skip
-    # is named in skipped_operations; a leg that gave up via EscalationRequest
-    # is named in escalated_operations and already fails the run through the
-    # escalated-evidence backstop above with its own, more specific reason;
-    # a reactive/budget-refused spawn was never a planned node to begin with
-    # (dropped_spawns never touches node_ids). A cancelled run never reaches
-    # this line -- run_dag raises and the whole evidence block above is
-    # skipped -- so no separate check is needed for it. What remains here is
-    # a node the plan expected but execution never observed in any of those
-    # ways; treat it as a failure with its own evidence rather than letting
-    # it render as "(no response)" below.
+    # Lost-node evidence: a planned node (node_ids/assignments, 1:1) whose
+    # result never landed in operation_results, and whose absence isn't
+    # already explained by skipped_operations (edge-condition skip),
+    # escalated_operations (already handled above), or dropped_spawns (never
+    # a planned node). A cancelled run never reaches this line at all. What's
+    # left is a node the plan expected but never observed in any known way;
+    # treat it as its own failure rather than rendering "(no response)" below.
     skipped_op_ids = {str(x) for x in dag_result.get("skipped_operations", [])}
     observed_op_ids = {str(k) for k in op_results}
     lost_evidence = [
@@ -2006,17 +1929,13 @@ async def _execute_dag(
         prior_failed_evidence = getattr(env, "_failed_operation_evidence", None) or []
         env._failed_operation_evidence = [*prior_failed_evidence, *lost_evidence]
 
-    # Lost-spawn evidence: mirrors the lost-node check above, but for the
-    # reactive surface. spawned_ids (when the executor reports it) is the
-    # roster of every node _accept_node actually accepted into the graph --
-    # spawned_operations is only a running count and can't answer "which
-    # nodes were accepted" on its own. An accepted spawn that reached a
-    # terminal EventStatus (e.g. CANCELLED) without ever producing a result
-    # is absent from operation_results, failed_operations, and
-    # skipped_operations alike; without this check it would also read as a
-    # clean completion. A spawn the executor refused to accept in the first
-    # place (dropped_spawns) never enters spawned_ids, so it stays excluded
-    # here exactly as dropped_spawns already is above.
+    # Lost-spawn evidence: mirrors the lost-node check above for the reactive
+    # surface. spawned_ids is the roster _accept_node actually accepted
+    # (spawned_operations is only a running count, not a roster). An accepted
+    # spawn that reached a terminal EventStatus (e.g. CANCELLED) with no
+    # result would otherwise be absent from every known-outcome set and read
+    # as a clean completion. A spawn the executor refused (dropped_spawns)
+    # never enters spawned_ids, so it stays excluded here too.
     spawned_ids = {str(x) for x in dag_result.get("spawned_ids", [])}
     lost_spawn_ids = (
         spawned_ids - observed_op_ids - skipped_op_ids - escalated_op_ids - failed_op_ids


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 9 (+148 / -398, net -250)
- New documentation: 218 lines in docs/internals/cli.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.