### PR TITLE
docs(studio/operator): trim inline prose, extract to docs/internals

### DIFF
--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -682,9 +682,9 @@ the write adapters project. `scrub_text` catches secrets and paths by
 *shape*: known token prefixes (`sk-`, `ghp_`, JWT-shaped strings), header
 and `Bearer` forms, `KEY=value`/`key: value` assignments under a
 secret-marker name, and absolute POSIX/Windows paths (collapsed to their
-leaf filename, so a real path like `/Users/lion/My Project/notes/secret.txt`
-is matched and redacted as a whole, not just its first space-free
-segment). Shape-based matching alone misses a secret that doesn't look
+leaf filename, so a path containing spaces, such as
+`/home/someone/My Project/notes/secret.txt`, is matched and redacted as a
+whole rather than only its first space-free segment). Shape-based matching alone misses a secret that doesn't look
 like one — an arbitrary passphrase or short internal token echoed back
 verbatim from a run's own environment, which a Studio-launched run
 inherits from this server process. `known_secret_values` reads that

--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -472,3 +472,292 @@ had a chance to run. A handler-raised `CancelledError` cannot be nested in
 records either form. Cancellation of the emitter task remains a plain
 `CancelledError` and propagates, so a broken handler is visible without
 stopping unrelated schedules or swallowing scheduler shutdown.
