### PR TITLE
docs(state): trim inline prose to a working density

### DIFF
--- a/docs/internals/state-db.md
+++ b/docs/internals/state-db.md
@@ -1,0 +1,215 @@
+# How StateDB persists and protects session state
+
+`lionagi/state/db.py` is the async SQLAlchemy layer behind every session,
+branch, message, schedule, and artifact that lionagi records. It runs against
+either SQLite (the default local store) or PostgreSQL (a shared server store),
+and most of its complexity exists to make those two backends behave the same
+way under concurrent writers, even though SQLite serializes writes for free
+and PostgreSQL does not.
+
+## Schema shape and how it evolves
+
+The schema is defined once, in `schema_meta.py`, as SQLAlchemy `Table`
+objects; `db.py` never hand-writes DDL that could drift from that source of
+truth (`schema.sql`/`schema_meta.py` parity is test-enforced). `SCHEMA_VERSION`
+records the shape this code understands. A writable `StateDB.open()` rewrites
+an older on-disk database into the current shape and stamps the new version;
+if the on-disk version is *higher* than `SCHEMA_VERSION`, open refuses rather
+than guessing what a later release's shape means (`SchemaTooNewError`).
+Read-only opens apply no schema migration at all and are unaffected by this
+check.
+
+Two kinds of schema change show up in the code:
+
+- **In-place table rebuilds**, used when SQLite's lack of `ALTER TABLE ...
+  DROP CONSTRAINT` means the only way to drop a stale `CHECK` constraint is
+  to create a new table with the right constraint, copy every row across,
+  drop the old table, and rename the new one into place. Because a legacy
+  install might have already been rebuilt in a previous release, each rebuild
+  first checks (by inspecting the live `CREATE TABLE` SQL for a marker
+  substring) whether the constraint it exists to remove is even still there,
+  and no-ops if not.
+- **Backfills**, used when a later release adds a column to a table that
+  already existed, and old rows need real values instead of the `DEFAULT`
+  placeholder `ALTER TABLE` gave them. Every backfill is guarded by a durable
+  claim row in `schema_meta` (`INSERT ... ON CONFLICT (key) DO NOTHING`), so
+  it runs exactly once even if an earlier release already added the column
+  without running the corresponding update.
+
+### The SQLite rebuild hazard: PRAGMA foreign_keys inside a transaction
+
+Rebuilding a table that other tables have a foreign key into (`schedules`,
+referenced by `schedule_runs.schedule_id ON DELETE CASCADE`) is dangerous:
+dropping the old table while `PRAGMA foreign_keys` is enforced cascades away
+every referencing row, even ones already safely copied into the new table.
+The fix looks obvious — turn the pragma off before the rebuild — but SQLite
+treats `PRAGMA foreign_keys` as a no-op while a transaction is open, and
+`engine.begin()` opens its transaction before the first statement runs. So
+toggling the pragma through an ordinary SQLAlchemy connection silently does
+nothing (this was verified: it cascade-deleted `schedule_runs` rows in this
+exact rebuild before the fix landed). The correct sequence goes through the
+raw driver connection instead, so the pragma flip is real autocommit rather
+than swallowed by a pending transaction, and stays *outside* any transaction
+entirely — SQLite only honors the pragma between transactions.
+
+That in turn means the CREATE/copy/DROP/RENAME/index sequence that follows
+needs its own explicit transaction. Running those steps as independent
+autocommit statements is not safe either: a failure between DROP and RENAME
+(cancellation, I/O error, a bad index statement) would leave only
+`schedules_new` on disk, and the next open's `metadata.create_all` would then
+create a fresh *empty* `schedules` table, stranding every original row.
+`BEGIN IMMEDIATE` wraps the sequence to restore the atomicity the old
+`engine.begin()` path had, without reintroducing the pragma-inside-transaction
+bug. After any rebuild, `_restore_foreign_keys()` turns enforcement back on:
+it runs from every rebuild's `finally` (including failure paths), closes any
+transaction still open first (since the pragma is inert otherwise), reads
+`PRAGMA foreign_keys` back rather than assuming the write took, and
+invalidates the pooled connection if enforcement can't be confirmed, so a
+connection with enforcement silently off is never handed back to the pool.
+
+## Locking model: SQLite serializes for free, PostgreSQL does not
+
+Most of the file's harder invariants exist because SQLite's single writer
+lock (`BEGIN IMMEDIATE`) gives free serialization that PostgreSQL's
+`READ COMMITTED` isolation does not. Three patterns recur:
+
+1. **Row-level `FOR UPDATE`**, used where one write depends on a value read
+   moments earlier from the same row — for example `attach_session_invocation`
+   re-pointing a session's `invocation_id`: without locking the prior value
+   before reading it, a second concurrent attach on PostgreSQL could read the
+   same prior `invocation_id` a first attach is about to move away from, then
+   decrement that now-stale value after the first attach already committed.
+2. **Admission conditions evaluated inside the write itself**, used where a
+   caller-side check-then-write would leave a race window — for example
+   `insert_session_control`, which makes "session still running" part of the
+   `INSERT ... WHERE EXISTS (...)` rather than a separate `SELECT` first. On
+   PostgreSQL, `EXISTS` under `READ COMMITTED` reads a snapshot, so a plain
+   form can admit a control against a session another transaction is
+   simultaneously terminalizing, and commit after that session's terminal
+   sweep already looked — leaving a pending control nobody will ever consume
+   (measured directly on PostgreSQL 16). The fix takes a row lock on the
+   session as part of the insert's own source query, so a concurrent terminal
+   transition waits for the admission to finish rather than racing past it.
+3. **Explicit multi-table `LOCK TABLE ... EXCLUSIVE MODE NOWAIT`**, used by
+   the two teardown paths that delete across `branches`, `progressions`, and
+   `sessions` (`delete_imported_session` and the analogous prune path). A
+   transaction alone isn't enough here because the *retention check* — "does
+   any survivor still reference this row" — is a read whose snapshot can go
+   stale if a concurrent writer commits a new reference right after it. The
+   table lock is taken **before the first read**, so nothing written after it
+   is missed; it's `NOWAIT` because a comma-separated `LOCK TABLE` acquires
+   its targets one at a time rather than atomically, and a *blocking* wait
+   there could deadlock against another writer (`prune_old_data`) that
+   touches the same tables in the reverse order. A `SET LOCAL lock_timeout =
+   '250ms'` additionally bounds every lock-acquisition wait inside the
+   transaction, including ones after the table locks are already held (the
+   soft-FK nulling that follows touches several more tables whose rows a
+   concurrent writer can hold). 250ms is chosen to sit below PostgreSQL's
+   default `deadlock_timeout` (1s), so a lock wait gives up before the
+   detector would even run, and above the row-lock hold times of ordinary
+   writers, so everyday contention resolves instead of aborting a teardown.
+   It is *not* a deadline for the whole transaction — it bounds no single
+   statement's execution and nothing about commit. Either way the cost falls
+   entirely on the rare teardown: a conflicting lock aborts the attempt, and
+   both callers log the failure and retry on a later sweep.
+
+## The session-control queue: a worked example
+
+`session_controls` is a small durable queue of verbs (pause, resume, message
+delivery, etc.) that a running session's poller drains. Three methods carry
+its full lifecycle, and they're worth reading as one sequence:
+
+1. **`insert_session_control`** admits a new control row only if the target
+   session is still `running` (see the admission-condition pattern above),
+   and returns the new control's id, or `None` if the session had already
+   terminalized.
+2. **`mark_session_control_applying`** is how a consumer claims a pending row
+   before attempting it: a compare-and-set that moves `result` from `NULL` to
+   `applying[:<owner>]`, returning the exact claim string it wrote, or `None`
+   if another consumer already claimed the row. The claim string has to come
+   back to the caller — not be reconstructed later — because
+   `finalize_session_control(expect_claim=...)` needs the caller's *own*
+   claim to avoid overwriting an outcome someone else recorded while it was
+   working. `applied_at` stays `NULL` through this step, so a poller crash
+   right after claiming is visible as a stuck row, not silently lost.
+3. **`finalize_session_control`** stamps the terminal result. Two mutually
+   exclusive guards are available: `expect_claim` (the write lands only if
+   the row still carries that exact claim string — used by the message-
+   delivery path, where a specific consumer owns the row) or
+   `only_if_unclaimed` (the write lands only if the row is still pending —
+   used by sweeps, which read a snapshot of pending rows and must not
+   overwrite one a consumer claimed and delivered in the meantime). Passing
+   both is a caller bug. This is a compare-and-set between cooperating
+   consumers, not an authorization boundary: the claim string lives in a
+   column every reader can see, so what it prevents is a consumer
+   overwriting a row it hasn't re-read — not a consumer that means to write
+   it, since anything that can call this method could write the row
+   directly anyway.
+
+`list_pending_session_controls` reads the queue back, and distinguishes
+"never touched" (`result IS NULL`) from "a consumer is or was mid-apply"
+(`result` starts with `applying`) so a status surface or a stuck-claim
+detector can tell them apart; `claimed_at` next to it gives the age of a
+claim that hasn't resolved.
+
+## Status transitions and the terminal-status floor
+
+`update_status` is the single path every entity's status write goes through.
+Two optional guards make it safe under concurrency: `expected_statuses`
+performs the write only if the current status is a member of a given set
+(pass `None` in the set to match a SQL NULL status); `expected_updated_at`
+adds an optimistic-lock version check — the row's `updated_at` must still
+equal the value the caller read, and any status write bumps it — which lets a
+caller distinguish "the row I read is still current" from "someone already
+re-touched it" in cases where status membership alone can't (a reaper racing
+a fresh claim on the same reapable status, for instance).
+
+On top of that sits an integrity floor: once an entity's status is terminal
+(per `TERMINAL_STATUSES_BY_ENTITY_TYPE`), any write that would *change* it is
+rejected and recorded in `admin_events` — a terminal record must never
+silently move back to running or oscillate to a different terminal value. A
+same-status write is not treated as a transition and passes through
+untouched, since callers rely on it to refresh a reason code on an
+already-terminal row. The one deliberate escape hatch is
+`override=True` with both `override_actor` and `override_justification`
+required — an operational repair that does change a terminal value, recorded
+in `admin_events` distinctly from an ordinary transition so the two are never
+confused when reading the audit trail later.
+
+`finalize_branch` applies the same terminal-status discipline to individual
+branch rows: the incoming status must itself be a genuine terminal outcome
+(rejecting, for example, the "running" that linked-engine reconciliation can
+produce when it suppresses a phantom "failed" back to "running"), and the
+existing row must still be in a pre-terminal state (`NULL` or `"running"`) —
+any other existing value, whichever terminal status it already holds, is
+immutable. A branch row that was never created at all (a DAG leg that never
+emitted a first message) simply matches zero rows.
+
+## `node_metadata` merges: read-modify-write without the read
+
+`merge_session_node_metadata` and `merge_invocation_node_metadata` both exist
+to close a clobber: the pattern they replaced was a `get_*()` read followed
+by an `update_*(node_metadata=...)` write, which let two concurrent callers
+each read the same row and overwrite each other's patch. Both now run as a
+single dialect-specific `UPDATE`, so the merge is serialized by the database
+itself (SQLite's write lock; PostgreSQL's ordinary row-level MVCC locking)
+instead of racing in Python. A patch value that is itself a nested dict is
+rejected before any SQL runs, because SQLite's `json_patch` merges nested
+objects recursively while PostgreSQL's `jsonb ||` replaces them shallowly —
+allowing either silently would make the two backends persist different state
+from the same call.
+
+On PostgreSQL the merge SQL also has to reproduce RFC 7396's "null in the
+patch deletes the key" semantics by hand, because `jsonb ||` keeps an
+explicit null instead of deleting it (unlike SQLite's `json_patch`, which
+already implements RFC 7396). Rather than stripping *all* nulls from the
+merged document — which would also strip nulls that pre-date this patch and
+have nothing to do with it — the statement subtracts exactly the set of keys
+the incoming patch itself set to null.
+
+## What was deliberately left alone
+
+Some large docstrings in `db.py` remain close to their original length
+because they encode invariants a caller genuinely needs and trimming further
+risked losing a fact rather than a word — the guiding rule throughout this
+pass was "when in doubt, keep the sentence."

--- a/docs/internals/state-misc.md
+++ b/docs/internals/state-misc.md
@@ -1,0 +1,104 @@
+# Session display names, and telling reclaimed or stale data from real data
+
+Two small, unrelated corners of the state package are documented here
+together because each is short enough that a document per file would be
+mostly white space: how a session gets the name shown to a person, and how
+the system tells "this data is missing because it was never there" apart
+from "this data is missing because something happened to it."
+
+(The schema/migration story, StateDB locking, and the transcript mirrors are
+covered in `state-db.md` and `state-transcript-mirrors.md`. The lifecycle
+transition machinery — `state/lifecycle/`, `transitions.py`, `reasons.py`,
+`schema_migrations.py`, `health.py`, `completion_evidence.py` — already has
+a thorough writeup in `runtime.md`; nothing here duplicates it.)
+
+## How a session's display name is chosen
+
+`session_naming.py` is a pure-transform module: no randomness, no database
+reads, so a row's resolved name is stable across re-reads and cheap enough to
+compute per row on a paginated list. It's shared between the write path
+(transcript-mirror ingestion) and the read path (Studio's API), so both sides
+agree on what "prompt-shaped" and "a sane display width" mean.
+
+`resolve_display_name` walks a fixed priority chain: an explicit user label,
+then a show/play name, then a playbook name, then an agent-role descriptor,
+then a sanitized prompt-derived name, and finally a short id as the
+unconditional fallback. `user_label` has no write path anywhere in the
+codebase yet — it's read defensively via `.get()` so a future rename feature
+can slot into the top of the chain without another reorder.
+
+The agent-role tier (`agent_role_label`) formats as `"claude-code · 1167 ·
+14:22"`: engine name, four characters of the row's own id, and a UTC
+HH:MM timestamp. The id slice earns its place empirically — name and minute
+alone looked sufficient until the common real case (several long-lived
+sessions of one engine) turned a page into near-identical strings like
+`"claude-code · 21:37"`, `"· 21:49"`, `"· 21:50"` that a viewer has to
+compare digit by digit. Four meaningless-looking characters turn a row into
+something a person can actually point at.
+
+The prompt-derived tier (`sanitize_prompt_name`) strips a leading
+system-message banner, a markdown separator or heading it wraps, and a short
+`"Label:"` prefix, repeating the strip since these nest (a `"Guidance:"`
+wrapper around a system-message block needs two passes to fully unwrap). It
+also has to handle a prompt that was routed through a YAML document and so
+kept its block-scalar indicator (`|` or `|-`) ahead of everything else,
+which would otherwise defeat every other strip pattern. The function returns
+`None`, never `""`, when there's no usable name left — both cases (empty
+input, or a banner-only input that strips to nothing) collapse to the same
+falsy value on purpose, so every `if sanitized:` caller keeps working
+unchanged, but `None` reads unambiguously as "nothing to show" rather than
+being confused with a real empty-string name.
+
+The prompt tier also declines a stored `name` that's a known placeholder —
+`"agent"`, `"session"`, `"flow"`, `"codex session"` — values written by a
+caller that had nothing more specific to record, not real content. Skipping
+these by comparing the literal value (rather than by reordering the priority
+chain) means rows with a real stored name are entirely unaffected; only rows
+carrying one of these exact placeholders fall through to the short-id
+fallback instead of rendering a page of identical cards.
+
+## Telling absent data from lost data
+
+Three small modules answer a related question from different angles: when a
+piece of session data is missing, is that because it was never collected, or
+because something removed or invalidated it after the fact? Conflating the
+two is the actual bug each one guards against.
+
+**`content_pruned.py`** handles reclaimed message bodies. Freeing space by
+simply emptying a message's `content` column would collapse two different
+truths into one: a body written as `""` or `{}` is exactly what a turn that
+genuinely produced nothing writes, so a reader handed an empty body can't
+tell "nothing happened here" from "something happened here and was later
+discarded." Instead, `li state null-content` replaces a reclaimed body with
+a small JSON marker (`{"lion_content_pruned": {"at": ..., "original_bytes":
+...}}`) that says plainly what it is. The size recorded is deliberately a
+per-row SQL expression (`pruned_content_sql`) evaluated against the row it's
+overwriting, not a single number computed once in Python and stamped onto
+every row in a batch — that would make `original_bytes` a batch average
+wearing a per-row name, technically present but answering a different
+question than its label claims. `content_was_pruned` reads the marker back;
+it accepts the column either as raw JSON text or as an already-parsed dict,
+since both shapes reach different callers, and treats anything unparseable
+as "not reclaimed" without asserting anything about whether the body is
+otherwise well-formed.
+
+**`staleness.py`** answers a liveness question, not a presence question: is
+a session that's still marked `"running"` actually stuck? The threshold is
+kind-aware (`STALE_THRESHOLDS`, keyed by `invocation_kind`) because
+multi-agent kinds like `flow` and `fanout` genuinely go quiet for longer
+between visible activity than a single `agent` session does — a flat
+threshold would either false-positive on healthy multi-agent runs or miss
+genuinely stuck single-agent ones. `staleness_check` only ever returns
+`"stale"` or `None`; terminal sessions are never flagged, since staleness is
+a property of something still claiming to be running.
+
+**`provenance.py`** writes the attribution columns (`model`, `provider`,
+`agent_hash`) at session creation. `agent_definition_hash` fingerprints the
+actual agent-profile file a session was launched from (a truncated SHA-256),
+searching every configured lionagi directory in order and returning `None`
+if no matching profile file is found — a session created without a
+resolvable profile simply carries no hash rather than a fabricated one.
+`resolve_model_spec` normalizes `(provider, model)` into a single
+`"provider/model"` string for storage, passing an already-qualified model
+name (one that already contains a `/`) through unchanged rather than
+double-prefixing it.

