### PR TITLE
docs(protocols): trim inline prose in protocols/models/adapters to working density

### DIFF
--- a/docs/internals/core.md
+++ b/docs/internals/core.md
@@ -469,6 +469,58 @@ even though it is a real, schema-covered field. Classifying it as "extra"
 would let a preprocessor set it by name and forward the raw, unvalidated
 value straight to the callable — a schema bypass.
 
+### Pile row serialization
+
+`Pile.dump`/`adump` write JSONL and CSV without a pandas dependency, via
+`_serialize_records` in `generic/pile.py`. JSONL is one compact JSON object
+per line, newline-terminated so `mode="a"` appends valid JSONL (matching the
+old `DataFrame.to_json(orient="records", lines=True)` output). CSV writes a
+header of every key seen across all rows, in first-appearance order; rows
+missing a key render that cell empty, as pandas did. Row values come from
+`to_dict(mode="json")` — lionagi's canonical orjson encoding (ISO datetimes,
+shortest round-trippable floats) — which is value-equal and round-trippable
+via `Element.from_dict`, but not byte-identical to the old pandas output for
+datetime and high-precision-float fields (pandas rendered epoch-ms datetimes
+and double-precision floats). `parquet` stays on the pandas `to_df` path
+since it needs a columnar engine; `_serialize_records` doesn't support it.
+
+### Progression membership sync
+
+`Progression.order` is a public, directly-mutable deque — tests, third-party
+callers, and `Pile` internals all mutate it in place (`p.order.append(x)`,
+`p.order[0] = x`, `p.order.popleft()`), not just through `Progression`'s own
+methods. `Progression` keeps an O(1) membership set (`_members`) in sync with
+that deque so `__contains__` doesn't have to scan.
+
+A naive staleness check comparing `len(order)` across calls misses any
+length-preserving external write — `order[0] = x`, or a `popleft()` paired
+with an `append()` — because the length is unchanged even though the
+contents are not. `generic/progression.py` solves this two ways:
+
+- `order` is always wrapped in a `_MembersDeque`, a `deque` subclass that
+  updates the bound `_members` set eagerly inside every mutating method
+  (`append`, `insert`, `__setitem__`, `__delitem__`, `extend`, ...), using a
+  duplicate-aware discard rule: an id is only dropped from the set once no
+  occurrence of it remains in the deque. `__imul__` with `n <= 0` clears the
+  set (every element is dropped); `n >= 1` only duplicates existing ids, so
+  the set of unique members is unchanged and needs no update. `rotate` and
+  `reverse` permute existing entries without changing which ids are present,
+  so neither touches the set.
+- `Progression._ensure_synced()` (called before any read of, or incremental
+  update to, `_members`/`_order_len`) additionally detects wholesale
+  replacement of `order` — `p.order = deque(...)`, or a plain-deque copy
+  produced by pydantic re-validation — and a wrapper that is bound to a
+  *different* `Progression` instance's `_members` set. Ownership is checked
+  by identity (`order._members_ref is self._members`), not just type and
+  length, so a foreign or unbound wrapper of matching length can't silently
+  pass as synced. Either case triggers `_rebuild_members()`, which rebuilds
+  `_members` from scratch and rebinds the wrapper.
+
+Public behavior — membership correctness after *any* direct `order`
+mutation, not just length-changing ones — must not be narrowed to a
+length-only check; that was tried and is exactly the case this design
+covers.
+
 ### Graph adjacency cache
 
 `Graph.get_predecessors_cached` / `get_successors_cached` memoize plain-tuple

--- a/lionagi/adapters/_base.py
+++ b/lionagi/adapters/_base.py
@@ -14,10 +14,6 @@ from typing import Any, ClassVar, Protocol, TypeVar, runtime_checkable
 
 T = TypeVar("T")
 
