### PR TITLE
docs(operations,session,engines): trim inline prose to working density

### DIFF
--- a/docs/internals/core.md
+++ b/docs/internals/core.md
@@ -20,6 +20,20 @@ runs synchronously at the tail of every node's execution — the only
 race-free point for a caller's `inject()` against the task group's
 convergence; `cli/orchestrate/flow.py`'s team-round wakeup logic is wired here.
 
+**`flow.py`** gate-reject contract — a playbook-authored node opts into gate
+semantics by setting `operation.metadata["is_gate"] = True` (e.g. via
+`OperationGraphBuilder.add_operation(..., is_gate=True)`). Once that node
+completes, its result is inspected for a top-level `"gate_verdict"` key; if
+the value is the string `"reject"` (case-insensitive), every direct and
+transitive dependent of the gate is short-circuited to SKIPPED instead of
+running against the baseline the gate just rejected. A node that isn't
+marked `is_gate`, or a gate whose result has no `gate_verdict` key (or any
+value other than `"reject"`), changes nothing — flows with no gate nodes
+stay byte-identical to before. The veto is transitive and absolute: if any
+incoming edge traces back to a rejecting gate, the dependent is skipped
+regardless of any other otherwise-valid incoming path, and the skip reason
+propagates to that node's own dependents in turn.
+
 **`lndl_middle/lndl_middle.py`** — LNDL seam Middle (ADR-0024 §1-2): advances
 a branch one LNDL round per inner chat call, looping internally up to a round
 budget (default 3). Opt-in via `branch.operate(instruction=..., middle=lndl_middle)`;
@@ -61,6 +75,28 @@ breaking field removal/rename; adding nullable fields is non-breaking.
   pinned into the terminal "escalated" lane — only a "blocked" urgency (default,
   matching historical give_up/higher_tier behavior) or an unaccompanied signal
   (no request attached) is treated as escalated.
+- `_extract_usage_dims` normalizes both provider usage shapes to "uncached
+  prompt tokens" for input. Anthropic-style: `input_tokens` already excludes
+  cache activity; cache reads/writes arrive separately as
+  `cache_read_input_tokens` / `cache_creation_input_tokens`. OpenAI-style:
+  `prompt_tokens` *includes* cached reads, split out under
+  `prompt_tokens_details.cached_tokens`, so it's subtracted here. `is_valid`
+  is False when an OpenAI-style report violates the token-count invariants (a
+  negative prompt total, or `cached_tokens` greater than `prompt_tokens`);
+  the returned numbers are still clamped into a safe, non-negative shape so a
+  caller that ignores validity still gets a sane aggregate, but a billing
+  consumer that checks `is_valid` can distinguish a genuine full-cache hit
+  from a provider sending garbage.
+- `_sum_model_usage` sums per-model whole-tree token counts from a
+  claude_code CLI `modelUsage` map; unlike the flat top-level `usage` field
+  (top-level-loop only), each entry here already includes descendant
+  subagent spend. An entry counts as valid only when it's a dict carrying
+  all four expected keys with non-negative-integer values — a genuinely
+  zero-usage model still reports the full shape, so a valid entry that sums
+  to zero is distinct from no valid entry at all. If any entry in the map is
+  malformed, the whole map is untrustworthy and `has_valid_entry` is False:
+  summing only the well-shaped entries would silently undercount whatever
+  the malformed entry actually spent.
 
 **`observer.py`** — `_PAYLOAD_BYTE_CAP` bounds the persisted `payload` JSON
 column in `session_signals`, not the SSE frame: the SSE generator wraps each
@@ -263,6 +299,24 @@ handler: a root-level `make_agent()` budget-out routes to partial-export
 instead of crashing; masking guard — a non-budget leaf anywhere in the group
 (including nested groups) must not be laundered into a partial, so it
 re-raises instead.
+
+**`flow_signals.py`** — `flow_progress_signals` turns executor node
+transitions into `NodeQueued`/`Started`/`Completed`/`Failed` session-bus
+signals for a live-rendered `Session.flow` DAG run (shared by the engine and
+Studio). `_on_progress` prefers the authored node id so every lifecycle
+signal maps back to the designer DAG, falling back to the executor's name
+for the engine's own ops and reactive spawns; it pins the first genuinely
+resolved name for an `op_id` so later started/completed/failed calls reuse
+it even if a branch-naming hook later renames the operation's cloned
+branch (the branch name is a display concern, not the correlation key).
+Whether a name is a placeholder is decided structurally by the producer and
+passed in via `name_is_fallback` — never inferred by comparing against the
+op_id's prefix, since a genuine authored name can coincide with that prefix
+by chance. `name_is_fallback` has no default: it's an internal seam with an
+enumerable, all-internal caller set (the four lifecycle producers in
+`operations/flow.py`), so an untagged call fails loudly (`TypeError`)
+instead of guessing wrong and reintroducing the split-identity bug this
+guards against.
 
 **`coding.py`** — `CodingChainEvent` `eid` prefixes (`W`/`P`/`T`/`V`/`K`) are
 namespaced against hypothesis engine's (`F`/`Q`/`E`/`H`/`X`/`R`/`C`/`A`) so