--- a/docs/internals/state-transcript-mirrors.md
+++ b/docs/internals/state-transcript-mirrors.md
@@ -1,0 +1,138 @@
+# How transcript mirroring turns external CLI logs into StateDB rows
+
+Two external coding CLIs — Claude Code and Codex — each write their own
+transcript format to disk as a conversation happens. Neither writes directly
+into StateDB. Instead, a *mirror* (`claude_mirror.py`, `codex_mirror.py`)
+tails the external format and turns it into ordinary lionagi messages,
+sessions, and branches, so the rest of the system (Studio, status APIs, the
+lifecycle machinery) can treat a mirrored CLI conversation exactly like a
+conversation lionagi itself is running. `_mirror_common.py` holds everything
+both mirrors share, since once a session id is known, status reconciliation
+and lineage linking are identical regardless of which CLI produced it.
+
+## Deterministic ids and idempotent writes
+
+A mirror never decides whether a row already exists by asking the database
+first. It derives every id — session id, branch id, message ids, progression
+ids — deterministically from the external tool's own conversation/session
+identifier (`session_db_id(uid)`, `_det(uid, "branch")`, etc.). Writing a
+batch of records is then naturally idempotent: replaying the same rollout or
+transcript segment through the mirror produces the same ids and the same
+rows, rather than duplicates. This matters because both mirrors are designed
+to be re-run over a file: a crash mid-import, a later sweep picking up new
+lines appended to the same file, or a reconciliation pass are all just
+another call with the same deterministic ids.
+
+Codex rollouts specifically use an enveloped JSONL format
+(`{type, timestamp, payload}` per line). Rollouts written before
+2025-09-20 use an older flat format with no envelope and mirror nothing —
+measured at 6 files out of 29,652 in the local corpus, not sampled. Such a
+file still gets a session row carrying zero counts, because completeness
+checking works by subtraction (see below) and a row is what there is to
+subtract against.
+
+## Completeness is a subtraction, not a self-report
+
+Both mirrors track, per record/event type, how many records they *saw* in
+the source file versus how many they actually *mirrored* into messages
+(`RecordTally` in `codex_mirror.py` plays this role). The design choice is
+deliberate: completeness is computed as `seen - mirrored`, a subtraction any
+consumer can do later, rather than the importer narrating its own
+completeness as it goes. A self-report goes stale silently the moment the
+importer's behavior changes; two counters that disagree cannot. A record
+that failed to parse at all is counted separately from one deliberately
+skipped by type — collapsing the two into one number would hide exactly
+where a corpus is damaged.
+
+## Bounding content: preview plus a recoverable source pointer
+
+Mirrored messages don't always store an external tool's raw content
+verbatim. When a caller passes `event_sources` (the exact
+`(byte_offset, byte_count, sha256)` of each source JSONL line) together with
+`max_preview_chars`, `_mirror_common.bound_mirror_content` truncates the
+message's content to a bounded preview and attaches a versioned pointer back
+into the source file, stored in `messages.node_metadata.mirror_source`. The
+full content is never lost — it's recoverable from the pointer — it's just
+not duplicated into SQLite. `_bound_content` applies a different truncation
+rule per message shape (instruction, assistant response, or an action
+response/request split between a function-name preview and an
+output/arguments preview), discriminated by which fields are present rather
+than an exact key match, since `RoledMessage.to_dict(mode="db")`'s live shape
+varies per instance even though the mirror only ever populates a fixed
+subset. An unrecognized shape fails bounded rather than persisting unbounded:
+it's replaced with a JSON preview and marked truncated.
+
+Reading a mirrored row back (`resolve_mirrored_content`) reverses this: it
+recovers the full content from the pointer, verifying every step, and
+degrades to the stored preview with a stable `reason` on any mismatch. A
+stale, moved, or rotated source file must never silently return content from
+a different file than the one that produced the row. This reconstruction
+path currently exists for tests and future integration — adapters aren't yet
+wired to call it live.
+
+## Attribution corrections after the fact
+
+Both mirrors guess at a session's `project`/`name` from cheap signals (the
+transcript's working directory, its first prompt) at create time, and never
+revisit those fields once the row exists — a later sweep will not clobber
+them. This creates a problem for one specific case: a flow escalation
+retries a node on a higher-tier CLI engine as an in-session child op, and
+that engine's own transcript gets mirrored independently, under a session id
+the mirror has no way to connect back to the originating run. Once the child
+op's branch reports that session id, the escalation call site calls
+`link_escalation_session` to stamp the link and *overwrite* the mirror's
+guessed `project`/`name`, since both are wrong for an escalation leg by
+construction (its `cwd` is a scratch workspace, its first prompt is injected
+guidance, not a task description). If the mirror hasn't created the session
+row yet, `link_escalation_session` returns `False` and the caller is
+expected to retry for a bounded window — which side writes first is an
+unresolved race, not a bug.
+
+`set_session_provenance` (in `db.py`) handles a related but distinct case for
+`artifacts_path`: a mirrored session's artifact root (the transcript's own
+`cwd`) is a weaker signal than a launcher-set root, so it's written via
+`COALESCE` rather than a plain assignment, so a later, more precise write is
+never clobbered by an earlier guess.
+
+## The engine underneath: SQLite tuning and credential safety
+
+`engine.py` builds the `AsyncEngine` both mirrors and the rest of `db.py`
+write through. Two things worth knowing if you're calling into it directly:
+
+- **`SQLITE_BUSY_TIMEOUT_MS`** controls how long a SQLite write waits on a
+  contended lock before reporting "database is locked". The default (5000ms)
+  is sized for the test suite, where a write that deliberately holds a lock
+  should fail fast rather than wait out a production-grade timeout — and for
+  years this was silently also the production value. It's read from
+  `LIONAGI_SQLITE_BUSY_TIMEOUT_MS` so a daemon's launch config can raise it
+  for a large, contended store while the test suite leaves it at the fast
+  default. `announce_busy_timeout()` logs the effective value once per
+  process, recomputed at call time (not cached at import) since the module
+  attribute is writable and tests retune it.
+- **Credential masking** (`mask_credentials`, `mask_db_url`) is a backstop
+  for logging and error messages that might otherwise leak a database
+  password. It's text-scanning, not URL-parsing, for the general case
+  (`mask_credentials`), which means a password containing a literal `@` is
+  masked only up to that character, and a bare secret argument outside a
+  `user:secret@` URL shape isn't matched at all — both are under-masking,
+  which is why this exists alongside other controls rather than instead of
+  them. `mask_db_url` tries a structured `urlparse` pass first and falls
+  back to the text scan for URLs it can't decompose, notably a schemeless
+  string, which parses as a path rather than a URL and would otherwise
+  return a password verbatim.
+
+## Verifying what artifacts actually landed
+
+`artifact_verifier.py` answers a narrower question than the mirrors: given a
+recorded verification verdict (produced artifacts, a `checked_at`
+timestamp), is that verdict still trustworthy, or might the files have
+changed since? `stale_artifact_markers` never re-runs the original
+pass/fail check — it only compares mtime and size (both from a single
+`stat()` call) against what the verdict recorded, so it stays a cheap
+read-time check rather than a full re-verify. Comparing size alongside mtime
+narrows, but does not close, the false-negative window a bare mtime check
+would have against a rewrite that happens to preserve both. It returns
+`None` only when the check can't be performed at all (no artifacts root
+configured, or a verdict recorded before this field existed) — callers use
+that to surface an explicit "unknown" state rather than treating an
+unchecked verdict as clean.

--- a/lionagi/state/_mirror_common.py
+++ b/lionagi/state/_mirror_common.py
@@ -186,15 +186,15 @@ def resolve_mirrored_content(
     reconstruct: Callable[[dict[str, object], str, str], dict[str, object] | None] | None = None,
 ) -> ResolvedContent:
     """Recover a mirrored row's full content from its source pointer, verifying
-    every step (mirror_spec.md §5). Never raises; degrades to the stored preview
-    with a stable ``reason`` on any mismatch — a stale/moved/rotated source must
-    never silently return content from a different file.
+    every step (mirror_spec.md §5). Never raises; degrades to the stored
+    preview with a stable ``reason`` on any mismatch -- a stale/moved/rotated
+    source must never silently return content from a different file.
 
-    ``reconstruct(parsed_record, source_session_uid, message_id)`` re-runs the
-    owning adapter's mapper and returns the derived message's full content dict
-    (or ``None`` if no derived message matches ``message_id``). Adapters are not
-    wired to call this in this round (mirror_spec.md §6) — it is exercised
-    directly by tests and available for a later integration.
+    ``reconstruct(parsed_record, source_session_uid, message_id)`` re-runs
+    the owning adapter's mapper and returns the derived message's full
+    content dict, or None if no derived message matches ``message_id``.
+    Adapters aren't wired to call this yet; it's exercised directly by tests
+    and available for later integration.
     """
     stored_content = row.get("content") or {}
     node_metadata = row.get("node_metadata") or {}