+
+## lionagi/studio/operator/
+
+The Operator (ADR-0083) is a durable, human-gated chat surface over Studio:
+one long-lived conversation per project view, backed by SQLite
+(`store.py`'s `OperatorStore`), that can read run state and propose
+mutating actions but never executes one without an explicit human decision.
+The package splits into the durable store, a Branch-backed engine that
+drives one provider turn (`engine.py`), a coordinator that wires turns to
+proposals (`coordinator.py`), a set of MCP-exposed read/write tools
+(`application_mcp.py` plus the per-action adapters), and shared
+redaction/catalog helpers.
+
+### Turn identity and the propose/poll/execute pattern
+
+Every mutating tool in this package — `cancel_run`, `resume_run`,
+`rename_session`, `launch_playbook` (`application_mcp.py`), and the
+stdio permission bridge (`permission_mcp.py`) — follows the same shape.
+The tool reads its durable turn identity from three environment variables
+(`LIONAGI_OPERATOR_DB_PATH`, `LIONAGI_OPERATOR_CONVERSATION_ID`,
+`LIONAGI_OPERATOR_REQUEST_ID`) set by the daemon around the provider
+subprocess; a real MCP call always has them, and their absence is treated
+as a hard configuration error, not a soft fallback. The tool then resolves
+its target, builds a command payload, and calls `OperatorStore.create_proposal`
+with a `risk` tier (`mutate`/`execute`/`admin`) and an idempotency key
+derived from `canonical_hash` — the same command submitted twice (e.g. a
+retried HTTP request) reuses the first proposal rather than creating a
+second one. It polls `get_proposal` until the status leaves `pending`
+(expiring it past its deadline if needed) and returns a redacted result.
+The proposal only carries the *decision*; the actual state-changing act
+lives in a paired `execute_*_command` function
+(`execute_cancel_command`, `execute_resume_command`,
+`execute_rename_session_command`), invoked by the coordinator only once a
+human allows the proposal. This split matters for ownership: a command
+captures the project it resolved against at proposal time, but every
+`execute_*` function re-fetches the target row and re-checks that project
+match immediately before writing, because a human's approval window is a
+gap the target's project (or status) can change across. Re-checking only at
+resolution time would let a race during that gap either write to a run that
+changed ownership or silently no-op in a way the caller couldn't
+distinguish from success.
+
+`cancel_run` additionally reuses `lionagi.cli.kill`'s exact primitives
+(`_kill_one`, `_list_running_children`) so a cancellation from the Operator
+is indistinguishable from one issued through `li kill --recursive`: running
+children are signalled deepest-first so none are orphaned, and
+`_persist_cancel`'s guard against a non-`running` row means a race that lets
+the process finish naturally during the approval window degrades to
+`already_terminal` rather than a double- or wrong-run cancel. `resume_run`
+is a distinct operation from un-pausing: the session lifecycle policy
+(`lionagi/state/lifecycle/policy.py`) has no edge back out of a terminal
+status such as `cancelled`, so resuming never reopens the old run's status —
+it launches a new invocation that either continues an `agent` run's branch
+with a new instruction (`li agent -r`) or replays a `play`/`flow`/`show-play`
+run's persisted checkpoint (`li o flow --resume`), and the two argument
+shapes are mutually exclusive because the checkpoint owns the plan for the
+second kind. `rename_session` renames a run's own record; it is
+deliberately separate from renaming the Operator conversation itself
+(`OperatorStore.update_conversation`), since one conversation can discuss
+many runs across its life.
+
+### Resolving a run reference
+
+`run_progress.py::resolve_run` (reused by `run_findings.py`,
+`resume_run.py`, and `rename_session.py`) and `cancel_run.py`'s own
+`_resolve_run` both accept the same reference vocabulary: an exact run/session
+id, an 8+ hex id prefix, a name or playbook substring (minimum 3
+characters), or the literal `"current"`. Id/prefix resolution reuses
+`lionagi.cli._util.fetch_unique_row`, the same primitive `li kill` uses, so
+a reference this tool accepts resolves identically to one typed at the CLI.
+Every arm is scoped to the calling turn's own project — read from the
+turn's stored context, never accepted as an argument — and a foreign
+project's run is reported exactly like a nonexistent one (`{"found": False}`)
+rather than surfaced as an ambiguity candidate or a resolved id, either of
+which would itself disclose that the id exists. A turn with no owner
+mapping at all raises `MissingOwnerContextError` rather than falling back
+to matching every project's runs (both modules keep their own small copy
+of this check and error rather than sharing one, so each stays
+self-contained). Nothing is ever guessed: an ambiguous prefix or substring
+match returns candidates instead of picking one, capped at `MAX_CANDIDATES`
+(10) with a `truncated` flag when more existed.
+
+`"current"` resolves against the turn's own frozen context, not a
+later-reported live view — deliberately, because a cancellation or rename
+acting on a view reported *after* the instruction was sent could target a
+run the human was never looking at when they issued it. (Contrast this
+with `get_current_view`, below, which does prefer a later live report — a
+read has no such hazard.) The frontend's selection payload for this key is
+carried under `"s"` for mission/history views (`OperatorPanel.tsx`'s
+`selection` writer) and under `"sel"` for the library space; there is never
+a `runId`/`run_id`/`sessionId` key on the wire for the former, which is why
+`cancel_run._current_run_id` reads `"s"` specifically while
+`run_progress._resolve_current` also tries the longer names for the paths
+that do use them.
+
+### View freshness: observation count, not wall clock
+
+The Operator tracks "where is the human right now" (`space`, `route`,
+`selection`, `filters`) two ways: as a snapshot frozen onto each turn's
+context, and as an out-of-band report a page can send any time via
+`OperatorStore.record_view`. Ordering between a turn's frozen snapshot and
+a later view report — and between two view reports from the same page — is
+by `observation_seq`, an integer each page increments for the views it
+sends, never by server arrival time or a wall clock. Arrival order is
+wrong because a page can queue a report before an instruction is sent and
+have it land after; a wall clock is wrong because it can step backwards and
+leave a stale view holding the higher timestamp. The `observer_id` that
+travels with every count identifies which page produced it, because a
+count means nothing compared across pages — two browser tabs on one
+conversation are two independent counters, and a reload starts a new one.
+`record_view` gives each observer its own row for the same reason: a
+shared row would let a delayed report from an older navigation overwrite a
+newer page's high-water mark. A report that does not count higher than
+that observer's own stored count is discarded outright.
+
+`application_mcp.py::get_current_view` is the read side: it starts from the
+turn's frozen context and only swaps in the stored view when that view's
+`observation_seq` is both present and strictly greater than the turn's own
+— otherwise the turn's snapshot is the most defensible answer available.
+The response reports whether the returned context is `"turn"` (nothing
+newer confirmed) or `"live"` (a fresher report exists), but never echoes
+the raw sequence number itself, since a bare count invites exactly the
+cross-page comparison this mechanism exists to prevent. `OperatorViewReport`
+(`types.py`) requires both `observation_seq` and `observer_id` for this
+reason — a report that cannot say who saw it or where it fell in their
+sequence can never be ordered against anything, so it is rejected outright
+rather than stored with a misleading freshness label.
+
+### Model catalog, provider selection, and effort clamping
+
+`catalog.py` is the single source of truth `GET /operator/models` renders
+from and the coordinator validates every turn's selection against before
+it reaches a provider CLI; model ids and effort ceilings are grounded in
+the provider request models themselves (`ClaudeEffort` for `claude_code`,
+the codex effort-ceiling tables in `service/providers.py` for `codex`, and
+`resolve_agy_model` — which folds effort into the model name rather than
+taking a separate parameter — for `gemini_code`). `model_effort_choices`
+derives the efforts it offers for a given model from the same clamp
+functions the request-build path applies (`_clamp_claude_effort`,
+`_clamp_codex_effort`, `_clamp_gemini_effort`), rather than restating a
+second copy of the ceilings: an effort is offered only when clamping it
+for that model is a no-op. This matters because the request path clamps
+silently — a non-Opus Claude model turns `xhigh` into `high`, most Codex
+models turn `max`/`ultra` into `xhigh`, Gemini Pro has no Medium tier — and
+offering a value the request would silently change is worse than not
+offering it: the operator picks one level and a different one runs with
+nothing said. `resolve_selection` validates a client's requested
+`(provider, model, effort)` the same way: when a model is named, effort is
+checked against that specific model's ceiling rather than its provider's
+whole vocabulary, so a stale client can't pin an effort the request path
+would then quietly reduce.
+
+### Provider session identity vs. durable branch identity
+
+`OperatorStore` tracks two different kinds of continuity for a
+conversation, and conflating them was a real bug each fixes. A **provider
+session id** (`claim_resolved_pair`, `set_provider_session_id`) is a
+resumability token that belongs to the exact `(provider, model)` pair that
+created it — resuming a Claude session against Codex is meaningless.
+Before `claim_resolved_pair` existed, only an explicit pin change could
+invalidate a stored session; an *unpinned* conversation runs on whatever
+the environment resolves to, re-read every turn, so moving the
+process-wide default provider silently tried to resume a session that
+belonged to the old pair. `claim_resolved_pair` compares the pair about to
+run against the pair that last ran and drops the stored session (returning
+`None` to resume with) exactly when they differ. A `NULL` stored pair — no
+turn has recorded a resolution yet, true for every conversation alive when
+this shipped — is not treated as a mismatch, which would otherwise drop
+every live session once at upgrade. `clear_provider_model` removes an
+explicit pin (an omitted `model` on a turn means "keep the current pin",
+so there has to be a separate way to ask for "no pin"), and drops the
+provider session as a consequence of the pair changing, not as its own
+separate effect — clearing an already-unpinned conversation is a no-op.
+
+A **branch id** (`claim_branch_id`) is a different, longer-lived identity:
+the id every turn of a conversation builds its in-process `Branch` with.
+Before this existed, every turn constructed a brand-new `Branch()` with a
+fresh random id, so the CLI's own persistence path
+(`setup_agent_persist` in `lionagi/cli/_runs.py`) saw a never-before-seen
+id each time and created a new `sessions` row per turn instead of one row
+per conversation. Feeding back the same claimed id lets that existing
+"resume" logic run instead — it looks up the id in the `branches` table
+and appends to the existing session when found. `claim_branch_id` mints
+the id once (a fresh UUID) and persists it; every call after that returns
+the same value. It is race-safe the same way `claim_resolved_pair` is —
+wrapped in the store's `BEGIN IMMEDIATE` transaction, so two turns racing
+to claim the first id block against each other rather than minting two.
+Note that this only ever stores an identity, never a live `Branch` object:
+turns arrive as separate HTTP requests, the daemon restarts between them,
+and two browser tabs can drive one conversation at once, so no Python
+object can be assumed shared across turns.
+
+`fork_conversation` copies a source conversation's turns into a new,
+independent one, but only turns that reached a terminal status
+(`completed`/`failed`/`cancelled`) — a turn still streaming is left out, so
+forking mid-turn ends the fork at the last completed turn rather than
+copying a half-written one, and the source conversation keeps streaming
+untouched. `up_to_sequence`, when given, additionally caps the fork at an
+earlier point in history so a user can branch from any prior turn, not
+only the tip. The fork starts with no provider session of its own, so it
+never silently resumes the source's provider-side session.
+
+### Redaction
+
+`redact.py` is shared by every read tool (`run_detail`, `run_progress`,
+`run_findings`) and by the tool-argument/artifact payloads those tools and
+the write adapters project. `scrub_text` catches secrets and paths by
+*shape*: known token prefixes (`sk-`, `ghp_`, JWT-shaped strings), header
+and `Bearer` forms, `KEY=value`/`key: value` assignments under a
+secret-marker name, and absolute POSIX/Windows paths (collapsed to their
+leaf filename, so a real path like `/Users/lion/My Project/notes/secret.txt`
+is matched and redacted as a whole, not just its first space-free
+segment). Shape-based matching alone misses a secret that doesn't look
+like one — an arbitrary passphrase or short internal token echoed back
+verbatim from a run's own environment, which a Studio-launched run
+inherits from this server process. `known_secret_values` reads that
+environment directly and returns every value stored under a
+secret-marker-named key (4+ characters, to exclude incidental short
+matches), and `scrub_text` strips any of those literal values in addition
+to the shape-based patterns.
+
+Whether a *field name* itself means a credential is decided once, by
+`is_secret_field_name`, and every redaction path shares it — two divergent
+copies of this rule used to exist, and a value under an `auth` key was
+withheld on some projections and served on others. `fold_field_name`
+normalizes separators first (`X-API-Key`, `api.key`, and `api_key` all fold
+to the same spelling) so the marker list only needs one spelling per
+concept. A short, closed set of names (`auth`, `authentication`, `bearer`)
+is matched by exact equality rather than substring, because those words
+also occur inside unrelated field names (`author`, `authorized_keys_count`)
+that must not be redacted. `redact_arguments` applies the same field-name
+judgment recursively, carrying the parent key down into nested containers
+— without that, `{"auth": "..."}` was withheld while `{"auth": {"value":
+"..."}}` was served, the same field-name gap recurring one level down.
+Two independent byte caps (`cap_by_bytes` for a list of items,
+`cap_payload_by_bytes` for one payload) bound aggregate response size after
+redaction; `cap_by_bytes` fails closed on a single oversized item — an
+item that alone exceeds the limit is elided rather than admitted whole,
+so one huge newest item can't blank out every older, smaller one that
+would otherwise fit.
+
+### Bounded read projections: run_detail, run_progress, run_findings
+
+All three read tools report **why** a run couldn't be read, not just that
+it couldn't: `run_detail` returns `{"known": False, "source": "unavailable"}`
+when the configured store cannot honestly be opened read-only (checked
+both before and after the underlying carrier call, so a store that
+disappears mid-call is reported as unavailable rather than as an empty
+result), versus `{"known": False, "source": "store"}` when the store is
+fine but no run matches — `get_run` collapses both situations into a bare
+`None`, so `run_detail` runs its own preflight to tell them apart. Every
+free-text field goes through `scrub_text` and `project` through
+`public_project`; `manifest` (an unbounded mapping) goes through the
+recursive redactor plus a byte cap. These fields are redacted even though
+today's StateDB-backed carrier already fills most of them with safe
+placeholders, because the projection has to be safe for what the field
+names promise across every backing carrier (a manifest-backed builder
+elsewhere fills the same names from raw, untrusted manifest text), not
+just for the values one code path happens to supply right now.
+
+`run_progress` reports operation counts two ways depending on what the run
+has: for an ordinary run it counts branches by status; for a DAG run (one
+with a `graph`) it instead derives per-node state from the session's
+recorded lifecycle signals, because a planned node with no branch
+materialized yet would otherwise be invisible to a branch count. Node
+state is read from the same `NodeQueued`/`NodeStarted`/... signal kinds the
+frontend's live SSE view and the in-run `Signal` bus both use, replayed
+over persisted `session_signals` rows since a bounded read tool can't
+subscribe to a live stream. `skipped` folds into the `completed` bucket
+(the node will never run, but the edge condition that skipped it did what
+it was written to do) while still being counted separately in
+`skippedCount`, and `escalated` folds into `pending` while being counted in
+`escalatedCount` — both counts are always present, including as zero, so a
+caller can tell "nothing happened" from "the field doesn't exist yet."
+
+`run_findings` derives tool-call outcomes (`success`/`error`/`pending`)
+from message content via the same `_detect_status` heuristic
+`lionagi.studio.services.runs` already uses for the run-detail step list,
+since plain session messages carry no structured `ok: bool`. Every section
+here is bounded by a message *window* (the carrier is called with a fixed
+`message_limit`) before any byte cap ever applies — the byte cap almost
+never fires in practice, so `truncated` reports both, and the response
+carries `total` alongside `returned`/`items` so a caller can tell "the last
+50 of 50" from "the last 50 of 48,000." The `errors` section's `partial`
+flag propagates from the same window: branch and session status rows are
+read in full, but the tool-call-derived half of the errors list was built
+from a possibly-incomplete message window, and failing to say so would let
+"no errors found" silently mean "no errors observed in what we happened to
+load."

