### PR TITLE
chore(tests): trim prose in protocols/models/adapters/casts tests

### DIFF
--- a/tests/adapters/test_async_postgres_adapter.py
+++ b/tests/adapters/test_async_postgres_adapter.py
@@ -5,9 +5,7 @@
 
 import pytest
 
-# ---------------------------------------------------------------------------
 # check_async_postgres_available
-# ---------------------------------------------------------------------------
 
 
 def test_check_async_postgres_available_reports_missing_optional_dependency(
@@ -35,9 +33,7 @@ def test_check_async_postgres_available_true_when_dependencies_present(monkeypat
     assert result is True
 
 
-# ---------------------------------------------------------------------------
 # to_obj calls _ensure_table before delegating to parent
-# ---------------------------------------------------------------------------
 
 
 async def test_async_postgres_to_obj_ensures_table_for_dsn_before_delegating(

--- a/tests/adapters/test_pydantic_spec_adapter.py
+++ b/tests/adapters/test_pydantic_spec_adapter.py
@@ -246,9 +246,7 @@ and more text"""
         assert original.age == 30
 
 
-# ---------------------------------------------------------------------------
 # callable default becomes default_factory
-# ---------------------------------------------------------------------------
 
 
 def test_pydantic_field_adapter_uses_callable_metadata_as_default_factory():
@@ -267,9 +265,7 @@ def test_pydantic_field_adapter_uses_callable_metadata_as_default_factory():
     assert instance.result == "computed"
 
 
-# ---------------------------------------------------------------------------
 # strict fuzzy_match_fields raises; non-strict coerces typos and drops unknowns
-# ---------------------------------------------------------------------------
 
 
 def test_pydantic_field_adapter_strict_fuzzy_match_raises_on_unmatched_key():

--- a/tests/models/test_audit_fixes.py
+++ b/tests/models/test_audit_fixes.py
@@ -14,9 +14,7 @@ from pydantic import Field
 from lionagi.models.hashable_model import HashableModel
 from lionagi.models.operable_model import OperableModel
 
-# ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 
 
 class _Sample(HashableModel):
@@ -28,9 +26,7 @@ class _OpSample(OperableModel):
     label: str = "x"
 
 
-# ---------------------------------------------------------------------------
 # HashableModel.from_json bytes round-trip
-# ---------------------------------------------------------------------------
 
 
 class TestHashableModelFromJsonBytes:
@@ -62,9 +58,7 @@ class TestHashableModelFromJsonBytes:
         assert from_bytes.value == from_str.value
 
 
-# ---------------------------------------------------------------------------
 # OperableModel.field_hasattr — attr vs field_name
-# ---------------------------------------------------------------------------
 
 
 class TestFieldHasattr:

--- a/tests/models/test_models_legacy_coverage.py
+++ b/tests/models/test_models_legacy_coverage.py
@@ -10,9 +10,7 @@ from pydantic.fields import FieldInfo
 from lionagi.models.field_model import FieldModel
 from lionagi.models.operable_model import OperableModel
 
-# ---------------------------------------------------------------------------
 # FieldModel tests
-# ---------------------------------------------------------------------------
 
 
 class TestFieldModelInit:
@@ -243,9 +241,7 @@ class TestFieldModelFactoryHelpers:
         assert ann is not int  # should be a union type
 
 
-# ---------------------------------------------------------------------------
 # OperableModel tests
-# ---------------------------------------------------------------------------
 
 
 class SimpleModel(OperableModel):

--- a/tests/protocols/action/test_action_manager.py
+++ b/tests/protocols/action/test_action_manager.py
@@ -303,9 +303,7 @@ def test_get_tool_schema_partial_list(populated_manager):
     assert "Tool brand_new_tool is not registered" in str(exc_info.value)
 
 
-# ---------------------------------------------------------------------------
 # Coverage gap: line 86 — duplicate Tool registration → name = tool.function
-# ---------------------------------------------------------------------------
 
 
 class TestRegisterToolDuplicateToolObject:

--- a/tests/protocols/action/test_tool.py
+++ b/tests/protocols/action/test_tool.py
@@ -7,7 +7,7 @@ from lionagi.protocols.action.tool import Tool
 
 # Helper functions - not test cases
 def example_func(x: int, y: str = "default") -> str:
-    """Test function with docstring.
+    """Function with docstring.
 
     Args:
         x: An integer parameter

--- a/tests/protocols/action/test_tool_invoke_hooks.py
+++ b/tests/protocols/action/test_tool_invoke_hooks.py
@@ -79,7 +79,7 @@ async def test_pre_then_security_pre_then_invoke_then_post_ordering():
 
 
 async def test_security_pre_sees_external_rewrite_with_no_user_hook():
-    """D3: security_pre always validates the post-rewrite values, even with
+    """security_pre always validates the post-rewrite values, even with
     no spec-level user pre-hook present."""
     order: list[str] = []
     calls: list[tuple[int, int]] = []
@@ -109,7 +109,7 @@ async def test_security_pre_sees_external_rewrite_with_no_user_hook():
     assert fc.response == 300
 
 
-# ── Deny / ask / unrecognized (D5) ──────────────────────────────────────────
+# Deny / ask / unrecognized
 
 
 async def test_deny_short_circuits_before_invoke_and_captures_as_failed():
@@ -790,7 +790,7 @@ async def test_no_hooks_registered_behaves_as_before():
 
 
 async def test_direct_function_calling_construction_bypasses_external_hooks():
-    """D3's named, tested limit: constructing FunctionCalling directly (not
+    """A documented, tested limit: constructing FunctionCalling directly (not
     via ActionManager.invoke) never sees the tool-pre/tool-post hook layer,
     even though the Tool object is the same one registered on a manager that
     has hooks attached."""

--- a/tests/protocols/generic/test_async_dump.py
+++ b/tests/protocols/generic/test_async_dump.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2025, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests verifying that Pile.adump and DataLogger.adump offload blocking I/O
+"""Verifying that Pile.adump and DataLogger.adump offload blocking I/O
 to a worker thread rather than blocking the event loop."""
 
 from __future__ import annotations
@@ -18,9 +18,7 @@ from lionagi.protocols.generic.log import DataLogger, DataLoggerConfig, Log
 from lionagi.protocols.generic.pile import Pile
 from lionagi.testing import MockElement
 
-# ---------------------------------------------------------------------------
 # Pile.adump
-# ---------------------------------------------------------------------------
 
 
 class TestPileAdump:
@@ -63,7 +61,7 @@ class TestPileAdump:
 
     @pytest.mark.asyncio
     async def test_adump_does_not_block_event_loop(self, pile_with_items, tmp_path):
-        """Verify that the event loop remains responsive during adump."""
+        """The event loop remains responsive during adump."""
         fp = tmp_path / "dump.json"
         sentinel = []
 
@@ -86,9 +84,7 @@ class TestPileAdump:
             await pile_with_items.adump(fp, obj_key="xml")
 
 
-# ---------------------------------------------------------------------------
 # DataLogger.adump
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoggerAdump:
@@ -219,9 +215,7 @@ class TestDataLoggerAdump:
         assert len(dl.logs) == 3
 
 
-# ---------------------------------------------------------------------------
 # Pile.adump — write-failure data preservation
-# ---------------------------------------------------------------------------
 
 
 class TestPileAdumpWriteFailure:
@@ -243,9 +237,7 @@ class TestPileAdumpWriteFailure:
         assert len(p) == 4
 
 
-# ---------------------------------------------------------------------------
 # Concurrent-append survival tests
-# ---------------------------------------------------------------------------
 
 
 class TestAdumpConcurrentAppend:

--- a/tests/protocols/generic/test_broadcaster.py
+++ b/tests/protocols/generic/test_broadcaster.py
@@ -9,9 +9,7 @@ import pytest
 
 from lionagi.service.broadcaster import Broadcaster
 
-# ---------------------------------------------------------------------------
 # Helpers -- fresh event/broadcaster types per test to avoid cross-pollution
-# ---------------------------------------------------------------------------
 
 
 def _make_broadcaster():
@@ -27,9 +25,7 @@ def _make_broadcaster():
     return _Evt, _Bcst
 
 
-# ---------------------------------------------------------------------------
 # Subclass / _event_type
-# ---------------------------------------------------------------------------
 
 
 class TestSubclass:
@@ -40,9 +36,7 @@ class TestSubclass:
         assert Bcst._event_type is Evt
 
 
-# ---------------------------------------------------------------------------
 # subscribe
-# ---------------------------------------------------------------------------
 
 
 class TestSubscribe:
@@ -68,9 +62,7 @@ class TestSubscribe:
         assert Bcst.get_subscriber_count() == 1
 
 
-# ---------------------------------------------------------------------------
 # unsubscribe
-# ---------------------------------------------------------------------------
 
 
 class TestUnsubscribe:
@@ -96,9 +88,7 @@ class TestUnsubscribe:
         assert Bcst.get_subscriber_count() == 0
 
 
-# ---------------------------------------------------------------------------
 # broadcast -- sync subscribers
-# ---------------------------------------------------------------------------
 
 
 class TestBroadcastSync:
@@ -132,9 +122,7 @@ class TestBroadcastSync:
         assert results_b == ["hi"]
 
 
-# ---------------------------------------------------------------------------
 # broadcast -- async subscribers
-# ---------------------------------------------------------------------------
 
 
 class TestBroadcastAsync:
@@ -168,9 +156,7 @@ class TestBroadcastAsync:
         assert async_results == ["mix"]
 
 
-# ---------------------------------------------------------------------------
 # broadcast -- wrong event type
-# ---------------------------------------------------------------------------
 
 
 class TestBroadcastWrongType:
@@ -187,9 +173,7 @@ class TestBroadcastWrongType:
             await Bcst.broadcast(OtherEvent())
 
 
-# ---------------------------------------------------------------------------
 # broadcast -- exception suppression
-# ---------------------------------------------------------------------------
 
 
 class TestBroadcastExceptionSuppression:
@@ -213,9 +197,7 @@ class TestBroadcastExceptionSuppression:
         assert after_error == ["ok"]
 
 
-# ---------------------------------------------------------------------------
 # get_subscriber_count
-# ---------------------------------------------------------------------------
 
 
 class TestGetSubscriberCount:
@@ -248,9 +230,7 @@ class TestGetSubscriberCount:
         assert Bcst.get_subscriber_count() == 0
 
 
-# ---------------------------------------------------------------------------
 # weakref cleanup
-# ---------------------------------------------------------------------------
 
 
 class TestWeakrefCleanup:
@@ -273,9 +253,7 @@ class TestWeakrefCleanup:
         assert Bcst.get_subscriber_count() == 0
 
 
-# ---------------------------------------------------------------------------
 # Subclass isolation
-# ---------------------------------------------------------------------------
 
 
 class TestSubclassIsolation:
@@ -312,9 +290,7 @@ class TestSubclassIsolation:
         assert BcstB.get_subscriber_count() == 1
 
 
-# ---------------------------------------------------------------------------
 # Singleton pattern per subclass
-# ---------------------------------------------------------------------------
 
 
 class TestSingleton:

--- a/tests/protocols/generic/test_container_iterator_protocol.py
+++ b/tests/protocols/generic/test_container_iterator_protocol.py
@@ -31,9 +31,7 @@ def progression(elements):
     return Progression(order=[e.id for e in elements])
 
 
-# --------------------------------------------------------------------------
 # The container is not an iterator
-# --------------------------------------------------------------------------
 
 
 def test_next_on_pile_raises_type_error(pile):
@@ -69,9 +67,7 @@ def test_iter_returns_a_distinct_object(pile, progression):
     assert iter(progression) is not progression
 
 
-# --------------------------------------------------------------------------
 # An iterator taken from the container behaves like one
-# --------------------------------------------------------------------------
 
 
 def test_repeated_next_on_pile_iterator_advances(pile, elements):
@@ -112,9 +108,7 @@ def test_copy_does_not_inherit_a_traversal_position(pile, elements):
     assert list(copy.deepcopy(pile)) == [pile.collections[e.id] for e in elements]
 
 
-# --------------------------------------------------------------------------
 # Ordinary traversal is unchanged
-# --------------------------------------------------------------------------
 
 
 def test_for_loop_over_pile(pile, elements):

--- a/tests/protocols/generic/test_event_enhanced.py
+++ b/tests/protocols/generic/test_event_enhanced.py
@@ -11,9 +11,7 @@ from lionagi.ln.concurrency._compat import ExceptionGroup
 from lionagi.ln.types import Unset
 from lionagi.protocols.generic.event import Event, EventStatus, Execution
 
-# ---------------------------------------------------------------------------
 # 1. Execution.retryable field
-# ---------------------------------------------------------------------------
 
 
 class TestExecutionRetryable:
@@ -64,9 +62,7 @@ class TestExecutionRetryable:
         assert "retryable=False" in s
 
 
-# ---------------------------------------------------------------------------
 # 2. Execution.add_error()
-# ---------------------------------------------------------------------------
 
 
 class TestExecutionAddError:
@@ -131,9 +127,7 @@ class TestExecutionAddError:
         assert len(ex.error.exceptions) == 10
 
 
-# ---------------------------------------------------------------------------
 # 3. Execution._serialize_exception_group()
-# ---------------------------------------------------------------------------
 
 
 class TestSerializeExceptionGroup:
@@ -175,7 +169,7 @@ class TestSerializeExceptionGroup:
         }
 
     def test_depth_limit(self):
-        """Verify that nesting deeper than MAX_DEPTH (100) is handled."""
+        """Nesting deeper than MAX_DEPTH (100) is handled."""
         ex = Execution()
         # Build a chain of 102 nested ExceptionGroups
         eg = ExceptionGroup("leaf", [ValueError("bottom")])
@@ -233,9 +227,7 @@ class TestSerializeExceptionGroup:
         assert d["error"] == "plain string"
 
 
-# ---------------------------------------------------------------------------
 # 4. Event.assert_completed()
-# ---------------------------------------------------------------------------
 
 
 class TestEventAssertCompleted:
@@ -298,9 +290,7 @@ class TestEventAssertCompleted:
             event.assert_completed()
 
 
-# ---------------------------------------------------------------------------
 # 5. Backward compatibility
-# ---------------------------------------------------------------------------
 
 
 class TestBackwardCompatibility:

--- a/tests/protocols/generic/test_event_lifecycle.py
+++ b/tests/protocols/generic/test_event_lifecycle.py
@@ -13,9 +13,7 @@ import pytest
 from lionagi.ln.types import Unset
 from lionagi.protocols.generic.event import Event, EventStatus
 
-# ---------------------------------------------------------------------------
 # Test helpers
-# ---------------------------------------------------------------------------
 
 
 class SuccessEvent(Event):
@@ -74,9 +72,7 @@ class StreamCancelledEvent(Event):
         yield "after"  # never reached
 
 
-# ---------------------------------------------------------------------------
 # invoke() lifecycle tests
-# ---------------------------------------------------------------------------
 
 
 class TestInvokeLifecycle:
@@ -195,9 +191,7 @@ class TestInvokeLifecycle:
         assert event.execution.response == "ok"
 
 
-# ---------------------------------------------------------------------------
 # stream() lifecycle tests
-# ---------------------------------------------------------------------------
 
 
 class TestStreamLifecycle:

--- a/tests/protocols/generic/test_flow.py
+++ b/tests/protocols/generic/test_flow.py
@@ -13,9 +13,7 @@ from lionagi.protocols.generic.pile import Pile
 from lionagi.protocols.generic.progression import Progression
 from lionagi.protocols.graph.node import Node
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_nodes(n: int = 3) -> list[Node]:
@@ -37,9 +35,7 @@ def _make_progression(nodes: list[Node], name: str | None = None) -> Progression
     return Progression(order=[n.id for n in nodes], name=name)
 
 
-# ---------------------------------------------------------------------------
 # Construction
-# ---------------------------------------------------------------------------
 
 
 class TestFlowCreation:
@@ -56,9 +52,7 @@ class TestFlowCreation:
         assert len(flow) == 0
 
 
-# ---------------------------------------------------------------------------
 # add_progression
-# ---------------------------------------------------------------------------
 
 
 class TestAddProgression:
@@ -100,9 +94,7 @@ class TestAddProgression:
         assert len(flow.progressions) == 1
 
 
-# ---------------------------------------------------------------------------
 # remove_progression
-# ---------------------------------------------------------------------------
 
 
 class TestRemoveProgression:
@@ -138,9 +130,7 @@ class TestRemoveProgression:
         assert len(flow.progressions) == 1
 
 
-# ---------------------------------------------------------------------------
 # get_progression
-# ---------------------------------------------------------------------------
 
 
 class TestGetProgression:
@@ -173,9 +163,7 @@ class TestGetProgression:
             flow.get_progression(uuid4())
 
 
-# ---------------------------------------------------------------------------
 # add_item
-# ---------------------------------------------------------------------------
 
 
 class TestAddItem:
@@ -240,9 +228,7 @@ class TestAddItem:
         assert node.id not in external
 
 
-# ---------------------------------------------------------------------------
 # remove_item
-# ---------------------------------------------------------------------------
 
 
 class TestRemoveItem:
@@ -279,9 +265,7 @@ class TestRemoveItem:
         assert len(flow) == 0
 
 
-# ---------------------------------------------------------------------------
 # clear
-# ---------------------------------------------------------------------------
 
 
 class TestFlowClear:
@@ -298,9 +282,7 @@ class TestFlowClear:
         assert len(flow.progressions) == 0
 
 
-# ---------------------------------------------------------------------------
 # __repr__ and __len__
-# ---------------------------------------------------------------------------
 
 
 class TestFlowReprLen:
@@ -331,9 +313,7 @@ class TestFlowReprLen:
         assert "progressions=1" in r
 
 
-# ---------------------------------------------------------------------------
 # Referential integrity on init
-# ---------------------------------------------------------------------------
 
 
 class TestReferentialIntegrityOnInit:

--- a/tests/protocols/generic/test_flow_serialization.py
+++ b/tests/protocols/generic/test_flow_serialization.py
@@ -8,9 +8,7 @@ from lionagi.protocols.generic.pile import Pile
 from lionagi.protocols.generic.progression import Progression
 from lionagi.protocols.graph.node import Node
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_nodes(n: int = 3) -> list[Node]:
@@ -29,9 +27,7 @@ def _flow_with_progression(n: int = 3, prog_name: str = "stage-1"):
     return flow, nodes, prog
 
 
-# ---------------------------------------------------------------------------
 # to_dict
-# ---------------------------------------------------------------------------
 
 
 class TestFlowToDict:
@@ -88,9 +84,7 @@ class TestFlowToDict:
         assert d["id"] == str(flow.id)
 
 
-# ---------------------------------------------------------------------------
 # Round-trip: to_dict -> from_dict
-# ---------------------------------------------------------------------------
 
 
 class TestFlowRoundTrip:
@@ -197,13 +191,11 @@ class TestFlowRoundTrip:
         assert flow2.name == flow.name
 
 
-# ---------------------------------------------------------------------------
 # _progression_names index rebuild
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionNamesRebuild:
-    """Test that _progression_names is rebuilt after deserialization."""
+    """_progression_names is rebuilt after deserialization."""
 
     def test_progression_names_rebuilt(self):
         flow, _, _ = _flow_with_progression(2, "my-stage")
@@ -252,9 +244,7 @@ class TestProgressionNamesRebuild:
         assert len(flow2._progression_names) == 0
 
 
-# ---------------------------------------------------------------------------
 # Empty flow round-trip
-# ---------------------------------------------------------------------------
 
 
 class TestEmptyFlowRoundTrip:
@@ -297,9 +287,7 @@ class TestEmptyFlowRoundTrip:
         assert flow2.name == "empty-but-named"
 
 
-# ---------------------------------------------------------------------------
 # Pile coercion (_coerce_pile classmethod)
-# ---------------------------------------------------------------------------
 
 
 class TestPileCoercion:
@@ -351,9 +339,7 @@ class TestPileCoercion:
         assert len(flow.items) == 2
 
 
-# ---------------------------------------------------------------------------
 # JSON round-trip
-# ---------------------------------------------------------------------------
 
 
 class TestFlowJsonRoundTrip:
@@ -377,9 +363,7 @@ class TestFlowJsonRoundTrip:
         assert flow2.get_progression("json-lookup") is not None
 
 
-# ---------------------------------------------------------------------------
 # Mutability after round-trip
-# ---------------------------------------------------------------------------
 
 
 class TestMutabilityAfterRoundTrip:

--- a/tests/protocols/generic/test_log_coverage.py
+++ b/tests/protocols/generic/test_log_coverage.py
@@ -11,9 +11,7 @@ from lionagi.protocols.generic.log import (
 )
 from lionagi.protocols.generic.pile import Pile
 
-# ---------------------------------------------------------------------------
 # DataLoggerConfig validators
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoggerConfigValidators:
@@ -34,9 +32,7 @@ class TestDataLoggerConfigValidators:
             DataLoggerConfig(hash_digits=-1)
 
 
-# ---------------------------------------------------------------------------
 # Log.from_dict / immutability
-# ---------------------------------------------------------------------------
 
 
 class TestLogFromDict:
@@ -55,9 +51,7 @@ class TestLogFromDict:
             restored.content = {"new": "data"}
 
 
-# ---------------------------------------------------------------------------
 # Log.create
-# ---------------------------------------------------------------------------
 
 
 class TestLogCreate:
@@ -76,9 +70,7 @@ class TestLogCreate:
         assert log.content == {"error": "No content to log."}
 
 
-# ---------------------------------------------------------------------------
 # DataLogger init with dict logs
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoggerInitFromDict:
@@ -90,9 +82,7 @@ class TestDataLoggerInitFromDict:
         assert len(dl.logs) == 1
 
 
-# ---------------------------------------------------------------------------
 # DataLogger.log — capacity auto-dump failure
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoggerLogCapacity:
@@ -107,9 +97,7 @@ class TestDataLoggerLogCapacity:
         assert len(dl.logs) >= 1
 
 
-# ---------------------------------------------------------------------------
 # DataLogger.dump — various paths
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoggerDump:
@@ -173,9 +161,7 @@ class TestDataLoggerDump:
                 dl.dump(persist_path=json_path)
 
 
-# ---------------------------------------------------------------------------
 # DataLogger.adump
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoggerAdump:
@@ -188,9 +174,7 @@ class TestDataLoggerAdump:
         assert json_path.exists()
 
 
-# ---------------------------------------------------------------------------
 # DataLogger._create_path with subfolder
-# ---------------------------------------------------------------------------
 
 
 class TestCreatePathSubfolder:
@@ -206,9 +190,7 @@ class TestCreatePathSubfolder:
         assert "mysub" in str(path)
 
 
-# ---------------------------------------------------------------------------
 # DataLogger.save_at_exit
-# ---------------------------------------------------------------------------
 
 
 class TestSaveAtExit:
@@ -247,9 +229,7 @@ class TestSaveAtExit:
             dl.save_at_exit()
 
 
-# ---------------------------------------------------------------------------
 # DataLogger.from_config
-# ---------------------------------------------------------------------------
 
 
 class TestFromConfig:
@@ -269,9 +249,7 @@ class TestFromConfig:
         assert len(dl.logs) == 1
 
 
-# ---------------------------------------------------------------------------
 # alog async method
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoggerAlog:
@@ -283,9 +261,7 @@ class TestDataLoggerAlog:
         assert len(dl.logs) == 1
 
 
-# ---------------------------------------------------------------------------
 # CSV dump path
-# ---------------------------------------------------------------------------
 
 
 class TestDataLoggerDumpCSV:

--- a/tests/protocols/generic/test_log_redaction.py
+++ b/tests/protocols/generic/test_log_redaction.py
@@ -48,7 +48,7 @@ def _dump(logger: DataLogger, tmp_path: Path, name: str = "out.json") -> tuple[i
     return fp.stat().st_size, json.loads(fp.read_text())
 
 
-# --- the reported case ------------------------------------------------------
+# the reported case
 
 
 def test_image_payload_is_not_written_to_the_log_file(tmp_path):
@@ -101,7 +101,7 @@ def test_redaction_survives_an_api_calling_event(tmp_path):
     assert call.payload["messages"][0]["content"][1]["image_url"]["url"] == PNG_URI
 
 
-# --- the knob ---------------------------------------------------------------
+# the knob
 
 
 def test_redaction_is_on_by_default():
@@ -174,7 +174,7 @@ async def test_async_dump_redacts(tmp_path):
     assert B64 not in fp.read_text()
 
 
-# --- the predicate ----------------------------------------------------------
+# the predicate
 
 
 @pytest.mark.parametrize(

--- a/tests/protocols/generic/test_pile_coverage.py
+++ b/tests/protocols/generic/test_pile_coverage.py
@@ -23,9 +23,7 @@ class ItemB(Element):
     pass
 
 
-# ---------------------------------------------------------------------------
 # _validate_item_type: string resolution and error paths
-# ---------------------------------------------------------------------------
 
 
 class TestValidateItemType:
@@ -65,9 +63,7 @@ class TestValidateItemType:
         assert _validate_item_type(PlainClass) == {PlainClass}
 
 
-# ---------------------------------------------------------------------------
 # _validate_progression: dict path, duplicates, ID not found
-# ---------------------------------------------------------------------------
 
 
 class TestValidateProgression:
@@ -114,9 +110,7 @@ class TestValidateProgression:
         assert isinstance(result, Progression)
 
 
-# ---------------------------------------------------------------------------
 # Pile with order kwarg, item_type serialization
-# ---------------------------------------------------------------------------
 
 
 class TestPileInit:
@@ -156,9 +150,7 @@ class TestPileInit:
         assert len(lst) == 2
 
 
-# ---------------------------------------------------------------------------
 # _getitem: callable key, UUID key, list key edge cases
-# ---------------------------------------------------------------------------
 
 
 class TestPileGetItem:
@@ -203,9 +195,7 @@ class TestPileGetItem:
         assert result is a
 
 
-# ---------------------------------------------------------------------------
 # _setitem: non-int key paths and mismatch errors
-# ---------------------------------------------------------------------------
 
 
 class TestPileSetItem:
@@ -240,9 +230,7 @@ class TestPileSetItem:
         assert new in p
 
 
-# ---------------------------------------------------------------------------
 # _get: list of non-int keys
-# ---------------------------------------------------------------------------
 
 
 class TestPileGet:
@@ -277,9 +265,7 @@ class TestPileGet:
             p.get(Element())
 
 
-# ---------------------------------------------------------------------------
 # _pop: non-int key paths
-# ---------------------------------------------------------------------------
 
 
 class TestPilePop:
@@ -322,9 +308,7 @@ class TestPilePop:
             p._pop([])
 
 
-# ---------------------------------------------------------------------------
 # adapt_to / adapt_from
-# ---------------------------------------------------------------------------
 
 
 class TestPileAdapters:
@@ -336,9 +320,7 @@ class TestPileAdapters:
         assert "collections" in result
 
 
-# ---------------------------------------------------------------------------
 # Async iteration
-# ---------------------------------------------------------------------------
 
 
 class TestPileAsyncIteration:
@@ -377,9 +359,7 @@ class TestPileAsyncIteration:
             assert len(pp) == 2
 
 
-# ---------------------------------------------------------------------------
 # to_list_type: None input (module-level function in pile.py)
-# ---------------------------------------------------------------------------
 
 
 class TestToListType:

--- a/tests/protocols/generic/test_pile_filter.py
+++ b/tests/protocols/generic/test_pile_filter.py
@@ -13,9 +13,7 @@ import pytest
 from lionagi.protocols.generic.element import Element
 from lionagi.protocols.generic.pile import Pile
 
-# ---------------------------------------------------------------------------
 # Fixtures / helpers
-# ---------------------------------------------------------------------------
 
 
 class Item(Element):
@@ -46,9 +44,7 @@ def pile_5(five_items):
     return Pile(collections=five_items)
 
 
-# ---------------------------------------------------------------------------
 # 1. to_df / dump (pandas-dependent)
-# ---------------------------------------------------------------------------
 
 pandas_missing = importlib.util.find_spec("pandas") is None
 
@@ -87,9 +83,7 @@ class TestIsHomogenous:
         assert Pile().is_homogenous() is True
 
 
-# ---------------------------------------------------------------------------
 # 11. adapt_to / adapt_from (json)
-# ---------------------------------------------------------------------------
 
 
 class TestAdaptTo:
@@ -119,9 +113,7 @@ class TestAdaptTo:
             await pile_3.adapt_to_async("json", many=True)
 
 
-# ---------------------------------------------------------------------------
 # 12. Misc: __repr__, __str__, __bool__, keys/values/items, size/is_empty
-# ---------------------------------------------------------------------------
 
 
 class TestMisc:
@@ -219,9 +211,7 @@ class TestMisc:
         assert pile_3[three_items[0].id].value == 999
 
 
-# ---------------------------------------------------------------------------
 # 13. AsyncPileIterator  (inner class)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -245,9 +235,7 @@ async def test_async_pile_iterator_stop():
         await it.__anext__()
 
 
-# ---------------------------------------------------------------------------
 # 14. filter() with lambda and type predicates
-# ---------------------------------------------------------------------------
 
 
 class TestFilterMethod:
@@ -281,9 +269,7 @@ class TestFilterMethod:
         assert values == [0, 2, 4]
 
 
-# ---------------------------------------------------------------------------
 # 15. pile[type] / pile[Filter] — getitem query via the Filter primitive
-# ---------------------------------------------------------------------------
 
 
 class TestGetitemFilter:

--- a/tests/protocols/generic/test_pile_indexing.py
+++ b/tests/protocols/generic/test_pile_indexing.py
@@ -14,9 +14,7 @@ from lionagi._errors import ItemNotFoundError
 from lionagi.protocols.generic.element import Element
 from lionagi.protocols.generic.pile import Pile, to_list_type
 
-# ---------------------------------------------------------------------------
 # Fixtures / helpers
-# ---------------------------------------------------------------------------
 
 
 class Item(Element):
@@ -81,9 +79,7 @@ def pile_5(five_items):
     return Pile(collections=five_items)
 
 
-# ---------------------------------------------------------------------------
 # 1. to_df / dump (pandas-dependent)
-# ---------------------------------------------------------------------------
 
 pandas_missing = importlib.util.find_spec("pandas") is None
 
@@ -181,9 +177,7 @@ class TestAsyncEdgeCases:
         assert item not in p
 
 
-# ---------------------------------------------------------------------------
 # 9. from_dict / to_dict serialization roundtrip
-# ---------------------------------------------------------------------------
 
 
 class TestSerializationRoundtrip:
@@ -227,6 +221,4 @@ class TestSerializationRoundtrip:
         assert isinstance(d["progression"], dict)
 
 
-# ---------------------------------------------------------------------------
 # 10. is_homogenous
-# ---------------------------------------------------------------------------

--- a/tests/protocols/generic/test_pile_mutation.py
+++ b/tests/protocols/generic/test_pile_mutation.py
@@ -13,9 +13,7 @@ from lionagi._errors import ItemExistsError, ValidationError
 from lionagi.protocols.generic.element import Element
 from lionagi.protocols.generic.pile import Pile
 
-# ---------------------------------------------------------------------------
 # Fixtures / helpers
-# ---------------------------------------------------------------------------
 
 
 class Item(Element):
@@ -26,9 +24,7 @@ class OtherItem(Element):
     name: str = ""
 
 
-# ---------------------------------------------------------------------------
 # Regression: sized Element that is falsy when empty must not be dropped
-# ---------------------------------------------------------------------------
 
 
 class TestIncludeFalsyElement:
@@ -89,9 +85,7 @@ def pile_5(five_items):
     return Pile(collections=five_items)
 
 
-# ---------------------------------------------------------------------------
 # 1. to_df / dump (pandas-dependent)
-# ---------------------------------------------------------------------------
 
 pandas_missing = importlib.util.find_spec("pandas") is None
 
@@ -170,9 +164,7 @@ class TestInPlaceSetOps:
             p ^= [self.a0]  # type: ignore[assignment]
 
 
-# ---------------------------------------------------------------------------
 # 3. Non-in-place set ops (__or__, __and__, __xor__)
-# ---------------------------------------------------------------------------
 
 
 class TestNonInPlaceSetOps:
@@ -360,9 +352,7 @@ class TestMultiItemPop:
         assert result.item_type == {Item}
 
 
-# ---------------------------------------------------------------------------
 # 4. filter_by_type
-# ---------------------------------------------------------------------------
 
 
 class TestFilterByType:
@@ -440,9 +430,7 @@ class TestFilterByType:
         assert len(result) == 6
 
 
-# ---------------------------------------------------------------------------
 # 5. Strict type enforcement
-# ---------------------------------------------------------------------------
 
 
 class TestStrictType:
@@ -485,9 +473,7 @@ class TestStrictType:
             )
 
 
-# ---------------------------------------------------------------------------
 # 6. __setitem__ with UUID keys and integer indices
-# ---------------------------------------------------------------------------
 
 
 class TestSetItem:
@@ -523,9 +509,7 @@ class TestSetItem:
             pile_3[100] = new
 
 
-# ---------------------------------------------------------------------------
 # 7. insert at start, middle, end
-# ---------------------------------------------------------------------------
 
 
 class TestInsert:
@@ -559,9 +543,7 @@ class TestInsert:
             pile_3.insert(0, three_items[0])
 
 
-# ---------------------------------------------------------------------------
 # 8. Async edge cases
-# ---------------------------------------------------------------------------
 
 
 def test_pile_setitem_rolls_back_on_key_item_id_mismatch():

--- a/tests/protocols/generic/test_pile_serialization.py
+++ b/tests/protocols/generic/test_pile_serialization.py
@@ -16,9 +16,7 @@ import pytest
 from lionagi.protocols.generic.element import Element
 from lionagi.protocols.generic.pile import Pile
 
-# ---------------------------------------------------------------------------
 # Fixtures / helpers
-# ---------------------------------------------------------------------------
 
 
 class Item(Element):
@@ -49,9 +47,7 @@ def pile_5(five_items):
     return Pile(collections=five_items)
 
 
-# ---------------------------------------------------------------------------
 # 1. to_df / dump (pandas-dependent)
-# ---------------------------------------------------------------------------
 
 pandas_missing = importlib.util.find_spec("pandas") is None
 
@@ -276,6 +272,4 @@ class TestSerializationFormat:
             await pile_3.adump(tmp_path / "x.json", obj_key="json", force_ascii=True)
 
 
-# ---------------------------------------------------------------------------
 # 2. Set operations — __ior__, __iand__, __ixor__ (in-place; these work)
-# ---------------------------------------------------------------------------

--- a/tests/protocols/generic/test_progression_coverage.py
+++ b/tests/protocols/generic/test_progression_coverage.py
@@ -16,9 +16,7 @@ def _make_prog(*elems) -> tuple[Progression, list[Element]]:
     return prog, items
 
 
-# ---------------------------------------------------------------------------
 # __getitem__: TypeError and empty-slice branches
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionGetItem:
@@ -33,9 +31,7 @@ class TestProgressionGetItem:
             _ = prog[10:20]
 
 
-# ---------------------------------------------------------------------------
 # __setitem__: slice path and out-of-range int insert
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionSetItem:
@@ -54,9 +50,7 @@ class TestProgressionSetItem:
         assert len(prog) == 3
 
 
-# ---------------------------------------------------------------------------
 # include: ValueError and empty-refs paths
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionInclude:
@@ -73,9 +67,7 @@ class TestProgressionInclude:
         assert len(prog) == original_len
 
 
-# ---------------------------------------------------------------------------
 # exclude: ValueError and empty-refs paths
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionExclude:
@@ -92,9 +84,7 @@ class TestProgressionExclude:
         assert len(prog) == original_len
 
 
-# ---------------------------------------------------------------------------
 # pop: middle-index path
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionPop:
@@ -107,9 +97,7 @@ class TestProgressionPop:
         assert len(prog) == 3
 
 
-# ---------------------------------------------------------------------------
 # remove: invalid UUID string
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionRemove:
@@ -125,9 +113,7 @@ class TestProgressionRemove:
         assert len(prog) == orig_len
 
 
-# ---------------------------------------------------------------------------
 # index: with end parameter
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionIndex:
@@ -142,9 +128,7 @@ class TestProgressionIndex:
             prog.index(items[3].id, 0, 2)
 
 
-# ---------------------------------------------------------------------------
 # __add__ and __isub__
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionArithmetic:
@@ -172,9 +156,7 @@ class TestProgressionArithmetic:
         assert len(prog) == 2
 
 
-# ---------------------------------------------------------------------------
 # Comparison operators
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionComparisons:

--- a/tests/protocols/generic/test_progression_membership_cache.py
+++ b/tests/protocols/generic/test_progression_membership_cache.py
@@ -30,9 +30,7 @@ def progression(elements):
     return Progression(order=[e.id for e in elements])
 
 
-# ---------------------------------------------------------------------------
 # Happy paths
-# ---------------------------------------------------------------------------
 
 
 def test_contains_happy_path_element_and_id(progression, elements):
@@ -60,10 +58,8 @@ def test_contains_invalid_candidate_returns_false(progression):
     assert object() not in progression
 
 
-# ---------------------------------------------------------------------------
 # Mutation invariants: `_members` (and thus `__contains__`) must reflect
 # every public mutation path.
-# ---------------------------------------------------------------------------
 
 
 def test_append_element_updates_membership(progression):
@@ -193,9 +189,7 @@ def test_move_swap_reverse_preserve_membership(progression, elements):
         assert e in progression
 
 
-# ---------------------------------------------------------------------------
 # Duplicate policy
-# ---------------------------------------------------------------------------
 
 
 def test_duplicate_ids_collapse_in_membership_but_not_in_order():
@@ -217,9 +211,7 @@ def test_construction_with_duplicates_then_single_removal_keeps_membership():
     assert other in p
 
 
-# ---------------------------------------------------------------------------
 # Slicing
-# ---------------------------------------------------------------------------
 
 
 def test_getitem_slice_returns_new_synced_progression(progression, elements):
@@ -245,10 +237,8 @@ def test_getitem_invalid_key_type_raises(progression):
         progression["bad-key"]
 
 
-# ---------------------------------------------------------------------------
 # External direct-`order`-mutation contract (the reason a naive cache-only
 # `__contains__` cannot be used, per ranked_targets.md Target 1 risk note).
-# ---------------------------------------------------------------------------
 
 
 def test_direct_order_mutation_is_observed_by_contains():
@@ -334,10 +324,8 @@ def test_order_mutators_sync_membership_after_order_reassignment(mutate):
     assert p._members == set(p.order)
 
 
-# ---------------------------------------------------------------------------
 # Length-preserving external mutation (the `_ensure_synced` length-only guard
 # cannot see these — the owning `_MembersDeque` must handle them directly).
-# ---------------------------------------------------------------------------
 
 
 def test_direct_order_setitem_length_preserving_membership_both_signs():
@@ -486,9 +474,7 @@ def test_progression_method_coverage_keeps_members_consistent_with_order():
     assert p._members == set(p.order)
 
 
-# ---------------------------------------------------------------------------
 # Serialization
-# ---------------------------------------------------------------------------
 
 
 def test_to_dict_excludes_private_cache(progression):
@@ -526,9 +512,7 @@ def test_equality_ignores_private_cache(elements):
     assert a != b
 
 
-# ---------------------------------------------------------------------------
 # Exceptions preserved
-# ---------------------------------------------------------------------------
 
 
 def test_pop_empty_raises_item_not_found():
@@ -559,7 +543,6 @@ def test_factory_prog_preserves_membership():
         assert i in p
 
 
-# ---------------------------------------------------------------------------
 # Performance regression: membership cost must not scale with n.
 #
 # Pre-fix, `__contains__` rebuilt `set(self.order)` on every call, making the
@@ -567,7 +550,6 @@ def test_factory_prog_preserves_membership():
 # not produce anywhere near a 20x growth in check time; we assert a generous
 # ratio ceiling well below linear scaling to stay robust to CI noise while
 # still failing hard if the O(n) behavior regresses.
-# ---------------------------------------------------------------------------
 
 
 def test_contains_cost_does_not_scale_with_size():

--- a/tests/protocols/generic/test_progression_membership_ownership.py
+++ b/tests/protocols/generic/test_progression_membership_ownership.py
@@ -27,11 +27,9 @@ from uuid import uuid4
 
 from lionagi.protocols.generic.progression import Progression, _MembersDeque
 
-# ---------------------------------------------------------------------------
 # Ownership-by-identity: sharing a `_MembersDeque` across two `Progression`
 # instances must never let a length-preserving mutation through one instance
 # corrupt the other's membership view.
-# ---------------------------------------------------------------------------
 
 
 def test_model_copy_shared_wrapper_both_instances_correct_after_setitem():
@@ -109,9 +107,7 @@ def test_deque_copy_of_members_deque_assigned_unbound_wrapper():
     assert src.order[0] in src
 
 
-# ---------------------------------------------------------------------------
 # Exhaustive accounting of every `deque` mutator.
-# ---------------------------------------------------------------------------
 
 
 def test_dir_deque_mutators_all_overridden_or_allowlisted():

--- a/tests/protocols/graph/test_graph.py
+++ b/tests/protocols/graph/test_graph.py
@@ -73,7 +73,7 @@ def cyclic_graph():
 
 
 class TestGraphBasics:
-    """Test basic graph operations"""
+    """Basic graph operations"""
 
     def test_empty_graph_creation(self, empty_graph):
         assert len(empty_graph.internal_nodes) == 0
@@ -131,7 +131,7 @@ class TestGraphBasics:
 
 
 class TestGraphTraversal:
-    """Test graph traversal operations"""
+    """Graph traversal operations"""
 
     def test_get_heads(self, complex_graph):
         graph, nodes, _ = complex_graph
@@ -172,7 +172,7 @@ class TestGraphTraversal:
 
 
 class TestGraphModification:
-    """Test graph modification operations"""
+    """Graph modification operations"""
 
     def test_remove_node(self, simple_graph):
         graph, node1, node2, edge = simple_graph
@@ -190,7 +190,7 @@ class TestGraphModification:
 
 
 class TestGraphProperties:
-    """Test graph property checks"""
+    """Graph property checks"""
 
     def test_is_acyclic_true(self, complex_graph):
         graph, _, _ = complex_graph
@@ -202,7 +202,7 @@ class TestGraphProperties:
 
 
 class TestEdgeConditions:
-    """Test edge conditions"""
+    """Edge conditions"""
 
     @pytest.mark.asyncio
     async def test_edge_condition_true(self):
@@ -229,7 +229,7 @@ class TestEdgeConditions:
 
 
 class TestGraphContainment:
-    """Test graph containment operations"""
+    """Graph containment operations"""
 
     def test_contains_node(self, simple_graph):
         graph, node1, node2, _ = simple_graph

--- a/tests/protocols/graph/test_graph_advanced.py
+++ b/tests/protocols/graph/test_graph_advanced.py
@@ -11,7 +11,7 @@ from .helpers import create_test_node
 
 @pytest.mark.slow
 class TestGraphPerformance:
-    """Test graph performance with large datasets"""
+    """Graph performance with large datasets"""
 
     def test_large_graph_creation(self):
         graph = Graph()
@@ -115,7 +115,7 @@ class TestGraphPerformance:
 
 @pytest.mark.asyncio
 class TestGraphConcurrency:
-    """Test concurrent graph operations"""
+    """Concurrent graph operations"""
 
     async def test_concurrent_node_additions(self):
         graph = Graph()
@@ -193,7 +193,7 @@ class TestGraphConcurrency:
 
 
 class TestGraphAdvancedOperations:
-    """Test advanced graph operations"""
+    """Advanced graph operations"""
 
     def test_graph_merge(self):
         # Create first graph

--- a/tests/protocols/graph/test_graph_basic.py
+++ b/tests/protocols/graph/test_graph_basic.py
@@ -53,7 +53,7 @@ def complex_graph():
 
 
 class TestGraphBasics:
-    """Test basic graph operations"""
+    """Basic graph operations"""
 
     def test_empty_graph_creation(self, empty_graph):
         assert len(empty_graph.internal_nodes) == 0
@@ -133,7 +133,7 @@ class TestEdgeRoundTrip:
 
 
 class TestGraphModification:
-    """Test graph modification operations"""
+    """Graph modification operations"""
 
     def test_remove_node(self, simple_graph):
         graph, node1, node2, edge = simple_graph
@@ -163,7 +163,7 @@ class TestGraphModification:
 
 
 class TestGraphContainment:
-    """Test graph containment operations"""
+    """Graph containment operations"""
 
     def test_contains_node(self, simple_graph):
         graph, node1, node2, _ = simple_graph
@@ -184,7 +184,7 @@ class TestGraphContainment:
 
 
 class TestGraphProperties:
-    """Test graph property checks"""
+    """Graph property checks"""
 
     def test_empty_graph_properties(self, empty_graph):
         assert len(empty_graph.internal_nodes) == 0

--- a/tests/protocols/graph/test_graph_edge.py
+++ b/tests/protocols/graph/test_graph_edge.py
@@ -37,10 +37,10 @@ def edge_test_graph():
 
 
 class TestEdgeBasics:
-    """Test basic edge functionality"""
+    """Basic edge functionality"""
 
     def test_edge_creation(self, edge_test_graph):
-        """Test creating edges with different configurations"""
+        """Creating edges with different configurations"""
         graph, node1, node2, _ = edge_test_graph
 
         edge = Edge(head=node1, tail=node2)
@@ -57,7 +57,7 @@ class TestEdgeBasics:
         assert edge_with_props.properties.get("custom_prop") == "test"
 
     def test_edge_properties(self, edge_test_graph):
-        """Test edge property management"""
+        """Edge property management"""
         graph, node1, node2, _ = edge_test_graph
 
         edge = Edge(head=node1, tail=node2)
@@ -73,7 +73,7 @@ class TestEdgeBasics:
         assert edge.properties.get("weight", None) is None
 
     def test_edge_validation(self, edge_test_graph):
-        """Test edge validation"""
+        """Edge validation"""
         graph, node1, node2, _ = edge_test_graph
 
         # Test with invalid head/tail
@@ -92,10 +92,10 @@ class TestEdgeBasics:
 
 @pytest.mark.asyncio
 class TestEdgeConditions:
-    """Test edge conditions"""
+    """Edge conditions"""
 
     async def test_edge_condition_true(self, edge_test_graph):
-        """Test edge condition that evaluates to True"""
+        """Edge condition that evaluates to True"""
         graph, node1, node2, _ = edge_test_graph
 
         condition = CustomEdgeCondition(value=True)
@@ -105,7 +105,7 @@ class TestEdgeConditions:
         assert await edge.check_condition()
 
     async def test_edge_condition_false(self, edge_test_graph):
-        """Test edge condition that evaluates to False"""
+        """Edge condition that evaluates to False"""
         graph, node1, node2, _ = edge_test_graph
 
         condition = CustomEdgeCondition(value=False)
@@ -115,7 +115,7 @@ class TestEdgeConditions:
         assert not await edge.check_condition()
 
     async def test_edge_no_condition(self, edge_test_graph):
-        """Test edge with no condition"""
+        """Edge with no condition"""
         graph, node1, node2, _ = edge_test_graph
 
         edge = Edge(head=node1, tail=node2)
@@ -124,7 +124,7 @@ class TestEdgeConditions:
         assert await edge.check_condition()
 
     async def test_custom_condition(self, edge_test_graph):
-        """Test edge with custom condition class"""
+        """Edge with custom condition class"""
         graph, node1, node2, _ = edge_test_graph
 
         class WeightCondition(EdgeCondition):
@@ -146,10 +146,10 @@ class TestEdgeConditions:
 
 
 class TestEdgeTypes:
-    """Test different edge types and configurations"""
+    """Different edge types and configurations"""
 
     def test_multi_label_edge(self, edge_test_graph):
-        """Test edge with multiple labels"""
+        """Edge with multiple labels"""
         graph, node1, node2, _ = edge_test_graph
 
         edge = Edge(head=node1, tail=node2, label=["label1", "label2", "label3"])
@@ -160,7 +160,7 @@ class TestEdgeTypes:
         assert "label1" in edge.properties.get("label")
 
     def test_weighted_edge(self, edge_test_graph):
-        """Test edge with weight property"""
+        """Edge with weight property"""
         graph, node1, node2, _ = edge_test_graph
 
         edge = Edge(head=node1, tail=node2)
@@ -170,7 +170,7 @@ class TestEdgeTypes:
         assert edge.properties.get("weight") == 5.5
 
     def test_custom_edge_type(self, edge_test_graph):
-        """Test custom edge type"""
+        """Custom edge type"""
         graph, node1, node2, _ = edge_test_graph
 
         class WeightedEdge(Edge):
@@ -195,10 +195,10 @@ class TestEdgeTypes:
 
 
 class TestEdgeOperations:
-    """Test edge operations in graph context"""
+    """Edge operations in graph context"""
 
     def test_parallel_edges(self, edge_test_graph):
-        """Test parallel edges between same nodes"""
+        """Parallel edges between same nodes"""
         graph, node1, node2, _ = edge_test_graph
 
         edge1 = Edge(head=node1, tail=node2)
@@ -215,7 +215,7 @@ class TestEdgeOperations:
         assert any(e.properties.get("type") == "type2" for e in edges)
 
     def test_bidirectional_edges(self, edge_test_graph):
-        """Test bidirectional edges"""
+        """Bidirectional edges"""
         graph, node1, node2, _ = edge_test_graph
 
         edge1 = Edge(head=node1, tail=node2)
@@ -228,7 +228,7 @@ class TestEdgeOperations:
         assert len(graph.find_node_edge(node2)) == 2
 
     def test_self_loop_edge(self, edge_test_graph):
-        """Test self-loop edge"""
+        """Self-loop edge"""
         graph, node1, _, _ = edge_test_graph
 
         edge = Edge(head=node1, tail=node1)
@@ -238,7 +238,7 @@ class TestEdgeOperations:
         assert edge.id in graph.node_edge_mapping[node1.id]["out"]
 
     def test_edge_removal_cleanup(self, edge_test_graph):
-        """Test proper cleanup after edge removal"""
+        """Proper cleanup after edge removal"""
         graph, node1, node2, _ = edge_test_graph
 
         edge = Edge(head=node1, tail=node2)

--- a/tests/protocols/graph/test_graph_primitives.py
+++ b/tests/protocols/graph/test_graph_primitives.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for expanded NodeConfig fields, create_node() audit field generation, and Node lifecycle with real Pydantic fields."""
+"""Graph primitives: node replacement, edge conditions, and predecessor/successor accessors."""
 
 from uuid import uuid4
 

--- a/tests/protocols/graph/test_graph_traversal.py
+++ b/tests/protocols/graph/test_graph_traversal.py
@@ -61,7 +61,7 @@ def cyclic_graph():
 
 
 class TestGraphTraversal:
-    """Test graph traversal operations"""
+    """Graph traversal operations"""
 
     def test_get_heads(self, traversal_graph):
         graph, nodes, _ = traversal_graph
@@ -116,7 +116,7 @@ class TestGraphTraversal:
 
 
 class TestGraphCyclicProperties:
-    """Test cyclic graph properties"""
+    """Cyclic graph properties"""
 
     def test_cyclic_graph_heads(self, cyclic_graph):
         graph, _, _ = cyclic_graph
@@ -144,7 +144,7 @@ class TestGraphCyclicProperties:
 
 
 class TestGraphTraversalEdgeCases:
-    """Test graph traversal edge cases"""
+    """Graph traversal edge cases"""
 
     def test_isolated_node_traversal(self):
         graph = Graph()

--- a/tests/protocols/graph/test_graph_types.py
+++ b/tests/protocols/graph/test_graph_types.py
@@ -61,7 +61,7 @@ def mixed_type_graph():
 
 
 class TestNodeTypes:
-    """Test different node types in graph"""
+    """Different node types in graph"""
 
     def test_type_a_nodes(self, mixed_type_graph):
         graph, nodes, _ = mixed_type_graph
@@ -98,7 +98,7 @@ class TestNodeTypes:
 
 
 class TestEdgeTypes:
-    """Test different edge types in graph"""
+    """Different edge types in graph"""
 
     def test_weighted_edges(self, mixed_type_graph):
         graph, _, edges = mixed_type_graph
@@ -126,7 +126,7 @@ class TestEdgeTypes:
 
 
 class TestMixedTypeOperations:
-    """Test operations with mixed node and edge types"""
+    """Operations with mixed node and edge types"""
 
     def test_mixed_type_traversal(self, mixed_type_graph):
         graph, nodes, _ = mixed_type_graph

--- a/tests/protocols/graph/test_node_config_expanded.py
+++ b/tests/protocols/graph/test_node_config_expanded.py
@@ -34,7 +34,7 @@ def _frozen_datetime(fixed):
 
 
 class TestNodeConfigNewFields:
-    """Test new fields added to NodeConfig."""
+    """New fields added to NodeConfig."""
 
     def test_embedding_enabled_default(self):
         cfg = NodeConfig()
@@ -92,7 +92,7 @@ class TestNodeConfigNewFields:
 
 
 class TestNodeConfigNewProperties:
-    """Test new computed properties on NodeConfig."""
+    """New computed properties on NodeConfig."""
 
     def test_has_embedding_false_by_default(self):
         cfg = NodeConfig()

--- a/tests/protocols/graph/test_node_edge_cases.py
+++ b/tests/protocols/graph/test_node_edge_cases.py
@@ -12,10 +12,10 @@ from lionagi.protocols.graph.node import Node, _ensure_postgres_adapter
 
 
 class TestNodeBasicFunctionality:
-    """Test basic Node functionality."""
+    """Basic Node functionality."""
 
     def test_node_creation_basic(self):
-        """Test basic Node creation."""
+        """Basic Node creation."""
         node = Node()
 
         assert isinstance(node, Node)
@@ -37,7 +37,7 @@ class TestNodeBasicFunctionality:
         assert node.embedding == embedding
 
     def test_node_inherits_from_element(self):
-        """Test that Node inherits from Element and has ID."""
+        """Node inherits from Element and has ID."""
         node = Node()
 
         assert isinstance(node, Element)
@@ -57,27 +57,27 @@ class TestNodeEmbeddingValidation:
     """Test Node embedding field validation."""
 
     def test_embedding_valid_list(self):
-        """Test embedding with valid float list."""
+        """Embedding with valid float list."""
         embedding = [1.0, 2.5, -3.7, 0.0]
         node = Node(embedding=embedding)
 
         assert node.embedding == embedding
 
     def test_embedding_valid_list_integers(self):
-        """Test embedding with integer list (converted to float)."""
+        """Embedding with integer list (converted to float)."""
         embedding = [1, 2, 3]
         node = Node(embedding=embedding)
 
         assert node.embedding == [1.0, 2.0, 3.0]
 
     def test_embedding_none(self):
-        """Test embedding with None value."""
+        """Embedding with None value."""
         node = Node(embedding=None)
 
         assert node.embedding is None
 
     def test_embedding_valid_json_string(self):
-        """Test embedding with valid JSON string."""
+        """Embedding with valid JSON string."""
         embedding_list = [1.5, 2.5, 3.5]
         embedding_json = orjson.dumps(embedding_list).decode()
         node = Node(embedding=embedding_json)
@@ -85,29 +85,29 @@ class TestNodeEmbeddingValidation:
         assert node.embedding == embedding_list
 
     def test_embedding_invalid_json_string(self):
-        """Test embedding with invalid JSON string."""
+        """Embedding with invalid JSON string."""
         with pytest.raises(ValueError, match="Invalid embedding string"):
             Node(embedding="invalid json")
 
     def test_embedding_json_non_list(self):
-        """Test embedding with JSON string that's not a list."""
+        """Embedding with JSON string that's not a list."""
         json_dict = orjson.dumps({"not": "a list"}).decode()
 
         with pytest.raises(ValueError, match="Invalid embedding string"):
             Node(embedding=json_dict)
 
     def test_embedding_invalid_list_values(self):
-        """Test embedding with list containing non-numeric values."""
+        """Embedding with list containing non-numeric values."""
         with pytest.raises(ValueError, match="Invalid embedding list"):
             Node(embedding=[1.0, "invalid", 3.0])
 
     def test_embedding_invalid_type(self):
-        """Test embedding with completely invalid type."""
+        """Embedding with completely invalid type."""
         with pytest.raises(ValueError, match="Invalid embedding type"):
             Node(embedding={"invalid": "type"})
 
     def test_embedding_empty_list(self):
-        """Test embedding with empty list."""
+        """Embedding with empty list."""
         node = Node(embedding=[])
 
         assert node.embedding == []
@@ -117,7 +117,7 @@ class TestNodeContentSerialization:
     """Test Node content serialization."""
 
     def test_content_serialization_element(self):
-        """Test content serialization with Element object."""
+        """Content serialization with Element object."""
         inner_element = Element()
         node = Node(content=inner_element)
 
@@ -128,7 +128,7 @@ class TestNodeContentSerialization:
         assert isinstance(serialized["content"], dict)
 
     def test_content_serialization_basemodel(self):
-        """Test content serialization with BaseModel object."""
+        """Content serialization with BaseModel object."""
 
         class TestModel(BaseModel):
             value: str = "test"
@@ -143,7 +143,7 @@ class TestNodeContentSerialization:
         assert serialized["content"] == {"value": "test"}
 
     def test_content_serialization_regular_object(self):
-        """Test content serialization with regular object."""
+        """Content serialization with regular object."""
         content = {"regular": "dict"}
         node = Node(content=content)
 
@@ -153,7 +153,7 @@ class TestNodeContentSerialization:
         assert serialized["content"] == content
 
     def test_content_validation_with_lion_class(self):
-        """Test content validation with lion_class in metadata."""
+        """Content validation with lion_class in metadata."""
         # Create a mock dict that looks like an Element
         content_dict = {
             "id": "test_id",
@@ -173,7 +173,7 @@ class TestNodeContentSerialization:
             assert node.content == mock_element
 
     def test_content_validation_regular_dict(self):
-        """Test content validation with regular dict."""
+        """Content validation with regular dict."""
         content_dict = {"regular": "dict"}
         node = Node(content=content_dict)
 
@@ -185,7 +185,7 @@ class TestNodeAdaptation:
     """Test Node adaptation methods."""
 
     def test_adapt_to_basic(self):
-        """Test basic adapt_to functionality."""
+        """Basic adapt_to functionality."""
         node = Node(content="test")
 
         # Mock the parent adapt_to method
@@ -200,7 +200,7 @@ class TestNodeAdaptation:
             assert kwargs["adapt_kw"] == {"mode": "db"}
 
     def test_adapt_from_basic(self):
-        """Test basic adapt_from functionality."""
+        """Basic adapt_from functionality."""
         test_data = {"test": "data"}
 
         # Mock the parent adapt_from method
@@ -219,7 +219,7 @@ class TestNodeAdaptation:
 
     @pytest.mark.asyncio
     async def test_adapt_to_async_basic(self):
-        """Test basic async adapt_to functionality."""
+        """Basic async adapt_to functionality."""
         node = Node(content="test")
 
         # Mock the parent adapt_to_async method
@@ -235,7 +235,7 @@ class TestNodeAdaptation:
 
     @pytest.mark.asyncio
     async def test_adapt_to_async_postgres(self):
-        """Test async adapt_to with postgres adapter."""
+        """Async adapt_to with postgres adapter."""
         node = Node(content="test")
 
         with patch("lionagi.protocols.graph.node._ensure_postgres_adapter") as mock_ensure:
@@ -250,7 +250,7 @@ class TestNodeAdaptation:
 
     @pytest.mark.asyncio
     async def test_adapt_from_async_basic(self):
-        """Test basic async adapt_from functionality."""
+        """Basic async adapt_from functionality."""
         test_data = {"test": "data"}
 
         with patch.object(Node, "adapt_from_async") as mock_adapt:
@@ -267,7 +267,7 @@ class TestNodeAdaptation:
 
     @pytest.mark.asyncio
     async def test_adapt_from_async_postgres(self):
-        """Test async adapt_from with postgres adapter."""
+        """Async adapt_from with postgres adapter."""
         test_data = {"test": "data"}
 
         with patch("lionagi.protocols.graph.node._ensure_postgres_adapter") as mock_ensure:
@@ -286,7 +286,7 @@ class TestNodeRegistration:
     """Test Node subclass registration."""
 
     def test_subclass_registration(self):
-        """Test that Node subclasses are registered in class registry."""
+        """Node subclasses are registered in class registry."""
 
         # Create a unique subclass to test registration
         class TestNodeSubclass(Node):
@@ -298,7 +298,7 @@ class TestNodeRegistration:
         assert LION_CLASS_REGISTRY[class_name] == TestNodeSubclass
 
     def test_pydantic_init_subclass_calls_super(self):
-        """Test that __pydantic_init_subclass__ calls super()."""
+        """__pydantic_init_subclass__ calls super()."""
         # Mock the super().__pydantic_init_subclass__ to verify it's called
         with patch.object(Node.__bases__[0], "__pydantic_init_subclass__") as mock_super:
 
@@ -310,7 +310,7 @@ class TestNodeRegistration:
 
 
 class TestPostgresAdapterIntegration:
-    """Test postgres adapter functionality."""
+    """Postgres adapter functionality."""
 
     def test_ensure_postgres_adapter_already_checked(self):
         """Test _ensure_postgres_adapter when already checked."""
@@ -374,7 +374,7 @@ class TestPostgresAdapterIntegration:
         assert Node._postgres_adapter_checked is True
 
     def test_ensure_postgres_adapter_flag_setting(self):
-        """Test that _ensure_postgres_adapter sets the flag regardless of outcome."""
+        """_ensure_postgres_adapter sets the flag regardless of outcome."""
         # Remove the flag to force checking
         if hasattr(Node, "_postgres_adapter_checked"):
             delattr(Node, "_postgres_adapter_checked")
@@ -398,7 +398,7 @@ class TestNodeIntegration:
     """Integration tests for Node functionality."""
 
     def test_node_full_lifecycle(self):
-        """Test complete Node lifecycle with various features."""
+        """Complete Node lifecycle with various features."""
         # Create node with content and embedding
         content = {"type": "test", "data": [1, 2, 3]}
         embedding = [0.1, 0.2, 0.3]
@@ -440,9 +440,7 @@ if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 
 
-# ---------------------------------------------------------------------------
-# D6 – Node embedding: JSON string must decode to a list of floats
-# ---------------------------------------------------------------------------
+# Node embedding: JSON string must decode to a list of floats
 
 
 class TestNodeEmbeddingJsonString:

--- a/tests/protocols/graph/test_node_serialization.py
+++ b/tests/protocols/graph/test_node_serialization.py
@@ -192,7 +192,7 @@ class TestEdgeCases:
 
 
 class TestManualSubclassWithConfig:
-    """Test setting node_config as a ClassVar on a hand-written subclass."""
+    """Setting node_config as a ClassVar on a hand-written subclass."""
 
     def test_manual_subclass_lifecycle(self):
         class Article(Node):

--- a/tests/protocols/graph/test_node_soft_delete.py
+++ b/tests/protocols/graph/test_node_soft_delete.py
@@ -250,14 +250,14 @@ class TestDeleteRestoreCycle:
         )
         a = cls(content={"status": "active"})
 
-        # --- initial state: real fields at defaults ---
+        # initial state: real fields at defaults
         assert a.version == 0
         assert a.updated_at is None
         assert a.is_deleted is False
         assert a.deleted_at is None
         assert a.content_hash is None
 
-        # --- touch once ---
+        # touch once
         a.touch(by="alice")
         assert a.version == 1
         assert a.updated_at is not None
@@ -265,14 +265,14 @@ class TestDeleteRestoreCycle:
         assert a.content_hash is not None
         hash_v1 = a.content_hash
 
-        # --- soft_delete ---
+        # soft_delete
         a.soft_delete(by="bob")
         assert a.is_deleted is True
         assert a.deleted_at is not None
         assert a.metadata["deleted_by"] == "bob"
         assert a.version == 2  # touch was called inside soft_delete
 
-        # --- restore ---
+        # restore
         a.restore(by="carol")
         assert a.is_deleted is False
         assert a.deleted_at is None
@@ -280,7 +280,7 @@ class TestDeleteRestoreCycle:
         assert a.version == 3  # touch was called inside restore
         assert a.metadata["updated_by"] == "carol"
 
-        # --- content change + rehash ---
+        # content change + rehash
         a.content = {"status": "updated"}
         a.touch(by="dave")
         assert a.version == 4

--- a/tests/protocols/messages/test_action_request.py
+++ b/tests/protocols/messages/test_action_request.py
@@ -12,7 +12,7 @@ from lionagi.protocols.types import MessageRole
 
 
 def test_action_request_content_initialization():
-    """Test basic initialization of ActionRequestContent"""
+    """Basic initialization of ActionRequestContent"""
     function = "test_function"
     arguments = {"arg1": "value1", "arg2": "value2"}
 
@@ -27,7 +27,7 @@ def test_action_request_content_initialization():
 
 
 def test_action_request_initialization():
-    """Test basic initialization of ActionRequest"""
+    """Basic initialization of ActionRequest"""
     function = "test_function"
     arguments = {"arg1": "value1", "arg2": "value2"}
 
@@ -177,7 +177,7 @@ def test_action_request_validator_with_none():
 
 
 def test_action_request_response_tracking():
-    """Test tracking of action response"""
+    """Tracking of action response"""
     content = ActionRequestContent(
         function="test",
         arguments={},
@@ -198,7 +198,7 @@ def test_action_request_response_tracking():
 
 
 def test_action_request_rendered_property():
-    """Test the rendered property using minimal_yaml"""
+    """The rendered property using minimal_yaml"""
     content = ActionRequestContent(
         function="test_function",
         arguments={"arg1": "value1", "arg2": 42, "arg3": True},
@@ -215,7 +215,7 @@ def test_action_request_rendered_property():
 
 
 def test_action_request_rendered_empty_arguments():
-    """Test the rendered property with empty arguments"""
+    """The rendered property with empty arguments"""
     content = ActionRequestContent(
         function="test_function",
         arguments={},
@@ -232,7 +232,7 @@ def test_action_request_rendered_empty_arguments():
 
 
 def test_action_request_rendered_nested_arguments():
-    """Test the rendered property with nested arguments"""
+    """The rendered property with nested arguments"""
     content = ActionRequestContent(
         function="complex_function",
         arguments={
@@ -251,7 +251,7 @@ def test_action_request_rendered_nested_arguments():
 
 
 def test_action_request_content_format():
-    """Test the format of action request content in chat message"""
+    """The format of action request content in chat message"""
     content = ActionRequestContent(
         function="test_function",
         arguments={"arg1": "value1"},
@@ -272,7 +272,7 @@ def test_action_request_content_format():
 
 
 def test_action_request_str_representation():
-    """Test string representation of ActionRequest"""
+    """String representation of ActionRequest"""
     content = ActionRequestContent(
         function="test_function",
         arguments={"arg1": "value1"},
@@ -316,7 +316,7 @@ def test_action_request_from_dict_with_empty_nested():
 
 
 def test_action_request_immutable_arguments():
-    """Test that arguments are properly copied and isolated"""
+    """Arguments are properly copied and isolated."""
     original_args = {"key": "value"}
     content = ActionRequestContent(
         function="test",

--- a/tests/protocols/messages/test_action_response.py
+++ b/tests/protocols/messages/test_action_response.py
@@ -36,7 +36,7 @@ def test_action_response_content_initialization_with_values():
 
 
 def test_action_response_content_dataclass_immutable_slots():
-    """Test that ActionResponseContent uses slots for memory efficiency."""
+    """ActionResponseContent uses slots for memory efficiency."""
     content = ActionResponseContent(function="test")
 
     assert hasattr(ActionResponseContent, "__slots__")
@@ -46,7 +46,7 @@ def test_action_response_content_dataclass_immutable_slots():
 
 
 def test_action_response_content_arguments_default_factory():
-    """Test that arguments field uses default factory for independent instances."""
+    """Arguments field uses default factory for independent instances."""
     content1 = ActionResponseContent()
     content2 = ActionResponseContent()
 
@@ -57,7 +57,7 @@ def test_action_response_content_arguments_default_factory():
 
 
 def test_action_response_content_rendered_property():
-    """Test the rendered property formats content as YAML."""
+    """The rendered property formats content as YAML."""
     content = ActionResponseContent(
         function="calculate_sum",
         arguments={"a": 10, "b": 20},
@@ -78,7 +78,7 @@ def test_action_response_content_rendered_property():
 
 
 def test_action_response_content_rendered_with_complex_output():
-    """Test rendered property with complex nested output."""
+    """Rendered property with complex nested output."""
     content = ActionResponseContent(
         function="process_data",
         arguments={"input": "data.json"},
@@ -99,7 +99,7 @@ def test_action_response_content_rendered_with_complex_output():
 
 
 def test_action_response_content_rendered_with_none_output():
-    """Test rendered property when output is None."""
+    """Rendered property when output is None."""
     content = ActionResponseContent(
         function="void_function",
         arguments={},
@@ -114,7 +114,7 @@ def test_action_response_content_rendered_with_none_output():
 
 
 def test_action_response_content_from_dict_flat_structure():
-    """Test from_dict with flat dictionary structure (new format)."""
+    """from_dict with flat dictionary structure (new format)."""
     data = {
         "function": "test_function",
         "arguments": {"param": "value"},
@@ -131,7 +131,7 @@ def test_action_response_content_from_dict_flat_structure():
 
 
 def test_action_response_content_from_dict_nested_structure():
-    """Test from_dict with nested 'action_response' key (old format - backward compat)."""
+    """from_dict with nested 'action_response' key (old format - backward compat)."""
     data = {
         "action_response": {
             "function": "legacy_function",
@@ -150,7 +150,7 @@ def test_action_response_content_from_dict_nested_structure():
 
 
 def test_action_response_content_from_dict_missing_fields():
-    """Test from_dict with missing optional fields."""
+    """from_dict with missing optional fields."""
     data = {
         "action_response": {
             "function": "minimal_function",
@@ -166,7 +166,7 @@ def test_action_response_content_from_dict_missing_fields():
 
 
 def test_action_response_content_from_dict_empty_dict():
-    """Test from_dict with completely empty dictionary."""
+    """from_dict with completely empty dictionary."""
     data = {}
 
     content = ActionResponseContent.from_dict(data)
@@ -178,7 +178,7 @@ def test_action_response_content_from_dict_empty_dict():
 
 
 def test_action_response_content_from_dict_action_request_id_coercion():
-    """Test that action_request_id is coerced to string if provided."""
+    """action_request_id is coerced to string if provided."""
     data = {
         "function": "test",
         "action_request_id": 12345,  # Integer, should be converted to string
@@ -191,7 +191,7 @@ def test_action_response_content_from_dict_action_request_id_coercion():
 
 
 def test_action_response_content_from_dict_nested_with_partial_fields():
-    """Test from_dict with nested structure but partial fields."""
+    """from_dict with nested structure but partial fields."""
     data = {
         "action_response": {
             "function": "partial_function",
@@ -285,7 +285,7 @@ def test_action_response_content_validator_invalid_type():
 
 
 def test_action_response_role_is_action():
-    """Test that ActionResponse has correct role."""
+    """ActionResponse has correct role."""
     response = ActionResponse(content=ActionResponseContent())
 
     assert response.role == MessageRole.ACTION
@@ -307,7 +307,7 @@ def test_action_response_with_action_request_id():
 
 
 def test_action_response_rendered_content():
-    """Test that ActionResponse can access rendered content."""
+    """ActionResponse can access rendered content."""
     response = ActionResponse(
         content={
             "function": "render_test",
@@ -325,7 +325,7 @@ def test_action_response_rendered_content():
 
 
 def test_action_response_content_access():
-    """Test direct access to ActionResponseContent fields through ActionResponse."""
+    """Direct access to ActionResponseContent fields through ActionResponse."""
     response = ActionResponse(
         content={
             "function": "access_test",
@@ -435,7 +435,7 @@ def test_action_response_dataclass_equality():
 
 
 def test_action_response_multiple_instances_independence():
-    """Test that multiple ActionResponse instances are independent."""
+    """Multiple ActionResponse instances are independent."""
     response1 = ActionResponse(content={"function": "func1", "arguments": {"x": 1}, "output": 1})
 
     response2 = ActionResponse(content={"function": "func2", "arguments": {"x": 2}, "output": 2})
@@ -450,7 +450,7 @@ def test_action_response_multiple_instances_independence():
 
 
 def test_action_response_content_rendered_is_always_string():
-    """Test that rendered property always returns a string, even for edge cases."""
+    """Rendered property always returns a string, even for edge cases."""
     test_cases = [
         ActionResponseContent(function="", arguments={}, output=None),
         ActionResponseContent(function="f", arguments={}, output=""),

--- a/tests/protocols/messages/test_assistant_response.py
+++ b/tests/protocols/messages/test_assistant_response.py
@@ -59,7 +59,7 @@ class ClaudeCodeResponse(BaseModel):
 
 
 def test_parse_assistant_response_anthropic_format():
-    """Test parsing Anthropic format with content field"""
+    """Parsing Anthropic format with content field"""
     response = AnthropicResponse(
         content=[
             AnthropicTextContent(type="text", text="Hello "),
@@ -75,7 +75,7 @@ def test_parse_assistant_response_anthropic_format():
 
 
 def test_parse_assistant_response_anthropic_dict():
-    """Test parsing Anthropic format as dictionary"""
+    """Parsing Anthropic format as dictionary"""
     response = {
         "content": [
             {"type": "text", "text": "First part "},
@@ -90,7 +90,7 @@ def test_parse_assistant_response_anthropic_dict():
 
 
 def test_parse_assistant_response_anthropic_string_content():
-    """Test parsing Anthropic format with string content"""
+    """Parsing Anthropic format with string content"""
     response = {"content": "Simple string content"}
 
     text, model_response = parse_assistant_response(response)
@@ -99,7 +99,7 @@ def test_parse_assistant_response_anthropic_string_content():
 
 
 def test_parse_assistant_response_openai_chat_format():
-    """Test parsing OpenAI chat completion format with choices"""
+    """Parsing OpenAI chat completion format with choices"""
     response = OpenAIChatResponse(
         choices=[
             OpenAIChoice(message=OpenAIMessage(content="Response 1")),
@@ -115,7 +115,7 @@ def test_parse_assistant_response_openai_chat_format():
 
 
 def test_parse_assistant_response_openai_streaming():
-    """Test parsing OpenAI streaming format with delta"""
+    """Parsing OpenAI streaming format with delta"""
     response = OpenAIChatResponse(
         choices=[
             OpenAIChoice(delta=OpenAIDelta(content="Hello ")),
@@ -128,7 +128,7 @@ def test_parse_assistant_response_openai_streaming():
 
 
 def test_parse_assistant_response_openai_responses_api():
-    """Test parsing OpenAI responses API format with output field"""
+    """Parsing OpenAI responses API format with output field"""
     response = OpenAIResponsesAPIResponse(
         output=[
             OpenAIOutputMessage(
@@ -149,7 +149,7 @@ def test_parse_assistant_response_openai_responses_api():
 
 
 def test_parse_assistant_response_claude_code_format():
-    """Test parsing Claude Code format with result field"""
+    """Parsing Claude Code format with result field"""
     response = ClaudeCodeResponse(result="Claude Code response")
 
     text, model_response = parse_assistant_response(response)
@@ -160,7 +160,7 @@ def test_parse_assistant_response_claude_code_format():
 
 
 def test_parse_assistant_response_raw_string():
-    """Test parsing raw string input"""
+    """Parsing raw string input"""
     response = "Simple text response"
 
     text, model_response = parse_assistant_response(response)
@@ -170,7 +170,7 @@ def test_parse_assistant_response_raw_string():
 
 
 def test_parse_assistant_response_list_of_responses():
-    """Test parsing list of multiple responses"""
+    """Parsing list of multiple responses"""
     responses = [
         {"content": [{"type": "text", "text": "First"}]},
         {"content": [{"type": "text", "text": " Second"}]},
@@ -184,7 +184,7 @@ def test_parse_assistant_response_list_of_responses():
 
 
 def test_parse_assistant_response_list_of_strings():
-    """Test parsing list of strings"""
+    """Parsing list of strings"""
     responses = ["Hello ", "world", "!"]
 
     text, model_response = parse_assistant_response(responses)
@@ -195,7 +195,7 @@ def test_parse_assistant_response_list_of_strings():
 
 
 def test_parse_assistant_response_empty_content():
-    """Test parsing response with empty/null content"""
+    """Parsing response with empty/null content"""
     response = OpenAIChatResponse(choices=[OpenAIChoice(message=OpenAIMessage(content=None))])
 
     text, model_response = parse_assistant_response(response)
@@ -204,7 +204,7 @@ def test_parse_assistant_response_empty_content():
 
 
 def test_parse_assistant_response_mixed_content_types():
-    """Test parsing response with mixed content types"""
+    """Parsing response with mixed content types"""
     response = {
         "content": [
             {"type": "text", "text": "Text block"},
@@ -219,7 +219,7 @@ def test_parse_assistant_response_mixed_content_types():
 
 
 def test_assistant_response_content_initialization():
-    """Test basic initialization of AssistantResponseContent"""
+    """Basic initialization of AssistantResponseContent"""
     content = AssistantResponseContent(assistant_response="Test content")
 
     assert content.assistant_response == "Test content"
@@ -227,21 +227,21 @@ def test_assistant_response_content_initialization():
 
 
 def test_assistant_response_content_default():
-    """Test default empty string initialization"""
+    """Default empty string initialization"""
     content = AssistantResponseContent()
 
     assert content.assistant_response == ""
 
 
 def test_assistant_response_content_rendered_property():
-    """Test rendered property returns plain text"""
+    """Rendered property returns plain text"""
     content = AssistantResponseContent(assistant_response="Rendered text")
 
     assert content.rendered == "Rendered text"
 
 
 def test_assistant_response_content_from_dict():
-    """Test from_dict classmethod"""
+    """from_dict classmethod"""
     data = {"assistant_response": "From dict"}
     content = AssistantResponseContent.from_dict(data)
 
@@ -250,7 +250,7 @@ def test_assistant_response_content_from_dict():
 
 
 def test_assistant_response_content_from_dict_empty():
-    """Test from_dict with missing field"""
+    """from_dict with missing field"""
     data = {}
     content = AssistantResponseContent.from_dict(data)
 
@@ -258,7 +258,7 @@ def test_assistant_response_content_from_dict_empty():
 
 
 def test_assistant_response_initialization():
-    """Test basic initialization of AssistantResponse"""
+    """Basic initialization of AssistantResponse"""
     content = AssistantResponseContent(assistant_response="Test response")
     response = AssistantResponse(content=content)
 
@@ -268,7 +268,7 @@ def test_assistant_response_initialization():
 
 
 def test_assistant_response_initialization_with_dict_content():
-    """Test initialization with dictionary content"""
+    """Initialization with dictionary content"""
     response = AssistantResponse(content={"assistant_response": "Dict content"})
 
     assert isinstance(response.content, AssistantResponseContent)
@@ -276,7 +276,7 @@ def test_assistant_response_initialization_with_dict_content():
 
 
 def test_assistant_response_initialization_with_none_content():
-    """Test initialization with None content creates empty content"""
+    """Initialization with None content creates empty content"""
     response = AssistantResponse(content=None)
 
     assert isinstance(response.content, AssistantResponseContent)
@@ -284,13 +284,13 @@ def test_assistant_response_initialization_with_none_content():
 
 
 def test_assistant_response_content_validation_invalid_type():
-    """Test content validation raises TypeError for invalid types"""
+    """Content validation raises TypeError for invalid types"""
     with pytest.raises(TypeError, match="content must be dict or AssistantResponseContent"):
         AssistantResponse(content="invalid string")
 
 
 def test_assistant_response_sender_recipient():
-    """Test custom sender and recipient"""
+    """Custom sender and recipient"""
     content = AssistantResponseContent(assistant_response="Test")
     response = AssistantResponse(
         content=content,
@@ -303,7 +303,7 @@ def test_assistant_response_sender_recipient():
 
 
 def test_from_response_anthropic():
-    """Test from_response with Anthropic format"""
+    """from_response with Anthropic format"""
     response = AnthropicResponse(
         content=[AnthropicTextContent(type="text", text="Anthropic response")]
     )
@@ -316,7 +316,7 @@ def test_from_response_anthropic():
 
 
 def test_from_response_openai_chat():
-    """Test from_response with OpenAI chat format"""
+    """from_response with OpenAI chat format"""
     response = OpenAIChatResponse(
         choices=[OpenAIChoice(message=OpenAIMessage(content="OpenAI response"))]
     )
@@ -333,7 +333,7 @@ def test_from_response_openai_chat():
 
 
 def test_from_response_raw_string():
-    """Test from_response with raw string"""
+    """from_response with raw string"""
     assistant_response = AssistantResponse.from_response("Plain text response")
 
     assert assistant_response.content.assistant_response == "Plain text response"
@@ -341,7 +341,7 @@ def test_from_response_raw_string():
 
 
 def test_from_response_list_of_responses():
-    """Test from_response with list of responses"""
+    """from_response with list of responses"""
     responses = [
         {"content": [{"type": "text", "text": "First "}]},
         {"content": [{"type": "text", "text": "Second"}]},
@@ -354,7 +354,7 @@ def test_from_response_list_of_responses():
 
 
 def test_from_response_default_recipient():
-    """Test from_response sets default recipient to USER"""
+    """from_response sets default recipient to USER"""
     response = "Test"
     assistant_response = AssistantResponse.from_response(response)
 
@@ -362,7 +362,7 @@ def test_from_response_default_recipient():
 
 
 def test_from_response_custom_recipient():
-    """Test from_response with custom recipient"""
+    """from_response with custom recipient"""
     response = "Test"
     assistant_response = AssistantResponse.from_response(response, recipient="system")
 
@@ -370,7 +370,7 @@ def test_from_response_custom_recipient():
 
 
 def test_from_response_preserves_all_formats():
-    """Test from_response with various formats"""
+    """from_response with various formats"""
     test_cases = [
         (
             ClaudeCodeResponse(result="Claude response"),
@@ -399,7 +399,7 @@ def test_from_response_preserves_all_formats():
 
 
 def test_model_response_property_access():
-    """Test model_response property accesses metadata"""
+    """model_response property accesses metadata"""
     model_data = {"choices": [{"message": {"content": "Test"}}]}
     response = AssistantResponse(
         content=AssistantResponseContent(assistant_response="Test"),
@@ -410,14 +410,14 @@ def test_model_response_property_access():
 
 
 def test_model_response_property_empty():
-    """Test model_response property returns empty dict if not set"""
+    """model_response property returns empty dict if not set"""
     response = AssistantResponse(content=AssistantResponseContent(assistant_response="Test"))
 
     assert response.model_response == {}
 
 
 def test_model_response_property_from_response():
-    """Test model_response is populated by from_response"""
+    """model_response is populated by from_response"""
     original_response = OpenAIChatResponse(
         choices=[OpenAIChoice(message=OpenAIMessage(content="Test"))],
         model="gpt-4",
@@ -432,7 +432,7 @@ def test_model_response_property_from_response():
 
 
 def test_assistant_response_complete_workflow():
-    """Test complete workflow from raw response to message"""
+    """Complete workflow from raw response to message"""
     # Simulate real API response
     api_response = AnthropicResponse(
         content=[
@@ -453,7 +453,7 @@ def test_assistant_response_complete_workflow():
 
 
 def test_assistant_response_streaming_simulation():
-    """Test handling streaming-like responses"""
+    """Handling streaming-like responses"""
     # Simulate stream chunks
     chunks = [
         OpenAIChatResponse(choices=[OpenAIChoice(delta=OpenAIDelta(content="Hello"))]),
@@ -469,7 +469,7 @@ def test_assistant_response_streaming_simulation():
 
 
 def test_assistant_response_empty_response():
-    """Test handling completely empty response"""
+    """Handling completely empty response"""
     response = AssistantResponse.from_response("")
 
     assert response.content.assistant_response == ""
@@ -477,14 +477,14 @@ def test_assistant_response_empty_response():
 
 
 def test_assistant_response_content_rendering():
-    """Test content rendering through rendered property"""
+    """Content rendering through rendered property"""
     response = AssistantResponse.from_response("Test content for rendering")
 
     assert response.content.rendered == "Test content for rendering"
 
 
 def test_assistant_response_role_immutable():
-    """Test that role is always ASSISTANT"""
+    """Role is always ASSISTANT."""
     response = AssistantResponse(content=AssistantResponseContent(assistant_response="Test"))
 
     assert response.role == MessageRole.ASSISTANT
@@ -492,7 +492,7 @@ def test_assistant_response_role_immutable():
 
 
 def test_parse_assistant_response_none_values():
-    """Test parsing response with None values doesn't crash"""
+    """Parsing response with None values doesn't crash"""
     response = {"content": None}
 
     text, model_response = parse_assistant_response(response)
@@ -502,7 +502,7 @@ def test_parse_assistant_response_none_values():
 
 
 def test_parse_assistant_response_malformed_structure():
-    """Test parsing with unexpected structure"""
+    """Parsing with unexpected structure"""
     response = {"unexpected_field": "value"}
 
     text, model_response = parse_assistant_response(response)
@@ -513,7 +513,7 @@ def test_parse_assistant_response_malformed_structure():
 
 
 def test_assistant_response_dataclass_slots():
-    """Test that AssistantResponseContent uses slots"""
+    """AssistantResponseContent uses slots."""
     content = AssistantResponseContent(assistant_response="Test")
 
     # Verify slots behavior - should not be able to add arbitrary attributes
@@ -522,7 +522,7 @@ def test_assistant_response_dataclass_slots():
 
 
 def test_from_response_with_complex_nested_structure():
-    """Test from_response handles complex nested structures"""
+    """from_response handles complex nested structures"""
     complex_response = {
         "content": [
             {"type": "text", "text": "Part 1"},
@@ -540,7 +540,7 @@ def test_from_response_with_complex_nested_structure():
 
 
 def test_model_response_is_readonly_through_property():
-    """Test that model_response property provides read access to metadata"""
+    """model_response property provides read access to metadata."""
     response = AssistantResponse.from_response("Test")
 
     model_response = response.model_response

--- a/tests/protocols/messages/test_instruction.py
+++ b/tests/protocols/messages/test_instruction.py
@@ -27,7 +27,7 @@ class NestedRequestModel(BaseModel):
 
 
 def test_instruction_content_basic_initialization():
-    """Test basic initialization of InstructionContent"""
+    """Basic initialization of InstructionContent"""
     content = InstructionContent(instruction="Test instruction")
 
     assert content.instruction == "Test instruction"
@@ -62,7 +62,7 @@ def test_instruction_content_all_fields():
 
 
 def test_instruction_content_rendered_text_only():
-    """Test rendered property returns minimal_yaml formatted text"""
+    """Rendered property returns minimal_yaml formatted text"""
     content = InstructionContent(instruction="Test instruction", guidance="Test guidance")
 
     rendered = content.rendered
@@ -72,7 +72,7 @@ def test_instruction_content_rendered_text_only():
 
 
 def test_instruction_content_rendered_with_context():
-    """Test rendered property includes context items"""
+    """Rendered property includes context items"""
     content = InstructionContent(
         instruction="Test",
         prompt_context=["context1", {"nested": "context"}],
@@ -84,7 +84,7 @@ def test_instruction_content_rendered_with_context():
 
 
 def test_instruction_content_rendered_with_response_format():
-    """Test rendered property includes response format as JSON example"""
+    """Rendered property includes response format as JSON example"""
     content = InstructionContent(
         instruction="Test",
         response_format={"name": "John", "age": 30},
@@ -99,7 +99,7 @@ def test_instruction_content_rendered_with_response_format():
 
 
 def test_instruction_content_rendered_plain_content_override():
-    """Test plain_content bypasses structured rendering"""
+    """plain_content bypasses structured rendering"""
     content = InstructionContent(
         instruction="This should be ignored",
         guidance="Also ignored",
@@ -112,7 +112,7 @@ def test_instruction_content_rendered_plain_content_override():
 
 
 def test_instruction_content_rendered_with_images():
-    """Test rendered property returns list[dict] when images present"""
+    """Rendered property returns list[dict] when images present"""
     content = InstructionContent(
         instruction="Analyze this image",
         images=["https://example.com/image.jpg"],
@@ -129,7 +129,7 @@ def test_instruction_content_rendered_with_images():
 
 
 def test_instruction_content_rendered_multiple_images():
-    """Test rendered property with multiple images"""
+    """Rendered property with multiple images"""
     content = InstructionContent(
         instruction="Compare these images",
         images=["image1.jpg", "data:image/png;base64,abc123", "image3.jpg"],
@@ -143,7 +143,7 @@ def test_instruction_content_rendered_multiple_images():
 
 
 def test_instruction_content_image_detail_auto():
-    """Test image_detail defaults to 'auto' when images present"""
+    """image_detail defaults to 'auto' when images present"""
     content = InstructionContent(instruction="Test", images=["image.jpg"], image_detail="auto")
 
     rendered = content.rendered
@@ -151,7 +151,7 @@ def test_instruction_content_image_detail_auto():
 
 
 def test_instruction_content_base64_image_handling():
-    """Test base64 images are properly formatted"""
+    """Base64 images are properly formatted"""
     base64_str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
     content = InstructionContent(instruction="Test", images=[base64_str], image_detail="high")
 
@@ -161,7 +161,7 @@ def test_instruction_content_base64_image_handling():
 
 
 def test_from_dict_basic():
-    """Test from_dict with basic fields"""
+    """from_dict with basic fields"""
     data = {"instruction": "Do this", "guidance": "Carefully"}
     content = InstructionContent.from_dict(data)
 
@@ -170,7 +170,7 @@ def test_from_dict_basic():
 
 
 def test_from_dict_with_context():
-    """Test from_dict with context as list"""
+    """from_dict with context as list"""
     data = {"instruction": "Test", "context": ["ctx1", "ctx2"]}
     content = InstructionContent.from_dict(data)
 
@@ -179,7 +179,7 @@ def test_from_dict_with_context():
 
 
 def test_from_dict_context_single_item():
-    """Test from_dict with context as single item (converts to list)"""
+    """from_dict with context as single item (converts to list)"""
     data = {"instruction": "Test", "context": "single_context"}
     content = InstructionContent.from_dict(data)
 
@@ -188,7 +188,7 @@ def test_from_dict_context_single_item():
 
 
 def test_from_dict_with_tool_schemas():
-    """Test from_dict with tool_schemas"""
+    """from_dict with tool_schemas"""
     schemas = [{"name": "tool1"}, {"name": "tool2"}]
     data = {"instruction": "Test", "tool_schemas": schemas}
     content = InstructionContent.from_dict(data)
@@ -198,7 +198,7 @@ def test_from_dict_with_tool_schemas():
 
 
 def test_from_dict_with_images():
-    """Test from_dict with images"""
+    """from_dict with images"""
     data = {
         "instruction": "Test",
         "images": ["img1.jpg", "img2.jpg"],
@@ -211,7 +211,7 @@ def test_from_dict_with_images():
 
 
 def test_from_dict_images_default_detail():
-    """Test from_dict sets image_detail to 'auto' when images present but detail not specified"""
+    """from_dict sets image_detail to 'auto' when images present but detail not specified"""
     data = {"instruction": "Test", "images": ["img.jpg"]}
     content = InstructionContent.from_dict(data)
 
@@ -219,7 +219,7 @@ def test_from_dict_images_default_detail():
 
 
 def test_from_dict_with_pydantic_model_instance():
-    """Test from_dict with Pydantic model class for response_format"""
+    """from_dict with Pydantic model class for response_format"""
     # Pass the CLASS to from_dict for proper schema generation
     data = {"instruction": "Test", "response_format": SampleRequestModel}
     content = InstructionContent.from_dict(data)
@@ -230,7 +230,7 @@ def test_from_dict_with_pydantic_model_instance():
 
 
 def test_from_dict_with_pydantic_model_class():
-    """Test from_dict with Pydantic model class for response_format"""
+    """from_dict with Pydantic model class for response_format"""
     data = {"instruction": "Test", "response_format": SampleRequestModel}
     content = InstructionContent.from_dict(data)
 
@@ -242,7 +242,7 @@ def test_from_dict_with_pydantic_model_class():
 
 
 def test_from_dict_with_nested_pydantic_model():
-    """Test from_dict with nested Pydantic model"""
+    """from_dict with nested Pydantic model"""
     data = {"instruction": "Test", "response_format": NestedRequestModel}
     content = InstructionContent.from_dict(data)
 
@@ -253,7 +253,7 @@ def test_from_dict_with_nested_pydantic_model():
 
 
 def test_from_dict_pydantic_model_auto_derives_response_format():
-    """Test from_dict derives schema via structure from Pydantic model"""
+    """from_dict derives schema via structure from Pydantic model"""
     data = {"instruction": "Test", "response_format": SampleRequestModel}
     content = InstructionContent.from_dict(data)
 
@@ -265,7 +265,7 @@ def test_from_dict_pydantic_model_auto_derives_response_format():
 
 
 def test_from_dict_with_dict_response_schema():
-    """Test from_dict with dict response_schema"""
+    """from_dict with dict response_schema"""
     schema = {"type": "object", "properties": {"field": {"type": "string"}}}
     data = {"instruction": "Test", "response_format": schema}
     content = InstructionContent.from_dict(data)
@@ -274,7 +274,7 @@ def test_from_dict_with_dict_response_schema():
 
 
 def test_from_dict_with_explicit_response_format():
-    """Test from_dict with explicit response_format dict"""
+    """from_dict with explicit response_format dict"""
     rf = {"name": "example", "age": 25}
     data = {"instruction": "Test", "response_format": rf}
     content = InstructionContent.from_dict(data)
@@ -283,7 +283,7 @@ def test_from_dict_with_explicit_response_format():
 
 
 def test_from_dict_response_format_overrides_auto_derive():
-    """Test explicit response_format prevents auto-derivation from Pydantic model"""
+    """Explicit response_format prevents auto-derivation from Pydantic model"""
     rf = {"custom": "format"}
     data = {
         "instruction": "Test",
@@ -296,7 +296,7 @@ def test_from_dict_response_format_overrides_auto_derive():
 
 
 def test_from_dict_invalid_response_schema_type():
-    """Test from_dict silently ignores invalid response_format type (fuzzy handling)"""
+    """from_dict silently ignores invalid response_format type (fuzzy handling)"""
     data = {"instruction": "Test", "response_format": "invalid"}
 
     # Fuzzy handling: invalid types are silently ignored
@@ -305,7 +305,7 @@ def test_from_dict_invalid_response_schema_type():
 
 
 def test_from_dict_invalid_response_format_type():
-    """Test from_dict silently ignores invalid response_format type (fuzzy handling)"""
+    """from_dict silently ignores invalid response_format type (fuzzy handling)"""
     data = {"instruction": "Test", "response_format": "invalid"}
 
     # Fuzzy handling: invalid types are silently ignored
@@ -314,7 +314,7 @@ def test_from_dict_invalid_response_format_type():
 
 
 def test_from_dict_empty_dict():
-    """Test from_dict with empty dict creates default InstructionContent"""
+    """from_dict with empty dict creates default InstructionContent"""
     content = InstructionContent.from_dict({})
 
     assert content.instruction is None
@@ -323,7 +323,7 @@ def test_from_dict_empty_dict():
 
 
 def test_instruction_basic_initialization():
-    """Test basic initialization of Instruction message"""
+    """Basic initialization of Instruction message"""
     instruction = Instruction(
         content={"instruction": "Test instruction"},
         sender="user",
@@ -547,7 +547,7 @@ def test_instruction_serialization():
 
 
 def test_minimal_yaml_rendering_strips_empty_fields():
-    """Test minimal_yaml rendering strips None, empty lists, empty dicts"""
+    """minimal_yaml rendering strips None, empty lists, empty dicts"""
     content = InstructionContent(
         instruction="Test",
         guidance=None,  # Should be stripped
@@ -562,7 +562,7 @@ def test_minimal_yaml_rendering_strips_empty_fields():
 
 
 def test_minimal_yaml_rendering_includes_non_empty_fields():
-    """Test minimal_yaml includes all non-empty fields"""
+    """minimal_yaml includes all non-empty fields"""
     content = InstructionContent(
         instruction="Do this",
         guidance="Be careful",
@@ -579,7 +579,7 @@ def test_minimal_yaml_rendering_includes_non_empty_fields():
 
 
 def test_minimal_yaml_response_format_as_json_block():
-    """Test minimal_yaml renders response_format as JSON code block"""
+    """minimal_yaml renders response_format as JSON code block"""
     content = InstructionContent(
         instruction="Test",
         response_format={"key": "value", "nested": {"field": 123}},
@@ -594,7 +594,7 @@ def test_minimal_yaml_response_format_as_json_block():
 
 
 def test_minimal_yaml_response_schema_included():
-    """Test minimal_yaml includes ResponseSchema for BaseModel, ResponseFormat for dict"""
+    """minimal_yaml includes ResponseSchema for BaseModel, ResponseFormat for dict"""
     # Dict mode: only ResponseFormat (no model_json_schema available)
     schema = {"type": "object", "properties": {"name": {"type": "string"}}}
     content = InstructionContent(instruction="Test", response_format=schema)
@@ -609,7 +609,7 @@ def test_minimal_yaml_response_schema_included():
 
 
 def test_instruction_content_empty():
-    """Test empty InstructionContent renders to empty string"""
+    """Empty InstructionContent renders to empty string"""
     content = InstructionContent()
     rendered = content.rendered
 
@@ -650,7 +650,7 @@ def test_instruction_with_https_image_url():
 
 
 def test_instruction_with_data_url_image():
-    """Test data URL images are passed through correctly"""
+    """Data URL images are passed through correctly"""
     data_url = "data:image/png;base64,iVBORw0KGgo="
     instruction = Instruction(
         content={
@@ -667,7 +667,7 @@ def test_instruction_with_data_url_image():
 
 
 def test_instruction_complex_nested_context():
-    """Test deeply nested context structures"""
+    """Deeply nested context structures"""
     complex_context = {
         "level1": {"level2": {"level3": ["value1", "value2"]}},
         "array": [1, 2, 3],
@@ -685,7 +685,7 @@ def test_instruction_complex_nested_context():
 
 
 def test_instruction_large_response_format():
-    """Test large response_format structures"""
+    """Large response_format structures"""
     large_format = {f"field_{i}": f"value_{i}" for i in range(20)}
     instruction = Instruction(
         content={"instruction": "Test", "response_format": large_format},
@@ -701,7 +701,7 @@ def test_instruction_large_response_format():
 
 
 def test_from_dict_preserves_field_types():
-    """Test from_dict preserves correct field types"""
+    """from_dict preserves correct field types"""
     data = {
         "instruction": "Test",
         "context": [{"a": 1}, "string"],

--- a/tests/protocols/messages/test_manager_actions.py
+++ b/tests/protocols/messages/test_manager_actions.py
@@ -22,7 +22,7 @@ def message_manager():
 
 
 def test_clear_messages_no_system(message_manager):
-    """Test clearing messages when no system message exists"""
+    """Clearing messages when no system message exists"""
     message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
     message_manager.add_message(assistant_response="Response", sender="assistant", recipient="user")
 
@@ -32,7 +32,7 @@ def test_clear_messages_no_system(message_manager):
 
 
 def test_clear_messages_preserves_system(message_manager):
-    """Test clearing messages preserves system message"""
+    """Clearing messages preserves system message"""
     system = message_manager.add_message(system="Test system")
     message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
     message_manager.add_message(assistant_response="Response", sender="assistant", recipient="user")
@@ -44,7 +44,7 @@ def test_clear_messages_preserves_system(message_manager):
 
 
 async def test_async_add_message(message_manager):
-    """Test async message addition"""
+    """Async message addition"""
     msg = await message_manager.a_add_message(
         instruction="Test", sender="user", recipient="assistant"
     )
@@ -53,7 +53,7 @@ async def test_async_add_message(message_manager):
 
 
 async def test_async_clear_messages(message_manager):
-    """Test async clear messages"""
+    """Async clear messages"""
     message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
     assert len(message_manager.messages) == 1
 
@@ -62,7 +62,7 @@ async def test_async_clear_messages(message_manager):
 
 
 def test_last_response(message_manager):
-    """Test last_response property"""
+    """last_response property"""
     assert message_manager.last_response is None
 
     message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
@@ -80,7 +80,7 @@ def test_last_response(message_manager):
 
 
 def test_last_instruction(message_manager):
-    """Test last_instruction property"""
+    """last_instruction property"""
     assert message_manager.last_instruction is None
 
     instruction1 = message_manager.add_message(
@@ -98,7 +98,7 @@ def test_last_instruction(message_manager):
 
 
 def test_assistant_responses_property(message_manager):
-    """Test assistant_responses property"""
+    """assistant_responses property"""
     assert len(message_manager.assistant_responses) == 0
 
     message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
@@ -119,7 +119,7 @@ def test_assistant_responses_property(message_manager):
 
 
 def test_instructions_property(message_manager):
-    """Test instructions property"""
+    """Instructions property"""
     assert len(message_manager.instructions) == 0
 
     instruction1 = message_manager.add_message(
@@ -139,7 +139,7 @@ def test_instructions_property(message_manager):
 
 
 def test_action_requests_property(message_manager):
-    """Test action_requests property"""
+    """action_requests property"""
     assert len(message_manager.action_requests) == 0
 
     request1 = message_manager.add_message(
@@ -157,7 +157,7 @@ def test_action_requests_property(message_manager):
 
 
 def test_action_responses_property(message_manager):
-    """Test action_responses property"""
+    """action_responses property"""
     assert len(message_manager.action_responses) == 0
 
     request = message_manager.add_message(
@@ -174,7 +174,7 @@ def test_action_responses_property(message_manager):
 
 
 def test_actions_property(message_manager):
-    """Test actions property (both requests and responses)"""
+    """Actions property (both requests and responses)"""
     assert len(message_manager.actions) == 0
 
     request = message_manager.add_message(

--- a/tests/protocols/messages/test_manager_hooks.py
+++ b/tests/protocols/messages/test_manager_hooks.py
@@ -197,8 +197,9 @@ def test_one_failing_sync_hook_does_not_prevent_others(mm: MessageManager):
 def test_sync_preflight_rejects_async_hook_before_pile_mutation(
     mm: MessageManager,
 ):
-    """R4-A MED-1 regression guard (also covered in test_manager_state.py).
-    Pinned here as part of the hooks contract suite.
+    """Regression guard for the async-hook-before-mutation contract (also
+    covered in test_manager_state.py). Pinned here as part of the hooks
+    contract suite.
     """
 
     async def async_hook(_msg):  # pragma: no cover — never invoked

--- a/tests/protocols/messages/test_manager_serialization.py
+++ b/tests/protocols/messages/test_manager_serialization.py
@@ -21,7 +21,7 @@ def message_manager():
 
 
 def test_to_chat_msgs_basic(message_manager):
-    """Test conversion to chat messages"""
+    """Conversion to chat messages"""
     message_manager.add_message(
         instruction="Test instruction", sender="user", recipient="assistant"
     )
@@ -38,7 +38,7 @@ def test_to_chat_msgs_basic(message_manager):
 
 
 def test_to_chat_msgs_with_progression(message_manager):
-    """Test conversion to chat messages with specific progression"""
+    """Conversion to chat messages with specific progression"""
     msg1 = message_manager.add_message(instruction="First", sender="user", recipient="assistant")
     msg2 = message_manager.add_message(
         assistant_response="Second", sender="assistant", recipient="user"
@@ -50,7 +50,7 @@ def test_to_chat_msgs_with_progression(message_manager):
 
 
 def test_to_chat_msgs_empty_progression(message_manager):
-    """Test conversion with empty progression"""
+    """Conversion with empty progression"""
     message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
 
     chat_msgs = message_manager.to_chat_msgs(progression=[])
@@ -58,7 +58,7 @@ def test_to_chat_msgs_empty_progression(message_manager):
 
 
 def test_to_chat_msgs_invalid_progression(message_manager):
-    """Test conversion with invalid progression raises error"""
+    """Conversion with invalid progression raises error"""
     message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
 
     with pytest.raises(ValueError, match="invalid"):
@@ -66,7 +66,7 @@ def test_to_chat_msgs_invalid_progression(message_manager):
 
 
 def test_remove_last_instruction_tool_schemas(message_manager):
-    """Test removing tool schemas from last instruction"""
+    """Removing tool schemas from last instruction"""
     instruction = message_manager.add_message(
         instruction="Test",
         tool_schemas={"tool1": {}, "tool2": {}},
@@ -80,14 +80,14 @@ def test_remove_last_instruction_tool_schemas(message_manager):
 
 
 def test_remove_last_instruction_tool_schemas_no_instruction(message_manager):
-    """Test removing tool schemas when no instruction exists leaves state unchanged"""
+    """Removing tool schemas when no instruction exists leaves state unchanged"""
     initial_count = len(message_manager.messages)
     message_manager.remove_last_instruction_tool_schemas()
     assert len(message_manager.messages) == initial_count
 
 
 def test_concat_recent_action_responses_to_instruction(message_manager):
-    """Test concatenating action responses to instruction"""
+    """Concatenating action responses to instruction"""
     instruction = message_manager.add_message(instruction="Test", context=[], sender="user")
 
     request = message_manager.add_message(action_function="func", action_arguments={})
@@ -101,7 +101,7 @@ def test_concat_recent_action_responses_to_instruction(message_manager):
 
 
 def test_progression_property(message_manager):
-    """Test progression property"""
+    """Progression property"""
     msg1 = message_manager.add_message(instruction="First", sender="user", recipient="assistant")
     msg2 = message_manager.add_message(
         assistant_response="Second", sender="assistant", recipient="user"
@@ -112,7 +112,7 @@ def test_progression_property(message_manager):
 
 
 def test_message_manager_bool(message_manager):
-    """Test bool evaluation of message manager"""
+    """Bool evaluation of message manager"""
     assert not message_manager
 
     message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
@@ -120,7 +120,7 @@ def test_message_manager_bool(message_manager):
 
 
 def test_message_manager_contains(message_manager):
-    """Test contains operator for message manager"""
+    """Contains operator for message manager"""
     msg = message_manager.add_message(instruction="Test", sender="user", recipient="assistant")
 
     assert msg in message_manager
@@ -130,7 +130,7 @@ def test_message_manager_contains(message_manager):
 
 
 def test_message_manager_with_response_format(message_manager):
-    """Test message manager with response format"""
+    """Message manager with response format"""
     instruction = message_manager.add_message(
         instruction="Test",
         response_format=RequestModel,
@@ -147,7 +147,7 @@ def test_message_manager_with_response_format(message_manager):
 
 
 def test_message_manager_with_images(message_manager):
-    """Test message manager with images"""
+    """Message manager with images"""
     instruction = message_manager.add_message(
         instruction="Describe this image",
         images=["image1.png", "image2.jpg"],
@@ -160,7 +160,7 @@ def test_message_manager_with_images(message_manager):
 
 
 def test_message_manager_with_tool_schemas(message_manager):
-    """Test message manager with tool schemas"""
+    """Message manager with tool schemas"""
     tool_schemas = {
         "tool1": {"type": "function", "function": {"name": "tool1"}},
         "tool2": {"type": "function", "function": {"name": "tool2"}},
@@ -177,7 +177,7 @@ def test_message_manager_with_tool_schemas(message_manager):
 
 
 def test_complete_conversation_flow(message_manager):
-    """Test a complete conversation flow"""
+    """A complete conversation flow"""
     system = message_manager.add_message(system="You are a helpful assistant")
     assert message_manager.system == system
 

--- a/tests/protocols/messages/test_manager_state.py
+++ b/tests/protocols/messages/test_manager_state.py
@@ -27,7 +27,7 @@ def message_manager():
 
 
 def test_message_manager_initialization():
-    """Test basic initialization of MessageManager"""
+    """Basic initialization of MessageManager"""
     manager = MessageManager()
     assert isinstance(manager.messages, Pile)
     assert not manager.messages
@@ -68,7 +68,7 @@ def test_message_manager_with_invalid_system():
 
 
 def test_set_system():
-    """Test setting and replacing system message"""
+    """Setting and replacing system message"""
     manager = MessageManager()
     system1 = System(content={"system_message": "System 1"})
     system2 = System(content={"system_message": "System 2"})
@@ -86,7 +86,7 @@ def test_set_system():
 
 
 def test_create_instruction_basic():
-    """Test creating basic instruction message"""
+    """Creating basic instruction message"""
     instruction = Instruction(
         content={"instruction": "Test instruction"},
         sender="user",
@@ -100,7 +100,7 @@ def test_create_instruction_basic():
 
 
 def test_create_instruction_with_all_params():
-    """Test creating instruction with all parameters"""
+    """Creating instruction with all parameters"""
     instruction = Instruction(
         content={
             "instruction": "Test instruction",
@@ -130,7 +130,7 @@ def test_create_instruction_with_all_params():
 
 
 def test_create_instruction_update_existing():
-    """Test updating existing instruction"""
+    """Updating existing instruction"""
     instruction = Instruction(content={"instruction": "Original"})
     instruction.update(guidance="New guidance", sender="user")
 
@@ -219,7 +219,7 @@ def test_add_message_instruction_context_replace(message_manager):
 
 
 def test_create_system_basic():
-    """Test creating basic system message"""
+    """Creating basic system message"""
     system = System(
         content={"system_message": "Test system"},
         sender="system",
@@ -233,7 +233,7 @@ def test_create_system_basic():
 
 
 def test_create_system_with_datetime():
-    """Test creating system message with datetime"""
+    """Creating system message with datetime"""
     system = System(content={"system_message": "Test system", "system_datetime": True})
 
     assert isinstance(system, System)
@@ -241,7 +241,7 @@ def test_create_system_with_datetime():
 
 
 def test_create_system_update_existing():
-    """Test updating existing system message"""
+    """Updating existing system message"""
     system = System(content={"system_message": "Original"})
     system.update(sender="system")
 
@@ -249,7 +249,7 @@ def test_create_system_update_existing():
 
 
 def test_create_assistant_response_basic():
-    """Test creating basic assistant response"""
+    """Creating basic assistant response"""
     response = AssistantResponse(
         content={"assistant_response": "Test response"},
         sender="assistant",
@@ -263,7 +263,7 @@ def test_create_assistant_response_basic():
 
 
 def test_create_assistant_response_update_existing():
-    """Test updating existing assistant response"""
+    """Updating existing assistant response"""
     response = AssistantResponse(content={"assistant_response": "Original"})
     response.update(sender="assistant")
 
@@ -271,7 +271,7 @@ def test_create_assistant_response_update_existing():
 
 
 def test_create_action_request_basic():
-    """Test creating basic action request"""
+    """Creating basic action request"""
     request = ActionRequest(
         content={"function": "test_function", "arguments": {"arg": "value"}},
         sender="user",
@@ -286,7 +286,7 @@ def test_create_action_request_basic():
 
 
 def test_create_action_request_update_existing():
-    """Test updating existing action request"""
+    """Updating existing action request"""
     request = ActionRequest(
         content={"function": "original", "arguments": {}},
         sender="user",
@@ -298,7 +298,7 @@ def test_create_action_request_update_existing():
 
 
 def test_create_action_response_basic():
-    """Test creating basic action response"""
+    """Creating basic action response"""
     request = ActionRequest(
         content={"function": "test", "arguments": {}},
         sender="user",
@@ -323,7 +323,7 @@ def test_create_action_response_basic():
 
 
 def test_create_action_response_without_request():
-    """Test that action response requires valid request ID"""
+    """Action response requires valid request ID."""
     # ActionResponse can be created without a request, but won't have proper linking
     response = ActionResponse(
         content={
@@ -338,7 +338,7 @@ def test_create_action_response_without_request():
 
 
 def test_create_action_response_update_existing():
-    """Test updating existing action response"""
+    """Updating existing action response"""
     request = ActionRequest(
         content={"function": "test", "arguments": {}},
         sender="user",
@@ -358,7 +358,7 @@ def test_create_action_response_update_existing():
 
 
 def test_add_message_instruction(message_manager):
-    """Test adding instruction via add_message"""
+    """Adding instruction via add_message"""
     instruction = message_manager.add_message(
         instruction="Test instruction",
         context={"key": "value"},
@@ -374,7 +374,7 @@ def test_add_message_instruction(message_manager):
 
 
 def test_add_message_system(message_manager):
-    """Test adding system message via add_message"""
+    """Adding system message via add_message"""
     system = message_manager.add_message(
         system="Test system",
         sender="system",
@@ -388,7 +388,7 @@ def test_add_message_system(message_manager):
 
 
 def test_add_message_assistant_response(message_manager):
-    """Test adding assistant response via add_message"""
+    """Adding assistant response via add_message"""
     response = message_manager.add_message(
         assistant_response="Test response",
         sender="assistant",
@@ -401,7 +401,7 @@ def test_add_message_assistant_response(message_manager):
 
 
 def test_add_message_action_request(message_manager):
-    """Test adding action request via add_message"""
+    """Adding action request via add_message"""
     request = message_manager.add_message(
         action_function="test_function",
         action_arguments={"arg": "value"},
@@ -415,7 +415,7 @@ def test_add_message_action_request(message_manager):
 
 
 def test_add_message_action_response(message_manager):
-    """Test adding action response via add_message"""
+    """Adding action response via add_message"""
     # First create and add a request
     request = message_manager.add_message(
         action_function="test_function",
@@ -439,7 +439,7 @@ def test_add_message_action_response(message_manager):
 
 
 def test_add_message_with_metadata(message_manager):
-    """Test adding message with metadata"""
+    """Adding message with metadata"""
     metadata = {"custom_key": "custom_value", "priority": "high"}
     msg = message_manager.add_message(
         instruction="Test",
@@ -452,7 +452,7 @@ def test_add_message_with_metadata(message_manager):
 
 
 def test_add_message_update_existing(message_manager):
-    """Test updating existing message via add_message"""
+    """Updating existing message via add_message"""
     msg1 = message_manager.add_message(
         instruction="First version",
         sender="user",
@@ -469,7 +469,7 @@ def test_add_message_update_existing(message_manager):
 
 
 def test_add_message_multiple_types_error(message_manager):
-    """Test that adding multiple message types raises error"""
+    """Adding multiple message types raises error."""
     with pytest.raises(ValueError, match="Only one message type can be added at a time"):
         message_manager.add_message(
             instruction="Test",
@@ -480,7 +480,7 @@ def test_add_message_multiple_types_error(message_manager):
 
 
 def test_add_message_system_instruction_error(message_manager):
-    """Test that adding system and instruction together raises error"""
+    """Adding system and instruction together raises error."""
     with pytest.raises(ValueError, match="Only one message type can be added at a time"):
         message_manager.add_message(
             system="System message",
@@ -516,7 +516,7 @@ def test_sync_add_message_accepts_sync_hook(message_manager):
 
 
 def test_sync_add_message_preflight_does_not_mutate_pile(message_manager):
-    """R4-A MED-1: the async-hook guard must fire BEFORE pile mutation.
+    """The async-hook guard must fire BEFORE pile mutation.
 
     Pre-fix: add_message created and inserted the message, THEN
     _fire_on_message_added raised. Caller catching the error would
@@ -538,11 +538,11 @@ def test_sync_add_message_preflight_does_not_mutate_pile(message_manager):
 
 
 async def test_a_add_message_action_response_with_empty_output(message_manager):
-    """R4-A HIGH-3: an ActionResponse with falsey output (empty string,
-    0, False, [], {}) used to be silently dropped because the dispatch
-    branch tested ``action_output`` truthiness instead of
-    ``action_output is not None``. The ActionRequest would then be
-    re-emitted as a duplicate via the fallback branch.
+    """An ActionResponse with falsey output (empty string, 0, False, [],
+    {}) used to be silently dropped because the dispatch branch tested
+    ``action_output`` truthiness instead of ``action_output is not
+    None``. The ActionRequest would then be re-emitted as a duplicate
+    via the fallback branch.
     """
     from lionagi.protocols.messages import ActionRequest, ActionResponse
 
@@ -612,8 +612,8 @@ async def test_a_add_message_passes_through_prebuilt_action_response(
     )
 
     # The hook observed an ActionResponse whose metadata['is_error']
-    # was already True at hook time (the bug R4 closed: live persist
-    # used to see is_error=False and serialize the wrong state).
+    # was already True at hook time. Previously live persist saw
+    # is_error=False and serialized the wrong state.
     assert any(
         kind == "ActionResponse" and meta.get("is_error") is True for kind, meta in captured
     ), f"hook never observed final is_error state: {captured}"

--- a/tests/protocols/messages/test_message.py
+++ b/tests/protocols/messages/test_message.py
@@ -135,7 +135,7 @@ def test_message_content_none_as_sentinel():
 
 
 def test_roled_message_initialization():
-    """Test basic initialization of Message with MessageContent."""
+    """Basic initialization of Message with MessageContent."""
     content = _MockContent(text="Hello")
     message = _MockMessage(
         content=content,
@@ -171,7 +171,7 @@ def test_roled_message_initialization_from_dict():
 
 
 def test_roled_message_content_always_message_content():
-    """Test that content is always MessageContent, never dict."""
+    """Content is always MessageContent, never dict."""
     message = _MockMessage(content={"text": "test"})
 
     assert isinstance(message.content, MessageContent)
@@ -179,7 +179,7 @@ def test_roled_message_content_always_message_content():
 
 
 def test_roled_message_role_classvar():
-    """Test role is a ClassVar property, not an instance field."""
+    """Role is a ClassVar property, not an instance field."""
     from typing import ClassVar
 
     class _UserMessage(RoledMessage):
@@ -202,26 +202,26 @@ def test_roled_message_role_classvar():
 
 
 def test_roled_message_role_ignored_in_constructor():
-    """Test that passing role= to constructor is silently ignored."""
+    """Passing role= to constructor is silently ignored."""
     message = _MockMessage(role="user", content=_MockContent(text="test"), sender="user")
     assert message.role == MessageRole.UNSET
 
 
 def test_roled_message_role_in_serialization():
-    """Test that role appears in serialized output."""
+    """Role appears in serialized output."""
     message = _MockMessage(content=_MockContent(text="test"))
     d = message.to_dict()
     assert d["role"] == "unset"
 
 
 def test_roled_message_role_default():
-    """Test default role is UNSET."""
+    """Default role is UNSET."""
     message = _MockMessage(content=_MockContent(text="test"))
     assert message.role == MessageRole.UNSET
 
 
 def test_roled_message_sender_recipient_validation():
-    """Test sender and recipient validation."""
+    """Sender and recipient validation."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="test"),
@@ -234,7 +234,7 @@ def test_roled_message_sender_recipient_validation():
 
 
 def test_roled_message_sender_recipient_string():
-    """Test sender and recipient with string values."""
+    """Sender and recipient with string values."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="test"),
@@ -247,7 +247,7 @@ def test_roled_message_sender_recipient_string():
 
 
 def test_roled_message_sender_recipient_none():
-    """Test sender and recipient with None values."""
+    """Sender and recipient with None values."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="test"),
@@ -280,7 +280,7 @@ def test_roled_message_chat_msg_property():
 
 
 def test_roled_message_chat_msg_property_error_handling():
-    """Test chat_msg property returns None on error."""
+    """chat_msg property returns None on error."""
     # This test assumes chat_msg can fail gracefully
     # In practice, it should work for valid messages
     message = _MockMessage(role=MessageRole.USER, content=_MockContent(text="Hello"))
@@ -289,7 +289,7 @@ def test_roled_message_chat_msg_property_error_handling():
 
 
 def test_roled_message_image_content_property():
-    """Test image_content property returns None for text content."""
+    """image_content property returns None for text content."""
     message = _MockMessage(role=MessageRole.USER, content=_MockContent(text="Hello"))
 
     # For simple text content, image_content should be None
@@ -297,7 +297,7 @@ def test_roled_message_image_content_property():
 
 
 def test_roled_message_update_sender():
-    """Test update() method updates sender."""
+    """Update() method updates sender."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="Hello"),
@@ -309,7 +309,7 @@ def test_roled_message_update_sender():
 
 
 def test_roled_message_update_recipient():
-    """Test update() method updates recipient."""
+    """Update() method updates recipient."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="Hello"),
@@ -321,7 +321,7 @@ def test_roled_message_update_recipient():
 
 
 def test_roled_message_update_content():
-    """Test update() method updates content via from_dict()."""
+    """Update() method updates content via from_dict()."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="Original", metadata={"version": 1}),
@@ -336,7 +336,7 @@ def test_roled_message_update_content():
 
 
 def test_roled_message_update_multiple_fields():
-    """Test update() method updates multiple fields at once."""
+    """Update() method updates multiple fields at once."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="Original"),
@@ -352,7 +352,7 @@ def test_roled_message_update_multiple_fields():
 
 
 def test_roled_message_update_preserves_other_fields():
-    """Test update() preserves fields not being updated."""
+    """Update() preserves fields not being updated."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="Original", metadata={"key": "value"}),
@@ -387,7 +387,7 @@ def test_roled_message_to_dict():
 
 
 def test_roled_message_serialization_to_dict():
-    """Test serialization of RoledMessage to dict."""
+    """Serialization of RoledMessage to dict."""
     message = _MockMessage(role=MessageRole.USER, content=_MockContent(text="test"), sender="user")
 
     serialized = message.to_dict()
@@ -396,7 +396,7 @@ def test_roled_message_serialization_to_dict():
 
 
 def test_roled_message_str_representation():
-    """Test string representation of RoledMessage."""
+    """String representation of RoledMessage."""
     message = _MockMessage(
         role=MessageRole.USER,
         content=_MockContent(text="test"),
@@ -411,25 +411,25 @@ def test_roled_message_str_representation():
 
 
 def test_validate_sender_recipient_message_role():
-    """Test validate_sender_recipient with MessageRole."""
+    """validate_sender_recipient with MessageRole."""
     result = validate_sender_recipient(MessageRole.USER)
     assert result == MessageRole.USER
 
 
 def test_validate_sender_recipient_string():
-    """Test validate_sender_recipient with valid string."""
+    """validate_sender_recipient with valid string."""
     result = validate_sender_recipient("user")
     assert result == MessageRole.USER
 
 
 def test_validate_sender_recipient_none():
-    """Test validate_sender_recipient with None."""
+    """validate_sender_recipient with None."""
     result = validate_sender_recipient(None)
     assert result == MessageRole.UNSET
 
 
 def test_message_workflow_complete():
-    """Test complete message workflow: create, update, serialize."""
+    """Complete message workflow: create, update, serialize."""
     # Create message
     message = _MockMessage(
         role=MessageRole.USER,
@@ -454,7 +454,7 @@ def test_message_workflow_complete():
 
 
 def test_message_content_immutability_via_update():
-    """Test that content updates create new instances via from_dict()."""
+    """Content updates create new instances via from_dict()."""
     message = _MockMessage(role=MessageRole.USER, content=_MockContent(text="Original"))
 
     original_content = message.content

--- a/tests/protocols/messages/test_system.py
+++ b/tests/protocols/messages/test_system.py
@@ -7,7 +7,7 @@ from lionagi.protocols.types import MessageRole, System
 
 
 def test_systemcontent_initialization():
-    """Test basic initialization of SystemContent dataclass"""
+    """Basic initialization of SystemContent dataclass"""
     # Default initialization
     content = SystemContent()
     assert content.system_message == "You are a helpful AI assistant. Let's think step by step."
@@ -25,7 +25,7 @@ def test_systemcontent_initialization():
 
 
 def test_systemcontent_slots():
-    """Test that SystemContent uses slots for memory efficiency"""
+    """SystemContent uses slots for memory efficiency."""
     content = SystemContent()
 
     assert not hasattr(content, "__dict__")
@@ -35,7 +35,7 @@ def test_systemcontent_slots():
 
 
 def test_systemcontent_rendered_without_datetime():
-    """Test rendered property without datetime"""
+    """Rendered property without datetime"""
     content = SystemContent(system_message="Test message")
 
     rendered = content.rendered
@@ -44,7 +44,7 @@ def test_systemcontent_rendered_without_datetime():
 
 
 def test_systemcontent_rendered_with_datetime():
-    """Test rendered property with datetime"""
+    """Rendered property with datetime"""
     content = SystemContent(system_message="Test message", system_datetime="2024-01-01T12:00")
 
     rendered = content.rendered
@@ -121,7 +121,7 @@ def test_systemcontent_from_dict_partial():
 
 
 def test_system_initialization():
-    """Test basic initialization of System"""
+    """Basic initialization of System"""
     system_msg = "Test system message"
     system = System(content=SystemContent(system_message=system_msg))
 
@@ -173,7 +173,7 @@ def test_system_with_custom_datetime():
 
 
 def test_system_update():
-    """Test updating System message"""
+    """Updating System message"""
     system = System(content={"system_message": "Initial message"})
 
     new_message = "Updated message"
@@ -210,7 +210,7 @@ def test_system_with_default_message():
 
 
 def test_system_str_representation():
-    """Test string representation of System"""
+    """String representation of System"""
     system = System(content={"system_message": "Test message"})
 
     str_repr = str(system)
@@ -221,7 +221,7 @@ def test_system_str_representation():
 
 
 def test_system_message_load():
-    """Test loading System from dictionary"""
+    """Loading System from dictionary"""
     protected_params = {
         "role": MessageRole.SYSTEM,
         "content": {"system_message": "Test message"},
@@ -310,7 +310,7 @@ def test_system_content_validator_with_invalid_type():
 
 
 def test_system_complete_workflow():
-    """Test complete workflow with System and SystemContent"""
+    """Complete workflow with System and SystemContent"""
     # Create system with datetime
     system = System(
         content={
@@ -337,7 +337,7 @@ def test_system_complete_workflow():
 
 
 def test_system_datetime_scenarios():
-    """Test all datetime scenarios in one comprehensive test"""
+    """All datetime scenarios in one comprehensive test"""
     # Scenario 1: datetime=True (auto-generate)
     sys1 = System(content={"system_message": "Test", "system_datetime": True})
     assert sys1.content.system_datetime is not None

--- a/tests/protocols/messages/test_to_dict_mode_contract.py
+++ b/tests/protocols/messages/test_to_dict_mode_contract.py
@@ -18,9 +18,7 @@ from lionagi.protocols.types import MessageRole
 MODES = ["python", "json", "db"]
 
 
-# ---------------------------------------------------------------------------
 # System
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -58,9 +56,7 @@ def test_system_python_mode_uses_metadata(system_msg):
     assert "node_metadata" not in d
 
 
-# ---------------------------------------------------------------------------
 # Instruction
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -97,9 +93,7 @@ def test_instruction_db_mode_uses_node_metadata(instruction_msg):
     assert "metadata" not in d
 
 
-# ---------------------------------------------------------------------------
 # AssistantResponse
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -132,9 +126,7 @@ def test_assistant_response_db_mode_uses_node_metadata(assistant_msg):
     assert "metadata" not in d
 
 
-# ---------------------------------------------------------------------------
 # ActionRequest
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -183,9 +175,7 @@ def test_action_request_with_response_id_roundtrip():
         assert restored.content.action_response_id == "resp-abc"
 
 
-# ---------------------------------------------------------------------------
 # ActionResponse
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -240,9 +230,7 @@ def test_action_response_with_error_roundtrip():
         assert restored.content.output is None
 
 
-# ---------------------------------------------------------------------------
 # Cross-mode parity: python and db modes produce equal restored objects
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(

--- a/tests/protocols/messages/test_utils.py
+++ b/tests/protocols/messages/test_utils.py
@@ -129,7 +129,7 @@ def test_instructioncontent_from_dict_with_images():
 
 
 def test_validate_sender_recipient(sample_element):
-    """Test sender/recipient validation"""
+    """Sender/recipient validation"""
     assert validate_sender_recipient(MessageRole.SYSTEM) == MessageRole.SYSTEM
     assert validate_sender_recipient(MessageRole.USER) == MessageRole.USER
 

--- a/tests/protocols/test_event_schema_drift.py
+++ b/tests/protocols/test_event_schema_drift.py
@@ -3,27 +3,22 @@
 
 """Event/signal schema drift gate (ADR-0033, ADR-0003).
 
-Regression class this guards against: the reactive-bus signal payloads
-(``lionagi.session.signal``), the in-process event execution status
-vocabulary (``lionagi.protocols.generic.event.EventStatus``), and the flow
-executor's own completion event (``lionagi.operations.flow.FlowEvent``)
-change shape silently -- a field gets renamed, removed, or an enum member is
-dropped -- and nothing in the suite notices until a downstream consumer (the
-Studio bus renderer, the CLI progress projector, a persisted signal replay,
-``flow_signals.py``'s ``NodeQueued(...)`` construction call) breaks on a
-``KeyError``/``AttributeError``/``ValidationError`` far away from the actual
-change.
+Guards against the reactive-bus signal payloads (``lionagi.session.signal``),
+``EventStatus`` (``lionagi.protocols.generic.event``), and the flow
+executor's ``FlowEvent`` (``lionagi.operations.flow``) changing shape
+silently -- a field renamed, removed, or an enum member dropped -- with
+nothing noticing until a downstream consumer (Studio's bus renderer, the
+CLI progress projector, a persisted signal replay, ``flow_signals.py``'s
+``NodeQueued(...)`` call) breaks far from the actual change.
 
-These tests pin the CURRENT, empirically-observed shape of every exported
-signal class, the ``EventStatus`` enum, the per-node ``NodeLifecycleState``
-vocabulary, and ``FlowEvent`` so any drift fails loudly, in this file, at the
-point of change -- and constructively instantiate every signal from its
-documented fields so a construction-site break (e.g. inside
-``lionagi/engines/flow_signals.py``) is caught here too.
+These tests pin the current, empirically-observed shape of every exported
+signal class, ``EventStatus``, ``NodeLifecycleState``, and ``FlowEvent``,
+and construct each signal from its documented fields so a construction-site
+break (e.g. inside ``lionagi/engines/flow_signals.py``) is caught here too.
 
 An intentional schema change bumps ``SIGNAL_SCHEMA_VERSION`` in
-``lionagi/session/signal.py`` and updates the golden tables below in the same
-change.
+``lionagi/session/signal.py`` and updates the golden tables below in the
+same change.
 """
 
 from __future__ import annotations
@@ -57,9 +52,7 @@ from lionagi.session.signal import (
     StructuredOutput,
 )
 
-# ---------------------------------------------------------------------------
 # 1. Signal module export surface
-# ---------------------------------------------------------------------------
 
 # The full exported name set from lionagi.session.signal (ADR-0033). Adding
 # or removing a signal type -- or renaming lane_for/build_run_end -- is a
@@ -101,9 +94,7 @@ def test_signal_schema_version_golden():
     assert Signal().schema_version == 1
 
 
-# ---------------------------------------------------------------------------
 # 2. Per-class field-set goldens (sorted field-name shape)
-# ---------------------------------------------------------------------------
 
 # Sorted field-name set per pydantic Signal subclass, empirically pinned via
 # `cls.model_fields.keys()`. Inherited Element/Signal fields (id, created_at,
@@ -314,9 +305,7 @@ def test_signal_payload_goldens_cover_every_exported_signal_class():
     assert exported_signal_classes == set(_SIGNAL_CLASSES)
 
 
-# ---------------------------------------------------------------------------
 # 3. Constructive: every signal is instantiable from its documented fields
-# ---------------------------------------------------------------------------
 
 # Field -> representative sample value, keyed by the exact field names used
 # across the payload-contract table in the lionagi/session/signal.py module
@@ -373,9 +362,7 @@ def test_signal_constructible_from_documented_fields(name):
     assert instance.schema_version == signal_mod.SIGNAL_SCHEMA_VERSION
 
 
-# ---------------------------------------------------------------------------
 # 4. EventStatus vocabulary + transition invariants (ADR-0003)
-# ---------------------------------------------------------------------------
 
 EXPECTED_EVENT_STATUS_VALUES = (
     "pending",
@@ -458,9 +445,7 @@ def test_event_status_setter_rejects_unknown_value():
         ev.status = "not-a-real-status"
 
 
-# ---------------------------------------------------------------------------
 # 5. NodeLifecycleState vocabulary + terminal-lane invariants (ADR-0033)
-# ---------------------------------------------------------------------------
 
 EXPECTED_NODE_LIFECYCLE_STATES = (
     "queued",
@@ -487,9 +472,7 @@ def test_node_lifecycle_terminal_lane_set_golden():
     assert signal_mod._TERMINAL == EXPECTED_NODE_LIFECYCLE_TERMINAL
 
 
-# ---------------------------------------------------------------------------
 # 6. FlowEvent shape (lionagi/operations/flow.py)
-# ---------------------------------------------------------------------------
 
 EXPECTED_FLOW_EVENT_FIELDS = ("operation_id", "name", "status", "result", "spawned")
 EXPECTED_FLOW_EVENT_STATUS_VALUES = frozenset({"completed", "failed", "skipped"})

--- a/tests/protocols/test_primitive_invariants.py
+++ b/tests/protocols/test_primitive_invariants.py
@@ -4,22 +4,20 @@
 """Invariant/property tests for the four core primitives: Pile, Progression,
 Element, and Graph.
 
-Regression class this guards against: these primitives sit on every hot path
-(message history, tool piles, the DAG executor) and keep attracting
-performance-motivated cleanups — swapping a linear scan for a dict lookup,
-caching a computed view, batching a lock acquisition. Each of those changes is
-"obviously behavior preserving" in isolation, but the actual contracts here
-(insertion-order iteration, Pile/Progression independence, exact serialization
-round-tripping, adjacency-mapping consistency under mutation) are enforced by
-convention across many call sites, not by a single invariant check. A cleanup
-that quietly breaks ordering, thread-safety, serialization, or adjacency
-consistency ships green and is only discovered downstream, far from the
-change that caused it.
+These primitives sit on every hot path (message history, tool piles, the
+DAG executor) and keep attracting performance cleanups -- a linear scan
+swapped for a dict lookup, a computed view cached, a lock acquisition
+batched -- that look behavior-preserving in isolation. The actual contracts
+here (insertion-order iteration, Pile/Progression independence, exact
+serialization round-tripping, adjacency-mapping consistency under mutation)
+are enforced by convention across many call sites, not a single invariant
+check, so a cleanup that quietly breaks one ships green and is only caught
+downstream.
 
-Every assertion below pins CURRENT, empirically observed behavior (including
-behavior that looks like a footgun, e.g. KeyError on iterate-while-mutate) —
-it is not aspirational. If a future change deliberately alters one of these
-contracts, the test (and this docstring) should be updated alongside it.
+Every assertion pins CURRENT, empirically observed behavior, including
+footguns like KeyError on iterate-while-mutate -- it is not aspirational.
+Update the test and this docstring together if a contract deliberately
+changes.
 """
 
 from __future__ import annotations
@@ -49,9 +47,7 @@ class MyNode(Node):
     of depending on the test module's own import path."""
 
 
-# ---------------------------------------------------------------------------
 # 1. Pile — ordering, O(1) access, thread-safety, async iteration
-# ---------------------------------------------------------------------------
 
 
 class TestPileOrderingInvariants:
@@ -297,9 +293,7 @@ class TestPileIterationMutationContract:
         assert fresh_order == [items[0].id, *[i.id for i in items[2:]]]
 
 
-# ---------------------------------------------------------------------------
 # 2. Progression / Pile independence
-# ---------------------------------------------------------------------------
 
 
 class TestProgressionPileIndependence:
@@ -362,9 +356,7 @@ class TestProgressionPileIndependence:
             assert len(prog) == len(items)
 
 
-# ---------------------------------------------------------------------------
 # 3. Element.to_dict / from_dict roundtrips
-# ---------------------------------------------------------------------------
 
 
 class TestElementToDictRoundtrip:
@@ -472,9 +464,7 @@ class TestElementToDictRoundtrip:
                 assert restored.metadata.get(k) == v
 
 
-# ---------------------------------------------------------------------------
 # 4. Graph adjacency consistency
-# ---------------------------------------------------------------------------
 
 
 class TestGraphAdjacencyConsistency:


### PR DESCRIPTION
Doc-only cleanup across the typed-core test scope (tests/protocols, tests/models, tests/adapters, tests/casts) — no assertions, imports, or test behavior changed.

- Removed 282 decoration-only comment banners (pure dash/equals divider lines and `# --- title ---` markers), keeping the section labels.
- Stripped a "Test that ..." / "Tests ..." / "Testing ..." narration prefix from 260 docstrings that only restated the test name.
- Compressed two dense module docstrings (test_event_schema_drift.py, test_primitive_invariants.py) to keep every fact while cutting redundant phrasing.
- Removed internal tracking-style labels ("R4-A HIGH-3", "R4-A MED-1", "D3"/"D5"/"D6") from docstrings/comments in tests/protocols/messages/test_manager_state.py, tests/protocols/messages/test_manager_hooks.py, tests/protocols/action/test_tool_invoke_hooks.py, and tests/protocols/graph/test_node_edge_cases.py, keeping the underlying regression rationale.
- Fixed a stale copy-pasted module docstring in tests/protocols/graph/test_graph_primitives.py that described a different file's contents.

Every touched file verified doc-only via ast_equal.py against HEAD.