--- a/lionagi/state/artifact_verifier.py
+++ b/lionagi/state/artifact_verifier.py
@@ -299,20 +299,16 @@ def stale_artifact_markers(
     """Cheaply flag whether a recorded verdict's produced artifacts may no
     longer match what was on disk at `checked_at`.
 
-    This never re-verifies pass/fail — it only checks mtime+size and presence
-    for the artifacts the recorded verdict already found, so a caller can
-    label the verdict's currency instead of presenting a completion-time
-    snapshot as current state. Comparing size alongside mtime (both already
-    available from a single `stat()` call, so this stays a cheap read-time
-    check rather than a re-verify) narrows, though does not close, the
-    false-negative window a bare mtime check would have against a rewrite
-    that preserves both mtime and size.
-
-    Returns None only when the check cannot be performed at all — no
-    `artifacts_root`, or a verdict missing the `checked_at`/`produced` fields
-    the check needs (e.g. a payload recorded before this check existed). The
-    caller uses that to report an explicit unknown state rather than
-    silently treating an unchecked verdict as clean.
+    Never re-verifies pass/fail -- only checks mtime+size and presence for
+    the artifacts the recorded verdict already found (both from one
+    `stat()` call), so a caller can label the verdict's currency instead of
+    presenting a completion-time snapshot as current state. Comparing size
+    alongside mtime narrows, but doesn't close, the false-negative window a
+    bare mtime check would have against a rewrite that preserves both.
+    Returns None only when the check can't be performed at all -- no
+    `artifacts_root`, or a verdict missing the fields it needs -- so the
+    caller can report an explicit unknown state rather than treating an
+    unchecked verdict as clean.
     """
     if not artifacts_root:
         return None

--- a/lionagi/state/claude_mirror.py
+++ b/lionagi/state/claude_mirror.py
@@ -224,20 +224,20 @@ async def mirror_session(
     event_sources: list[tuple[int, int, str]] | None = None,
     max_preview_chars: int | None = None,
 ) -> int:
-    """Idempotently write a batch of Claude events for one session; returns msgs written.
-    Live/idle transitions are owned by ``reconcile_session_status``, not this writer.
+    """Idempotently write a batch of Claude events for one session; returns
+    msgs written. Live/idle transitions are owned by
+    ``reconcile_session_status``, not this writer.
 
-    ``event_sources`` is the per-event ``(byte_offset, byte_count, sha256)`` of each
-    raw JSONL line in ``events`` (same order/length), and ``source_path`` is the
-    transcript file they came from. When both are given together with
-    ``max_preview_chars``, every message's content is bounded via
-    ``bound_mirror_content`` before it is written, with a resolvable source pointer
-    on ``node_metadata.mirror_source``. Omitting them keeps the legacy unbounded
-    write, for callers with no live transcript file behind the events.
-
-    ``cwd`` is the transcript's own working directory -- the CLI's artifact root
-    (issue #2848) -- written to ``artifacts_path`` on create, and backfilled on an
-    existing row that lacks one without ever overwriting one that is already set.
+    ``event_sources`` is the per-event ``(byte_offset, byte_count, sha256)``
+    of each raw JSONL line in ``events`` (same order/length), and
+    ``source_path`` is the transcript file they came from. When both are
+    given together with ``max_preview_chars``, message content is bounded
+    via ``bound_mirror_content`` with a resolvable pointer on
+    ``node_metadata.mirror_source``; omitting them keeps the legacy
+    unbounded write. ``cwd`` is the transcript's own working directory --
+    the CLI's artifact root -- written to ``artifacts_path`` on create, and
+    backfilled on an existing row that lacks one without overwriting one
+    already set.
     """
     sid = session_db_id(session_uid)
     branch_id = _det(session_uid, "branch")
@@ -400,21 +400,19 @@ async def link_escalation_session(
 ) -> bool:
     """Attribute a mirrored CLI transcript to the run whose escalation spawned it.
 
-    A flow escalation (``operations.flow._schedule_escalation``) retries a node on a
-    higher-tier CLI engine as an in-session child op; the engine's own transcript is
-    mirrored independently (by this module, possibly in another process) under a
-    session uid the mirror has no way to connect back to the run. The escalation call
-    site learns that uid once the child op's branch reports it
-    (``branch.chat_model.provider_session_id``) and calls this to stamp the link —
-    overwriting the mirror's cwd-guessed ``project`` and first-prompt-derived ``name``,
-    which are wrong for an escalation leg by construction: its transcript's ``cwd`` is
-    the leg's scratch workspace, not a project, and its first prompt is the injected
-    escalation guidance, not a task description. The mirror never revisits either
-    field once a session row exists, so this write is never clobbered by a later sweep.
-
-    Returns ``False`` if the mirror hasn't created the session row yet — the escalation
-    call site is expected to retry for a bounded window rather than lose the link,
-    since which side writes first is a race with no fixed winner.
+    A flow escalation retries a node on a higher-tier CLI engine as an
+    in-session child op; that engine's transcript is mirrored independently
+    (possibly in another process) under a session uid the mirror can't
+    connect back to the run. The escalation call site learns the uid once
+    the child op's branch reports it and calls this to stamp the link,
+    overwriting the mirror's cwd-guessed ``project`` and first-prompt-derived
+    ``name`` -- both wrong for an escalation leg by construction, since its
+    ``cwd`` is a scratch workspace and its first prompt is injected guidance,
+    not a task description. The mirror never revisits either field once a
+    session row exists, so this write is never clobbered later. Returns
+    False if the mirror hasn't created the session row yet; the caller is
+    expected to retry for a bounded window, since which side writes first is
+    an unresolved race.
     """
     sid = session_db_id(session_uid)
     existing = await db.get_session(sid)

--- a/lionagi/state/codex_mirror.py
+++ b/lionagi/state/codex_mirror.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Mirror Codex CLI/app rollouts (~/.codex/sessions/**/rollout-*.jsonl) into StateDB,
-one lionagi message per conversation record, under deterministic ids.
+"""Mirror Codex CLI/app rollouts (~/.codex/sessions/**/rollout-*.jsonl) into
+StateDB, one lionagi message per conversation record, under deterministic ids.
 
-Reads the enveloped rollout format, where each line is ``{type, timestamp, payload}``.
-Rollouts written before 2025-09-20 use a flat format with no envelope, and mirror
-nothing; that was measured over the whole local corpus rather than sampled, at 6 files
-out of 29,652. Such a file still gets a session row carrying its counts, because a
-rollout that mirrors nothing is the case the per-type count pair exists to expose and
-a row is what there is to subtract against.
+Reads the enveloped rollout format, where each line is ``{type, timestamp,
+payload}``. Rollouts written before 2025-09-20 use a flat, unenveloped format
+and mirror nothing (measured at 6 files out of 29,652 in the local corpus);
+such a file still gets a session row carrying its (zero) counts, since a row
+is what a completeness check has to subtract against.
 """
 
 from __future__ import annotations
@@ -121,15 +120,12 @@ _TURN_FIELDS = ("model", "effort", "turn_id")
 class RecordTally:
     """Per-record-type counts from both sides of one file's import.
 
-    Completeness is then a subtraction any consumer can do — ``seen`` minus
-    ``mirrored``, per type — rather than a narrative the importer writes about
-    itself. A self-report goes stale silently when the importer's behaviour
-    changes; two numbers that disagree cannot.
-
-    ``unparseable`` is deliberately its own count and never folded into a type's
-    skip. A line that could not be read is not a line deliberately not mirrored,
-    and rolling the two together makes the subtraction stop discriminating exactly
-    where a corpus is damaged.
+    Completeness is a subtraction any consumer can do (``seen`` minus
+    ``mirrored``, per type) rather than a self-report that can go stale
+    silently. ``unparseable`` is its own count, never folded into a type's
+    skip, since a line that couldn't be read is not a line deliberately not
+    mirrored -- rolling the two together would hide exactly where a corpus
+    is damaged.
     """
 
     seen: dict[str, int] = field(default_factory=dict)
@@ -416,20 +412,18 @@ async def mirror_session(
 ) -> tuple[int, RecordTally]:
     """Idempotently write a batch of codex records for one rollout.
 
-    Returns the messages written and the tally for this batch. ``turn`` is the
-    turn_context carried in from the previous batch, so attribution survives a
-    file being mirrored across several passes; it is updated in place as records
-    are walked. ``source_path`` is the rollout file this batch came from, stamped
-    into the session's provenance so any row resolves back to its file.
-
-    ``event_sources`` is the per-record ``(byte_offset, byte_count, sha256)`` of
-    each raw JSONL line in ``records`` (same order/length). When both it and
-    ``max_preview_chars`` are given, every message's content is bounded via
-    ``bound_mirror_content`` before it is written, with a resolvable source
-    pointer on ``node_metadata.mirror_source``. Omitting them keeps the legacy
-    unbounded write, for callers with no live rollout file behind the records.
-
-    Live/idle transitions are owned by ``reconcile_session_status``, not this writer.
+    Returns the messages written and the tally for this batch. ``turn`` is
+    the turn_context carried in from the previous batch (updated in place as
+    records are walked), so attribution survives a file being mirrored
+    across several passes. ``source_path`` is stamped into the session's
+    provenance so any row resolves back to its file. ``event_sources`` is
+    the per-record ``(byte_offset, byte_count, sha256)`` of each raw JSONL
+    line in ``records`` (same order/length); when both it and
+    ``max_preview_chars`` are given, message content is bounded via
+    ``bound_mirror_content`` with a resolvable pointer on
+    ``node_metadata.mirror_source`` -- omitting them keeps the legacy
+    unbounded write. Live/idle transitions are owned by
+    ``reconcile_session_status``, not this writer.
     """
     sid = session_db_id(rollout_uid)
     branch_id = _det(rollout_uid, "branch")

--- a/lionagi/state/content_pruned.py
+++ b/lionagi/state/content_pruned.py
@@ -3,26 +3,17 @@
 
 """The marker a reclaimed message body leaves in its place.
 
-Freeing space by emptying a message's content has one failure mode that
-matters, and it is not losing the text. It is losing the fact that text was
-ever there. A body written as an empty string, or as ``{}``, is exactly what a
-turn that genuinely produced nothing writes, so a reader handed one cannot say
-which it is looking at, and neither can anything above it: nothing downstream
-has a second source for that distinction, so the two collapse into one state
-permanently and silently.
-
-A reclaimed body is therefore not emptied. It is replaced by a value that says
-what it is and what used to be there, and this module is the vocabulary both
-sides use. The writer is ``li state null-content``; the readers are whatever
-displays or counts message bodies. Kept out of ``db.py`` so asking the question
-costs a reader nothing but this import.
-
-A marker records ``at`` and ``original_bytes``, and ``original_bytes`` is the
-size of the body THAT ROW held rather than an average over whatever batch it was
-reclaimed in. That is a property of how the marker is written -- see
-``pruned_content_sql`` -- and it is stated here because this is the docstring a
-reader of the marker reaches for, and a per-row name over a batch number would
-fabricate exactly the kind of fact the marker exists to preserve.
+Emptying a message's content to free space risks losing not the text but the
+fact that text was ever there: an empty string or ``{}`` is exactly what a
+turn that genuinely produced nothing writes, so a reader can't tell the two
+apart once collapsed. A reclaimed body is therefore never emptied -- it's
+replaced by a marker that says what it is and what used to be there. This
+module is the vocabulary both sides use: the writer is ``li state
+null-content``; the readers are whatever displays or counts message bodies.
+Kept out of ``db.py`` so asking the question costs a reader nothing but this
+import. The marker records ``at`` and ``original_bytes`` -- the size of the
+body that specific row held, not an average over a batch (see
+``pruned_content_sql``).
 """
 
 from __future__ import annotations
@@ -47,19 +38,13 @@ CONTENT_PRUNED_KEY = "lion_content_pruned"
 def pruned_content_sql(*, at_param: str = "at", size_expr: str = "LENGTH(content)") -> str:
     """The marker as a SQL expression, evaluated per row against the row it replaces.
 
-    A marker records ``at`` and ``original_bytes``. The size is built from an
-    expression over the row being replaced rather than passed in, and that is the
-    whole reason this is SQL rather than a dict: the database can read each old
-    body's length while overwriting it, in one statement, so ``original_bytes``
-    is the row's OWN size.
-
-    The alternative -- computing one size in Python and writing the same marker
-    everywhere -- makes the field a batch average wearing a per-row name. That
-    number is not wrong so much as answering a different question than its label,
-    which is the failure the marker exists to prevent rather than commit.
-
-    ``size_expr`` is a caller-supplied SQL fragment and is not a place to put
-    anything a caller did not write; the default is the only production use.
+    The size is built from a SQL expression over the row being replaced,
+    rather than computed once in Python and reused, which is the whole
+    reason this returns SQL rather than a dict: the database reads each old
+    body's length while overwriting it, in one statement, so
+    ``original_bytes`` is genuinely the row's own size and not a batch
+    average wearing a per-row name. ``size_expr`` is a caller-supplied SQL
+    fragment; the default is the only production use.
     """
     return (
         f"json_object('{CONTENT_PRUNED_KEY}', "
@@ -70,21 +55,16 @@ def pruned_content_sql(*, at_param: str = "at", size_expr: str = "LENGTH(content
 def content_was_pruned(content: Any) -> bool:
     """True when this body was reclaimed, as opposed to having been empty.
 
-    Takes the column either raw (the JSON text SQLite stores) or hydrated (the
-    dict a reader has already parsed), because those reach consumers by
-    different routes and a predicate that only served one of them would answer
-    "no" for the other -- which is the same wrong answer as having no marker at
-    all, arrived at more expensively.
-
-    Anything unparseable is not reclaimed. This says nothing about the body
-    being well-formed; it answers one question only.
+    Takes the column either raw (JSON text as SQLite stores it) or hydrated
+    (a dict a reader already parsed), since those reach consumers by
+    different routes. Anything unparseable is treated as not reclaimed; this
+    says nothing about whether the body is well-formed, it answers one
+    question only.
     """
     if isinstance(content, str):
-        # A marker is a few dozen bytes and a body can be megabytes. The
-        # substring test is what keeps this from parsing every row it is handed
-        # -- and it only ever short-circuits to False, so a body that merely
-        # mentions the key still goes through the parse below and is judged on
-        # its structure rather than on its text.
+        # Cheap substring test before parsing -- a marker is a few dozen
+        # bytes, a body can be megabytes. Only ever short-circuits to False,
+        # so a body that merely mentions the key still gets parsed below.
         if CONTENT_PRUNED_KEY not in content:
             return False
         try:

--- a/lionagi/state/db.py
+++ b/lionagi/state/db.py
@@ -136,25 +136,20 @@ _IMPORTED_ROLE_LABEL_BACKFILL_KEY = "migration.imported_role_label_backfill"
 
 
 class SchemaTooNewError(RuntimeError):
-    """The database records a schema version this code does not understand.
+    """``schema_meta.version`` is higher than ``SCHEMA_VERSION``.
 
-    Raised by a writable open when ``schema_meta.version`` is higher than
-    ``SCHEMA_VERSION``. A writable open rewrites the database into the shape
-    this code applies and then stamps that shape into the version row; neither
-    step has established anything about a shape written by a later release, so
-    both are refused rather than performed blind. Read-only opens apply no
-    schema and are unaffected.
+    Raised only by a writable open, which would otherwise rewrite the database
+    into a shape this code understands and stamp that shape into the version
+    row — blind, since a later release's shape is unknown here. Read-only
+    opens apply no schema and are unaffected.
     """
 
 
 def state_db_file() -> Path | None:
-    """The local file a default ``StateDB()`` would open, if it opens one at all.
+    """The local file a default ``StateDB()`` would open, or None.
 
-    Resolved the same way ``StateDB.__init__`` resolves it, so the two cannot
-    disagree about which store is in play. Returns None when the configured
-    store is not a local file — a server, or an in-memory database — because
-    then there is no path to report and nothing a filesystem check can say
-    about it.
+    Resolved the same way ``StateDB.__init__`` resolves it. None when the
+    configured store is not a local file (server, or in-memory).
     """
     raw = settings.LIONAGI_STATE_DB_URL
     if raw is None:
@@ -173,63 +168,48 @@ def state_db_file() -> Path | None:
 def read_only_open_supported() -> bool:
     """Whether ``StateDB(readonly=True)`` can open the configured store at all.
 
-    Read-only mode is SQLite-only by contract: it is an ``mode=ro`` URI open of
-    an existing file, and ``make_readonly_engine()`` rejects every other
-    dialect. ``StateDB.open()``'s read-only branch is not dialect-gated, so an
-    unconditional ``readonly=True`` does not degrade on a server-backed store,
-    it fails at open. Callers that want read-only as an optimisation, rather
-    than as a safety requirement, pass this instead of True and take the
-    ordinary open where read-only is unavailable.
+    Read-only mode is SQLite-only: an ``mode=ro`` URI open of an existing
+    file. ``StateDB.open()``'s read-only branch is not dialect-gated, so an
+    unconditional ``readonly=True`` fails at open rather than degrading on a
+    server-backed store. Callers that want read-only as an optimisation
+    (not a safety requirement) check this first and fall back to the
+    ordinary open when it's unavailable; callers that need read-only for
+    safety must NOT use this, since it hands them a writable connection on
+    the stores it returns False for.
 
-    Callers that need read-only for safety must NOT use this: it hands them a
-    writable connection on the stores it returns False for, which is the
-    opposite of what they asked for.
-
-    ``state_db_file()`` returns a path exactly when the configured store is an
-    on-disk SQLite file, which is the set read-only mode accepts for any URL an
-    async engine can be built from at all. It is not literally the same set:
-    ``make_readonly_engine()`` also requires the ``sqlite+aiosqlite:///``
-    spelling, and an unrecognised driver such as ``sqlite+pysqlite:///`` passes
-    ``normalize_state_db_url()`` untouched. Such a URL fails the ordinary open
-    too, since a sync driver cannot back an async engine, so it is broken
-    either way and only the exception differs.
+    Not exactly the set ``state_db_file()`` returns a path for: an
+    unrecognised sync driver spelling (e.g. ``sqlite+pysqlite:///``) also
+    fails the ordinary open, since a sync driver can't back an async engine,
+    so it's broken either way and only the exception differs.
     """
     return state_db_file() is not None
 
 
 def state_db_known_absent() -> bool:
-    """Whether the store a default ``StateDB()`` would open is known not to exist.
+    """Whether the store a default ``StateDB()`` would open is known absent.
 
-    Callers use this to tell "there is no store, so there is no record of
-    anything" apart from "the store is there and something went wrong reading
-    it". Those are different answers and a caller acts differently on each, so
-    the check has to be about the store that will actually be opened. Testing
-    ``DEFAULT_DB_PATH`` instead asks about a file that need not be involved:
-    ``LIONAGI_STATE_DB_URL`` moves the store elsewhere, and then the default
-    path is absent while every row being asked about exists.
-
-    Only a positive answer is confident. Where existence is not a filesystem
-    question this reports False and leaves the open attempt to give the real
-    answer.
+    Distinguishes "no store, so no record of anything" from "the store is
+    there and something went wrong reading it" — callers act differently on
+    each. Checks the store that will actually be opened (honoring
+    ``LIONAGI_STATE_DB_URL``), not the default path. Only a positive answer
+    is confident; where existence isn't a filesystem question this returns
+    False and leaves the open attempt to give the real answer.
     """
     path = state_db_file()
     return path is not None and not path.exists()
 
 
-# The single definition of which schedule_run statuses count as "fired and
-# resolved" for budget bookkeeping (max_runs, one-shot auto-disable). The
-# scheduler service layer must observe the same set — both its defaults and
-# this one point here so they cannot drift. 'timed_out' counts: a reaped run
-# fired and consumed real work. 'skipped' (never ran) and 'running' (not yet
-# resolved) do not; admission paths that need in-flight rows opt in
+# Schedule-run statuses counted as "fired and resolved" for budget bookkeeping
+# (max_runs, one-shot auto-disable). The scheduler service layer's defaults
+# must match this set. 'timed_out' counts: a reaped run consumed real work.
+# 'skipped' and 'running' don't; admission paths needing in-flight rows opt in
 # explicitly with ("running", *TERMINAL_RUN_STATUSES).
 TERMINAL_RUN_STATUSES: tuple[str, ...] = ("completed", "failed", "cancelled", "timed_out")
 
-# Lifecycle states that count as "a run actually executed", for health/evidence
-# reads that must not mistake a pending row for proof anything happened.
-# 'running' is included even though it isn't terminal -- it has started.
-# 'queued', 'waiting_dependency' and 'retry_wait' (ADR-0071's durable queue)
-# are pending, not evidence, exactly like 'skipped' already was.
+# Statuses counted as "a run actually executed", for health/evidence reads
+# that must not mistake a pending row for proof anything happened. 'running'
+# counts even though it isn't terminal — it has started. Queued/waiting
+# statuses are pending, not evidence, like 'skipped'.
 EXECUTED_RUN_STATUSES: tuple[str, ...] = ("running", *TERMINAL_RUN_STATUSES)
 
 _VALID_STATUS_SOURCES: frozenset[str] = frozenset({"executor", "agent", "admin", "system"})
@@ -390,7 +370,7 @@ ADMIN_TRANSITION_TARGETS = frozenset({"failed", "aborted", "cancelled"})
 
 _SESSION_STATUSES = VALID_SESSION_STATUSES
 
-# ── ADR-0035 terminal-status vocabulary ────────────────────────────────
+# Terminal-status vocabulary
 # Terminal-state definitions live here, with the record schema, rather than
 # in any one CLI surface — update_status() enforces them uniformly for
 # every entity_type at the single write path; `li wait` reads the same
@@ -405,7 +385,7 @@ TERMINAL_STATUSES_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
 SESSION_TERMINAL_STATUSES = TERMINAL_STATUSES_BY_ENTITY_TYPE["session"]
 
 # Terminal branches.status values. branches has no lifecycle-policy entry of
-# its own (it never goes through update_status()'s ADR-0035 machinery) — but
+# its own (it never goes through update_status()'s status-integrity machinery) — but
 # every status finalize_branch() ever receives is a session final_status
 # passed straight through by cli/_runs.py teardown_persist(), so this IS
 # SESSION_TERMINAL_STATUSES, not a second hand-maintained list that could
@@ -442,7 +422,7 @@ EXTRA_STATUS_WRITE_FIELDS_BY_ENTITY_TYPE: dict[str, frozenset[str]] = {
     "play": frozenset({"ended_at"}),
 }
 
-# ── ADR-0035 status vocabulary (valid, not just terminal) ──────────────
+# Status vocabulary (valid, not just terminal)
 # update_status() rejects any new_status outside its entity_type's set here —
 # the terminal-overwrite floor above stops a terminal record from moving;
 # this stops ANY record (terminal or not) from being written to a status
@@ -580,23 +560,17 @@ def _install_begin_immediate(sync_engine) -> None:
 async def _restore_foreign_keys(conn, driver) -> None:
     """Turn foreign-key enforcement back on after a legacy table rebuild.
 
-    Every rebuild calls this from its ``finally``, so it runs on the failure
-    paths too, and those are the ones that need the care. Two things can leave a
-    pooled connection with enforcement silently off:
-
-    ``PRAGMA foreign_keys`` is a no-op while a transaction is open, so a rollback
-    that itself failed leaves its transaction alive and the pragma inert. Any
-    surviving transaction is therefore closed first.
-
-    And a write is not a result. The setting is read back rather than assumed,
-    and a connection whose enforcement cannot be confirmed is invalidated so it
-    is never handed out again.
-
-    Cancellation gets its own handling rather than falling through. It arrives as
-    a BaseException, so catching ``Exception`` would let it skip the read-back and
-    the invalidation both, which is the one outcome this function exists to
-    prevent. The invalidation is shielded so it completes, and the cancellation is
-    then re-raised untouched.
+    Called from every rebuild's ``finally``, including failure paths, since
+    those are the ones that need the care. Two things can leave a pooled
+    connection with enforcement silently off: ``PRAGMA foreign_keys`` is a
+    no-op while a transaction is open, so a failed rollback that leaves its
+    transaction alive makes the pragma inert (any surviving transaction is
+    closed first); and a write is not a result, so the setting is read back
+    rather than assumed, and a connection whose enforcement can't be
+    confirmed is invalidated so it's never handed out again. Cancellation is
+    handled separately (not via a blanket ``except Exception``, which would
+    swallow it) so the read-back/invalidation still runs, shielded, before
+    the cancellation is re-raised.
     """
     cancelled_exc = get_cancelled_exc_class()
 
@@ -714,7 +688,7 @@ class StateDB:
             ),
         )
 
-    # ── backward-compat path property ─────────────────────────────────
+    # backward-compat path property
 
     @property
     def path(self) -> Path | None:
@@ -726,7 +700,7 @@ class StateDB:
             return Path(":memory:") if suffix == ":memory:" else None
         return None
 
-    # ── Connection lifecycle ───────────────────────────────────────────
+    # Connection lifecycle
 
     async def open(self) -> None:
         if self._engine is not None:
@@ -780,7 +754,7 @@ class StateDB:
     async def __aexit__(self, *exc: Any) -> None:
         await self.close()
 
-    # ── Internal connection helpers ────────────────────────────────────
+    # Internal connection helpers
 
     @asynccontextmanager
     async def _read(self):
@@ -798,7 +772,7 @@ class StateDB:
             async with self._engine.begin() as conn:
                 yield conn
 
-    # ── Public query surface (portable across both dialects) ───────────
+    # Public query surface (portable across both dialects)
     # Replaces direct `db.db.execute(...)` access from CLI/studio consumers.
     # Accepts the legacy qmark (?) form with a sequence of params, or named
     # (:name) SQL with a dict; SQLAlchemy translates the paramstyle per dialect.
@@ -893,7 +867,7 @@ class StateDB:
         row = await self._raw_sqlite_exec(f"PRAGMA wal_checkpoint({mode})", fetch=True)
         return tuple(row) if row is not None else None
 
-    # ── Schema management ──────────────────────────────────────────────
+    # Schema management
 
     def _raise_if_schema_too_new(self, recorded: str | None) -> None:
         if recorded is None:
@@ -980,7 +954,7 @@ class StateDB:
             # existing DBs created before the completion-trust gate carry a
             # 6-value CHECK on invocations.status that omits 'completed_empty'.
             await self._drop_legacy_invocations_status_check()
-            # ADR-0071 D2: existing DBs carry a 5-value CHECK on
+            # Existing DBs carry a 5-value CHECK on
             # schedule_runs.status and a NOT NULL schedule_id, from before
             # schedule_runs was generalized into the task-application entity.
             await self._drop_legacy_schedule_runs_check()
@@ -1093,30 +1067,20 @@ class StateDB:
             await self._backfill_dispatched_at(conn)
 
     async def _backfill_dispatched_at(self, conn) -> None:
-        """Set the dispatch marker on running rows that predate its backfill.
+        """Stamp ``dispatched_at`` on pre-existing running rows, once.
 
-        ``dispatched_at`` is only stamped going forward, by
-        ``SchedulerEngine._mark_dispatched()``. Without a backfill, every row
-        left at ``status = 'running'`` from before this column existed would
-        have ``dispatched_at IS NULL`` -- indistinguishable from a row whose
-        launch genuinely never got confirmed. ``list_undispatched_schedule_
-        runs()`` (consumed by ``SchedulerEngine._recover_undispatched_
-        fires()`` on the next daemon startup) would then treat every such row
-        as crashed-before-dispatch and re-fire it, even one that is still
-        genuinely executing across the upgrade restart.
-
-        Stamping ``dispatched_at`` to the row's own ``fired_at`` (NOT NULL by
-        schema) excludes these pre-existing rows from that scan -- the same
-        "no signal to distinguish, so don't auto-retry" resolution
-        ``_backfill_action_cwd()`` applies to ``action_cwd``. A still-running
-        row is left alone (nothing re-fires it); a row that actually crashed
-        pre-migration falls through to ``reap_stale_schedule_runs()``'s
-        wall-clock deadline instead of being auto-retried on ambiguous
-        evidence. Scoped to ``schedule_id IS NOT NULL`` to match
-        ``list_undispatched_schedule_runs()`` and leave the leased ad-hoc
-        task queue (its own dispatch/lease model) untouched. A durable
-        ``schema_meta`` marker makes this a one-time migration even when an
-        earlier release already added the column without running the update.
+        Without this, a ``status = 'running'`` row from before the column
+        existed has ``dispatched_at IS NULL`` -- indistinguishable from a
+        launch that never got confirmed, which ``list_undispatched_schedule_
+        runs()`` would then re-fire on the next daemon startup even though
+        it's still genuinely executing. Stamped to the row's own
+        ``fired_at`` (NOT NULL by schema) to exclude it from that scan,
+        matching ``_backfill_action_cwd()``'s "no signal, so don't
+        auto-retry" resolution; a row that actually crashed pre-migration
+        still falls through to ``reap_stale_schedule_runs()``'s wall-clock
+        deadline. Scoped to ``schedule_id IS NOT NULL`` to leave the ad-hoc
+        task queue's own dispatch/lease model untouched. See
+        docs/internals/state-db.md for the full backfill rationale.
         """
         await conn.execute(
             text(
@@ -1141,22 +1105,15 @@ class StateDB:
     async def _backfill_imported_role_label(self, conn) -> None:
         """Null out ``agent_name`` on rows imported from a desktop transcript.
 
