### PR TITLE
chore(studio): trim scheduler/shell docstrings, relocate rationale to docs/internals

### DIFF
--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -71,6 +71,113 @@ shallow merge?).
 and 404. Warns once instead of stripping silently, since a reverse proxy whose
 public prefix genuinely ends in `/api` needs visibility into the rewrite.
 
+**`_await_vite_ready_url`** — A background thread drains Vite's stdout for
+the life of the dev-server process so Vite never blocks on a full pipe
+buffer; once the function itself returns (ready URL found, or timed out) that
+thread stops parsing lines and only keeps draining. It's a daemon thread with
+no explicit join, so it exits with the process rather than needing shutdown
+wiring.
+
+## lionagi/studio/scheduler/engine.py
+
+**`_reserve_max_runs_budget` / `_release_max_runs_claim`** — The single-process
+analogue of a DB-backed compare-and-set for `schedule['max_runs']`; only one
+scheduler process runs today, so no DB-backed reservation exists. Guarded by
+an engine-wide lock so the tick loop, `fire_now()`, and GitHub polling can't
+both read the same count and both claim it before either claim is visible.
+Reads `inflight` (this process's outstanding claims) *before* the awaited
+`count_schedule_runs()` call, not after — release() is deliberately lock-free
+(a claim must still release from a cancelled/failing `_fire()`'s `finally`
+without depending on this lock), so a concurrent fire's claim can vanish
+mid-await. Reading `inflight` first means the sum can only ever over-count
+(a spurious refusal, self-correcting on the next tick), never under-count
+into an actual overshoot — reading it after the await would let a fire that
+both persists its row and releases its claim inside this call's await window
+disappear from both the persisted count (read too early) and the in-flight
+snapshot (read too late). The claim is released from `_fire()`'s own
+`finally`, not from inside `_check_max_runs()`: a fire failing before ever
+reaching `_check_max_runs()` (e.g. `create_invocation` raising) would
+otherwise leak the claim for the life of the process. Chain children never
+call this — only top-level fires consume budget.
+
+**`_fire_inner` delivery contract** — At-least-once up to confirmed process
+launch, at-most-once past it, across three windows: (1) before the occurrence
+transaction commits, a crash leaves nothing durable, so a restart fires
+fresh, never a duplicate. (2) Between commit and `spawn_and_wait()`
+confirming launch (`on_launched` stamping `dispatched_at`), the row is
+durable but undispatched; `_recover_undispatched_fires()` finds it on startup
+and re-fires via `supersedes_run_id`, which routes the occurrence insert
+through `tombstone_and_replace_schedule_run()` to tombstone the orphan and
+insert the replacement atomically (its CAS also requires `dispatched_at IS
+NULL`, so a launch confirmed in the race against recovery wins and the
+tombstone is a no-op). (3) Once `dispatched_at` is confirmed, the process
+genuinely exists and is never re-fired — resolved by the stale-run reaper or
+its own terminal write. A duplicate real-world side effect is worse than one
+unretried outcome, hence the asymmetry. The occurrence-insert and any
+`extra_schedule_fields` cursor advance land in the same transaction as this
+delivery boundary — see `_write_occurrence()` for the atomic-with-tombstone
+recovery path.
+
+**`_reconcile_dispatched_orphans`** — Startup-only; handles schedule_runs rows
+that were confirmed dispatched but never reached a terminal status, which
+`_recover_undispatched_fires()` (safe to blindly re-fire) can't touch since a
+row here may have a genuinely live child. Resolves only from positive
+completion evidence: when every session linked to the invocation has
+independently reached a terminal status (each session's own teardown writes
+its own terminal status, independent of whether the dispatching scheduler
+survived to see the exit code), the schedule_run is finalized via
+`resolve_invocation_terminal()`. Unknown liveness is never treated as death —
+a row with no sessions yet, or any non-terminal session, falls through
+unchanged to the wall-clock stale reaper (`reap_stale_schedule_runs`).
+
+**`_recompute_armed_cron_schedules`** — Startup-only re-resolution of every
+enabled cron schedule's `next_fire_at` under the current timezone
+interpretation, guarding against stale fire times after
+`LIONAGI_SCHEDULER_TZ` (or the host timezone) changed since the schedule was
+last armed. A schedule already due (`next_fire_at <= now`) is left alone here
+so it flows through `_check_missed_fires()` first — `missed_fire_policy`
+("run_once"/"skip") must get a chance to run before anything advances the
+timestamp, and `_check_missed_fires()` runs immediately after this method
+returns in `_tick_loop`, synchronously advancing `next_fire_at` via the
+recovery path before the following `_tick()` call. Only schedules still ahead
+of now — the timezone-migration correction case this hook exists for — are
+recomputed here; the method never fires anything itself.
+
+**`_check_budget`** — Pre-fire cumulative spend gate, not a mid-run
+interrupt: a run already in flight is never killed when it crosses the
+budget line, since its cost is unknown until it terminates, so a schedule may
+overshoot by up to one run's cost before the next fire is refused. Pair with
+`LIONAGI_STUDIO_INVOCATION_DEADLINE_SECONDS` to bound a single run's
+worst-case spend. `spend["cost_usd"]` sums only *reported* cost — a session
+whose engine never priced itself contributes nothing, not a confirmed $0 —
+so this deliberately does not force exhaustion over unreported sessions
+alone (that would turn a data gap into an outage); it only surfaces the gap
+via a log line and `unreported_sessions` in the schedule's spend rollup, so a
+near-zero reading with many unreported sessions reads as "unknown," not
+"cheap."
+
+**`_threshold_alert_update_fields`** — Stamps `last_alert_at` into the same
+`update_schedule()` call that already writes `last_fired_at`/`next_fire_at`
+inside `_fire_inner()`, deliberately placed after `create_schedule_run()` has
+durably persisted the run row. Stamping the cooldown any earlier (e.g. before
+`_fire()` starts) risks consuming it on a pre-persistence failure (e.g.
+`create_invocation()` raising) that leaves zero durable record an alert was
+ever attempted — the exact silent-loss shape the feature exists to prevent.
+Only top-level fires (`chain_depth == 0`) of a threshold-configured schedule
+stamp the cooldown; `on_success`/`on_fail` chain children are follow-on
+actions of the same alert cycle, not a new one.
+
+## lionagi/studio/scheduler/subprocess.py
+
+**`spawn_and_wait`** — Both stdout/stderr streams are captured and drained
+concurrently, bounded rather than buffered whole: a single `communicate()`
+call on both pipes would hold an entire streaming leg's output in memory,
+and draining one stream at a time deadlocks once the other fills its buffer.
+When `action_kind="command"`, the command allow-list check re-runs here,
+immediately before spawn, closing the window where an awaited DB call
+between `build_argv()` and this function gives a revoked
+`LIONAGI_SCHEDULER_COMMAND_ALLOWLIST` env var a scheduling point to land in.
+
 ## lionagi/studio/services/schedules.py
 
 - **`_svc_validate_action_command`** — Delegates to the subprocess validators

--- a/lionagi/studio/_traceback_dump.py
+++ b/lionagi/studio/_traceback_dump.py
@@ -3,24 +3,16 @@
 
 """Periodic all-thread stack dumps, armed by an environment variable.
 
-A daemon that stops answering on one route is asking a question only a stack
-can answer, and the usual way to get one is to attach a sampling profiler to
-the live process. On macOS that needs root, which a rule against improvised
-elevation puts out of reach at exactly the moment the process is wedged.
+Uses ``faulthandler.dump_traceback_later`` to write every thread's stack to
+a file on a timer, with no process attach and no elevated privileges needed
+(a sampling profiler attach needs root on macOS). Off unless
+``LIONAGI_STUDIO_TRACEBACK_DUMP`` names a path -- absent that, this module
+arms no timer and changes no behaviour.
 
-``faulthandler.dump_traceback_later`` answers the same question from inside:
-every thread's stack, written to a file on a timer, with no attach and no
-privileges. It is stdlib, it is already imported by nothing else here, and it
-costs a wedged process nothing it was doing anyway.
-
-It is off unless ``LIONAGI_STUDIO_TRACEBACK_DUMP`` names a path. Absent that
-variable this module arms no timer, opens no file, and changes no behaviour.
-
-Capture windows are operator-bounded. ``repeat=True`` appends every interval
-for as long as the process runs, so an armed daemon left running writes an
-unbounded file. Nothing here rotates or truncates it: the intended use is a
-short reproduction window, and a size cap that silently stopped writing would
-lose the frames the window exists to catch.
+``repeat=True`` appends every interval for as long as the process runs, and
+nothing here rotates or truncates the file -- an armed daemon left running
+writes it unbounded. Intended for a short reproduction window, not
+always-on operation.
 """
 
 from __future__ import annotations

--- a/lionagi/studio/cli.py
+++ b/lionagi/studio/cli.py
@@ -609,31 +609,14 @@ def _await_vite_ready_url(
 ) -> str | None:
     """Read Vite's startup banner for the address it actually bound.
 
-    Loopback hosts read the `Local:` line. Non-loopback hosts (a LAN IP, or
-    the `0.0.0.0`/`::` wildcard) read `Network:` instead, since that is the
-    address reachable from outside this machine. When Vite reports more than
-    one matching line (multiple interfaces), the first one wins and a note is
-    printed saying so — callers get a single deterministic URL either way.
-
-    Returns None on failure and prints one of three distinct, actionable
-    warnings so a crashed Vite doesn't read the same as a slow one:
-
-    - the process exited early (exit code included);
-    - its output stream ended without matching a readiness line while the
-      process is still running (unexpected format);
-    - it genuinely never produced a matching line before `timeout`.
-
-    Every case includes the last `_STARTUP_TAIL_LINES` of captured output
-    (stdout merged with stderr — see `_launch_vite_dev`) so "check the Vite
-    output" is something the warning can actually show, not just say.
-
-    Callers must not construct a guessed URL from the requested host/port
-    on the failure path, since nothing may be listening there.
-
-    A background thread keeps draining stdout for the life of the process so
-    Vite never blocks on a full pipe buffer; once this function returns, that
-    thread stops parsing (the `done` flag below) and only drains. It is a
-    daemon thread and needs no explicit join — it exits with the process.
+    Loopback hosts read the `Local:` line; non-loopback hosts (LAN IP, or the
+    `0.0.0.0`/`::` wildcard) read `Network:` instead, since that's what's
+    reachable from outside this machine. Returns None on failure, printing
+    one of three distinct warnings (early exit, stream EOF while still
+    running, or a genuine timeout) each with the last `_STARTUP_TAIL_LINES`
+    of captured output. Callers must not construct a guessed URL on the
+    failure path. See docs/internals/studio.md for the background drain
+    thread's lifecycle.
     """
     parse = _parse_vite_network_url if _host_wants_lan_url(host) else _parse_vite_local_url
     hits: queue.Queue[object] = queue.Queue()
@@ -1520,17 +1503,12 @@ def _cmd_export(args: argparse.Namespace) -> int:
     return EXIT_EXPORT_PARTIAL if has_blocked else 0
 
 
-# ---------------------------------------------------------------------------
-# Typed quick-create — `li schedule create <kind> <name> ...`
-#
-# Dispatched from cli/main.py *before* the legacy `sched_sub` argparse tree
-# (a reserved kind token right after "create", mirroring how `agent status` /
-# `monitor run` / `wait` are special-cased there) so the existing flat
-# `li schedule create NAME --cron ... --prompt ...` form is untouched.
-# Compiles straight into a ScheduleMember and runs it through the identical
-# resolve_member()/create_quick_schedule() path a ScheduleSet member uses —
-# no forked validation, per the schedule-declaration design.
-# ---------------------------------------------------------------------------
+# Typed quick-create — `li schedule create <kind> <name> ...`. Dispatched from
+# cli/main.py before the legacy `sched_sub` argparse tree (a reserved kind
+# token right after "create"), leaving the flat `li schedule create NAME
+# --cron ... --prompt ...` form untouched. Compiles into a ScheduleMember and
+# runs it through the same resolve_member()/create_quick_schedule() path a
+# ScheduleSet member uses.
 
 QUICK_CREATE_KINDS = ("agent", "flow", "playbook", "command")
 

--- a/lionagi/studio/config.py
+++ b/lionagi/studio/config.py
@@ -268,7 +268,7 @@ CORS_ORIGINS: list[str] = (
     ]
 )
 
