### PR TITLE
docs(providers): trim inline prose in CLI subprocess/secret/codex/claude_code modules

### DIFF
--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -148,6 +148,48 @@ requires a system task (`trio.lowlevel.spawn_system_task`), which is immune
 to any enclosing cancel scope and is stopped via `driver_cancel_scope`
 instead.
 
+## Codex config profile resolution and effort clamping
+
+**`providers/openai/_codex_profile.py`**, **`providers/openai/codex.py`**
+
+codex reaches a model from another provider through a config profile: `-p
+<name>` layers `$CODEX_HOME/<name>.config.toml` over the base config, and
+that file names a `model` and the `model_provider` that serves it. So
+`codex/<name>` in a lionagi model string should mean "run that profile," not
+"run a model literally called `<name>`." lionagi can't forward this with
+`-p` — codex accepts exactly one profile per invocation, and lionagi already
+spends that slot on a generated profile carrying MCP server secrets. Instead
+`resolve_codex_config_profile()` reads the file directly: the profile's
+`model` becomes the request's model, and its remaining scalar keys become
+`-c` overrides (table-valued keys, notably `mcp_servers`, are dropped and
+logged — lionagi decides a leg's MCP servers itself, and silently
+re-introducing servers from a config file would go around that).
+
+Two limits keep this from misfiring on an ordinary model id. Only a bare
+name is looked up (no dots, no separators), so a vendor id like
+`deepseek/deepseek-v4-flash-0731` is never treated as a profile path — a
+real model id carries dots or a slash, which the bare-name check rejects.
+And a symlinked profile file whose target can't be read raises loudly rather
+than silently falling through to "no profile" — `Path.is_file()` follows a
+broken symlink and returns False either way, and the whole point of this
+code is to stop a profile name from silently reaching codex as a literal
+model id.
+
+This resolution runs once, at the request-model level (`_resolve_config_profile`),
+so both the CLI and library entry points reach it — for a while only the CLI
+path resolved profiles, and a request built as
+`Branch(chat_model="codex/deepseek-flash")` sent the profile name to codex as
+a model id, which codex rejected as unsupported. It has to run *before*
+effort clamping (`_resolve_profile_then_clamp_effort`), since the clamp's
+ceilings are keyed on the model id and a profile names a different model
+than the caller did. Both steps are folded into one `mode="before"` model
+validator, deliberately not left as two separate validators relying on
+pydantic's ordering — pydantic runs `mode="before"` validators in *reverse*
+definition order, so getting this wrong silently applies one model's effort
+ceiling to a different model's profile. Caller-supplied `config_overrides`
+still win over the profile's, since an override at the call site is an
+explicit instruction and the profile is only a default sitting in a file.
+
 ## Codex c override TOML serialization
 
 **`providers/openai/codex.py`**
@@ -179,3 +221,189 @@ summing across every flushed message reconstructs the true total exactly
 once. `num_turns` is the exception: each `turn.completed` occurrence is
 already a per-event delta (incremented locally, not read off the event), so
 it is always safe to emit as `1`.