-        The mirror used to write the engine name into ``agent_name``, which is
-        a role field. Stopping that write only fixes imports from here on:
-        rows already in the store keep the engine label, and because the role
-        tier sits ahead of the prompt tier in ``resolve_display_name`` they
-        would keep rendering the engine forever while new imports rendered
-        their prompt. That split is worse than either state on its own,
-        because the surface looks fixed.
-
-        Scoped by ``source_kind``, not by the label's value. Selecting on
-        ``agent_name = 'codex'`` would be selecting on the symptom: a live
-        session legitimately running a role of that name would be caught by
-        it, whereas ``source_kind`` names the thing that actually makes the
-        field meaningless. Branch rows are reached through their session for
-        the same reason -- the branches table has no ``source_kind`` of its
-        own, so its rows are identified by the session they belong to rather
-        than by what they happen to contain.
+        The mirror used to write the engine name into ``agent_name`` (a role
+        field); stopping that write only fixes imports from here on, so
+        already-stored rows are backfilled here to avoid a permanent split
+        where old imports render the engine name and new ones render the
+        prompt (``resolve_display_name`` checks role before prompt). Scoped
+        by ``source_kind`` rather than the label's value, since a live
+        session can legitimately run a role literally named "codex". Branch
+        rows are reached through their session because branches has no
+        ``source_kind`` of its own.
         """
         await conn.execute(
             text(
@@ -1185,38 +1142,23 @@ class StateDB:
         """Give every pre-existing attention-disposition row the shape the
         fencing/ordering added after it now assumes.
 
