### PR TITLE
chore(tests): trim prose in studio/plugins/docs test suites

### DIFF
--- a/docs/internals/studio.md
+++ b/docs/internals/studio.md
@@ -426,6 +426,52 @@ carrying the reason and — whenever `notify_request()` finds a notify
 payload — emits a `dispatch_outbox` row via
 `lionagi.dispatch.outbox.enqueue_dispatch`.
 
+## lionagi/studio/scheduler/engine.py
+
+**`_reserve_max_runs_budget`** — reserves one top-level fire against a
+schedule's `max_runs` cap. A fire consumes budget the instant it fires, not
+when it resolves, so the count it checks is `fired + inflight`: `fired` is
+the persisted count of `running`-or-terminal `schedule_run` rows, and
+`inflight` is an in-process counter of fires that have claimed budget but
+whose occurrence row has not yet committed. The two are disjoint views of
+the same fire — a claim is released the moment the occurrence row lands —
+so summing them counts each fire exactly once, except for a brief instant
+during the handoff where a fire can appear in both; that only ever
+over-counts, which just causes a spurious refusal that self-corrects on the
+next tick. Only one scheduler process runs today, so this reservation is
+in-memory (an `asyncio.Lock`-guarded dict), not a database compare-and-set.
+
+The order of the two reads inside that lock is the load-bearing part.
+`inflight` is read *before* the `await` on `count_schedule_runs()`, not
+after. `release()` (called from `_fire()`'s `finally` block on every exit
+path, so a claim always gets freed even from a cancelled or failing fire)
+does not take the lock — it must work even while a fire is mid-cancellation,
+where acquiring a lock from a `finally` block risks a deadlock. That makes
+it possible for a concurrent fire to release its claim *while this call is
+suspended awaiting the database*. If `inflight` were read after that await,
+a fire that both writes its occurrence row and releases its claim entirely
+inside the suspended window would vanish from both counts at once: too late
+for the in-flight snapshot (already released) and too early for the
+persisted count (the read started before the write landed) — letting a
+bounded schedule fire one more time than `max_runs` allows. Reading
+`inflight` first means it still captures that other fire's claim before it
+can disappear, so the sum can only ever over-count, never under-count.
+
+`_tick()`'s ad-hoc task-worker pass runs single-flight: a second `_tick()`
+firing while the first pass is still in progress must not start a second
+pass, and must not await the first pass either — a slow or hung worker pass
+would otherwise stall every schedule's due-time evaluation for the whole
+tick. `_tick()` starts the pass as a background task and returns promptly
+regardless of whether it is still running.
+
+`resolve_terminal` (child-session outcome inference) does not trust a
+leader process's exit code as evidence that a still-running child session's
+own work has finished — the terminal stamp comes from the leader's stderr
+pipe closing, not from the child's work actually ending. A child session
+that has not reached any terminal status of its own is reported as
+`completed_empty` (no positive evidence) rather than being inferred as
+`completed`.
+
 ## lionagi/studio/scheduler/worker.py
 
 `claim_and_execute`'s D4 match rule: row R is claimable iff its capability

--- a/tests/docs/test_advanced.py
+++ b/tests/docs/test_advanced.py
@@ -7,9 +7,7 @@ import pytest
 from lionagi.testing import LionAGIMockFactory
 
 
-# ===================================================================
 # Performance (performance.md)
-# ===================================================================
 class TestPerformance:
     """Patterns from performance.md: concurrency utilities, rate limiting."""
 
@@ -73,9 +71,7 @@ class TestPerformance:
         assert model is not None
 
 
-# ===================================================================
 # Observability (observability.md)
-# ===================================================================
 class TestObservability:
     """Patterns from observability.md: logging, hooks, message inspection."""
 
@@ -163,9 +159,7 @@ class TestObservability:
         assert mocked_branch.logs is not None
 
 
-# ===================================================================
 # Error Handling (error-handling.md)
-# ===================================================================
 class TestErrorHandling:
     """Patterns from error-handling.md: rate limiting, provider fallback."""
 
@@ -224,9 +218,7 @@ class TestErrorHandling:
         assert r3.execution.response == "third attempt"
 
 
-# ===================================================================
 # Flow Composition (flow-composition.md)
-# ===================================================================
 class TestFlowComposition:
     """Patterns from flow-composition.md: Builder, Graph, Session orchestration."""
 
@@ -294,9 +286,7 @@ class TestFlowComposition:
         assert inspect.iscoroutinefunction(session.flow)
 
 
-# ===================================================================
 # Custom Operations (custom-operations.md)
-# ===================================================================
 class TestCustomOperations:
     """Patterns from custom-operations.md: register_operation, operation decorator."""
 

--- a/tests/docs/test_agent_sandbox_api.py
+++ b/tests/docs/test_agent_sandbox_api.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 import inspect
 from dataclasses import fields
 
-# =============================================================================
 # AgentSpec
-# =============================================================================
 
 
 class TestAgentSpecPresets:
@@ -62,9 +60,7 @@ class TestAgentSpecPresets:
         assert len(spec.hook_handlers) == 0
 
 
-# =============================================================================
 # PermissionPolicy
-# =============================================================================
 
 
 class TestPermissionPolicyModes:
@@ -137,9 +133,7 @@ class TestPermissionPolicyModes:
         assert decision.behavior == "allow"
 
 
-# =============================================================================
 # Hooks
-# =============================================================================
 
 
 class TestHookSignatures:
@@ -202,9 +196,7 @@ class TestHookSignatures:
         assert "sink" not in param_names
 
 
-# =============================================================================
 # SandboxSession
-# =============================================================================
 
 
 class TestSandboxSessionAPI:
@@ -290,9 +282,7 @@ class TestSandboxSessionAPI:
         assert "base_branch" in param_names
 
 
-# =============================================================================
 # create_agent factory
-# =============================================================================
 
 
 class TestCreateAgentFactory:

--- a/tests/docs/test_api_docs_drift.py
+++ b/tests/docs/test_api_docs_drift.py
@@ -7,9 +7,7 @@ import pytest
 DOCS_DIR = Path(__file__).resolve().parents[2] / "docs" / "api"
 
 
-# ---------------------------------------------------------------------------
 # 1. Gemini provider uses GEMINI_API_KEY, not GOOGLE_API_KEY
-# ---------------------------------------------------------------------------
 class TestIModelDocs:
     """Verify imodel.md matches live provider configuration."""
 
@@ -44,9 +42,7 @@ class TestIModelDocs:
         assert "GEMINI_API_KEY" in content
 
 
-# ---------------------------------------------------------------------------
 # 2. Operations doc import paths resolve
-# ---------------------------------------------------------------------------
 class TestOperationsDocs:
     """Verify that every import shown in operations.md actually works."""
 
@@ -101,9 +97,7 @@ class TestOperationsDocs:
         assert HookEventTypes is not None
 
 
-# ---------------------------------------------------------------------------
 # 3. Session.flow() return type is a wrapper dict, not Note
-# ---------------------------------------------------------------------------
 class TestFlowReturnType:
     """Verify Session.flow() return type documentation accuracy."""
 
@@ -163,9 +157,7 @@ class TestFlowReturnType:
         assert "final_context" in content
 
 
-# ---------------------------------------------------------------------------
 # 4. Builder is a public export
-# ---------------------------------------------------------------------------
 class TestBuilderExport:
     """Verify Builder is importable as documented in flow.md."""
 

--- a/tests/docs/test_cookbook.py
+++ b/tests/docs/test_cookbook.py
@@ -9,9 +9,7 @@ from lionagi.session.branch import Branch
 from lionagi.session.session import Session
 from lionagi.testing import LionAGIMockFactory
 
-# ---------------------------------------------------------------------------
 # Inline Pydantic models (as cookbook docs define them)
-# ---------------------------------------------------------------------------
 
 
 class Claim(BaseModel):
@@ -34,9 +32,7 @@ class CandidateEvaluation(BaseModel):
     recommendation: str
 
 
-# ---------------------------------------------------------------------------
 # Brainstorming cookbook
-# ---------------------------------------------------------------------------
 
 
 class TestBrainstorming:
@@ -102,9 +98,7 @@ class TestBrainstorming:
         assert len(b2.messages) == 1
 
 
-# ---------------------------------------------------------------------------
 # Code Review Crew cookbook
-# ---------------------------------------------------------------------------
 
 
 class TestCodeReviewCrew:
@@ -153,9 +147,7 @@ class TestCodeReviewCrew:
         assert OperationGraphBuilder is not None
 
 
-# ---------------------------------------------------------------------------
 # Claim Extraction cookbook
-# ---------------------------------------------------------------------------
 
 
 class TestClaimExtraction:
@@ -204,9 +196,7 @@ class TestClaimExtraction:
         assert result is not None
 
 
-# ---------------------------------------------------------------------------
 # Research Synthesis cookbook
-# ---------------------------------------------------------------------------
 
 
 class TestResearchSynthesis:
@@ -267,9 +257,7 @@ class TestResearchSynthesis:
         assert found.name == "my_researcher"
 
 
-# ---------------------------------------------------------------------------
 # Data Persistence cookbook
-# ---------------------------------------------------------------------------
 
 
 class TestDataPersistence:
@@ -315,9 +303,7 @@ class TestDataPersistence:
         assert len(df) == 1
 
 
-# ---------------------------------------------------------------------------
 # HR Automation cookbook
-# ---------------------------------------------------------------------------
 
 
 class TestHRAutomation:

--- a/tests/docs/test_core_concepts.py
+++ b/tests/docs/test_core_concepts.py
@@ -4,9 +4,7 @@ import pytest
 
 from lionagi.testing import LionAGIMockFactory
 
-# ---------------------------------------------------------------------------
 # A -- Imports & Construction (no mocks, no LLM calls)
-# ---------------------------------------------------------------------------
 
 
 class TestImportsAndTopLevelExports:
@@ -205,9 +203,7 @@ class TestSessionConstruction:
         assert len(session.branches) >= 1
 
 
-# ---------------------------------------------------------------------------
 # B -- Schema & Tool Registration (no mocks)