+
+## A session-terminal error must be turned back into a stream chunk
+
+**`providers/anthropic/claude_code.py`**, **`providers/openai/codex.py`**
+
+Both CLI providers drive their subprocess through an internal generator that
+yields ordinary `StreamChunk`s interleaved with, at the end, a `CLISession`
+object carrying the run's terminal verdict (`is_error`, usage, cost, turns,
+duration). `CLISession` is never itself yielded to the caller of `stream()`
+— only the chunks are — so a failure recorded solely on that object reaches
+nobody: the result chunk emitted beside it carries usage and cost but never
+the error flag, and a run that ended in error looks exactly like one that
+succeeded to anything consuming the stream. `stream()` therefore checks
+`item.is_error` when it sees the `CLISession` and synthesizes one final
+`StreamChunk(type="error", is_error=True, ...)` if no chunk already reported
+an error — the guard exists because a chunk-level error should never be
+double-reported, not because one currently occurs; today nothing else in
+either module constructs one, so the guard is presently vacuous but is kept
+as the natural place a future real error chunk would need it.
+
+The fix is scoped to `stream()` only. `_call()` drives the same generator
+and returns the session as a dict without branching on `is_error`, so the
+one-shot (non-streaming) helpers built on `_call()` still return an ordinary
+answer for a failed session — a separate gap, not closed by this. Per-tool
+failures already have their own carriers and are outside this concern
+entirely; this is about the session-terminal verdict only.
+
+## CLI subprocess lifecycle
+
+**`providers/_cli_subprocess.py`**
+
+Every CLI-backed provider (codex, claude_code, gemini, pi, ...) spawns
+through `ndjson_from_cli()`. Most of the module exists to answer one
+question honestly: is the child, and everything it spawned, actually gone
+when the caller is done with it?
+
+A pid and its process-group id are both recyclable — once reaped, the
+kernel is free to hand them to an unrelated process. `SpawnedProcess` (pid,
+pgid, create_time) is what makes a later signal target provably still the
+same child: `observe_spawned()` reads the group id bracketed by two
+start-time reads, before and after, and reports no identity
+(`create_time=None`) if the process was replaced mid-read or was already
+reaped or zombied. A consumer that gets `create_time=None` must treat it as
+"no identity captured," not as a statement about the child. `on_spawn`,
+when given, fires with this observation once the child exists and is
+awaited before any output is consumed, so a caller with durable accounting
+has recorded the process before anything can happen to it; its exceptions
+are not swallowed, since a failed recording leaves a live process nothing
+is tracking.
+
+Group cleanup only signals when it can prove the recorded group id is
+still this child's: either the leader is unreaped (its pid can't have been
+recycled yet, so no scan is needed), or, after reaping, a live member is
+still found occupying that group id. A process-table read that comes back
+incomplete and empty is *not* treated as an empty group — it is logged as
+`"unproven"` and left alone, because an unprovable group and a reissued one
+look identical from here. `end_child_group()` awaits a graceful terminate
+bounded by `grace`, then does a synchronous group sweep in a `finally` so a
+second cancellation can't interpose; the graceful path only runs on the
+not-yet-waited branch, since calling it after a drain has already happened
+would signal whatever now holds a possibly-recycled group id. A process
+group is also not a containment boundary — a descendant that calls
+`setsid()` leaves it, and cleanup then says nothing about that descendant.
+
+One hole is stated rather than closed: if the coroutine awaiting subprocess
+creation is cancelled after the OS has created the child but before the
+pid comes back, nothing in this process can reach it — asyncio closes the
+direct child's transport but never touches its group. This was measured,
+not reasoned about: a leg spawned under a loop that shuts down mid-creation
+leaves a SIGTERM-ignoring descendant running. Closing the window needs the
+pid before the creation call returns, which means reimplementing
+`create_subprocess_exec` on stdlib internals outside their public surface —
+declined as too fragile across Python versions, so the loss is logged as a
+warning instead.
+
+Streaming has its own hazard. `stdin_data` feeds a large prompt through a
+pipe (avoiding the OS argv length limit) via a task that runs concurrently
+with the stdout/stderr readers — writing it sequentially would deadlock
+once the data exceeds the pipe buffer and the child blocks writing output
+nobody is draining yet. stdout EOF requires *every* holder of the pipe's
+write end to close it, not just the spawned child: a CLI child that spawns
+its own long-lived helpers (MCP servers, daemons) leaks the write end into
+them, and when the child dies but its orphans keep the pipe open, a plain
+`read()` waits forever — a finished leg reads as "running" for the rest of
+the caller's budget. `ndjson_from_cli` races each read against the child's
+exit, then bounds the post-exit drain to 10s (`_POST_EXIT_DRAIN_GRACE`)
+once the child has exited; after that grace, teardown ends the process
+group, which is what actually closes the orphans' copy of the pipe. Stderr
+is drained concurrently and capped at 256 KiB; on a nonzero exit,
+`_no_stderr_reason()` distinguishes "the child wrote nothing" from "the
+drain itself failed" from "stderr was never opened," since a caller acts on
+those differently and collapsing them makes a broken capture read exactly
+like a quiet subprocess.
+
+Every CLI provider's request model wraps its `env` and `on_spawn` fields in
+`Redacted` at the top of every model-level `mode="before"` validator
+(`redact_runtime_fields_in_place`), so a rejected request never carries a
+child environment or a bound callback into `str(err)`, `err.errors()`, or
+`err.json()`. This matters because pydantic keeps a failing validator's raw
+input on the error — `repr=False`/`exclude` on a field don't help, since a
+model-level validator holds the whole raw mapping regardless of per-field
+settings. `Redacted` deliberately isn't a mapping, so serialization sees no
+structure to walk, and it refuses (`TypeError`, not `ValueError` — pydantic
+quotes a `ValueError` verbatim into the validation error) when the raw
+input is immutable and can't be substituted in place.
+
+## Declared secret lookup
+
+**`providers/_secret_resolution.py`**
+
+A CLI provider authenticates by reading its own process environment (an
+`env_key`), so when a secret actually lives somewhere else — a keychain, a
+password manager, a vault agent — the spawning process has nothing to pass
+on, and the child dies with a missing-variable error that says nothing
+about where the value should have come from. `secrets.lookup` in
+`~/.lionagi/settings.yaml` (the **global** file only, never the
+project-local one — where a secret lives is a property of the machine, and
+a checked-out repo has no business naming the program that reads this
+machine's secrets) names a fixed command and the variable names it may be
+asked to resolve:
+
+```yaml
+secrets:
+  lookup:
+    argv: [security, find-generic-password, -s, "{name}", -a, lionagi, -w]
+    names: [OPENROUTER_API_KEY]
+```
+
+`resolve_secret_lookup_config()` validates the block atomically — one bad
+name rejects the whole lookup rather than being dropped from it, since a
+config that silently resolves fewer names than it declares is
+indistinguishable from a working one until something using the dropped
+name fails. `fill_declared_secrets()` (called from `ndjson_from_cli` on
+every CLI spawn) only looks up names still missing from the environment —
+an already-set variable is never overwritten, so exporting one remains the
+way to override the store for a single run — and a refused or misconfigured
+lookup returns the environment unchanged, exactly like an absent one, but
+logs the distinction first: without that, a child dying on a missing
+variable gives no hint that the operator's own lookup config is what's
+broken.
+
+The resolved value reaches the child only through its environment: never a
+file, an argv, or a log line. A lookup command's stdout can carry the
+secret itself, so `_run_lookup()` only ever logs the program name, the
+variable name, and the exit status — never the command's own output, on
+success or failure. Lookups run on the spawn path with a 15s timeout; a
+keychain that wants to prompt interactively will exceed it by design — the
+prompt gets answered once, out of band, with the variable exported, rather
+than blocking every spawn on a UI it can't display.
+
+## Runtime-only endpoint state kept out of serialization
+
+**`providers/_agentic_handlers.py`**
+
+An `Endpoint`'s `EndpointConfig.kwargs` is both a supported way to pass
+provider-specific options through and the thing `to_dict()` serializes —
+which puts it on the path to `iModel.to_dict()`, `Branch.to_dict()`, and
+the run snapshots written to disk. For CLI providers, two of those kwargs
+are not safe to write down: a child `env` (credentials) and an `on_spawn`
+callback (which closes over whatever supervisor object created it).
+`AgenticHandlersMixin` moves anything named in `_runtime_state_fields` out
+of `config.kwargs` into an in-memory-only `_runtime_state` dict, at every
+point the config could otherwise be read or written down: construction,
+and again before any serialization, since `EndpointConfig.update()` and
+`iModel.from_dict()` can both reintroduce the values into `kwargs` after
+construction.
+
+Identity matters more than value here. `Endpoint.__init__` deep-copies a
+supplied `EndpointConfig`, and deep-copying a bound method copies its
+receiver too — so a naive copy silently hands a callback to a *copy* of the
+supervisor, which then never hears from the real one, while every wiring
+check still passes. The runtime fields are read off the caller's own
+config *before* that copy happens, specifically to preserve identity, and
+copied only shallowly afterwards, since these are live objects and a deep
+copy would hand the copy a different object under the same name. A caller
+that hands over an already-built `Endpoint` instance instead of a config
+missed that window entirely, so `adopt_runtime_state()` writes the values
+directly onto the supplied instance rather than dropping them.
+
+`create_payload()` rebuilds the request model from `to_dict(request)`,
+which is a `model_dump()` and so omits every field declared
+`exclude=True`. Runtime-state fields are typically `exclude=True` on the
+request model, so the rebuild would otherwise silently revert them to
+defaults; `_carried_runtime_state()` re-attaches them from the original
+request object, at lower precedence than anything already present from an
+explicit kwarg or the endpoint config.

--- a/lionagi/providers/_agentic_handlers.py
+++ b/lionagi/providers/_agentic_handlers.py
@@ -31,19 +31,10 @@ class AgenticHandlersMixin:
 
     @classmethod
     def take_supplied_runtime_state(cls, config, kwargs: dict) -> dict:
-        """Lift the declared runtime values off the caller's OWN objects.
-
-        Called before ``Endpoint.__init__``, which copies a supplied
-        ``EndpointConfig`` with ``model_copy(deep=True)``. A deep copy of a
-        bound method copies its receiver too, so the callback that reaches the
-        CLI would notify a copy of the supervisor while the real one — the
-        thing that owns the durable process accounting — hears nothing, and
-        every wiring check still passes. Reading the values here, from the
-        object the caller handed in, is what preserves identity.
-
-        Nothing is mutated: the copy still happens and the copied values are
-        still removed from the serialized config afterwards. This only decides
-        which of the two the endpoint ends up holding.
+        """Lift the declared runtime values off the caller's OWN objects,
+        before ``Endpoint.__init__`` deep-copies the supplied config and
+        silently rebinds any callback to a copy of its receiver.
+        See docs/internals/providers.md#runtime-only-endpoint-state-kept-out-of-serialization.
         """
         taken: dict[str, object] = {}
         source = getattr(config, "kwargs", None)
@@ -61,23 +52,13 @@ class AgenticHandlersMixin:
     def adopt_runtime_state(self, kwargs: dict) -> tuple[str, ...]:
         """Take declared runtime values onto an endpoint already built.
 
-        The constructor route lifts these off the caller's config before the
-        endpoint exists. A caller who hands over an endpoint INSTANCE has
-        missed that window entirely: the endpoint was built without them, and
-        the values arrive beside an object that is finished. They are written
-        here instead of dropped, which is what happened before and is the worst
-        of the three options — a child would inherit the wrong environment and
-        no supervisor would hear about it, with nothing raised and nothing
-        logged.
-
-        Writing onto the supplied instance rather than a copy is deliberate and
-        matches what the same branch already does with ``provider`` and
-        ``base_url``: the caller handed this object over to be configured. A
-        ``None`` is not a value here, it is the absence of one, and it must not
-        erase state the endpoint was built with.
-
-        Returns the names it could not place, so the caller can refuse rather
-        than let them evaporate.
+        For a caller handing over a finished ``Endpoint`` instance rather than
+        a config, who has missed the constructor's lift-before-copy window.
+        Writes onto the supplied instance, not a copy — matching ``provider``
+        and ``base_url`` on the same branch. ``None`` here means absence, not
+        a value, and must not erase existing state. Returns the names it
+        could not place, so the caller can refuse rather than let them
+        evaporate silently.
         """
         placed = set()
         for name in self._runtime_state_fields:
@@ -104,19 +85,13 @@ class AgenticHandlersMixin:
     def _init_runtime_state(self, supplied: dict | None = None) -> None:
         """Move declared runtime state out of the serializable endpoint config.
 
-        ``iModel(**kwargs)`` forwards anything it does not recognise into
-        ``EndpointConfig.kwargs``, which is a supported way to configure an
-        endpoint and also the thing ``Endpoint.to_dict`` serializes — so it
-        reaches ``iModel.to_dict``, ``Branch.to_dict``, and from there the run
-        snapshots written to disk. A child environment left there is a
-        credential in a saved file, and a callback left there is a function in a
-        structure something is about to JSON-encode.
-
-        Holding it here instead keeps the same configuration route working while
-        the value stays in memory. It also survives ``iModel.copy``, which deep
-        copies the config and then calls ``copy_runtime_state_to``: a deep copy
-        of a bound callback rebinds it to a copied receiver, so the original
-        supervisor would quietly stop hearing from the copy's legs.
+        ``EndpointConfig.kwargs`` reaches ``iModel.to_dict``, ``Branch.to_dict``,
+        and the run snapshots written to disk, so a child environment or
+        callback left there is a credential or a live object about to be
+        JSON-encoded. Holding it in memory here instead keeps the same
+        configuration route working; ``copy_runtime_state_to`` (used by
+        ``iModel.copy``) copies it shallowly for the same reason.
+        See docs/internals/providers.md#runtime-only-endpoint-state-kept-out-of-serialization.
         """
         self._runtime_state: dict[str, object] = {}
         self.drain_runtime_state()
@@ -129,33 +104,20 @@ class AgenticHandlersMixin:
     def drain_runtime_state(self) -> None:
         """Move declared runtime values out of the serializable config.
 
-        Called wherever the config is about to be READ rather than only at
-        construction, because construction is not the only way these values
-        get in. ``EndpointConfig.update()`` puts unknown keys straight back
-        into ``kwargs``, and ``iModel.from_dict()`` assigns a hydrated config
-        over the specialized one. Both are public routes and both bypass a
-        drain that happens once.
-
-        Draining keeps the value working while taking it out of what gets
-        written down: the value moves to ``_runtime_state``, which
-        ``create_payload`` reads at the same precedence ``config.kwargs`` had.
-
-        Serialization is the only place this is called from besides
-        construction, and deliberately so. ``create_payload`` reads
-        ``config.kwargs`` directly, so a value sitting there still works
-        without being drained first, and a drain on that path was measured to
-        change no observable behaviour. Writing it down is what makes a
-        credential durable, so that is where the drain belongs.
+        Called wherever the config could be re-populated after construction
+        (``EndpointConfig.update()``, ``iModel.from_dict()``) and again before
+        serialization — not on the ``create_payload`` read path, since a value
+        still sitting in ``config.kwargs`` there works fine unread; writing it
+        down is what makes a credential durable, so that's where draining
+        belongs.
         """
         for name in self._runtime_state_fields:
             if name in self.config.kwargs:
                 self._runtime_state[name] = self.config.kwargs.pop(name)
 
     def to_dict(self, **kwargs):
-        """Drain before serializing. A child environment reaching a run
-        snapshot is a credential in a saved file, and the value that got there
-        after construction is the same credential as the one that was there
-        before it."""
+        """Drain before serializing, so a child environment can't reach a run
+        snapshot as a credential in a saved file."""
         self.drain_runtime_state()
         return super().to_dict(**kwargs)
 
@@ -208,17 +170,12 @@ class AgenticHandlersMixin:
     def _carried_runtime_state(self, request, req_dict: dict) -> dict:
         """Values from ``_runtime_state_fields`` that the rebuild would lose.
 
-        The request model is rebuilt here from ``to_dict(request)``, which goes
-        through ``model_dump()`` and so omits every field declared
-        ``exclude=True``. For a field that only shapes serialization that is
-        harmless, but the fields named in ``_runtime_state_fields`` carry live
-        objects the process needs — a child environment, a spawn callback — and
-        losing them hands the CLI a request whose runtime wiring silently
-        reverted to its defaults. The names are declared rather than derived
-        from ``exclude``, because most excluded fields genuinely have nothing to
-        carry and a rule that swept them all in would change unrelated
-        behaviour. Anything already in ``req_dict`` came from an explicit kwarg
-        or from the endpoint config and keeps precedence.
+        ``to_dict(request)`` goes through ``model_dump()``, which omits every
+        ``exclude=True`` field — harmless for most, but the runtime-state
+        fields carry live objects (env, spawn callback) whose loss would
+        silently revert the CLI request's wiring to defaults. Anything already
+        in ``req_dict`` (explicit kwarg or endpoint config) keeps precedence.
+        See docs/internals/providers.md#runtime-only-endpoint-state-kept-out-of-serialization.
         """
         model = self._request_model
         if model is None or not isinstance(request, model):

--- a/lionagi/providers/_cli_subprocess.py
+++ b/lionagi/providers/_cli_subprocess.py
@@ -38,9 +38,9 @@ def spawned_pgid(pid: int) -> int:
     """The process group of a just-spawned child.
 
     Falls back to the child's own pid: every spawn here uses
-    ``start_new_session``, so the child leads its own group by construction and
-    that pid IS the group id whenever the read fails because the child has
-    already exited.
+    ``start_new_session``, so the child leads its own group and that pid IS
+    the group id whenever the read fails because the child has already
+    exited.
     """
     try:
         return os.getpgid(pid)
@@ -51,15 +51,8 @@ def spawned_pgid(pid: int) -> int:
 def spawned_create_time(pid: int) -> float | None:
     """When the process at *pid* started, or None if that cannot be established.
 
-    The pid and the group id are both recyclable: once a process is reaped the
-    kernel is free to hand its numbers to anything, so a reader that has only
-    those two integers cannot tell this child from a stranger that arrived
-    later. The start time is what binds them to one process, and it is readable
-    only here, while the child is known to exist.
-
-    None is not a claim. It means the probe found no process or errored, and a
-    consumer must treat it as "no identity was captured" rather than as a
-    statement about the child.
+    None means "no identity was captured," not a statement about the child.
+    See docs/internals/providers.md#cli-subprocess-lifecycle.
     """
     import psutil
 
@@ -76,17 +69,11 @@ def spawned_create_time(pid: int) -> float | None:
 class SpawnedProcess:
     """The identity of a CLI child, as read at the moment it came into being.
 
-    ``pid`` and ``pgid`` are the handles a later sweep signals. ``create_time``
-    is what makes them an identity rather than two integers the OS may have
-    reissued in the meantime, so a consumer that intends to act on this record
-    later must compare a live start-time read against it and refuse to signal
-    when they disagree or when this field is None.
-
-    The group is the initial one, and a process group is not a containment
-    boundary: a child or descendant that calls ``setsid()`` leaves it, and this
-    record then says nothing about that process. Callers who need "nothing the
-    leg started survives" must either require non-daemonizing CLIs or use a
-    platform containment primitive; the group alone will not give it to them.
+    A consumer acting on this later must re-verify ``create_time`` against a
+    live read and refuse to signal when they disagree or it is None — pid and
+    pgid are both recyclable. The group is the initial one and is not a
+    containment boundary: a descendant that calls ``setsid()`` leaves it.
+    See docs/internals/providers.md#cli-subprocess-lifecycle.
     """
 
     pid: int
@@ -97,22 +84,9 @@ class SpawnedProcess:
 class Redacted:
     """A runtime-only value, wrapped so that nothing can print or serialize it.
 
-    ``repr=False`` on the field keeps a value out of a request's own
-    representation, and that is only one channel. Pydantic keeps the raw input
-    of a failing ``mode="before"`` validator on the error, and a model-level
-    validator holds the WHOLE raw mapping, so a request rejected for an
-    unrelated reason — an empty prompt, say — carries the child environment
-    along with the reason.
-
-    **Not a mapping, and that is the entire point.** A ``dict`` subclass with a
-    quiet ``__repr__`` closes the rendering channel and leaves the
-    serialization one wide open: ``str(err)`` and ``err.errors()`` go through
-    ``repr``, but ``err.json()`` walks the structure and writes out every key
-    and value, and ``err.json()`` is what a structured logger emits. Pydantic
-    has no structure to walk here, so all three channels get the same summary.
-
-    The real value stays reachable through :meth:`reveal` for the one validator
-    that has to look at it.
+    Deliberately not a mapping, so ``err.json()`` (which walks a structure)
+    has nothing to walk, same as ``repr()``-based channels.
+    See docs/internals/providers.md#cli-subprocess-lifecycle.
     """
 
     __slots__ = ("_value", "_label")
@@ -135,15 +109,10 @@ class Redacted:
 def raise_if_env_is_not_a_string_map(value: Mapping) -> None:
     """Reject a malformed environment without quoting anything out of it.
 
-    A string key is a variable NAME and naming it is what makes the error
-    actionable. A key of any other type is not a name, and printing it prints
-    whatever the caller put there — a tuple holding a token, for instance — so
-    those are reported by position and type only. Values are never printed at
-    all, whatever their type.
-
-    Raises TypeError rather than ValueError because pydantic converts
-    ValueError into a validation error that quotes the entire rejected input,
-    and lets anything else through untouched.
+    Values are never printed, whatever their type; non-string keys are
+    reported by position and type only, since printing one could print a
+    credential the caller embedded there. Raises TypeError, not ValueError —
+    pydantic quotes a ValueError's rejected input verbatim into the error.
     """
     named: list[str] = []
     unnamed: list[str] = []
@@ -161,40 +130,15 @@ def raise_if_env_is_not_a_string_map(value: Mapping) -> None:
 
 
 def redact_runtime_fields_in_place(data) -> None:
-    """Wrap the runtime-only values in a raw request mapping so nothing can
-    print or serialize them.
-
-    Called at the top of every model-level ``mode="before"`` validator, because
-    that is the one place a validator holds the WHOLE raw input, and pydantic
-    keeps a failing validator's raw input on the error. ``exclude`` and
-    ``repr=False`` do not reach that channel: they govern the model, and this
-    runs before a model exists.
-
-    Every declared runtime field is wrapped, not just ``env``. ``on_spawn`` is
-    a callback, and a bound one carries its receiver into its own ``repr``, so
-    a supervisor holding credentials would print them from the same error. The
-    wrapper is unwrapped by the field validators, which are the only code that
-    needs the value.
-
-    Anything the raw mapping holds under any other key is untouched and is not
-    covered by this. The claim here is about the two declared runtime fields.
-
-    **An immutable mapping is refused, not skipped.** Substituting in place is
-    not a convenience here, it is the whole mechanism: pydantic keeps the
-    object that was passed INTO the failing validator, so handing back a
-    sanitized copy changes nothing about what the error holds. When the raw
-    input cannot be written to, there is no way to make it safe, and the only
-    two options are to leak it or to refuse it. ``BaseModel.model_validate()``
-    accepts any mapping, so this route is public and reachable, and skipping
-    quietly meant a credential in ``str(exc)``, ``exc.errors()`` and
-    ``exc.json()`` alike.
-
-    The refusal is a ``TypeError`` because pydantic converts ``ValueError`` and
-    ``AssertionError`` into a ``ValidationError`` that quotes the rejected
-    input, which would reintroduce exactly what is being prevented. It names
-    the fields and the mapping type and never the values. A mapping carrying
-    neither runtime field has nothing to protect and passes through, so
-    read-only inputs are not broken in general.
+    """Wrap ``env``/``on_spawn`` in a raw request mapping so nothing can print
+    or serialize them. Called at the top of every model-level
+    ``mode="before"`` validator, the one place that holds pydantic's WHOLE raw
+    input on a failing validation. Substitution must happen in place, since
+    pydantic keeps the object passed INTO the failing validator on the error —
+    handing back a sanitized copy changes nothing about what the error holds.
+    An immutable mapping is therefore refused (TypeError, not ValueError —
+    pydantic quotes a ValueError's input verbatim), not silently skipped.
+    See docs/internals/providers.md#cli-subprocess-lifecycle.
     """
     if not isinstance(data, Mapping):
         return
@@ -220,41 +164,12 @@ def redact_runtime_fields_in_place(data) -> None:
 def _kill_abandoned_spawn(task: asyncio.Future) -> None:
     """End the group of a child nobody is left to receive.
 
-    Runs as a done-callback because by then there is nothing left to await
-    from: the coroutine that asked for the child has already unwound.
-
-    A cancelled task is a KNOWN HOLE here, not a case of nothing having
-    happened, and it is logged rather than passed over in silence. Interpreter
-    shutdown cancels pending tasks, and a cancellation landing inside the
-    creation call leaves a child the OS has made and whose pid was never
-    returned to anyone in this process. asyncio closes the transport on that
-    path, which ends the direct child; the group it leads is not reached,
-    because reaching it needs the pid.
-
-    This was measured rather than reasoned about: a leg spawned under a loop
-    that then shuts down leaves a SIGTERM-ignoring descendant running, and it
-    still does. Recording the handle as soon as the creation call returns was
-    tried and removed — it covers only a window between the call returning and
-    the caller resuming, which is not where the cancellation lands.
-
-    Closing it needs the pid before the creation call returns. There is a route
-    to that: driving ``loop.subprocess_exec`` with a protocol that records
-    ``transport.get_pid()`` in ``connection_made``, which the loop schedules
-    before the cancellable wait. It is declined here because it means
-    reimplementing ``create_subprocess_exec`` on top of stdlib classes outside
-    that module's ``__all__``, pinning this file to their shape across every
-    Python version supported.
-
-    Nor does anything recover it later. This said the opposite until it was
-    read against the code: that the orphan is in the record the caller writes
-    and a later sweep still finds it. ``on_spawn`` fires only once the creation
-    call has returned, which is precisely what did not happen here, so the
-    window leaves no record of any kind — which is what the log line is for,
-    and why it is a warning. Left as a stated hole, not a handled one.
-
-    The exception is retrieved where there is one, or asyncio reports it as
-    never-retrieved at exit and a cancelled spawn starts looking like a defect
-    in the spawn.
+    Runs as a done-callback since the awaiting coroutine has already unwound
+    by the time this fires. A cancellation landing inside the creation call
+    is a known, unclosed hole (logged, not silently passed over): the child
+    exists but its pid was never returned to this process, so only its
+    direct-child transport gets closed, never its group.
+    See docs/internals/providers.md#cli-subprocess-lifecycle.
     """
     if task.cancelled():
         log.warning(
@@ -272,20 +187,10 @@ def _kill_abandoned_spawn(task: asyncio.Future) -> None:
 
 
 def _end_group_with_evidence(proc: Any) -> str:
-    """End a child's group wherever its identity can be established.
-
-    TWO facts establish that a recorded group id still belongs to this child,
-    and they cover different moments, so checking only one leaves a hole where
-    the other applies. While the child is unreaped its pid cannot have been
-    reissued, so the group id is provably still its own and no scan is needed.
-    Once it has been reaped, only a live member pins that id, which is what the
-    membership scan looks for.
-
-    Checking only the second is what left a SIGTERM-ignoring descendant running
-    whenever the process table could not be read: the refusal is correct AFTER
-    the reap and wrong before it, where identity was never in question. The rule
-    was stated correctly and implemented halfway, which is the kind of gap that
-    reads as caution rather than as a defect.
+    """End a child's group wherever its identity can be established: while
+    unreaped (pid can't have been reissued, no scan needed) or, once reaped,
+    only if a live member still pins the group id.
+    See docs/internals/providers.md#cli-subprocess-lifecycle.
     """
     pgid = getattr(proc, "pid", None)
     if getattr(proc, "returncode", None) is None:
@@ -296,12 +201,10 @@ def _end_group_with_evidence(proc: Any) -> str:
 def _kill_group_if_occupied(pgid: Any) -> str:
     """End a process group if it can be shown to still hold someone.
 
-    Returns what happened, which the caller does not currently branch on but a
-    reader of the log needs: ``killed``, ``empty``, ``unproven`` or
-    ``no-group``. The unproven case is the one that matters — a process table
-    that could not be read completely and showed no members is not an empty
-    group, and it is the only outcome here where something may still be running
-    and nothing was done about it, so it says so rather than passing as clean.
+    Returns ``killed``/``empty``/``unproven``/``no-group`` for the log, not
+    for caller branching. ``unproven`` is the case that matters: a process
+    table read that failed and showed no members is not an empty group, and
+    is the only outcome where something may still be running unaddressed.
     """
     if not isinstance(pgid, int):
         return "no-group"
@@ -322,43 +225,14 @@ def _kill_group_if_occupied(pgid: Any) -> str:
 async def end_child_group(proc: Any, *, grace: float = 5.0) -> None:
     """End every member of the child's group, and survive being cancelled.
 
-    Two things this does that awaiting the graceful helper alone does not.
-
-    It drains the GROUP rather than the process. The graceful helper returns as
-    soon as the process it holds a handle to is gone, and a descendant that
-    ignores SIGTERM outlives a parent that does not — so the group is read
-    afterwards and killed if anyone is still in it. A group that answers with
-    members is still the group whose id was recorded, because a group id is not
-    reissued while it has members.
-
-    It cannot be interrupted into leaving something running. The graceful pass
-    waits out a grace period, and that wait is a cancellation point that a
-    runner being torn down is exactly where it meets. So a synchronous kill
-    runs in a ``finally`` when that pass did not finish: no await, so nothing
-    can interpose.
-
-    Every signal it sends is conditioned on the recorded group id still being
-    this child's, and there are exactly two things that establish that. Either
-    the child has not been waited, in which case its pid cannot have been
-    reissued and the polite signal is safe; or the group answers with a live
-    member, and an occupied group is never reissued. Nothing else counts, and
-    the graceful helper is therefore reached ONLY on the not-yet-waited path:
-    it signals the group id it is given without checking anything, so calling it
-    after a normal drain would send SIGTERM to whatever now holds a recycled id.
-
-    The escalation keys on that membership evidence rather than on whether the
-    direct child is dead. Those are different facts: a leader that died to
-    SIGTERM sets ``returncode`` while a descendant ignoring SIGTERM is still in
-    its group, and a backstop gated on the leader's liveness reads that as
-    nothing left to do. Confusing the two is the defect this function exists to
-    fix, so it must not be the condition the fix runs under.
-
-    What it therefore cannot close, rather than papering over it: a scan that
-    could not read the whole process table and saw no members leaves emptiness
-    unproved, and this refuses to signal on that, because an unprovable group
-    and a reissued one look the same from here. That refusal is logged rather
-    than silent — it is the one outcome where something may still be running
-    and nothing was done about it.
+    Drains the GROUP, not just the process — a descendant ignoring SIGTERM can
+    outlive a parent that doesn't, so the group is read afterwards and killed
+    if still occupied. Escalation is keyed on that membership evidence, not on
+    whether the direct child died, since those are different facts. The
+    graceful helper (reached only on the not-yet-waited path, since it signals
+    the group id unconditionally) is backed by a synchronous kill in a
+    ``finally`` so a second cancellation can't interpose.
+    See docs/internals/providers.md#cli-subprocess-lifecycle.
     """
     swept = False
     try:
@@ -384,20 +258,13 @@ _POST_EXIT_DRAIN_GRACE = 10.0
 def observe_spawned(pid: int) -> SpawnedProcess:
     """Read pid, group and start time as one observation of one process.
 
-    The group and the start time are two facts read separately by pid, and a
-    pid the OS reassigns between them answers the later read as the replacement
-    process. A record assembled from those two answers would describe no
-    process that ever existed, so the group read is bracketed by the start
-    time: read before, read again after, required to be unchanged. A failed
-    bracket yields ``create_time=None``, which already means "no identity was
-    captured" and is what stops a consumer from signalling on it.
-
-    The bracket rejects a replacement arriving DURING the observation. It
-    cannot speak for one that arrived before the first read, and the window
-    where that is possible is a child that exits and is reaped between the
-    spawn call returning and the first probe. What covers that window is the
-    probe itself: a reaped pid holds no process and an exited-not-yet-reaped
-    one is a zombie, and :func:`spawned_create_time` answers None to both.
+    The group read is bracketed by a start-time read before and after,
+    required unchanged, since the pid could otherwise be reassigned mid-read
+    and the two facts would describe a process that never existed. A failed
+    bracket yields ``create_time=None`` ("no identity captured"). A pid
+    reassigned before the first probe is separately covered:
+    :func:`spawned_create_time` returns None for both a reaped pid and a
+    zombie.
     """
     created = spawned_create_time(pid)
     pgid = spawned_pgid(pid)
@@ -413,17 +280,11 @@ def _no_stderr_reason(
 ) -> str:
     """Why a nonzero exit came with no stderr to quote.
 
-    A child that failed silently and a capture that failed to read it are
-    different facts about different components, and the caller acts on them
-    differently: the first is the child's own report and there is nothing more
-    to find, the second means the report exists somewhere this process did not
-    look. Collapsing both into the exit code makes a broken instrument read
-    exactly like a quiet subprocess, which is the direction that hides the
-    instrument.
-
-    The drain error contributes its exception type and never its message: that
-    message can embed the bytes being read when it raised, and this string is
-    what a caller stores or forwards.
+    Distinguishes a child that failed silently from a capture that failed to
+    read it — the caller acts on those differently, and collapsing them makes
+    a broken instrument read like a quiet subprocess. The drain error
+    contributes only its exception type, never its message, which can embed
+    the bytes being read when it raised.
     """
     exited = f"CLI subprocess exited with code {rc}"
     if drain_error is not None:
@@ -443,27 +304,13 @@ async def ndjson_from_cli(
     tail_repair: Callable[[str], dict | None] | None = None,
     on_spawn: Callable[[SpawnedProcess], None | Awaitable[None]] | None = None,
 ) -> AsyncIterator[dict]:
-    """Yield dicts from an NDJSON-emitting CLI subprocess; tail_repair handles malformed final chunks.
-
-    ``stdin_data`` feeds text to the child over a pipe instead of the command
-    line, which is how an arbitrarily large prompt is delivered without
-    hitting the OS argument-length limit. It overrides ``stdin``: the child
-    always gets a pipe, the data is written by a task that runs concurrently
-    with the stdout/stderr readers below (a sequential write would deadlock as
-    soon as the data exceeds the pipe buffer and the child is blocked writing
-    output nobody is draining), and the pipe is closed afterwards so the child
-    sees EOF rather than waiting forever for more input.
-
-    ``on_spawn`` is called once with a :class:`SpawnedProcess` immediately
-    after the child exists, for a caller that must record the process identity
-    of a process it did not itself spawn. It may be a coroutine function; the
-    result is awaited before the first byte of output is read, so a recorder
-    that writes durably has finished writing before anything can consume the
-    stream. Its failure is deliberately not swallowed: a caller whose recording
-    fails has no record of a child that is now running, and continuing would
-    leave a live process outside whatever domain the record defines. The
-    exception propagates through the teardown below, which ends the group it
-    was called for.
+    """Yield dicts from an NDJSON-emitting CLI subprocess; tail_repair handles
+    malformed final chunks. ``stdin_data`` overrides ``stdin`` and is written
+    concurrently with the stdout/stderr readers below, then closed so the
+    child sees EOF. ``on_spawn`` is awaited (may be a coroutine function)
+    before any output is read, and its failure is not swallowed — it
+    propagates through the teardown below, which ends the child's group.
+    See docs/internals/providers.md#cli-subprocess-lifecycle.
     """
     # Every CLI provider spawns through here, so a secret the child must read
     # from its own environment is filled in one place rather than four. Purely
@@ -570,22 +417,12 @@ async def ndjson_from_cli(
         payload = stdin_data.encode() if isinstance(stdin_data, str) else stdin_data
         stdin_task = asyncio.create_task(_write_stdin(payload))
 
-    # stdout EOF requires EVERY holder of the pipe's write end to close it —
-    # not just the child. A CLI child that spawns its own long-lived helpers
-    # (MCP servers, daemons) leaks the write end into them, so when the child
-    # dies its orphans keep the pipe open and a plain read() waits forever: a
-    # finished leg whose artifacts are on disk reads as "running" for the rest
-    # of the caller's budget. Racing each read against the child's exit, then
-    # bounding the drain once it has exited, turns that hang into the normal
-    # end-of-stream path; teardown then ends the process group, which is what
-    # actually closes the orphans' copy of the pipe.
+    # Guards against orphan-held pipes leaving stdout open forever; see
+    # docs/internals/providers.md#cli-subprocess-lifecycle.
     async def _await_child_exit() -> int:
-        # proc.wait() alone cannot be the exit signal: on newer Pythons it does
-        # not complete until every pipe transport disconnects, which is exactly
-        # what an orphan-held pipe prevents. returncode is set at process exit
-        # regardless of pipe state, so the wait races against a returncode
-        # poll; wait()'s result is preferred when it does complete, because it
-        # is the canonical exit code (and the only one a test double carries).
+        # wait() alone can block on an orphan-held pipe on newer Pythons, so it
+        # races a returncode poll; wait()'s result wins when it completes, since
+        # it's the canonical exit code (and the only one a test double carries).
         wait_task = asyncio.create_task(proc.wait())
         try:
             while proc.returncode is None and not wait_task.done():
@@ -614,11 +451,9 @@ async def ndjson_from_cli(
             await asyncio.wait({read_task, exit_task}, return_when=asyncio.FIRST_COMPLETED)
             child_exited = exit_task.done()
         if child_exited and not read_task.done():
-            # The grace is per read, never a shared deadline: output the child
-            # buffered before exiting must survive a consumer that processes
-            # slowly between reads. Only a read that produces nothing for the
-            # whole grace ends the stream. wait_for cancels the read on
-            # timeout, so nothing is left pending.
+            # Grace is per read, not a shared deadline, so buffered output
+            # survives a slow consumer; only a read producing nothing for the
+            # whole grace ends the stream.
             try:
                 return await asyncio.wait_for(read_task, _POST_EXIT_DRAIN_GRACE)
             except asyncio.TimeoutError:
@@ -682,13 +517,9 @@ async def ndjson_from_cli(
             except asyncio.CancelledError:
                 raise
             err = b"".join(stderr_chunks).decode(errors="replace").strip()
-            # Emptiness is decided on what was captured, before the drain note
-            # is appended. Deciding it on the concatenated string instead lets
-            # the note itself count as output, so a truncated drain that
-            # captured nothing would report neither the exit code nor the fact
-            # that there was nothing to quote. No probe I built reaches that
-            # arm; this orders the two steps so its reachability stops
-            # mattering.
+            # Emptiness decided on what was captured, before the drain note is
+            # appended, so a truncated drain that captured nothing still gets
+            # a message instead of the note masquerading as output.
             if not err:
                 err = _no_stderr_reason(rc, stderr_unavailable, stderr_drain_error)
             if drain_truncated:

--- a/lionagi/providers/_provider_errors.py
+++ b/lionagi/providers/_provider_errors.py
@@ -79,19 +79,11 @@ class ProviderTeardownError(ProviderError):
 
 
 class ProviderPermissionError(ProviderError):
-    """The turn produced nothing because the CLI could not be granted a tool permission.
-
-    Separate from the adapter catch-all because the two demand opposite
-    responses. An adapter error carries no identified cause and tells a caller
-    nothing it can act on. This one names a configuration defect on THIS side
-    that a person can fix in one line, and it is not a provider fault at all:
-    the provider answered, and answered successfully. A headless CLI cannot
-    prompt for a permission, so a tool call it was not pre-granted is denied and
-    the turn returns empty.
-
-    Not retryable, and the distinction matters more here than elsewhere: an
-    unmodified retry reproduces this exactly, forever, while a consumer reading
-    it as a provider condition waits for an outage that is not happening.
+    """The turn produced nothing because the CLI could not be granted a tool
+    permission. Not a provider fault — a headless CLI can't prompt for a
+    permission, so a tool call it wasn't pre-granted is denied and the turn
+    returns empty. Not retryable: an unmodified retry reproduces this
+    exactly, forever, unlike an actual provider outage.
     """
 
 

--- a/lionagi/providers/_secret_resolution.py
+++ b/lionagi/providers/_secret_resolution.py
@@ -2,31 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fill declared secrets into a spawned CLI child's environment.
 
-A CLI provider authenticates from its own process environment: a codex model
-provider names an ``env_key`` and the CLI reads that variable itself. When the
-secret is kept somewhere other than the environment -- a keychain, a password
-manager, a vault agent -- the spawning process has no value to pass on, and
-the child dies with a missing-variable error that says nothing about where the
-value was meant to come from.
-
-``secrets.lookup`` in ``~/.lionagi/settings.yaml`` names a command that prints
-one secret to stdout, and the variables it may be asked for::
-
-    secrets:
-      lookup:
-        argv: [security, find-generic-password, -s, "{name}", -a, lionagi, -w]
-        names: [OPENROUTER_API_KEY]
-
-Read from the **global** settings file only, never the project-local one. The
-merged project file is content of whatever tree happens to be checked out, and
-a repository has no business naming the program that reads this machine's
-secrets. Where the value lives is a property of the machine, so it is
-configured once, where the machine is configured.
-
-The resolved value reaches the child through its environment and nowhere else:
-never a file, never an argv, never a log line. Failures are best-effort and
-additive -- a lookup that does not work leaves the environment exactly as it
-would have been, and the child fails the way it already failed.
+See docs/internals/providers.md#declared-secret-lookup for the design
+(``secrets.lookup`` in the global ``~/.lionagi/settings.yaml``, never the
+project-local one).
 """
 
 from __future__ import annotations
@@ -80,12 +58,10 @@ class ResolvedSecretLookup:
 class SecretLookupResolution:
     """The outcome of resolving ``secrets.lookup``: a lookup, or why not.
 
-    ``reason`` is set iff a lookup was asked for and refused. Chosen silence
-    (nothing configured, or ``enabled: false``) carries no reason, so a
-    misconfigured lookup stays distinguishable from an absent one instead of
-    both arriving as "no secrets were filled". Reasons are short stable
-    identifiers and never interpolate configured values; the offending value
-    goes in the matching warning.
+    ``reason`` is set iff a lookup was asked for and refused (not for chosen
+    silence — nothing configured, or ``enabled: false``), so a misconfigured
+    lookup stays distinguishable from an absent one. Reasons are short stable
+    identifiers; the offending value goes in the matching warning instead.
     """
 
     lookup: ResolvedSecretLookup | None = None
@@ -106,8 +82,8 @@ def resolve_secret_lookup_config(
     """Resolve ``secrets.lookup`` to a validated lookup, or to why there is none.
 
     Every refusal is total: one bad name rejects the whole block rather than
-    being dropped from it. A silently skipped name reads as configured while
-    resolving nothing, which is the failure this is meant to make visible.
+    being dropped from it, so a silently-skipped name can't read as configured
+    while resolving nothing.
     """
     if settings is None:
         # Imported here rather than at module scope: this module is reached
@@ -203,10 +179,9 @@ def resolve_secret_lookup_config(
 async def _run_lookup(lookup: ResolvedSecretLookup, name: str) -> str | None:
     """Run the lookup for one variable, returning its value or None.
 
-    Nothing derived from the command's output reaches a log: stdout carries
-    the secret on success, and a command that prints its errors there would
-    otherwise have them recorded through the same channel. Only the program
-    name, the variable name and the exit status are ever reported.
+    Nothing derived from the command's own output reaches a log — only the
+    program name, the variable name, and the exit status are ever reported,
+    since stdout carries the secret on success.
     """
     argv = tuple(arg.replace(_NAME_PLACEHOLDER, name) for arg in lookup.argv)
     program = os.path.basename(argv[0])
@@ -263,21 +238,14 @@ async def fill_declared_secrets(
 ) -> Mapping[str, str] | None:
     """Return the environment a CLI child should get, with declared secrets filled.
 
-    ``env`` follows the CLI request-model convention: ``None`` means the child
-    inherits this process's environment. That is returned unchanged when there
-    is nothing to add, so a machine that configures no lookup spawns exactly
-    the environment it did before, and an inheriting child stays an inheriting
-    child rather than being handed a snapshot.
-
-    A variable that already carries a value is never looked up and never
-    overwritten, so exporting one is still the way to override the store for a
-    single run.
-
-    A REFUSED lookup returns ``env`` unchanged, exactly as an absent one does,
-    and says so before it does. The two are one value apart at the return and
-    the child dies the same way in both cases -- on a missing variable, naming
-    the variable and not the lookup -- so without this the operator debugging
-    that child has nothing pointing at their own configuration.
+    ``env=None`` means the child inherits this process's environment, and is
+    returned unchanged when there's nothing to add, so an inheriting child
+    stays inheriting rather than being handed a snapshot. A variable already
+    carrying a value is never looked up or overwritten. A refused lookup
+    returns ``env`` unchanged too, but logs the distinction first — otherwise
+    the child dies the same way (missing variable) whether the lookup was
+    absent or misconfigured, with nothing pointing at the operator's own
+    config.
     """
     resolution = resolve_secret_lookup_config(settings=settings)
     lookup = resolution.lookup

--- a/lionagi/providers/anthropic/claude_code.py
+++ b/lionagi/providers/anthropic/claude_code.py
@@ -237,20 +237,11 @@ class ClaudeCodeRequest(BaseModel):
     def _env_is_a_string_map(cls, value):
         """Reject a malformed environment without printing anything from it.
 
-        A child environment routinely holds credentials, and a pydantic
-        ValidationError quotes the whole rejected input into its message, so
-        letting the ordinary string check fail here would print every value in
-        the map beside the one bad entry. TypeError is the escape: pydantic
-        converts ValueError and AssertionError into validation errors and lets
-        anything else propagate untouched, so nothing from the mapping reaches
-        a traceback or a log line. It is also the right exception for a wrongly
-        typed mapping.
-
-        The value arrives wrapped when it came through a model-level validator,
-        which is what keeps it off that validator's error. This is the code that
-        needs to look at it, so this is where it is unwrapped; what the model
-        then stores is an ordinary mapping, kept out of dumps by ``exclude`` and
-        out of the request's representation by ``repr=False``.
+        TypeError is the escape from a pydantic ValidationError, which quotes
+        the whole rejected input — and a child environment routinely holds
+        credentials. Unwrapped here (from the ``Redacted`` a model-level
+        validator applied) since this is the code that needs to look at it;
+        see docs/internals/providers.md#cli-subprocess-lifecycle.
         """
         if isinstance(value, Redacted):
             value = value.reveal()
@@ -268,15 +259,11 @@ class ClaudeCodeRequest(BaseModel):
     @field_validator("on_spawn", mode="before")
     @classmethod
     def _unwrap_on_spawn(cls, value):
-        """Undo the wrapping a model-level validator applied.
+        """Undo the ``Redacted`` wrapping a model-level validator applied.
 
-        The callback is wrapped there for the same reason the environment is: a
-        BOUND callback carries its receiver into its own ``repr``, so a
-        supervisor holding a credential would print it from an error about some
-        unrelated field. Nothing but this validator needs the wrapper gone, and
-        pydantic rejects it outright as not callable if it survives — which is
-        the failure mode this method exists to prevent, and the one a test that
-        only checks for leaks would never see.
+        A bound callback carries its receiver into its own ``repr``, so a
+        supervisor holding a credential would print it from an unrelated
+        field's error if left wrapped past this point.
         """
         if isinstance(value, Redacted):
             value = value.reveal()
@@ -963,33 +950,8 @@ class ClaudeCodeCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
         async with contextlib.aclosing(stream_claude_code_cli(request_obj, **handlers)) as gen:
             async for item in gen:
                 if isinstance(item, CLISession):
-                    # The session carries the run's terminal verdict and is not
-                    # itself yielded here, so a failure recorded only there
-                    # reaches nobody on this stream: the result chunk emitted
-                    # beside it carries usage, cost, turns and duration, never
-                    # the error flag. A run that ended in error then looks
-                    # exactly like one that succeeded, and that is the direction
-                    # consumers believe without checking.
-                    #
-                    # The scope is this stream and no wider. `_call()` below
-                    # drives the same generator itself and returns the session
-                    # as a dict, so the flag is present there and nothing
-                    # branches on it; the one-shot helpers built on `_call()`
-                    # still return an ordinary answer for a failed session.
-                    # Closing that is a separate change with a separate
-                    # compatibility question, and this comment is not a claim
-                    # that it is closed.
-                    #
-                    # Per-tool failures already have their own carriers, so this
-                    # is only about the session-terminal verdict.
-                    #
-                    # The already-reported guard is vacuous today: nothing else
-                    # in this module constructs an error chunk, so the condition
-                    # is always true. It is kept because the emission it guards
-                    # belongs to this file, and the natural place to add a real
-                    # error chunk is a few lines up — at which point the guard
-                    # is what stops one failure being reported twice. Do not
-                    # read it as currently load-bearing.
+                    # Turns the session's terminal verdict into a chunk — see
+                    # docs/internals/providers.md#a-session-terminal-error-must-be-turned-back-into-a-stream-chunk.
                     if item.is_error and not any(c.type == "error" for c in item.chunks):
                         yield StreamChunk(
                             type="error",
@@ -1030,13 +992,10 @@ class ClaudeCodeCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
             and responses
             and not isinstance(responses[-1], CLISession)
         ):
-            # Deep on purpose for everything else, then the runtime-only
-            # fields are put back BY IDENTITY. A deep copy of a bound method
-            # copies its receiver, so the continuation would notify a copy of
-            # the supervisor while the real one -- the thing holding the
-            # durable process accounting -- never hears about the second
-            # subprocess. A stateless callback hides this completely, which is
-            # why it needs saying rather than leaving to a copy mode.
+            # Deep copy, then put env/on_spawn back BY IDENTITY: a deep-copied
+            # bound method rebinds to a copied receiver, so the continuation's
+            # supervisor callback would otherwise silently stop being the
+            # original one that holds the durable process accounting.
             req2 = request.model_copy(deep=True)
             for _runtime_field in ("env", "on_spawn"):
                 object.__setattr__(req2, _runtime_field, getattr(request, _runtime_field))

--- a/lionagi/providers/openai/_codex_profile.py
+++ b/lionagi/providers/openai/_codex_profile.py
@@ -2,13 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Resolution of a codex config profile named as a model.
 
-Lives at the provider layer rather than under ``cli/`` because both entry
-points need it. A codex request built through the library --
-``Branch(chat_model="codex/deepseek-flash")`` -- reaches the same spawn as one
-built through ``li agent``, and while this resolution sat in the CLI package
-only the CLI path got it: the library path sent the profile NAME to codex as a
-model id, and codex answered with an unsupported-model error naming a model
-nobody had asked for.
+Lives at the provider layer, not under ``cli/``, so both the library and CLI
+entry points reach it. See
+docs/internals/providers.md#codex-config-profile-resolution-and-effort-clamping.
 """
 
 from __future__ import annotations
@@ -38,34 +34,12 @@ def _unreadable_symlink_target(path: Path) -> str | None:
 def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | None:
     """Resolve a codex model part that names a codex config profile.
 
-    codex reaches models from other providers through a config profile:
-    ``-p <name>`` layers ``$CODEX_HOME/<name>.config.toml`` over the base
-    config, and such a file names a ``model`` and the ``model_provider`` that
-    serves it. So ``codex/<name>`` should mean "run that profile", not "run a
-    model literally called ``<name>``".
-
-    lionagi cannot forward this by passing ``-p``. codex accepts exactly one
-    profile per invocation and lionagi already spends that slot on a generated
-    profile carrying MCP server secrets, which is why supplying both is
-    refused outright. The file is therefore read here and its settings applied
-    directly: the profile's ``model`` becomes the model, and its remaining
-    scalars become ``-c`` overrides, which outrank config either way.
-
-    Two deliberate limits, both narrowing rather than widening:
-
-    * Only a bare name is looked up, so an ordinary vendor model id such as
-      ``deepseek/deepseek-v4-flash-0731`` is never treated as a path. Bare
-      excludes dots as well as separators, so a profile must be named like
-      ``deepseek-flash`` and one named ``gpt-5.6-sol`` is not resolved at all.
-      That cuts the other way usefully: model ids carry dots and version
-      numbers, so a profile name cannot collide with a real one and quietly
-      stand in for it.
-    * Table-valued keys (notably ``mcp_servers``) are not applied, and are
-      logged. lionagi decides a leg's MCP server set explicitly, and quietly
-      re-introducing servers from a config file would go around that.
-
-    Returns ``None`` when no such profile file exists, leaving the name to be
-    treated as a model id exactly as before.
+    Only a bare name is looked up (no dots/separators), so an ordinary vendor
+    model id is never treated as a profile path. Table-valued keys (notably
+    ``mcp_servers``) are not applied, and are logged instead. Returns
+    ``None`` when no such profile file exists, leaving the name to be
+    treated as a model id exactly as before. See
+    docs/internals/providers.md#codex-config-profile-resolution-and-effort-clamping.
     """
     try:
         validate_bare_name(model, label="codex config profile name")
@@ -75,11 +49,9 @@ def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | Non
     codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
     profile_path = codex_home / f"{model}.config.toml"
     if not profile_path.is_file():
-        # A symlink whose target is unreadable is not the same as no profile.
-        # `is_file()` follows the link and answers False for both, so falling
-        # through here would send the name to codex as a model id — the exact
-        # silent substitution this function exists to prevent, arriving through
-        # a file the operator can see sitting right there.
+        # A broken symlink is not the same as no profile: is_file() answers
+        # False for both, and falling through would send the name to codex as
+        # a literal model id.
         broken_target = _unreadable_symlink_target(profile_path)
         if broken_target is not None:
             raise ValueError(
@@ -127,9 +99,5 @@ def resolve_codex_config_profile(model: str) -> tuple[str, dict[str, Any]] | Non
             ", ".join(sorted(skipped)),
         )
 
-    # Say which model is actually being run. A profile whose name collides with
-    # a real model id would otherwise substitute without a word, which is the
-    # quiet half of the same failure this function fixes: the caller asks for
-    # one thing, a different thing runs, and the leg looks healthy either way.
     logger.info("codex profile %r resolves to model %r", model, resolved)
     return resolved, overrides

--- a/lionagi/providers/openai/codex.py
+++ b/lionagi/providers/openai/codex.py
@@ -66,14 +66,11 @@ CodexApprovalMode = Literal[
 
 CodexColorMode = Literal["always", "never", "auto"]
 
-# The effort words lionagi itself produces. Deliberately a tuple of strings
-# and not a Literal on the request fields: codex reaches models other than
-# OpenAI's through the `model_providers` tables in ~/.codex/config.toml, and
-# each of those models carries its own effort vocabulary. The value is emitted
-# verbatim as `-c reasoning_effort=<val>` for the CLI to interpret, so codex
-# and the provider it is configured against are the authority on what is
-# valid — a closed set here would reject a working configuration before the
-# CLI ever saw it, and would need editing every time a model is added.
+# The effort words lionagi itself produces. Deliberately a tuple, not a
+# Literal on the request fields: codex reaches non-OpenAI models through
+# `model_providers` in ~/.codex/config.toml, each with its own effort
+# vocabulary, and the value is emitted verbatim as `-c reasoning_effort=<val>`
+# for codex to interpret — a closed set here would reject valid configs.
 CODEX_REASONING_EFFORTS: tuple[str, ...] = (
     "none",
     "minimal",
@@ -95,14 +92,10 @@ __all__ = ("CodexCodeRequest", "stream_codex_cli", "CodexCLIEndpoint")
 _TOML_BARE_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 # The CLI's mid-stream retry announcement, e.g. "Reconnecting... 1/5 (stream
-# disconnected before completion: ...)". Anchored to the observed prefix on
-# purpose: a message that doesn't match falls through to the terminal-error
-# branch, so a wording change in the CLI degrades to the old (fail-closed)
-# behaviour rather than misclassifying a real failure as a notice. The
-# trailing "(" is load-bearing: the retry notice always carries a
-# parenthesized reason, and requiring it keeps terminal messages that merely
-# BEGIN with the retry prefix ("Reconnecting... 5/5 failed") on the terminal
-# path.
+# disconnected before completion: ...)". A non-matching message falls through
+# to the terminal-error branch (fail-closed on a CLI wording change). The
+# trailing "(" is load-bearing: it excludes terminal messages that merely
+# begin with the retry prefix, e.g. "Reconnecting... 5/5 failed".
 _RECONNECT_NOTICE_RE = re.compile(r"^\s*Reconnecting\.\.\.\s*\d+/\d+\s*\(")
 
 
@@ -258,20 +251,11 @@ class CodexCodeRequest(BaseModel):
     def _env_is_a_string_map(cls, value):
         """Reject a malformed environment without printing anything from it.
 
-        A child environment routinely holds credentials, and a pydantic
-        ValidationError quotes the whole rejected input into its message, so
-        letting the ordinary string check fail here would print every value in
-        the map beside the one bad entry. TypeError is the escape: pydantic
-        converts ValueError and AssertionError into validation errors and lets
-        anything else propagate untouched, so nothing from the mapping reaches
-        a traceback or a log line. It is also the right exception for a wrongly
-        typed mapping.
-
-        The value arrives wrapped when it came through a model-level validator,
-        which is what keeps it off that validator's error. This is the code that
-        needs to look at it, so this is where it is unwrapped; what the model
-        then stores is an ordinary mapping, kept out of dumps by ``exclude`` and
-        out of the request's representation by ``repr=False``.
+        TypeError is the escape from a pydantic ValidationError, which quotes
+        the whole rejected input — and a child environment routinely holds
+        credentials. Unwrapped here (from the ``Redacted`` a model-level
+        validator applied) since this is the code that needs to look at it;
+        see docs/internals/providers.md#cli-subprocess-lifecycle.
         """
         if isinstance(value, Redacted):
             value = value.reveal()
@@ -289,25 +273,18 @@ class CodexCodeRequest(BaseModel):
     @field_validator("on_spawn", mode="before")
     @classmethod
     def _unwrap_on_spawn(cls, value):
-        """Undo the wrapping a model-level validator applied.
+        """Undo the ``Redacted`` wrapping a model-level validator applied.
 
-        The callback is wrapped there for the same reason the environment is: a
-        BOUND callback carries its receiver into its own ``repr``, so a
-        supervisor holding a credential would print it from an error about some
-        unrelated field. Nothing but this validator needs the wrapper gone, and
-        pydantic rejects it outright as not callable if it survives — which is
-        the failure mode this method exists to prevent, and the one a test that
-        only checks for leaks would never see.
+        A bound callback carries its receiver into its own ``repr``, so a
+        supervisor holding a credential would print it from an unrelated
+        field's error if left wrapped past this point.
         """
         if isinstance(value, Redacted):
             value = value.reveal()
         if value is None or callable(value):
             return value
-        # Rejected HERE rather than handed back for pydantic to reject, because
-        # unwrapping is what re-exposes the value: pydantic renders a failing
-        # field's input, and an object with a credential-bearing __repr__ is
-        # exactly the shape this carrier exists to keep out of an error. A
-        # TypeError names the type and never the object.
+        # Rejected here, not handed back to pydantic: pydantic renders a
+        # failing field's input, which would re-expose the unwrapped value.
         raise TypeError(f"on_spawn must be callable, got {type(value).__name__}")
 
     # ── system prompt (order 40) ──────────────────────────────────
@@ -402,31 +379,12 @@ class CodexCodeRequest(BaseModel):
     def _resolve_config_profile(cls, values):
         """Turn a model that names a codex config profile into the profile.
 
-        Runs at the REQUEST level so both entry points reach it. The CLI
-        resolves this too, and did so alone for a while: a request built
-        through the library -- ``Branch(chat_model="codex/deepseek-flash")`` --
-        carried the profile NAME all the way to the spawn, codex read it as a
-        model id, and every leg died with an unsupported-model error naming a
-        model nobody had asked for.
-
-        Idempotent by construction, so the CLI path is unaffected: it has
-        already replaced the name with the profile's model id, and a real model
-        id carries dots or a slash, which the bare-name check rejects.
-
-        NOT a validator of its own, and that is deliberate. It has to run
-        before the effort clamp, whose ceilings are keyed on the model -- a
-        profile names a different model than the caller did, so clamping first
-        applies one model's ceiling to another's effort. Two ``mode="before"``
-        validators looked like the way to order that, and it is the wrong way:
-        pydantic runs them in REVERSE definition order, so the one written
-        first runs last. Written that way the clamp saw the profile NAME, and
-        the test that caught it is the one asserting a clamped OUTCOME rather
-        than that the effort survived. Called explicitly from the single
-        validator below, the order is stated rather than inherited.
-
-        Caller-supplied ``config_overrides`` WIN over the profile's. An
-        override passed at the call site is an explicit instruction; the
-        profile is a default sitting in a file.
+        Idempotent by construction: a real model id carries dots or a slash,
+        which the bare-name check rejects, so a CLI-resolved model passes
+        through unchanged. Not a validator of its own — called explicitly
+        from the validator below, before the effort clamp, since the clamp's
+        ceilings are keyed on the model. See
+        docs/internals/providers.md#codex-config-profile-resolution-and-effort-clamping.
         """
         from ._codex_profile import resolve_codex_config_profile
 
@@ -449,15 +407,12 @@ class CodexCodeRequest(BaseModel):
     def _resolve_profile_then_clamp_effort(cls, values):
         """Resolve a config-profile model, THEN clamp effort against it.
 
-        One validator running two steps in a written order, rather than two
-        validators relying on pydantic's. The clamp's ceilings are keyed on the
-        model id and a profile names a different model than the caller did, so
-        the sequence is load-bearing rather than cosmetic.
-
-        `values` is the raw constructor input, which omits `model` when the
-        caller relies on the field default (Pydantic v2 applies defaults
-        after `mode="before"` validators) — fall back to the field's own
-        default so the clamp is consistent either way.
+        One validator running two steps in a written order rather than relying
+        on pydantic's (reverse-definition) validator ordering — see
+        docs/internals/providers.md#codex-config-profile-resolution-and-effort-clamping.
+        `values` omits `model` when the caller relies on the field default
+        (Pydantic v2 applies defaults after `mode="before"` validators), so
+        fall back to the field's own default.
         """
         from lionagi.service.providers import _clamp_codex_effort
 
@@ -952,14 +907,11 @@ async def stream_codex_cli(
                     else obj.get("message", str(err))
                 )
                 # The CLI announces its OWN retry of a dropped provider stream
-                # as an error-typed event ("Reconnecting... 1/5 (...)") and then
-                # keeps going. Treating that notice as terminal kills the leg
-                # before the CLI's second attempt ever runs, so it is surfaced
-                # as a non-error chunk and the stream keeps consuming. A retry
-                # that ultimately fails produces a real terminal event (or the
-                # process exits), which still takes the branch below — and an
-                # unrecognized notice text fails toward terminal, the direction
-                # that loses a leg rather than the one that hangs it.
+                # as an error-typed event and keeps going; surfaced as a
+                # non-error chunk so the leg isn't killed before that retry
+                # runs. An unrecognized notice text falls through to the
+                # terminal branch below (fails toward losing the leg, not
+                # hanging it).
                 if (
                     typ == "error"
                     and isinstance(_err_message, str)
@@ -994,11 +946,6 @@ async def stream_codex_cli(
                 else:
                     if request.verbose_output:
                         log.error("Codex error: %s", session.result)
-                # The flag follows the classification above, so a consumer
-                # reading it sees the same verdict as one reading the metadata.
-                # Benign end-of-stream keeps `is_error` false: the type is
-                # "error" only because that is the event the CLI sends, and the
-                # three conditions above are what say it is not one.
                 sc = StreamChunk(
                     type="error",
                     content=session.result,
@@ -1160,11 +1107,8 @@ class CodexCLIEndpoint(AgenticHandlersMixin, AgenticEndpoint):
         async with contextlib.aclosing(stream_codex_cli(request_obj, **handlers)) as gen:
             async for item in gen:
                 if isinstance(item, CLISession):
-                    # The parser already yields an error chunk for a failed
-                    # turn, so without the guard a single failure is reported
-                    # twice — once as it happens and once as the session ends.
-                    # This is the session-terminal verdict; per-tool failures
-                    # have their own carriers and are not what this counts.
+                    # Turns the session's terminal verdict into a chunk — see
+                    # docs/internals/providers.md#a-session-terminal-error-must-be-turned-back-into-a-stream-chunk.
                     if item.is_error and not any(c.type == "error" for c in item.chunks):
                         yield StreamChunk(
                             type="error",


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 7 (+203 / -584, net -381)
- New documentation: 228 lines in docs/internals/providers.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.