-        ``attention_dispositions`` and ``attention_disposition_history``
-        shipped in an earlier release that never bumped ``SCHEMA_VERSION``;
-        a later release added ``revision``, ``sequence``, and the
-        ``attention_disposition_revisions`` ledger on top without a
-        migration. ``metadata.create_all()`` only creates *missing* tables,
-        so a store that already had the first two tables gained the new
-        columns' ``ALTER TABLE ... DEFAULT`` placeholder (1 and 0) but never
-        their real values -- this runs once (via the ``schema_meta`` claim
-        in ``_backfill_attention_dispositions_once``) to fill them in:
-
-        1. ``sequence`` is assigned in ``(created_at, id)`` order -- the same
-           tie-break ``_next_history_sequence`` would have used had the
-           column existed when each row was written -- so history reads
-           that already depend on ``ORDER BY sequence`` see rows in their
-           original append order instead of raising on the missing column.
-        2. ``attention_dispositions.revision`` is raised from the placeholder
-           1 to the item_id's true operation count (its row count in
-           ``attention_disposition_history``), so a client that already
-           echoed back a revision from before this migration ran is not
-           handed a lower one that reads as a rollback.
-        3. ``attention_disposition_revisions`` is seeded for every
-           currently-active item_id at that same count, so the next PUT/
-           DELETE continues the ledger from there instead of restarting it
-           at 0 and silently disagreeing with the row's own (just-backfilled)
-           revision.
-        4. ``attention_disposition_revisions`` is also seeded for item_ids
-           that exist only in history -- acknowledged (or otherwise set)
-           and then undone (DELETE) before this migration ran -- whose
-           latest recorded transition is delete-shaped (``new_state ==
-           'open'``). Without this, the fence has no row to check: a PUT
-           that predates the pre-migration DELETE and is replayed after the
-           upgrade would recreate the disposition instead of being rejected.
+        ``metadata.create_all()`` only creates missing tables, so a store
+        that already had ``attention_dispositions`` /
+        ``attention_disposition_history`` gained the later ``revision``/
+        ``sequence``/``attention_disposition_revisions`` columns as inert
+        ``DEFAULT`` placeholders, never their real values. This runs once
+        (via the ``schema_meta`` claim in
+        ``_backfill_attention_dispositions_once``) to fill them in:
+        ``sequence`` is assigned in ``(created_at, id)`` order so
+        ``ORDER BY sequence`` reads see original append order;
+        ``revision`` is raised to the item_id's true history row count so a
+        client's already-echoed revision never reads as a rollback;
+        ``attention_disposition_revisions`` is seeded at that same count for
+        every active item_id, and also for item_ids that exist only in
+        history with a delete-shaped latest transition, so a pre-migration
+        PUT replayed after upgrade is rejected by the fence rather than
+        recreating the disposition. Full rationale in
+        docs/internals/state-db.md.
         """
         hist_rows = (
             (
@@ -1491,12 +1433,12 @@ class StateDB:
             _rebuild,
         )
 
-    # Substring present only in the post-#1174 schedules CREATE SQL;
+    # Substring present only in the current schedules CREATE SQL;
     # its absence indicates a legacy DB whose action_kind CHECK needs rebuilding.
     _LEGACY_SCHEDULES_FLOW_YAML_MARKER = "'flow_yaml'"
 
     async def _drop_legacy_action_kind_check(self) -> None:
-        """Rebuild ``schedules`` if it still carries the pre-#1174 action_kind CHECK.
+        """Rebuild ``schedules`` if it still carries the legacy action_kind CHECK.
 
         The old CHECK omits ``'flow_yaml'``; SQLite cannot drop a constraint via
         ALTER TABLE, so we use the rename → CREATE new → INSERT SELECT → DROP
@@ -1548,29 +1490,15 @@ class StateDB:
         rebuild_table = _schedules_table.to_metadata(MetaData(), name="schedules_new")
         create_stmt = str(CreateTable(rebuild_table).compile(dialect=self._engine.dialect))
 
-        # ``schedules`` is an FK target (schedule_runs.schedule_id ON DELETE
-        # CASCADE): dropping it while `PRAGMA foreign_keys` is enforced
-        # cascades away every schedule_runs row that referenced it, even
-        # with the rows already safely copied into the new table first.
-        # `engine.begin()` opens its transaction before our first statement
-        # runs, and SQLite treats `PRAGMA foreign_keys` as a no-op inside a
-        # pending transaction -- so toggling it through a normal SQLAlchemy
-        # connection never actually takes effect (verified: it silently
-        # cascade-deleted schedule_runs rows in this exact rebuild before
-        # this fix). Go through the raw driver connection instead (same
-        # technique as ``_drop_legacy_invocations_status_check``) so the
-        # pragma flip is real autocommit, not swallowed by an open txn.
-        #
-        # The pragma flip itself must stay OUTSIDE any transaction (SQLite
-        # only honors it between transactions), but the CREATE/copy/DROP/
-        # RENAME/index sequence that follows needs its own explicit
-        # transaction: running those as independent autocommit statements
-        # left a failure between DROP and RENAME (cancellation, I/O error,
-        # a bad index statement) with only `schedules_new` on disk --
-        # `metadata.create_all` would then create a fresh *empty*
-        # `schedules` on the next open, stranding every original row.
-        # `BEGIN IMMEDIATE` reclaims the atomicity the old `engine.begin()`
-        # path had, without reintroducing the pragma-inside-transaction bug.
+        # ``schedules`` is an FK target with ON DELETE CASCADE, so dropping it
+        # while foreign keys are enforced cascades away schedule_runs rows
+        # even after they're copied into the new table. `PRAGMA foreign_keys`
+        # is a no-op inside a pending transaction in SQLite, so it must be
+        # toggled through the raw driver connection (autocommit) rather than
+        # a normal SQLAlchemy connection -- see docs/internals/state-db.md
+        # for the failure this fixes and why the rebuild then needs its own
+        # explicit `BEGIN IMMEDIATE` transaction around CREATE/copy/DROP/
+        # RENAME/index rather than independent autocommit statements.
         async def _rebuild() -> None:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
@@ -1668,29 +1596,15 @@ class StateDB:
         rebuild_table = _schedules_table.to_metadata(MetaData(), name="schedules_new")
         create_stmt = str(CreateTable(rebuild_table).compile(dialect=self._engine.dialect))
 
-        # ``schedules`` is an FK target (schedule_runs.schedule_id ON DELETE
-        # CASCADE): dropping it while `PRAGMA foreign_keys` is enforced
-        # cascades away every schedule_runs row that referenced it, even
-        # with the rows already safely copied into the new table first.
-        # `engine.begin()` opens its transaction before our first statement
-        # runs, and SQLite treats `PRAGMA foreign_keys` as a no-op inside a
-        # pending transaction -- so toggling it through a normal SQLAlchemy
-        # connection never actually takes effect (verified: it silently
-        # cascade-deleted schedule_runs rows in this exact rebuild before
-        # this fix). Go through the raw driver connection instead (same
-        # technique as ``_drop_legacy_invocations_status_check``) so the
-        # pragma flip is real autocommit, not swallowed by an open txn.
-        #
-        # The pragma flip itself must stay OUTSIDE any transaction (SQLite
-        # only honors it between transactions), but the CREATE/copy/DROP/
-        # RENAME/index sequence that follows needs its own explicit
-        # transaction: running those as independent autocommit statements
-        # left a failure between DROP and RENAME (cancellation, I/O error,
-        # a bad index statement) with only `schedules_new` on disk --
-        # `metadata.create_all` would then create a fresh *empty*
-        # `schedules` on the next open, stranding every original row.
-        # `BEGIN IMMEDIATE` reclaims the atomicity the old `engine.begin()`
-        # path had, without reintroducing the pragma-inside-transaction bug.
+        # ``schedules`` is an FK target with ON DELETE CASCADE, so dropping it
+        # while foreign keys are enforced cascades away schedule_runs rows
+        # even after they're copied into the new table. `PRAGMA foreign_keys`
+        # is a no-op inside a pending transaction in SQLite, so it must be
+        # toggled through the raw driver connection (autocommit) rather than
+        # a normal SQLAlchemy connection -- see docs/internals/state-db.md
+        # for the failure this fixes and why the rebuild then needs its own
+        # explicit `BEGIN IMMEDIATE` transaction around CREATE/copy/DROP/
+        # RENAME/index rather than independent autocommit statements.
         async def _rebuild() -> None:
             async with self._engine.connect() as conn:
                 driver = (await conn.get_raw_connection()).driver_connection
@@ -1940,7 +1854,7 @@ class StateDB:
         )
 
     async def _backup_before_rebuild(self, label: str) -> None:
-        """Copy the on-disk state.db aside before an in-place table rebuild (ADR-0071 D2).
+        """Copy the on-disk state.db aside before an in-place table rebuild.
 
         No-op for in-memory databases and non-sqlite dialects, where there is no
         single database file to copy. Rollback path: stop the daemon, restore
@@ -1962,13 +1876,13 @@ class StateDB:
         backup_path = p.with_name(f"{p.name}.pre-{label}.{int(time.time())}.bak")
         shutil.copy2(p, backup_path)
 
-    # Substring present only in the post-ADR-0071 schedule_runs CREATE SQL
+    # Substring present only in the current schedule_runs CREATE SQL
     # (the widened status CHECK); its absence indicates a legacy DB whose
     # schedule_runs still carries the 5-value CHECK and a NOT NULL schedule_id.
     _LEGACY_SCHEDULE_RUNS_QUEUE_MARKER = "'waiting_dependency'"
 
     async def _drop_legacy_schedule_runs_check(self) -> None:
-        """Rebuild ``schedule_runs`` if it still carries the pre-ADR-0071 status CHECK.
+        """Rebuild ``schedule_runs`` if it still carries the legacy status CHECK.
 
         SQLite cannot widen a CHECK constraint nor drop a NOT NULL via ALTER
         TABLE, so this uses the same rename → CREATE new → INSERT SELECT →
@@ -2113,7 +2027,7 @@ class StateDB:
                         await driver.execute(idx_sql)
                     for trig_sql in trigger_sqls:
                         await driver.execute(trig_sql)
-                    # New ADR-0071 queue indexes: not part of the pre-rebuild
+                    # New queue indexes: not part of the pre-rebuild
                     # index set, so replaying index_sqls above never creates
                     # them. Create explicitly (idempotent) so a migrated DB ends
                     # up with the same indexes as a freshly-created one.
@@ -2257,7 +2171,7 @@ class StateDB:
             _rebuild,
         )
 
-    # ── Schema version ─────────────────────────────────────────────────
+    # Schema version
 
     async def schema_version(self) -> str | None:
         async with self._read() as conn:
@@ -2268,7 +2182,7 @@ class StateDB:
             )
         return row["value"] if row else None
 
-    # ── Messages ───────────────────────────────────────────────────────
+    # Messages
 
     _UNKNOWN_TYPE_ID = 0
 
@@ -2376,7 +2290,7 @@ class StateDB:
         )
         return row["type_id"]
 
-    # ── Progressions ───────────────────────────────────────────────────
+    # Progressions
 
     async def create_progression(
         self, progression_id: str, collection: list[str] | None = None
@@ -2461,7 +2375,7 @@ class StateDB:
             {"v": message_id, "id": progression_id},
         )
 
-    # ── Sessions ───────────────────────────────────────────────────────
+    # Sessions
 
     async def create_session(self, session: dict[str, Any]) -> None:
         _validate_session_status(session.get("status"))
@@ -2482,7 +2396,7 @@ class StateDB:
         # run) without ever passing through _transition() or the admin CAS —
         # both of which derive duration_ms from started_at/ended_at. Derive
         # it here too so a terminal insert is never the one path that skips
-        # ADR-0035's duration centralization.
+        # duration centralization.
         duration_ms = session.get("duration_ms")
         if (
             duration_ms is None
@@ -2597,26 +2511,19 @@ class StateDB:
         """Point an existing session row at *invocation_id*.
 
         ``create_session``'s ``INSERT ... ON CONFLICT (id) DO NOTHING`` only
-        links a session to its invocation at the moment the row is first
-        inserted; a resume reopens that same row instead of inserting a new
-        one, so its invocation_id would otherwise never be recorded. This is
-        the same sessions.invocation_id + invocations.session_count linkage
-        applied to a row that already exists, guarded so a repeat call (or
-        one that finds the link already current) does not double-count.
-        Repointing away from a prior invocation also decrements that
-        invocation's count, so it stops claiming a session it no longer has.
+        links a session to its invocation at first insert; a resume reopens
+        the same row instead, so its invocation_id would otherwise never be
+        recorded. Applies the same sessions.invocation_id +
+        invocations.session_count linkage to an existing row, guarded so a
+        repeat call doesn't double-count; repointing away from a prior
+        invocation also decrements that invocation's count.
 
         On PostgreSQL the prior-invocation read takes ``FOR UPDATE``: SQLite's
-        ``_tx()`` already serializes writers with its own write lock plus
-        ``BEGIN IMMEDIATE``, so a second attach cannot even start its SELECT
-        until the first has committed. PostgreSQL at READ COMMITTED has no
-        such serialization — a second concurrent attach could read the same
-        prior invocation_id a first attach is about to repoint away from,
-        then decrement that stale value after its own UPDATE's WHERE clause
-        re-evaluates against the row the first attach already moved.
-        Locking the row before reading it forces the second attach to block
-        until the first commits, so it re-reads the invocation the first
-        attach actually left the session on.
+        ``_tx()`` already serializes writers, but PostgreSQL at READ
+        COMMITTED doesn't, so without the row lock a second concurrent
+        attach could read the same prior invocation_id a first attach is
+        about to repoint away from and decrement a now-stale value. Locking
+        first forces the second attach to block until the first commits.
         """
         now = time.time()
         async with self._tx() as conn:
@@ -2721,92 +2628,42 @@ class StateDB:
         return [self._row_to_dict(row) for row in rows]
 
     async def delete_imported_session(self, session_id: str, *, require_source_kind: str) -> bool:
-        """Delete a mirror-imported session and everything the mirror wrote for it:
-        the session row, its branches, their progressions, the messages those
-        progressions hold, and the session's status-transition history. Returns
-        True only when a row was actually deleted.
+        """Delete a mirror-imported session and everything the mirror wrote for
+        it: the session row, its branches, their progressions, the messages
+        those progressions hold, and the session's status-transition history.
+        Returns True only when a row was actually deleted.
 
-        Fails closed on ownership twice over: the row's ``source_kind`` must equal
-        ``require_source_kind`` exactly AND that value must start with
-        ``imported_``. A live run's session is never eligible, and an importer
-        naming its own kind cannot reach a different importer's rows. The kind is
-        a mismatch guard rather than an authorization boundary: a caller that
-        names a valid imported kind tears down rows of that kind, so every
-        importer reconciles its own imports through this one method. Anything a
-        survivor still references is
-        retained, not deleted: messages held by an outside progression or
-        pointed at by a surviving session/branch, and target progressions a
-        survivor's progression_id names (together with their messages) — a
-        reference someone else holds is not this session's to destroy.
+        Fails closed on ownership twice: ``source_kind`` must equal
+        ``require_source_kind`` exactly, and that value must start with
+        ``imported_`` -- a live run's session is never eligible, and one
+        importer can't reach another's rows. A progression or message still
+        referenced by a surviving session/branch is retained, not deleted.
 
-        Concurrency: the retention checks and the deletes they authorise are
-        serialised against every writer that could create a new reference, so a
-        reference that appears after the check cannot be destroyed by the delete.
-        On SQLite the process write lock does this. On PostgreSQL a transaction
-        alone does not: at READ COMMITTED the check reads a snapshot, a
-        concurrent writer can commit a new reference after it, and the delete
-        would then proceed against a set that is no longer accurate. The table
-        lock below closes that window. It is taken NOWAIT, and the transaction
-        also runs under a bounded lock_timeout, so a teardown that cannot hold
-        what it needs gives up rather than queueing behind live writers; both
-        callers treat that as a row to revisit on a later sweep. Bounding the
-        lock waits is what keeps this transaction from sitting in a deadlock
-        cycle with a writer that reaches the same tables in another order. It
-        does not make one impossible, and it is not a deadline for the whole
-        teardown: the guarantee is only that no single lock-acquisition wait
-        lasts long enough to become a detected cycle on a server using
-        PostgreSQL's default deadlock_timeout.
+        Concurrency: retention checks and the deletes they authorise are
+        serialised against every writer that could create a new reference
+        (SQLite: the process write lock; PostgreSQL: an EXCLUSIVE table lock,
+        since READ COMMITTED alone lets a concurrent writer commit a new
+        reference after the check runs). The lock is NOWAIT under a bounded
+        lock_timeout, so a teardown that can't get it gives up and is
+        revisited on a later sweep rather than queueing behind live writers
+        or risking a deadlock. See docs/internals/state-db.md for the full
+        locking rationale shared with the table-lock block below.
         """
         if not require_source_kind.startswith("imported_"):
             return False
         async with self._tx() as conn:
             if self.dialect != "sqlite":
