### PR TITLE
chore(tests): trim prose in tests/mcp, tests/dispatch, tests/contracts

### DIFF
--- a/docs/internals/contracts.md
+++ b/docs/internals/contracts.md
@@ -1,0 +1,82 @@
+# Public-surface contract tests (`tests/contracts/`)
+
+This covers the "V0 behavior-preservation gate" implemented by
+`tests/contracts/_capture.py` and `tests/contracts/test_public_surfaces.py`. Its job
+is to catch an observable public surface changing by accident during refactors —
+HTTP routes, OpenAPI shape, the CLI's argparse tree, MCP tool projections,
+machine-mode output classification, and the set of public imports.
+
+## How the gate works
+
+Before any consolidation edit, each of these surfaces was captured once by calling
+the functions in `_capture.py` against the pre-edit worktree, and the result was
+frozen as JSON under `tests/contracts/data/`. `test_public_surfaces.py` calls the
+same functions again against the live code and diffs the fresh capture against the
+frozen baseline, field for field. A diff means an observable surface changed.
+
+A diff is never routine, but it is not always wrong. There are two cases:
+
+- **Unintended delta** — an edit changed observable behavior it was supposed to
+  preserve. Fix the code, not the baseline. This is the case the gate exists for,
+  and the common one.
+- **Intended delta** — a change deliberately adds to or alters the public surface,
+  and the baseline is now a stale description of it. Record the new baseline.
+  Refusing to record an intended change doesn't preserve anything — it just leaves
+  the gate red until someone refreshes the baseline anyway, usually with less care
+  than the procedure below asks for.
+
+A capture bug, where the baseline never described the code correctly in the first
+place, is fixed the same way as an intended delta.
+
+## Recording an intended delta
+
+All three steps are required, because a wholesale baseline refresh is exactly how
+an unrelated regression gets laundered in unnoticed:
+
+1. Regenerate to a scratch file and diff it against the committed baseline *before*
+   installing it. Read that diff as the change's own claim about its surface, and
+   confirm every line in it belongs to the intended change — this is the step that
+   catches a second, unnoticed delta riding along.
+2. Say in the commit message what moved and what did not: the counts that changed,
+   and the ones that stayed put.
+3. Where a count is also asserted as a literal in `test_public_surfaces.py`, update
+   it by hand and mutation-probe it (restore the old value, confirm the test goes
+   red, restore the new one). Those literals are a second, independent lock on
+   facts the JSON also carries — they stay hand-typed rather than derived from the
+   baseline, which would collapse two checks into one.
+
+## Waiver: redacting host-volatile output
+
+Two fields carry inherent host-state volatility and are excluded from the
+byte-for-byte comparison: the `agent status` specialized-CLI case includes a live
+session UUID and elapsed timers, and machine-mode `monitor`/`agent` cases report
+live run state. Their exit codes and envelope shape are still compared; their
+literal stdout is not.
+
+More generally, every case captured by `SPECIALIZED_CASES` / `MACHINE_CASES` in
+`_capture.py` is redacted by default. A case's literal stdout/stderr may only be
+committed to this public repository if its argv is listed in
+`_COMMITTABLE_SPECIALIZED_ARGV` / `_COMMITTABLE_MACHINE_ARGV` in
+`test_public_surfaces.py`, each entry stating why that argv's output is safe:
+static argparse usage/help/error text, derived from this repo's own source,
+carrying no session/host/run state. This is a population rule enforced against the
+live set of cases, not a fixed list someone has to remember to grow —
+`test_new_case_defaults_closed_without_declaration` in `test_public_surfaces.py`
+checks that a new case defaults to closed (redacted) until someone adds a reasoned
+entry to the allowlist.
+
+Two mechanisms in `_capture.py` back the redaction:
+
+- `differential_capture()` runs a given argv three times — once under the ambient
+  environment, once under a deliberately different `HOME`/`TMPDIR`/`USER` and
+  working directory, and once more after a wall-clock gap crossing a one-second
+  boundary. Output that reads anything from the environment, the current
+  directory, or the clock necessarily differs across the three runs; genuinely
+  static argparse text does not. This checks the property that actually matters
+  (does the output depend on the machine at all) instead of guessing at what a
+  leaked value looks like.
+- `known_machine_identity()` closes the gap `differential_capture` can't: a value
+  that's constant on one machine but still identifying (a hostname baked into a
+  banner line, for instance) won't vary between two runs on the same box. It
+  redacts a small set of literal identifying values — hostname, real username,
+  home directory, this checkout's path — directly, rather than pattern-matching.

--- a/docs/internals/mcp.md
+++ b/docs/internals/mcp.md
@@ -107,6 +107,32 @@ may still resolve a second later, true of any threshold — no value distinguish
 itself as uniquely correct here. Choosing the longest window this function will
 honour is a bet that a spawn which has outlived one is likelier stuck than slow.
 