--- a/lionagi/studio/operator/application_mcp.py
+++ b/lionagi/studio/operator/application_mcp.py
@@ -851,23 +851,13 @@ async def get_current_view(arguments: dict[str, Any]) -> dict[str, Any]:
     context = context if isinstance(context, dict) else None
     source = "turn"
 
-    # The turn's context is frozen at submit, so it is only the freshest answer
-    # until the human moves. Prefer a view the SAME PAGE observed later in its
-    # own count of the views it has seen.
-    #
-    # Both halves of that are load-bearing. Server arrival order cannot stand in
-    # for the count: a report the browser saw before the instruction can arrive
-    # after it, and ordering by arrival would present a view from before the
-    # question as the answer to it, labelled live. Nor can a wall clock, which
-    # can step backwards and leave a stale view holding the higher number. And a
-    # count from a different page cannot be compared at all: two tabs on one
-    # conversation are looking at two different pages, they count
-    # independently, and only the page the instruction came from can say where
-    # the human is.
-    #
-    # When the turn names no observer or no count there is nothing to compare
-    # against, so the honest answer is the turn's own snapshot rather than a
-    # freshness claim that cannot be supported.
+    # The turn's context is frozen at submit, so it is only the freshest
+    # answer until the human moves. Prefer a view the SAME PAGE observed
+    # later, by its own observation count -- never server arrival order or a
+    # wall clock, and never a count from a different page. See
+    # docs/internals/studio.md ("View freshness: observation count, not
+    # wall clock"). When the turn names no observer or no count, the turn's
+    # own snapshot is the honest answer.
     turn_seq = (context or {}).get("observationSeq")
     turn_observer = (context or {}).get("observerId")
     if isinstance(turn_seq, int) and isinstance(turn_observer, str):
@@ -884,14 +874,10 @@ async def get_current_view(arguments: dict[str, Any]) -> dict[str, Any]:
         "project": public_project(context.get("project")),
         "selection": context.get("selection"),
         "filters": context.get("filters"),
-        # "turn" means nothing observed later than the instruction has been
-        # reported, so the human may have moved since. "live" means this is
-        # where they are.
-        #
-        # The observation count that decided this is deliberately NOT returned.
-        # It counts what one page has seen and means nothing outside that page,
-        # so a bare number here could only invite a comparison that is not
-        # valid -- which is the defect this whole mechanism was built to remove.
+        # "turn": nothing observed later has been reported, so the human may
+        # have moved since. "live": this is where they are. The observation
+        # count itself is deliberately not returned -- it means nothing
+        # outside the page that counted it.
         "source": source,
     }
 

--- a/lionagi/studio/operator/cancel_run.py
+++ b/lionagi/studio/operator/cancel_run.py
@@ -2,27 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """Studio Operator lifecycle service/adapter: ``cancel_run``.
 
-Contract: `../analyst/implementation_brief.md` §3.3. Cancels one Studio run
-(a `sessions` row) by reference -- a run id, an id prefix, a name substring,
-or ``"current"`` -- gated on the same durable human allow/deny proposal flow
-``launch_playbook`` uses (`application_mcp.py::launch_playbook`).
-
-Real in-process cancellation only, per the implementer brief: the actual
-state-changing act reuses the exact primitives ``li kill`` uses --
-``lionagi.cli._util.fetch_unique_row`` for id/prefix resolution and
-``lionagi.cli.kill._kill_one`` (SIGTERM/SIGKILL identity-checked termination
-plus ``_persist_cancel``'s guarded status write) -- so a cancellation
-performed through the Operator MCP surface is indistinguishable from one
-performed by a human running ``li kill`` directly. No subprocess is spawned;
-`application_mcp.py::launch_playbook`, which this module's proposal flow
-mirrors, does not shell out either -- it creates a proposal and polls it,
-same as `cancel_run` below.
-
-``resume_run`` (`resume_run.py`) is a separate adapter: it does not un-gate
-a cancelled run's status -- the lifecycle policy
-(`lionagi/state/lifecycle/policy.py`) has no edge out of ``cancelled`` -- it
-launches a new, separate invocation that continues the same branch's
-conversation with new input, which needs no such edge.
+Cancels one Studio run (a `sessions` row) by reference -- a run id, an id
+prefix, a name substring, or ``"current"`` -- gated on the same durable
+human allow/deny proposal flow ``launch_playbook`` uses
+(`application_mcp.py::launch_playbook`). Real in-process cancellation only:
+the state-changing act reuses the exact primitives ``li kill`` uses
+(``lionagi.cli._util.fetch_unique_row`` for id/prefix resolution,
+``lionagi.cli.kill._kill_one`` for identity-checked termination), so a
+cancellation through the Operator is indistinguishable from one run through
+``li kill`` directly -- no subprocess is spawned. See
+docs/internals/studio.md ("Turn identity and the propose/poll/execute
+pattern") for why ``resume_run`` is a separate operation rather than an
+un-gate of a cancelled run's status.
 """
 
 from __future__ import annotations
@@ -106,21 +97,10 @@ async def _current_run_id(store: OperatorStore, request_id: str) -> str | None:
     """The run the human was looking at when this instruction was sent.
 
     Deliberately reads the turn's OWN frozen context rather than a
-    later-reported live view. `get_current_view`'s freshness merge (prefer a
-    view the same page reported after the instruction was sent) is right for
-    a read -- show the freshest honestly-labelled answer -- but wrong for a
-    cancellation: acting on a view reported after the instruction was sent
-    could target a run the human was never looking at when they said "stop
-    it". Freezing to turn-start intent is the conservative choice for a
-    state-changing tool.
-
-    Reads the "s" key: the frontend's `select` effect resolver
-    (apps/studio/frontend/src/components/operator/operatorEffects.ts:147)
-    reads `selection.s ?? selection.runId ?? selection.run_id ??
-    selection.sessionId`, but the writer that actually populates the
-    reported selection (OperatorPanel.tsx:253) only ever sets `"s"` (or
-    `"sel"` for the library space) -- there is no `runId`/`run_id`/
-    `sessionId` key ever placed on the wire for mission/history views.
+    later-reported live view -- acting on a view reported after the
+    instruction was sent could target a run the human was never looking at
+    when they said "stop it". See docs/internals/studio.md ("Resolving a
+    run reference") for why this reads the "s" key specifically.
     """
     turn = await store.get_turn(request_id)
     context = turn.get("context")