-                # Taken before the first read, so everything read afterwards
-                # stays true for the rest of the transaction and no re-check is
-                # needed. These three tables are exactly the ones a survivor's
-                # reference can live in: a progression's collection holds message
-                # ids, and sessions and branches point progression_id and their
-                # message pointers at rows this teardown would otherwise remove.
-                # EXCLUSIVE conflicts with the ROW EXCLUSIVE that ordinary INSERT
-                # and UPDATE already take, so the writers need no changes and pay
-                # nothing on their own path.
-                #
-                # Two separate guards, because they cover different waits.
-                #
-                # lock_timeout bounds each LOCK-ACQUISITION wait, including the
-                # ones after the table locks are already held -- the soft-FK
-                # nulling below updates artifacts and four other tables, and
-                # those rows can be held by someone else. A wait while holding is
-                # what a deadlock cycle is made of, so bounding it is what keeps
-                # the teardown from sitting in one. It is not a deadline for the
-                # transaction: it caps no single statement's execution, no sum of
-                # successive lock waits, and nothing about commit or connection
-                # checkout. A long statement can still hold all three EXCLUSIVE
-                # locks, and nothing here bounds that. 250ms is chosen against
-                # PostgreSQL's deadlock_timeout, whose default is 1s, so one lock
-                # wait gives up well before the detector runs. It is also meant
-                # to sit above the row-lock holds of the ordinary writers so
-                # everyday contention resolves instead of aborting a teardown;
-                # that second half is the design intent behind the number and is
-                # not something this change measures. A server configured with a
-                # deadlock_timeout below this bound can still detect a cycle
-                # first; the teardown then aborts with a deadlock error rather
-                # than a lock timeout, which
-                # the callers treat identically.
-                #
-                # NOWAIT covers the acquisition itself, where waiting is
-                # pointless rather than merely bounded. A comma-separated LOCK
-                # TABLE takes the three locks one at a time in the written order
-                # rather than atomically, so a blocking form holds one table
-                # while waiting for the next, which closes a cycle with any
-                # writer touching the same tables in a different order.
-                # prune_old_data is exactly such a writer: it updates sessions
-                # before deleting from progressions, the reverse of the order
-                # here.
-                #
-                # The cost falls entirely on this rare teardown: a conflicting
-                # lock aborts the attempt, and both callers log the failure and
-                # retry on a later sweep.
+                # Table lock taken before the first read so the rest of the
+                # transaction can't observe a survivor's reference change
+                # underneath it (branches/progressions/sessions are the only
+                # tables that can hold one). lock_timeout bounds each
+                # acquisition wait against deadlock; NOWAIT makes the initial
+                # LOCK TABLE itself non-blocking, since it locks the three
+                # tables one at a time and a blocking wait there could close a
+                # cycle with prune_old_data's reverse lock order. See
+                # docs/internals/state-db.md for the full reasoning (the
+                # 250ms choice, why it's not a transaction deadline, and the
+                # retry-on-conflict contract both callers rely on).
                 await conn.execute(text("SET LOCAL lock_timeout = '250ms'"))
                 await conn.execute(
                     text("LOCK TABLE branches, progressions, sessions IN EXCLUSIVE MODE NOWAIT")
@@ -3266,14 +3123,10 @@ class StateDB:
             )
         return (
             f"UPDATE {table} SET "  # noqa: S608
-            # jsonb `||` merges keys but keeps an explicit null (unlike sqlite's
-            # json_patch, which deletes the key per RFC 7396). Rather than
-            # jsonb_strip_nulls over the whole merged document -- which also
-            # strips nulls that were already in the stored value and had
-            # nothing to do with this patch -- subtract exactly the set of
-            # keys the *patch* itself set to null, computed from :patch alone.
-            # That reproduces RFC 7396 (null-in-patch deletes the key) without
-            # touching any null that predates this merge.
+            # jsonb `||` keeps an explicit null (unlike sqlite's json_patch,
+            # which deletes the key per RFC 7396); reproduce RFC 7396 by
+            # subtracting exactly the keys :patch itself set to null, rather
+            # than jsonb_strip_nulls which would also strip pre-existing nulls.
             "node_metadata = (("
             "  CASE"
             "    WHEN node_metadata IS NULL THEN '{}'::jsonb"
@@ -3296,13 +3149,10 @@ class StateDB:
         merge_invocation_node_metadata(): validate the patch, then run the
         single dialect-specific UPDATE for *table*.
 
-        A patch value that is itself a dict is rejected here, before any SQL
-        runs, on every dialect equally: sqlite's json_patch merges a nested
-        object recursively while postgres's `jsonb ||` replaces it shallowly,
-        and choosing one silently would make the two backends persist
-        different state from the same call. Raising is dialect-agnostic
-        because it only inspects the patch this call was given, not stored
-        state, so it adds no read before the write.
+        A nested-dict patch value is rejected here, before any SQL runs:
+        sqlite's json_patch merges nested objects recursively while
+        postgres's `jsonb ||` replaces them shallowly, so allowing one would
+        make the two backends persist different state from the same call.
         """
         for key, value in patch.items():
             if isinstance(value, dict):
@@ -3323,27 +3173,19 @@ class StateDB:
     async def merge_session_node_metadata(self, session_id: str, patch: dict[str, Any]) -> None:
         """Atomically merge *patch* into the session's node_metadata column.
 
-        Replaces the former get_session() + update_session(node_metadata=...)
-        pair: that was a read in one operation and a write in another, so two
-        concurrent callers could both read the same row and each write back a
-        patch that clobbered the other's. This runs as a single UPDATE, so
-        the merge is serialized by the database (the sqlite write lock for
-        that dialect; ordinary row-level MVCC locking on postgres) instead of
-        racing in Python.
+        Runs as a single UPDATE (serialized by the database) rather than a
+        get_session() + update_session(node_metadata=...) pair, which let two
+        concurrent callers each read the same row and clobber the other's
+        write.
         """
         await self._merge_node_metadata("sessions", session_id, patch)
 
     async def merge_invocation_node_metadata(
         self, invocation_id: str, patch: dict[str, Any]
     ) -> None:
-        """Atomically merge *patch* into the invocation's node_metadata column.
-
-        Same contract and same clobber this closes as
-        merge_session_node_metadata(), for the invocations table: a
-        get_invocation() + update_invocation(node_metadata=...) pair used to
-        let two concurrent callers each read the same row and write back a
-        patch that clobbered the other's.
-        """
+        """Atomically merge *patch* into the invocation's node_metadata
+        column. Same contract and same clobber this closes as
+        ``merge_session_node_metadata()``, for the invocations table."""
         await self._merge_node_metadata("invocations", invocation_id, patch)
 
     async def update_artifact_verification(
@@ -3374,17 +3216,17 @@ class StateDB:
     ) -> None:
         """Write attribution/provenance fields without touching updated_at.
 
-        Project bucketing and conversation lineage describe where a session came
-        from, not whether it is live, so they must never move the liveness clock
-        (which reconcile_session_status and the phantom reaper read). project and
-        project_source are written together (the source is meaningless alone).
-        The session update and the projects-registry upsert run as one locked
-        write so neither can commit without the other.
-
-        ``artifacts_path`` is written via ``COALESCE`` rather than a plain
-        assignment: a mirrored CLI session's artifact root is its transcript's
-        ``cwd``, a weaker signal than a launcher-set root (issue #2848), so a
-        later, more precise write must never be clobbered by an earlier guess.
+        Project bucketing and conversation lineage describe where a session
+        came from, not whether it's live, so they must never move the
+        liveness clock that ``reconcile_session_status`` and the phantom
+        reaper read. ``project``/``project_source`` are written together
+        (source is meaningless alone); the session update and the
+        projects-registry upsert run as one locked write so neither commits
+        without the other. ``artifacts_path`` is written via ``COALESCE``,
+        not a plain assignment: a mirrored CLI session's artifact root (its
+        transcript's ``cwd``) is a weaker signal than a launcher-set root, so
+        a later, more precise write must never be clobbered by an earlier
+        guess.
         """
         sets: list[str] = []
         params: dict[str, Any] = {}
@@ -3418,7 +3260,7 @@ class StateDB:
             if project:
                 await self._upsert_project_stmt(conn, project, project_source or "cwd_dir")
 
-    # ── Status reason model ───────────────────────────────────────────
+    # Status reason model
 
     async def _route_status_change(
         self,
@@ -3497,37 +3339,27 @@ class StateDB:
     ) -> bool:
         """Atomically transition an entity's status and record the reason.
 
-        When *expected_statuses* is provided, the transition is only performed
-        if the current status is a member of that set.  Pass ``None`` inside
-        the set to match a SQL NULL status (e.g. ``{None}`` for null-status
-        sessions, ``{"running", None}`` to accept either).
+        ``expected_statuses``, if given, gates the transition on the current
+        status being a member of that set; pass ``None`` inside the set to
+        match a SQL NULL status. ``expected_updated_at``, if given, adds an
+        optimistic-lock version check requiring the row's ``updated_at`` to
+        still match (any status write bumps it) -- lets a caller distinguish
+        "still the stale row I read" from "someone already re-touched it"
+        when status membership alone can't (e.g. a reaper vs. a fresh claim
+        on the same reapable status). Returns True if applied, False if
+        skipped for either reason; callers that ignore the return value are
+        unaffected.
 
-        When *expected_updated_at* is provided, the guarded write additionally
-        requires the row's ``updated_at`` to still equal that value — an
-        optimistic-lock version check enforced by storage (the same mechanism
-        as the ``previous_status`` compare-and-set). A concurrent writer that
-        touched the row (any status write bumps ``updated_at``) loses the race
-        and the transition is skipped. This lets a caller that decided to act
-        on a stale snapshot (status membership alone cannot distinguish "still
-        stale" from "just re-touched", e.g. a reaper vs. a fresh claim on the
-        same reapable status) refuse to act once the row has moved.
-
-        Returns ``True`` when the transition was applied, ``False`` when it was
-        skipped because the current status was not in *expected_statuses* or
-        the row's ``updated_at`` no longer matches *expected_updated_at*.  All
-        existing callers that ignore the return value are unaffected.
-
-        ADR-0035 integrity floor: once an entity's status is terminal (per
-        TERMINAL_STATUSES_BY_ENTITY_TYPE), any write that would CHANGE it is
-        rejected and recorded in admin_events — a terminal record must not
-        silently move back to running or oscillate to a different terminal
-        value. A same-status write (new_status == previous_status) is not a
-        transition — it is allowed through untouched, since callers already
-        rely on it to attach/refresh a reason code on an already-terminal row
-        without that counting as leaving terminal. Pass override=True with
-        override_actor and override_justification for a deliberate
-        operational repair that does change the value; the repair is itself
-        recorded in admin_events, distinctly from an ordinary transition.
+        Integrity floor: once an entity's status is terminal (per
+        ``TERMINAL_STATUSES_BY_ENTITY_TYPE``), any write that would change it
+        is rejected and recorded in admin_events -- a terminal record must
+        not silently move back to running or to a different terminal value.
+        A same-status write is not a transition and passes through untouched
+        (callers rely on this to refresh a reason code on an already-terminal
+        row). Pass ``override=True`` with ``override_actor`` and
+        ``override_justification`` for a deliberate operational repair that
+        does change the value; it's recorded in admin_events distinctly from
+        an ordinary transition.
         """
         if source not in _VALID_STATUS_SOURCES:
             raise ValueError(
@@ -3753,7 +3585,7 @@ class StateDB:
             for r in rows
         ]
 
-    # ── Projects ──────────────────────────────────────────────────────
+    # Projects
 
     async def _upsert_project_stmt(
         self,
@@ -3904,7 +3736,7 @@ class StateDB:
             )
         return result.rowcount > 0
 
-    # ── Schedules (ADR-0070) ──────────────────────────────────────────
+    # Schedules
 
     async def create_schedule(self, schedule: dict[str, Any]) -> None:
         stmt, params = self._build_schedule_insert_stmt(schedule)
@@ -4256,7 +4088,7 @@ class StateDB:
             )
         return result.rowcount > 0
 
-    # ── Schedule Runs (ADR-0070) ──────────────────────────────────────
+    # Schedule Runs
 
     async def create_schedule_run(self, run: dict[str, Any]) -> None:
         stmt, params = self._build_schedule_run_insert_stmt(run)
@@ -4899,7 +4731,7 @@ class StateDB:
         return self._row_to_dict(row) if row else None
 
     async def get_schedule_run_by_invocation(self, invocation_id: str) -> dict[str, Any] | None:
-        """Look up the schedule_run that fired a given invocation (ADR-0070).
+        """Look up the schedule_run that fired a given invocation.
 
         invocation_id is 1:1 with schedule_runs in practice (each fire mints a
         fresh invocation), but the ORDER BY + LIMIT keeps this defensively
@@ -4937,7 +4769,7 @@ class StateDB:
             )
         return [self._row_to_dict(r) for r in rows]
 
-    # ── Invocations (ADR-0077) ──────────────────────────────────────────
+    # Invocations
 
     async def create_invocation(self, invocation: dict[str, Any]) -> None:
         status = invocation.get("status", "running")
@@ -5170,7 +5002,7 @@ class StateDB:
             )
         return [self._row_to_dict(r) for r in rows]
 
-    # ── Artifacts (ADR-0077) ─────────────────────────────────────────────
+    # Artifacts
 
     async def insert_artifact(
         self,
@@ -5199,7 +5031,7 @@ class StateDB:
         if not name:
             raise ValueError("artifact name is required")
         if file_path is not None:
-            # Studio artifact file references (ADR-0077 delta 5) must stay
+            # Studio artifact file references must stay
             # relative and non-traversing before they can ever be served for
             # preview/download — reject absolute paths and `..` at write time
             # rather than trusting whatever recorded the reference.
@@ -5298,7 +5130,7 @@ class StateDB:
             )
         return self._row_to_dict(row) if row else None
 
-    # ── Admin events (ADR-0057) ─────────────────────────────────────────
+    # Admin events
 
     async def insert_admin_event(
         self,
@@ -5358,7 +5190,7 @@ class StateDB:
             rows = (await conn.execute(text(query), params)).mappings().all()
         return [self._row_to_dict(r) for r in rows]
 
-    # ── Branches ───────────────────────────────────────────────────────
+    # Branches
 
     async def create_branch(self, branch: dict[str, Any]) -> None:
         async with self._tx() as conn:
@@ -5429,31 +5261,17 @@ class StateDB:
     ) -> bool:
         """Guarded terminal-status write for one branch row (BRANCH_END).
 
-        Two-sided guard; both conditions must hold for the write to land:
-
-        - *status* itself must be a genuine terminal outcome
-          (``_BRANCH_TERMINAL_STATUSES`` == ``SESSION_TERMINAL_STATUSES`` —
-          every value BRANCH_END ever carries is a session final_status
-          passed straight through by cli/_runs.py teardown_persist()). A
-          non-terminal payload — e.g. the "running" the linked-engine
-          reconciliation path can produce when it suppresses a phantom
-          "failed" back to "running" — is rejected outright: this method
-          never stamps a branch "ended" with a non-terminal status. Returns
-          False without touching the row.
-        - the EXISTING row must still be in a legitimate pre-terminal state:
-          NULL (never touched) or "running" (the only two values flow.py's
-          own per-op writer -- or anything else -- ever leaves a branch in
-          before its real terminal outcome lands; this method itself never
-          writes "running", it only ever writes a terminal status). Any
-          other existing value — whichever terminal status it already
-          holds — is immutable: a run-level finalize must never flap a
-          branch that already reached its outcome, regardless of which
-          terminal status that was (completed, failed, cancelled,
-          timed_out, aborted, completed_empty) or what this call's own
-          *status* argument is.
-
-        A branch row that was never created (a DAG leg that never emitted a
-        first message) matches zero rows and is a harmless no-op.
+        Two-sided guard, both must hold for the write to land: *status*
+        itself must be a genuine terminal outcome (rejected outright
+        otherwise, e.g. the "running" that linked-engine reconciliation can
+        produce when suppressing a phantom "failed" -- this method never
+        stamps a branch "ended" with a non-terminal status); and the
+        existing row must still be NULL or "running" (the only pre-terminal
+        values a branch is ever left in). Any other existing value -- an
+        already-terminal status, whichever it is -- is immutable: a
+        run-level finalize must never flap a branch that already reached its
+        outcome. A branch row that was never created (a DAG leg that never
+        emitted a first message) matches zero rows and is a harmless no-op.
         Returns True when a row was actually updated.
         """
         if status not in _BRANCH_TERMINAL_STATUSES:
@@ -5561,7 +5379,7 @@ class StateDB:
         by_id = {r["id"]: self._row_to_dict(r) for r in rows}
         return [by_id[mid] for mid in message_ids if mid in by_id]
 
-    # ── Shows ─────────────────────────────────────────────────────────
+    # Shows
 
     async def create_show(self, show: dict[str, Any]) -> None:
         _validate_enum(
@@ -5703,7 +5521,7 @@ class StateDB:
                     params,
                 )
 
-    # ── Plays ─────────────────────────────────────────────────────────
+    # Plays
 
     async def create_play(self, play: dict[str, Any]) -> None:
         _validate_enum(
@@ -5841,7 +5659,7 @@ class StateDB:
             async with self._tx() as conn:
                 await conn.execute(stmt, params)
 
-    # ── Definitions ───────────────────────────────────────────────────
+    # Definitions
 
     async def save_definition(
         self,
@@ -5979,7 +5797,7 @@ class StateDB:
             )
         return [dict(r) for r in rows]
 
-    # ── Session signals (Phase C Move 1) ─────────────────────────────
+    # Session signals
 
     async def insert_session_signal(
         self,
@@ -6080,7 +5898,7 @@ class StateDB:
             )
         return result
 
-    # ── Engine runs (Phase C Move 2) ──────────────────────────────────
+    # Engine runs
 
     async def insert_engine_run(
         self,
@@ -6213,7 +6031,7 @@ class StateDB:
             result.append(d)
         return result
 
-    # ── Engine definitions ─────────────────────────────────────────────
+    # Engine definitions
 
     async def create_engine_def(self, defn: dict[str, Any]) -> None:
         now = time.time()
@@ -6339,7 +6157,7 @@ class StateDB:
             )
         return result.rowcount > 0
 
-    # ── Workflow definitions ───────────────────────────────────────────
+    # Workflow definitions
 
     @staticmethod
     def _decode_workflow_def(row: Any) -> dict[str, Any]:
@@ -6449,7 +6267,7 @@ class StateDB:
             )
         return result.rowcount > 0
 
-    # ── Session controls (ADR-0069 D1–D3: live-control transport) ──────────
+    # Session controls -- live-control transport
     # session_controls rows are written by `li o ctl pause|resume|msg` and
     # consumed by the control poller task in cli/orchestrate/flow.py's
     # _execute_dag. Apply/stamp
@@ -6479,35 +6297,20 @@ class StateDB:
     ) -> str | None:
         """Queue a control verb for *session_id*; returns the new control id, or None.
 