+#### spawn-failure-per-op-error
+
+A submit whose child could not be started raises `SpawnError` (a `RuntimeError`),
+carrying the run_id. It didn't always: `_record_spawn_failure` has always raised
+for every `Popen` failure regardless of errno, but dispatch only caught `OpError`
+and the schema-projection errors, so a `SpawnError` escaped uncaught and took the
+whole batch down with it, including ops beside it that had already succeeded and
+the caller had no way to tell which run failed or why. Making it a per-op error
+lets the batch keep its other results, and gives the caller the run_id whose log
+holds the cause.
+
+A first version of that fix watched the freshly spawned child for a few seconds
+and converted an immediate non-zero exit into a refused submit. It was removed
+before merge on a measurement, not an opinion: ten real children spawned to die
+on their own arguments (e.g. an agent profile that doesn't exist), timed end to
+end on a loaded machine, took between 2.08 and 5.52 seconds to exit. A fixed
+window has to sit above the slowest case it's meant to catch, and every healthy
+submit pays that window regardless. At three seconds it would miss several of
+those ten while taxing every good submit; at six it would catch them at twice
+the tax. The distribution is a property of machine load, not of the defect, so
+no constant is right on both counts. What the watch was reaching for already
+exists on the read side instead: `status()` reports `possibly_orphaned` for a
+process that's gone with no end recorded, and returns `log_tail` in the same
+response — a caller probing once after submit learns the same thing without
+anyone paying for a window.
+
 #### kill-reason-codes
 
 `kill()` reason-code taxonomy (`lionagi/mcp/jobs.py`), grouped by what a caller

--- a/tests/contracts/_capture.py
+++ b/tests/contracts/_capture.py
@@ -415,30 +415,21 @@ def capture_specialized() -> list[dict[str, Any]]:
     return [_run_cli(list(argv)) for argv in SPECIALIZED_CASES]
 
 
-# A handful of the committable specialized-CLI cases capture argparse's own
-# rendered usage/help/error text verbatim (see _COMMITTABLE_SPECIALIZED_ARGV
-# in test_public_surfaces.py). That text depends on the interpreter's
-# HelpFormatter, which CPython has changed more than once across this
-# project's CI matrix. Two distinct changes are in play here, and only one of
-# them is stable enough to pin per minor version:
+# Committable specialized-CLI cases capture argparse's own rendered
+# usage/help/error text verbatim, which depends on the interpreter's
+# HelpFormatter. Two distinct CPython rendering changes are in play, only
+# one of which is stable enough to pin per minor version:
 #
-# - Invalid-choice quoting (e.g. "choose from 'a', 'b'" vs "choose from a,
-#   b") is NOT a stable per-minor-version property: it was dropped in 3.12,
-#   and CPython has since flipped it again *within* the 3.14 series (a local
-#   3.14.3 interpreter renders unquoted; CI's 3.14.6 renders quoted, for the
-#   same argparse call). A per-minor-version baseline key cannot represent a
-#   property that changes between patch releases of the same minor. This is
-#   handled by narrow, named normalization -- see
-#   ``normalize_argparse_choice_quoting`` below -- applied only to the
-#   "(choose from ...)" fragment, so the choice names themselves (this
-#   project's own subcommand list) still fail the comparison if they change.
-# - The 3.13 metavar collapse (a repeated per-option-string metavar folded
-#   into one shared metavar, e.g. "-f PATH, --file PATH" -> "-f, --file
-#   PATH") is a real, stable rendering change that also reflows the
-#   surrounding wrapped usage lines. It has not been observed to vary within
-#   a minor version, so it keeps its own pinned baseline rather than being
-#   normalized away -- normalizing it would risk masking an actual change in
-#   this CLI's own usage/help text.
+# - Invalid-choice quoting ("choose from 'a', 'b'" vs "choose from a, b") is
+#   NOT stable per minor version: dropped in 3.12, then flipped again
+#   *within* the 3.14 series (3.14.3 renders unquoted, CI's 3.14.6 quoted,
+#   for the same call). Handled by narrow normalization on just the
+#   "(choose from ...)" fragment -- see ``normalize_argparse_choice_quoting``
+#   -- so the choice names themselves still fail comparison if they change.
+# - The 3.13 metavar collapse ("-f PATH, --file PATH" -> "-f, --file PATH",
+#   which also reflows wrapped usage lines) is stable within a minor
+#   version, so it keeps its own pinned baseline rather than being
+#   normalized away.
 _SPECIALIZED_BASELINE_BY_PYVER: dict[tuple[int, int], str] = {
     (3, 10): "specialized",
     (3, 11): "specialized",  # measured byte-identical to 3.10's capture (mod. choice quoting)
@@ -484,16 +475,13 @@ _CHOOSE_FROM_RE = re.compile(r"\(choose from ((?:'[^']*'|[^,)]+)(?:, (?:'[^']*'|
 
 
 def normalize_argparse_choice_quoting(text: str) -> str:
-    """Strip the quote characters CPython's argparse ``HelpFormatter`` wraps
-    each choice name in inside a "(choose from ...)" invalid-choice error.
+    """Strip the quote characters argparse's ``HelpFormatter`` wraps each
+    choice name in inside a "(choose from ...)" invalid-choice error.
 
-    This targets exactly that fragment, not the surrounding text: the choice
-    *names* are this project's own subcommand list and remain fully
-    compared by the caller (a renamed, added, or removed choice still
-    produces a different normalized fragment and fails); only the
-    quote-or-not rendering argparse wraps them in -- which CPython has
-    flipped more than once within a single Python 3.14 patch series -- is
-    discarded.
+    Targets exactly that fragment: the choice names remain fully compared by
+    the caller (a renamed/added/removed choice still fails), only the
+    quote-or-not rendering -- which CPython has flipped more than once
+    within a single 3.14 patch series -- is discarded.
     """
 
     def _sub(match: re.Match[str]) -> str:
@@ -657,18 +645,15 @@ def capture_machine() -> list[dict[str, Any]]:
     return cases
 
 
-# ── Fresh-process import-laziness trace ──────────────────────────────────────
-
-# Self-contained subprocess payload: import only the named seed via the
-# registry's own `load_cli_command`, then report which *other* seeds' modules
-# leaked in, whether the HTTP registry got realized as a side effect, and
-# which seed(s) ended up in `_cli_realized`. Comparing against
-# `{s.module for s in iter_cli_seeds() if s.module != seed.module}` handles
-# shared modules (studio/schedule -> lionagi.studio.cli;
-# handshake/runs/lifecycle -> lionagi.cli.machine) for free: a shared
-# module's string is removed from the "other" set together with the selected
-# seed's own module, so loading `studio` never flags `lionagi.studio.cli`
-# even though `schedule` also maps to it.
+# Fresh-process import-laziness trace: self-contained subprocess payload that
+# imports only the named seed via `load_cli_command`, then reports which
+# *other* seeds' modules leaked in, whether the HTTP registry got realized as
+# a side effect, and which seed(s) ended up in `_cli_realized`. Comparing
+# against modules belonging to seeds other than this one's own handles
+# shared modules for free (e.g. studio/schedule both map to
+# lionagi.studio.cli): a shared module is excluded from "other" together
+# with the selected seed's own module, so loading `studio` never flags
+# `lionagi.studio.cli` even though `schedule` also uses it.
 _IMPORT_TRACE_SCRIPT = (
     "import sys, json\n"
     "from lionagi._auto import load_cli_command, seed_for, iter_cli_seeds, _http, _cli_realized\n"
@@ -736,15 +721,13 @@ _COMPAT_TRACE_SCRIPT = (
 
 def _run_compat_trace(module_name: str, timeout: float = 20.0) -> dict[str, Any]:
     """Import *module_name* alone in a fresh subprocess and report its public
-    ``dir()``. A compat module's own ``__init__.py`` declares its intended
-    re-exports, but Python also binds any submodule onto its parent package's
-    namespace the moment *anything* imports that submodule dotted-path --
-    including unrelated code elsewhere in the process (e.g. a lazy import
-    inside a different module). In-process capture would pick up whichever of
-    those happened to run first in this pytest worker, making the result
-    depend on suite composition rather than the compat module's own surface.
-    A fresh subprocess with a declared import set (only *module_name* itself)
-    removes that dependency."""
+    ``dir()``. Python binds any submodule onto its parent package's
+    namespace the moment *anything* imports that dotted path, including
+    unrelated code elsewhere in the process -- so in-process capture would
+    pick up whichever import happened to run first in this pytest worker,
+    making the result depend on suite composition rather than the compat
+    module's own surface. A fresh subprocess with a declared import set
+    (only *module_name* itself) removes that dependency."""
     proc = subprocess.run(
         [sys.executable, "-c", _COMPAT_TRACE_SCRIPT, module_name],
         cwd=REPO_ROOT,

--- a/tests/contracts/test_public_surfaces.py
+++ b/tests/contracts/test_public_surfaces.py
@@ -2,58 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """V0 behavior-preservation gate for the consolidation manifest.
 
-Each test loads the frozen baseline captured before any consolidation edit
-(``tests/contracts/data/*.json``, generated once by running the functions in
-``_capture.py`` against the pre-consolidation worktree) and compares it,
-field for field, against a fresh capture of the live code. A delta here means
-an observable public surface changed.
-
-A delta is therefore never routine, but it is not always wrong. Two cases:
-
-*Unintended* delta — a consolidation edit changed observable behavior it was
-supposed to preserve. Fix the code, not the baseline. This is the case the
-gate exists for and the common one.
-
-*Intended* delta — a change deliberately adds to or alters the public surface,
-and the baseline is now the stale description. Record it. Refusing to record
-an intended change does not preserve anything; it only leaves the gate red
-until someone refreshes the baseline anyway, with less care than this note
-asks for.
-
-Recording an intended delta requires all three, because a wholesale refresh is
-exactly how an unrelated regression gets laundered into the baseline:
-
-1. Regenerate to a scratch file and diff it against the committed baseline
-   *before* installing it. Read that diff as the change's own claim about its
-   surface, and confirm every line belongs to the intended change. This is the
-   step that catches a second, unnoticed delta riding along.
-2. Say in the commit message what moved and what did not — the counts that
-   changed, and the ones that stayed put.
-3. Where a count is also asserted as a literal in this file, update it by hand
-   and mutation-probe it: restore the old value, confirm the test goes red,
-   restore the new one. Those literals are a second, independent lock on facts
-   the JSON also carries; keep them hand-typed rather than derived from the
-   baseline, which would collapse two checks into one.
-
-A capture bug — where the baseline never described the code correctly — is
-fixed the same way and is not a third case.
-
-Two fields carry inherent host-state volatility and are excluded from the
-byte-for-byte comparison: the "agent status" specialized-CLI case includes a
-live session UUID and elapsed timers, and machine-mode "monitor"/"agent"
-cases report live run state. Their exit codes and envelope shape are still
-compared; their literal stdout is not.
-
-Waiver:
-  W-02: the "agent status" / "doctor --machine" / "handshake --machine" /
-    "runs --machine" cases carry live session, git-identity, and daemon
-    state that is non-deterministic across checkouts and wall clocks. These
-    -- and every other case captured by SPECIALIZED_CASES / MACHINE_CASES --
-    are redacted by default: only an argv listed in
-    _COMMITTABLE_SPECIALIZED_ARGV / _COMMITTABLE_MACHINE_ARGV, with a stated
-    reason, is compared byte-for-byte or committed as literal text below.
-    See test_new_case_defaults_closed_without_declaration for why this is a
-    population rule, not a list someone has to remember to grow.
+Compares a fresh capture of live public surfaces (HTTP routes, OpenAPI, CLI
+parser tree, MCP projections, machine-mode output, public imports) against
+the frozen baseline in ``tests/contracts/data/*.json``. A delta means an
+unintended behavior change (fix the code) or an intended one (update the
+baseline per the recorded procedure). See docs/internals/contracts.md for
+the full protocol, including the host-volatility redaction waiver.
 """
 
 from __future__ import annotations
@@ -71,18 +25,11 @@ from tests.contracts import _capture
 
 DATA_DIR = Path(__file__).parent / "data"
 
-# Case-level allowlist: the ONLY way a case's literal captured stdout/stderr
-# may be committed to this public repository. Each entry states why that
-# argv's output is safe -- static argparse usage/help/error text, derived
-# from this repo's own source, carrying no session/host/run state. A case
-# captured by SPECIALIZED_CASES / MACHINE_CASES (tests/contracts/_capture.py)
-# with no entry here is untrusted BY DEFAULT: excluded from the byte-for-byte
-# comparison below, and its committed fixture entry must carry the
-# redaction marker (test_volatile_fixture_cases_are_fully_redacted enforces
-# this against the live population, not a fixed list -- see
-# test_new_case_defaults_closed_without_declaration). Making a new case's
-# output committable requires adding a reasoned entry here: a deliberate,
-# reviewable diff, not something that happens by omission.
+# The ONLY way a case's literal captured stdout/stderr may be committed here:
+# each entry states why that argv's output is safe (static argparse text,
+# no session/host/run state). A case with no entry is untrusted by default
+# and redacted (see docs/internals/contracts.md and
+# test_new_case_defaults_closed_without_declaration).
 _COMMITTABLE_SPECIALIZED_ARGV: dict[tuple[str, ...], str] = {
     ("--help",): "top-level argparse usage/help text",
     ("wait",): "argparse usage + required-argument error",
@@ -115,12 +62,8 @@ _COMMITTABLE_MACHINE_ARGV: dict[tuple[str, ...], str] = {
 
 
 def _volatile_argv_for(file_name: str) -> set[tuple[str, ...]]:
-    """Every argv captured for *file_name* that is NOT declared committable
-    above -- derived from the live capture-case population in _capture.py,
-    not a hand-maintained denylist. A case appended to SPECIALIZED_CASES /
-    MACHINE_CASES with no matching committable-allowlist entry is
-    automatically volatile: excluded from byte-for-byte comparison and
-    required to be redacted in the committed fixture."""
+    """Argv captured for *file_name* not declared committable above --
+    derived from the live case population, not a hand-maintained denylist."""
     if file_name == "specialized":
         return set(_capture.SPECIALIZED_CASES) - set(_COMMITTABLE_SPECIALIZED_ARGV)
     if file_name == "machine":
@@ -143,21 +86,14 @@ def test_http_route_count_is_135():
 
 
 def _routes_by_key(payload: dict) -> dict[str, dict]:
-    """Project a ``capture_http()`` payload's routes into a dict keyed by
-    their actual identity, ``(methods, path)`` -- with the
-    registration-order-derived ``ordinal`` field dropped.
+    """Key routes by ``(methods, path)`` identity, dropping ``ordinal``.
 
-    ``ordinal`` reflects the position a route's decorator happened to run at
-    in *this* process, not a fact about the route: ``load_studio_route_modules``
-    imports each area module in a fixed order, but ``import_module`` on an
-    already-imported module is a no-op, so a route's real position depends on
-    whichever test in the same worker imported its owning service module
-    first (many tests import a single ``lionagi.studio.services.*`` module
-    directly to unit-test a handler, without going through ``create_app()``).
-    Comparing ``ordinal`` positionally turns one such incidental reordering
-    into a whole-file diff, since every route after the moved one shifts too.
-    Keying by identity instead means an actual added/removed/changed route
-    diffs as one entry.
+    ``ordinal`` reflects decorator-registration order in this process, which
+    varies with which test imported a service module first (many tests
+    import a single ``lionagi.studio.services.*`` module directly, bypassing
+    ``create_app()``). Comparing it positionally turns one incidental
+    reordering into a whole-file diff; keying by identity instead means only
+    an actual added/removed/changed route diffs.
     """
     by_key: dict[str, dict] = {}
     for route in payload["routes"]:
@@ -167,20 +103,11 @@ def _routes_by_key(payload: dict) -> dict[str, dict]:
 
 
 def _openapi_by_shape(payload: dict) -> dict:
-    """Project a ``capture_http()`` payload's openapi block for comparison,
-    with ``info.version`` dropped.
-
-    ``info.version`` is the application's own version string. Every release
-    bump changes it by design, and it describes the build rather than the
-    shape of the HTTP surface. Comparing it makes each version bump a
-    behavior-preservation failure on a pull request that changed no route --
-    and since the baseline is only meant to be regenerated when an
-    intentional route change lands, the two get coupled: either the version
-    is stale in the fixture, or every release carries a regenerated baseline
-    whose diff is indistinguishable from a real surface change. The package
-    version is asserted from the package metadata; this gate covers the
-    surface. Same reasoning as ``ordinal`` above: drop the field that is not
-    a fact about the routes.
+    """Openapi block with ``info.version`` dropped -- it's the app's build
+    version, bumped on every release regardless of route changes, and would
+    otherwise make every release a false behavior-preservation failure here.
+    Same reasoning as ``ordinal`` above: drop the field that is not a fact
+    about the routes.
     """
     openapi = payload["openapi"]
     info = {k: v for k, v in openapi.get("info", {}).items() if k != "version"}
@@ -247,17 +174,11 @@ def test_cli_surface_matches_baseline():
 def _assert_stderr_matches_baseline(
     argv: tuple[str, ...], got_stderr: str, exp_stderr: str
 ) -> None:
-    """Compare one case's live stderr against its frozen baseline, tolerating
-    only the argparse choice-quoting rendering difference (see
-    ``_capture.normalize_argparse_choice_quoting``) -- everything else,
-    including a changed/added/removed/renamed choice name, must still match
-    byte-for-byte.
-
-    A normalization that silently accepts a difference reads identically to
-    a byte-for-byte match that never needed it, so any case where
-    normalization was load-bearing announces itself via a pytest warning
-    (visible in the run's warnings summary even when the test passes)
-    instead of passing silently.
+    """Compare stderr against baseline, tolerating only the argparse
+    choice-quoting rendering difference (``_capture.normalize_argparse_choice_quoting``)
+    -- a changed/added/removed/renamed choice still fails byte-for-byte.
+    Warns (rather than passing silently) whenever normalization was load-bearing,
+    so the warnings summary shows every case that needed it.
     """
     if got_stderr == exp_stderr:
         return
@@ -295,15 +216,14 @@ def test_cli_specialized_paths_match_baseline():
 def test_normalize_argparse_choice_quoting_is_quoting_agnostic():
     """Property 1: the same choice list, quoted or bare, normalizes to the
     same fragment. Uses this project's own frozen baselines rather than a
-    synthetic example: ``specialized.json`` (captured on 3.10, quoted) and
-    ``specialized_py312.json`` (captured on 3.12, bare) are, for
-    ``bogus-unknown-command``, identical in every other respect (both
-    predate the 3.13 usage-line-wrap/metavar-collapse change -- unlike
-    specialized_py314.json, which also differs in wrapping and would make
-    this comparison conflate two unrelated rendering changes) -- so this
-    pair isolates exactly the quoting difference the normalizer targets.
-    This is also why the version map collapses (3, 10)-(3, 12) onto one
-    baseline file above."""
+    synthetic example: ``specialized.json`` (3.10, quoted) and
+    ``specialized_py312.json`` (3.12, bare) are, for
+    ``bogus-unknown-command``, identical in every other respect -- both
+    predate the 3.13 usage-line-wrap/metavar-collapse change, unlike
+    specialized_py314.json, which would conflate two unrelated rendering
+    changes -- so this pair isolates exactly the quoting difference the
+    normalizer targets. Also why the version map collapses (3, 10)-(3, 12)
+    onto one baseline file above."""
     quoted = {tuple(c["argv"]): c for c in _load("specialized")}[("bogus-unknown-command",)][
         "stderr"
     ]
@@ -627,20 +547,13 @@ def test_fixtures_carry_no_host_specific_state():
     )
 
 
-# `test_fixtures_carry_no_host_specific_state` above only catches leaks that
-# happen to match one of a few path patterns. That is a pattern-shaped check:
-# it says nothing about a captured field that leaks host state through some
-# other shape (a session id, a library version, a CVE posture, a directory
-# listing). The check below instead enumerates the *population* every
-# byte-for-byte comparison already excludes as volatile (_volatile_argv_for,
-# above -- derived from _COMMITTABLE_SPECIALIZED_ARGV / _COMMITTABLE_MACHINE_
-# ARGV, not a hand-written denylist) and requires every captured stream of
-# every case in that population to be either empty or carry the redaction
-# marker -- never literal captured text. A case's content having no
-# *currently visible* host-specific value is not an exemption: if it is
-# excluded from comparison, pinning its literal bytes has no oracle value
-# and is pure downside if the command ever starts reporting live state
-# through that field.
+# `test_fixtures_carry_no_host_specific_state` above only catches leaks
+# matching a few path patterns -- it says nothing about host state leaking
+# through some other shape (a session id, a library version, a directory
+# listing). The check below instead requires every case in the volatile
+# population (_volatile_argv_for) to carry either an empty stream or the
+# redaction marker, never literal captured text -- no currently-visible leak
+# is an exemption, since pinning volatile bytes has no oracle value.
 _REDACTION_MARKER_RE = re.compile(r"^\[redacted: .+\]$", re.DOTALL)
 
 
@@ -731,27 +644,13 @@ def test_new_case_becomes_committable_only_via_declaration(monkeypatch):
     assert _unredacted_fields("specialized", cases) == []
 
 
-# ── Differential check on committable streams ────────────────────────────
-#
-# A case-level committable declaration means a human read that command's
-# output once and judged it safe. That judgment decays: the SAME command can
-# grow env-, cwd-, or clock-derived content later (a new flag whose default
-# reads an env var, a banner that prints the working directory, a dependency
-# bump that starts stamping a timestamp) without ever leaving the allowlist.
-# A vocabulary/pattern check only catches shapes someone thought to list; it
-# also produces false accepts, since a real username or hostname can just
-# happen to collide with an ordinary CLI word already public in this repo's
-# own source (e.g. "admin", "runner").
-#
-# The property that actually matters: committable output must not depend on
-# the machine, the environment, or the clock at all. `differential_capture`
-# runs each committable case more than once under deliberately different
-# HOME/TMPDIR/USER/cwd and at two different wall-clock moments; anything
-# derived from any of those necessarily differs across the runs, and
-# genuinely static argparse usage/error text does not. A hostname is the one
-# thing that is identifying but constant on a given machine, so it cannot
-# show up as cross-run variance -- that gap is closed separately by
-# `known_machine_identity`, which redacts by known value rather than shape.
+# A committable declaration decays: the same command can grow env-, cwd-, or
+# clock-derived content later without ever leaving the allowlist. The checks
+# below re-verify the property that actually matters -- committable output
+# must not depend on the machine, environment, or clock at all -- via
+# `differential_capture` (see docs/internals/contracts.md). A hostname is
+# identifying but constant per machine, so it can't show up as cross-run
+# variance; that gap is closed separately by `known_machine_identity`.
 
 
 def _offending_fields(runs: list[dict]) -> list[str]:
@@ -769,19 +668,14 @@ def _offending_fields(runs: list[dict]) -> list[str]:
 
 def _identity_hits(text: str, identity: frozenset[str]) -> list[str]:
     """Whole-word/whole-path occurrences of a known machine-identity value in
-    *text*, INCLUDING a path root appearing as a prefix of a longer path
-    (e.g. identity value ``/Users/lion`` must hit inside
-    ``/Users/lion/some/deeper/path``, not just an exact standalone
-    occurrence) -- a value under a redacted root is exactly as identifying as
-    the root itself. Only the trailing boundary allows a `/` continuation;
-    a following word character still must not match, so a same-prefixed but
-    distinct name (``/Users/lionx``) is not misreported as a hit. The
-    leading boundary is unchanged and still word-bounded: a short real
-    username can legitimately be a substring of an unrelated CLI word (this
-    repo's own real capture hit this -- the checkout's username is a
-    substring of "lionagi", which appears throughout genuinely static help
-    text), and a raw substring match would misreport that collision as a
-    leak."""
+    *text*, including as a path-root prefix of a longer path (``/Users/lion``
+    must hit inside ``/Users/lion/deeper/path`` -- a value under a redacted
+    root is as identifying as the root itself), while a same-prefixed but
+    distinct name (``/Users/lionx``) is not a hit. Word-bounded on the
+    leading edge too: a short real username can legitimately be a substring
+    of an unrelated CLI word (this repo's checkout username is a substring
+    of "lionagi"), and a raw substring match would misreport that as a leak.
+    """
     return [v for v in identity if v and re.search(rf"(?<![\w/]){re.escape(v)}(?!\w)", text)]
 
 

--- a/tests/mcp/stdio_client.py
+++ b/tests/mcp/stdio_client.py
@@ -3,16 +3,15 @@
 """Drive a real ``python -m lionagi.mcp`` over stdio, the way a client does.
 
 Every other module under ``tests/mcp/`` exercises the Python objects beneath
-the transport, so a defect that lives in the wire shape — a key read from the
-op rather than from ``args``, a schema that only the projector sees — is
-invisible to all of them. This starts the server as a subprocess and speaks
-JSON-RPC to it: ``initialize``, ``notifications/initialized``, then
-``tools/call``, in that order, because the server refuses work before the
-handshake completes.
+the transport, so a defect in the wire shape itself (a key read from the op
+rather than from ``args``, a schema only the projector sees) is invisible to
+all of them. This starts the server as a subprocess and speaks JSON-RPC to
+it in handshake order: ``initialize``, ``notifications/initialized``, then
+``tools/call`` -- the server refuses work before the handshake completes.
 
-Every wait is bounded. A server that stops answering has to fail the test that
-is waiting on it rather than hang the suite, and the child is terminated on
-every exit path including an exception mid-conversation.
+Every wait is bounded, and the child is terminated on every exit path
+including an exception mid-conversation, so a server that stops answering
+fails the waiting test instead of hanging the suite.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_admission_without_a_named_model.py
+++ b/tests/mcp/test_admission_without_a_named_model.py
@@ -4,20 +4,16 @@
 """What the pre-spawn model check admits, per command.
 
 The check exists to refuse a submission the command would reject in its first
-second, because such a run never reaches the hook that records an end: the job
-stays non-terminal and a caller waiting on it waits forever. So its answer has
-to track what each command actually does with the arguments, not a general idea
-of what a model source looks like.
-
-Two commands disagreed with it.
-
-Flow and fanout read "no model and no agent" as a request to orchestrate and
-answer it with the default orchestrator profile. A submission naming neither is
-therefore complete, and refusing it here refused a run that would have started.
-
-An agent reads its positionals as ``[MODEL] PROMPT``, so a lone positional is
-the prompt. Treating any positional as a model admitted ``query=["do it"]`` with
-no model anywhere, which is exactly the run that dies on start.
+second: such a run never reaches the hook that records an end, so the job
+stays non-terminal and a caller waiting on it waits forever. Its answer has to
+track what each command actually does with the arguments, not a general idea
+of what a model source looks like. Two commands disagreed with a naive check:
+flow/fanout read "no model and no agent" as a request to orchestrate (and use
+the default orchestrator profile), so refusing that combination refused a run
+that would have started; and `agent` reads its positionals as
+``[MODEL] PROMPT``, so treating any positional as a model wrongly admitted
+``query=["do it"]`` with no model anywhere -- exactly the run that dies on
+start.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_catalog_coverage.py
+++ b/tests/mcp/test_catalog_coverage.py
@@ -3,15 +3,16 @@
 """Every command the CLI offers is either registered or named absent.
 
 The privilege fence already guards the other direction: a verb cannot become
-reachable without someone writing its path into a reviewed list. Nothing guarded
-this one. A command could be added to the CLI and the catalog would simply not
-mention it, and silence reads the same as considered-and-declined -- which is the
-one thing the absent entries exist to distinguish. Twenty-three commands had
-accumulated that way before this test existed.
+reachable without someone writing its path into a reviewed list. Nothing
+guarded this one -- a command could be added to the CLI and the catalog
+would simply not mention it, and silence reads the same as
+considered-and-declined, which is the one thing the absent entries exist to
+distinguish. Twenty-three commands had accumulated that way before this
+test existed.
 
-The CLI surface is measured here rather than listed, because a list of command
-paths in a test is a second copy of the parser tree and would go stale in the
-same way the catalog did.
+The CLI surface is measured here rather than listed, since a list of
+command paths in a test is a second copy of the parser tree that would go
+stale the same way the catalog did.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_catalog_sufficiency.py
+++ b/tests/mcp/test_catalog_sufficiency.py
@@ -2,17 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """The catalog has to be enough to write the call it describes.
 
-The tool tells a caller to start with ``help=true`` and says the answer is
-enough to make the common call. That promise is only kept if the entry carries
-everything the call is gated on, so these tests construct ops from the catalog
-reply and nothing else, and check that what refuses them is never the gate the
-catalog was supposed to have satisfied.
+``help=true`` promises its answer is enough to make the common call. That
+promise only holds if the entry carries everything the call is gated on, so
+these tests build ops from the catalog reply alone and check that nothing
+refuses them on a gate the catalog was supposed to have satisfied.
 
-The spawn verbs are the gated ones, and running one starts a background agent.
-So the ops here are steered into a refusal that lies *past* every gate — an
-unreadable prompt file — and the assertion is on which refusal comes back. A
-call rejected for its prompt is a call whose fingerprint was accepted, which is
-the fact under test; nothing is spawned to establish it.
+The spawn verbs are the gated ones, and running one starts a background
+agent, so the ops here are steered into a refusal that lies *past* every
+gate (an unreadable prompt file): a call rejected for its prompt is a call
+whose fingerprint was accepted, which is the fact under test -- nothing is
+actually spawned to establish it.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_dispatch.py
+++ b/tests/mcp/test_dispatch.py
@@ -542,16 +542,15 @@ def test_a_stale_playbook_fingerprint_is_told_the_same_qualified_source(a_playbo
 def test_targeted_help_withholds_a_fingerprint_no_successful_call_can_carry():
     """`play.submit` requires a playbook, so its argument-free fingerprint is dead.
 
-    Every *successful* `play.submit` op names a playbook and therefore resolves a
-    schema that is not the argument-free one. The argument-free fingerprint is
-    accepted only by a call that omits the playbook, which then fails validation —
-    so its sole effect is to buy a round-trip on the way to a different error. The
-    catalog withheld it and targeted help returned it, so one contract had two
-    answers depending on which way you asked.
-
-    Withholding it is not silence — the answer names the parameter the fingerprint
-    varies with, so the caller knows to ask again with a playbook rather than to
-    retry with a stale string.
+    Every *successful* `play.submit` op names a playbook and resolves a
+    schema that is not the argument-free one -- that fingerprint is accepted
+    only by a call that omits the playbook, which then fails validation, so
+    its sole effect is to buy a round-trip on the way to a different error.
+    The catalog withheld it while targeted help returned it, so one contract
+    had two answers depending on which way you asked. Withholding it is not
+    silence: the answer names the parameter the fingerprint varies with, so
+    the caller knows to ask again with a playbook rather than retry with a
+    stale string.
     """
     answer = call(help="play.submit")
     assert "schema_fingerprint" not in answer

--- a/tests/mcp/test_lifecycle.py
+++ b/tests/mcp/test_lifecycle.py
@@ -2,15 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """The lifecycle read: a run stopped by `li kill` has to read as terminal.
 
-The kill path writes the StateDB row and signals the process. It does not write
-the MCP job record and it does not write the CLI run manifest, so before this
-seam existed a killed run was indistinguishable from an orphan — a dead pid with
-no recorded end — and `job.wait` sat on it for its whole window.
+The kill path writes the StateDB row and signals the process, but writes
+neither the MCP job record nor the CLI run manifest -- so before this seam
+existed, a killed run was indistinguishable from an orphan (a dead pid with
+no recorded end) and `job.wait` sat on it for its whole window.
 
-The first test here is end to end on purpose: a real submit, a real child that
-persists a real session row, a real `li kill`, and a real `jobs.wait`. A unit
-test over `_derive` with a hand-built record would only assert its own fixture,
-and the defect lived in the gap between the writers, not in the classifier.
+The first test here is end to end on purpose: a real submit, a real child
+that persists a real session row, a real `li kill`, and a real `jobs.wait`.
+A unit test over `_derive` with a hand-built record would only assert its
+own fixture -- the defect lived in the gap between the writers, not in the
+classifier.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_lifecycle_verb_is_readonly.py
+++ b/tests/mcp/test_lifecycle_verb_is_readonly.py
@@ -2,16 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """`lifecycle` is reachable from the MCP surface, so its read must be a read.
 
-The ordinary store open reconciles the schema: `create_all`, index reconciliation
-and seed inserts. A reporting path that used it would write to the store it
-reports on, and against a store it may not write to it fails on an
-`INSERT INTO schema_meta` while presenting itself as a read. Only
-``readonly=True`` avoids that, and nothing in the function's own docstring makes
-it so.
+The ordinary store open reconciles the schema (`create_all`, index
+reconciliation, seed inserts), so a reporting path that used it would write
+to the store it reports on -- failing on `INSERT INTO schema_meta` against a
+store it may not write to, while presenting itself as a read. Only
+``readonly=True`` avoids that.
 
-These are behavioural probes rather than an assertion about which keyword was
-passed. A keyword check passes as soon as someone writes the keyword; what has to
-hold is that the path does not need write access.
+These are behavioural probes, not an assertion about which keyword was
+passed: a keyword check passes as soon as someone writes the keyword, but
+what has to hold is that the path does not need write access.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_machine_observability.py
+++ b/tests/mcp/test_machine_observability.py
@@ -191,19 +191,18 @@ def test_mcp_transport_delivers_when_the_calling_process_denies_direct_filesyste
 ):
     """The sandbox failure this MCP transport exists to fix, reproduced directly.
 
-    `denied_home` stands in for a sandboxed worker's own restricted view of
+    `denied_home` stands in for a sandboxed worker's restricted view of
     `~/.lionagi`: a `workspace-write`-style sandbox denies a process direct
-    filesystem access to a path outside its grant, which `chmod` reproduces
-    here — a subprocess pointed at `denied_home` cannot even create the
-    `teams/` directory. That subprocess is the same command a sandboxed
-    worker would shell out to directly (the original bug).
+    filesystem access outside its grant, which `chmod` reproduces here -- a
+    subprocess pointed at `denied_home` can't even create `teams/`. That's
+    the same command a sandboxed worker would shell out to directly (the
+    original bug).
 
-    The MCP dispatcher path below never touches `denied_home` at all:
-    `dispatch.request()` runs in this test process, using the `home`
-    fixture's own `LIONAGI_HOME` — exactly as the real MCP server does, since
-    it is a separate, unsandboxed process from the worker and never inherits
-    the worker's sandbox. That process separation, not a shared filesystem
-    grant, is what lets the message through.
+    The MCP dispatcher path below never touches `denied_home`: it runs in
+    this test process using the `home` fixture's own `LIONAGI_HOME`, exactly
+    as the real MCP server does, since it's a separate, unsandboxed process
+    that never inherits the worker's sandbox. Process separation, not a
+    shared filesystem grant, is what lets the message through.
     """
     denied_home = tmp_path / "denied-home"
     denied_home.mkdir()

--- a/tests/mcp/test_notify_failure_classification.py
+++ b/tests/mcp/test_notify_failure_classification.py
@@ -35,9 +35,7 @@ def _py(script: str) -> list[str]:
     return [sys.executable, "-c", script]
 
 
-# ---------------------------------------------------------------------------
 # The invariant: the stored field is a bounded enum, not free text
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -90,9 +88,7 @@ def test_classifier_failure_yields_unknown_and_carries_nothing_out(monkeypatch):
     assert "hunter2" not in out
 
 
-# ---------------------------------------------------------------------------
 # The point of the change: a failure is now classifiable
-# ---------------------------------------------------------------------------
 
 
 def test_a_missing_notifier_is_distinguishable_from_a_refused_message():
@@ -180,9 +176,7 @@ def test_a_timeout_is_classified_without_touching_the_exceptions_captured_output
     assert "hunter2" not in repr(out)
 
 
-# ---------------------------------------------------------------------------
 # Degraded trust: a zero exit that does not mean delivered
-# ---------------------------------------------------------------------------
 
 
 def test_kkernel_exec_without_strict_is_marked_unverified():

--- a/tests/mcp/test_notify_hook.py
+++ b/tests/mcp/test_notify_hook.py
@@ -576,18 +576,14 @@ def test_a_configuration_with_no_program_in_it_names_none(job, monkeypatch):
 def test_the_delivery_commands_own_output_is_still_never_kept(job, monkeypatch):
     """Naming the program changes nothing about what the command may say.
 
-    Its stdout and stderr are free text that can carry a credential the command
+    Its stdout/stderr are free text that can carry a credential the command
     obtained anywhere, so the record holds only fields this hook chose. That
-    invariant is unchanged; what changed is how it is kept. The output used to
-    be discarded at the pipe, which also discarded any way to tell one failure
-    from another, so every failed delivery recorded a bare exit code. It is now
-    read, matched against a closed vocabulary, and dropped — only the matched
-    name is stored.
-
-    So this pins the boundary rather than the mechanism: the stored key set is
-    fixed, and the value in the one new field comes from the closed set. A
-    future change that lets an unmatched failure contribute its own words fails
-    here instead of passing review.
+    invariant is unchanged; what changed is how it's kept: output used to be
+    discarded at the pipe, which also discarded any way to tell one failure
+    from another, so every failed delivery recorded a bare exit code. It is
+    now read, matched against a closed vocabulary, and dropped -- only the
+    matched name is stored, so a future change letting an unmatched failure
+    contribute its own words fails here instead of passing review.
     """
     seen: dict = {}
 

--- a/tests/mcp/test_orphan_reaping.py
+++ b/tests/mcp/test_orphan_reaping.py
@@ -809,15 +809,12 @@ def test_a_child_recorded_end_wins_over_a_later_reaper_observation(
 ):
     """Ties the general hook-wins-over-reaper guarantee (see
     ``test_a_hook_end_that_lands_first_survives_the_reaper`` above) to the
-    concrete mechanism the CLI's direct-path notice delivery depends on:
-    `--notify` for an MCP-spawned run always resolves to
+    concrete mechanism: `--notify` for an MCP-spawned run always resolves to
     `lionagi.mcp._notify_hook`, so calling it IS how a run records its own
-    end, whichever of the two CLI-side notify paths (registered callback, or
-    a run that lost its persistence and delivers directly) triggered it.
-
-    Ordering matters here specifically: the child's hook runs and wins the
-    write BEFORE the reaper ever observes this run, and the reap that follows
-    must decline rather than overwrite it with `indeterminate`.
+    end, whichever CLI-side notify path triggered it. Ordering matters here
+    specifically: the child's hook runs and wins the write BEFORE the reaper
+    ever observes this run, and the reap that follows must decline rather
+    than overwrite it with `indeterminate`.
     """
     _pid_absent(monkeypatch)
     rid = _stranded()

--- a/tests/mcp/test_privilege_fence.py
+++ b/tests/mcp/test_privilege_fence.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Operations that grant privilege stay off this surface.
 
-Every caller here is an agent. Trusting a plugin lets a bundle run code in the
-process, trusting a hook does the same for a hook bundle, and migrating the store
-rewrites what the rest of these verbs report on. Exposing any of them would let
-the thing being granted a right be the thing that grants it. These stay
-human-at-a-terminal operations.
+Every caller here is an agent. Trusting a plugin lets a bundle run code in
+the process, trusting a hook does the same for a hook bundle, and migrating
+the store rewrites what the rest of these verbs report on -- exposing any of
+them would let the thing being granted a right be the thing that grants it,
+so these stay human-at-a-terminal operations.
 
-The fence is an allowlist, so the interesting assertions are about the routes
-around it rather than about the three names: a verb that is not registered, a
-command path that is not a verb's path, and the absence of any parameter that
-carries opaque argv.
+The fence is an allowlist, so the interesting assertions are about the
+routes around it rather than the three names: a verb that is not
+registered, a command path that is not a verb's path, and the absence of
+any parameter that carries opaque argv.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_roster.py
+++ b/tests/mcp/test_roster.py
@@ -3,14 +3,14 @@
 """The roster verbs: which agent profiles exist here, and what one of them runs.
 
 A caller submits a run by naming a profile, so the value of these verbs is
-entirely in whether their answer is the answer the run would get. That is what
-these assert: the same file wins, the reported configuration is the one the
-loader produced, and a name that does not exist comes back naming the ones that
-do rather than as an empty result.
+entirely in whether their answer is the answer the run would get: the same
+file wins, the reported configuration is the one the loader produced, and a
+name that does not exist comes back naming the ones that do rather than as
+an empty result.
 
-Every root here is a temp directory. Nothing in this file may read the real
-``~/.lionagi/agents/``, which is why HOME is redirected and the working directory
-moved before any resolution happens.
+Every root here is a temp directory -- nothing in this file may read the
+real ``~/.lionagi/agents/``, which is why HOME and the working directory are
+redirected before any resolution happens.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_schedule_verbs.py
+++ b/tests/mcp/test_schedule_verbs.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """The schedule verbs, end to end, through the real `li` subprocess.
 
-Nothing here mocks the child. The defect these verbs are exposed to is not in
-either half but in the seam: the dispatcher renders argv from a schema projected
-off one parser, and the child then parses those tokens with the parser it builds
-for itself. A test that stubs the subprocess asserts that the first half agrees
-with itself.
+Nothing here mocks the child. The defect these verbs are exposed to lives in
+the seam, not either half: the dispatcher renders argv from a schema
+projected off one parser, and the child parses those tokens with the parser
+it builds for itself -- a test that stubs the subprocess would only assert
+the first half agrees with itself.
 
-What is substituted is the Studio the child talks to — a real HTTP server on a
-loopback port, recording every request. That keeps the assertions about the
-request the child actually composed, and keeps the suite from writing to
-whatever schedule store the machine running it happens to have.
+What is substituted is the Studio the child talks to: a real HTTP server on
+a loopback port, recording every request. That keeps the assertions about
+the request the child actually composed, and keeps the suite from writing
+to whatever schedule store the machine running it happens to have.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_spawn_failure_is_a_per_op_error.py
+++ b/tests/mcp/test_spawn_failure_is_a_per_op_error.py
@@ -1,42 +1,13 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""A submit whose child could not be started raises ``SpawnError``, which is a
-``RuntimeError``. Dispatch caught ``OpError`` and the schema-projection errors
-and nothing else, so this one escaped and took the entire batch down with it —
-including the ops beside it that had already succeeded.
-
-That was reachable before any of this: ``_record_spawn_failure`` raises it for
-every ``Popen`` failure, deliberately for every exception rather than an errno
-family. A caller who batched a submit alongside anything else lost the lot, and
-the response said nothing about which run failed or why.
-
-It is now a per-op error carrying the run_id, so the batch keeps its other
-results and the caller has the id whose log holds the cause.
-
-WHY THERE IS NO STARTUP WATCH HERE
-
-A first version of this fix watched the freshly spawned child for a few seconds
-and converted an immediate non-zero exit into a refused submit. It was removed
-before merge, on a measurement rather than an opinion.
-
-Ten real children spawned to die on their own arguments (`li agent -a
-<nonexistent-profile>`), timed end to end on a machine at load average 76:
-
-    2.08  2.43  2.53  2.55  2.81  3.35  3.64  3.67  3.82  5.52   seconds
-
-A fixed window has to sit above the slowest of those to catch the class it
-exists for, and every healthy submit pays whatever that window is. At three
-seconds it would have missed four of these ten while taxing every good submit;
-at six it would catch them and tax every good submit twice as much. The
-distribution is a property of the machine's load, not of the defect, so no
-constant is right on both counts.
-
-The thing it was reaching for already exists on the read side: ``status()``
-reports ``possibly_orphaned`` for a process that is gone with no end recorded,
-and returns ``log_tail`` in the same response, which is where the cause has been
-the whole time. A caller probing once after submit learns this without anyone
-paying for a window.
+"""A submit whose child could not be started raises ``SpawnError`` (a
+``RuntimeError``) carrying the run_id. Dispatch used to catch only ``OpError``
+and the schema-projection errors, so this one escaped and took the whole batch
+down with it, including ops beside it that had already succeeded. It is now a
+per-op error, so the batch keeps its other results and the caller has the id
+whose log holds the cause. See docs/internals/mcp.md
+(spawn-failure-per-op-error) for why there is deliberately no startup watch.
 """
 
 from __future__ import annotations

--- a/tests/mcp/test_wait_and_spawn.py
+++ b/tests/mcp/test_wait_and_spawn.py
@@ -812,24 +812,21 @@ async def test_wait_and_list_agree_on_the_spawn_phase(sandbox, monkeypatch):
 async def test_a_spawn_that_starts_between_observations_returns_to_pending(sandbox, monkeypatch):
     """The bucket is a reading of the current record, never a latch.
 
-    This is what makes the bucket safe to put a live-but-slow spawn in: the row
-    leaves it the moment its phase advances, so the cost of a wrong guess is one
-    poll interval rather than a run written off. The claim is asserted across two
-    observations inside ONE wait, not across two calls — two calls would pass even
-    if a latch survived for the length of a call, which is exactly where a cache
-    would sit.
+    This is what makes the bucket safe for a live-but-slow spawn: the row
+    leaves it the moment its phase advances, so the cost of a wrong guess is
+    one poll interval, not a run written off. Asserted across two
+    observations inside ONE wait, not across two calls -- two calls would
+    pass even if a latch survived for the length of a call, exactly where a
+    cache would sit. The clock and the sleep are both driven rather than
+    waited on, since a wall-clock version would race its own deadline and a
+    flaky stickiness test is worse than none.
 
-    Both the clock and the sleep are driven rather than waited on. A wall-clock
-    version would either sleep for real or race its own deadline, and a flaky test
-    for a stickiness property is worse than no test: it fails for reasons unrelated
-    to stickiness and gets muted.
-
-    The pid moves with the phase, and it has to: a record claiming ``started`` with
-    no pid is not a running run to the classifier, it is an orphan, so a fixture
-    that only advanced the phase would be asserting a transition into a state it
-    cannot represent. Liveness is answered per-pid rather than by a flat ``False``
-    for the same reason — the source state needs a dead probe and the destination
-    state needs a live one, inside one test.
+    The pid moves with the phase, and has to: a record claiming ``started``
+    with no pid reads as an orphan, not a running run, to the classifier, so
+    a fixture that only advanced the phase would assert a transition into a
+    state it cannot represent. Liveness is answered per-pid rather than by a
+    flat ``False`` for the same reason -- the source state needs a dead
+    probe and the destination state needs a live one, inside one test.
     """
     import anyio
 


### PR DESCRIPTION
Cut narration and restated-in-prose test bodies from docstrings/comments while preserving every regression rationale, external-contract note, and deliberate-scope decision. Removed stale section-divider banners in test_notify_failure_classification.py. Moved two genuinely essay-length docstrings (the public-surface baseline-capture/waiver protocol, and the SpawnError per-op-error design rationale with its measured startup-watch rejection) to docs/internals/contracts.md (new) and docs/internals/mcp.md respectively, each with a one-line pointer left in the source.

No executable code, imports, or assertions changed; verified file-by-file with ast_equal.py against HEAD after every edit and again after ruff format/check.