--- a/lionagi/engines/flow_signals.py
+++ b/lionagi/engines/flow_signals.py
@@ -60,27 +60,9 @@ async def flow_progress_signals(
         meta = node_edge_meta.setdefault(op_id, {})
         parent_id = meta.get("parent_id")
         depends_on = meta.get("depends_on", [])
-        # Prefer the authored node id so every lifecycle signal maps back to the
-        # designer DAG; fall back to the executor's name (engine's own ops, reactive spawns).
-        # Pin the first GENUINELY resolved name for this op_id so later
-        # started/completed/failed calls reuse it even if a branch-naming hook
-        # (spawn_branch_setup) later renames the operation's cloned branch --
-        # the branch name is a display concern, not the correlation key.
-        # Whether a name is a placeholder ("no reference_id / no branch bound
-        # yet", see flow.py's _display_name/_branch_display_name) is decided
-        # structurally by the producer and passed in via name_is_fallback --
-        # never inferred here by comparing against op_id's prefix, since a
-        # genuine authored name can coincide with that prefix by chance.
-        #
-        # name_is_fallback has no default: this is an internal seam with an
-        # enumerable, all-internal caller set (the four lifecycle producers in
-        # operations/flow.py, all of which already pass the bit explicitly).
-        # "Unknown provenance" isn't a real state a caller can be in here, so
-        # there is no safe value to default to -- treating an untagged call as
-        # fallback silently produced the exact split-identity bug this guards
-        # against for a caller whose first name happened to be authored.
-        # Requiring the keyword makes a caller that doesn't know its own
-        # provenance fail loudly (TypeError) instead of guessing wrong.
+        # Pin the first genuinely-resolved name per op_id (see
+        # docs/internals/core.md, engines/flow_signals.py) so later signals
+        # stay correlated even if the branch is later renamed.
         sig_name = meta.get("name")
         if sig_name is None:
             sig_name = name

--- a/lionagi/operations/builder.py
+++ b/lionagi/operations/builder.py
@@ -67,10 +67,7 @@ class OperationGraphBuilder:
         one added before it.
 
         `is_gate=True` opts this node into the flow executor's gate-reject
-        contract (see `lionagi/operations/flow.py`): if its result carries a
-        top-level `gate_verdict="reject"`, every downstream dependent is
-        short-circuited to skipped instead of running against the baseline
-        this node just rejected.
+        contract — see `docs/internals/core.md` (`operations/flow.py`).
         """
         node = create_operation(operation=operation, parameters=parameters)
 

--- a/lionagi/operations/chat/_prepare.py
+++ b/lionagi/operations/chat/_prepare.py
@@ -256,14 +256,12 @@ async def _apply_context_providers(
 ) -> tuple[Instruction | None, "ProviderReport | None"]:
     """Gather registered ContextProviders for call-local prompt rendering.
 
-    Returns the (pre-)built Instruction and its report, or ``(None, None)``
-    when no providers are registered (zero-overhead path). A branch with no
-    system message has no render target — providers are skipped, not invoked;
-    see ``branch.last_context_report``.
-
-    ``ins``, when given, is reused as-is instead of building a second
-    Instruction — for callers that already constructed one before this
-    async, potentially side-effecting gather runs.
+    Returns ``(None, None)`` when no providers are registered (zero-overhead
+    path), or when the branch has no system message (no render target —
+    providers are skipped, not invoked; see ``branch.last_context_report``).
+    ``ins``, when given, is reused as-is rather than building a second
+    Instruction, since the caller's copy may already reflect a side-effecting
+    gather.
     """
     if not branch._context_providers:
         return None, None

--- a/lionagi/operations/flow.py
+++ b/lionagi/operations/flow.py
@@ -46,16 +46,7 @@ logger = logging.getLogger(__name__)
 
 UNLIMITED_CONCURRENCY = int(os.environ.get("LIONAGI_MAX_CONCURRENCY", "10000"))
 
-# Gate-reject contract (issue #2860). A playbook-authored node opts into gate
-# semantics by setting ``operation.metadata["is_gate"] = True`` (e.g. via
-# ``OperationGraphBuilder.add_operation(..., is_gate=True)``). Once that node
-# completes, its result is inspected for a top-level ``"gate_verdict"`` key;
-# if the value is the string "reject" (case-insensitive), every direct and
-# transitive dependent of the gate is short-circuited to SKIPPED instead of
-# running against the baseline the gate just rejected. A node that isn't
-# marked ``is_gate``, or a gate whose result has no ``gate_verdict`` key (or
-# any value other than "reject"), changes nothing -- this keeps flows with no
-# gate nodes byte-identical to before.
+# Gate-reject contract: see docs/internals/core.md (operations/flow.py).
 GATE_VERDICT_KEY = "gate_verdict"
 GATE_VERDICT_REJECT = "reject"
 SKIP_REASON_UPSTREAM_GATE_REJECT = "upstream_gate_reject"
@@ -467,15 +458,11 @@ class DependencyAwareExecutor:
         self._emit_progress(str(operation.id), branch_name, status, elapsed, name_is_fallback)
 
     def _emit_abandoned_terminal(self, operation: Operation) -> None:
-        """Safety net for cancellation and unexpected flow-level errors.
-
-        If `operation` already emitted "started" but execution left
-        `_execute_operation` through the CancelledError or generic-Exception
-        handler without going through the normal completed/failed paths, the
-        node would otherwise render as perpetually running. Emit a "failed"
-        terminal (there is no separate cancelled/abandoned signal kind) so
-        every start still gets exactly one terminal outcome. No-op if this
-        operation never started, or a terminal was already emitted for it.
+        """Safety net: emit "failed" (no separate cancelled/abandoned signal
+        kind exists) for an operation that emitted "started" but left
+        `_execute_operation` via cancellation or an unhandled exception,
+        bypassing the normal completed/failed paths. No-op if the operation
+        never started or already has a terminal emitted.
         """
         if operation.id not in self._started_ops:
             return
@@ -668,11 +655,8 @@ class DependencyAwareExecutor:
 
     def _record_gate_verdict(self, operation: Operation) -> None:
         """Called on a completed ``is_gate`` operation; records a REJECT
-        verdict (see the module-level gate-reject contract) so
-        ``_check_edge_conditions`` can veto this gate's dependents. A result
-        with no ``gate_verdict`` key, or any value other than "reject",
-        leaves ``_gate_rejections`` untouched -- the gate completed normally
-        and nothing downstream is affected."""
+        verdict (see the gate-reject contract in docs/internals/core.md) so
+        ``_check_edge_conditions`` can veto this gate's dependents."""
         result = operation.response
         if result is not None and not isinstance(result, str | int | float | bool):
             result = to_dict(result, recursive=True)
@@ -691,17 +675,11 @@ class DependencyAwareExecutor:
         }
 
     async def _check_edge_conditions(self, operation: Operation) -> bool:
-        """Return True if at least one valid incoming path exists or no edges; False if all incoming edges failed.
-
-        A gate reject is an absolute veto layered on top of that: if any
-        incoming edge traces back (directly or transitively) to a rejecting
-        gate, this operation is skipped regardless of any other otherwise
-        valid incoming path -- a node must never run against a baseline one
-        of its ancestors just rejected. The veto is recorded in
-        ``self._skip_reasons`` so a caller skipped for this reason (and, in
-        turn, that caller's own dependents) can be tagged and so this
-        propagates transitively via the existing `skipped_operations` check
-        below without extra bookkeeping.
+        """Return True if at least one valid incoming path exists or no
+        edges; False if all incoming edges failed. A transitive gate reject
+        is an absolute veto on top of that (docs/internals/core.md), recorded
+        in ``self._skip_reasons`` so it propagates to dependents via the
+        existing `skipped_operations` check below.
         """
         # Snapshot before awaiting: iterating the live adjacency dict across
         # an await would raise RuntimeError if reactive injection attaches an

--- a/lionagi/session/branch.py
+++ b/lionagi/session/branch.py
@@ -290,15 +290,12 @@ class Branch(Element, Relational):
 
     @property
     def last_context_report(self):
-        """ProviderReport from this task's latest provider pass, when present.
-
-        Otherwise returns the branch's most recently completed provider pass
-        for backward compatibility. Concurrent passes use last-writer semantics
-        for that branch-level fallback.
-
-        When the branch has no system message there is no render target, so
-        providers are not invoked and the report lists every registered
-        provider under ``skipped``.
+        """ProviderReport from this task's latest provider pass, or the
+        branch's most recently completed pass as a fallback (concurrent
+        passes use last-writer semantics for that fallback). When the branch
+        has no system message there is no render target, so providers are
+        not invoked and the report lists every registered provider under
+        ``skipped``.
         """
         task_report = self._last_context_report.get()
         if task_report is not None:

--- a/lionagi/session/signal.py
+++ b/lionagi/session/signal.py
@@ -259,22 +259,11 @@ def lane_for(signals: Iterable[Signal | Any]) -> NodeLifecycleState:
 
 
 def _extract_usage_dims(usage: dict[str, Any]) -> tuple[int, int, int, int, bool]:
-    """Split a raw provider usage dict into (input, output, cached, cache_write, is_valid) tokens.
-
-    Anthropic-style: ``input_tokens`` already excludes cache activity; cache
-    reads/writes arrive separately as ``cache_read_input_tokens`` /
-    ``cache_creation_input_tokens``. OpenAI-style: ``prompt_tokens`` INCLUDES
-    cached reads, split out under ``prompt_tokens_details.cached_tokens`` --
-    subtracted here so the returned "input" figure means "uncached prompt
-    tokens" under both conventions.
-
-    ``is_valid`` is False when the OpenAI-style provider report violates the
-    token-count invariants (a negative prompt total, or cached_tokens greater
-    than prompt_tokens). The returned numbers are still clamped into a safe,
-    non-negative shape so a caller that ignores validity still gets a sane
-    aggregate -- but a billing consumer that checks ``is_valid`` can tell a
-    genuine full-cache hit from a provider sending garbage, which the clamp
-    alone makes indistinguishable.
+    """Split a raw provider usage dict into (input, output, cached,
+    cache_write, is_valid) tokens, normalizing Anthropic- and OpenAI-style
+    shapes to "uncached prompt tokens" for input — see docs/internals/core.md
+    (session/signal.py) for the per-provider field layout and the meaning of
+    ``is_valid``.
     """
     output_tokens = int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0)
     if "cache_read_input_tokens" in usage or "cache_creation_input_tokens" in usage:
@@ -286,11 +275,6 @@ def _extract_usage_dims(usage: dict[str, Any]) -> tuple[int, int, int, int, bool
     prompt_tokens = int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0)
     details = usage.get("prompt_tokens_details")
     cached = int(details.get("cached_tokens", 0) or 0) if isinstance(details, dict) else 0
-    # Provider invariants: prompt_tokens must be non-negative, and
-    # cached_tokens must not exceed it. A violation would otherwise produce a
-    # negative "uncached input" figure that reaches billing aggregates --
-    # clamp into a safe, non-negative shape instead of propagating it, but
-    # report the violation via is_valid rather than absorbing it silently.
     is_valid = prompt_tokens >= 0 and 0 <= cached <= prompt_tokens
     prompt_tokens = max(0, prompt_tokens)
     cached = max(0, min(cached, prompt_tokens))
@@ -316,21 +300,10 @@ def _as_nonneg_int(value: Any) -> int | None:
 
 
 def _sum_model_usage(model_usage: dict[str, Any]) -> tuple[int, int, int, int, bool]:
-    """Sum per-model whole-tree token counts from a claude_code CLI ``modelUsage`` map.
-
-    Unlike the flat top-level ``usage`` field (top-level-loop only), each
-    entry here already includes descendant subagent spend, so this is the
-    whole-tree figure when present.
-
-    Returns ``(input, output, cached, cache_write, has_valid_entry)``. An
-    entry only counts as valid when it is a dict carrying all four expected
-    keys with non-negative-integer values -- a genuinely zero-usage model
-    still reports the full shape, so a valid entry that happens to sum to
-    zero is distinct from no valid entry at all. If ANY entry in the map is
-    malformed (missing keys, non-dict, or a value that is not a real
-    non-negative integer), the whole map is untrustworthy and
-    ``has_valid_entry`` is False -- summing only the well-shaped entries
-    would silently undercount whatever the malformed entry actually spent.
+    """Sum per-model whole-tree token counts (including descendant subagent
+    spend) from a claude_code CLI ``modelUsage`` map. Returns ``(input,
+    output, cached, cache_write, has_valid_entry)`` — see docs/internals/core.md
+    (session/signal.py) for the entry-validity and all-or-nothing rules.
     """
     input_tokens = output_tokens = cached = cache_write = 0
     all_valid = bool(model_usage)


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 6 (+38 / -113, net -75)
- New documentation: 54 lines in docs/internals/core.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.