-        The insert is conditional on the session still being 'running', and the
-        condition is evaluated by the insert statement itself rather than by a
-        caller that read the status a moment earlier. That is what closes the
-        race against a run tearing down: a caller-side status check and the
-        insert are two statements, and a run can terminalize between them,
-        leaving a control nobody will ever consume. Here the two outcomes are
-        the only ones: an insert that commits was admitted against a running
-        session and is therefore visible to that run's terminal sweep, and one
-        that arrives after terminalization inserts nothing and returns None for
-        the caller to refuse.
-
-        Evaluating the condition in the statement is enough on SQLite, whose
-        writers are serialised, and is NOT enough on PostgreSQL, where two
-        clients run concurrently: under READ COMMITTED the EXISTS clause reads a
-        snapshot, so an admission can pass against a session another transaction
-        is terminalizing, and commit after that run's sweep has already looked.
-        The row then exists, is pending, and has no consumer, which is exactly
-        the outcome the condition is here to prevent. Measured on PostgreSQL 16:
-        the plain form admits, the terminalizing transaction's sweep sees zero
-        rows, and one row is pending once the admission commits.
-
-        So on PostgreSQL the source of the insert takes a row lock on the
-        session. A concurrent terminal transition then waits for the admission
-        to finish rather than passing it, which orders the two and restores the
-        SQLite property: whatever was admitted is committed before the status
-        moves, and anything after it fails the condition. The wait is bounded by
-        a single-statement insert.
-
-        Serialised through _tx() like the other append-only session logs.
+        The admission condition (session still 'running') is evaluated by the
+        INSERT statement itself, not by a caller-side status check, to close
+        the race against a run tearing down between the two: an insert that
+        commits was admitted against a running session and is visible to
+        that run's terminal sweep; one arriving after terminalization inserts
+        nothing and returns None. Evaluating the condition in the statement
+        is enough on SQLite (serialised writers), but not on PostgreSQL: at
+        READ COMMITTED the EXISTS clause reads a snapshot, so an admission
+        can pass and commit after the terminalizing transaction's sweep has
+        already looked, leaving a pending row with no consumer -- so on
+        PostgreSQL the insert's source takes a row lock on the session,
+        making a concurrent terminal transition wait for the admission to
+        finish rather than pass it. Serialised through ``_tx()`` like the
+        other append-only session logs.
         """
         control_id = uuid.uuid4().hex
         admit_source = (
@@ -6580,28 +6383,20 @@ class StateDB:
     ) -> str | None:
         """Claim a non-idempotent (message) control as mid-apply, before attempting it.
 
-        The stamp is a compare-and-set: only a row no consumer has claimed
-        (``result IS NULL``) moves to 'applying'. Returns the claim string this
-        call wrote, or None if another consumer got there first. Two consumers
-        that read the same pending row therefore cannot both apply it; the loser
-        sees None and leaves the row alone. Returning a value rather than raising
-        keeps the ordinary "someone else got there first" case off the error path.
-
-        **The claim comes back because the claimant needs it to finish safely.**
-        finalize_session_control(expect_claim=...) is what stops a slow consumer
-        from overwriting an outcome that someone else recorded while it was
-        working, and a caller can only pass a claim it holds. Rebuilding the
-        string at the call site instead is how the two drift apart, so this is
-        the only place it is constructed.
-
-        *owner* names the claimant, and the claim is stored as ``applying:<owner>``.
-        Naming it is what lets a second consumer tell "someone else is mid-apply"
-        from "I am mid-apply", which a bare 'applying' cannot express; a caller
-        that has no meaningful identity omits it and gets the bare form.
-        claimed_at is stamped either way, so a wedged claim carries its own age.
-
-        applied_at stays NULL — the row remains "pending" until finalize_session_control()
-        runs, so a poller crash right after this stamp is visible, not silently lost.
+        Compare-and-set: only a row no consumer has claimed (``result IS
+        NULL``) moves to 'applying'. Returns the claim string this call
+        wrote, or None if another consumer got there first (returning rather
+        than raising keeps that ordinary case off the error path). The
+        claim must be returned to the caller: it's what
+        ``finalize_session_control(expect_claim=...)`` needs to stop a slow
+        consumer from overwriting an outcome someone else recorded while it
+        was working, and this is the only place the string is constructed
+        (rebuilding it at the call site would let the two drift apart).
+        *owner*, if given, is embedded (``applying:<owner>``) so a second
+        consumer can tell "someone else is mid-apply" from "I am mid-apply".
+        ``claimed_at`` is stamped either way, so a wedged claim carries its
+        own age. ``applied_at`` stays NULL until ``finalize_session_control()``
+        runs, so a poller crash right after this stamp is visible, not lost.
         """
         claim = f"applying:{owner}" if owner else "applying"
         async with self._tx() as conn:
@@ -6628,28 +6423,19 @@ class StateDB:
     ) -> bool:
         """Stamp applied_at + a terminal *result* ('applied' or 'rejected:<reason>').
 
-        With *expect_claim*, the write applies only while the row still carries
-        that exact claim string, and the return value says whether it did. A
-        consumer that claimed a row passes its own claim here, so a write aimed
-        at a row whose claim has moved on lands nowhere instead of overwriting
-        it. Without it the write is unconditional, which is what the idempotent
-        (pause/resume) path wants.
-
-        With *only_if_unclaimed*, the write applies only while the row is still
-        pending. This is what a sweep wants: reading the pending rows and then
-        deciding from that snapshot is a check against a value that can change
-        before the write, and the window is exactly wide enough for a consumer
-        to claim the row and deliver it, after which an unconditional write
-        records a delivered message as never delivered. The two guards are
-        alternatives, not a pair; asking for both is a caller bug.
-
-        This is a compare-and-set between cooperating consumers and NOT an
-        authorization boundary. The claim string is stored in a column every
-        reader can see, so any caller that can reach this method can also pass
-        it; what the check rules out is a consumer writing an outcome onto a row
-        whose state it has not re-read, not a consumer that means to. Nothing
-        reachable from a shared database can do better than that, since a caller
-        able to call this method is equally able to write the row directly.
+        With *expect_claim*, the write applies only while the row still
+        carries that exact claim string (return value says whether it did),
+        so a write aimed at a row whose claim has moved on lands nowhere
+        instead of overwriting it; without it the write is unconditional,
+        which is what the idempotent (pause/resume) path wants. With
+        *only_if_unclaimed*, the write applies only while the row is still
+        pending -- what a sweep wants, since a consumer could otherwise claim
+        and deliver the row in the window between the sweep's read and its
+        write. The two guards are alternatives, not a pair; passing both is a
+        caller bug. This is a compare-and-set between cooperating consumers,
+        not an authorization boundary: the claim string is visible to any
+        reader, so what it rules out is a consumer overwriting a row it
+        hasn't re-read, not a consumer that means to write it.
         """
         if expect_claim is not None and only_if_unclaimed:
             raise ValueError(
@@ -6757,7 +6543,7 @@ class StateDB:
                 pass
         return d
 
-    # ── Helpers ────────────────────────────────────────────────────────
+    # Helpers
 
     @staticmethod
     def _row_to_dict(row: Any) -> dict[str, Any]:
@@ -6794,7 +6580,7 @@ class StateDB:
         return d
 
 
-# ── Shared singleton accessor ─────────────────────────────────────────────────
+# Shared singleton accessor
 # One open StateDB connection is reused across all hook firings for a given
 # DB URL.  This avoids the per-firing connect + schema-check cost
 # and is the prerequisite for session-lifecycle hook wiring.

--- a/lionagi/state/engine.py
+++ b/lionagi/state/engine.py
@@ -22,22 +22,14 @@ _log = logging.getLogger(__name__)
 def _busy_timeout_from_env() -> int:
     """The sqlite busy_timeout (ms) this deployment asked for, or the default.
 
-    The default of 5000 is sized for the test suite — a test that deliberately
-    holds a write lock should fail fast, not wait out a production-grade
-    timeout — and for years it was also silently the production value. On a
-    large store contended by more than one long-lived process, five seconds is
-    the difference between a write that waits and a write that reports
-    "database is locked" after having already waited as long as it was allowed
-    to. That is a deployment property, so it comes from the environment: a
-    daemon's launch config sets it high, the suite sets nothing and keeps the
-    fast failure.
-
-    An unusable value falls back to the default and says so. Refusing to start
-    over a malformed tuning knob would trade a slower lock wait for no daemon
-    at all, which is not a trade the knob's owner asked for. Zero and negative
-    values are refused the same way: busy_timeout=0 means "never wait", which
-    turns every momentary lock into an error and is never what a deployment
-    that bothered to set the variable wants.
+    The default (5000) is sized for the test suite -- a test holding a write
+    lock deliberately should fail fast, not wait out a production timeout --
+    and for years was silently also the production value. This is a
+    deployment property, read from the environment so a daemon's launch
+    config can set it high while the test suite sets nothing. An unusable,
+    zero, or negative value falls back to the default and logs a warning,
+    rather than refusing to start over a malformed tuning knob; zero would
+    mean "never wait", turning every momentary lock into an error.
     """
     raw = os.environ.get("LIONAGI_SQLITE_BUSY_TIMEOUT_MS")
     if raw is None:
@@ -65,21 +57,13 @@ _busy_timeout_announced = False
 
 
 def announce_busy_timeout() -> None:
-    """Say once per process what busy_timeout this process's connections use.
+    """Log once per process what busy_timeout this process's connections use,
+    and whether it came from the environment or the built-in default.
 
-    The value is a deployment property that lives in one config file's env
-    block, so it is set once per config and every new config that spawns a
-    lionagi process starts at the built-in default. Against a large contended
-    store that default is the difference between a write that waits and a write
-    that reports "database is locked", and until now nothing said which one was
-    in effect — it could only be inferred by reading the config that launched
-    the process, from outside the process.
-
-    The source is recomputed here rather than recorded when the module was
-    imported, so the line describes what is actually in effect at the moment a
-    connection is about to use it. That matters because the module attribute is
-    writable: tests retune it, and a provenance captured at import would keep
-    claiming the environment's answer after something else had replaced it.
+    Recomputed at call time rather than recorded at import, since
+    ``SQLITE_BUSY_TIMEOUT_MS`` is writable (tests retune it) and a
+    provenance captured at import would keep claiming the environment's
+    answer after something else replaced it.
     """
     global _busy_timeout_announced
     if _busy_timeout_announced:
@@ -262,20 +246,13 @@ def _mask_secret(secret: str) -> str:
 def mask_credentials(text: str) -> str:
     """Return *text* with the secret in every ``user:secret@`` masked.
 
-    For prose rather than for a URL: an error message that quotes the store it
-    failed to open carries the credential just as plainly as the URL field
-    beside it, and masking only the field closes one of two channels onto the
-    same secret.
-
-    Text is scanned rather than parsed because the strings that reach here are
-    not URLs and cannot be made into them. Two consequences worth stating: a
+    For prose rather than a URL -- an error message that quotes the store it
+    failed to open carries the credential as plainly as the URL field beside
+    it. A backstop, not the only control: text is scanned, not parsed, so a
     password containing a literal ``@`` is masked only up to that character,
-    and a secret passed as a bare argument rather than inside a URL is not
-    matched at all. Both are under-masking, so neither is a reason to skip the
-    pass, and both are why this is a backstop rather than the only control.
-
-    Masking is idempotent: the token it writes contains a space, and a space
-    cannot appear inside a secret this pattern will match.
+    and a secret passed as a bare argument (not inside a URL) isn't matched
+    at all. Masking is idempotent -- the token it writes contains a space,
+    which can't appear inside a secret this pattern matches.
     """
     return _CREDENTIAL_IN_TEXT.sub(lambda m: f"{m.group(1)}:{_mask_secret(m.group(2))}@", text)
 
@@ -283,14 +260,14 @@ def mask_credentials(text: str) -> str:
 def mask_db_url(url: str) -> str:
     """Return *url* with any password replaced by the first-6-chars mask.
 
-    The structured pass comes first, and text scanning is the fallback for the
-    URLs it cannot decompose. A string with no scheme parses as a path rather
-    than as a URL, so ``urlparse`` reports no password for it and the
-    credential would otherwise be returned verbatim by the function whose whole
-    job is to remove it. Such a value is refused as a store setting, which is
-    not a reason to drop the arm: what reaches here is whatever a caller was
-    handed, including a driver quoting its own connection string, an older log
-    line, and the ``./``-prefixed path that spelling makes acceptable.
+    Tries the structured `urlparse` pass first and falls back to text
+    scanning (``mask_credentials``) for URLs it can't decompose -- notably a
+    string with no scheme, which parses as a path rather than a URL, so
+    ``urlparse`` reports no password and would otherwise return the
+    credential verbatim. Such a value is refused as a store setting, but
+    what reaches this function includes whatever a caller was handed:
+    a driver's own quoted connection string, an older log line, a
+    ``./``-prefixed path.
     """
     try:
         parsed = urlparse(url)

--- a/lionagi/state/reasons.py
+++ b/lionagi/state/reasons.py
@@ -66,7 +66,7 @@ class RunReasons:
     COMPLETED_EMPTY_NO_EVIDENCE = "run.completed_empty.no_evidence"
     # DAG's own result stands even when a post-completion finalize step raised
     COMPLETED_FINALIZE_ERROR = "run.completed.finalize_error"
-    # a gate node rejected mid-DAG (issue #2860) and its dependent subtree was
+    # a gate node rejected mid-DAG and its dependent subtree was
     # short-circuited to skipped rather than run against the rejected
     # baseline -- the run genuinely completed, so status stays "completed",
     # but the reason distinguishes it from a clean pass
@@ -76,11 +76,11 @@ class RunReasons:
     FAILED_ARTIFACT_WRITE = "run.failed.artifact_write"
     TIMED_OUT_DEADLINE = "run.timed_out.deadline"
     ABORTED_USER = "run.aborted.user"
-    CANCELLED_SIGINT = "run.cancelled.sigint"  # issue #1055
+    CANCELLED_SIGINT = "run.cancelled.sigint"
     CANCELLED_SIGTERM = "run.cancelled.sigterm"  # externally delivered SIGTERM (exit 143)
     CANCELLED_SYSTEM = "run.cancelled.system"
     CANCELLED_ORCHESTRATOR = "run.cancelled.orchestrator"
-    # `li kill` — Phase 2 reason codes (issue #1094)
+    # `li kill` reason codes
     CANCELLED_MANUAL_KILL = "run.cancelled.manual_kill"
     CANCELLED_FORCE_KILL = "run.cancelled.force_kill"
     CANCELLED_STALE_AUTO = "run.cancelled.stale_auto"