-# ---------------------------------------------------------------------------
-# URL / credential sanitization
-# ---------------------------------------------------------------------------
-
 _CREDENTIAL_SCHEMES = frozenset(
     {
         "postgresql",
@@ -157,10 +153,6 @@ def _redact_details(details: dict[str, Any]) -> dict[str, Any]:
         redacted[k] = v
     return redacted
 
-
-# ---------------------------------------------------------------------------
-# Exception hierarchy
-# ---------------------------------------------------------------------------
 
 _ADAPTER_PYTHON_ERRORS = (KeyError, ImportError, AttributeError, ValueError)
 
@@ -313,11 +305,6 @@ class AdapterQueryError(AdapterError):
     __slots__ = ()
 
 
-# ---------------------------------------------------------------------------
-# dispatch_adapt_meth
-# ---------------------------------------------------------------------------
-
-
 def dispatch_adapt_meth(
     adapt_meth: str | Callable,
     obj: Any,
@@ -329,11 +316,6 @@ def dispatch_adapt_meth(
     if cls is None:
         raise ValueError("cls required when adapt_meth is a string")
     return getattr(cls, adapt_meth)(obj, **(adapt_kw or {}))
-
-
-# ---------------------------------------------------------------------------
-# Adapter protocol
-# ---------------------------------------------------------------------------
 
 
 @runtime_checkable
@@ -367,11 +349,6 @@ class Adapter(Protocol[T]):
         adapt_kw: dict[str, Any] | None = None,
         **kw: Any,
     ) -> Any: ...
-
-
-# ---------------------------------------------------------------------------
-# AdapterBase helper
-# ---------------------------------------------------------------------------
 
 
 class AdapterBase:
@@ -417,11 +394,6 @@ class AdapterBase:
             details=details,
             cause=exc,
         ) from exc
-
-
-# ---------------------------------------------------------------------------
-# AdapterRegistry
-# ---------------------------------------------------------------------------
 
 
 class AdapterRegistry:
@@ -483,11 +455,6 @@ class AdapterRegistry:
             raise AdapterError(f"Error adapting to {obj_key}", original_error=str(exc)) from exc
 
 
-# ---------------------------------------------------------------------------
-# Adaptable mixin
-# ---------------------------------------------------------------------------
-
-
 class Adaptable:
     """Mixin adding synchronous adapt-from/adapt-to to any class."""
 
@@ -528,11 +495,6 @@ class Adaptable:
         return self._registry().adapt_to(self, obj_key=obj_key, adapt_meth=adapt_meth, **kw)
 
 
-# ---------------------------------------------------------------------------
-# AsyncAdapter protocol
-# ---------------------------------------------------------------------------
-
-
 @runtime_checkable
 class AsyncAdapter(Protocol[T]):
     """Protocol for stateless async data format adapters."""
@@ -561,11 +523,6 @@ class AsyncAdapter(Protocol[T]):
         adapt_meth: str = "model_dump",
         **kw: Any,
     ) -> Any: ...
-
-
-# ---------------------------------------------------------------------------
-# AsyncAdapterRegistry
-# ---------------------------------------------------------------------------
 
 
 class AsyncAdapterRegistry:
@@ -629,11 +586,6 @@ class AsyncAdapterRegistry:
             raise AdapterError(
                 f"Error in async adapt_to for {obj_key}", original_error=str(exc)
             ) from exc
-
-
-# ---------------------------------------------------------------------------
-# AsyncAdaptable mixin
-# ---------------------------------------------------------------------------
 
 
 class AsyncAdaptable:

--- a/lionagi/protocols/_concepts.py
+++ b/lionagi/protocols/_concepts.py
@@ -50,19 +50,10 @@ class Sendable(ABC):  # noqa: B024
 class Observable(Protocol):
     """A thing with durable identity that a Pile can hold and observe.
 
-    Structural (protocol) admission contract: an object conforms by exposing an
-    ``id``, whether or not it inherits anything. ``isinstance(obj, Observable)``
-    is true for any object with an ``id`` attribute. This is the duck-typed
-    contract the Pile, Session, SessionObserver, and reactive event layers are
-    built on -- identity by capability, not by inheritance.
-
-    Intentional design, not a defect: admission is structural on purpose. A
-    2026-07 change briefly made it nominal (isinstance required inheriting this
-    class); that was a regression and is reverted here. A later reader or audit
-    that sees a duck-typed object satisfy ``isinstance(obj, Observable)`` -- or
-    that Pile admits an object which does not inherit ``Observable`` -- is
-    looking at the designed behavior, guarded by
-    ``tests/protocols/test_observable_protocol.py``. Do not "fix" it back to
+    Admission is structural, not nominal: any object exposing ``id`` satisfies
+    ``isinstance(obj, Observable)``, whether or not it inherits this class.
+    This is intentional (see CLAUDE.md, "Key Design Patterns") and guarded by
+    ``tests/protocols/test_observable_protocol.py`` -- do not narrow it to
     inheritance-only admission.
     """
 

--- a/lionagi/protocols/action/manager.py
+++ b/lionagi/protocols/action/manager.py
@@ -518,17 +518,9 @@ class ActionManager(Manager):
     ) -> dict[str, list[str]]:
         from lionagi.service.connections.mcp_wrapper import MCPConnectionPool
 