-# ---------------------------------------------------------------------------
 
 
 class TestSchemaAndToolRegistration:
@@ -313,9 +309,7 @@ class TestSchemaAndToolRegistration:
         assert tool.tool_schema["function"]["name"] == "search"
 
 
-# ---------------------------------------------------------------------------
 # C -- API/Method Existence (no mocks, no calls)
-# ---------------------------------------------------------------------------
 
 
 class TestBranchMethodsExist:
@@ -433,9 +427,7 @@ class TestMessageTypeConstruction:
         assert MessageRole.ASSISTANT.value == "assistant"
 
 
-# ---------------------------------------------------------------------------
 # D -- LLM Integration (mocked, uses fixtures from conftest)
-# ---------------------------------------------------------------------------
 
 
 class TestMockedLLMOperations:

--- a/tests/docs/test_for_ai_agents.py
+++ b/tests/docs/test_for_ai_agents.py
@@ -6,9 +6,7 @@ import pytest
 
 from lionagi.testing import LionAGIMockFactory
 
-# =============================================================================
 # Orchestration Guide (orchestration-guide.md)
-# =============================================================================
 
 
 class TestOrchestrationGuide:
@@ -141,9 +139,7 @@ class TestOrchestrationGuide:
         assert branch_a.chat_model is not branch_b.chat_model
 
 
-# =============================================================================
 # Self-Improvement (self-improvement.md)
-# =============================================================================
 
 
 class TestSelfImprovement:
@@ -255,9 +251,7 @@ class TestSelfImprovement:
         assert MessageRole is not None
 
 
-# =============================================================================
 # Pattern Selection (pattern-selection.md)
-# =============================================================================
 
 
 class TestPatternSelection:
@@ -334,9 +328,7 @@ class TestPatternSelection:
         assert "text" in params
 
 
-# =============================================================================
 # Claude Code Usage (claude-code-usage.md)
-# =============================================================================
 
 
 class TestClaudeCodeUsage:

--- a/tests/docs/test_integrations.py
+++ b/tests/docs/test_integrations.py
@@ -5,9 +5,7 @@ from pydantic import BaseModel
 
 from lionagi.service.imodel import iModel
 
-# ===========================================================================
 # LLM Providers (llm-providers.md)
-# ===========================================================================
 
 
 class TestLLMProviders:
@@ -154,9 +152,7 @@ class TestLLMProviders:
             pytest.skip("codex provider could not be constructed")
 
 
-# ===========================================================================
 # CLI Providers — Detailed (llm-providers.md CLI section + claude-code-usage.md)
-# ===========================================================================
 
 
 class TestCLIEndpointArchitecture:
@@ -458,9 +454,7 @@ class TestCLISessionManagement:
             pytest.skip("claude_code provider could not be constructed")
 
 
-# ===========================================================================
 # Tools (tools.md)
-# ===========================================================================
 
 
 class TestTools:
@@ -571,9 +565,7 @@ class TestTools:
         assert tool.request_options is SearchParams
 
 
-# ===========================================================================
 # MCP (mcp-servers.md)
-# ===========================================================================
 
 
 class TestMCP:

--- a/tests/docs/test_patterns.py
+++ b/tests/docs/test_patterns.py
@@ -6,9 +6,7 @@ import pytest
 
 from lionagi.testing import LionAGIMockFactory
 
-# ============================================================================
 # Helpers / tool functions used across tests
-# ============================================================================
 
 
 def search_knowledge(query: str) -> str:
@@ -21,9 +19,7 @@ def search_papers(query: str, max_results: int = 5) -> str:
     return f"Papers about: {query}"
 
 
-# ============================================================================
 # Fan-Out/In Pattern
-# ============================================================================
 
 
 class TestFanOutIn:
@@ -122,9 +118,7 @@ class TestFanOutIn:
         assert len(result) > 0
 
 
-# ============================================================================
 # Sequential Analysis Pattern
-# ============================================================================
 
 
 class TestSequentialAnalysis:
@@ -206,9 +200,7 @@ class TestSequentialAnalysis:
         assert asyncio.iscoroutinefunction(branch.communicate)
 
 
-# ============================================================================
 # Tournament Validation Pattern
-# ============================================================================
 
 
 class TestTournamentValidation:
@@ -301,9 +293,7 @@ class TestTournamentValidation:
         assert "Best solution" in verdict
 
 
-# ============================================================================
 # Conditional Flows Pattern
-# ============================================================================
 
 
 class TestConditionalFlows:
@@ -383,9 +373,7 @@ class TestConditionalFlows:
         assert code_branch.name == "code"
 
 
-# ============================================================================
 # ReAct with RAG Pattern
-# ============================================================================
 
 
 class TestReActWithRAG:

--- a/tests/docs/test_quickstart.py
+++ b/tests/docs/test_quickstart.py
@@ -3,9 +3,7 @@
 import pytest
 
 
-# ---------------------------------------------------------------------------
 # 1. Import lionagi
-# ---------------------------------------------------------------------------
 def test_import_lionagi():
     """Verify that `import lionagi` succeeds and exposes the version."""
     import lionagi
@@ -14,9 +12,7 @@ def test_import_lionagi():
     assert isinstance(lionagi.__version__, str)
 
 
-# ---------------------------------------------------------------------------
 # 2. __version__ is a string
-# ---------------------------------------------------------------------------
 def test_version_is_string():
     """lionagi.__version__ should be a non-empty string."""
     import lionagi
@@ -25,9 +21,7 @@ def test_version_is_string():
     assert len(lionagi.__version__) > 0
 
 
-# ---------------------------------------------------------------------------
 # 3. Core public exports
-# ---------------------------------------------------------------------------
 def test_core_exports():
     """The top-level package exposes Branch, iModel, and Session."""
     from lionagi import Branch, Session, iModel
@@ -37,9 +31,7 @@ def test_core_exports():
     assert Session is not None
 
 
-# ---------------------------------------------------------------------------
 # 4. Minimal Branch construction
-# ---------------------------------------------------------------------------
 def test_branch_minimal_construction():
     """Branch() with no arguments should produce a valid instance."""
     from lionagi import Branch
@@ -49,9 +41,7 @@ def test_branch_minimal_construction():
     assert branch.id is not None
 
 
-# ---------------------------------------------------------------------------
 # 5. Branch with system prompt
-# ---------------------------------------------------------------------------
 def test_branch_with_system_prompt():
     """Branch(system='...') sets the system message."""
     from lionagi import Branch
@@ -62,9 +52,7 @@ def test_branch_with_system_prompt():
     assert len(branch.msgs.messages) > 0
 
 
-# ---------------------------------------------------------------------------
 # 6. iModel construction
-# ---------------------------------------------------------------------------
 def test_imodel_construction():
     """iModel can be constructed with explicit provider, model, and api_key."""
     from lionagi import iModel
@@ -73,9 +61,7 @@ def test_imodel_construction():
     assert model is not None
 
 
-# ---------------------------------------------------------------------------
 # 7. communicate returns a response (mocked)
-# ---------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_communicate_returns_response(mocked_branch):
     """await branch.communicate('...') should return a response string."""
@@ -85,9 +71,7 @@ async def test_communicate_returns_response(mocked_branch):
     assert len(result) > 0
 
 
-# ---------------------------------------------------------------------------
 # 8. Tool registration via Branch constructor
-# ---------------------------------------------------------------------------
 def test_tool_registration():
     """Branch(tools=[fn1, fn2]) registers callable tools properly."""
     from lionagi import Branch

--- a/tests/studio/services/test_admit.py
+++ b/tests/studio/services/test_admit.py
@@ -120,7 +120,7 @@ async def _mark_running(db: StateDB, run_id: str, *, now: float) -> None:
     assert result.applied is True
 
 
-# ── 1. Capability mismatch -> deferred, never terminal ──────────────────────
+# Capability mismatch -> deferred, never terminal
 
 
 async def test_capability_mismatch_defers_not_terminal(db: StateDB) -> None:
@@ -145,7 +145,7 @@ async def test_capability_match_and_no_holder_admits(db: StateDB) -> None:
     assert decision == AdmissionDecision(admitted=True)
 
 
-# ── 2. Concurrency block (within waiter cap) -> deferred, never terminal ────
+# Concurrency block (within waiter cap) -> deferred, never terminal
 
 
 async def test_concurrency_block_within_cap_defers(db: StateDB) -> None:
@@ -198,7 +198,7 @@ async def test_claimed_keys_pass_local_holder_blocks_even_when_db_shows_no_runni
     assert "deferred" in decision.reason_summary
 
 
-# ── 3. Waiter-cap overflow -> terminal, unless opted into deferred ─────────
+# Waiter-cap overflow -> terminal, unless opted into deferred
 
 
 async def test_waiter_cap_exceeded_is_terminal_rejection(db: StateDB) -> None:
@@ -246,7 +246,7 @@ async def test_waiter_cap_exceeded_but_opted_into_deferred_stays_deferred(db: St
     assert "opted into deferred" in decision.reason_summary
 
 
-# ── 4. Duration guard -> terminal, unconditional ────────────────────────────
+# Duration guard -> terminal, unconditional
 
 
 async def test_duration_guard_rejects_when_at_or_above_lease_ttl(db: StateDB) -> None:
@@ -307,7 +307,7 @@ async def test_duration_guard_takes_priority_over_capability_mismatch(db: StateD
     assert decision.reason_code == RunReasons.SKIPPED_DURATION_EXCEEDS_LEASE
 
 
-# ── 5. Pure helper functions ─────────────────────────────────────────────
+# Pure helper functions
 
 
 def test_normalize_action_args_handles_json_string_dict_and_junk():
@@ -405,7 +405,7 @@ def test_notify_request_rejects_present_but_null_optional_fields():
     ) == {"deliver_to": "lambda:leo", "kind": "terminal_notify"}
 
 
-# ── 6. waiter_ahead_count / holder_is_running direct coverage ───────────────
+# waiter_ahead_count / holder_is_running direct coverage
 
 
 async def test_holder_is_running_true_and_false(db: StateDB) -> None:

--- a/tests/studio/services/test_task_applications.py
+++ b/tests/studio/services/test_task_applications.py
@@ -1,16 +1,13 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""ADR-0071 D1 slice 2: the task-application submit surface.
+"""ADR-0071: the task-application submit surface.
 
-Covers submit_task's round-trip write, the CAS-governed queued -> cancelled
-cancel path, and rejection of a malformed TaskApplication. The transition
-vocabulary's negative-boundary tests (queued -> running is now allowed by
-D3; terminal re-entry is rejected) live in test_task_worker.py alongside the
-worker that exercises the queued -> running edge. ADR-0071 D3's
-submit-time AdmissionRejectedError pre-check (duration guard, waiter cap) is
-covered in the final section; the authoritative claim-time admit() gate is
-covered in test_admit.py and test_worker_admission.py.
+The transition vocabulary's negative-boundary tests (queued -> running is
+allowed; terminal re-entry is rejected) live in test_task_worker.py
+alongside the worker that exercises the queued -> running edge. The
+authoritative claim-time admit() gate is covered in test_admit.py and
+test_worker_admission.py.
 """
 
 from __future__ import annotations
@@ -43,7 +40,7 @@ def _actor() -> Actor:
     return Actor(type="operator", id="test")
 
 
-# ── 1. Submit round-trip ─────────────────────────────────────────────────
+# Submit round-trip
 
 
 async def test_submit_task_writes_queued_row_with_every_field(db: StateDB) -> None:
@@ -118,7 +115,7 @@ async def test_submit_task_eligibility_only_capabilities_no_concurrency_key(db: 
     assert row["concurrency_key"] is None
 
 
-# ── 2. CAS-governed queued -> cancelled ──────────────────────────────────
+# CAS-governed queued -> cancelled
 
 
 async def test_cancel_task_succeeds_via_transition_store(db: StateDB) -> None:
@@ -152,7 +149,7 @@ async def test_cancel_task_twice_is_not_applied_second_time(db: StateDB) -> None
     assert await cancel_task(db, run_id, actor=_actor()) is False
 
 
-# ── 3. Rejection paths ───────────────────────────────────────────────────
+# Rejection paths
 
 
 async def test_submit_task_rejects_unknown_action_kind(db: StateDB) -> None:
@@ -209,7 +206,7 @@ async def test_submit_task_rejects_idempotency_key_until_dedup_exists(db: StateD
     assert row["n"] == 0
 
 
-# ── 4. ADR-0071 D3: submit-time AdmissionRejectedError pre-check ──────────
+# ADR-0071 D3: submit-time AdmissionRejectedError pre-check
 
 
 async def test_submit_task_rejects_duration_at_or_above_lease_ttl(db: StateDB) -> None:

--- a/tests/studio/services/test_task_worker.py
+++ b/tests/studio/services/test_task_worker.py
@@ -89,7 +89,7 @@ async def _failing_execute(row: dict) -> tuple[int, str]:
     return 1, "boom"
 
 
-# ── 1. Claim CAS race ────────────────────────────────────────────────────
+# Claim CAS race
 
 
 async def test_two_concurrent_claims_exactly_one_wins(tmp_path) -> None:
@@ -114,7 +114,7 @@ async def test_two_concurrent_claims_exactly_one_wins(tmp_path) -> None:
     assert row["status"] == "completed"
 
 
-# ── 2. Cancel beats claim ────────────────────────────────────────────────
+# Cancel beats claim
 
 
 async def test_cancelled_before_claim_is_never_leased(db: StateDB) -> None:
@@ -131,7 +131,7 @@ async def test_cancelled_before_claim_is_never_leased(db: StateDB) -> None:
     assert row["leased_by"] is None
 
 
-# ── 3. Lease-expiry recovery ─────────────────────────────────────────────
+# Lease-expiry recovery
 
 
 async def test_expired_lease_recovers_to_queued(db: StateDB) -> None:
@@ -194,7 +194,7 @@ async def test_live_lease_is_never_reaped(db: StateDB) -> None:
     assert row["leased_by"] == "w1"
 
 
-# ── 4. Bounded re-queue (R1) ─────────────────────────────────────────────
+# Bounded re-queue
 
 
 async def test_third_lease_expiry_fails_terminal_not_requeued(db: StateDB) -> None:
@@ -239,7 +239,7 @@ async def test_third_lease_expiry_fails_terminal_not_requeued(db: StateDB) -> No
     assert counts == {"requeued": 0, "failed": 0}
 
 
-# ── 5. Terminal re-entry rejected (R2) ───────────────────────────────────
+# Terminal re-entry rejected
 
 
 async def test_completed_to_running_rejected(db: StateDB) -> None:
@@ -286,7 +286,7 @@ async def test_failed_to_running_rejected(db: StateDB) -> None:
         )
 
 
-# ── 6. Claim predicate ───────────────────────────────────────────────────
+# Claim predicate
 
 
 async def test_capability_carrying_row_is_never_leased(db: StateDB) -> None:
@@ -316,7 +316,7 @@ async def test_scheduler_fired_row_is_never_leased(db: StateDB) -> None:
     assert row["status"] == "queued"
 
 
-# ── 7. Round trip ─────────────────────────────────────────────────────────
+# Round trip
 
 
 async def test_submit_claim_execute_completed_round_trip(db: StateDB) -> None:
@@ -426,7 +426,7 @@ async def test_stale_worker_cannot_finalize_a_reclaimed_lease(db: StateDB) -> No
     assert row["lease_expires_at"] == t0 + 3600
 
 
-# ── Global slot reservation hook (#2751) ─────────────────────────────────
+# Global slot reservation hook
 
 
 async def test_worker_tick_respects_injected_global_slot_reservation(db: StateDB) -> None:

--- a/tests/studio/services/test_task_worker_capabilities.py
+++ b/tests/studio/services/test_task_worker_capabilities.py
@@ -1,17 +1,11 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""ADR-0071 D5: capability-class matching in the claim loop.
+"""ADR-0071: capability-class matching in the claim loop.
 
-Covers the workers-registry heartbeat upsert, the subset-match claim rule
-(eligibility∪serialization tokens), execution_target matching (including the
-NULL/empty = claimable-by-any case), heartbeat-TTL claim eligibility (and its
-non-interference with lease-expiry recovery), serialization-class
-concurrency admission, affinity-class candidate ordering, cross-dialect JSON
-normalization (SQLite string vs. Postgres native value), and the keyset-paged
-claim scan (a persistent prefix of ineligible older rows must never hide a
-later eligible row). D3's original claim-race/lease/vocabulary tests live
-untouched in test_task_worker.py.
+The keyset-paged claim scan must never let a persistent prefix of ineligible
+older rows hide a later eligible row. Original claim-race/lease/vocabulary
+tests live in test_task_worker.py.
 """
 
 from __future__ import annotations
@@ -59,7 +53,7 @@ async def _status_of(db: StateDB, run_id: str) -> dict:
     return await db.fetch_one("SELECT status, leased_by FROM schedule_runs WHERE id = ?", (run_id,))
 
 
-# ── 1. Heartbeat registry upsert ─────────────────────────────────────────
+# Heartbeat registry upsert
 
 
 async def test_register_heartbeat_writes_a_worker_row(db: StateDB) -> None:
@@ -90,7 +84,7 @@ async def test_register_heartbeat_upserts_not_duplicates(db: StateDB) -> None:
     assert rows[0]["last_heartbeat_at"] == later
 
 
-# ── 2. Subset-match claim rule ───────────────────────────────────────────
+# Subset-match claim rule
 
 
 async def test_matching_capability_worker_claims(db: StateDB) -> None:
@@ -128,7 +122,7 @@ async def test_extra_advertised_capabilities_still_claims(db: StateDB) -> None:
     assert row["status"] == "completed"
 
 
-# ── 3. Execution-target matching ─────────────────────────────────────────
+# Execution-target matching
 
 
 async def test_execution_target_mismatch_not_claimed(db: StateDB) -> None:
@@ -169,7 +163,7 @@ async def test_null_execution_target_claimable_by_any_worker(db: StateDB) -> Non
     assert row["status"] == "completed"
 
 
-# ── 4. Heartbeat-TTL claim eligibility ───────────────────────────────────
+# Heartbeat-TTL claim eligibility
 
 
 async def test_stale_heartbeat_worker_skipped_for_new_claims(db: StateDB) -> None:
@@ -246,7 +240,7 @@ async def test_stale_workers_inflight_lease_still_recovers_via_reap(db: StateDB)
     assert row["leased_by"] is None
 
 
-# ── 5. Serialization-class concurrency admission ─────────────────────────
+# Serialization-class concurrency admission
 
 
 async def test_serialization_tasks_share_concurrency_key(db: StateDB) -> None:
@@ -337,7 +331,7 @@ async def test_eligibility_and_affinity_tasks_never_serialize(db: StateDB) -> No
     assert (await _status_of(db, run_id_2))["status"] == "completed"
 
 
-# ── 6. Affinity-class ordering ───────────────────────────────────────────
+# Affinity-class ordering
 
 
 async def test_affinity_matched_task_preferred_over_earlier_plain_task(db: StateDB) -> None:
@@ -387,7 +381,7 @@ async def test_affinity_ordering_does_not_starve_plain_tasks(db: StateDB) -> Non
     assert (await _status_of(db, run_id_affinity))["status"] == "completed"
 
 
-# ── 7. No eligible worker => stays queued ────────────────────────────────
+# No eligible worker => stays queued
 
 
 async def test_no_eligible_worker_task_remains_queued_across_ticks(db: StateDB) -> None:
@@ -402,7 +396,7 @@ async def test_no_eligible_worker_task_remains_queued_across_ticks(db: StateDB) 
     assert row["leased_by"] is None
 
 
-# ── 8. Cross-dialect JSON normalization ──────────────────────────────────
+# Cross-dialect JSON normalization
 
 
 def test_normalize_json_list_null_and_empty():
@@ -492,8 +486,7 @@ async def test_sqlite_backed_claim_still_works_after_normalization_change(db: St
     assert (await _status_of(db, run_id))["status"] == "completed"
 
 
-# ── 9. Keyset-paged claim scan (no starvation behind a long ineligible
-#      prefix) ────────────────────────────────────────────────────────────
+# Keyset-paged claim scan (no starvation behind a long ineligible prefix)
 
 
 async def test_eligible_row_behind_a_long_ineligible_prefix_is_still_claimed(

--- a/tests/studio/services/test_worker_admission.py
+++ b/tests/studio/services/test_worker_admission.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""ADR-0071 D3: the admit() seam wired into the worker claim loop.
+"""ADR-0071: the admit() seam wired into the worker claim loop.
 
-Covers the convoy-incident regression (N jobs behind one holder, the
-(N+1)th over the waiter cap is rejected, not silently queued) and the
-requirement that a claim-time terminal rejection surfaces
-observably: the row lands on a terminal status carrying the reason, and a
+N jobs behind one holder: the (N+1)th over the waiter cap must be rejected,
+not silently queued, and a claim-time terminal rejection must surface
+observably -- the row lands on a terminal status carrying the reason, and a
 notify-carrying submission produces a dispatch_outbox row. Direct
 admit()-in-isolation unit tests live in test_admit.py.
 """
@@ -112,7 +111,7 @@ async def _reason_history(db: StateDB, run_id: str) -> list[dict]:
     return [dict(r) for r in rows]
 
 
-# ── 1. Convoy-shape regression ───────────────────────────────────────────
+# Convoy-shape regression
 
 
 async def test_convoy_third_waiter_over_cap_is_rejected_not_queued(db: StateDB) -> None:
@@ -229,7 +228,7 @@ async def test_duration_invalid_waiter_does_not_consume_cap_after_affinity_sort(
     assert (await _status_of(db, valid_id))["status"] == "queued"
 
 
-# ── 2. Claim-time rejection surfaces observably ──────────────────────────
+# Claim-time rejection surfaces observably
 
 
 async def test_claim_time_rejection_persists_reason_on_the_row(db: StateDB) -> None:

--- a/tests/studio/test_admin_health_timezone.py
+++ b/tests/studio/test_admin_health_timezone.py
@@ -59,9 +59,7 @@ def _health_timezone(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict:
     return response.json()["scheduler_timezone"]
 
 
-# ---------------------------------------------------------------------------
 # Each source is reported distinguishably
-# ---------------------------------------------------------------------------
 
 
 def test_explicit_scheduler_env_var_is_reported_as_its_own_source(monkeypatch, tmp_path):
@@ -122,9 +120,7 @@ def test_surrendered_utc_is_distinguishable_from_a_chosen_one(monkeypatch, tmp_p
     assert surrendered["source"] != chosen["source"]
 
 
-# ---------------------------------------------------------------------------
 # The payload carries enough to date the value
-# ---------------------------------------------------------------------------
 
 
 def test_payload_carries_resolution_and_process_start_times(monkeypatch, tmp_path):
@@ -139,9 +135,7 @@ def test_payload_carries_resolution_and_process_start_times(monkeypatch, tmp_pat
         assert parsed <= datetime.now(tz=timezone.utc)
 
 
-# ---------------------------------------------------------------------------
 # The reported value is the one the scheduler actually uses
-# ---------------------------------------------------------------------------
 
 
 def test_reported_zone_is_the_one_fire_times_are_computed_in(monkeypatch, tmp_path):

--- a/tests/studio/test_github_filter_validation.py
+++ b/tests/studio/test_github_filter_validation.py
@@ -33,9 +33,7 @@ def _create_data(**overrides) -> dict:
     return base
 
 
-# ---------------------------------------------------------------------------
 # _svc_validate_github_filter — pure logic
-# ---------------------------------------------------------------------------
 
 
 def test_validate_github_filter_none_is_noop():
@@ -96,9 +94,7 @@ def test_validate_github_filter_rejects_non_bool_same_repo_only():
         _svc_validate_github_filter({"same_repo_only": 1})
 
 
-# ---------------------------------------------------------------------------
 # create_schedule / update_schedule — validation fires before any DB write
-# ---------------------------------------------------------------------------
 
 
 def test_create_schedule_rejects_unknown_github_filter_key():

--- a/tests/studio/test_github_poller.py
+++ b/tests/studio/test_github_poller.py
@@ -518,9 +518,7 @@ def test_github_poll_respects_cursor_high_water_mark(monkeypatch):
     assert [i.event["pr_number"] for i in items] == [2]
 
 
-# ---------------------------------------------------------------------------
 # github_filter={"event": "pr_merged"} -- merged-PR mode
-# ---------------------------------------------------------------------------
 
 
 def test_github_poll_merged_mode_polls_closed_state(monkeypatch):
@@ -919,9 +917,7 @@ def test_github_poll_401_surviving_retry_logs_at_error_with_schedule_id_and_name
     assert "401" in msg
 
 
-# ---------------------------------------------------------------------------
 # Token caching — avoid a `gh auth token` shell-out on every poll
-# ---------------------------------------------------------------------------
 
 
 def test_github_poll_caches_working_token_across_polls(monkeypatch):
@@ -1075,9 +1071,7 @@ def test_github_poll_pagination_401_clears_cached_token(monkeypatch):
     assert gh_mod._cached_token is None
 
 
-# ---------------------------------------------------------------------------
 # GithubPollResult.poll_status — observer self-health signal
-# ---------------------------------------------------------------------------
 
 
 def test_github_poll_result_with_items_has_ok_status(monkeypatch):
@@ -1170,9 +1164,7 @@ def test_github_poll_result_default_poll_status_is_ok():
     assert result.poll_status == "ok"
 
 
-# ---------------------------------------------------------------------------
 # Scan reach: how far back a single merged-mode poll can actually see
-# ---------------------------------------------------------------------------
 
 
 def _all_merged(page):

--- a/tests/studio/test_run_view.py
+++ b/tests/studio/test_run_view.py
@@ -195,7 +195,7 @@ def test_fallback_outcome_status_dominates_over_exit_code_zero():
     assert outcome["code"] != "completed"
 
 
-# ── exit_code_for_view: reuses the existing shared status vocabulary ───────
+# exit_code_for_view: reuses the existing shared status vocabulary
 
 
 @pytest.mark.parametrize(

--- a/tests/studio/test_schedule_action_cwd.py
+++ b/tests/studio/test_schedule_action_cwd.py
@@ -33,9 +33,7 @@ def _create_data(**overrides) -> dict:
     return base
 
 
-# ---------------------------------------------------------------------------
 # _svc_validate_action_cwd — pure logic
-# ---------------------------------------------------------------------------
 
 
 def test_validate_action_cwd_none_is_noop():
@@ -77,9 +75,7 @@ def test_validate_action_cwd_rejects_file_not_directory(tmp_path):
         _svc_validate_action_cwd(str(f))
 
 
-# ---------------------------------------------------------------------------
 # create_schedule — explicit action_cwd wins, validated before the DB write
-# ---------------------------------------------------------------------------
 
 
 def test_create_schedule_rejects_invalid_action_cwd():
@@ -209,9 +205,7 @@ def test_create_schedule_without_action_project_stays_none_without_lookup(monkey
     fake_get_project.assert_not_awaited()
 
 
-# ---------------------------------------------------------------------------
 # update_schedule — action_cwd validated at the PATCH boundary
-# ---------------------------------------------------------------------------
 
 
 def test_update_schedule_rejects_invalid_action_cwd():

--- a/tests/studio/test_schedule_declaration.py
+++ b/tests/studio/test_schedule_declaration.py
@@ -26,9 +26,7 @@ from lionagi.studio.services.schedule_declaration import (
     resolve_schedule_set,
 )
 
-# ---------------------------------------------------------------------------
 # fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -82,9 +80,7 @@ schedules:
 """
 
 
-# ---------------------------------------------------------------------------
 # Closed-schema rejection at every level
-# ---------------------------------------------------------------------------
 
 
 def test_top_level_unknown_key_rejected():
@@ -456,9 +452,7 @@ def test_wrong_api_version_rejected():
         )
 
 
-# ---------------------------------------------------------------------------
 # Trigger resolution
-# ---------------------------------------------------------------------------
 
 
 def test_resolve_cron_trigger_persists_timezone(agent_profile):
@@ -639,9 +633,7 @@ def test_resolve_github_trigger_rejects_invalid_repo(tmp_path, monkeypatch):
         resolve_schedule_set(doc, tmp_path)
 
 
-# ---------------------------------------------------------------------------
 # Target resolution
-# ---------------------------------------------------------------------------
 
 
 def test_agent_target_resolves_model_from_profile(agent_profile):
@@ -845,9 +837,7 @@ schedules:
     }
 
 
-# ---------------------------------------------------------------------------
 # cwd / project resolution
-# ---------------------------------------------------------------------------
 
 
 def test_relative_cwd_resolves_against_manifest_dir(tmp_path, monkeypatch):
@@ -953,9 +943,7 @@ schedules:
     assert resolved["hourly"].cwd == str(tmp_path.resolve())
 
 
-# ---------------------------------------------------------------------------
 # Atomic validate/diff/apply service
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -1237,10 +1225,8 @@ async def test_dry_run_plan_never_writes(temp_db_path, agent_profile):
         assert rows == []
 
 
-# ---------------------------------------------------------------------------
 # Command-target args: both create paths write action_command_args, so both
 # must hold it to the same contract
-# ---------------------------------------------------------------------------
 
 
 def _command_manifest(args_yaml: str, cwd: Path) -> str:

--- a/tests/studio/test_schedule_export.py
+++ b/tests/studio/test_schedule_export.py
@@ -28,9 +28,7 @@ from lionagi.studio.services.schedule_export import (
     format_report,
 )
 
-# ---------------------------------------------------------------------------
 # fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -75,9 +73,7 @@ def _legacy_row(schedule_id: str, name: str, *, cwd: Path, **overrides) -> dict:
     return row
 
 
-# ---------------------------------------------------------------------------
 # Legacy conversion — happy path per action kind
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -184,9 +180,7 @@ async def test_legacy_flow_yaml_row_converts_ready(temp_db_path, agent_profile):
     assert written.read_text() == "workers: 2\n"
 
 
-# ---------------------------------------------------------------------------
 # Legacy conversion — BLOCKED cases
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -264,9 +258,7 @@ async def test_legacy_malformed_trigger_is_blocked_and_omitted(temp_db_path, age
     assert "demo/badcron" not in doc.schedules
 
 
-# ---------------------------------------------------------------------------
 # Round-trip: export legacy -> validate -> apply to a fresh DB -> compare
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -304,9 +296,7 @@ async def test_legacy_export_round_trips_to_a_fresh_db(tmp_path, monkeypatch, ag
     assert resolved_target["model"] == "anthropic/claude-sonnet-5"
 
 
-# ---------------------------------------------------------------------------
 # Default export — authored_spec round-trip incl. quoted notify "on"
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -410,9 +400,7 @@ async def test_default_export_is_deterministically_name_sorted(temp_db_path, age
     assert report_lines == ["demo/aaa-first", "demo/zzz-last"]
 
 
-# ---------------------------------------------------------------------------
 # CLI surface — --output vs stdout, never writes the database
-# ---------------------------------------------------------------------------
 
 
 def _export_args(**overrides) -> types.SimpleNamespace:
@@ -484,10 +472,8 @@ def test_export_never_writes_the_database(temp_db_path, agent_profile, tmp_path)
     assert before[0]["enabled"] == after[0]["enabled"]
 
 
-# ---------------------------------------------------------------------------
 # Mixed-project export -- one document per project, exact qualified-name
 # round-trip (no double-qualification)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -593,9 +579,7 @@ async def test_managed_mixed_project_export_round_trips_exact_qualified_names(
     assert doubled is None
 
 
-# ---------------------------------------------------------------------------
 # flow_yaml action_model override -- BLOCKED, not silently dropped
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -626,9 +610,7 @@ async def test_legacy_flow_yaml_with_action_model_is_blocked(temp_db_path, agent
     assert "demo/model-flow" not in doc.schedules
 
 
-# ---------------------------------------------------------------------------
 # action_extra_args -- BLOCKED, not silently dropped
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -652,9 +634,7 @@ async def test_legacy_row_with_action_extra_args_is_blocked(temp_db_path, agent_
     assert "demo/extra-args" not in doc.schedules
 
 
-# ---------------------------------------------------------------------------
 # github_poll poll_interval_sec -- BLOCKED only when set and non-default
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -704,9 +684,7 @@ async def test_legacy_github_poll_at_default_interval_stays_ready(temp_db_path, 
     assert doc.schedules["poll-default"].trigger.github.repo == "octo/repo"
 
 
-# ---------------------------------------------------------------------------
 # CLI exit code -- 2 when any row is BLOCKED, document + report still emitted
-# ---------------------------------------------------------------------------
 
 
 def test_cli_export_returns_partial_exit_code_when_a_row_is_blocked(
@@ -743,10 +721,8 @@ def test_cli_export_returns_partial_exit_code_when_a_row_is_blocked(
     assert "1 ready, 1 blocked" in report_text
 
 
-# ---------------------------------------------------------------------------
 # Flow snapshot portability -- sidecar path is relative, YAML carries no
 # host prefix, absolute cwd is flagged on the report line
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -807,9 +783,7 @@ async def test_legacy_absolute_cwd_kept_verbatim_but_flagged_on_report_line(
     assert str(agent_profile) in lines[0].message
 
 
-# ---------------------------------------------------------------------------
 # Rows with no stored project — name identity across re-apply
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -902,9 +876,7 @@ async def test_legacy_row_with_project_not_matching_qualified_name_disclosed_in_
     assert "foo/nightly" in doc.schedules
 
 
-# ---------------------------------------------------------------------------
 # GitHub cadence fallback and sibling-file collisions
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_schedule_github_cursor_patch.py
+++ b/tests/studio/test_schedule_github_cursor_patch.py
@@ -69,9 +69,7 @@ def _expect_rejected(fields, match):
     asyncio.run(_run())
 
 
-# ---------------------------------------------------------------------------
 # _svc_validate_github_cursor — pure logic
-# ---------------------------------------------------------------------------
 
 
 def test_validate_cursor_accepts_the_api_spelling():
@@ -145,9 +143,7 @@ def test_why_the_format_is_strict_rather_than_pedantic():
             _svc_validate_github_cursor(wrong)
 
 
-# ---------------------------------------------------------------------------
 # The API request model — the gate that was actually missing
-# ---------------------------------------------------------------------------
 
 
 def test_patch_model_carries_github_cursor():
@@ -170,9 +166,7 @@ def test_patch_model_distinguishes_unset_from_explicit_null():
     }
 
 
-# ---------------------------------------------------------------------------
 # update_schedule — end to end against a mocked store
-# ---------------------------------------------------------------------------
 
 
 def test_update_persists_the_cursor_verbatim():
@@ -206,9 +200,7 @@ def test_update_rejects_an_impossible_cursor_before_any_write():
     _expect_rejected({"github_cursor": "2026-02-30T00:00:00Z"}, "not a real timestamp")
 
 
-# ---------------------------------------------------------------------------
 # The interleaving: an operator PATCH vs an in-flight poll, against a real store
-# ---------------------------------------------------------------------------
 
 from lionagi.state.db import StateDB  # noqa: E402
 

--- a/tests/studio/test_schedule_runs_regression.py
+++ b/tests/studio/test_schedule_runs_regression.py
@@ -91,9 +91,7 @@ async def _seed_run_with_error_detail(db: StateDB) -> tuple[str, str]:
     return sched_id, run_id
 
 
-# ---------------------------------------------------------------------------
-# Issue #2292 — route default limit
-# ---------------------------------------------------------------------------
+# Route default limit
 
 
 def test_list_schedule_runs_route_default_limit_is_50() -> None:
@@ -134,9 +132,7 @@ async def test_list_schedule_runs_route_explicit_limit_passthrough(
     assert result["has_next"] is True
 
 
-# ---------------------------------------------------------------------------
-# Issue #2293 — double read of the schedule_runs row
-# ---------------------------------------------------------------------------
+# Double read of the schedule_runs row
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_schedule_tz_recompute.py
+++ b/tests/studio/test_schedule_tz_recompute.py
@@ -463,9 +463,7 @@ async def test_create_non_cron_empty_expr_still_accepted(temp_db_path):
     assert created["name"] == "create-interval-empty-cron-test"
 
 
-# ---------------------------------------------------------------------------
 # PATCH exclude_unset semantics + enable/startup dead-cron guards
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_budget.py
+++ b/tests/studio/test_scheduler_budget.py
@@ -61,9 +61,7 @@ def _make_svc() -> AsyncMock:
     return svc
 
 
-# ---------------------------------------------------------------------------
 # service-boundary validation — non-finite budgets must be rejected
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
@@ -111,9 +109,7 @@ def test_validate_rate_limit_accepts_positive_window_cap():
     assert validate_rate_limit({"max_fires": 3, "window_sec": 120}) == (3, 120)
 
 
-# ---------------------------------------------------------------------------
 # _check_budget — pure read, no reservation
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -201,9 +197,7 @@ async def test_check_budget_either_bound_trips_when_both_set():
     assert await engine._check_budget(schedule) is True
 
 
-# ---------------------------------------------------------------------------
 # _maybe_fire — auto-disables + records, does not fire when over budget
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -280,9 +274,7 @@ async def test_maybe_fire_fires_normally_when_under_budget():
     svc.update_schedule.assert_not_awaited()
 
 
-# ---------------------------------------------------------------------------
 # rolling-window fire cap — reserve capacity, defer automatic fires
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -378,9 +370,7 @@ async def test_tick_github_rate_limit_defers_without_polling_or_disabling():
     svc.update_schedule.assert_not_awaited()
 
 
-# ---------------------------------------------------------------------------
 # _tick_github — disables over-budget schedules WITHOUT polling
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -441,9 +431,7 @@ async def test_tick_github_polls_normally_when_under_budget():
     )
 
 
-# ---------------------------------------------------------------------------
 # fire_now — refuses (does not disable) at exhaustion
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -478,9 +466,7 @@ async def test_fire_now_succeeds_when_under_budget():
     mock_tracked.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
 # sum_schedule_spend — real StateDB aggregate
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_coordination.py
+++ b/tests/studio/test_scheduler_coordination.py
@@ -1,18 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for lionagi.studio.scheduler.coordination.compute_files_overlap()
-and lionagi.studio.services.scheduler_state.flush_run_telemetry().
-
-Covers:
-  * Overlap fixture: two workers reading one shared + N distinct files ->
-    count=1, top-1 with the correct worker count.
-  * Zero-worker / zero-overlap invocations report {"count": 0, "top": []},
-    never an error.
-  * top_n truncation and deterministic tie-breaking.
-  * Terminal flush: telemetry lands exactly once per run (pop_run_counters
-    is consumed, node_metadata["coordination"] merges rather than clobbers
-    pre-existing node_metadata, and a run with nothing to report leaves
-    node_metadata untouched).
+"""Tests for compute_files_overlap() and flush_run_telemetry()
+(lionagi.studio.scheduler.coordination / lionagi.studio.services.scheduler_state).
 """
 
 from __future__ import annotations
@@ -92,9 +81,7 @@ async def _make_worker_session(
         )
 
 
-# ---------------------------------------------------------------------------
 # compute_files_overlap
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -201,9 +188,7 @@ async def test_worker_with_no_file_touching_messages_excluded(db: StateDB):
     assert overlap == {"count": 0, "top": []}
 
 
-# ---------------------------------------------------------------------------
 # flush_run_telemetry
-# ---------------------------------------------------------------------------
 
 
 def _make_svc() -> AsyncMock:
@@ -318,9 +303,7 @@ async def test_flush_run_telemetry_writes_when_only_overlap_is_nonzero():
     svc.update_invocation.assert_awaited_once()
 
 
-# ---------------------------------------------------------------------------
 # flush_run_telemetry must be best-effort: I/O failures never propagate
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_cwd.py
+++ b/tests/studio/test_scheduler_cwd.py
@@ -23,9 +23,7 @@ import pytest
 # which requires fastapi (the `studio` extra); skip gracefully in a bare-core install.
 pytest.importorskip("fastapi", reason="studio extra not installed")
 
-# ---------------------------------------------------------------------------
 # spawn_and_wait: cwd passthrough to create_subprocess_exec
-# ---------------------------------------------------------------------------
 
 
 def _exited_proc(returncode: int = 0) -> MagicMock:
@@ -90,9 +88,7 @@ async def test_spawn_and_wait_default_cwd_is_none():
     assert captured.get("cwd") is None
 
 
-# ---------------------------------------------------------------------------
 # _resolve_action_cwd
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -292,10 +288,8 @@ async def test_resolve_action_cwd_env_fallback_still_serves_ownerless_rows(monke
     assert await _resolve_action_cwd(schedule) == str(env_dir)
 
 
-# ---------------------------------------------------------------------------
 # _resolve_action_cwd: action_cwd (persisted execution root) outranks
 # action_project (ADR-0070 delta 1)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -574,10 +568,8 @@ async def test_resolve_action_cwd_pre_migration_row_warns_deprecated(monkeypatch
     )
 
 
-# ---------------------------------------------------------------------------
 # The refusal names both the configured root and the daemon directory it
 # declined to substitute, so the failure is diagnosable from the message.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -611,9 +603,7 @@ async def test_refusal_names_configured_root_and_daemon_cwd(tmp_path, monkeypatc
     assert str(daemon_dir) in message
 
 
-# ---------------------------------------------------------------------------
 # _fire() threads the resolved cwd into spawn_and_wait
-# ---------------------------------------------------------------------------
 
 
 def _minimal_schedule(**overrides) -> dict:
@@ -687,11 +677,9 @@ async def test_fire_threads_resolved_cwd_into_spawn_and_wait(tmp_path, monkeypat
     assert kwargs.get("cwd") == str(project_dir)
 
 
-# ---------------------------------------------------------------------------
 # Fail-closed attribution: a schedule carrying an execution root whose
 # configured directories are all gone is refused before spawn (identity
 # protection), recorded with FAILED_CWD_INHERIT_REFUSED, and never spawned.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -772,9 +760,7 @@ async def test_fire_plain_nonzero_exit_keeps_generic_reason(monkeypatch):
     assert call.kwargs["reason_code"] == RunReasons.FAILED_EXIT_NONZERO
 
 
-# ---------------------------------------------------------------------------
 # SchedulerEngine._backfill_action_cwd — one-shot startup migration
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -1011,9 +997,7 @@ async def test_refusal_names_an_empty_execution_root_as_empty_not_as_the_project
     assert excinfo.value.configured_root == ""
 
 
-# ---------------------------------------------------------------------------
 # declarative manifest path: relative in, absolute out
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("raw", [".", "sub", "../", "sub/..", "./sub"])

--- a/tests/studio/test_scheduler_engine.py
+++ b/tests/studio/test_scheduler_engine.py
@@ -30,9 +30,7 @@ async def _cancel_after_launch(*args, on_launched=None, **kwargs):
     raise asyncio.CancelledError()
 
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _minimal_schedule(**overrides) -> dict:
@@ -79,9 +77,7 @@ def _make_svc() -> AsyncMock:
     return svc
 
 
-# ---------------------------------------------------------------------------
 # resolve_invocation_terminal tests (pure-logic, no DB)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -120,8 +116,8 @@ async def test_resolve_terminal_completed_empty_child_taints_invocation():
 @pytest.mark.asyncio
 async def test_resolve_terminal_nonterminal_child_not_trusted_as_completed():
     """A leader process exiting 0 is not evidence that a still-running child
-    session's own work finished (see #2535 -- the terminal stamp today comes
-    from the leader's stderr pipe closing, not from the work ending). A
+    session's own work finished (the terminal stamp today comes from the
+    leader's stderr pipe closing, not from the work ending). A
     child session that has not reached ANY terminal status must not be
     silently trusted via the fallback_status="completed" path -- it belongs
     on completed_empty (no positive evidence), the same bucket a
@@ -231,9 +227,7 @@ async def test_resolve_terminal_cancelled():
     assert status == "cancelled"
 
 
-# ---------------------------------------------------------------------------
 # SchedulerEngine._fire() — happy path (exit_code=0)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -945,9 +939,7 @@ async def test_fire_cancellation_schedule_run_cas_miss_does_not_skip_side_effect
     svc.count_schedule_runs.assert_awaited()
 
 
-# ---------------------------------------------------------------------------
 # Coordination telemetry: terminal-write races must not leak signal counters
-# ---------------------------------------------------------------------------
 
 
 def _lose_invocation_race(entity_type, entity_id, *, new_status, **kwargs):
@@ -1164,9 +1156,7 @@ async def test_fire_normal_completion_dispatches_signal_before_flush_pops_counte
     assert coordination["signals"]["emitted"] == {"ScheduleRunSucceeded": 1}
 
 
-# ---------------------------------------------------------------------------
 # SchedulerEngine.fire_now() — delegates through service
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -1196,9 +1186,7 @@ async def test_fire_now_returns_none_when_schedule_missing():
     assert run_id is None
 
 
-# ---------------------------------------------------------------------------
 # _maybe_fire() tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -1237,9 +1225,7 @@ async def test_maybe_fire_fires_when_no_overlap():
     mock_tracked.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
 # create_skipped_run helper
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -1265,9 +1251,7 @@ async def test_create_skipped_run_calls_svc_create_and_update_status():
     assert call.kwargs["new_status"] == "skipped"
 
 
-# ---------------------------------------------------------------------------
 # SchedulerEngine construction — default vs injected service
-# ---------------------------------------------------------------------------
 
 
 def test_engine_uses_default_svc_when_none_provided():
@@ -1286,11 +1270,9 @@ def test_engine_uses_injected_svc():
     assert engine._svc is svc
 
 
-# ---------------------------------------------------------------------------
 # Cron timezone resolution — the P1 fix: cron_expr is resolved in the
 # configured timezone (default: system local), not UTC. next_fire_at is
 # still stored as a UTC epoch.
-# ---------------------------------------------------------------------------
 
 
 def test_compute_next_fire_uses_configured_timezone(monkeypatch):
@@ -1411,10 +1393,8 @@ def test_compute_next_fire_cron_null_resolved_timezone_uses_scheduler_tz(monkeyp
     assert got_utc == datetime(2026, 7, 2, 22, 0, 0, tzinfo=timezone.utc)
 
 
-# ---------------------------------------------------------------------------
 # 'at' trigger — fire-once semantics (no next occurrence to compute; the
 # fired row's next_fire_at must be explicitly cleared, not left in place).
-# ---------------------------------------------------------------------------
 
 
 def test_compute_next_fire_at_trigger_returns_none():
@@ -1588,11 +1568,9 @@ async def test_maybe_fire_at_trigger_already_fired_refused_by_max_runs_gate():
     svc.update_schedule.assert_awaited_once_with("sched-001", enabled=0)
 
 
-# ---------------------------------------------------------------------------
 # recompute_next_fire — shared recompute+log path for daemon start, PATCH,
 # and disable->enable (services/schedules.py hooks it too; see
 # tests/studio/test_schedule_tz_recompute.py for those integration paths).
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -2187,7 +2165,7 @@ async def test_check_missed_fires_excludes_github_poll(monkeypatch):
 async def test_tick_does_not_await_worker_pass_before_evaluating_schedules(monkeypatch, tmp_path):
     """_tick() must not await the ad-hoc task-worker pass before loading and
     evaluating due schedules -- a hung/slow worker pass would otherwise defer
-    every schedule's evaluation for the whole pass (see #2750). The worker
+    every schedule's evaluation for the whole pass. The worker
     pass here never completes; _tick() must still return promptly and fire
     the due schedule in the same cycle."""
     import lionagi.state.db as state_db_mod
@@ -2256,8 +2234,7 @@ async def test_tick_does_not_await_worker_pass_before_evaluating_schedules(monke
 @pytest.mark.asyncio
 async def test_tick_worker_pass_is_single_flight(monkeypatch, tmp_path):
     """A second _tick() must not start a second worker-pass task while the
-    first is still running -- single-flight, not an unguarded task per tick
-    (see #2750's fix-shape constraint)."""
+    first is still running -- single-flight, not an unguarded task per tick."""
     import lionagi.state.db as state_db_mod
     import lionagi.studio.scheduler.engine as engine_mod
     from lionagi.studio.scheduler.engine import SchedulerEngine
@@ -2303,9 +2280,7 @@ async def test_tick_worker_pass_is_single_flight(monkeypatch, tmp_path):
         await asyncio.wait_for(engine._worker_task, timeout=2.0)
 
 
-# ---------------------------------------------------------------------------
 # max_runs / one-shot semantics
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -2566,9 +2541,7 @@ async def test_max_runs_build_argv_exception_still_checked():
     assert disable_calls
 
 
-# ---------------------------------------------------------------------------
 # max_runs enforcement BEFORE firing (pre-flight reservation), not just after
-# ---------------------------------------------------------------------------
 
 
 class _StatefulSvc:
@@ -2769,8 +2742,8 @@ async def test_max_runs_claim_released_on_pre_run_failure_allows_retry():
     """A max_runs claim must not leak when the fire fails before a terminal
     schedule_run is ever recorded (e.g. create_invocation() raising).
 
-    Reproduces the round-2 finding: reserve the budget, let create_invocation
-    blow up once, confirm the claim is released (not stuck inflight with zero
+    Reserves the budget, lets create_invocation
+    blow up once, confirms the claim is released (not stuck inflight with zero
     terminal runs), then confirm a retry fire succeeds and the schedule
     completes exactly max_runs times total — not zero (stuck) and not more
     than max_runs (double-fired)."""
@@ -2813,22 +2786,13 @@ async def test_max_runs_claim_released_on_pre_run_failure_allows_retry():
 
 @pytest.mark.asyncio
 async def test_max_runs_reservation_snapshots_inflight_before_stale_count_read():
-    """Pins the round-3 finding: a concurrent reserve must not overshoot
-    max_runs by combining a stale persisted count with an already-released
-    in-flight claim.
-
-    Forces the exact interleaving the reviewer's reproducer exploited:
-    fire A holds a claim (in-flight, not yet terminal). Reserve B starts its
-    admission check and its count_schedule_runs() read is suspended
-    mid-flight. While B is suspended, A completes: its terminal run is
-    recorded AND its claim is released — both entirely inside B's await
-    window. B's count() then resumes and returns the count as it was
-    when the read started (stale — before A's write), simulating a real
-    DB read that began before the write landed. If _reserve_max_runs_budget
-    read `inflight` only after this await (the round-2 shape), it would see
-    inflight=0 (already released) + used=0 (stale) and incorrectly admit a
-    second top-level fire for max_runs=1. Reading `inflight` before the
-    await (the round-3 fix) must still see A's claim and refuse B."""
+    """A concurrent reserve must not overshoot max_runs by combining a stale
+    persisted count with an already-released in-flight claim. Forces fire A
+    to complete (recording its run and releasing its claim) entirely inside
+    the window where B's own count_schedule_runs() read is suspended, so B's
+    read comes back stale. See docs/internals/studio.md's
+    scheduler/engine.py section (`_reserve_max_runs_budget`) for why reading
+    `inflight` before that await is what keeps this safe."""
     from lionagi.studio.scheduler.engine import SchedulerEngine
 
     svc = _StatefulSvc()
@@ -2878,9 +2842,7 @@ async def test_max_runs_reservation_snapshots_inflight_before_stale_count_read()
     assert await real_count("sched-once", chain_depth=0) == 1
 
 
-# ---------------------------------------------------------------------------
 # _fire() — action_kind='command'
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -2962,9 +2924,7 @@ async def test_fire_command_kind_nonzero_exit_records_failed_status():
     assert failed_calls, "Expected update_status('schedule_run', ..., new_status='failed')"
 
 
-# ---------------------------------------------------------------------------
 # error_detail on the broad-except handler (real StateDB)
-# ---------------------------------------------------------------------------
 
 
 class _DbSvc:

--- a/tests/studio/test_scheduler_github_fire_per_event.py
+++ b/tests/studio/test_scheduler_github_fire_per_event.py
@@ -94,9 +94,7 @@ def _spawn_patches():
     )
 
 
-# ---------------------------------------------------------------------------
 # Multi-event poll -> N fires, each single-event
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -187,9 +185,7 @@ async def test_single_event_poll_behavior_unchanged():
     assert engine._global_inflight == 0
 
 
-# ---------------------------------------------------------------------------
 # Budget exhaustion mid-batch -> cursor stops before first undispatched event
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -290,9 +286,7 @@ async def test_global_slot_exhaustion_mid_batch_stops_cursor_before_undispatched
     assert engine._global_inflight == 0
 
 
-# ---------------------------------------------------------------------------
 # Draft-filtered events interleaved with dispatchable ones
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -324,11 +318,9 @@ async def test_filtered_event_between_dispatched_events_still_advances_cursor():
     )
 
 
-# ---------------------------------------------------------------------------
 # Cursor/re-listing regression: an event dropped for budget must reappear on
 # the next real github_poll() call once the persisted cursor reflects only
 # what was actually dispatched.
-# ---------------------------------------------------------------------------
 
 
 def _pr(number, updated, *, state="open", merged_at=None):
@@ -434,10 +426,8 @@ async def test_undispatched_event_is_relisted_on_next_poll(monkeypatch, caplog):
     assert [i.event["pr_number"] for i in items] == [2]
 
 
-# ---------------------------------------------------------------------------
 # Truncated merged-mode scan: no permanent skip, no duplicate dispatch
 # across two consecutive ticks.
-# ---------------------------------------------------------------------------
 
 
 def _closed_page(hour: int, base_number: int, *, merges: dict[int, str] | None = None):
@@ -535,10 +525,8 @@ async def test_merged_mode_truncated_scan_no_skip_no_duplicate_across_two_ticks(
     assert fired_prs == [1410, 1405]
 
 
-# ---------------------------------------------------------------------------
 # Observer self-health: _tick_github stamps last_healthy_poll_at /
 # poller_consecutive_401 from GithubPollResult.poll_status
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_global_slot.py
+++ b/tests/studio/test_scheduler_global_slot.py
@@ -55,9 +55,7 @@ def _make_svc() -> AsyncMock:
     return svc
 
 
-# ---------------------------------------------------------------------------
 # _reserve_global_slot / _release_global_slot — pure reservation logic
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -131,9 +129,7 @@ async def test_release_global_slot_decrements_and_floors_at_zero(monkeypatch):
     assert engine._global_inflight == 0
 
 
-# ---------------------------------------------------------------------------
 # _maybe_fire — defers on no slot, fires normally when available
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -209,9 +205,7 @@ async def test_maybe_fire_fires_when_slot_available(monkeypatch):
     assert kwargs["global_slot_claim"] is not None
 
 
-# ---------------------------------------------------------------------------
 # _tick_github — defers before fetch when no slot; releases on no-events
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -393,9 +387,7 @@ async def test_tick_github_fires_and_releases_slot_on_completion(monkeypatch):
     assert engine._global_inflight == 0
 
 
-# ---------------------------------------------------------------------------
 # fire_now — refuses (does not defer) at capacity
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -437,9 +429,7 @@ async def test_fire_now_succeeds_when_slot_available(monkeypatch):
     assert kwargs["global_slot_claim"] is not None
 
 
-# ---------------------------------------------------------------------------
 # Slot released after a real _fire() completes
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -502,9 +492,7 @@ async def test_fire_releases_global_slot_on_exception(monkeypatch):
     assert engine._global_inflight == 0
 
 
-# ---------------------------------------------------------------------------
 # Deferred-record throttling
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -528,13 +516,11 @@ async def test_maybe_record_deferred_throttles_after_first(monkeypatch):
     assert svc.create_schedule_run.await_count == 2
 
 
-# ---------------------------------------------------------------------------
 # _run_task_worker_tick — ad-hoc executions draw from their own independent
 # concurrency pool (MAX_ADHOC_CONCURRENT / _adhoc_inflight), never the
 # scheduled-fire cap. A shared counter let a continuously replenished stream
 # of scheduled fires starve the ad-hoc lane indefinitely; each lane now has
 # its own guaranteed capacity.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_notify.py
+++ b/tests/studio/test_scheduler_notify.py
@@ -106,9 +106,7 @@ async def test_unregistered_scope_never_fires():
     assert name not in DEFAULT_TERMINAL_CALLBACKS
 
 
-# ---------------------------------------------------------------------------
 # _fire_inner registration-lifetime regressions (mock service level)
-# ---------------------------------------------------------------------------
 
 from unittest.mock import AsyncMock, patch  # noqa: E402
 

--- a/tests/studio/test_scheduler_occurrence_atomicity.py
+++ b/tests/studio/test_scheduler_occurrence_atomicity.py
@@ -711,7 +711,7 @@ async def test_recovery_never_double_fires_across_two_passes(tmp_path, monkeypat
 
 @pytest.mark.asyncio
 async def test_tombstone_and_replace_schedule_run_refuses_when_dispatch_confirmed(tmp_path):
-    """The CAS predicate requires dispatched_at IS NULL, not just status='running': a launch confirmation landing between a recovery scan and this write means the row is no longer undispatched, and tombstoning it would flip an actually-launched run to 'failed' and fire a duplicate -- reviewer repro: dispatched_at already set must refuse (applied=False), inserting nothing."""
+    """The CAS predicate requires dispatched_at IS NULL, not just status='running': a launch confirmation landing between a recovery scan and this write means the row is no longer undispatched, and tombstoning it would flip an actually-launched run to 'failed' and fire a duplicate -- dispatched_at already set must refuse (applied=False), inserting nothing."""
     db_path = tmp_path / "state.db"
     sid = "sched-dispatched-race"
 
@@ -743,7 +743,7 @@ async def test_tombstone_and_replace_schedule_run_refuses_when_dispatch_confirme
 
 @pytest.mark.asyncio
 async def test_recovery_refire_is_noop_when_dispatch_confirmed_mid_race(tmp_path, monkeypatch):
-    """The reviewer-specified race: a concurrently-confirmed launch (dispatched_at stamped) lands after recovery's scan but before its atomic re-fire write; the strengthened CAS makes that write a no-op, leaving the live run completely untouched, and abandonment cancels only the doomed pre-spawn recovery invocation, never the live run's own."""
+    """A concurrently-confirmed launch (dispatched_at stamped) lands after recovery's scan but before its atomic re-fire write; the strengthened CAS makes that write a no-op, leaving the live run completely untouched, and abandonment cancels only the doomed pre-spawn recovery invocation, never the live run's own."""
     import lionagi.state.db as state_db_mod
 
     db_path = tmp_path / "state.db"
@@ -817,10 +817,8 @@ async def test_recovery_refire_is_noop_when_dispatch_confirmed_mid_race(tmp_path
     assert recovery_invocation["status_reason_code"] == RunReasons.CANCELLED_STALE_AUTO
 
 
-# ---------------------------------------------------------------------------
 # _reconcile_dispatched_orphans -- confirmed-dispatch rows the scheduler
-# never recorded an outcome for (#2755)
-# ---------------------------------------------------------------------------
+# never recorded an outcome for
 
 
 async def _seed_dispatched_run_with_session(

--- a/tests/studio/test_scheduler_predispatch_cursor.py
+++ b/tests/studio/test_scheduler_predispatch_cursor.py
@@ -133,9 +133,7 @@ def _run_status_calls(svc: AsyncMock, status: str) -> list:
     ]
 
 
-# ---------------------------------------------------------------------------
 # Pre-dispatch refusal: unresolvable execution root
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -231,9 +229,7 @@ async def test_unbuildable_action_args_leave_the_cursor_unmoved():
     assert failed[0].kwargs["reason_code"] == RunReasons.FAILED_EXCEPTION
 
 
-# ---------------------------------------------------------------------------
 # Post-dispatch failure: at-most-once is preserved
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -284,9 +280,7 @@ async def test_successful_run_advances_the_cursor():
     assert advanced == [FIRST_EVENT_AT, SECOND_EVENT_AT]
 
 
-# ---------------------------------------------------------------------------
 # Cancellation: which side of the split it lands on depends on the process
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -354,9 +348,7 @@ async def test_cancellation_after_launch_still_records_a_cancelled_run():
     assert fields["github_cursor"] == FIRST_EVENT_AT
 
 
-# ---------------------------------------------------------------------------
 # The refusal is not always a property of the schedule: bounded retry
-# ---------------------------------------------------------------------------
 
 
 def _poison_command_schedule(**overrides) -> dict:
@@ -465,9 +457,7 @@ async def test_event_specific_argv_failure_progresses_at_the_limit(_command_allo
     assert cleared[0].kwargs["predispatch_refusal_event"] is None
 
 
-# ---------------------------------------------------------------------------
 # Committed occurrence, no launch: the row stays in the recovery lane
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_signals.py
+++ b/tests/studio/test_scheduler_signals.py
@@ -1,21 +1,11 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for the OBSERVER W2 scheduler signal bus + mint call sites.
+"""Tests for the scheduler signal bus and its mint call sites.
 
-Covers:
-  * SchedulerSignalBus.observe/unobserve/emit: type matching, predicate
-    (reason_code) filtering, sync + async handler dispatch.
-  * Failure semantics: emit() raises an ExceptionGroup (never a blanket
-    swallow) while still running every matching handler; the engine's mint
-    call site catches that group, writes a durable admin_events row, and
-    the tick loop keeps going (a broken handler never stops unrelated
-    schedules).
-  * build_schedule_run_signal(): mint-site-agnostic field derivation from
-    entity_id/new_status/reason_code (the same fields any
-    _guarded_terminal_status caller already has).
-  * SchedulerEngine._fire_inner() actually mints the right signal on each
-    terminal path (succeeded, failed-nonzero-exit, failed-exception,
-    cancelled).
+emit() raises an ExceptionGroup rather than swallowing handler failures,
+but still runs every matching handler first; the engine's mint call site
+catches that group, writes a durable admin_events row, and keeps ticking —
+a broken handler must never stop unrelated schedules.
 """
 
 from __future__ import annotations
@@ -35,9 +25,7 @@ from lionagi.studio.scheduler.signals import (
     record_handler_failure,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers (mirrors tests/studio/test_scheduler_engine.py's fixtures)
-# ---------------------------------------------------------------------------
 
 
 def _minimal_schedule(**overrides) -> dict:
@@ -82,9 +70,7 @@ def _make_svc() -> AsyncMock:
     return svc
 
 
-# ---------------------------------------------------------------------------
 # SchedulerSignalBus — observe/emit matching + dispatch
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -199,9 +185,7 @@ async def test_emit_with_zero_handlers_is_a_noop():
     assert results == []
 
 
-# ---------------------------------------------------------------------------
 # Per-run coordination counters (emitted/received/acted_on) + pop_run_counters
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -361,9 +345,7 @@ async def test_counters_are_isolated_per_run_id():
     assert counters_r2 == {"emitted": {"ScheduleRunSucceeded": 1}, "received": 1, "acted_on": 1}
 
 
-# ---------------------------------------------------------------------------
 # Failure semantics: ExceptionGroup, never a blanket swallow, siblings still run
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -519,9 +501,7 @@ async def test_emit_reraises_cancellation_even_with_other_handler_failures():
     assert isinstance(exc_info.value.__cause__.exceptions[0], RuntimeError)
 
 
-# ---------------------------------------------------------------------------
 # record_handler_failure — durable surfaced record
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -578,9 +558,7 @@ async def test_record_handler_failure_is_best_effort_and_never_raises(monkeypatc
     await record_handler_failure(eg, sig)
 
 
-# ---------------------------------------------------------------------------
 # build_schedule_run_signal — mint-site-agnostic field derivation
-# ---------------------------------------------------------------------------
 
 
 def test_build_schedule_run_signal_completed_derives_succeeded():
@@ -627,9 +605,7 @@ def test_build_schedule_run_signal_unknown_status_raises():
         build_schedule_run_signal(entity_id="run-4", new_status="running", reason_code="x")
 
 
-# ---------------------------------------------------------------------------
 # SchedulerEngine._fire_inner integration — mint on each terminal path
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -843,11 +819,9 @@ async def test_fire_build_argv_exception_does_not_mint_when_write_lost_race():
     assert captured == []
 
 
-# ---------------------------------------------------------------------------
 # Regression: a broken handler surfaces a durable record and the tick loop
 # continues -- it must not stop this schedule's own bookkeeping, and a
 # following, unrelated fire must still succeed normally.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/studio/test_scheduler_spawn_resolve.py
+++ b/tests/studio/test_scheduler_spawn_resolve.py
@@ -13,9 +13,7 @@ import pytest
 
 from lionagi.studio.scheduler import subprocess as sched_subprocess
 
-# ---------------------------------------------------------------------------
 # resolve_li_executable
-# ---------------------------------------------------------------------------
 
 
 def test_resolve_li_executable_finds_absolute_path_in_normal_env():
@@ -190,9 +188,7 @@ def test_resolve_li_executable_returns_none_and_names_every_tried_strategy_when_
     assert "console_scripts" in detail
 
 
-# ---------------------------------------------------------------------------
 # build_argv: executable_prefix passthrough
-# ---------------------------------------------------------------------------
 
 
 def _minimal_agent_schedule(**overrides) -> dict:
@@ -225,9 +221,7 @@ def test_build_argv_uses_explicit_executable_prefix():
     assert argv[1] == "agent"
 
 
-# ---------------------------------------------------------------------------
 # render_action_prompt
-# ---------------------------------------------------------------------------
 
 
 def test_render_action_prompt_substitutes_trigger_context_vars():

--- a/tests/studio/test_scheduler_threshold.py
+++ b/tests/studio/test_scheduler_threshold.py
@@ -60,9 +60,7 @@ def _make_svc() -> AsyncMock:
     return svc
 
 
-# ---------------------------------------------------------------------------
 # threshold.py — pure validation + comparison
-# ---------------------------------------------------------------------------
 
 
 def test_validate_threshold_config_accepts_well_formed():
@@ -130,9 +128,7 @@ def test_compare_rejects_unknown_op():
         compare("lt", 1, 2)
 
 
-# ---------------------------------------------------------------------------
 # services/schedules.py — service-boundary validation
-# ---------------------------------------------------------------------------
 
 
 def test_svc_validate_threshold_config_accepts_none():
@@ -165,9 +161,7 @@ def test_svc_validate_threshold_config_rejects_unknown_key():
         )
 
 
-# ---------------------------------------------------------------------------
 # SchedulerEngine._evaluate_threshold_breach
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -266,9 +260,7 @@ async def test_evaluate_threshold_breach_flags_partial_spend_when_sessions_unrep
     }
 
 
-# ---------------------------------------------------------------------------
 # SchedulerEngine._maybe_fire — full threshold-alert integration
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -425,12 +417,10 @@ async def test_maybe_fire_threshold_still_honors_overlap_policy():
     assert not last_alert_calls
 
 
-# ---------------------------------------------------------------------------
 # _maybe_fire() — synchronous in-process cooldown reservation. last_alert_at
 # alone (a DB read) can go stale between ticks; these tests pin the
 # in-memory _threshold_pending gate that closes the resulting duplicate-fire
 # race, independent of when (or whether) the durable stamp lands.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -547,10 +537,8 @@ async def test_maybe_fire_exception_between_reserve_and_fire_releases_threshold_
     mock_tracked.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
 # _fire() / _fire_inner() — threshold cooldown stamp lands AFTER the
 # schedule_run row is durably persisted, not before the fire starts.
-# ---------------------------------------------------------------------------
 
 
 def _threshold_ctx(**overrides) -> dict:
@@ -807,9 +795,7 @@ async def test_fire_non_threshold_schedule_never_stamps_last_alert_at():
     assert not _last_alert_calls(svc)
 
 
-# ---------------------------------------------------------------------------
 # StateDB.metric_value — real in-memory DB, window math
-# ---------------------------------------------------------------------------
 
 
 async def _make_session(
@@ -976,10 +962,8 @@ async def test_metric_value_unknown_metric_raises():
     await state.close()
 
 
-# ---------------------------------------------------------------------------
 # StateDB.metric_value — github_poll_healthy_age_minutes / _consecutive_401
 # (observer self-health)
-# ---------------------------------------------------------------------------
 
 
 async def _make_github_schedule(state, sched_id: str, **overrides):
@@ -1110,9 +1094,7 @@ async def test_metric_value_github_poll_consecutive_401_counts_and_resets():
     await state.close()
 
 
-# ---------------------------------------------------------------------------
 # create_schedule / update_schedule round-trip threshold_config + last_alert_at
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -1154,9 +1136,7 @@ async def test_schedule_round_trips_threshold_config_and_last_alert_at():
     await state.close()
 
 
-# ---------------------------------------------------------------------------
 # VALID_METRICS and _THRESHOLD_METRIC_QUERIES, named in one place
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Strip decorative comment banners and box-drawing section dividers, tighten narrative docstrings down to the regression/contract they pin, and remove internal tracking references (round counts, issue numbers) from test docstrings and comments. No executable code or test assertions changed; verified per-file with the AST-equality guardrail.

Extract the scheduler engine's max_runs reservation-ordering invariant, single-flight tick worker pass, and terminal-status trust rule into docs/internals/studio.md, with a pointer left in the originating test.