### PR TITLE
docs(mcp): trim jobs.py essay blocks to docs/internals/mcp.md pointers

### DIFF
--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -404,6 +404,57 @@ group."
   `all_terminal=true` (stop). `all_terminal` means every run has a recorded
   end, not that every run succeeded — read each entry's `outcome` for that.
 
+#### reservation-giveback
+
+`_discard_reservation()` (`lionagi/mcp/jobs.py`) gives a reserved run
+directory back after a submission fails before its job record is published.
+
+A submission that fails partway through writing has already left files
+behind, so removing only an empty directory would give the reservation back
+for some failures and not others. The files a submission writes into its own
+reservation are named by a fixed list and only those are ever removed — they
+are addressed as fixed names under the reservation directory, never through a
+path a caller handed in (a caller-named MCP config file lives wherever it
+lives and is never touched, whatever it points at).
+
+`rmdir` refuses a directory with anything in it, and that refusal stays the
+safety net rather than becoming a check taken beforehand: whatever this is
+asked to remove, a directory holding a run's state survives it. A removal
+that fails for any other reason leaves a directory nobody claimed, which is
+worth less than the error that sent us here, so it is swallowed rather than
+raised.
+
+The function returns whether the directory is actually gone afterward. When
+it is not, a marker (`RESERVATION_ROLLBACK_INCOMPLETE`) is left in what
+remains of it, so a directory found later under the jobs root with no job
+record reads as a giveback that could not run rather than one that
+succeeded — both otherwise look like the same empty absence of a job. The
+marker write is itself best-effort: `_discard_reservation_and_warn()` checks
+the marker's actual presence before logging, rather than assuming it landed
+just because the directory survived.
+
+#### write-job-publish
+
+`_write_job()` (`lionagi/mcp/jobs.py`) publishes a job record by writing a
+per-write-unique temp file in the same directory and calling `os.replace()`.
+`os.replace` is atomic on the same filesystem, so a concurrent reader
+(`status()` / `list_jobs()`) never observes a torn file, and a failed write
+leaves the previous record intact instead of a partial one. The temp name
+being unique per write means two writers to the same run (the pid-attach
+write in `submit()` and the terminal hook) never collide on the temp file
+itself. This makes each publish all-or-nothing; it does not serialize two
+writers, so a read-modify-write pair can still lose an update (last replace
+wins — see `_locked_job()` in [locked-job-contract](#locked-job-contract) for
+what does serialize writers).
+
+Non-finite floats are refused before the temp file is opened, so a refused
+record leaves neither a staging file nor a published one. `json.dumps` would
+otherwise write a non-finite float as the bare token `NaN` or `Infinity`,
+which only Python reads back — every non-Python reader of this record, and
+every strict JSON parser, would fail on it long after the run that wrote it.
+The start time already has a representation for "unreadable" (`null`), so
+nothing here encodes a sentinel this check would need to special-case.
+
 ### `mcp/_notify_hook.py`
 
 #### deliver-terminal-notice-two-callers

--- a/lionagi/mcp/jobs.py
+++ b/lionagi/mcp/jobs.py
@@ -269,28 +269,11 @@ def _reserve_run_dir() -> tuple[str, Path]:
 def _discard_reservation(d: Path) -> bool:
     """Give a reserved directory back, along with what a submission put in it.
 
-    A submission that fails partway through writing has already left files
-    behind, so removing only an empty directory would give the reservation back
-    for some failures and not others. The files a submission writes into its own
-    reservation are named here, and only those: they are addressed as fixed
-    names under *d*, never through a path a caller handed in. A caller may name
-    an MCP config that lives anywhere at all, and that file is theirs — it is not
-    part of this reservation whatever it points at, and nothing here can be
-    talked into deleting it.
+    See docs/internals/mcp.md#reservation-giveback for why only the fixed
+    reservation filenames are removed, why ``rmdir``'s refusal is the safety
+    net rather than a pre-check, and what the stranding marker means.
 
-    ``rmdir`` refuses a directory with anything in it, and that refusal stays the
-    safety here rather than becoming a check taken beforehand: whatever this is
-    asked to remove, a directory holding a run's state survives it — anything not
-    on the short list above stops the removal. A removal that fails for any other
-    reason leaves a directory nobody claimed, which is worth less than the error
-    that sent us here.
-
-    Returns whether the directory is actually gone afterward. When it is not —
-    the one case this function suppresses rather than raises for — a marker is
-    left in what remains of it, so a directory found later under the jobs root
-    with no job record reads as a giveback that could not run rather than as one
-    that succeeded; both leave the same absence of a job otherwise, and nothing
-    else here tells them apart.
+    Returns whether the directory is actually gone afterward.
     """
     for name in _RESERVATION_CONTENTS:
         try:
@@ -313,19 +296,12 @@ def _discard_reservation(d: Path) -> bool:
 
 
 def _discard_reservation_and_warn(d: Path, run_id: str) -> None:
-    """Give a reservation back, and say so when the giveback itself fails.
+    """Give a reservation back, and log a warning when the giveback fails.
 
-    ``_discard_reservation``'s own marker only helps an operator who later
-    goes looking under the jobs root. The boolean it returns is the only
-    signal available at the moment the failure actually happens, so every
-    caller that discards a reservation on an error path must act on it here
-    rather than let a `False` disappear along with the exception it rode in on.
-
-    The boolean says nothing about whether the marker write itself landed —
-    that write is best-effort and suppresses its own ``OSError`` — so this
-    checks the marker's actual presence afterward rather than assuming it from
-    the directory surviving. An operator reading the warning must not be sent
-    looking for a file that was never written.
+    Checks the stranding marker's actual presence rather than assuming it from
+    the directory surviving, since the marker write is itself best-effort — an
+    operator reading the warning must not be sent looking for a file that was
+    never written. See docs/internals/mcp.md#reservation-giveback.
     """
     if _discard_reservation(d):
         return
@@ -350,21 +326,11 @@ def _discard_reservation_and_warn(d: Path, run_id: str) -> None:
 
 
 def _write_job(record: dict[str, Any]) -> None:
-    # Publish atomically: write a unique temp file in the same directory, then
-    # os.replace() it into place. os.replace is atomic on the same filesystem, so
-    # a concurrent reader (status / list_jobs) never observes a torn file — and a
-    # failed write leaves the previous record intact instead of a partial one. The
-    # temp name is per-write-unique so two writers to the same run (the pid-attach
-    # write in submit() and the terminal hook) never collide on the temp itself.
-    # This makes each publish all-or-nothing; it does not serialize two writers,
-    # so a read-modify-write pair can still lose an update (last replace wins).
-    # Checked before the temp file is opened, so a refused record leaves neither a
-    # staging file nor a published one. json.dumps would write a non-finite float
-    # as the bare token NaN or Infinity, which only Python reads back: every
-    # reader of this record that is not Python — and every strict parser — would
-    # fail on it long after the run that wrote it. The start time already has a
-    # representation for "unreadable" and it is null, so nothing here encodes a
-    # sentinel that this refuses.
+    # Publish via write-temp-then-os.replace: atomic on the same filesystem, so a
+    # concurrent reader never observes a torn file, but this does not serialize
+    # two writers (last replace wins). Non-finite floats are refused before the
+    # temp file is opened, since json.dumps would write NaN/Infinity as a bare
+    # token only Python reads back. See docs/internals/mcp.md#write-job-publish.
     raise_if_non_finite(record)
     d = config.job_dir(record["run_id"])
     d.mkdir(parents=True, exist_ok=True)
@@ -1196,18 +1162,10 @@ def submit(
         "kind": kind,
         "argv": argv,
         "cwd": cwd,
-        # Both working directories, because they answer different questions and a
-        # notice signed by the wrong one is the failure this pair exists to close.
-        # `cwd` is where the run executes. `submit_cwd` is this process's own
-        # directory, which is the submitting seat's: it is what the server was
-        # started in, and therefore what any directory-anchored identity lookup
-        # resolves the submitter from. A notifier that resolves who it is from its
-        # working directory reports the run's directory owner unless it is run in
-        # the submitter's, so the delivery uses this one — see
-        # _notify_hook.deliver_terminal_notice. Recorded even when the two agree,
-        # so a record read afterwards can always say which identity a notice
-        # carried rather than leaving it to be inferred from a path that has since
-        # been reused.
+        # `cwd` is where the run executes; `submit_cwd` is this server process's
+        # own directory. Recorded separately even when they agree — a directory-
+        # anchored notifier must sign as the submitter, not the run, so delivery
+        # resolves identity from submit_cwd. See docs/internals/mcp.md#deliver-terminal-notice-two-callers.
         "submit_cwd": _submit_cwd(),
         "label": label,
         "notify_command": notify_command,


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 1 (+20 / -62, net -42)
- New documentation: 51 lines in docs/internals/mcp.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.