### PR TITLE
docs: trim inline prose in service/ln/libs, extract to docs/internals

### DIFF
--- a/docs/internals/ln-primitives.md
+++ b/docs/internals/ln-primitives.md
@@ -1,0 +1,108 @@
+# Process-group identity: telling a live child from a reused pid
+
+`lionagi/ln/_proc.py` answers one question for callers that manage child
+processes (agent runtimes, sandboxed tool execution): is the process I
+started still the one I think it is? The kernel reuses pids, and on a
+long-running host a pid recorded at spawn time can point at a completely
+different process minutes later. Every function in this module exists to
+answer identity questions without being fooled by that reuse.
+
+## The bracketing technique
+
+A single read of "is pid P in group G" is not enough to trust, because the OS
+can recycle P between the moment you read its group and the moment you act on
+that answer. `pinned_member()` fixes this by bracketing the group-membership
+read with two reads of the process's start time (`process_create_time()`):
+read the start time, read group membership and an ownership marker, then read
+the start time again. If the two start-time reads disagree, the pid was
+reissued to a different process somewhere in between, and the whole
+observation is discarded as `"unknown"` — never treated as evidence about the
+original process or its group.
+
+`process_create_time()` itself returns one of three states, and the
+distinction matters to every caller:
+
+- `("found", t)` — the process exists and started at `t`.
+- `("gone", None)` — the process has exited (including a zombie: it still
+  holds its pid until reaped, so a zombie cannot be a candidate for pid
+  reuse; treating it as gone is what keeps that guarantee).
+- `("unknown", None)` — the probe itself failed. This must never be read as
+  "the process is dead" or as license to signal it; it means the read did
+  not come off.
+
+`start_time_matches()` compares a recorded start time against a freshly read
+one within `CREATE_TIME_TOLERANCE` (0.1s), because two reads of a kernel
+clock for the *same* process can differ in the last decimal place even
+though two live reads of the same process must otherwise agree exactly.
+
+## The marker, and why a `None` reading is ambiguous
+
+`process_marker()` reads an environment variable from a target process
+(`psutil.Process(pid).environ()`), used to mark which run "owns" a spawned
+process group. A `None` result is ambiguous on its own: on macOS, reading the
+environment of a protected system binary silently returns an empty
+environment instead of raising, so "the marker was read and is absent" and
+"the environment could not be read at all" produce the identical `None`.
+`pinned_member()` carries a separate `marker_read` flag alongside the marker
+value specifically to break that ambiguity — a member that was inspected and
+found markerless is distinguishable from one that refused inspection.
+Absence of a marker can withhold ownership; it can never assert that a group
+is *not* the caller's, precisely because the negative reading is not
+trustworthy.
+
+## Scanning a whole group
+
+`live_group_members()` and `group_member_pids()` both scan every pid on the
+system and keep the ones in a target process group, but they are not
+interchangeable and one is not a cheaper version of the other:
+
+- `live_group_members()` returns full `(pid, create_time, marker,
+  marker_read)` tuples via `pinned_member()`, because a caller weighing a
+  member's marker against its age needs both facts to come from one
+  bracketed observation of the same process, not two independent reads that
+  could straddle a pid reuse.
+- `group_member_pids()` is the marker-free membership read, for a caller that
+  only wants to know whether a group is empty. It re-derives membership with
+  its own start-time bracket rather than dropping a field from
+  `live_group_members()`, because the marker has to be read *inside* the
+  identity bracket to belong to the same observation — reading it outside
+  that bracket, and then discarding it, is a different (and looser)
+  observation, not a cheaper version of the same one.
+
+Both functions return a `complete` flag alongside the results. A process that
+vanished mid-scan is simply not a live member, but a process whose identity
+*couldn't* be determined — an `OSError` on `os.getpgid`, an unresolved
+start-time bracket — sets `complete = False` rather than being silently
+dropped, because the group may still hold a member the scan never resolved.
+An incomplete scan is never read as an empty group: it is a member that may
+not have been seen, which is exactly the situation where treating the group
+as safe to signal would be wrong. `group_member_pids()` leans on one more
+fact to justify acting on a non-empty answer without further identity work:
+a process group id is not reissued while the group still has members, so a
+group that answers with members is still the group whose id was recorded,
+even though individual member pids inside it can still be reused elsewhere.
+
+## Signalling a group
+
+`safe_pgid_value()` and the module-private `_safe_pgid()` both refuse to
+return a group id that is unsafe to signal: `pgid <= 1` (init, or the value a
+misbehaving process double reports) and the caller's own process group (so a
+bad child object can never cause the caller to signal itself). `_safe_pgid()`
+additionally treats `pid == 1` as unsafe for the same reason — on CI, pid 1
+is often the harness's own session leader, and `MagicMock().pid` also
+defaults to 1, so this check doubles as a test-double guard.
+
+`kill_group_now()` is a synchronous, no-`await` SIGKILL: it exists as the
+backstop for cleanup paths whose own graceful shutdown can itself be
+cancelled. A backstop that can be interrupted mid-await is not a backstop, so
+this one never awaits anything.
+
+`terminate_process_group()` / `aterminate_process_group()` send `sig_first`
+(default SIGTERM) to both the process group and the direct child — signalling
+the child directly is normally redundant with the group signal, but prevents
+orphaning it on platforms where `killpg` is unavailable. Passing `grace=None`
+skips the polite signal entirely and sends SIGKILL immediately. With a grace
+period, the async version waits up to `grace` seconds (via an `anyio`
+cancel scope, not `asyncio.wait_for` — `wait_for` raises "no running event
+loop" on a non-asyncio `anyio` backend before its timeout can apply) and
+escalates to SIGKILL if the process hasn't exited by then.

--- a/docs/internals/service-layer.md
+++ b/docs/internals/service-layer.md
@@ -1,0 +1,120 @@
+# iModel construction: routing a model spec to a provider, and back
+
+`iModel` (`lionagi/service/imodel.py`) is the wrapper a caller builds once per
+provider connection: it owns rate limiting, hooks, and streaming on top of an
+`Endpoint`. Most of what a caller needs is in its constructor and its
+`copy()`/`to_dict()`/`from_dict()` round trip, and both hide real decisions
+about how a plain model string becomes a routed request.
+
+## Effort-suffix routing
+
+Callers can write a model name like `"gpt-5.6-luna-high"` and have the
+trailing `-high` stripped and routed to whichever kwarg the provider uses for
+reasoning effort (`effort`, `reasoning_effort`, `thinking`, ...). This
+happens once, in `iModel.__init__`, so every construction site gets it for
+free without repeating the parsing.
+
+The suffix only strips when two conditions both hold: the resolved provider
+actually has an effort kwarg (`PROVIDER_EFFORT_KWARG`, in
+`lionagi/service/providers.py`), and the model name is written in lionagi's
+own `provider/model-effort` grammar rather than borrowed whole from another
+vendor's catalogue. The second check is `split_effort_suffix()`, and its rule
+is a single fact: lionagi's grammar spends its one `/` on the provider, so if
+the model *name* (the part after any `/`) still contains a `/`, it isn't in
+that grammar — it's a literal vendor id, reached for instance through a CLI
+provider's own config profile naming its own `model_provider`. Those ids end
+in whatever the vendor chose, and a trailing word that happens to spell an
+effort level (`"low"`, `"high"`, ...) is part of the id, not a suffix to
+strip. Splitting it anyway would produce a model nobody serves. An explicit
+effort kwarg passed by the caller always wins over anything inferred from the
+suffix.
+
+Two providers clamp the extracted effort further, because their model
+catalogues don't support every level lionagi recognizes:
+
+- **Claude** (`_clamp_claude_effort`): only the Opus line, from Opus 4.7
+  onward, accepts `xhigh` — everything else clamps to `high`. There is no
+  `ultra` tier at all; `ultra` always clamps to `max`. The set of models
+  that accept `xhigh` is an explicit allow-list of exact strings (both the
+  bare alias and the `claude-` prefixed form, since callers pass either), so
+  a new Opus release silently loses `xhigh` — the request still succeeds,
+  one tier lower, with nothing in the result saying so — until its name is
+  added to `_CLAUDE_XHIGH_MODELS`.
+- **Codex** (`_clamp_codex_effort`): reasoning-effort ceilings are
+  model-dependent, sourced from the CLI's own live model list
+  (`_CODEX_ULTRA_MODELS`, `_CODEX_MAX_ONLY_MODELS`,
+  `_CODEX_XHIGH_CEILING_MODELS`). Unrecognized (future) models pass through
+  unclamped rather than being rejected.
+- **Gemini** (`_clamp_gemini_effort`): the CLI has no effort kwarg at all —
+  effort is baked into the `--model` name as `Low`/`Medium`/`High`, and the
+  Pro variant has no `Medium` tier (`Medium` promotes to `High` for Pro).
+
+## Runtime-state adoption
+
+Some endpoints (CLI/agentic ones) carry runtime-only state — a spawned
+child's environment, an `on_spawn` callback — that must never be written to
+disk (see `RUNTIME_STATE_NAMES` below). When `iModel.__init__` receives an
+already-constructed `Endpoint` instance, it calls
+`endpoint.adopt_runtime_state(kwargs)` to place any runtime values the caller
+passed at construction time — for an endpoint constructed inline (not via an
+existing `Endpoint`), those values flow through the normal config path
+instead, so this adoption step only fires for the "endpoint already built"
+case, which otherwise misses the window where runtime kwargs are normally
+lifted out of config. If the endpoint has nowhere to put a given runtime
+value (a plain, non-CLI endpoint has no runtime state at all —
+`Endpoint.drain_runtime_state()` is a no-op for it), `iModel.__init__` raises
+`TypeError` rather than dropping the value silently. Silently discarding it
+would hand a spawned child a default environment while the caller believes it
+configured one — indistinguishable from a working setup until something the
+child needed turns out to be missing.
+
+## Copy and runtime state
+
+`iModel.copy()` builds a new `iModel` with a fresh id but the same
+configuration. Before the deep copy, it calls
+`self.endpoint.drain_runtime_state()`. This ordering matters: a runtime value
+that arrived after construction (through `update()`, for instance) is still
+sitting in `config.kwargs` at copy time, and a naive deep copy would take it
+along — duplicating a child's environment into the copy, and rebinding a
+callback that was meant for one receiver onto the copy's receiver as well,
+leaving the *original* caller's supervisor hearing nothing from the new
+copy's legs. Draining first empties `config.kwargs` of anything runtime-only,
+so the deep copy carries nothing live, and `copy_runtime_state_to()` then
+transfers the live objects onto the new endpoint explicitly, once.
+
+## Runtime state across serialization channels
+
+`EndpointConfig` (`lionagi/service/connections/endpoint_config.py`) has to
+keep `RUNTIME_STATE_NAMES` (`env`, `on_spawn`) out of anything written down —
+these are a child process's environment (commonly holding credentials) and a
+callback whose representation carries whatever object it's bound to — while
+still making their *presence* visible to a developer debugging a live
+session. The config exposes three different read channels, and each needs
+its own exclusion because none of them share code:
+
+- **`model_dump()` / `to_dict()`** (via the `kwargs` field serializer,
+  `_serialize_kwargs`): excludes `RUNTIME_STATE_NAMES` from `kwargs`
+  entirely. This is the channel `Endpoint.to_dict()`, `iModel.to_dict()`, and
+  every persisted run snapshot go through, and it has to be excluded *here*
+  — at the field serializer — rather than relying on endpoints to drain
+  their runtime state before dumping, because `EndpointConfig` is public:
+  `model_dump()` is directly callable by any caller, `update()` can put a
+  runtime value back into `kwargs` after an endpoint already drained it
+  once, and `iModel.from_dict()` assigns a freshly hydrated config over a
+  drained one. Excluding at the one channel every dump has to pass through
+  makes the answer independent of who's asking, rather than depending on
+  whether some upstream drain step happened to run first.
+- **`dict(config)` / `list(config)`** (`__iter__`): Pydantic's
+  `BaseModel.__iter__` yields raw `__dict__` values directly and does not run
+  field serializers, so it needs the identical exclusion applied separately,
+  or `json.dumps(dict(config), default=str)` — an ordinary way to write a
+  config to a log — would leak runtime state the field serializer already
+  hides from `model_dump()`.
+- **`repr(config)`** (`__repr_args__`): deliberately does the *opposite* —
+  it reports that a runtime key is set (`"<env: set, not shown>"`) without
+  showing its content. Both other channels omit the key outright, because a
+  dump is something a config gets rebuilt from, and a stand-in string would
+  hydrate back as a real value of the wrong type. `repr` is never rebuilt
+  from, so it's free to say what it's withholding — which is exactly what a
+  developer staring at a traceback or a debugger needs, when they're asking
+  why an environment variable wasn't applied.

--- a/lionagi/libs/schema/load_pydantic_model_from_schema.py
+++ b/lionagi/libs/schema/load_pydantic_model_from_schema.py
@@ -38,10 +38,7 @@ except ImportError:
 
 B = TypeVar("B", bound=BaseModel)
 
-# ---------------------------------------------------------------------------
 # JSON-Schema type -> Python type mapping
-# ---------------------------------------------------------------------------
-
 _JSON_TYPE_MAP: dict[str, type] = {
     "string": str,
     "number": float,
@@ -55,9 +52,7 @@ class _CreateModelUnsupportedError(Exception):
     """Raised when create_model cannot represent the schema."""
 
 
-# ---------------------------------------------------------------------------
 # Internal helpers for create_model approach
-# ---------------------------------------------------------------------------
 
 
 def _sanitize_model_name(raw: str) -> str | None:
@@ -310,9 +305,7 @@ def _create_model_from_schema(
     return _build_model_from_object(schema_dict, model_name, root_schema, models_cache)
 
 
-# ---------------------------------------------------------------------------
 # Fallback: datamodel-code-generator + exec_module
-# ---------------------------------------------------------------------------
 
 
 def _load_via_codegen(
@@ -399,9 +392,7 @@ def _load_via_codegen(
         return model_class
 
 
-# ---------------------------------------------------------------------------
 # Public API
-# ---------------------------------------------------------------------------
 
 
 def load_pydantic_model_from_schema(

--- a/lionagi/libs/schema/minimal_yaml.py
+++ b/lionagi/libs/schema/minimal_yaml.py
@@ -5,7 +5,7 @@ from typing import Any
 import orjson
 import yaml
 
-# --- YAML Dumper with minimal, readable settings --------------------------------
+# YAML Dumper with minimal, readable settings
 
 
 class MinimalDumper(yaml.SafeDumper):
@@ -23,7 +23,7 @@ def _represent_str(dumper: yaml.SafeDumper, data: str):
 
 MinimalDumper.add_representer(str, _represent_str)
 
-# --- Optional pruning of empty values -------------------------------------------
+# Optional pruning of empty values
 
 
 def _is_empty(x: Any) -> bool:
@@ -58,7 +58,7 @@ def _prune(x: Any) -> Any:
     return x
 
 
-# --- Public API ------------------------------------------------------------------
+# Public API
 
 
 def minimal_yaml(

--- a/lionagi/ln/_hash.py
+++ b/lionagi/ln/_hash.py
@@ -45,7 +45,7 @@ def _do_init() -> None:
     PydanticBaseModel = BaseModel
 
 
-# --- Canonical Representation Generator ---
+# Canonical Representation Generator
 _PRIMITIVE_TYPES = (str, int, float, bool, type(None))
 _TYPE_MARKER_DICT = 0
 _TYPE_MARKER_LIST = 1

--- a/lionagi/ln/_json_dump.py
+++ b/lionagi/ln/_json_dump.py
@@ -35,7 +35,7 @@ __all__ = [
 _NATIVE = (dt.datetime, dt.date, dt.time, UUID)
 _SERIALIZATION_METHODS = ("model_dump", "to_dict", "dict")
 
-# --------- helpers ------------------------------------------------------------
+# helpers
 
 _ADDR_PAT = re.compile(r" at 0x[0-9A-Fa-f]+")
 
@@ -80,7 +80,7 @@ def _default_serializers(
     return ser
 
 
-# --------- default() factory --------------------------------------------------
+# default() factory
 
 
 def get_orjson_default(
@@ -174,7 +174,7 @@ def _cached_default(
     )
 
 
-# --------- defaults & options -------------------------------------------------
+# defaults & options
 
 
 def make_options(
@@ -206,7 +206,7 @@ def make_options(
     return opt
 
 
-# --------- non-finite float detection -----------------------------------------
+# non-finite float detection
 
 # orjson writes inf, -inf and nan as `null`, indistinguishable from a genuine
 # null on read. Detection below walks the object the way orjson does, so it
@@ -383,7 +383,7 @@ def _dumpb(
     return out
 
 
-# --------- dump helpers -------------------------------------------------------
+# dump helpers
 
 
 def json_dumpb(
@@ -487,7 +487,7 @@ def json_dumps(
     return orjson.loads(out) if as_loaded else out.decode("utf-8")
 
 
-# --------- streaming for very large outputs ----------------------------------
+# streaming for very large outputs
 
 
 def json_lines_iter(

--- a/lionagi/ln/_proc.py
+++ b/lionagi/ln/_proc.py
@@ -72,21 +72,8 @@ def pinned_member(
     ``("found", (pid, create_time, marker, marker_read))`` when a single process
     answered all of it, ``("gone", None)`` when the pid holds no live member of
     this group, and ``("unknown", None)`` when the reads could not be tied to one
-    process.
-
-    Group, start time and marker are three facts, each read by pid, and a pid
-    the OS reassigns between two of those reads answers the later ones as the
-    replacement process. A verdict assembled from those answers would describe
-    no process that ever existed, so the reads are bracketed by the start time:
-    read before, read again after, required to be unchanged. That is the value
-    that tells a recycled pid from the process that held it, and it is what
-    binds the other two to the same process. Failing the bracket is "unknown" —
-    a measurement that did not come off, never evidence about the group.
-
-    *marker_read* travels with the marker because a None marker alone does not
-    say which of two things happened. The environment read and held no marker,
-    and the environment could not be read at all, are the same None; only this
-    flag tells a member that was inspected from one that refused inspection.
+    process. Bracketed by a start-time re-read to rule out pid reuse mid-read;
+    see docs/internals/ln-primitives.md#process-group-identity for why.
     """
     state, created = process_create_time(pid)
     if state == "gone":
@@ -114,15 +101,10 @@ def live_group_members(
     """Live members of process group *pgid*, and whether the scan was complete.
 
     Returns ``(members, complete)`` where each member is ``(pid, create_time,
-    marker, marker_read)`` from :func:`pinned_member`, so a caller weighing a
-    member's marker against its age is weighing one process, not two readings.
-
-    A vanished-mid-scan process is simply not a live member; a process whose
-    group/identity couldn't be read leaves *complete* false (the group may hold
-    an unseen member) rather than being silently dropped. Zombies are excluded —
-    an unreaped corpse still counts as a group member to the kernel. A member
-    whose marker alone couldn't be read is still a seen member (*marker_read*
-    false), not a gap in membership.
+    marker, marker_read)`` from :func:`pinned_member`. ``complete`` is False
+    when a process's group/identity couldn't be read (the group may hold an
+    unseen member) rather than silently dropping it; zombies are excluded, but
+    a member whose marker alone couldn't be read still counts as seen.
     """
     import psutil
 
@@ -156,16 +138,10 @@ def group_member_pids(pgid: int) -> tuple[list[int], bool]:
     """Pids currently in group *pgid*, and whether the scan was complete.
 
     The marker-free membership read, for a caller asking only whether a group
-    is empty. It is a separate function rather than :func:`live_group_members`
-    with a field dropped because the marker has to be read INSIDE the identity
-    bracket to belong to the same process, so a read without it is a different
-    observation and not a cheaper version of the same one.
-
-    A caller may act on a non-empty answer without further identity work: a
-    process group id is not reissued while the group still has members, so a
-    group that answers with members is still the one whose id was recorded. An
-    incomplete scan is never emptiness — it is a member that may not have been
-    seen, which is exactly the case where signalling nothing is wrong.
+    is empty. Not a cheaper :func:`live_group_members` with a field dropped —
+    see docs/internals/ln-primitives.md#process-group-identity for why the
+    marker has to be read inside the same bracket. An incomplete scan is never
+    reported as emptiness.
     """
     import psutil
 
@@ -240,9 +216,8 @@ def kill_group_now(pgid: Any) -> bool:
 def _safe_pgid(proc: Any) -> int | None:
     """Return the process-group id to signal, or None when unsafe."""
     pid = getattr(proc, "pid", None)
-    # pid must be int > 1: pid==1 is init/session leader on CI (would SIGKILL
-    # the harness itself; also catches MagicMock.pid==1). Never signal our own
-    # group if a bad process double or non-isolated child leaks through.
+    # pid==1 is init/session leader (would SIGKILL the harness itself; also
+    # catches MagicMock.pid==1) — never signal it or our own group.
     if not (hasattr(os, "killpg") and hasattr(os, "getpgrp") and isinstance(pid, int) and pid > 1):
         return None
     try:

--- a/lionagi/ln/_utils.py
+++ b/lionagi/ln/_utils.py
@@ -252,7 +252,7 @@ def is_import_installed(package_name: str) -> bool:
     return importlib.util.find_spec(package_name) is not None
 
 
-# --- Dynamic type loading ---
+# Dynamic type loading
 
 _TYPE_CACHE: dict[str, type] = {}
 
@@ -300,7 +300,7 @@ def load_type_from_string(type_str: str) -> type:
         raise ValueError(f"Failed to load type '{type_str}': {e}") from e
 
 
-# --- Type extraction ---
+# Type extraction
 
 
 def extract_types(item_type: Any) -> set[type]:
@@ -334,7 +334,7 @@ def extract_types(item_type: Any) -> set[type]:
     return {item_type}
 
 
-# --- UUID / datetime coercion ---
+# UUID / datetime coercion
 
 
 def to_uuid(value: Any) -> UUID:
@@ -378,7 +378,7 @@ def coerce_created_at(v: Any) -> datetime:
     raise ValueError(f"Expected datetime/timestamp/string, got {type(v).__name__}")
 
 
-# --- Synchronization decorators ---
+# Synchronization decorators
 
 
 def synchronized(func: Callable[P, R]) -> Callable[P, R]:

--- a/lionagi/ln/types/base.py
+++ b/lionagi/ln/types/base.py
@@ -84,7 +84,6 @@ class Params:
 
     @classmethod
     def allowed(cls) -> set[str]:
-        """Return the keys of the parameters."""
         if "_allowed_keys" in cls.__dict__ and cls.__dict__["_allowed_keys"]:
             return cls._allowed_keys
         cls._allowed_keys = {i for i in cls.__dataclass_fields__.keys() if not i.startswith("_")}
@@ -147,12 +146,10 @@ class DataClass:
     _allowed_keys: ClassVar[set[str]] = field(default=set(), init=False, repr=False)
 
     def __post_init__(self):
-        """Post-initialization to ensure all fields are set."""
         self._validate()
 
     @classmethod
     def allowed(cls) -> set[str]:
-        """Return the keys of the parameters."""
         if "_allowed_keys" in cls.__dict__ and cls.__dict__["_allowed_keys"]:
             return cls._allowed_keys
         cls._allowed_keys = {i for i in cls.__dataclass_fields__.keys() if not i.startswith("_")}

--- a/lionagi/service/connections/endpoint_config.py
+++ b/lionagi/service/connections/endpoint_config.py
@@ -147,42 +147,16 @@ class EndpointConfig(BaseModel):
 
     @field_serializer("kwargs")
     def _serialize_kwargs(self, v: dict):
-        """Keep runtime-only values out of every dump of this config.
-
-        The endpoint holding these drains them out of ``kwargs`` when it
-        serializes itself, which covers ``Endpoint.to_dict``, ``iModel.to_dict``
-        and the run snapshots written underneath them. That drain does not cover
-        this model's own public API. ``EndpointConfig`` inherits Pydantic's
-        ``model_dump``, callers use it directly, and two supported routes put a
-        runtime value back into ``kwargs`` after an endpoint has already drained
-        it once: a post-construction ``update()``, and ``iModel.from_dict``,
-        which assigns a freshly hydrated config over the drained one.
-
-        Excluding here rather than draining on every read is what makes the
-        answer independent of who is asking. A drain has to be reached, and the
-        set of routes that reach it is open-ended because this model is public.
-
-        Omitted rather than replaced with a placeholder: a dump is something a
-        config is rebuilt from, and a stand-in string would hydrate as a real
-        value of the wrong type. ``repr`` is not rebuilt from, so it reports
-        presence instead — see :meth:`__repr_args__`.
+        """Excludes RUNTIME_STATE_NAMES (env, on_spawn) from every dump of this
+        config (model_dump, to_dict, run snapshots), independent of caller.
+        See docs/internals/service-layer.md#runtime-state-across-serialization-channels.
         """
         return {k: val for k, val in v.items() if k not in RUNTIME_STATE_NAMES}
 
     def __iter__(self):
-        """The same exclusion on the conversion Pydantic's dump does not run.
-
-        ``dict(config)`` and ``list(config)`` go through ``BaseModel.__iter__``,
-        which yields the raw values held in ``__dict__``. No field serializer
-        runs on that path, so the exclusion above does not reach it, and
-        ``json.dumps(dict(config), default=str)`` is an ordinary way to write a
-        config to a log or a file.
-
-        Omits rather than reports presence, matching the dump: a mapping of
-        field names to values is something a config can be rebuilt from, so a
-        stand-in string would come back as a real value of the wrong type.
-        ``repr`` is the one channel nothing is rebuilt from, and it is the only
-        one that names what it withheld.
+        """Applies the same RUNTIME_STATE_NAMES exclusion on the ``dict(config)``/
+        ``list(config)`` path, which bypasses the field serializer above. See
+        docs/internals/service-layer.md#runtime-state-across-serialization-channels.
         """
         for name, value in super().__iter__():
             if name == "kwargs" and isinstance(value, dict):
@@ -190,13 +164,10 @@ class EndpointConfig(BaseModel):
             yield name, value
 
     def __repr_args__(self):
-        """The same values, on the channel a dump does not reach.
-
-        ``repr`` walks ``kwargs`` whole, so a config whose ``env`` is excluded
-        from every dump still prints it in a traceback, a log line, or a
-        debugger. Presence is reported and content is not: a reader asking why
-        an environment was not applied needs to know one is set, and that is the
-        entire question ``repr`` gets asked here.
+        """Unlike dump/iter, repr reports RUNTIME_STATE_NAMES presence (not
+        content) rather than omitting it — repr is never rebuilt from, so a
+        reader needs to see that e.g. ``env`` is set. See
+        docs/internals/service-layer.md#runtime-state-across-serialization-channels.
         """
         for name, value in super().__repr_args__():
             if name == "kwargs" and isinstance(value, dict):

--- a/lionagi/service/connections/mcp_wrapper.py
+++ b/lionagi/service/connections/mcp_wrapper.py
@@ -98,9 +98,9 @@ class _MCPRecoveryCapability:
         self.security = security
 
 
-# --- Generic-executor admission rule -----------------------------------
-# Registration-time admission control, independent of MCPSecurityConfig
-# (transport auth) and PermissionPolicy (invocation-time) — see docs/internals/runtime.md.
+# Generic-executor admission rule: registration-time admission control,
+# independent of MCPSecurityConfig (transport auth) and PermissionPolicy
+# (invocation-time) — see docs/internals/runtime.md.
 
 AdmissionReason: TypeAlias = Literal[
     "unbounded-command-input",
@@ -303,9 +303,9 @@ def _has_structural_ref_siblings(siblings: Mapping) -> bool:
     return any(key not in _ANNOTATION_ONLY_REF_SIBLING_KEYWORDS for key in siblings)
 
 
-# --- Keyword registry for the sufficiency proof --------------------------
-# Classifies every Draft 2020-12 keyword into one of four classes, then
-# walks the whole document unconditionally. See docs/internals/runtime.md.
+# Keyword registry for the sufficiency proof: classifies every Draft 2020-12
+# keyword into one of four classes, then walks the whole document
+# unconditionally. See docs/internals/runtime.md.
 
 # Annotation-only: carry no assertion that admits/denies an instance value.
 _INERT_ANNOTATION_KEYWORDS = frozenset(
@@ -805,8 +805,7 @@ def _property_is_free_form(
 _MAX_SCHEMA_WALK_DEPTH = 12
 _MAX_SCHEMA_WALK_NODES = 5000
 
-# --- Walker keyword whitelist -------------------------------------------
-# WHITELIST not blacklist — enumerating "keywords we understand" avoids the
+# Walker keyword whitelist — enumerating "keywords we understand" avoids the
 # denylist arms race. See docs/internals/runtime.md.
 
 # Keywords whose value never carries a subschema; contentSchema included by

--- a/lionagi/service/connections/registry.py
+++ b/lionagi/service/connections/registry.py
@@ -169,13 +169,10 @@ class EndpointRegistry:
             provenance = getattr(cls._plugin_registration, "provenance", None)
             if provenance is not None:
                 entry.plugin_name, entry.plugin_target = provenance
-            # Validation (does anyone else already own this alias?) and the
-            # claim itself must be one atomic transaction: check-then-claim
-            # split across the lock lets two concurrent registrations both
-            # pass the check before either publishes. Entry publication is
-            # folded into the same critical section, since an alias claimed
-            # with no corresponding entry (or vice versa) is its own
-            # inconsistency.
+            # Alias-ownership check and the claim itself run as one atomic
+            # transaction under the lock (a split check-then-claim lets two
+            # concurrent registrations both pass), with entry publication
+            # folded into the same critical section.
             with cls._lock:
                 cls._claim_provider_identity(canonical_provider, canonical_provider_aliases)
                 cls._entries.append(entry)

--- a/lionagi/service/imodel.py
+++ b/lionagi/service/imodel.py
@@ -90,13 +90,9 @@ class iModel:  # noqa: N801
 
                     provider = settings.LIONAGI_CHAT_PROVIDER
 
-            # Effort-suffixed model names ("gpt-5.6-luna-high") work at every
-            # construction site: strip the suffix and route it to the
-            # provider's effort kwarg. Gated twice so a real model name is not
-            # mangled — to providers that have an effort kwarg at all, and to
-            # names written in lionagi's own grammar rather than borrowed whole
-            # from another vendor's catalogue (see split_effort_suffix). An
-            # explicit effort kwarg always wins over the suffix.
+            # Effort-suffixed model names ("gpt-5.6-luna-high") are stripped and
+            # routed to the provider's effort kwarg here so it works at every
+            # construction site. See docs/internals/service-layer.md#effort-suffix-routing.
             from .providers import (
                 _CLAUDE_PROVIDER_NAMES,
                 PROVIDER_EFFORT_KWARG,
@@ -122,11 +118,10 @@ class iModel:  # noqa: N801
             kwargs["api_key"] = api_key
         if isinstance(endpoint, Endpoint):
             self.endpoint = endpoint
-            # A finished endpoint missed the window where these are lifted off
-            # the caller's config, so they are placed now. Refusing the ones
-            # that have nowhere to go is the point: dropping them silently
-            # hands the child a default environment and leaves the supervisor
-            # hearing nothing, which is indistinguishable from working.
+            # Runtime state (spawned-child hooks, env) that missed the normal
+            # config window is placed now; refused outright if it has nowhere
+            # to go, rather than silently dropped. See
+            # docs/internals/service-layer.md#runtime-state-adoption.
             adopt = getattr(self.endpoint, "adopt_runtime_state", None)
             unplaced = (
                 adopt(kwargs)
@@ -422,15 +417,12 @@ class iModel:  # noqa: N801
 
     def copy(self, share_session: bool = False, share_executor: bool = False) -> iModel:
         """Create a new iModel with the same config but a fresh ID. See
-        docs/internals/runtime.md for what state is/isn't shared with the copy."""
+        docs/internals/service-layer.md#copy-and-runtime-state for what state
+        is/isn't shared with the copy."""
         endpoint_cls = type(self.endpoint)
-        # Drain before the deep copy, not after. A runtime value that arrived
-        # after construction is still sitting in config.kwargs, so a deep copy
-        # takes it along: a child environment gets duplicated, and a bound
-        # callback is rebound to a copied receiver, leaving the caller's own
-        # supervisor to hear nothing from the copy's legs. Draining first means
-        # the copied config has nothing runtime-only in it and the live objects
-        # transfer whole, just below.
+        # Drain before the deep copy so no runtime-only state (child env, bound
+        # callbacks) rides along duplicated; see
+        # docs/internals/service-layer.md#copy-and-runtime-state.
         self.endpoint.drain_runtime_state()
         new_endpoint = endpoint_cls(
             config=self.endpoint.config.model_copy(deep=True),
@@ -480,11 +472,9 @@ class iModel:  # noqa: N801
         endpoint = Endpoint.from_dict(data.get("endpoint", {}))
 
         # openai_compatible=True: rehydrating a persisted iModel must never
-        # raise just because its provider isn't (or is no longer) registered
-        # -- the deserialized `endpoint` below is already a complete,
-        # authoritative config either way, this lookup only exists to recover
-        # a registered subclass and a freshly env-sourced API key when one
-        # applies.
+        # raise just because its provider isn't (or is no longer) registered.
+        # This lookup only recovers a registered subclass and a fresh
+        # env-sourced API key when one applies; `endpoint` is already complete.
         if e1 := match_endpoint(
             provider=endpoint.config.provider,
             endpoint=endpoint.config.endpoint,

--- a/lionagi/service/providers.py
+++ b/lionagi/service/providers.py
@@ -75,14 +75,10 @@ def _clamp_codex_effort(effort: str, model: str | None) -> str:
     return effort
 
 
-# Claude: the Opus line accepts xhigh from 4.7 onward. Everything else clamps
-# to high. Claude has no ultra tier at all: ultra clamps to max for every model.
-#
-# This is an allow-list of exact model strings, so a new Opus release is absent
-# until it is added here, and its absence costs it xhigh silently -- the request
-# still succeeds, one tier lower, with nothing in the result saying so. Add new
-# Opus identifiers in the same change that makes them routable, both the bare
-# alias and the claude- prefixed form, since callers pass either.
+# Claude: only the Opus line (from 4.7 on) accepts xhigh; everything else clamps
+# to high, and there is no ultra tier (clamps to max). Allow-list of exact model
+# strings: a new Opus release silently loses xhigh until added here — both the
+# bare alias and the claude- prefixed form, since callers pass either.
 _CLAUDE_XHIGH_MODELS = frozenset(
     {
         "opus",
@@ -287,17 +283,10 @@ _EFFORT_SUFFIX_RE = re.compile(
 def split_effort_suffix(model: str) -> tuple[str, str] | None:
     """Split a bare model name into ``(name, effort)``, or None when it carries none.
 
-    The trailing-effort convention belongs to lionagi's own ``provider/model-effort``
-    grammar, which spends its single slash on the provider. So a slash still present
-    in the model name means the name was not written in that grammar: it is a literal
-    id from another vendor's catalogue, reached for instance through a codex config
-    profile that names its own ``model_provider``. Those ids end in whatever the
-    vendor chose, and a trailing word that happens to spell an effort level is part
-    of the id. Splitting it produces a model nobody serves, and the provider rejects
-    a name the caller never asked for.
-
-    Used by both places that would otherwise strip a suffix, so the rule is stated
-    once rather than drifting between them.
+    A model name containing "/" is a literal vendor id, not lionagi's own
+    ``provider/model-effort`` grammar, so it is never split even if it ends in
+    a word that spells an effort level. See
+    docs/internals/service-layer.md#effort-suffix-routing.
     """
     if "/" in model:
         return None

--- a/lionagi/service/types/cli_session.py
+++ b/lionagi/service/types/cli_session.py
@@ -52,22 +52,12 @@ _EDIT_TOOLS = ("Edit", "edit", "edit_file", "patch", "MultiEdit")
 
 
 def _extract_activity(session: CLISession) -> dict[str, Any]:
-    """Bounded, metadata-only record of what a leg did.
-
-    Carries no tool inputs by design. Tool arguments hold file paths, shell
-    command strings and prompts, so a block containing them could not be
-    recorded on the default path without a redactor in front of it; counting
-    instead of quoting removes the need for one. The full detail, inputs
-    included, stays available through populate_summary() under the caller's
-    explicit opt-in.
-
-    Usage and cost are absent for a different reason: they already travel in
-    the response metadata and are summed per branch downstream, so repeating
-    them here would create a second value for one fact, free to disagree
-    with the first.
-
-    Size is bounded by the number of DISTINCT tool names rather than by the
-    number of calls, so a long run costs the same few keys as a short one.
+    """Bounded, metadata-only record of what a leg did: tool call counts and
+    file-operation counts, no raw tool inputs (those can hold file paths,
+    shell commands and prompts — see populate_summary() for the full,
+    opt-in detail) and no usage/cost (already summed downstream from
+    response metadata). Bounded by distinct tool names, not call count, so a
+    long run costs the same few keys as a short one.
     """
     tool_counts: dict[str, int] = {}
     file_operations = {"reads": 0, "writes": 0, "edits": 0}


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 13 (+76 / -177, net -101)
- New documentation: 228 lines in docs/internals/ln-primitives.md docs/internals/service-layer.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.