-# ── Launch admission config ───────────────────────────────────────────────────
+# Launch admission config
 # Maximum number of on-demand launch tasks that may run in parallel.
 # When saturated, POST /api/launches returns 429.
 MAX_LAUNCHES: int = int(os.environ.get("LIONAGI_STUDIO_MAX_LAUNCHES", "4"))
@@ -286,7 +286,7 @@ MAX_SCHEDULED_CONCURRENT: int = int(os.environ.get("LIONAGI_STUDIO_MAX_SCHEDULED
 # 0 = unlimited (worker executions impose no concurrency limit of their own).
 MAX_ADHOC_CONCURRENT: int = int(os.environ.get("LIONAGI_STUDIO_MAX_ADHOC_CONCURRENT", "4"))
 
-# ── Lifecycle reaper config ───────────────────────────────────────────────────
+# Lifecycle reaper config
 # Default invocation deadline in seconds (2 hours). Override per action kind
 # via LIONAGI_STUDIO_INVOCATION_DEADLINE_<KIND>_SECONDS (e.g. _AGENT_SECONDS).
 # Pairs with per-schedule budget_usd/budget_tokens (schedules table, see
@@ -321,7 +321,7 @@ SHOW_STALE_HOURS: float = float(os.environ.get("LIONAGI_STUDIO_SHOW_STALE_HOURS"
 # Minimum seconds between consecutive periodic reaper runs (throttle).
 REAPER_INTERVAL_SECONDS: int = int(os.environ.get("LIONAGI_STUDIO_REAPER_INTERVAL_SECONDS", "300"))
 
-# ── Scheduler cron timezone ───────────────────────────────────────────────────
+# Scheduler cron timezone
 # Cron expressions (trigger_type="cron") are interpreted in this IANA timezone;
 # next_fire_at is always stored as a UTC epoch regardless. Resolved once here
 # and frozen for the process lifetime, so it's reported on /api/admin/health
@@ -367,7 +367,7 @@ def scheduler_timezone_report() -> dict[str, Any]:
     }
 
 
-# ── DB maintenance config ─────────────────────────────────────────────────────
+# DB maintenance config
 # Size threshold in bytes above which /api/stats raises a size_alert (500 MB).
 DB_SIZE_ALERT_BYTES: int = int(
     os.environ.get("LIONAGI_STUDIO_DB_SIZE_ALERT_BYTES", str(500 * 1024 * 1024))
@@ -403,7 +403,7 @@ DISPATCH_RETENTION_DEAD_LETTER_DAYS: int = int(
     os.environ.get("LIONAGI_STUDIO_DISPATCH_RETENTION_DEAD_LETTER_DAYS", "30")
 )
 
-# ── Ambient transcript mirror ─────────────────────────────────────────────────
+# Ambient transcript mirror
 # When on, studio tails the local agent transcript trees in-process so those
 # sessions show up (and stream live) without a separate `li mirror`. Bounded by
 # the window below, so startup catches up the recent window only and never

--- a/lionagi/studio/scheduler/engine.py
+++ b/lionagi/studio/scheduler/engine.py
@@ -334,20 +334,15 @@ async def _resolve_action_cwd(schedule: dict) -> str | None:
     """Resolve the working directory for a scheduled subprocess spawn.
 
     Layered resolution (first hit wins): ``action_cwd`` (the schedule's own
-    persisted execution root, ADR-0070 delta 1) -> ``action_project``'s
-    stored path -> fall-through. On fall-through, a schedule that carries an
-    explicit ``action_cwd``/``action_project`` fails closed
-    (``SchedulerCwdInheritRefusedError``) rather than silently inheriting the
-    daemon's cwd, which can itself resolve to a project and run the action in
-    the wrong place with no visible failure; ``LIONAGI_SCHEDULER_CWD`` is
-    consulted only for ownerless (pre-migration) rows, else ``None`` inherits
-    the daemon cwd with a deprecation warning.
-
-    Returns the resolved cwd, or ``None`` for the ownerless fall-through.
-    Raises ``SchedulerCwdInheritRefusedError`` for the owner-carrying
-    fall-through.
-
-    Imports ``lionagi.studio.services.projects`` lazily so this module stays
+    persisted execution root) -> ``action_project``'s stored path ->
+    fall-through. A schedule carrying an explicit ``action_cwd``/
+    ``action_project`` fails closed (``SchedulerCwdInheritRefusedError``) on
+    fall-through rather than silently inheriting the daemon's cwd, which can
+    itself resolve to a project and run the action in the wrong place with no
+    visible failure. ``LIONAGI_SCHEDULER_CWD`` is consulted only for
+    ownerless (pre-migration) rows; otherwise ``None`` inherits the daemon
+    cwd with a deprecation warning. Imports
+    ``lionagi.studio.services.projects`` lazily so this module stays
     importable without the ``studio`` (fastapi) extra.
     """
     action_cwd = schedule.get("action_cwd")
@@ -568,24 +563,17 @@ class SchedulerEngine:
         }
 
     async def _backfill_action_cwd(self) -> None:
-        """One-shot startup backfill: give pre-migration schedules a persisted execution root.
-
-        ADR-0070 delta 1. ``action_cwd`` is additive and nullable (see
-        ``MIGRATION_COLUMNS``), so rows created before this feature shipped
-        have it unset. For any such row whose ``action_project`` resolves to
-        a directory that still exists on disk, snapshot that path into
-        ``action_cwd`` -- the same derivation `create_schedule()` performs
-        for newly created schedules. A row with no resolvable
-        ``action_project`` is left with ``action_cwd`` unset. Note that such a
-        row still *carries* an execution root, so it does not fall through to
-        the ownerless ``LIONAGI_SCHEDULER_CWD`` path: ``_resolve_action_cwd()``
-        fails closed for it when the schedule fires, until its project is
-        registered at an existing path or it is given an explicit
-        ``action_cwd``.
-
-        Idempotent: only rows where ``action_cwd`` is still ``None`` are
-        touched, so re-running this on every daemon startup is a no-op once
-        every backfillable row has been filled in.
+        """One-shot startup backfill: give pre-migration schedules a persisted
+        execution root. ``action_cwd`` is additive and nullable, so rows
+        created before this feature shipped have it unset; for any such row
+        whose ``action_project`` resolves to a directory that still exists,
+        snapshot that path into ``action_cwd`` (the same derivation
+        ``create_schedule()`` performs for new schedules). A row with no
+        resolvable ``action_project`` is left with ``action_cwd`` unset --
+        it still carries an owner, so ``_resolve_action_cwd()`` fails closed
+        for it rather than falling through to ``LIONAGI_SCHEDULER_CWD``, until
+        its project resolves or it gets an explicit ``action_cwd``. Idempotent:
+        only rows where ``action_cwd`` is still ``None`` are touched.
         """
         try:
             schedules = await self._svc.list_schedules()
@@ -622,29 +610,17 @@ class SchedulerEngine:
 
     async def _recompute_armed_cron_schedules(self) -> None:
         """Re-resolve every enabled cron schedule's next_fire_at under the
-        current timezone interpretation before the tick loop starts.
+        current timezone interpretation before the tick loop starts, guarding
+        against stale fire times after LIONAGI_SCHEDULER_TZ (or the host tz)
+        changed since a schedule was last armed.
 
-        Guards against silently-stale fire times if LIONAGI_SCHEDULER_TZ (or
-        the host's local timezone) changed since a schedule was last armed —
-        the same interpretation change that PATCH and enable also trigger via
-        recompute_next_fire().
-
-        A schedule whose stored next_fire_at is already due (<= now) is left
-        untouched here: it must flow through _check_missed_fires() first, so
-        missed_fire_policy ("run_once" / "skip") gets a chance to run before
-        anything advances next_fire_at into the future. _check_missed_fires()
-        runs right after this method returns (see _tick_loop), and the
-        recovery path (_recover_missed_fire_run_once() / _record_missed_
-        fire_skip()) is what advances next_fire_at once the policy has been
-        applied — synchronously, before _check_missed_fires() returns, so
-        the _tick() call that immediately follows never observes the same
-        past-due timestamp. Only schedules whose stored next_fire_at is
-        still ahead of now — the timezone-migration correction case this
-        hook exists for — are recomputed here.
-
-        This method never fires anything itself, so it has no
-        occurrence-insert to reconcile against schedule_runs -- that
-        consultation happens in _check_missed_fires() for any due schedule.
+        A schedule already due (next_fire_at <= now) is left untouched: it
+        must flow through ``_check_missed_fires()`` first so
+        ``missed_fire_policy`` gets a chance to run before anything advances
+        the timestamp. Only schedules still ahead of now -- the
+        timezone-migration correction case this hook exists for -- are
+        recomputed here. See docs/internals/studio.md for the full
+        ordering against ``_check_missed_fires()``.
         """
         try:
             schedules = await self._svc.list_schedules(enabled=True)
@@ -894,28 +870,17 @@ class SchedulerEngine:
     async def _reconcile_dispatched_orphans(self) -> None:
         """Startup-only reconciliation for schedule_runs rows that were
         confirmed dispatched (an external process was launched) but never
-        reached a terminal status (see #2755).
+        reached a terminal status.
 
-        Unlike ``_recover_undispatched_fires()`` (``dispatched_at IS NULL``,
-        safe to re-fire because nothing was ever launched), a row here may
-        have a genuinely live child still working -- re-firing would
-        double-execute it, and blindly terminalizing it would falsely mark
-        live work dead. Neither is safe from wall-clock alone.
-
-        This only acts where positive completion evidence already exists in
-        the DB without needing new process-identity capture: an action that
-        spawned its own session(s) (e.g. ``agent``/``play``) writes each
-        session's own terminal status from *inside* that child process, via
-        its own teardown -- entirely independent of whether the scheduler
-        that dispatched it survived to see the exit code. When every linked
-        session has independently reached a terminal status, the
-        schedule_run is finalized from that evidence via
-        ``resolve_invocation_terminal()`` (the same resolution the live
-        ``_fire()`` path uses for the invocation row). A row with no
-        sessions yet, or with any session still non-terminal, is left
-        untouched -- unknown liveness is never treated as death; it falls
-        through to the existing wall-clock stale reaper
-        (``reap_stale_schedule_runs``) unchanged.
+        Unlike ``_recover_undispatched_fires()`` (safe to re-fire because
+        nothing was ever launched), a row here may have a genuinely live
+        child still working, so wall-clock alone can't resolve it. This only
+        acts where positive completion evidence already exists: when every
+        session linked to the invocation has independently reached a
+        terminal status, the schedule_run is finalized from that evidence
+        via ``resolve_invocation_terminal()``. A row with no sessions yet, or
+        any non-terminal session, is left for the existing wall-clock stale
+        reaper (``reap_stale_schedule_runs``). See docs/internals/studio.md.
         """
         try:
             rows = await self._svc.list_dispatched_running_schedule_runs()
@@ -1608,48 +1573,19 @@ class SchedulerEngine:
         """Atomically claim one top-level fire against schedule['max_runs'].
 
         Returns ``(allowed, claim)``. ``allowed`` is False only when the
-        schedule is bounded (``max_runs`` set) and has already consumed its
-        budget — persisted fired rows (running or resolved) plus fires
-        claimed in this process whose occurrence rows have not yet
-        committed; callers must refuse to fire in that case. ``claim`` is a ``_MaxRunsClaim`` token when a
-        bounded schedule's budget was actually reserved, or ``None`` when
-        the schedule is unbounded (``max_runs`` unset — always allowed, no
-        claim to release). Guarded by an engine-wide lock so concurrent
-        callers — the tick loop, fire_now(), github polling — can't both
-        read the same count and both claim it before either claim is
-        visible. This is the single-process analogue of a DB-backed
-        compare-and-set; only one scheduler process runs today, so a
-        DB-backed reservation is not needed. Chain children (chain_depth>0)
-        never call this — only top-level fires consume budget.
+        schedule is bounded (``max_runs`` set) and its budget — persisted
+        fired rows plus in-flight claims — is already spent. ``claim`` is a
+        ``_MaxRunsClaim`` when a bounded schedule's budget was reserved, or
+        ``None`` when unbounded (always allowed, nothing to release). Chain
+        children (chain_depth>0) never call this.
 
         Whenever ``allowed`` is True the caller MUST pass ``claim`` through
-        to ``_fire()`` as ``max_runs_claim=`` (even when it is ``None``) so
-        it gets released — exactly once, on every exit path including
-        pre-run failures — from ``_fire()``'s own ``finally`` block. Unlike
-        an earlier implementation, the claim is no longer released from inside
-        ``_check_max_runs()`` alone: a fire that fails before ever reaching
-        ``_check_max_runs()`` (e.g. ``create_invocation`` raising) would
-        otherwise leak the claim permanently for the life of the process,
-        since nothing else would ever release it.
-
-        Snapshot ordering matters here: ``inflight`` is read BEFORE the
-        awaited ``count_schedule_runs()`` call, not after. ``release()`` is
-        deliberately lock-free (a claim must still release from a
-        cancelled/failing ``_fire()``'s ``finally`` without depending on
-        this lock, which would otherwise reintroduce cancellation-unsafe
-        lock-acquire-in-finally hazards), so a concurrent fire's claim can
-        be released by another task while this call is suspended awaiting
-        the DB. If ``inflight`` were read *after* that await (an intermediate
-        design), a fire that both persists its occurrence row and releases
-        its claim entirely within this call's await window would vanish
-        from both the persisted count (read too early, before the write)
-        and the in-flight snapshot (read too late, after the release) —
-        the exact gap that adversarial concurrency testing exploited.
-        Reading ``inflight`` first captures that other fire's claim before
-        it can disappear: the persisted count may still be stale, but the
-        in-flight snapshot backstops it, so the sum can only ever
-        over-count (spurious refusal, safe and self-correcting on the next
-        tick) — never under-count (an actual overshoot).
+        to ``_fire()`` as ``max_runs_claim=`` (even when ``None``) so it
+        gets released exactly once, on every exit path, from ``_fire()``'s
+        own ``finally`` block. Guarded by an engine-wide lock so concurrent
+        callers can't both claim the same budget before either is visible.
+        See docs/internals/studio.md for the inflight/persisted-count read
+        ordering that keeps this safe under concurrency.
         """
         max_runs = schedule.get("max_runs")
         if not max_runs:
@@ -1657,22 +1593,11 @@ class SchedulerEngine:
         sid = schedule["id"]
         async with self._max_runs_lock:
             inflight = self._max_runs_inflight.get(sid, 0)
-            # A fired run consumes budget the moment it fires, not when it
-            # resolves — so persisted 'running' rows count alongside terminal
-            # ones, or a bounded schedule under overlap_policy=allow admits
-            # fires past its budget while a long action is still executing.
-            # Claims and rows are disjoint representations of a fire: a claim
-            # covers only the window before the occurrence row commits, and
-            # _fire_inner() releases it the moment _write_occurrence()
-            # succeeds (the same ownership transfer the rate-limit claim
-            # does), so summing the two counts each fire exactly once. In
-            # the transfer instant a fire can briefly appear as both — that
-            # overlap only ever over-counts (a spurious refusal, corrected
-            # on the next tick), the safe direction. A restart-orphaned
-            # 'running' row whose claim died with the process, and a fresh
-            # claim-only admission, are DIFFERENT fires and both count —
-            # taking a max() of the two views instead of their sum would
-            # collapse them and admit past the cap.
+            # Persisted 'running' rows count budget alongside terminal ones
+            # (a fire spends budget when it fires, not when it resolves);
+            # claims cover only the pre-commit window and release the
+            # instant _write_occurrence() succeeds, so summing the two
+            # counts each fire exactly once. See docs/internals/studio.md.
             fired = await self._svc.count_schedule_runs(
                 sid,
                 chain_depth=0,
@@ -1820,26 +1745,14 @@ class SchedulerEngine:
         """Return True if the schedule has exhausted its configured spend budget.
 
         Pre-fire cumulative gate, not a mid-run interrupt: a run already in
-        flight is not killed when it crosses the budget line, because its
-        cost is unknown until it terminates. So a schedule may overshoot its
-        budget by up to one run's cost before the next fire is refused. Pair
-        with LIONAGI_STUDIO_INVOCATION_DEADLINE_SECONDS to bound a single
-        run's worst-case spend.
-
-        Unlike max_runs / the global slot this is a pure DB read with
-        nothing to reserve or release -- both budget_usd and budget_tokens
-        unset means unbounded (always False). Either configured bound
-        tripping is sufficient to report exhausted.
-
-        ``spend["cost_usd"]`` is a sum of *reported* cost only -- a session
-        whose engine never priced itself contributes nothing to it, not a
-        confirmed $0. This deliberately does not force exhaustion just
-        because some sessions are unreported (that would turn a data gap
-        into an outage for schedules that are, as far as anyone can tell,
-        fine); it only makes the gap visible via a log line here and via
-        ``unreported_sessions`` in the schedule's spend rollup, so a near-
-        zero reading with many unreported sessions is legible as "unknown",
-        not silently trusted as "cheap".
+        flight is never killed, so a schedule may overshoot its budget by up
+        to one run's cost. Pair with
+        LIONAGI_STUDIO_INVOCATION_DEADLINE_SECONDS to bound a single run's
+        worst case. Unbounded (both budget_usd/budget_tokens unset) always
+        returns False. ``spend["cost_usd"]`` sums only *reported* cost; a
+        session whose engine never priced itself is surfaced via
+        ``unreported_sessions`` and a log line, not treated as a confirmed
+        $0. See docs/internals/studio.md.
         """
         budget_usd = schedule.get("budget_usd")
         budget_tokens = schedule.get("budget_tokens")
@@ -2269,24 +2182,13 @@ class SchedulerEngine:
     def _threshold_alert_update_fields(
         self, schedule: dict, chain_depth: int, now: float
     ) -> dict[str, Any]:
-        """Extra ``update_schedule()`` fields for a threshold-alert fire.
-
-        Folded into the SAME schedule update call that already writes
-        ``last_fired_at``/``next_fire_at`` inside ``_fire_inner()`` --
-        deliberately placed AFTER ``create_schedule_run()`` has durably
-        persisted the run row (both the invalid-action-failure branch and
-        the normal running branch call this only once their own
-        ``create_schedule_run()`` has already succeeded). Stamping the
-        cooldown any earlier (e.g. in ``_maybe_fire()`` before ``_fire()``
-        even starts) risks consuming it on a ``create_invocation()`` (or
-        other pre-persistence) failure that leaves zero durable record an
-        alert was ever attempted -- the exact silent-loss shape this
-        feature exists to prevent.
-
-        Only top-level fires (``chain_depth == 0``) of a
-        threshold-configured schedule stamp the cooldown; on_success/
-        on_fail chain children are follow-on actions of the same alert
-        cycle, not a new one, and must not restamp it.
+        """Extra ``update_schedule()`` fields for a threshold-alert fire:
+        stamps ``last_alert_at`` for top-level fires (``chain_depth == 0``)
+        of a threshold-configured schedule only, and only once
+        ``create_schedule_run()`` has already durably persisted the run row
+        -- stamping any earlier risks consuming the cooldown on a
+        pre-persistence failure that leaves no durable record an alert was
+        attempted. See docs/internals/studio.md.
         """
         if chain_depth != 0 or not schedule.get("threshold_config"):
             return {}
@@ -2388,45 +2290,18 @@ class SchedulerEngine:
         whether or not a process ultimately ran -- a commit with no launch
         is re-fired by startup recovery, not by the caller.
 
-        PRE-DISPATCH REFUSALS DO NOT CONSUME THE TRIGGER. Everything that
-        can refuse without starting a process -- resolving the `li`
-        executable, building argv, resolving the execution root -- runs
-        BEFORE the occurrence transaction, so its failure is recorded
-        without the cursor advance in *extra_schedule_fields*. Nothing ran,
-        so re-offering the trigger is not a re-execution, and the caller
-        learns that from the False return. Only a failure of something that
-        did start (non-zero exit, timeout, kill) keeps the at-most-once
-        advance below.
-
-        DELIVERY CONTRACT -- at-least-once up to confirmed process launch,
-        at-most-once past it. Three windows: (1) before the occurrence
-        transaction commits, a crash leaves nothing durable, so a restart
-        fires fresh -- never a duplicate. (2) Between commit and
-        ``spawn_and_wait()`` confirming launch (``on_launched`` stamping
-        ``dispatched_at``), the row is durable but undispatched;
-        ``_recover_undispatched_fires()`` finds it on startup and re-fires
-        via *supersedes_run_id*, which routes the occurrence insert through
-        ``tombstone_and_replace_schedule_run()`` to tombstone the orphan and
-        insert the replacement atomically (its CAS also requires
-        ``dispatched_at IS NULL``, so a launch that gets confirmed in the
-        race against recovery wins and the tombstone is a no-op). (3) Once
-        ``dispatched_at`` is confirmed, the process genuinely exists and is
-        never re-fired -- the row is resolved by the stale-run reaper or its
-        own terminal write. This boundary is deliberate: a duplicate
-        real-world side effect is worse than one unretried outcome.
+        Pre-dispatch refusals (resolving the `li` executable, building argv,
+        resolving the execution root -- everything before the occurrence
+        transaction) never consume the trigger. Delivery is at-least-once up
+        to confirmed process launch and at-most-once past it (``dispatched_at``
+        stamped). See docs/internals/studio.md for the three delivery windows
+        and how ``_recover_undispatched_fires()``/*supersedes_run_id* close
+        the undispatched-but-committed gap.
         """
         sid = schedule["id"]
         now = time.time()
-        # Flipped by on_launched below, the instant the OS process is
-        # confirmed to exist. Every exit path reads it to tell "nothing was
-        # started" apart from "something was started and then failed".
-        dispatched = False
-        # Flipped once the occurrence transaction commits -- the point past
-        # which the trigger (and, for a github_poll, its cursor advance) is
-        # durably spent. Between it and *dispatched* lies the window where a
-        # failure must leave the row for startup recovery instead of
-        # finalizing it.
-        occurrence_committed = False
+        dispatched = False  # set by on_launched once the OS process is confirmed to exist
+        occurrence_committed = False  # set once the occurrence transaction commits
         _tmp_path: str | None = None
 
         inv_id = uuid.uuid4().hex[:12]

--- a/lionagi/studio/scheduler/subprocess.py
+++ b/lionagi/studio/scheduler/subprocess.py
@@ -585,28 +585,16 @@ async def spawn_and_wait(
 ) -> tuple[int, str]:
     """Spawn subprocess and wait for completion. Returns (exit_code, output_tail).
 
-    Both streams are captured and drained concurrently, bounded rather than
-    buffered whole -- a single ``communicate()`` on both pipes holds an
-    entire streaming leg's output in memory, and draining one at a time
-    deadlocks once the other fills.
-
-    If *tmp_path* is given it is deleted after the subprocess exits (used by
-    the ``flow_yaml`` action kind's temp spec file). *cwd* pins the
-    subprocess working directory; ``None`` inherits the daemon's own cwd, so
-    callers should resolve a concrete path first (see
-    SchedulerEngine._resolve_action_cwd).
-
-    *action_kind* re-runs the command allow-list check here, immediately
-    before spawn, when ``"command"`` -- closes the window where an awaited
-    DB call between ``build_argv`` and this function gives a revoked
-    allow-list env var a scheduling point to land in.
-
-    *on_launched*, if given, is awaited right after ``create_subprocess_exec``
-    confirms the OS process exists, before waiting on completion -- the
-    scheduler engine uses this to mark a schedule_run "dispatched" durably,
-    closing the recovery scan's committed-but-never-launched window. A
-    failing callback is logged and swallowed, never allowed to fail the
-    process that already launched.
+    Both streams are drained concurrently and bounded rather than buffered
+    whole. *tmp_path*, if given, is deleted after exit. *cwd* pins the
+    subprocess working directory (``None`` inherits the daemon's own --
+    callers should resolve a concrete path first, see
+    ``SchedulerEngine._resolve_action_cwd``). *on_launched*, if given, is
+    awaited right after the OS process is confirmed to exist, before waiting
+    on completion; a failing callback is logged and swallowed, never allowed
+    to fail an already-launched process. See docs/internals/studio.md for
+    the allow-list re-check race this closes and why streams can't drain
+    sequentially.
     """
     if action_kind == "command":
         command = argv[0] if argv else ""


### PR DESCRIPTION
Documentation-only change. Inline docstrings and comment blocks in this scope are trimmed to a working density, and the substantive design rationale moves into `docs/internals/` as prose rather than staying inline where a reader of the code has to scroll past it.

No executable code is changed. Every touched Python file was checked with a docstring-stripped AST comparison against the base branch: each file is parsed before and after, every docstring is removed from every module, class and function body, and the two ASTs must be identical. A file that did not compare equal was reverted rather than committed. The check was re-run after formatting, since formatting can move code.

- Python files touched: 5 (+121 / -288, net -167)
- New documentation: 107 lines in docs/internals/studio.md 

Public API docstrings are trimmed to their contract and not removed. Where a docstring recorded a real invariant, an ordering constraint, a unit, or a hazard, that text is kept.