-        # An omitted policy is not upgraded to a permissive one here:
-        # `mcp_security` stays None and flows through to
-        # `register_mcp_server` -> `MCPConnectionPool.get_client`, which
-        # reaches the wrapper's fail-closed `MCPSecurityConfig()` default --
-        # unless the process owner has called `set_security_config()`, an
-        # explicit process-wide decision that then applies to every
-        # omitted-policy call. Either way, this loader path never recovers a
-        # policy some OTHER caller authorized for the same identity; only the
-        # MCP proxy's own reconnect does that. A caller wanting the permissive
-        # behavior outright passes `mcp_security=MCPSecurityConfig.trusted()`
-        # explicitly.
+        # An omitted policy is not upgraded to a permissive one: it flows
+        # through to the wrapper's fail-closed default. See
+        # docs/internals/agent-runtime.md for the full trust model.
         loaded_names = MCPConnectionPool.load_config(config_path)
 
         if server_names is None:

--- a/lionagi/protocols/generic/pile.py
+++ b/lionagi/protocols/generic/pile.py
@@ -36,23 +36,13 @@ _ADAPTER_REGISTERED = False
 
 
 def _serialize_records(records: list[dict], obj_key: str) -> str:
-    """Serialize row dicts to a JSONL or CSV string using only the standard
-    library, so the common serialization paths carry no pandas dependency.
+    """Serialize row dicts to a JSONL or CSV string, stdlib-only (no pandas).
 
-    - ``json`` → one compact JSON object per line (JSONL), newline-terminated
-      so ``mode="a"`` stays valid JSONL, matching the prior
-      ``DataFrame.to_json(orient="records", lines=True)`` which ended in "\n".
-    - ``csv`` → a header of every key seen (in first-appearance order) followed
-      by one row per record; missing keys render empty, as pandas did.
-
-    Values come from ``to_dict(mode="json")``, i.e. lionagi's canonical orjson
-    encoding (ISO datetimes, shortest round-trippable floats). That is
-    value-equal and round-trippable via ``Element.from_dict``, but its text is
-    not byte-identical to pandas for datetime/high-precision-float fields
-    (pandas rendered epoch-ms datetimes and double_precision floats).
-
-    ``parquet`` is intentionally unsupported here — it stays on the pandas /
-    ``to_df`` path in ``dump``/``adump`` since it needs a columnar engine.
+    Values come from ``to_dict(mode="json")``; text is value-equal and
+    round-trippable via ``Element.from_dict`` but not byte-identical to
+    pandas for datetime/high-precision-float fields. ``parquet`` stays on
+    the pandas ``to_df`` path in ``dump``/``adump``. See
+    docs/internals/core.md, "Pile row serialization".
     """
     if obj_key == "json":
         return "".join(
@@ -79,16 +69,10 @@ def _serialize_records(records: list[dict], obj_key: str) -> str:
 def _validate_item_type(value, /) -> set[type[T]] | None:
     """Normalize item_type to a set of classes.
 