@@ -171,7 +171,7 @@ class DispatchReasons:
     ACKED_CONSUMER = "dispatch.acked.consumer"
 
 
-# ── Validator ────────────────────────────────────────────────────────
+# Validator
 
 
 def _collect(*classes: type) -> frozenset[str]:
@@ -197,7 +197,7 @@ VALID_REASON_CODES: Final[frozenset[str]] = _collect(
 ) | {LEGACY_IMPORTED}
 
 
-# ── Validation helpers ───────────────────────────────────────────────
+# Validation helpers
 
 
 def validate_reason_code(code: str) -> str:
@@ -225,7 +225,7 @@ def validate_entity_type(entity_type: str) -> str:
     )
 
 
-# ── Table mapping ────────────────────────────────────────────────────
+# Table mapping
 # StateDB.update_status() uses this to resolve canonical entity_type
 # → physical table name for the UPDATE statement.
 

--- a/lionagi/state/schema_meta.py
+++ b/lionagi/state/schema_meta.py
@@ -23,7 +23,7 @@ from sqlalchemy import (
 
 metadata = MetaData()
 
-# ── schema_meta ───────────────────────────────────────────────────────────────
+# schema_meta
 
 schema_meta = Table(
     "schema_meta",
@@ -32,7 +32,7 @@ schema_meta = Table(
     Column("value", Text, nullable=False),
 )
 
-# ── message_types ─────────────────────────────────────────────────────────────
+# message_types
 
 message_types = Table(
     "message_types",
@@ -41,7 +41,7 @@ message_types = Table(
     Column("lion_class", Text, nullable=False, unique=True),
 )
 
-# ── messages ──────────────────────────────────────────────────────────────────
+# messages
 
 messages = Table(
     "messages",
@@ -79,7 +79,7 @@ Index(
 )
 Index("idx_messages_created", messages.c.created_at)
 
-# ── progressions ─────────────────────────────────────────────────────────────
+# progressions
 
 progressions = Table(
     "progressions",
@@ -89,7 +89,7 @@ progressions = Table(
     Column("collection", Text, nullable=False, server_default="[]"),
 )
 
-# ── projects ──────────────────────────────────────────────────────────────────
+# projects
 
 projects = Table(
     "projects",
@@ -107,7 +107,7 @@ projects = Table(
 Index("idx_projects_source", projects.c.source)
 Index("idx_projects_updated", projects.c.updated_at)
 
-# ── invocations ───────────────────────────────────────────────────────────────
+# invocations
 # Defined before sessions because sessions FK -> invocations.
 
 invocations = Table(
@@ -144,7 +144,7 @@ Index("idx_invocations_skill", invocations.c.skill)
 Index("idx_invocations_status", invocations.c.status)
 Index("idx_invocations_updated", invocations.c.updated_at)
 
-# ── sessions ──────────────────────────────────────────────────────────────────
+# sessions
 
 sessions = Table(
     "sessions",
@@ -252,7 +252,7 @@ Index(
     postgresql_where=text("cc_session_id IS NOT NULL"),
 )
 
-# ── branches ──────────────────────────────────────────────────────────────────
+# branches
 
 branches = Table(
     "branches",
@@ -283,7 +283,7 @@ Index("idx_branches_session_created", branches.c.session_id, branches.c.created_
 Index("idx_branches_system_msg_id", branches.c.system_msg_id)
 Index("idx_branches_progression_id", branches.c.progression_id)
 
-# ── definitions ───────────────────────────────────────────────────────────────
+# definitions
 
 definitions = Table(
     "definitions",
@@ -308,7 +308,7 @@ UniqueConstraint(
     definitions.c.kind, definitions.c.name, definitions.c.version, name="idx_def_unique_version"
 )
 
-# ── shows ─────────────────────────────────────────────────────────────────────
+# shows
 
 shows = Table(
     "shows",
@@ -343,7 +343,7 @@ Index("idx_shows_topic", shows.c.topic)
 Index("idx_shows_status", shows.c.status)
 Index("idx_shows_updated", shows.c.updated_at)
 
-# ── plays ─────────────────────────────────────────────────────────────────────
+# plays
 
 plays = Table(
     "plays",
@@ -395,7 +395,7 @@ Index("idx_plays_status", plays.c.status)
 Index("idx_plays_session", plays.c.session_id)
 UniqueConstraint(plays.c.show_id, plays.c.name, name="idx_plays_show_name")
 
-# ── teams ─────────────────────────────────────────────────────────────────────
+# teams
 
 teams = Table(
     "teams",
@@ -424,7 +424,7 @@ Index("idx_teams_name", teams.c.name)
 Index("idx_teams_updated", teams.c.updated_at)
 Index("idx_teams_status", teams.c.status)
 
-# ── team_messages ─────────────────────────────────────────────────────────────
+# team_messages
 
 team_messages = Table(
     "team_messages",
@@ -454,7 +454,7 @@ Index(
     postgresql_where=text("session_id IS NOT NULL"),
 )
 
-# ── schedules ─────────────────────────────────────────────────────────────────
+# schedules
 
 schedules = Table(
     "schedules",
@@ -601,7 +601,7 @@ Index(
     postgresql_where=text("owner_key IS NOT NULL"),
 )
 
-# ── schedule_runs ─────────────────────────────────────────────────────────────
+# schedule_runs
 # ADR-0071 D2: generalized task-application entity, schedule_id nullable.
 
 schedule_runs = Table(
@@ -688,7 +688,7 @@ Index(
     postgresql_where=text("status IN ('queued', 'running', 'retry_wait')"),
 )
 
-# ── workers ─────────────────────────────────────────────────────────────────
+# workers
 # ADR-0071 D5: capability-matching worker registry.
 
 workers = Table(
@@ -703,7 +703,7 @@ workers = Table(
 
 Index("idx_workers_heartbeat", workers.c.last_heartbeat_at)
 
-# ── admin_events ──────────────────────────────────────────────────────────────
+# admin_events
 
 admin_events = Table(
     "admin_events",
@@ -725,7 +725,7 @@ Index(
     postgresql_where=text("target_id IS NOT NULL"),
 )
 
-# ── artifacts ─────────────────────────────────────────────────────────────────
+# artifacts
 
 artifacts = Table(
     "artifacts",
@@ -809,7 +809,7 @@ Index(
     postgresql_where=text("session_id IS NOT NULL"),
 )
 
-# ── status_transitions ────────────────────────────────────────────────────────
+# status_transitions
 
 status_transitions = Table(
     "status_transitions",
@@ -841,7 +841,7 @@ Index(
 )
 Index("idx_status_transitions_created", status_transitions.c.created_at)
 
-# ── terminal_deliveries ─────────────────────────────────────────────────────────
+# terminal_deliveries
 # Reconciliation-consumer acknowledgment ledger; see
 # lionagi/state/lifecycle/deliveries.py and docs/internals/runtime.md.
 
@@ -859,7 +859,7 @@ Index(
     terminal_deliveries.c.acked_at,
 )
 
-# ── session_signals ───────────────────────────────────────────────────────────
+# session_signals
 
 session_signals = Table(
     "session_signals",
@@ -883,7 +883,7 @@ UniqueConstraint(
 )
 Index("idx_session_signals_session_ts", session_signals.c.session_id, session_signals.c.ts)
 
-# ── engine_runs ───────────────────────────────────────────────────────────────
+# engine_runs
 
 engine_runs = Table(
     "engine_runs",
@@ -918,7 +918,7 @@ Index(
     postgresql_where=text("session_id IS NOT NULL"),
 )
 
-# ── engine_defs ───────────────────────────────────────────────────────────────
+# engine_defs
 
 engine_defs = Table(
     "engine_defs",
@@ -939,7 +939,7 @@ Index("idx_engine_defs_name", engine_defs.c.name)
 Index("idx_engine_defs_kind", engine_defs.c.kind)
 Index("idx_engine_defs_updated", engine_defs.c.updated_at)
 
-# ── workflow_defs ─────────────────────────────────────────────────────────────
+# workflow_defs
 # Named workflow definitions from the Studio Designer; spec_json is the
 # versioned node/edge graph, validated in the studio service layer.
 
@@ -957,7 +957,7 @@ workflow_defs = Table(
 Index("idx_workflow_defs_name", workflow_defs.c.name)
 Index("idx_workflow_defs_updated", workflow_defs.c.updated_at)
 
-# ── session_controls (ADR-0069 D1–D3: live-control transport) ─────────────────
+# session_controls -- live-control transport
 # One row per operator control verb queued against a live session, polled by
 # `cli/orchestrate/flow.py`'s `_execute_dag`; see docs/internals/runtime.md
 # for the verb-classed apply/stamp ordering.
@@ -1001,7 +1001,7 @@ Index(
     postgresql_where=text("applied_at IS NULL"),
 )
 
-# ── dispatch_outbox (ADR-0059: durable dispatch outbox) ─────────────────────
+# dispatch_outbox -- durable dispatch outbox
 # Producer-driven at-least-once delivery; the scheduler tick re-attempts
 # until success, backoff exhaustion, or max_attempts.
 
@@ -1051,7 +1051,7 @@ Index(
     postgresql_where=text("status IN ('pending', 'delivering')"),
 )
 
-# ── run_tags ──────────────────────────────────────────────────────────────────
+# run_tags
 # Free-form review labels on a run (session); kept in canonical metadata (not
 # only schema.sql) so create_all builds it consistently on every backend.
 
@@ -1068,7 +1068,7 @@ run_tags = Table(
     Column("created_at", Float, nullable=False),
 )
 
-# ── approvals (studio operator permission ledger) ──────────────────────────
+# approvals -- studio operator permission ledger
 # Server-side confirm-flow: proposed, granted/denied, consumed exactly once.
 
 approvals = Table(
@@ -1107,7 +1107,7 @@ Index(
     postgresql_where=text("session_id IS NOT NULL"),
 )
 
-# ── approval_evidence (hash-chained audit trail on the approval ledger) ────
+# approval_evidence -- hash-chained audit trail on the approval ledger
 # Append-only, same transaction as the approvals status change; see schema.sql.
 
 approval_evidence = Table(
@@ -1150,7 +1150,7 @@ Index(
 
 Index("idx_run_tags_tag", run_tags.c.tag)
 
-# ── attention_dispositions (Studio needs-attention discharge lifecycle) ────
+# attention_dispositions -- Studio needs-attention discharge lifecycle
 # One row per derived attention item (item_id == "run:<id>" | "inv:<id>" |
 # "sched:<id>", the id boardReducer.buildAttentionItems already builds).
 # Records what an operator decided about seeing a condition; the source
@@ -1178,7 +1178,7 @@ attention_dispositions = Table(
     Column("revision", Integer, nullable=False, server_default="1"),
 )
 
-# ── attention_disposition_revisions (per-item_id revision ledger) ─────────
+# attention_disposition_revisions -- per-item_id revision ledger
 # Survives a DELETE of the disposition row itself so a PUT that recreates
 # item_id afterward can still be fenced against the last operation --
 # without this, a delayed replay of an earlier PUT could resurrect a
@@ -1191,7 +1191,7 @@ attention_disposition_revisions = Table(
     Column("revision", Integer, nullable=False),
 )
 
-# ── attention_disposition_history (append-only discharge ledger) ──────────
+# attention_disposition_history -- append-only discharge ledger
 
 attention_disposition_history = Table(
     "attention_disposition_history",

--- a/lionagi/state/schema_migrations.py
+++ b/lionagi/state/schema_migrations.py
@@ -24,7 +24,7 @@ MIGRATION_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("ended_at", "REAL"),
         # Activity marker for staleness detection (read by ADR-0057 D6).
         ("last_message_at", "REAL"),
-        # #1235: live flow phase for the `li monitor` PHASE column.
+        # Live flow phase for the `li monitor` PHASE column.
         ("current_phase", "TEXT"),
         # Optional FK to invocations table.
         ("invocation_id", "TEXT"),

--- a/lionagi/state/session_naming.py
+++ b/lionagi/state/session_naming.py
@@ -84,21 +84,15 @@ def sanitize_prompt_name(raw: str | None, *, max_len: int = DISPLAY_NAME_MAX_LEN
 def agent_role_label(agent_name: str, started_at: float | None, run_id: str | None = None) -> str:
     """Deterministic label for an agent-only session: the agent's name, a short
     slice of the row's own id, and a UTC HH:MM stamp from its start time
-    ("claude-code · 1167 · 14:22"). Every part is a pure function of the row,
-    so no lookup against sibling rows is needed and a re-read always formats
-    the same way. UTC rather than local time keeps the label independent of
-    the resolving machine's timezone.
+    ("claude-code · 1167 · 14:22"). Pure function of the row (UTC, not local
+    time, so it's independent of the resolving machine), so a re-read always
+    formats the same way.
 
-    The id slice is what makes a list of these readable. Name and minute alone
-    were chosen first, on the reasoning that a same-name same-minute collision
-    is an edge case the row id already covers everywhere identity actually
-    matters. Watching the real surface refuted that: the common case is
-    several long-lived sessions of one engine, so a page of them reads as
-    "claude-code · 21:37", "claude-code · 21:49", "claude-code · 21:50" —
-    near-identical strings a viewer has to compare digit by digit. Four
-    characters of the id are stable, meaningless to an outsider, and turn a
-    row into something you can point at.
-
+    The id slice earns its place: name+minute alone reads fine until the
+    common case of several long-lived sessions of one engine turns a page
+    into near-identical strings ("claude-code · 21:37", "· 21:49", "· 21:50")
+    a viewer has to compare digit by digit. Four characters of id, though
+    meaningless to an outsider, make each row something you can point at.
     Each part is dropped when its input is missing rather than rendered
     blank, so a row with only a name still returns that bare name.
     """
@@ -121,25 +115,13 @@ def _stripped(session_row: dict[str, Any], key: str) -> str:
     return str(value).strip() if value else ""
 
 
-# Stored names that identify nothing. Each is a default written when the writer
-# had nothing better: "Codex session" is the codex mirror's fallback at its
-# create path, "agent" is lionagi's default branch name. "session" and "flow"
-# are here on the strength of the stored data rather than a located writer, and
-# that is the weaker grounding of the four -- said plainly so the next reader
-# knows which entries to re-derive rather than trusting the list wholesale.
-#
-# Counted in one store: agent 11851, codex session 917, session 600, flow 273.
-# A title tier that accepts these renders a page of identical cards, which is
-# the complaint this guards against.
-#
-# Matched by VALUE, deliberately, rather than by reordering the tiers. A reorder
-# would re-rank every row that has both a stored name and a derivable prompt --
-# including the mirrored Claude rows and the live codex rows whose stored names
-# are real -- so it would change populations that have nothing wrong with them.
-# Keying on the value leaves every one of those exactly where it was.
-#
-# Compared case-folded because these are written by several call sites and the
-# casing is not guaranteed to agree between them.
+# Stored names that identify nothing, written when the writer had nothing
+# better ("agent" is lionagi's default branch name, "Codex session" the codex
+# mirror's create-path fallback; "session"/"flow" are weaker-grounded entries
+# kept on the strength of the stored data alone). Matched by value rather than
+# by reordering the priority tiers, so rows with a real stored name and a
+# derivable prompt are unaffected. Compared case-folded since several call
+# sites write these with inconsistent casing.
 _UNINFORMATIVE_STORED_NAMES: frozenset[str] = frozenset(
     {
         "agent",


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 11 (+470 / -757, net -287)
- New documentation: 457 lines in docs/internals/state-db.md docs/internals/state-misc.md docs/internals/state-transcript-mirrors.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.