@@ -139,10 +119,8 @@ async def _allowed_project(store: OperatorStore, request_id: str) -> str:
     Raises :class:`MissingOwnerContextError` rather than returning a
     sentinel when the turn's own context names no project -- a turn with no
     owner mapping must never be treated as authorized for every project's
-    runs. Mirrors ``run_progress.py::_allowed_project`` -- kept as a
-    separate small copy rather than a shared import so this module's
-    identity/store handling stays self-contained the same way
-    ``_current_run_id`` above already does.
+    runs. A separate small copy of ``run_progress.py::_allowed_project``, so
+    this module's identity/store handling stays self-contained.
     """
     turn = await store.get_turn(request_id)
     context = turn.get("context")
@@ -183,19 +161,14 @@ async def _resolve_run(db: Any, ref: str, *, project: str) -> dict[str, Any] | N
     """Resolve *ref* to exactly one `sessions` row (a Studio "run").
 
     Mirrors `lionagi.cli._util.fetch_unique_row`'s exact-id-then-prefix
-    discipline, narrowed to the `sessions` table because a Studio "run" is a
-    session (`lionagi/studio/services/runs.py::get_run` is
-    `_sessions_svc.get_session` under a product-facing name). A prefix
-    matching more than one session raises `AmbiguousRunReferenceError`
-    rather than picking one -- never guess which process to signal.
-
-    Every arm -- exact id, ambiguous prefix, and the name/playbook substring
-    scan below -- is scoped to ``project`` (the calling turn's own project --
-    callers always name one; see ``_allowed_project``): a lifecycle tool
-    must not resolve, let alone propose cancelling, another project's run by
-    id, prefix, or label. A foreign exact/prefix match is reported exactly
-    like a nonexistent one (``None``) rather than as e.g. "already
-    terminal", which would itself confirm the id exists.
+    discipline, narrowed to the `sessions` table. A prefix matching more
+    than one session raises `AmbiguousRunReferenceError` rather than picking
+    one -- never guess which process to signal. Every arm is scoped to
+    ``project`` (the calling turn's own; see ``_allowed_project``): a
+    foreign exact/prefix match is reported exactly like a nonexistent one
+    (``None``), never as e.g. "already terminal", which would itself
+    confirm the id exists. See docs/internals/studio.md ("Resolving a run
+    reference").
     """
     from lionagi.cli._util import AmbiguousIdError, fetch_unique_row
 
@@ -401,20 +374,15 @@ async def execute_cancel_command(command: dict[str, Any]) -> dict[str, Any]:
     """The real state-changing act -- the adapter's other half.
 
     Wire this into `OperatorCoordinator`'s ``command_executor`` for
-    ``command_type == "cancel"`` (see module docstring). Re-resolves the
-    session by exact id at execution time: the human's deliberation window
-    may have let the run finish or fail on its own, or its project could
-    have been reassigned since ``cancel_run`` resolved it -- ownership is
-    checked again here, not trusted from resolution alone. `_persist_cancel`
-    is a no-op once the row is no longer 'running', so a race here degrades
-    to ``already_terminal`` -- never a double cancel, never a wrong-run
-    cancel.
-
-    Reuses `lionagi.cli.kill`'s own deepest-first child traversal
-    (``_list_running_children``/``_kill_one``) so a cancel through the
-    Operator reaps a still-running owning invocation exactly the way
-    ``li kill --recursive`` does -- otherwise the session's process goes
-    terminal while its child process is orphaned.
+    ``command_type == "cancel"``. Re-resolves the session by exact id and
+    re-checks ownership at execution time rather than trusting the
+    resolution `cancel_run` captured. `_persist_cancel` is a no-op once the
+    row is no longer 'running', so a race here degrades to
+    ``already_terminal`` -- never a double cancel, never a wrong-run cancel.
+    Reuses `lionagi.cli.kill`'s deepest-first child traversal
+    (``_list_running_children``/``_kill_one``) so a still-running owning
+    invocation is reaped exactly the way ``li kill --recursive`` does,
+    rather than orphaned when the parent session goes terminal.
     """
     from lionagi.cli.kill import _kill_one, _list_running_children
     from lionagi.state.db import StateDB

--- a/lionagi/studio/operator/catalog.py
+++ b/lionagi/studio/operator/catalog.py
@@ -3,15 +3,11 @@
 """The Operator's model catalog: which models exist, which provider each runs
 through, and which reasoning-effort levels each accepts.
 
-This is the single source of truth the frontend renders from (``GET
-/operator/models``) and the coordinator validates a turn's selection against
-before it ever reaches a provider CLI. Model identifiers and effort ceilings
-are grounded in the provider request models themselves — see
-``lionagi/providers/anthropic/claude_code.py`` (``ClaudeEffort``),
-``lionagi/providers/openai/codex.py`` plus the codex effort-ceiling tables in
-``lionagi/service/providers.py``, and
-``lionagi/providers/google/gemini_code.py`` (effort folds into the model
-name via ``resolve_agy_model`` rather than a separate parameter).
+Single source of truth for ``GET /operator/models`` and for the selection
+the coordinator validates before a turn reaches a provider CLI. See
+docs/internals/studio.md ("Model catalog, provider selection, and effort
+clamping") for how ids and effort ceilings are grounded in the provider
+request models.
 """
 
 from __future__ import annotations
@@ -83,22 +79,12 @@ def effort_choices(provider: str) -> tuple[OperatorEffort, ...]:
 
 
 def model_effort_choices(model: str) -> tuple[OperatorEffort, ...]:
-    """The efforts a specific model actually honors, not the ones its provider
-    has a name for.
-
-    Effort ceilings are per model, and the request path enforces them by
-    silently clamping: a Claude model that is not Opus turns ``xhigh`` into
-    ``high``, most Codex models turn ``max`` and ``ultra`` into ``xhigh``, and
-    Gemini Pro has no Medium tier so ``medium`` becomes High. Offering a value
-    the request will change is worse than not offering it, because the operator
-    picks a level and the provider is asked for a different one with nothing
-    said.
-
-    So the choices are derived from the same clamp functions the request path
-    uses, rather than restated here: an effort is offered only when clamping it
-    for this model leaves it alone. Deriving rather than duplicating is the
-    point -- a new ceiling added to the provider tables narrows this catalog on
-    its own, and cannot drift away from what the request will do.
+    """The efforts a specific model actually honors, derived from the same
+    clamp functions the request-build path applies rather than restated here
+    -- an effort is offered only when clamping it for this model is a no-op.
+    See docs/internals/studio.md ("Model catalog, provider selection, and
+    effort clamping") for why offering a value the request would silently
+    change is worse than not offering it.
     """
     spec = _BY_ID.get(model)
     if spec is None:
@@ -152,11 +138,9 @@ def resolve_selection(
     in ``build_operator_branch`` is unchanged for a turn that specifies none of
     them. Raises ``OperatorSelectionError`` for an unknown model, an unknown
     provider, a model that does not belong to an explicitly given provider, or
-    an effort the selection cannot honor. When a model is named, the effort is
+    an effort the selection cannot honor. When a model is named, effort is
     checked against that model's own ceiling rather than its provider's whole
-    vocabulary: the catalog offers per-model choices, so accepting a value the
-    catalog does not offer would let a stale client pin an effort the request
-    path then quietly clamps.
+    vocabulary -- see ``model_effort_choices``.
     """
     resolved_provider = provider
     if model is not None:

--- a/lionagi/studio/operator/redact.py
+++ b/lionagi/studio/operator/redact.py
@@ -138,28 +138,17 @@ def _leaf(match: re.Match[str]) -> str:
     return raw.rsplit(sep, 1)[-1] or "[redacted-path]"
 
 
-# `scrub_text`'s regexes above only catch a secret that is *shaped* like one
-# (a known prefix, a header, an "KEY=value" assignment). A run's own config
-# can carry a secret with none of those shapes -- an arbitrary passphrase, a
-# short internal token -- and such a value survives every pattern above
-# untouched if it is echoed back verbatim in a message, tool-call argument,
-# or error string. A Studio-launched run inherits this server process's
-# environment, so that environment *is* the run's own config; this treats
-# any environment value stored under a secret-marker key
-# (see `_SECRET_KEY_MARKERS`) as a literal string to strip out of every
-# projection, in addition to (not instead of) the shape-based patterns
-# above. Values under 4 characters are excluded: below that length a literal
-# match is far more likely to be incidental shared substring noise (a short
-# numeric id, a single word) than an actual secret worth destroying
-# unrelated context for.
+# Complement to the shape-based patterns below: catches a secret with no
+# recognizable shape by matching literal values from this process's own
+# environment (which a Studio-launched run inherits). See
+# docs/internals/studio.md ("Redaction"). Values under 4 characters are
+# excluded as more likely incidental substring noise than a real secret.
 _KNOWN_VALUE_MIN_LEN = 4
 
 
 def known_secret_values() -> frozenset[str]:
     """Literal secret values read from this process's own environment --
-    the config a Studio-launched run actually inherits. See the module
-    comment above `_KNOWN_VALUE_MIN_LEN` for why this exists alongside the
-    shape-based patterns in `scrub_text`, and the length cutoff chosen."""
+    the config a Studio-launched run actually inherits."""
     values: set[str] = set()
     for key, value in os.environ.items():
         if not value or len(value) < _KNOWN_VALUE_MIN_LEN:
@@ -208,15 +197,10 @@ _FIELD_SEPARATOR_RE = re.compile(r"[^a-z0-9]+")
 def fold_field_name(key: str) -> str:
     """Reduce a field name to the spelling the secret markers are written in.
 
-    Separators do not change which field a name refers to. HTTP headers arrive
-    as X-API-Key, config files write api.key, and our own records write
-    api_key, so every marker containing an underscore would otherwise match
-    only the last of those. Folding any run of non-alphanumeric characters to a
-    single underscore makes all the spellings compare equal.
-
-    This lives here, and not beside either caller, because both redaction
-    layers have to agree about it. When they disagreed, the same credential was
-    withheld on one path and served on the other.
+    Separators do not change which field a name refers to (``X-API-Key``,
+    ``api.key``, ``api_key`` all fold to the same spelling), so every marker
+    only needs one spelling. Shared by both redaction layers -- see
+    docs/internals/studio.md ("Redaction").
     """
     return _FIELD_SEPARATOR_RE.sub("_", key.lower())
 
@@ -229,15 +213,9 @@ _EXACT_SECRET_FIELD_NAMES = frozenset({"auth", "authentication", "bearer"})
 
 
 def is_secret_field_name(key: str) -> bool:
-    """Say whether a field name names a credential.
-
-    This is the whole rule, in one place, because two copies of it disagreed:
-    one carried the exact-match names above and the other did not, so a value
-    under an `auth` key was withheld on the session and artifact paths and
-    served on the tool-argument and manifest paths. Sharing the separator fold
-    alone was not enough — the vocabulary has to be shared too, or the same
-    class of gap simply moves to whichever name the two lists differ on.
-    """
+    """Say whether a field name names a credential. The single shared rule
+    every redaction path in this module uses -- see
+    docs/internals/studio.md ("Redaction")."""
     folded = fold_field_name(key)
     return folded in _EXACT_SECRET_FIELD_NAMES or any(
         marker in folded for marker in _SECRET_KEY_MARKERS
@@ -279,19 +257,12 @@ def redact_scalar(key: str, value: Any) -> Any:
 
 
 def redact_arguments(value: Any, *, parent_key: str = "") -> Any:
-    """Recursively redact secret- and absolute-path-shaped values. Used on
-    tool-call arguments and on artifact contract/verification payloads, the
-    two places a new Operator read tool could otherwise widen exposure
-    beyond what the existing tools already show.
+    """Recursively redact secret- and absolute-path-shaped values, used on
+    tool-call arguments and artifact contract/verification payloads.
 
-    ``parent_key`` carries the field name a container arrived under, because a
-    credential name has to cover what is nested beneath it and not only a scalar
-    sitting directly on it. Without it the name was consulted for scalars alone,
-    so ``{"auth": "..."}`` was withheld while ``{"auth": {"value": "..."}}`` was
-    served — the same split, across two shapes, that sharing the field-name rule
-    had just closed across two layers. The session and artifact projection
-    already judges the name before descending into a container; this is that
-    same step, on this path.
+    ``parent_key`` carries the field name a container arrived under, so a
+    credential name covers what is nested beneath it, not only a scalar
+    sitting directly on it -- see docs/internals/studio.md ("Redaction").
     """
     if isinstance(value, (dict, list)) and is_secret_field_name(parent_key):
         return "[redacted]"

--- a/lionagi/studio/operator/rename_session.py
+++ b/lionagi/studio/operator/rename_session.py
@@ -4,16 +4,11 @@
 
 Gives one Studio run (a `sessions` row) a human name through the Operator,
 gated on the same durable human allow/deny proposal flow `cancel_run` and
-`resume_run` use (`application_mcp.py::launch_playbook`'s shape). This is
-deliberately distinct from renaming the Operator's own *conversation*
-(`store.py::update_conversation`, shipped separately as a direct human
-UI/REST action): a conversation can talk about many runs over its life, and
-this tool names the run the conversation is currently discussing, not the
-conversation thread itself.
-
-Reuses `run_progress.py::resolve_run` for reference resolution -- the same
-id/prefix/name/"current" vocabulary and project-scoping `resume_run` already
-uses -- rather than a third private copy of that logic.
+`resume_run` use. Deliberately distinct from renaming the Operator's own
+*conversation* (`store.py::update_conversation`, a direct human UI/REST
+action) -- see docs/internals/studio.md ("Turn identity and the
+propose/poll/execute pattern"). Reuses `run_progress.py::resolve_run` for
+reference resolution rather than a third private copy of that logic.
 """
 
 from __future__ import annotations

--- a/lionagi/studio/operator/resume_run.py
+++ b/lionagi/studio/operator/resume_run.py
@@ -6,27 +6,14 @@ Delegates to the real, supported ``POST /runs/{run_id}/resume`` surface
 (`lionagi/studio/services/run_resume.py::resume_run`) for the actual launch
 decision -- this adapter never picks an argv or a resume path itself. It
 does read the run's recorded ``invocation_kind`` before creating a proposal,
-though: that is what lets the proposal's summary say the true thing the
-dispatcher is about to do, and lets an argument combination the dispatcher
-would always reject (e.g. an instruction for a checkpoint-replay kind) be
-refused before a human ever sees an approvable proposal for it, instead of
-after they approve one that was always going to fail. For an ``agent`` run
-that means the same ``li agent -r`` path a human resuming from the CLI or
-Studio UI uses, continuing the branch with a new instruction. For a
-``play``/``flow``/``show-play`` run it means replaying the run's persisted
-checkpoint via ``li o flow --resume`` -- the checkpoint owns the plan, so no
-instruction is accepted for those kinds. Gated on the same durable human
+so the proposal's summary says the true thing the dispatcher is about to do
+and an argument combination the dispatcher would reject (e.g. an
+instruction for a checkpoint-replay kind) is refused before a human ever
+sees an approvable proposal for it. Gated on the same durable human
 allow/deny proposal flow ``cancel_run``/``launch_playbook`` use, since it
-starts a new process.
-
-This is a distinct operation from "un-pausing a paused run": the session
-lifecycle policy has no edge back out of a terminal state such as
-``cancelled`` (see `cancel_run.py`'s module docstring and
-`lionagi/state/lifecycle/policy.py`), so a resumed run does not reopen its
-old status -- it launches a new, separate invocation that continues (agent)
-or replays (play/flow/show-play) the same run. ``resume_run()`` (the real
-service function) accepts any run with a resumable branch or checkpoint,
-including terminal ones; this adapter does not narrow that further.
+starts a new process. See docs/internals/studio.md ("Turn identity and the
+propose/poll/execute pattern") for why this is a distinct operation from
+un-pausing a paused or cancelled run, and accepts a run in any status.
 """
 
 from __future__ import annotations

--- a/lionagi/studio/operator/run_detail.py
+++ b/lionagi/studio/operator/run_detail.py
@@ -5,32 +5,10 @@
 A bounded, single-run counterpart to ``run_progress``/``run_findings`` --
 unlike those two, this tool takes a bare run/session id rather than a
 resolvable reference (no ``resolve_run`` indirection), and projects the
-carrier's own detail fields directly rather than deriving a progress or
-findings summary from them.
-
-Carrier: ``lionagi.studio.services.runs.get_run``, called directly. That
-function already resolves its own store access correctly (through
-``sessions.get_session`` -> ``_open_db``, never through ``StateDB``), so this
-module never constructs a ``StateDB`` itself.
-
-Availability is reported as a ``known``/``source`` pair rather than a bare
-``None``, because ``get_run`` collapses two different situations into the
-same ``None`` return: the store could not be read at all, and the store was
-read fine but no run matched. Those need different answers, so this module
-runs its own preflight (mirroring the ``state_db_known_absent()``/
-``read_only_open_supported()`` pairing every other bounded-read path in this
-package already checks before opening a connection) both before calling the
-carrier and again after a ``None``, so a store that disappears between the
-two calls is reported as unavailable rather than as an empty result.
-
-Redaction reuses the existing helpers in ``redact.py`` exactly as
-``run_progress``/``run_findings`` do -- free-text identifier fields
-(``name``, ``playbook_name``, ``agent_name``, ``model``, ``worker_name``) are
-passed through ``scrub_text``, matching ``run_progress.py``'s own treatment
-of the same fields; ``project`` goes through ``public_project``;
-``status_reason_summary`` goes through ``redact_scalar`` with a manually
-derived truncation flag, since ``redact_scalar`` reports no clipping signal
-of its own.
+carrier's (``lionagi.studio.services.runs.get_run``) own detail fields
+directly. See docs/internals/studio.md ("Bounded read projections") for the
+``known``/``source`` availability contract and the redaction rules shared
+with ``run_progress``/``run_findings``.
 """
 
 from __future__ import annotations
@@ -83,17 +61,12 @@ def _scrub(value: Any) -> Any:
 def _summary(raw: Any) -> tuple[Any, bool]:
     """Redact ``status_reason_summary`` and say truthfully whether it clipped.
 
-    ``redact_scalar`` applies the cap to ``scrub_text(value)``, not to the raw
-    value, and scrubbing moves the length in both directions -- an absolute
-    path collapses to its leaf, a secret header expands to a marker. Deriving
-    the flag from the raw length therefore describes a different string than
-    the one that was actually capped, and the two disagree whenever scrubbing
-    carries the length across the cap.
-
-    The cap clipped exactly when the output sits at the cap while the scrubbed
-    input ran past it. Testing that, rather than testing the raw length, also
-    keeps the secret-value path honest: there ``redact_scalar`` substitutes a
-    short marker instead of slicing, so nothing was truncated.
+    Truncation is detected against the *scrubbed* input, not the raw value:
+    scrubbing changes length in both directions (a path collapses to its
+    leaf, a header expands to a marker), so the cap clipped exactly when the
+    output sits at the cap while the scrubbed input ran past it. This also
+    keeps the secret-value path honest, where ``redact_scalar`` substitutes a
+    short marker instead of slicing -- nothing was truncated there.
     """
     redacted = redact_scalar("status_reason_summary", raw)
     if not isinstance(raw, str) or not isinstance(redacted, str):
@@ -104,25 +77,13 @@ def _summary(raw: Any) -> tuple[Any, bool]:
 def _project(run: dict[str, Any]) -> tuple[dict[str, Any], bool]:
     """Redact and rename ``get_run``'s detail fields for the Operator surface.
 
-    Returns ``(fields, truncated)``, where ``truncated`` is the aggregate over
-    every field bounded here: the capped ``status_reason_summary`` and the
-    byte-capped ``manifest``.
-
-    ``cwd``, ``state_root``, ``artifact_root``, ``manifest``, ``task`` and
-    ``error`` are shown by no other Operator tool, and they are the fields
-    shaped to carry filesystem layout and arbitrary payloads. On the carrier
-    this module actually calls they are not yet dangerous: ``get_run``'s
-    StateDB path constant-fills ``task``/``error``/``cwd``/``manifest`` with
-    ``""``/``None``/``None``/``{}`` and already runs both roots through
-    ``public_path``. They are redacted here anyway because that is a property
-    of the carrier, not of this projection -- ``runs.py``'s own manifest-backed
-    builder fills the same field names from raw manifest text (``task`` from
-    ``manifest["prompt"]``, ``error`` from ``manifest["error"]``), so the
-    projection has to be safe for the values the field names promise rather
-    than for the placeholders one code path happens to supply today. The
-    path-shaped and free-text fields go through ``scrub_text`` like every
-    other free-text field here; ``manifest`` goes through the recursive
-    redactor and a byte cap because it is an unbounded mapping.
+    Returns ``(fields, truncated)``, the aggregate over every field bounded
+    here (``status_reason_summary`` and ``manifest``). ``cwd``, ``state_root``,
+    ``artifact_root``, ``manifest``, ``task`` and ``error`` carry filesystem
+    layout and arbitrary payloads and are shown by no other Operator tool;
+    they are redacted for what the field names promise across every backing
+    carrier, not just the safe placeholders today's StateDB carrier happens
+    to fill -- see docs/internals/studio.md ("Bounded read projections").
     """
     raw_summary = run.get("status_reason_summary")
     redacted_summary, summary_truncated = _summary(raw_summary)

--- a/lionagi/studio/operator/run_findings.py
+++ b/lionagi/studio/operator/run_findings.py
@@ -5,13 +5,12 @@
 Per-branch message tails, tool calls with inferred outcomes, errors (both
 tool-level and branch/session status failures), and declared artifacts with
 their verification state. Bounded and redacted on the same rules as
-``run_progress``/the existing read tools — see ``redact.py``.
-
-Tool-call outcomes are inferred from message content via the same
-``_detect_status`` heuristic ``lionagi.studio.services.runs`` already uses to
-build the run-detail step list; there is no structured ``ok: bool`` on a
-plain session's ActionRequest/ActionResponse messages to read instead (see
-``read_tools_implementation.md`` for the source citation this replaces).
+``run_progress``/the existing read tools — see ``redact.py`` and
+docs/internals/studio.md ("Bounded read projections"). Tool-call outcomes
+are inferred from message content via the same ``_detect_status`` heuristic
+``lionagi.studio.services.runs`` already uses to build the run-detail step
+list, since a plain session's ActionRequest/ActionResponse messages carry
+no structured ``ok: bool``.
 """
 
 from __future__ import annotations

--- a/lionagi/studio/operator/run_progress.py
+++ b/lionagi/studio/operator/run_progress.py
@@ -6,15 +6,10 @@ Resolves a human-supplied run reference (a run/session id, an id prefix, a
 name/playbook substring, or ``"current"``) to at most one session, then
 reports how far that run's operations have gotten. Every number here is a
 direct read of stored state — it reflects what the database recorded, not
-necessarily a live process (see the ``freshness`` field).
-
-Id/prefix resolution reuses ``lionagi.cli._util.fetch_unique_row`` — the same
-exact-id-then-prefix primitive ``li kill`` and ``cancel_run.py`` use — rather
-than a bespoke hex-only regex, so a reference this tool accepts and a
-reference ``cancel_run`` accepts resolve identically.
-
-``resolve_run`` is imported by ``run_findings.py`` so both read tools accept
-the same reference vocabulary.
+necessarily a live process (see the ``freshness`` field). ``resolve_run`` is
+also imported by ``run_findings.py``, ``resume_run.py``, and
+``rename_session.py`` so every tool accepts the same reference vocabulary --
+see docs/internals/studio.md ("Resolving a run reference").
 """
 
 from __future__ import annotations
@@ -142,18 +137,15 @@ async def _allowed_project() -> str | None:
     """The project this Operator turn is scoped to, or ``None`` when there is
     no turn identity to enforce at all.
 
-    Reads the same durable turn identity ``cancel_run.py``/``get_current_view``
-    use. Falls open (no restriction) only when the turn identity environment
-    is entirely absent — a real MCP subprocess always has it set (see
+    Falls open (no restriction) only when the turn identity environment is
+    entirely absent -- a real MCP subprocess always has it set (see
     ``engine.py::build_operator_branch``); tests and direct calls that omit
-    the whole identity get the pre-existing unscoped behavior rather than a
-    hard failure. When the identity *is* present -- a real turn exists --
-    but that turn's own context names no project, this raises
+    it get the pre-existing unscoped behavior. When the identity *is*
+    present but that turn's own context names no project, this raises
     :class:`MissingOwnerContextError` rather than falling open: a turn with
-    an owner but no declared project must never be treated as authorized
-    for every project's runs. A lookup failure for a present identity also
-    propagates rather than silently falling open, since that would defeat
-    the isolation this exists to provide.
+    an owner but no declared project must never be authorized for every
+    project's runs. A lookup failure for a present identity also propagates
+    rather than silently falling open.
     """
     import os
 
@@ -206,13 +198,9 @@ async def resolve_run(ref: str) -> dict[str, Any]:
     Never guesses: an id prefix matching more than one session, or a
     name/playbook substring matching 2-``MAX_CANDIDATES`` sessions, comes
     back as candidates; more than ``MAX_CANDIDATES`` text matches come back
-    as the newest ``MAX_CANDIDATES`` plus ``truncated: True``.
-
-    Every arm -- exact id, ambiguous prefix, "current", and the text search
-    below -- is scoped to the calling turn's project (when it names one). A
-    foreign project's run is reported exactly like a nonexistent one, never
-    as e.g. an ambiguity candidate or a resolved id, which would themselves
-    confirm the id exists.
+    as the newest ``MAX_CANDIDATES`` plus ``truncated: True``. Every arm is
+    scoped to the calling turn's project (when it names one) -- see
+    docs/internals/studio.md ("Resolving a run reference").
     """
     from lionagi.cli._util import AmbiguousIdError, fetch_unique_row
     from lionagi.state.db import StateDB
@@ -283,16 +271,13 @@ def _resolution_from_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
 # SESSION_TERMINAL_STATUSES branch below and counts as an op failure.
 _COMPLETED_STATUSES = frozenset({"completed"})
 
-# Per-node lifecycle lane, mirroring the ONLY existing "how far along is a DAG
-# run" projection this codebase has:
-# apps/studio/frontend/src/lib/operationGraph.ts::laneFor/buildNodeStatusesByName
-# (live SSE events) and lionagi/session/signal.py::lane_for (live Signal
-# objects). Neither is usable from a bounded, non-streaming read tool, so this
-# reimplements the same state machine over the persisted
-# ``session_signals`` rows both of those ultimately read from — the frontend
-# correlates a planned graph node's live status by its authored id, carried as
-# ``payload["name"]`` on every Node* signal, never by the runtime op_id (see
-# operationGraph.ts's own comment on this), which is why this keys on name too.
+# Per-node lifecycle lane, reimplementing over persisted ``session_signals``
+# rows the same state machine the live SSE view
+# (apps/studio/frontend/src/lib/operationGraph.ts::laneFor) and the in-run
+# Signal bus (lionagi/session/signal.py::lane_for) use, since neither is
+# usable from a bounded, non-streaming read tool. Keyed on the node's
+# authored id (``payload["name"]``), matching how the frontend correlates a
+# planned graph node to its live status -- never the runtime op_id.
 _NODE_KIND_TO_STATE: dict[str, str] = {
     "NodeQueued": "queued",
     "NodeStarted": "running",

--- a/lionagi/studio/operator/store.py
+++ b/lionagi/studio/operator/store.py
@@ -4,17 +4,17 @@
 
 These defensive ``CREATE TABLE IF NOT EXISTS`` statements intentionally make
 the protocol usable by direct Studio service callers as well as through the
-normal StateDB-opening daemon lifespan.  The tables use the canonical StateDB
-file and never fall back to process memory.
+normal StateDB-opening daemon lifespan. The tables use the canonical
+StateDB file and never fall back to process memory.
 
-Streamed frames are written once per provider chunk, so the durable record
-carries an explicit retention contract enforced on the write path -- see
+Streamed frames are written once per provider chunk under an explicit
+retention contract enforced on the write path -- see
 ``MAX_FRAME_PAYLOAD_BYTES``, ``MAX_FRAMES_PER_TURN`` and
-``MAX_TURN_PAYLOAD_BYTES``.  Nothing is ever dropped silently: an oversized
+``MAX_TURN_PAYLOAD_BYTES``. Nothing is ever dropped silently: an oversized
 payload is stored truncated and says so, and frames refused past a turn's
-budget are counted into a single ``truncation`` summary frame naming what was
-elided and how much.  Terminal ``done`` frames are exempt so a turn can always
-be closed.
+budget are counted into a single ``truncation`` summary frame naming what
+was elided and how much. Terminal ``done`` frames are exempt so a turn can
+always be closed.
 """
 
 from __future__ import annotations
@@ -205,13 +205,11 @@ class OperatorStore:
 
         A store with no file at all is refused as
         :class:`StoreNotAddressableError` rather than as an
-        ``OperatorStoreError``, because those two say different things to a
-        caller. An Operator error is about this subsystem and the routes map it
-        to 503, which invites a retry; a server-backed or in-memory store is
-        not a condition that resolves by waiting, and the app answers 501 for
-        it everywhere else. Reusing the existing refusal also keeps one
-        definition of which stores this SQLite-direct layer can open, instead of
-        a second one here that could drift from it.
+        ``OperatorStoreError``: an Operator error maps to 503 (invites a
+        retry) while a server-backed or in-memory store answers 501
+        everywhere else in the app, since waiting does not make it
+        addressable. Reusing the existing refusal keeps one definition of
+        which stores this SQLite-direct layer can open.
         """
         if self._db_path is not None:
             return self._db_path
@@ -555,15 +553,13 @@ class OperatorStore:
         """Copy a conversation's completed turns into a new, independent conversation.
 
         Only turns that reached a terminal status (completed/failed/cancelled)
-        are copied whole -- forking a conversation with a turn actively
-        streaming therefore ends the fork at the last completed turn instead
-        of copying a half-written one; the original conversation keeps
-        streaming untouched. ``up_to_sequence``, when given, additionally caps
-        the fork at the turn ending at or before that point in the source
-        conversation's history, so a user can branch from any earlier turn
-        rather than always from the tip. The new conversation starts with no
-        provider session of its own, so it does not resume the source's
-        provider-side session.
+        are copied whole, so forking mid-stream ends the fork at the last
+        completed turn rather than copying a half-written one; the source
+        conversation keeps streaming untouched. ``up_to_sequence``, when
+        given, additionally caps the fork at an earlier point in history.
+        The new conversation starts with no provider session of its own --
+        see docs/internals/studio.md ("Provider session identity vs.
+        durable branch identity").
         """
         await self.ensure_schema()
         source = await self.get_conversation(conversation_id)
@@ -710,19 +706,14 @@ class OperatorStore:
     ) -> bool:
         """Record where the page *observer* is now, independently of any turn.
 
-        *seq* is how many views that page had seen when it saw this one. Each
-        report is its own request, so two navigations by one page can arrive
-        reversed; a report that does not count higher than that page's own
-        stored count is DISCARDED, because otherwise the stale view wins and is
-        still labelled current, which is the exact failure this whole mechanism
-        exists to fix.
-
-        Each page gets its own row. A shared row would make every report erase
-        the previous page's high-water mark, and a delayed older report from the
-        page that asked could then be re-admitted as its latest -- the same stale
-        view, arriving by a longer road.
-
-        Returns whether the report was applied.
+        *seq* is how many views that page had seen when it saw this one. A
+        report that does not count higher than that page's own stored count
+        is DISCARDED, since two navigations by one page can arrive reversed
+        and admitting the lower count would let a stale view win while still
+        labelled current. Each page gets its own row, so one page's report
+        can never erase another's high-water mark -- see
+        docs/internals/studio.md ("View freshness: observation count, not
+        wall clock"). Returns whether the report was applied.
         """
         await self.ensure_schema()
         now = time.time()
@@ -802,22 +793,15 @@ class OperatorStore:
         """Record what this turn will run on and return the session it may resume.
 
         A provider session belongs to the (provider, model) pair that created
-        it, and until now the only thing that could invalidate one was an
-        explicit pin change. An unpinned conversation has no pin to change: it
-        runs on whatever the environment resolves to, which is re-read every
-        turn, so moving the default silently resumed a session that belonged to
-        the old pair. This compares the pair that is about to run against the
-        pair that last ran, which is the comparison the pin check could never
-        make.
-
-        Returns the session id to resume with, or ``None`` when the pair moved
-        and the stored session no longer belongs to this turn.
-
-        A stored pair of ``NULL`` returns the session unchanged. It means no
-        turn has recorded a resolution yet, which is not evidence that anything
-        changed, and every conversation alive when this ships is in exactly
-        that state -- reading it as a mismatch would drop every live session
-        once, at upgrade, and would look like the check working.
+        it. This compares the pair about to run against the pair that last
+        ran and drops the stored session (returning ``None``) exactly when
+        they differ -- catching the case an explicit pin change alone
+        cannot: an unpinned conversation re-reads the environment default
+        every turn, so moving that default silently tried to resume a
+        session belonging to the old pair. A stored pair of ``NULL`` (no
+        turn has resolved one yet -- true for every conversation alive at
+        upgrade) is not treated as a mismatch. See docs/internals/studio.md
+        ("Provider session identity vs. durable branch identity").
         """
         await self.ensure_schema()
         async with open_db(str(self.path())) as db:
@@ -859,41 +843,22 @@ class OperatorStore:
         """Return the identity every turn of this conversation builds its
         Branch with, minting and persisting one on the first call.
 
-        This is the fix for the Operator's own log showing N unrelated
-        branches for one N-turn conversation: previously every turn built a
-        brand-new ``Branch()`` with a fresh random id, so
-        ``setup_agent_persist`` (``lionagi/cli/_runs.py``) saw a never-before-
-        seen branch id on every turn and created a new ``sessions`` row for
-        each one. Feeding the SAME id back in lets that existing machinery's
-        own "resume" arm run instead: it looks up ``branch_id`` in the
-        ``branches`` table, and when found, reopens that branch's existing
-        session and appends to it rather than inserting a new row --
-        `setup_agent_persist` already contains this append path (used for CLI
-        resume); nothing about that machinery is changed here. This method
-        only decides what id every turn hands it.
-
-        A brand-new Branch object is still constructed in-process on every
-        turn -- this stores an IDENTITY (a UUID), never a live Branch, since
-        turns arrive as separate HTTP requests, the daemon restarts between
-        them, and two browser tabs can drive one conversation concurrently.
-        None of those can be assumed to share a Python object.
-
-        Idempotent and race-safe: wrapped in the store's usual
-        ``BEGIN IMMEDIATE`` transaction (the same pattern
-        ``claim_resolved_pair`` uses), which SQLite serializes against any
-        other write transaction on this file. Two turns racing to claim the
-        first id for one conversation therefore never see a NULL row at the
-        same time -- the second transaction blocks until the first commits,
-        then reads back the id the first one just wrote and returns that
-        instead of minting its own. The conversation never ends up with two
-        candidate ids to disagree about.
-
-        A conversation created before this column existed reads NULL here on
-        its first post-upgrade turn and adopts an id at that point --
-        deliberately, rather than backfilling one via migration. Its turns
-        already on record stay exactly as they were recorded; only turns from
-        here forward group under the newly-claimed id. No history is
-        rewritten.
+        Feeding the same claimed id into every turn's ``Branch()`` lets the
+        CLI's own "resume" logic (``setup_agent_persist`` in
+        ``lionagi/cli/_runs.py``) find it in the ``branches`` table and
+        append to the existing session, instead of a fresh random id
+        creating a new ``sessions`` row on every turn. This method only
+        decides what id gets handed in; a brand-new in-process ``Branch``
+        object is still constructed every turn, since turns arrive as
+        separate HTTP requests and two browser tabs can drive one
+        conversation concurrently -- no Python object can be assumed
+        shared. Idempotent and race-safe via the store's usual
+        ``BEGIN IMMEDIATE`` transaction: two turns racing to claim the
+        first id block against each other rather than minting two. A
+        conversation created before this column existed adopts an id on its
+        first post-upgrade turn rather than via migration backfill; turns
+        already on record are untouched. See docs/internals/studio.md
+        ("Provider session identity vs. durable branch identity").
         """
         await self.ensure_schema()
         async with open_db(str(self.path())) as db:
@@ -1017,16 +982,11 @@ class OperatorStore:
     async def clear_provider_model(self, conversation_id: str) -> None:
         """Drop this conversation's provider/model pin so it runs on the default again.
 
-        Omitting a model on a turn means "leave the pin alone", which is what
-        an unchanged composer sends, so it cannot also mean "remove the pin" --
-        without this there is no way back to the daemon's own default once a
-        conversation has been pinned. The provider session goes with it: a
-        session belongs to the pair that created it, and the next turn resolves
-        its provider from the environment rather than from that pair.
-
-        Clearing a conversation that has no pin does nothing at all. Dropping
-        the session is a consequence of the pin changing, so a repeated clear
-        must not keep discarding sessions that no pin is invalidating.
+        Omitting a model on a turn means "leave the pin alone" -- it cannot
+        also mean "remove the pin" -- so this is the only way back to the
+        daemon's default once a conversation is pinned. The provider session
+        goes with it, as a consequence of the pair changing, not as its own
+        effect: clearing an already-unpinned conversation does nothing.
         """
         await self.ensure_schema()
         async with open_db(str(self.path())) as db:

--- a/lionagi/studio/operator/types.py
+++ b/lionagi/studio/operator/types.py
@@ -88,23 +88,11 @@ class OperatorContextSnapshot(WireModel):
     route: str = Field(min_length=1, max_length=4096)
     selection: dict[str, str] | None = None
     filters: dict[str, Any] = Field(default_factory=dict)
-    # Who observed this view, and how many views they had seen when they did.
-    #
-    # Ordering is by count and deliberately not by any clock. Server arrival
-    # order answers a different question, since a view seen before an
-    # instruction can arrive after it. A wall clock answers it wrongly too: it
-    # can step backwards, and then a view from before the step outranks
-    # everything observed after it.
-    #
-    # A count means nothing outside the page that did the counting, which is why
-    # the observer travels with it. Two tabs on one conversation are looking at
-    # two different pages; only the one the instruction came from can say where
-    # the human is, and comparing the other's count against it is what makes an
-    # abandoned page look current. A reload is a new observer for the same
-    # reason.
-    #
-    # Both are optional here so a client that sends neither degrades to "cannot
-    # establish freshness" rather than to a false claim of it.
+    # Who observed this view and how many views they had seen when they did;
+    # ordering uses this count, never arrival order or a wall clock — see
+    # docs/internals/studio.md ("View freshness: observation count, not wall
+    # clock"). Both optional: a client sending neither degrades to "cannot
+    # establish freshness" rather than a false claim of it.
     observation_seq: int | None = Field(default=None, ge=1, alias="observationSeq")
     observer_id: str | None = Field(default=None, min_length=1, max_length=128, alias="observerId")
 


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 11 (+197 / -413, net -216)
- New documentation: 289 lines in docs/internals/studio.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.