-    Conformance is deliberately not checked here. Observable is a structural
-    protocol, so whether something is admissible is a property of an instance
-    (does it expose an ``id``?), not of its class -- a class that only assigns
-    ``self.id`` in ``__init__`` declares nothing at class level yet its
-    instances conform perfectly. Any class-level approximation would reject
-    exactly those types while the pile itself accepts their instances.
-
-    Admission stays honest instead: every item is checked against Observable
-    as it is included, so a class that cannot produce conforming instances
-    simply never gets one past that gate.
+    Conformance is not checked here: Observable is a structural protocol
+    (see ``_concepts.Observable``), so admissibility is a property of each
+    instance, not its class. Every item is checked against Observable as it
+    is included instead.
     """
     if value is None:
         return None

--- a/lionagi/protocols/generic/progression.py
+++ b/lionagi/protocols/generic/progression.py
@@ -27,15 +27,10 @@ __all__ = (
 class _MembersDeque(deque):
     """A ``deque`` that keeps a bound membership ``set`` in sync on every mutation.
 
-    ``Progression.order`` is a public, directly-mutable deque: external code
-    (tests, third-party callers, ``Pile`` internals) mutates it in place —
-    ``p.order.append(x)``, ``p.order[0] = x``, ``p.order.popleft()``, etc. A
-    length-only staleness check (comparing ``len(order)`` across calls) cannot
-    detect a length-preserving external write (e.g. ``order[0] = x``, or a
-    ``popleft()`` paired with an ``append()``), so this class instead updates
-    the bound set eagerly, inside every mutating operation, using the same
-    duplicate-aware discard rule as the rest of ``Progression`` (an id is only
-    dropped from the set once no occurrence of it remains in the deque).
+    Needed because ``Progression.order`` is public and directly mutable
+    in place; a length-only staleness check can't see a length-preserving
+    write (``order[0] = x``, or ``popleft()`` + ``append()``). See
+    docs/internals/core.md, "Progression membership sync".
     """
 
     def __init__(self, iterable=(), /, members: set | None = None):
@@ -155,18 +150,11 @@ class Progression(Element, Ordering[T], Generic[T]):
         description="A human-readable identifier for the progression.",
     )
     _members: set[UUID] = PrivateAttr(default_factory=set)
-    # Length of `order` as of the last known-good `_members` sync, used only to
-    # detect that `order` was replaced wholesale (`p.order = deque(...)`).
-    #
-    # CRITICAL DESIGN RATIONALE: `order` is a public, directly-mutable deque,
-    # and external code (tests, third-party callers, `Pile` internals) is
-    # expected to mutate it in place rather than going through `Progression`'s
-    # methods. `order` is therefore always wrapped in a `_MembersDeque` (see
-    # above), which keeps `_members` correct on every such mutation, including
-    # length-preserving ones (`order[0] = x`, `popleft()` + `append()`) that a
-    # length-only staleness check cannot see. Public behavior — membership
-    # correctness after *any* direct `order` mutation — must never be
-    # narrowed to "only length-changing mutations are safe".
+    # Length of `order` as of the last known-good `_members` sync; detects
+    # wholesale replacement (`p.order = deque(...)`). See
+    # docs/internals/core.md, "Progression membership sync" — membership
+    # correctness after any direct `order` mutation must not be narrowed to
+    # "only length-changing mutations are safe".
     _order_len: int = PrivateAttr(default=0)
 
     def model_post_init(self, __context: Any) -> None:
@@ -182,15 +170,11 @@ class Progression(Element, Ordering[T], Generic[T]):
 
     def _ensure_synced(self) -> None:
         # Must be called before any read of, or incremental update to,
-        # `_members`/`_order_len`. `_MembersDeque` keeps `_members` correct on
-        # every direct mutation of `order` itself, but `order` can also be
-        # replaced wholesale (`p.order = deque(...)`, or a plain-deque copy
-        # produced by pydantic re-validation), or be a wrapper that belongs to
-        # (is bound to) a *different* `Progression` instance's `_members` set
-        # — ownership is checked by identity
+        # `_members`/`_order_len`. Ownership is checked by identity
         # (`order._members_ref is self._members`), not just type and length,
         # so a foreign or unbound wrapper of matching length can't silently
-        # pass as synced.
+        # pass as synced. See docs/internals/core.md, "Progression membership
+        # sync".
         order = self.order
         if (
             not isinstance(order, _MembersDeque)


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 5 (+30 / -127, net -97)
- New documentation: 52 lines in docs/internals/core.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.