### PR TITLE
chore(tests): trim prose in libs/ln/tools/hooks/agent/lndl test suites

### DIFF
--- a/tests/agent/test_coding_preset_guard.py
+++ b/tests/agent/test_coding_preset_guard.py
@@ -9,20 +9,11 @@ import pytest
 
 from lionagi.agent.spec import AgentSpec
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 async def _make_branch(spec: AgentSpec):
     from lionagi.agent.factory import create_agent
 
     return await create_agent(spec, load_settings=False)
-
-
-# ---------------------------------------------------------------------------
-# AgentSpec.coding() — destructive-command guard
-# ---------------------------------------------------------------------------
 
 
 async def test_coding_preset_blocks_rm_rf():
@@ -106,11 +97,6 @@ async def test_coding_preset_guard_destructive_in_hook_handlers():
     assert not spec.hook_handlers.get("pre:bash"), (
         "guard_destructive must not also be registered in the ordinary pre:bash bucket"
     )
-
-
-# ---------------------------------------------------------------------------
-# Path-policy tests — the "strict path policy" claim must be functionally true
-# ---------------------------------------------------------------------------
 
 
 async def _invoke_pre_hooks(branch, tool_name: str, args: dict) -> None:
@@ -214,11 +200,6 @@ async def test_coding_preset_secure_false_no_path_guard():
     assert not spec.hook_handlers.get("pre:editor")
 
 
-# ---------------------------------------------------------------------------
-# Relative-path tests (guard_paths resolves against workspace root, not cwd)
-# ---------------------------------------------------------------------------
-
-
 async def test_coding_preset_reader_allows_relative_in_workspace(tmp_path):
     """A workspace-relative reader path ("src/foo.py") must be allowed."""
     spec = AgentSpec.coding(cwd=str(tmp_path))
@@ -263,11 +244,9 @@ async def test_coding_preset_editor_blocks_relative_traversal(tmp_path):
         )
 
 
-# ---------------------------------------------------------------------------
 # GateResult unification (ADR-0086 delta row 1) — the built-in coding guards
 # now get the same security -> user -> security recheck a PermissionPolicy
 # has always gotten, closing the mutation-gap asymmetry.
-# ---------------------------------------------------------------------------
 
 
 async def test_coding_preset_guard_rechecks_command_mutated_by_user_hook(tmp_path):
@@ -380,14 +359,6 @@ async def test_coding_preset_evaluator_exception_fails_closed(tmp_path):
     bash_tool = branch.acts.registry["bash"]
     with pytest.raises(PermissionError, match="evaluator error"):
         await bash_tool.preprocessor({"action": "run", "command": "echo hi"})
-
-
-# ---------------------------------------------------------------------------
-# Symlink-escape tests driven through the bound AgentSpec.coding() preprocessor
-# (proves the canonical containment helper is wired end-to-end via the
-# security_pre / GateResult path, not just the guard_paths() factory closure
-# in isolation).
-# ---------------------------------------------------------------------------
 
 
 async def test_coding_preset_reader_blocks_symlink_escaping_workspace(tmp_path):

--- a/tests/agent/test_factory.py
+++ b/tests/agent/test_factory.py
@@ -12,18 +12,9 @@ from lionagi.agent.factory import create_agent
 from lionagi.agent.spec import AgentSpec
 from lionagi.session.branch import Branch
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 async def _make(config: AgentSpec) -> Branch:
     return await create_agent(config, load_settings=False)
-
-
-# ---------------------------------------------------------------------------
-# Default config
-# ---------------------------------------------------------------------------
 
 
 async def test_create_agent_default_config_returns_branch():
@@ -46,11 +37,6 @@ async def test_create_agent_default_no_coding_tools():
         "subagent",
     }
     assert not coding_tools.intersection(branch.acts.registry.keys())
-
-
-# ---------------------------------------------------------------------------
-# Coding preset
-# ---------------------------------------------------------------------------
 
 
 # Lean default plus context — sandbox/subagent are opt-in, not registered by default.
@@ -81,11 +67,6 @@ async def test_create_agent_coding_all_tools_async():
     branch = await _make(config)
     for name, tool in branch.acts.registry.items():
         assert asyncio.iscoroutinefunction(tool.func_callable), f"Tool '{name}' is not async"
-
-
-# ---------------------------------------------------------------------------
-# Permissions wired as preprocessor
-# ---------------------------------------------------------------------------
 
 
 async def test_create_agent_with_permissions_sets_preprocessor():
@@ -274,11 +255,6 @@ async def test_create_agent_standalone_permissions_recheck_user_mutated_args():
         await bash_tool.preprocessor({"action": "run", "command": "echo ok"})
 
 
-# ---------------------------------------------------------------------------
-# load_settings=False — no side effects
-# ---------------------------------------------------------------------------
-
-
 async def test_create_agent_load_settings_false_no_side_effects(monkeypatch):
     """load_settings=False must not read .lionagi/settings.yaml."""
     called = []
@@ -356,11 +332,6 @@ async def test_create_agent_autoloads_project_mcp_when_trusted(tmp_path, monkeyp
     assert security_seen == [MCPSecurityConfig.trusted()]
 
 
-# ---------------------------------------------------------------------------
-# Hooks wired into tools
-# ---------------------------------------------------------------------------
-
-
 async def test_pre_hook_registered_on_tool():
     config = AgentSpec.coding()
     calls = []
@@ -397,11 +368,6 @@ async def test_post_hook_registered_on_tool():
     assert "reader" in calls
 
 
-# ---------------------------------------------------------------------------
-# Model string parsed into provider / model / effort / yolo kwargs
-# ---------------------------------------------------------------------------
-
-
 async def test_create_agent_parses_model_provider_effort_and_yolo_kwargs(monkeypatch):
     import lionagi.cli._providers as providers_mod
     import lionagi.service.imodel as imodel_mod
@@ -428,11 +394,6 @@ async def test_create_agent_parses_model_provider_effort_and_yolo_kwargs(monkeyp
     assert captured.get("stream") is True
 
 
-# ---------------------------------------------------------------------------
-# trust_project_settings=False prevents project settings from loading
-# ---------------------------------------------------------------------------
-
-
 async def test_create_agent_does_not_load_project_settings_without_trust(tmp_path, monkeypatch):
     import lionagi.agent.settings as settings_mod
 
@@ -454,11 +415,6 @@ async def test_create_agent_does_not_load_project_settings_without_trust(tmp_pat
     assert calls == [False], f"load_settings called with include_project={calls}"
 
 
-# ---------------------------------------------------------------------------
-# _chain_post_hooks ignores non-dict hook returns; dict returns update result
-# ---------------------------------------------------------------------------
-
-
 async def test_agent_post_hooks_ignore_non_dict_results_and_keep_previous_result():
     """Non-dict hook return is ignored; a subsequent dict return is applied."""
     from lionagi.agent.factory import _chain_post_hooks
@@ -476,12 +432,10 @@ async def test_agent_post_hooks_ignore_non_dict_results_and_keep_previous_result
     assert final == {"ok": 2}
 
 
-# ---------------------------------------------------------------------------
 # model spec without "/" — provider resolves from settings default, not the
 # bare model string (a bare model used to become its own garbage provider,
 # which construction never rejected — it silently fell through to a generic
 # Endpoint and only failed later with a missing-API-key error).
-# ---------------------------------------------------------------------------
 
 
 async def test_create_agent_model_without_slash_uses_settings_default_provider(monkeypatch):
@@ -548,12 +502,10 @@ async def test_create_agent_backends_alias_unaffected(monkeypatch):
     assert captured.get("model") == "sonnet"
 
 
-# ---------------------------------------------------------------------------
 # spec.cwd forwarded into the CLI provider request's repo/workspace field —
 # every CLI provider's request model runs its subprocess against `repo`
 # (defaults to the calling process cwd), so a workspace assigned via
 # spec.cwd must reach it or the agent silently runs in the host cwd instead.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -596,11 +548,6 @@ async def test_create_agent_no_cwd_does_not_set_repo_kwarg(monkeypatch):
     assert "repo" not in captured
 
 
-# ---------------------------------------------------------------------------
-# system_prompt without lion_system (line 104)
-# ---------------------------------------------------------------------------
-
-
 async def test_create_agent_system_prompt_without_lion_system():
     config = AgentSpec.compose("implementer", system_prompt="You are a helpful assistant.")
     config.lion_system = False
@@ -608,11 +555,6 @@ async def test_create_agent_system_prompt_without_lion_system():
     sys_msg = branch.msgs.system
     assert sys_msg is not None
     assert "helpful assistant" in sys_msg.rendered
-
-
-# ---------------------------------------------------------------------------
-# _apply_permissions: non-PermissionPolicy non-dict → returns early (lines 127-130)
-# ---------------------------------------------------------------------------
 
 
 async def test_apply_permissions_invalid_type_returns_early():
@@ -624,21 +566,11 @@ async def test_apply_permissions_invalid_type_returns_early():
     assert config.hook_handlers.get("security_pre:*", []) == []
 
 
-# ---------------------------------------------------------------------------
-# _chain_pre_hooks: no hooks → returns None (line 158)
-# ---------------------------------------------------------------------------
-
-
 def test_chain_pre_hooks_no_hooks_returns_none():
     from lionagi.agent.factory import _chain_pre_hooks
 
     result = _chain_pre_hooks("tool", [], [])
     assert result is None
-
-
-# ---------------------------------------------------------------------------
-# _chain_pre_hooks: hook returns dict → args updated (line 165)
-# ---------------------------------------------------------------------------
 
 
 async def test_chain_pre_hooks_dict_return_updates_args():
@@ -653,11 +585,6 @@ async def test_chain_pre_hooks_dict_return_updates_args():
     assert result["cmd"] == "ls"
 
 
-# ---------------------------------------------------------------------------
-# _chain_post_hooks: non-dict initial result bypasses hooks (line 176)
-# ---------------------------------------------------------------------------
-
-
 async def test_chain_post_hooks_non_dict_result_returned_unchanged():
     from lionagi.agent.factory import _chain_post_hooks
 
@@ -667,11 +594,6 @@ async def test_chain_post_hooks_non_dict_result_returned_unchanged():
     chained = _chain_post_hooks("tool", [hook])
     result = await chained("plain string result")
     assert result == "plain string result"
-
-
-# ---------------------------------------------------------------------------
-# standalone tools: reader, editor, search registration (lines 196, 206-228)
-# ---------------------------------------------------------------------------
 
 
 async def test_create_agent_registers_standalone_reader():
@@ -704,11 +626,6 @@ async def test_attach_hooks_adds_postprocessor_for_standalone_tool():
     assert tool.postprocessor is not None
 
 
-# ---------------------------------------------------------------------------
-# _register_coding_tools: malformed key (line 243) and error phase (lines 253-254)
-# ---------------------------------------------------------------------------
-
-
 async def test_register_coding_tools_skips_malformed_keys():
     config = AgentSpec.coding()
     config.hook_handlers["malformed_no_colon"] = [lambda *a: None]
@@ -726,11 +643,6 @@ async def test_register_coding_tools_error_hook_wired():
     config.on_error("bash", my_error)
     branch = await _make(config)
     assert isinstance(branch, Branch)
-
-
-# ---------------------------------------------------------------------------
-# _load_mcp: explicit mcp_config_path (lines 279-281)
-# ---------------------------------------------------------------------------
 
 
 async def test_load_mcp_explicit_config_path_used(tmp_path, monkeypatch):
@@ -752,11 +664,6 @@ async def test_load_mcp_explicit_config_path_used(tmp_path, monkeypatch):
     await create_agent(config, load_settings=False)
 
     assert calls == [str(mcp_file)]
-
-
-# ---------------------------------------------------------------------------
-# _load_mcp: trust_project_settings + .lionagi dir stops search (line 291)
-# ---------------------------------------------------------------------------
 
 
 async def test_load_mcp_breaks_at_lionagi_dir(tmp_path, monkeypatch):
@@ -787,14 +694,7 @@ async def test_load_mcp_breaks_at_lionagi_dir(tmp_path, monkeypatch):
     assert calls and calls[0] == str(mcp_file)
 
 
-# ---------------------------------------------------------------------------
 # Search tool workspace containment wiring (regression)
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Forwarding AgentSpec MCP fields into the claude_code CLI's own request
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)

--- a/tests/agent/test_factory_external_hooks.py
+++ b/tests/agent/test_factory_external_hooks.py
@@ -195,13 +195,6 @@ def test_multiple_entries_wire_independently():
     assert len(branch._hooks.handlers_for(HookPoint.USER_PROMPT_SUBMIT)) == 1
 
 
-# ---------------------------------------------------------------------------
-# Session-bus wiring: create_agent() always builds a standalone branch with
-# no HookBus yet; a configured UserPromptSubmit hook must still fire once
-# that branch joins a Session (the only thing that ever attaches a bus).
-# ---------------------------------------------------------------------------
-
-
 class _FakeStream:
     """Minimal async-read stand-in for a StreamReader: returns *data* on the
     first ``read()`` call, then EOF -- matches how ``_read_capped``'s
@@ -328,12 +321,10 @@ async def test_user_prompt_submit_hook_survives_reparent_to_another_session(monk
         )
 
 
-# ---------------------------------------------------------------------------
 # Cross-branch isolation: a session's HookBus is shared by every branch it
 # owns, so a branch-owned external handler must not fire for another
 # branch's event, and a reparented/removed branch must not leave a stale
 # registration behind on its old session's bus.
-# ---------------------------------------------------------------------------
 
 
 async def test_two_branches_with_different_hooks_do_not_observe_each_others_prompts(

--- a/tests/agent/test_gate_fault_is_not_a_verdict.py
+++ b/tests/agent/test_gate_fault_is_not_a_verdict.py
@@ -35,11 +35,6 @@ def _policy(**kw) -> PermissionPolicy:
     return PermissionPolicy(mode="rules", **kw)
 
 
-# --------------------------------------------------------------------------
-# the escalate decision, which is where the two were conflated
-# --------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_escalate_without_a_handler_is_a_fault():
     hook = _policy(escalate={"bash": ["*"]}).to_pre_hook()
@@ -95,11 +90,6 @@ async def test_an_allowed_call_is_untouched():
     assert await hook("bash", "run", {"command": "ls -la"}) is None
 
 
-# --------------------------------------------------------------------------
-# what the gate layer does with each
-# --------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_the_gate_marks_a_declared_fault_errored():
     hook = _policy(escalate={"bash": ["*"]}).to_pre_hook()
@@ -134,11 +124,6 @@ async def test_an_unexpected_exception_stays_errored():
     assert result.allowed is False
     assert result.errored is True
     assert "evaluator error" in result.reason
-
-
-# --------------------------------------------------------------------------
-# the flag has readers, which is the other half of the row
-# --------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_hooks.py
+++ b/tests/agent/test_hooks.py
@@ -85,11 +85,6 @@ async def test_guard_paths_allows_unrelated_path(tmp_path):
     assert result is None
 
 
-# ---------------------------------------------------------------------------
-# Glob deny patterns
-# ---------------------------------------------------------------------------
-
-
 async def test_guard_paths_glob_deny_blocks_key_file(tmp_path):
     """'*.key' deny pattern must block files whose name matches via fnmatch component matching."""
     hook = guard_paths(denied_paths=["*.key"])
@@ -124,10 +119,8 @@ async def test_guard_paths_glob_deny_blocks_dotenv(tmp_path):
         await hook("reader", "read", {"path": str(tmp_path / ".env")})
 
 
-# ---------------------------------------------------------------------------
 # GLOB_CHARS security: only "*?[" trigger fnmatch; "~{}" stay in substring mode
 # so patterns like "secret~" correctly block "mysecret~backup" via containment.
-# ---------------------------------------------------------------------------
 
 
 async def test_guard_paths_tilde_deny_uses_substring_mode(tmp_path):
@@ -149,11 +142,6 @@ async def test_guard_paths_tilde_deny_allows_unrelated(tmp_path):
     hook = guard_paths(denied_paths=["secret~"])
     result = await hook("reader", "read", {"path": str(tmp_path / "config.py")})
     assert result is None
-
-
-# ---------------------------------------------------------------------------
-# Canonical workspace containment: symlink escapes and DENIED_NAMES floor
-# ---------------------------------------------------------------------------
 
 
 async def test_guard_paths_blocks_direct_symlink_escaping_workspace(tmp_path):

--- a/tests/agent/test_nudge.py
+++ b/tests/agent/test_nudge.py
@@ -16,21 +16,12 @@ from lionagi.agent.nudge import (
 from lionagi.service.token_budget import TokenBudget
 from lionagi.session.branch import Branch
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _make_engine(monkeypatch, used: int, limit: int, rules=None) -> NudgeEngine:
     branch = Branch()
     budget = TokenBudget(used=used, limit=limit)
     monkeypatch.setattr(nudge_mod, "get_token_budget", lambda b: budget)
     return NudgeEngine(branch, rules=rules)
-
-
-# ---------------------------------------------------------------------------
-# Default rule set: status (always)
-# ---------------------------------------------------------------------------
 
 
 def test_status_rule_fires_every_call(monkeypatch):
@@ -47,20 +38,10 @@ def test_status_rule_includes_evicted_and_action_result_counts(monkeypatch):
     assert "0 messages" in msg  # empty branch, no evicted/action results shown
 
 
-# ---------------------------------------------------------------------------
-# Default rule set: budget_critical (always)
-# ---------------------------------------------------------------------------
-
-
 def test_critical_rule_fires_every_call(monkeypatch):
     engine = _make_engine(monkeypatch, used=95_000, limit=100_000)  # 95% -> critical
     msgs = [engine.evaluate() for _ in range(3)]
     assert all("nearly full" in m for m in msgs)
-
-
-# ---------------------------------------------------------------------------
-# Default rule set: budget_warning (cooldown 5), mutually exclusive with critical
-# ---------------------------------------------------------------------------
 
 
 def test_warning_rule_does_not_fire_when_critical(monkeypatch):
@@ -82,11 +63,6 @@ def test_warning_rule_cooldown_suppresses_then_refires(monkeypatch):
 
     sixth = engine.evaluate()  # call_count=6, last fired at 1 -> 6-1=5 >= cooldown(5)
     assert "Consider evicting" in sixth
-
-
-# ---------------------------------------------------------------------------
-# Default rule set: jit_guidance (once)
-# ---------------------------------------------------------------------------
 
 
 def test_jit_guidance_fires_exactly_once(monkeypatch):
@@ -157,11 +133,6 @@ def test_jit_guidance_does_not_fire_below_threshold(monkeypatch):
     assert ContextTool.GUIDANCE not in (msg or "")
 
 
-# ---------------------------------------------------------------------------
-# Bash failure streak (cooldown 10)
-# ---------------------------------------------------------------------------
-
-
 def test_bash_failure_streak_requires_three_consecutive_failures(monkeypatch):
     engine = _make_engine(monkeypatch, used=100, limit=100_000)
     engine.record_call("bash", "", False)
@@ -211,11 +182,6 @@ def test_bash_failure_streak_ignores_successes():
     assert BASH_FAILURE_RULE.condition(ctx) is False  # only 2 of last 3 failed
 
 
-# ---------------------------------------------------------------------------
-# NudgeContext.recent()
-# ---------------------------------------------------------------------------
-
-
 def test_context_recent_filters_by_tool_and_limits():
     calls = (
         ToolCallRecord("bash", "", True, 0.0),
@@ -239,11 +205,6 @@ def test_context_recent_filters_by_tool_and_limits():
     last_two = ctx.recent("bash", 2)
     assert len(last_two) == 2
     assert [c.ok for c in last_two] == [False, False]
-
-
-# ---------------------------------------------------------------------------
-# Priority ordering + token-cap dropping
-# ---------------------------------------------------------------------------
 
 
 def test_priority_ordering_and_token_cap_drops_lowest_priority(monkeypatch):
@@ -281,11 +242,6 @@ def test_merge_preserves_priority_order_when_all_fit(monkeypatch):
     assert msg.index("B") < msg.index("C") < msg.index("A")
 
 
-# ---------------------------------------------------------------------------
-# Rules that never fire -> None
-# ---------------------------------------------------------------------------
-
-
 def test_no_rules_returns_none(monkeypatch):
     engine = _make_engine(monkeypatch, used=0, limit=100_000, rules=[])
     assert engine.evaluate() is None
@@ -297,21 +253,11 @@ def test_all_conditions_false_returns_none(monkeypatch):
     assert engine.evaluate() is None
 
 
-# ---------------------------------------------------------------------------
-# default_nudge_rules() returns independent instances
-# ---------------------------------------------------------------------------
-
-
 def test_default_nudge_rules_are_fresh_each_call():
     a = default_nudge_rules()
     b = default_nudge_rules()
     assert a is not b
     assert [r.id for r in a] == [r.id for r in b]
-
-
-# ---------------------------------------------------------------------------
-# Per-rule exception containment — a raising rule never breaks evaluate()
-# ---------------------------------------------------------------------------
 
 
 def test_raising_condition_is_contained_other_rules_still_fire(monkeypatch):

--- a/tests/agent/test_permissions.py
+++ b/tests/agent/test_permissions.py
@@ -29,11 +29,6 @@ def test_deny_all_rejects_any_tool():
         assert p.check(tool, action, args).behavior == "deny"
 
 
-# ---------------------------------------------------------------------------
-# Preset: read_only
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "tool,action,args",
     [
@@ -59,11 +54,6 @@ def test_read_only_denies(tool, action, args):
     assert p.check(tool, action, args).behavior == "deny"
 
 
-# ---------------------------------------------------------------------------
-# Preset: safe
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "cmd,expected",
     [
@@ -85,11 +75,6 @@ def test_safe_allows_non_bash():
     assert p.check("editor", "write", {"file_path": "/tmp/f.py"}).behavior == "allow"
 
 
-# ---------------------------------------------------------------------------
-# Custom rules: deny > allow > escalate ordering
-# ---------------------------------------------------------------------------
-
-
 def test_deny_beats_allow_when_both_match():
     p = PermissionPolicy(mode="rules", allow={"bash": ["git *"]}, deny={"bash": ["git *"]})
     assert p.check("bash", "run", {"command": "git status"}).behavior == "deny"
@@ -105,11 +90,6 @@ def test_default_deny_when_no_rule_matches():
     d = p.check("bash", "run", {"command": "pytest tests/"})
     assert d.behavior == "deny"
     assert "no matching rule" in d.reason
-
-
-# ---------------------------------------------------------------------------
-# fnmatch pattern matching
-# ---------------------------------------------------------------------------
 
 
 def test_fnmatch_wildcard_matches_any():
@@ -133,11 +113,6 @@ def test_shell_control_operator_denied():
     assert d.behavior == "deny"
 
 
-# ---------------------------------------------------------------------------
-# to_pre_hook
-# ---------------------------------------------------------------------------
-
-
 async def test_pre_hook_raises_on_deny():
     hook = PermissionPolicy.deny_all().to_pre_hook()
     with pytest.raises(PermissionError):
@@ -155,11 +130,6 @@ async def test_pre_hook_escalate_without_handler_raises():
         await hook("bash", "run", {"command": "uv run pytest"})
 
 
-# ---------------------------------------------------------------------------
-# Tool alias normalization
-# ---------------------------------------------------------------------------
-
-
 def test_tool_aliases_normalized_at_init():
     p = PermissionPolicy(
         mode="rules",
@@ -172,21 +142,11 @@ def test_tool_aliases_normalized_at_init():
     assert "reader" in p.escalate and "reader_tool" not in p.escalate
 
 
-# ---------------------------------------------------------------------------
-# Rules mode denies tool with no matching allow entry
-# ---------------------------------------------------------------------------
-
-
 def test_permission_policy_rules_default_denies_unmatched_tool():
     p = PermissionPolicy(mode="rules", allow={"reader": ["*"]})
     d = p.check("bash", "run", {"command": "pwd"})
     assert d.behavior == "deny"
     assert "no matching rule" in d.reason
-
-
-# ---------------------------------------------------------------------------
-# Shell control operator denied even under wildcard allow
-# ---------------------------------------------------------------------------
 
 
 def test_permission_policy_rejects_shell_control_before_wildcard_allow():

--- a/tests/agent/test_profile_layout.py
+++ b/tests/agent/test_profile_layout.py
@@ -11,8 +11,6 @@ import pytest
 
 from lionagi.cli._providers import _resolve_profile_path, list_agents, load_agent_profile
 
-# ── _resolve_profile_path ────────────────────────────────────────────
-
 
 def test_resolver_prefers_directory_layout(tmp_path: Path) -> None:
     agents_dir = tmp_path / "agents"
@@ -38,9 +36,6 @@ def test_resolver_returns_none_when_missing(tmp_path: Path) -> None:
     agents_dir = tmp_path / "agents"
     agents_dir.mkdir()
     assert _resolve_profile_path(agents_dir, "ghost") is None
-
-
-# ── Full loader behaviour via HOME override ──────────────────────────
 
 
 @pytest.fixture

--- a/tests/agent/test_profile_name_normalization.py
+++ b/tests/agent/test_profile_name_normalization.py
@@ -22,9 +22,6 @@ def _write(path: Path, body: str) -> Path:
     return path
 
 
-# ── per-directory resolver ───────────────────────────────────────────
-
-
 def test_hyphen_request_resolves_underscore_file(tmp_path: Path) -> None:
     agents_dir = tmp_path / "agents"
     path = _write(agents_dir / "postmortem_lead.md", "x\n")
@@ -94,9 +91,6 @@ def test_one_spelling_in_both_layouts_is_not_ambiguous(tmp_path: Path) -> None:
     _write(agents_dir / "postmortem_lead.md", "flat\n")
 
     assert _resolve_profile_path(agents_dir, "postmortem-lead") == dir_path
-
-
-# ── full loader across both lookup roots ─────────────────────────────
 
 
 @pytest.fixture

--- a/tests/agent/test_settings.py
+++ b/tests/agent/test_settings.py
@@ -51,11 +51,6 @@ def test_apply_hooks_rejects_shell_string_commands():
         apply_hooks_from_settings(AgentSpec.compose("implementer"), settings)
 
 
-# ---------------------------------------------------------------------------
-# A1: deep merge of global + project settings
-# ---------------------------------------------------------------------------
-
-
 def test_load_settings_deep_merges_global_and_project_settings(tmp_path, monkeypatch):
     home = tmp_path / "home"
     project = tmp_path / "project"
@@ -76,11 +71,6 @@ def test_load_settings_deep_merges_global_and_project_settings(tmp_path, monkeyp
     assert bash_hooks[0]["command"] == ["guard", "global"]
     assert bash_hooks[1]["command"] == ["guard", "local"]
     assert settings["permissions"]["mode"] == "rules"
-
-
-# ---------------------------------------------------------------------------
-# A2: cwd parent discovery
-# ---------------------------------------------------------------------------
 
 
 def test_load_settings_discovers_parent_project_settings_from_cwd(tmp_path, monkeypatch):
@@ -116,11 +106,6 @@ def test_load_settings_discovers_parent_of_explicit_project_dir(tmp_path, monkey
     assert settings["notifications"]["enabled"] is True
 
 
-# ---------------------------------------------------------------------------
-# A3: untrusted python hook rejected via explicit trusted_hook_modules
-# ---------------------------------------------------------------------------
-
-
 def test_apply_hooks_from_settings_rejects_untrusted_python_hook():
     settings = {"hooks": {"pre": {"bash": [{"python": "os:path"}]}}}
 
@@ -130,11 +115,6 @@ def test_apply_hooks_from_settings_rejects_untrusted_python_hook():
             settings,
             trusted_hook_modules={"lionagi.agent.hooks"},
         )
-
-
-# ---------------------------------------------------------------------------
-# A4: shell pre hook raises PermissionError on nonzero subprocess exit
-# ---------------------------------------------------------------------------
 
 
 async def test_shell_pre_hook_raises_permission_error_on_nonzero_exit(monkeypatch):
@@ -153,11 +133,6 @@ async def test_shell_pre_hook_raises_permission_error_on_nonzero_exit(monkeypatc
 
     with pytest.raises(PermissionError, match="blocked"):
         await hook("bash", "run", {"file_path": "test.py"})
-
-
-# ---------------------------------------------------------------------------
-# Timed-out hook subprocess termination: kills process group, awaits cleanup
-# ---------------------------------------------------------------------------
 
 
 async def test_pre_hook_timeout_kills_process_group(monkeypatch):
@@ -216,13 +191,11 @@ async def test_post_hook_timeout_kills_process_group(monkeypatch):
     assert killed, "Expected killpg to be called after post-hook timeout"
 
 
-# ---------------------------------------------------------------------------
 # aterminate_process_group must never signal the init/session process group.
 # A test double (or a not-yet-spawned proc) whose ``pid`` coerces to 1 via
 # __index__ would make os.killpg(1, ...) signal process group 1 — which on a
 # CI runner contains the test process itself, SIGKILLing the whole run. Only a
 # real child pid (> 1) may be signalled.
-# ---------------------------------------------------------------------------
 
 
 def test_kill_proc_group_ignores_unreal_pid(monkeypatch):

--- a/tests/agent/test_settings_coverage.py
+++ b/tests/agent/test_settings_coverage.py
@@ -16,10 +16,6 @@ from lionagi.agent.settings import (
 )
 from lionagi.agent.spec import AgentSpec
 
-# ---------------------------------------------------------------------------
-# _import_hook: untrusted module raises, no colon returns None, ImportError
-# ---------------------------------------------------------------------------
-
 
 def test_import_hook_no_colon_returns_none():
     result = _import_hook("lionagi.agent.hooks", trusted_hook_modules={"lionagi.agent.hooks"})
@@ -53,11 +49,6 @@ def test_import_hook_nonexistent_module_in_trusted_set_returns_none():
         trusted_hook_modules={"lionagi.agent.hooks_nonexistent"},
     )
     assert result is None
-
-
-# ---------------------------------------------------------------------------
-# _resolve_hook_spec: string shorthand, dict without python/command → None
-# ---------------------------------------------------------------------------
 
 
 def test_resolve_hook_spec_string_shorthand_trusted():
@@ -98,11 +89,6 @@ def test_resolve_hook_spec_dict_command_returns_callable():
         trusted_hook_modules={"lionagi.agent.hooks"},
     )
     assert callable(result)
-
-
-# ---------------------------------------------------------------------------
-# _make_shell_hook: post hook path exercised
-# ---------------------------------------------------------------------------
 
 
 async def test_make_shell_post_hook_runs_and_returns_none(monkeypatch):
@@ -162,11 +148,6 @@ async def test_make_shell_pre_hook_nonzero_empty_stderr_uses_fallback(monkeypatc
     hook = _make_shell_hook(["guard"], "pre", "bash")
     with pytest.raises(PermissionError, match="Hook blocked"):
         await hook("bash", "run", {})
-
-
-# ---------------------------------------------------------------------------
-# apply_hooks_from_settings: non-list hook_specs wrapped, all phases wired
-# ---------------------------------------------------------------------------
 
 
 def test_apply_hooks_from_settings_wraps_single_dict_in_list():

--- a/tests/agent/test_settings_external_hooks.py
+++ b/tests/agent/test_settings_external_hooks.py
@@ -86,12 +86,6 @@ def test_parse_external_hooks_multiple_events_and_matchers():
     assert events == {"PreToolUse", "SessionStart"}
 
 
-# ---------------------------------------------------------------------------
-# apply_hooks_from_settings: hooks_external lands on config.external_hooks,
-# never on config.hook_handlers (the legacy shape's storage).
-# ---------------------------------------------------------------------------
-
-
 def test_apply_hooks_from_settings_populates_external_hooks_field():
     settings = {
         "hooks_external": {

--- a/tests/agent/test_spec.py
+++ b/tests/agent/test_spec.py
@@ -11,10 +11,6 @@ from lionagi.agent.spec import AgentSpec, _resolve_permissions
 from lionagi.casts.profile import Profile
 from lionagi.session.branch import Branch
 
-# ---------------------------------------------------------------------------
-# _resolve_permissions
-# ---------------------------------------------------------------------------
-
 
 class TestResolvePermissions:
     def test_none(self):
@@ -52,11 +48,6 @@ class TestResolvePermissions:
             _resolve_permissions(42)
 
 
-# ---------------------------------------------------------------------------
-# AgentSpec.compose
-# ---------------------------------------------------------------------------
-
-
 class TestAgentSpecCompose:
     def test_basic(self):
         spec = AgentSpec.compose("analyst")
@@ -83,11 +74,6 @@ class TestAgentSpecCompose:
         assert spec.effort == "high"
 
 
-# ---------------------------------------------------------------------------
-# AgentSpec.coding preset
-# ---------------------------------------------------------------------------
-
-
 class TestAgentSpecCoding:
     def test_coding_preset(self):
         spec = AgentSpec.coding()
@@ -110,12 +96,6 @@ class TestAgentSpecCoding:
         spec = AgentSpec.coding(role="reviewer")
         assert spec.profile.role.name == "reviewer"
         assert "coding" in spec.tools
-
-
-# ---------------------------------------------------------------------------
-# Role -> Policy Binding Contract: fail-closed when a valid role has no
-# policy entry in the active pack; empty-but-present entry stays silent.
-# ---------------------------------------------------------------------------
 
 
 class TestRolePolicyBindingContract:
@@ -165,11 +145,6 @@ class TestRolePolicyBindingContract:
         assert "## Authority" not in msg
 
 
-# ---------------------------------------------------------------------------
-# AgentSpec.build_system_message
-# ---------------------------------------------------------------------------
-
-
 class TestAgentSpecSystemMessage:
     def test_contains_role_body(self):
         spec = AgentSpec.compose("analyst")
@@ -204,11 +179,6 @@ class TestAgentSpecSystemMessage:
         )
         msg = spec.build_system_message()
         assert "Be concise." in msg
-
-
-# ---------------------------------------------------------------------------
-# AgentSpec.emission_operable
-# ---------------------------------------------------------------------------
 
 
 class TestAgentSpecEmission:
@@ -259,11 +229,6 @@ class TestAgentSpecEmission:
         assert spec.emits == (Finding,)
 
 
-# ---------------------------------------------------------------------------
-# Hook methods
-# ---------------------------------------------------------------------------
-
-
 class TestAgentSpecHooks:
     def test_pre(self):
         spec = AgentSpec.compose("analyst")
@@ -300,11 +265,6 @@ class TestAgentSpecHooks:
 
         result = spec.pre("bash", h)
         assert result is spec
-
-
-# ---------------------------------------------------------------------------
-# Factory: create_agent with AgentSpec
-# ---------------------------------------------------------------------------
 
 
 class TestCreateAgentWithSpec:
@@ -360,11 +320,6 @@ class TestCreateAgentWithSpec:
         spec = AgentSpec.compose("analyst")
         await create_agent(spec, load_settings=False)
         assert calls == []
-
-
-# ---------------------------------------------------------------------------
-# YAML round-trip
-# ---------------------------------------------------------------------------
 
 
 class TestAgentSpecYaml:

--- a/tests/hooks/test_api_call_hookpoints.py
+++ b/tests/hooks/test_api_call_hookpoints.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""ADR-0047 delta row 2 (issue #1965): API_PRE_CALL / API_POST_CALL / API_STREAM_CHUNK
+"""ADR-0047 delta row 2: API_PRE_CALL / API_POST_CALL / API_STREAM_CHUNK
 gain a real emit site through the typed, optional service-to-session adapter in
 ``operations/_api_hooks.py``, wired at ``operations/chat/chat.py`` (one-shot API
 calls) and ``operations/run/run.py`` (CLI streaming). A standalone iModel (no
@@ -61,9 +61,6 @@ def _make_fake_cli_model(chunks: list[StreamChunk]) -> iModel:
 
     m.stream = stream
     return m
-
-
-# ── chat() (one-shot API path) ───────────────────────────────────────────────
 
 
 async def test_chat_emits_api_pre_and_post_call_on_success():
@@ -195,9 +192,6 @@ async def test_chat_without_session_bus_does_not_crash():
     assert result == "hello"
 
 
-# ── run() (CLI streaming path) ───────────────────────────────────────────────
-
-
 async def test_run_emits_pre_call_stream_chunks_and_post_call():
     branch = Branch()
     branch.chat_model = _make_fake_cli_model(
@@ -322,7 +316,7 @@ async def test_chat_api_post_call_never_leaks_secret_shaped_error_text():
     assert secret not in json_dumps(post)
 
 
-# ── unified pairing/field invariant ──────────────────────────────────────────
+# unified pairing/field invariant
 #
 # Every API_PRE_CALL is followed by exactly one API_POST_CALL carrying
 # whatever is actually known at that point about how the call ended:
@@ -455,9 +449,6 @@ async def test_api_post_call_field_invariant_holds_across_exit_paths(scenario):
         assert post["status"] in ("failed", "error")
 
 
-# ── closed telemetry payload (issue #1965 fix leg r3) ───────────────────────
-
-
 async def test_api_post_call_closed_payload_scrubs_secret_shaped_marker_everywhere():
     """SessionObserver-backed probe: a settled call whose status object,
     tokens mapping, model name, and provider name all carry the SAME
@@ -522,9 +513,6 @@ async def test_api_post_call_closed_payload_preserves_legitimate_values():
     assert post["status"] == "completed"
 
 
-# ── multi-turn usage accumulation (issue #1965 fix leg r3) ──────────────────
-
-
 async def test_run_accumulates_usage_across_multiple_flush_windows():
     """Codex splits one run() call into multiple flush windows (a tool-call
     round-trip forces a flush between "result" chunks) and reports marginal
@@ -586,9 +574,6 @@ async def test_run_single_result_chunk_usage_unaffected_by_accumulator():
 
     post = calls[HookPoint.API_POST_CALL][0]
     assert post["tokens"] == {"input_tokens": 5, "output_tokens": 3}
-
-
-# ── stream chunk_type redaction (issue #1965 fix leg r4) ────────────────────
 
 
 async def test_api_stream_chunk_scrubs_secret_shaped_marker_in_chunk_type():
@@ -673,9 +658,6 @@ async def test_api_stream_chunk_redacts_prefixless_credential_chunk_type():
     payload = _sanitize_signal_payload(observer.by_type(HookSignal)[0])
     assert secret not in json_dumps(payload)
     assert payload["kwargs"]["chunk_type"] == "unknown"
-
-
-# ── fix-forward: emit-site numeric / logging / credential-shape hardening ────
 
 
 def test_typed_usage_drops_non_finite_counts_without_raising():

--- a/tests/hooks/test_builtins.py
+++ b/tests/hooks/test_builtins.py
@@ -21,9 +21,6 @@ def _make_mock_db():
     return AsyncMock()
 
 
-# ── persist_message: one logical persistence event ───────────────────────────
-
-
 async def test_persist_message_appends_to_branch_progression():
     msg = {"id": "msg1", "role": "user", "content": "hi"}
     mock_db = _make_mock_db()
@@ -225,9 +222,6 @@ async def test_explicit_message_hook_retries_middle_transaction_failure(
     state_db_module._SHARED.pop(null_url, None)
 
 
-# ── persist_session_start: running status must carry a reason_code ─────────────
-
-
 class TestPersistSessionStartReasonCode:
     """persist_session_start must write a reason_code or the bus silently drops every provenance field."""
 
@@ -288,9 +282,6 @@ class TestPersistSessionStartReasonCode:
         assert row["provider"] == "openai"
         # A canonical "started" reason was recorded, not the deprecation default.
         assert row["status_reason_code"] == RunReasons.STARTED_OK
-
-
-# ── Singleton reuse: same instance returned across multiple firings ───────────
 
 
 async def test_shared_db_returns_same_instance(tmp_path, monkeypatch):
@@ -374,9 +365,6 @@ async def test_concurrent_hook_firings_use_same_instance(tmp_path, monkeypatch):
     # Cleanup
     await first.close()
     _db_module._SHARED.pop(db_url, None)
-
-
-# ── Lifecycle hook emission: SESSION_START / SESSION_END / BRANCH_CREATE ──────
 
 
 def _redirect_shared_db(monkeypatch, tmp_path):

--- a/tests/hooks/test_bus.py
+++ b/tests/hooks/test_bus.py
@@ -9,8 +9,6 @@ import pytest
 
 from lionagi.hooks import HookBus, HookPoint, StopHook, hook
 
-# ── Basic dispatch ────────────────────────────────────────────────────────────
-
 
 async def test_emit_calls_registered_handlers_in_order():
     bus = HookBus()
@@ -58,9 +56,6 @@ async def test_off_unregistered_handler_is_noop():
     bus.off(HookPoint.MESSAGE_ADD, h)
 
 
-# ── Sync handlers accepted ────────────────────────────────────────────────────
-
-
 async def test_sync_handler_runs_without_await():
     bus = HookBus()
     calls: list[int] = []
@@ -71,9 +66,6 @@ async def test_sync_handler_runs_without_await():
     bus.on(HookPoint.SESSION_END, sync_handler)
     await bus.emit(HookPoint.SESSION_END, session_id="s", status="completed")
     assert calls == [1]
-
-
-# ── Isolation: handler errors do NOT abort ───────────────────────────────────
 
 
 async def test_handler_exception_is_logged_and_swallowed():
@@ -110,9 +102,6 @@ async def test_sync_handler_exception_is_also_swallowed():
     assert fired_after == ["after"]
 
 
-# ── StopHook short-circuits remaining handlers ───────────────────────────────
-
-
 async def test_stop_hook_aborts_siblings_but_not_operation():
     bus = HookBus()
     calls: list[str] = []
@@ -130,9 +119,6 @@ async def test_stop_hook_aborts_siblings_but_not_operation():
     assert calls == ["stopper"]
 
 
-# ── Read introspection ──────────────────────────────────────────────────────
-
-
 async def test_handlers_for_returns_copy_not_internal_list():
     bus = HookBus()
 
@@ -144,9 +130,6 @@ async def test_handlers_for_returns_copy_not_internal_list():
     snapshot.clear()  # Should not affect the bus.
 
     assert bus.handlers_for(HookPoint.SESSION_START) == [h]
-
-
-# ── @hook decorator ──────────────────────────────────────────────────────────
 
 
 def test_hook_decorator_tags_function_with_point():
@@ -173,9 +156,6 @@ def test_hook_decorator_rejects_unknown_point():
             pass
 
 
-# ── HookPoint vocabulary pinned ──────────────────────────────────────────────
-
-
 def test_hook_point_vocabulary():
     """Pin the 12-event vocabulary so a removal is visible in this test."""
     values = {p.value for p in HookPoint}
@@ -194,9 +174,6 @@ def test_hook_point_vocabulary():
         "artifact.created",
         "prompt.submit",
     }
-
-
-# ── FIX 1: on() validates HookPoint ─────────────────────────────────────────
 
 
 def test_on_string_valid_point_registers():
@@ -237,9 +214,6 @@ def test_handlers_for_invalid_string_raises_value_error():
         bus.handlers_for("session.starts")
 
 
-# ── Dormant-point registration warns (issue #1965) ───────────────────────────
-
-
 def test_registering_on_dormant_point_warns():
     """ARTIFACT_CREATED has no production emit site — registering a handler on
     it must not be silently accepted; the caller learns about it via warning,
@@ -275,9 +249,9 @@ def test_registering_on_dormant_point_by_string_value_warns():
     ],
 )
 def test_registering_on_now_wired_api_points_does_not_warn(recwarn, point):
-    """Regression guard for issue #1965: these three used to be dormant.
-    Now that they have production emit sites (operations/_api_hooks.py),
-    registering a handler on them must NOT trigger the dormant-point warning."""
+    """These three points used to be dormant. Now that they have production
+    emit sites (operations/_api_hooks.py), registering a handler on them
+    must NOT trigger the dormant-point warning."""
     bus = HookBus()
 
     async def h(**kw):
@@ -285,9 +259,6 @@ def test_registering_on_now_wired_api_points_does_not_warn(recwarn, point):
 
     bus.on(point, h)
     assert not any(issubclass(w.category, UserWarning) for w in recwarn.list)
-
-
-# ── FIX 2: blocking_emit propagates exceptions for TOOL_PRE ──────────────────
 
 
 async def test_blocking_emit_propagates_exception():
@@ -333,10 +304,7 @@ async def test_blocking_emit_stop_hook_short_circuits_without_error():
     assert calls == ["stopper"]
 
 
-# ── FIX 3: handlers snapshotted before dispatch ───────────────────────────────
-
-
-# ── USER_PROMPT_SUBMIT is the second blocking point (ADR-0048 D2) ───────────
+# USER_PROMPT_SUBMIT is the second blocking point (ADR-0048 D2)
 
 
 async def test_blocking_emit_propagates_exception_for_user_prompt_submit():

--- a/tests/hooks/test_bus_observer.py
+++ b/tests/hooks/test_bus_observer.py
@@ -16,8 +16,6 @@ from lionagi.hooks import (
 )
 from lionagi.session.observer import SessionObserver
 
-# ── Transport recording ──────────────────────────────────────────────────────
-
 
 async def test_bound_emit_records_hooksignal_on_observer():
     # MESSAGE_ADD is intentionally suppressed from the HookSignal transport:
@@ -62,9 +60,6 @@ async def test_bind_and_unbind():
     bus.bind(None)  # unbind — subsequent emits record nowhere
     await bus.emit(HookPoint.API_POST_CALL, model="y")
     assert len(obs.by_type(HookSignal)) == 1
-
-
-# ── Dispatch discipline is preserved when bound ──────────────────────────────
 
 
 async def test_ordered_dispatch_unchanged_when_bound():
@@ -139,9 +134,6 @@ async def test_blocking_guard_records_pass_and_denial_before_reraising():
     }
 
 
-# ── Transport isolation ──────────────────────────────────────────────────────
-
-
 async def test_transport_failure_never_breaks_dispatch():
     class BrokenObserver:
         async def emit(self, *_a, **_k):
@@ -157,9 +149,6 @@ async def test_transport_failure_never_breaks_dispatch():
     # The broken transport must not turn a successful dispatch into a failure.
     await bus.emit(HookPoint.SESSION_START, session_id="s")
     assert calls == [1]
-
-
-# ── build_session_bus binds the observer ─────────────────────────────────────
 
 
 async def test_build_session_bus_binds_observer():

--- a/tests/hooks/test_conformance_matrix.py
+++ b/tests/hooks/test_conformance_matrix.py
@@ -79,11 +79,6 @@ def _mock_proc(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
     return proc
 
 
-# ---------------------------------------------------------------------------
-# Claude Code fixture: import report + resulting hooks_external entries
-# ---------------------------------------------------------------------------
-
-
 def test_claude_fixture_imports_mappable_events_and_rejects_the_rest():
     data = _load("claude_settings.json")
     external, report = _translate_config(data, source_label="claude")
@@ -131,11 +126,6 @@ def test_claude_fixture_entries_parse_and_construct_adapters():
         assert callable(handler)
 
 
-# ---------------------------------------------------------------------------
-# Codex fixture: PreCompact (out of scope, no runtime seam) is rejected.
-# ---------------------------------------------------------------------------
-
-
 def test_codex_fixture_rejects_precompact_no_seam():
     data = _load("codex_hooks.json")
     external, report = _translate_config(data, source_label="codex")
@@ -152,11 +142,6 @@ def test_codex_fixture_marks_dv1_1_transcript_divergence_for_user_prompt_submit(
     ups_lines = [line for line in report if "UserPromptSubmit" in line and "imported" in line]
     assert ups_lines
     assert any("transcript_path/turn_id" in line for line in ups_lines)
-
-
-# ---------------------------------------------------------------------------
-# Field-guarantee rows, exercised end to end against a mocked subprocess.
-# ---------------------------------------------------------------------------
 
 
 async def test_pre_tool_use_field_guarantees_reach_the_subprocess(monkeypatch):
@@ -210,11 +195,6 @@ async def test_user_prompt_submit_field_guarantees_include_model_and_permission_
     assert env["permission_mode"] == "default"
 
 
-# ---------------------------------------------------------------------------
-# Exit-code protocol, exactly as the ADR states it (D1/D4 acceptance).
-# ---------------------------------------------------------------------------
-
-
 async def test_exit_code_protocol_zero_two_and_other(monkeypatch):
     hook = external_hook_adapter(event="PreToolUse", command=["guard"])
 
@@ -242,13 +222,6 @@ async def test_exit_code_protocol_zero_two_and_other(monkeypatch):
     # reason text must not collapse the two into indistinguishable output.
     assert error.decision == "deny"
     assert "unexpected crash" in error.reason
-
-
-# ---------------------------------------------------------------------------
-# Malformed/partial exit-0 responses (D1/D4 acceptance): only a
-# genuinely empty stdout means "no opinion" (allow). Every other shape that
-# fails to yield a recognized decision must fail closed on a blocking seam.
-# ---------------------------------------------------------------------------
 
 
 async def test_malformed_exit_zero_responses_fail_closed_not_allow(monkeypatch):
@@ -279,12 +252,6 @@ async def test_empty_stdout_is_the_only_legitimate_no_opinion_allow(monkeypatch)
     monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0)))
     result = await hook("bash", {})
     assert result.decision == "allow"
-
-
-# ---------------------------------------------------------------------------
-# Named divergence Dv1-4: LionAGI fails closed on a blocking-event timeout,
-# where Claude Code cancels the hook and lets the prompt proceed (fail open).
-# ---------------------------------------------------------------------------
 
 
 async def test_dv1_4_timeout_fails_closed_unlike_claude_codes_fail_open(monkeypatch):

--- a/tests/hooks/test_external_adapter.py
+++ b/tests/hooks/test_external_adapter.py
@@ -31,10 +31,6 @@ from lionagi.hooks.external import (
 )
 from lionagi.protocols.action.tool_hooks import ToolPostDecision, ToolPreDecision
 
-# ---------------------------------------------------------------------------
-# validate_argv (D4: non-empty argv of non-empty/non-whitespace strings)
-# ---------------------------------------------------------------------------
-
 
 def test_validate_argv_accepts_nonempty_string_list():
     assert validate_argv(["uv", "run", "guard.py"]) == ["uv", "run", "guard.py"]
@@ -54,11 +50,6 @@ def test_validate_argv_accepts_nonempty_string_list():
 def test_validate_argv_rejects(bad):
     with pytest.raises(ExternalHookConfigError):
         validate_argv(bad)
-
-
-# ---------------------------------------------------------------------------
-# build_envelope: D1 field guarantees per event
-# ---------------------------------------------------------------------------
 
 
 def test_envelope_common_fields_always_present():
@@ -127,11 +118,6 @@ def test_envelope_post_tool_use_failure_guarantees_tool_response_as_error():
     assert env["tool_response"] == {"error": "boom"}
 
 
-# ---------------------------------------------------------------------------
-# match_hook: harness matcher semantics
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("matcher", [None, "", "*"])
 def test_match_hook_empty_or_star_matches_everything(matcher):
     assert match_hook(matcher, "bash") is True
@@ -148,11 +134,6 @@ def test_match_hook_exact_or_list():
 def test_match_hook_unanchored_regex_fallback():
     assert match_hook("^bash$", "bash") is True
     assert match_hook("bash.*", "bash_tool") is True
-
-
-# ---------------------------------------------------------------------------
-# Trust gate (D7): content-pinned to the resolved executable, not argv alone
-# ---------------------------------------------------------------------------
 
 
 def test_is_command_trusted_no_source_is_project_authored():
@@ -176,13 +157,6 @@ def test_is_command_trusted_imported_with_matching_record(monkeypatch, tmp_path)
 
 def test_command_hash_changes_with_argv():
     assert compute_command_hash(["a", "b"]) != compute_command_hash(["a", "c"])
-
-
-# ---------------------------------------------------------------------------
-# Content-pinned trust (Issue 3 fix): resolution, digesting, and the exact
-# attack this closes -- an argv-only-hashed approval carrying over to a
-# different resolved executable.
-# ---------------------------------------------------------------------------
 
 
 def test_resolve_hook_executable_relative_path(tmp_path):
@@ -297,11 +271,6 @@ def test_trust_does_not_carry_over_when_relative_command_resolves_elsewhere(monk
     assert is_command_trusted(["./guard"], source="imported:claude", cwd=str(attacker_dir)) is False
 
 
-# ---------------------------------------------------------------------------
-# external_hook_adapter: unsupported event fails config load
-# ---------------------------------------------------------------------------
-
-
 def test_adapter_rejects_unmappable_event():
     with pytest.raises(ExternalHookConfigError, match="no seam"):
         external_hook_adapter(event="Stop", command=["guard"])
@@ -310,11 +279,6 @@ def test_adapter_rejects_unmappable_event():
 def test_adapter_rejects_invalid_argv():
     with pytest.raises(ExternalHookConfigError):
         external_hook_adapter(event="PreToolUse", command="echo unsafe")
-
-
-# ---------------------------------------------------------------------------
-# PreToolUse: exit-code contract + stdout decision parsing
-# ---------------------------------------------------------------------------
 
 
 class _FakeStream:
@@ -498,16 +462,6 @@ async def test_pre_tool_use_nonjson_stdout_fails_closed_on_blocking_seam(monkeyp
     assert result.decision == "deny"
 
 
-# ---------------------------------------------------------------------------
-# Malformed/partial exit-0 responses on a blocking seam: only a
-# genuinely empty stdout means "no opinion" (allow). Every other case that
-# fails to yield a recognized decision -- a scalar JSON value, an empty
-# object, a hookSpecificOutput with no permissionDecision key, and an
-# EXPLICIT null permissionDecision -- must fail closed, never fall through
-# to the empty-stdout allow convention.
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "stdout",
     [
@@ -571,12 +525,6 @@ async def test_pre_tool_use_matcher_skips_non_matching_tool(monkeypatch):
     spawn.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# PostToolUse: advisory only -- a deny/error becomes a surfaced note, never
-# a raised exception (the action already happened).
-# ---------------------------------------------------------------------------
-
-
 async def test_post_tool_use_allow_returns_none(monkeypatch):
     monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0)))
     hook = external_hook_adapter(event="PostToolUse", command=["notify"])
@@ -605,12 +553,6 @@ async def test_post_tool_use_error_result_maps_tool_response_to_error_dict(monke
     await hook("bash", {"command": ["ls"]}, None, err)
     envelope = json.loads(proc.stdin.written.decode())
     assert envelope["tool_response"] == {"error": "kaboom"}
-
-
-# ---------------------------------------------------------------------------
-# Timeout: process group is killed; blocking events fail closed, advisory
-# events are logged and continue.
-# ---------------------------------------------------------------------------
 
 
 async def test_pre_tool_use_timeout_kills_process_group_and_denies(monkeypatch):
@@ -651,11 +593,6 @@ async def test_post_tool_use_timeout_surfaces_reason_not_raise(monkeypatch):
     assert "timed out" in result.reason
 
 
-# ---------------------------------------------------------------------------
-# UserPromptSubmit: blocking HookBus seam -- a deny verdict raises.
-# ---------------------------------------------------------------------------
-
-
 async def test_user_prompt_submit_deny_raises_permission_error(monkeypatch):
     stdout = json.dumps({"decision": "block", "reason": "hygiene check failed"}).encode()
     monkeypatch.setattr(
@@ -670,11 +607,6 @@ async def test_user_prompt_submit_allow_does_not_raise(monkeypatch):
     monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_mock_proc(0)))
     hook = external_hook_adapter(event="UserPromptSubmit", command=["hygiene"])
     await hook(session_id="s-1", branch_id="b-1", prompt="do a thing")  # must not raise
-
-
-# ---------------------------------------------------------------------------
-# SessionStart/SessionEnd/PostToolUseFailure: advisory -- deny is logged, not raised.
-# ---------------------------------------------------------------------------
 
 
 async def test_session_start_deny_is_logged_not_raised(monkeypatch):
@@ -695,11 +627,6 @@ async def test_post_tool_use_failure_stringifies_error_into_tool_response(monkey
     envelope = json.loads(proc.stdin.written.decode())
     assert envelope["tool_response"] == {"error": "disk full"}
     assert envelope["tool_name"] == "bash"
-
-
-# ---------------------------------------------------------------------------
-# Untrusted command: imported entries never execute without a trust record.
-# ---------------------------------------------------------------------------
 
 
 async def test_untrusted_imported_pre_tool_use_denies_without_spawning(monkeypatch, tmp_path):
@@ -737,16 +664,6 @@ async def test_untrusted_imported_advisory_event_is_error_not_raise(monkeypatch,
     hook = external_hook_adapter(event="SessionStart", command=["notify"], source="imported:codex")
     await hook(session_id="s-1")  # advisory: must not raise even though untrusted
     spawn.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Approval cwd vs exec cwd, and the hash-to-exec TOCTOU (real subprocesses,
-# no mocking of create_subprocess_exec): a trust record pins a relative
-# command to the executable it resolves to IN THE APPROVED DIRECTORY: the
-# process that actually runs must be that exact file, never whatever
-# same-named program happens to sit in the calling process's own cwd, and
-# never a file swapped into the approved path after its digest was read.
-# ---------------------------------------------------------------------------
 
 
 async def test_approved_relative_command_runs_from_approval_cwd_not_process_cwd(
@@ -976,12 +893,6 @@ async def test_trusted_exec_spawns_a_private_copy_not_the_configured_path(monkey
     assert not executed_path.parent.exists(), "the private directory must be removed after exit"
 
 
-# ---------------------------------------------------------------------------
-# Bounded subprocess output (Issue 2 fix): stdout AND stderr are capped while
-# streaming, never after an unbounded `communicate()`-style full buffer.
-# ---------------------------------------------------------------------------
-
-
 async def test_read_capped_truncates_and_logs(caplog):
     from lionagi.hooks.external import _MAX_STDOUT_BYTES, _read_capped
 
@@ -1009,14 +920,6 @@ async def test_read_capped_none_stream_returns_empty():
     result = await _read_capped(None, 1_048_576, "stdout")
     assert result.data == b""
     assert result.truncated is False
-
-
-# ---------------------------------------------------------------------------
-# Truncation-to-allow: a hook response cut off at the cap must
-# never be parsed as a decision -- a truncated exit-0 stdout is a hook
-# failure (deny on a blocking seam), not "whatever the retained prefix
-# happened to say."
-# ---------------------------------------------------------------------------
 
 
 async def test_truncated_stdout_on_blocking_seam_denies_even_with_a_complete_allow_prefix(
@@ -1123,13 +1026,6 @@ async def test_real_subprocess_large_dual_pipe_output_does_not_hang():
     assert result.decision == "deny"
     assert "truncat" in result.reason.lower()
     assert elapsed < 15, "hook should complete well within its own timeout, not hang"
-
-
-# ---------------------------------------------------------------------------
-# Non-serializable tool results (Issue 9 fix): serialize the envelope BEFORE
-# spawning; ADR-0048 D1's tool_response string fallback so PostToolUse hooks
-# still fire; no path leaves a spawned process handle unterminated.
-# ---------------------------------------------------------------------------
 
 
 class _Unserializable:

--- a/tests/hooks/test_loader.py
+++ b/tests/hooks/test_loader.py
@@ -29,9 +29,6 @@ def _agent_hooks_contract() -> str:
     return " ".join(AGENT_HOOKS_REFERENCE.read_text().replace("`", "").split())
 
 
-# ── Registry ──────────────────────────────────────────────────────────────────
-
-
 def test_builtins_resolvable_by_name():
     """ADR-0047 D3 — names must be agent-YAML addressable."""
     for name in (
@@ -68,9 +65,6 @@ def test_register_handler_makes_it_addressable():
         _REGISTRY.pop("my_custom_handler_for_test", None)
 
 
-# ── load_hooks_for_agent ─────────────────────────────────────────────────────
-
-
 def test_load_hooks_resolves_string_names_to_callables():
     resolved = load_hooks_for_agent(
         {
@@ -96,9 +90,6 @@ def test_load_hooks_rejects_non_list_value():
 def test_load_hooks_empty_or_none_returns_empty_map():
     assert load_hooks_for_agent(None) == {}
     assert load_hooks_for_agent({}) == {}
-
-
-# ── build_session_bus override semantics ─────────────────────────────────────
 
 
 def test_build_session_bus_uses_defaults_when_no_profile():
@@ -225,9 +216,6 @@ def test_artifact_created_is_deprecated_and_has_no_production_emit_site():
                     emit_sites.append(f"{path.relative_to(ROOT)}:{node.lineno}")
 
     assert emit_sites == []
-
-
-# ── Deprecation alias ─────────────────────────────────────────────────────────
 
 
 import asyncio

--- a/tests/hooks/test_tool_hooks.py
+++ b/tests/hooks/test_tool_hooks.py
@@ -11,8 +11,6 @@ import pytest
 
 from lionagi.hooks.bus import HookBus, HookPoint, StopHook
 
-# ── Helpers ────────────────────────────────────────────────────────────────────
-
 
 def _make_branch(hooks: HookBus | None = None):
     """Return a minimal branch-like mock that _act() can drive."""
@@ -44,9 +42,6 @@ def _make_func_call(tool_name: str, response=None, duration: float = 0.01):
     fc.status = "completed"
     fc.func_tool.id = "tool-id"
     return fc
-
-
-# ── TOOL_PRE ──────────────────────────────────────────────────────────────────
 
 
 async def test_tool_pre_fires_before_invocation():
@@ -148,9 +143,6 @@ async def test_tool_pre_stophook_blocks_invocation():
     assert order == ["stopper"]
 
 
-# ── TOOL_POST ─────────────────────────────────────────────────────────────────
-
-
 async def test_tool_post_fires_on_success():
     bus = HookBus()
     post_calls: list[dict] = []
@@ -225,9 +217,6 @@ async def test_tool_post_does_not_fire_on_error():
     assert post_calls == []
 
 
-# ── TOOL_ERROR ────────────────────────────────────────────────────────────────
-
-
 async def test_tool_error_fires_on_invocation_exception():
     bus = HookBus()
     error_calls: list[dict] = []
@@ -300,9 +289,6 @@ async def test_tool_error_does_not_fire_on_success():
     await _act(branch, {"function": "ok_tool", "arguments": {}})
 
     assert error_calls == []
-
-
-# ── No-op when no hook bus ────────────────────────────────────────────────────
 
 
 async def test_no_hooks_registered_still_invokes():

--- a/tests/hooks/test_user_prompt_submit_matrix.py
+++ b/tests/hooks/test_user_prompt_submit_matrix.py
@@ -69,11 +69,6 @@ def _make_fake_cli_model(chunks: list[StreamChunk]) -> iModel:
     return m
 
 
-# ---------------------------------------------------------------------------
-# Row 1: direct chat() -> 1
-# ---------------------------------------------------------------------------
-
-
 async def test_direct_chat_fires_once():
     branch = LionAGIMockFactory.create_mocked_branch(response="hello")
     calls = _wire_prompt_submit_counter(branch)
@@ -83,11 +78,6 @@ async def test_direct_chat_fires_once():
     assert len(calls) == 1
     assert calls[0]["branch_id"] == str(branch.id)
     assert "hi there" in calls[0]["prompt"]
-
-
-# ---------------------------------------------------------------------------
-# Row 2: chat_and_record() delegating to chat() -> 1 total (forwarded, not re-originated)
-# ---------------------------------------------------------------------------
 
 
 async def test_chat_and_record_delegates_to_chat_fires_once():
@@ -125,11 +115,6 @@ async def test_chat_and_record_mints_exactly_one_token_and_forwards_it(monkeypat
     assert len(mint_calls) == 1
 
 
-# ---------------------------------------------------------------------------
-# Row 3: communicate() -> 1
-# ---------------------------------------------------------------------------
-
-
 async def test_communicate_fires_once():
     branch = LionAGIMockFactory.create_mocked_branch(response="hello")
     calls = _wire_prompt_submit_counter(branch)
@@ -138,11 +123,6 @@ async def test_communicate_fires_once():
 
     assert result == "hello"
     assert len(calls) == 1
-
-
-# ---------------------------------------------------------------------------
-# Row 4: operate() delegating to communicate() -> 1
-# ---------------------------------------------------------------------------
 
 
 async def test_operate_delegating_to_communicate_fires_once():
@@ -155,11 +135,6 @@ async def test_operate_delegating_to_communicate_fires_once():
 
     assert result == "hello"
     assert len(calls) == 1
-
-
-# ---------------------------------------------------------------------------
-# Row 5: direct run() (CLI streaming) -> 1
-# ---------------------------------------------------------------------------
 
 
 async def test_direct_run_fires_once():
@@ -175,11 +150,9 @@ async def test_direct_run_fires_once():
     assert calls[0]["branch_id"] == str(branch.id)
 
 
-# ---------------------------------------------------------------------------
 # CLI guard-rejection failure semantics: a USER_PROMPT_SUBMIT handler that
 # rejects a run() prompt must leave no trace of it in the transcript, and
 # the rejection must surface as this run's failure, not a silent success.
-# ---------------------------------------------------------------------------
 
 
 async def test_run_guard_rejection_leaves_no_instruction_persisted():
@@ -336,11 +309,6 @@ async def test_run_yielded_instruction_already_in_branch_messages():
     await gen.aclose()
 
 
-# ---------------------------------------------------------------------------
-# Row 6: ReAct() with extension rounds + a final-answer turn -> 1 total
-# ---------------------------------------------------------------------------
-
-
 async def test_react_multi_round_fires_once_total():
     """Round 1 forwards the ReAct()-driven turn; extension rounds and the
     final-answer turn are internal continuations (no-origin) and stay silent."""
@@ -399,12 +367,6 @@ async def test_react_with_interpret_fires_once_total():
     assert len(calls) == 1
 
 
-# ---------------------------------------------------------------------------
-# Row 7: failing-then-repaired parse (parse._inner_parse() -> Branch.chat()
-# with no-origin) -> 1 total, zero additional from the repair
-# ---------------------------------------------------------------------------
-
-
 class _StrictAnswer(BaseModel):
     answer: str
 
@@ -439,13 +401,6 @@ async def test_parse_inner_parse_uses_no_origin_directly():
     assert resolve_turn_origin(no_origin).disposition == "no-origin"
 
 
-# ---------------------------------------------------------------------------
-# interpret(): a direct (non-ReAct) call is itself a public ingress — raw
-# user text reaching a model for the first time in a turn — so it mints and
-# fires on its own default disposition, same as chat()/communicate().
-# ---------------------------------------------------------------------------
-
-
 async def test_direct_interpret_call_fires_once():
     branch = LionAGIMockFactory.create_mocked_branch(response="rewritten prompt")
     calls = _wire_prompt_submit_counter(branch)
@@ -454,11 +409,6 @@ async def test_direct_interpret_call_fires_once():
 
     assert result == "rewritten prompt"
     assert len(calls) == 1
-
-
-# ---------------------------------------------------------------------------
-# Supporting unit coverage for the TurnOrigin value type itself
-# ---------------------------------------------------------------------------
 
 
 def test_turn_origin_unset_mints_a_token_on_resolve():

--- a/tests/libs/algo/test_string_similarity.py
+++ b/tests/libs/algo/test_string_similarity.py
@@ -138,7 +138,6 @@ def test_levenshtein_similarity(s1: str, s2: str, expected: float) -> None:
 
 
 def test_similarity_algorithms_bounds() -> None:
-    """Test that all similarity algorithms return values between 0 and 1."""
     test_cases = [
         ("hello", "hello"),
         ("hello", "world"),
@@ -157,7 +156,6 @@ def test_similarity_algorithms_bounds() -> None:
 
 
 def test_all_algorithms_handle_special_characters() -> None:
-    """Test that all algorithms handle special characters properly."""
     special_chars = "!@#$%^&*()"
     normal_text = "hello"
 
@@ -172,7 +170,6 @@ def test_all_algorithms_handle_special_characters() -> None:
 
 
 def test_all_algorithms_handle_unicode() -> None:
-    """Test that all algorithms handle Unicode characters properly."""
     unicode_text1 = "hello世界"
     unicode_text2 = "hello世界"
 
@@ -184,7 +181,6 @@ def test_all_algorithms_handle_unicode() -> None:
 
 
 def test_all_algorithms_handle_long_strings() -> None:
-    """Test that all algorithms handle long strings properly."""
     long_text1 = "a" * 1000
     long_text2 = "a" * 999 + "b"
 

--- a/tests/libs/concurrency/test_completion_stream.py
+++ b/tests/libs/concurrency/test_completion_stream.py
@@ -11,11 +11,6 @@ from lionagi.ln.concurrency.patterns import CompletionStream
 pytestmark = pytest.mark.anyio
 
 
-# =============================================================================
-# Basic Lifecycle Tests
-# =============================================================================
-
-
 async def test_completion_stream_basic_usage(anyio_backend):
     """Test CompletionStream basic async for loop."""
 
@@ -62,11 +57,6 @@ async def test_completion_stream_empty_awaitables(anyio_backend):
     assert results == []
 
 
-# =============================================================================
-# Concurrency Limit Tests
-# =============================================================================
-
-
 async def test_completion_stream_with_limit(anyio_backend):
     """Test CompletionStream respects concurrency limit."""
     current_running = {"count": 0, "max": 0}
@@ -108,11 +98,6 @@ async def test_completion_stream_limit_none_allows_all_concurrent(
     assert current_running["max"] == NUM_TASKS
 
 
-# =============================================================================
-# Early Termination & Cancellation Tests
-# =============================================================================
-
-
 async def test_completion_stream_early_break_exits_cleanly(anyio_backend):
     """Test breaking early exits the stream cleanly without consuming all results."""
     consumed = []
@@ -149,11 +134,6 @@ async def test_completion_stream_consume_all_results(anyio_backend):
 
     assert len(results) == 10
     assert set(results) == {i * 2 for i in range(10)}
-
-
-# =============================================================================
-# Exception Handling Tests
-# =============================================================================
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
@@ -226,11 +206,6 @@ async def test_completion_stream_exception_early_in_iteration(anyio_backend):
     )
 
 
-# =============================================================================
-# Context Manager Tests
-# =============================================================================
-
-
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
 async def test_completion_stream_not_in_context_manager_raises(anyio_backend):
     """Test CompletionStream raises when used outside context manager."""
@@ -275,11 +250,6 @@ async def test_completion_stream_proper_cleanup_in_aexit(anyio_backend):
 
     # Resources should be cleaned up (streams closed)
     # Task group should have exited
-
-
-# =============================================================================
-# Edge Cases & Stress Tests
-# =============================================================================
 
 
 @pytest.mark.slow
@@ -378,11 +348,6 @@ async def test_completion_stream_with_immediate_results(anyio_backend):
 
     assert len(results) == 5
     assert results == {i: i * 2 for i in range(5)}
-
-
-# =============================================================================
-# Integration Tests
-# =============================================================================
 
 
 @pytest.mark.slow

--- a/tests/libs/fuzzy/test_to_dict_edge_cases.py
+++ b/tests/libs/fuzzy/test_to_dict_edge_cases.py
@@ -138,14 +138,12 @@ def test_to_dict_error_without_suppress():
 
 
 def test_to_dict_mapping_preservation():
-    """Test that mapping types are converted properly"""
     ordered = OrderedDict([("z", 26), ("a", 1)])
     result = to_dict(ordered)
     assert result == {"z": 26, "a": 1}
 
 
 def test_to_dict_bytes_not_enumerated():
-    """Test that bytes are not treated as iterable for enumeration"""
     # bytes should not be enumerated, but we need to check behavior
     try:
         result = to_dict(b"test")

--- a/tests/libs/schema/test_as_readable.py
+++ b/tests/libs/schema/test_as_readable.py
@@ -334,11 +334,6 @@ class TestEnvironmentDetection:
             assert not in_notebook()
 
 
-# ---------------------------------------------------------------------------
-# Coverage gap tests (lines 239-241, 103-104)
-# ---------------------------------------------------------------------------
-
-
 class TestAsReadableJsonFallback:
     def test_json_fallback_when_dumps_raises(self, monkeypatch):
         from unittest.mock import MagicMock

--- a/tests/libs/schema/test_schema_loader_exec_boundary.py
+++ b/tests/libs/schema/test_schema_loader_exec_boundary.py
@@ -11,11 +11,6 @@ Python module execution.
 Fix: The codegen/exec fallback requires explicit allow_codegen=True.
 Default is allow_codegen=False — unsupported schemas raise RuntimeError
 before any code generation or exec_module call.
-
-These tests verify:
-1. allow_codegen=False (default) blocks the exec path.
-2. _load_via_codegen is never called without allow_codegen=True.
-3. Simple schemas that create_model() handles still work normally.
 """
 
 import unittest.mock
@@ -28,9 +23,7 @@ from lionagi.libs.schema.load_pydantic_model_from_schema import (
     load_pydantic_model_from_schema,
 )
 
-# ---------------------------------------------------------------------------
 # Security boundary: exec path is blocked by default
-# ---------------------------------------------------------------------------
 
 
 class TestExecBoundaryDefault:
@@ -104,11 +97,6 @@ class TestExecBoundaryDefault:
             load_pydantic_model_from_schema({"type": "object"}, allow_codegen=False)
 
         assert "allow_codegen" in str(exc_info.value)
-
-
-# ---------------------------------------------------------------------------
-# Normal operation: create_model path works for common schemas
-# ---------------------------------------------------------------------------
 
 
 class TestNormalCreateModelPath:

--- a/tests/libs/test_file_process.py
+++ b/tests/libs/test_file_process.py
@@ -10,10 +10,6 @@ import pytest
 
 from lionagi.libs.file.process import chunk, dir_to_files
 
-# ---------------------------------------------------------------------------
-# dir_to_files: verbose logging (line 76)
-# ---------------------------------------------------------------------------
-
 
 def test_dir_to_files_verbose_logs_count(tmp_path, caplog):
     (tmp_path / "a.txt").write_text("hello")
@@ -23,11 +19,6 @@ def test_dir_to_files_verbose_logs_count(tmp_path, caplog):
         result = dir_to_files(tmp_path, verbose=True)
 
     assert len(result) == 2
-
-
-# ---------------------------------------------------------------------------
-# dir_to_files: inner process_file exception with ignore_errors=True (lines 55-58)
-# ---------------------------------------------------------------------------
 
 
 def test_dir_to_files_process_file_exception_ignored_with_verbose(tmp_path, monkeypatch, caplog):
@@ -59,11 +50,6 @@ def test_dir_to_files_process_file_exception_ignored_with_verbose(tmp_path, monk
     assert result == []
 
 
-# ---------------------------------------------------------------------------
-# dir_to_files: inner exception with ignore_errors=False → bubbles as ValueError (lines 59-60, 79-80)
-# ---------------------------------------------------------------------------
-
-
 def test_dir_to_files_process_file_exception_raised_when_not_ignored(tmp_path, monkeypatch):
     class _BadPath:
         def is_file(self):
@@ -89,11 +75,6 @@ def test_dir_to_files_process_file_exception_raised_when_not_ignored(tmp_path, m
         dir_to_files(tmp_path, file_types=[".py"], ignore_errors=False)
 
 
-# ---------------------------------------------------------------------------
-# chunk: as_node=True returns node objects (line 171)
-# ---------------------------------------------------------------------------
-
-
 def test_chunk_as_node_returns_nodes():
     text = "word " * 200
     result = chunk(text=text, as_node=True, chunk_size=100, threshold=10)
@@ -102,21 +83,11 @@ def test_chunk_as_node_returns_nodes():
     assert all(hasattr(c, "content") for c in result)
 
 
-# ---------------------------------------------------------------------------
-# chunk: unsupported output file format → ValueError (line 168)
-# ---------------------------------------------------------------------------
-
-
 def test_chunk_unsupported_output_format_raises(tmp_path):
     text = "word " * 200
     out = str(tmp_path / "out.xyz")
     with pytest.raises(ValueError, match="Unsupported output file format"):
         chunk(text=text, output_file=out, chunk_size=100, threshold=10)
-
-
-# ---------------------------------------------------------------------------
-# chunk: reader_tool="docling" without docling → ImportError (lines 123-128)
-# ---------------------------------------------------------------------------
 
 
 def test_chunk_docling_not_installed_raises(tmp_path, monkeypatch):

--- a/tests/libs/test_filters.py
+++ b/tests/libs/test_filters.py
@@ -20,9 +20,6 @@ class Bundle(BaseModel):
     novelty: float = 0.0
 
 
-# -- TypeFilter -------------------------------------------------------------
-
-
 def test_type_filter_direct_instance():
     f = TypeFilter(Finding)
     fnd = Finding(claim="x")
@@ -39,9 +36,6 @@ def test_type_filter_scans_fields():
 
 def test_type_filter_no_match():
     assert TypeFilter(Finding).matches(Bundle(flower_name="rose")) == []
-
-
-# -- SpecFilter via Spec.q --------------------------------------------------
 
 
 def test_spec_q_returns_field_ref():
@@ -73,9 +67,6 @@ def test_spec_filter_is_in_and_present():
     assert flower.q.present()(Bundle()) is False
 
 
-# -- composition ------------------------------------------------------------
-
-
 def test_filter_composition():
     flower = Spec(str, name="flower_name")
     novelty = Spec(float, name="novelty")
@@ -102,9 +93,6 @@ def test_field_ref_not_hashable():
 
     with pytest.raises(TypeError):
         {flower.q}  # noqa: B018
-
-
-# -- exception handling: FieldRef-safe vs user-predicate visible ------------
 
 
 def test_field_ref_filter_safe_on_missing_field():

--- a/tests/libs/test_json_dump_core.py
+++ b/tests/libs/test_json_dump_core.py
@@ -232,7 +232,6 @@ def test_safe_fallback_custom_clip():
 
 
 def test_safe_fallback_without_error():
-    """Test that safe_fallback prevents raising TypeError."""
 
     class UnserializableObject:
         pass

--- a/tests/libs/test_json_dump_edge_cases.py
+++ b/tests/libs/test_json_dump_edge_cases.py
@@ -123,7 +123,6 @@ def test_numeric_types():
 
 
 def test_cached_default_reuse():
-    """Test that cached default is reused for same parameters."""
     result1 = json_dumps(Path("/tmp/test1"))
     result2 = json_dumps(Path("/tmp/test2"))
 
@@ -132,7 +131,6 @@ def test_cached_default_reuse():
 
 
 def test_type_cache_in_default():
-    """Test that type cache works correctly in default function."""
     paths = [Path(f"/tmp/test{i}") for i in range(10)]
 
     for path in paths:
@@ -141,7 +139,6 @@ def test_type_cache_in_default():
 
 
 def test_non_serializable_without_safe_fallback():
-    """Test that non-serializable objects raise TypeError."""
 
     class NotSerializable:
         pass
@@ -153,7 +150,6 @@ def test_non_serializable_without_safe_fallback():
 
 
 def test_non_serializable_with_safe_fallback():
-    """Test that safe_fallback handles non-serializable objects."""
 
     class NotSerializable:
         pass

--- a/tests/libs/test_json_dump_non_finite.py
+++ b/tests/libs/test_json_dump_non_finite.py
@@ -93,7 +93,7 @@ def test_element_to_dict_rejects_non_finite(mode):
         _Scored(value=float("inf")).to_dict(mode=mode)
 
 
-# --- what the check costs is only paid when it is asked for ---
+# what the check costs is only paid when it is asked for
 
 
 @pytest.mark.parametrize("bad", NON_FINITE)
@@ -122,7 +122,7 @@ def test_db_json_column_rejects_non_finite():
         _to_json_column({"v": float("inf")})
 
 
-# --- orjson.Fragment is an opaque boundary the check cannot see past ---
+# orjson.Fragment is an opaque boundary the check cannot see past
 
 
 def test_fragment_contents_are_not_checked():
@@ -146,7 +146,7 @@ def test_fragment_contents_are_not_checked():
         json_dumpb({"raw": orjson.Fragment(b"{}"), "v": float("inf")}, check_non_finite=True)
 
 
-# --- the guard must not disturb anything that is legitimately serializable ---
+# the guard must not disturb anything that is legitimately serializable
 
 
 def test_genuine_nulls_still_serialize():
@@ -179,7 +179,7 @@ def test_extreme_but_finite_floats_are_untouched():
     assert math.copysign(1, restored["neg"]) == -1
 
 
-# --- forms orjson encodes natively, which never reach the default() hook ---
+# forms orjson encodes natively, which never reach the default() hook
 
 
 @pytest.mark.parametrize("bad", NON_FINITE)

--- a/tests/libs/test_operable.py
+++ b/tests/libs/test_operable.py
@@ -120,7 +120,6 @@ class TestOperable:
             operable.get_specs(include={"field1", "invalid_field"})
 
     def test_field_ordering_preserved(self):
-        """Test that field ordering is preserved across tuple position."""
         specs = [
             Spec(str, name="field_a"),
             Spec(int, name="field_b"),
@@ -143,19 +142,16 @@ class TestOperable:
             operable.create_model(adapter="unsupported")  # type: ignore
 
     def test_immutability(self):
-        """Test that Operable is immutable."""
         spec1 = Spec(str, name="field1")
         operable = Operable((spec1,))
         with pytest.raises(dataclasses.FrozenInstanceError):  # frozen dataclass (not pydantic)
             operable.name = "new_name"
 
     def test_type_validation(self):
-        """Test that non-Spec objects are rejected."""
         with pytest.raises(TypeError, match="All specs must be Spec objects"):
             Operable(("not_a_spec",))
 
     def test_duplicate_name_detection(self):
-        """Test that duplicate field names are detected."""
         spec1 = Spec(str, name="field1")
         spec2 = Spec(int, name="field1")  # Duplicate name
         with pytest.raises(ValueError, match="Duplicate field names found"):

--- a/tests/libs/test_schema_loader.py
+++ b/tests/libs/test_schema_loader.py
@@ -10,10 +10,6 @@ from lionagi.libs.schema.load_pydantic_model_from_schema import (
     load_pydantic_model_from_schema,
 )
 
-# ---------------------------------------------------------------------------
-# Basic input validation
-# ---------------------------------------------------------------------------
-
 
 def test_loader_invalid_json_string_raises():
     with pytest.raises(ValueError):
@@ -23,11 +19,6 @@ def test_loader_invalid_json_string_raises():
 def test_loader_wrong_type_raises():
     with pytest.raises(TypeError):
         load_pydantic_model_from_schema(12345)
-
-
-# ---------------------------------------------------------------------------
-# Simple object schemas
-# ---------------------------------------------------------------------------
 
 
 def test_simple_object_with_required_fields():
@@ -91,11 +82,6 @@ def test_field_with_default_value():
     assert inst.count == 10
 
 
-# ---------------------------------------------------------------------------
-# Type coverage
-# ---------------------------------------------------------------------------
-
-
 def test_all_primitive_types():
     schema = {
         "type": "object",
@@ -144,11 +130,6 @@ def test_array_without_items():
     assert inst.data == [1, "two", 3.0]
 
 
-# ---------------------------------------------------------------------------
-# Enum support
-# ---------------------------------------------------------------------------
-
-
 def test_enum_constraint():
     schema = {
         "type": "object",
@@ -163,11 +144,6 @@ def test_enum_constraint():
     cls = load_pydantic_model_from_schema(schema, "StatusModel")
     inst = cls(status="active")
     assert inst.status.value == "active"
-
-
-# ---------------------------------------------------------------------------
-# Nested objects
-# ---------------------------------------------------------------------------
 
 
 def test_nested_object():
@@ -190,11 +166,6 @@ def test_nested_object():
     inst = cls(name="Alice", address={"street": "123 Main", "city": "NYC"})
     assert inst.address.street == "123 Main"
     assert inst.address.city == "NYC"
-
-
-# ---------------------------------------------------------------------------
-# $ref and $defs
-# ---------------------------------------------------------------------------
 
 
 def test_ref_with_defs():
@@ -248,11 +219,6 @@ def test_ref_with_definitions():
     assert inst.foreground.r == 255
 
 
-# ---------------------------------------------------------------------------
-# anyOf / oneOf
-# ---------------------------------------------------------------------------
-
-
 def test_anyof_nullable():
     """anyOf with null type is common for nullable fields."""
     schema = {
@@ -274,11 +240,6 @@ def test_anyof_nullable():
     assert inst2.value is None
 
 
-# ---------------------------------------------------------------------------
-# Generic object (dict without properties)
-# ---------------------------------------------------------------------------
-
-
 def test_generic_dict_object():
     schema = {
         "type": "object",
@@ -289,11 +250,6 @@ def test_generic_dict_object():
     cls = load_pydantic_model_from_schema(schema, "WithMeta")
     inst = cls(metadata={"key": "value"})
     assert inst.metadata == {"key": "value"}
-
-
-# ---------------------------------------------------------------------------
-# Title sanitization
-# ---------------------------------------------------------------------------
 
 
 def test_title_sanitization():
@@ -321,11 +277,6 @@ def test_title_with_numbers():
     assert cls.__name__ == "Fallback"
 
 
-# ---------------------------------------------------------------------------
-# Array of objects
-# ---------------------------------------------------------------------------
-
-
 def test_array_of_nested_objects():
     schema = {
         "type": "object",
@@ -351,11 +302,6 @@ def test_array_of_nested_objects():
     assert inst.items[1].label == "b"
 
 
-# ---------------------------------------------------------------------------
-# Field descriptions
-# ---------------------------------------------------------------------------
-
-
 def test_field_descriptions_preserved():
     schema = {
         "type": "object",
@@ -370,11 +316,6 @@ def test_field_descriptions_preserved():
     cls = load_pydantic_model_from_schema(schema, "Described")
     field_info = cls.model_fields["name"]
     assert field_info.description == "The user's full name"
-
-
-# ---------------------------------------------------------------------------
-# Type list (e.g. ["string", "null"])
-# ---------------------------------------------------------------------------
 
 
 def test_type_as_list():
@@ -392,11 +333,6 @@ def test_type_as_list():
     assert inst2.value is None
 
 
-# ---------------------------------------------------------------------------
-# Round-trip: model -> schema -> model
-# ---------------------------------------------------------------------------
-
-
 def test_roundtrip_schema():
     """A model's own json_schema should produce an equivalent model."""
 
@@ -409,11 +345,6 @@ def test_roundtrip_schema():
     inst = cls(name="test")
     assert inst.name == "test"
     assert inst.count == 0
-
-
-# ---------------------------------------------------------------------------
-# allOf (merge)
-# ---------------------------------------------------------------------------
 
 
 def test_allof_merge():

--- a/tests/libs/test_spec.py
+++ b/tests/libs/test_spec.py
@@ -11,7 +11,6 @@ class TestCommonMeta:
     """Test CommonMeta enum and utilities."""
 
     def test_allowed_returns_all_values(self):
-        """Test that allowed() returns all enum values."""
         allowed = CommonMeta.allowed()
         assert "name" in allowed
         assert "nullable" in allowed
@@ -240,7 +239,6 @@ class TestSpec:
         assert updated.name == "field"
 
     def test_immutability(self):
-        """Test that Spec is immutable."""
         spec = Spec(str, name="field")
         with pytest.raises(dataclasses.FrozenInstanceError):  # frozen dataclass (not pydantic)
             spec.base_type = int

--- a/tests/libs/test_types.py
+++ b/tests/libs/test_types.py
@@ -16,10 +16,6 @@ from lionagi.ln.types import (
     not_sentinel,
 )
 
-# ============================================================================
-# Test Enum.allowed() - Line 154
-# ============================================================================
-
 
 class MyTestEnum(Enum):
     """Test enum for testing"""
@@ -37,11 +33,6 @@ def test_enum_allowed():
     assert "value2" in allowed
     assert "value3" in allowed
     assert len(allowed) == 3
-
-
-# ============================================================================
-# Test Params - Lines 188, 197, 214
-# ============================================================================
 
 
 @dataclass(slots=True, frozen=True, init=False)
@@ -115,11 +106,6 @@ def test_params_strict_mode():
     """Test Params strict mode validation - Lines 246-248"""
     with pytest.raises(ValueError, match="Missing required parameter"):
         MyParamsStrict(field1="value")  # field2 is missing and strict=True
-
-
-# ============================================================================
-# Test DataClass - Lines 214, 246-248, 251-253, etc.
-# ============================================================================
 
 
 @dataclass(slots=True)
@@ -240,11 +226,6 @@ def test_dataclass_eq_not_dataclass():
     assert obj != 42
 
 
-# ============================================================================
-# Test Params methods
-# ============================================================================
-
-
 def test_params_to_dict():
     """Test Params.to_dict() method"""
     params = MyParams(field1="test", field2=42)
@@ -303,11 +284,6 @@ def test_params_default_kw():
     assert isinstance(result, dict)
     assert result["field1"] == "test"
     assert result["field2"] == 42
-
-
-# ============================================================================
-# Test sentinel utilities
-# ============================================================================
 
 
 def test_is_sentinel():

--- a/tests/libs/utils/test_alcall.py
+++ b/tests/libs/utils/test_alcall.py
@@ -11,10 +11,6 @@ from pydantic import BaseModel
 from lionagi.ln import AlcallParams, BcallParams, alcall, bcall
 from lionagi.ln.concurrency import BaseExceptionGroup
 
-# =============================================================================
-# Test fixtures and helper functions
-# =============================================================================
-
 
 async def async_func(x: int, add: int = 0) -> int:
     await asyncio.sleep(0)
@@ -46,11 +42,6 @@ class PydanticTestModel(BaseModel):
     value: int
 
 
-# =============================================================================
-# Test alcall function - Basic functionality
-# =============================================================================
-
-
 class TestAlcallBasic:
     @pytest.mark.anyio
     async def test_alcall_basic_async_function(self):
@@ -68,11 +59,6 @@ class TestAlcallBasic:
     async def test_alcall_empty_input(self):
         results = await alcall([], async_func)
         assert results == []
-
-
-# =============================================================================
-# Test alcall function - func parameter validation
-# =============================================================================
 
 
 class TestAlcallFuncValidation:
@@ -107,11 +93,6 @@ class TestAlcallFuncValidation:
     async def test_alcall_func_empty_iterable_raises(self):
         with pytest.raises(ValueError, match="Only one callable"):
             await alcall([1, 2, 3], [])
-
-
-# =============================================================================
-# Test alcall function - Input processing
-# =============================================================================
 
 
 class TestAlcallInputProcessing:
@@ -155,11 +136,6 @@ class TestAlcallInputProcessing:
     async def test_alcall_input_non_iterable(self):
         result = await alcall(5, async_func)
         assert result == [5]
-
-
-# =============================================================================
-# Test alcall function - Retry and timeout
-# =============================================================================
 
 
 class TestAlcallRetryTimeout:
@@ -240,11 +216,6 @@ class TestAlcallRetryTimeout:
             assert mock_sleep.await_args_list == [call(0.1), call(0.2)]
 
 
-# =============================================================================
-# Test alcall function - Exception handling
-# =============================================================================
-
-
 class TestAlcallExceptionHandling:
     @pytest.mark.anyio
     async def test_alcall_exception_reraises_after_retry_exhaustion(self):
@@ -301,11 +272,6 @@ class TestAlcallExceptionHandling:
         assert results == ["failed", "failed", "failed"]
 
 
-# =============================================================================
-# Test alcall function - Concurrency and throttling
-# =============================================================================
-
-
 class TestAlcallConcurrency:
     @pytest.mark.anyio
     async def test_alcall_max_concurrent(self):
@@ -325,11 +291,6 @@ class TestAlcallConcurrency:
             inputs = [1, 2, 3]
             await alcall(inputs, async_func, delay_before_start=0.5)
             mock_sleep.assert_any_call(0.5)
-
-
-# =============================================================================
-# Test alcall function - Output processing
-# =============================================================================
 
 
 class TestAlcallOutputProcessing:
@@ -367,11 +328,6 @@ class TestAlcallOutputProcessing:
             output_unique=True,
         )
         assert sorted(results) == [1, 2, 3]
-
-
-# =============================================================================
-# Test bcall function
-# =============================================================================
 
 
 class TestBcall:
@@ -423,10 +379,6 @@ class TestBcall:
         assert batches == [[1, 2], [3, 4], [5]]
 
 
-# =============================================================================
-# =============================================================================
-
-
 class TestParams:
     # AlcallParams/BcallParams.__call__ are thin alcall/bcall wrappers; dataclass inheritance
     # makes them hard to unit-test directly — coverage comes from the alcall tests above.
@@ -446,11 +398,6 @@ class TestParams:
         assert hasattr(BcallParams, "__annotations__")
         assert "batch_size" in BcallParams.__annotations__
         # Lines 310-311 covered conceptually through bcall tests
-
-
-# =============================================================================
-# Test edge cases and combinations
-# =============================================================================
 
 
 class TestEdgeCases:
@@ -494,11 +441,6 @@ class TestEdgeCases:
             throttle_period=0.01,
         )
         assert results == [1, 2, 3, 4, 5]
-
-
-# =============================================================================
-# Test return_exceptions parameter
-# =============================================================================
 
 
 class TestReturnExceptions:

--- a/tests/libs/utils/test_bcall_params.py
+++ b/tests/libs/utils/test_bcall_params.py
@@ -16,10 +16,6 @@ import pytest
 
 from lionagi.ln import BcallParams
 
-# ---------------------------------------------------------------------------
-# Basic functionality
-# ---------------------------------------------------------------------------
-
 
 class TestBcallParamsCall:
     @pytest.mark.anyio

--- a/tests/libs/utils/test_lcall.py
+++ b/tests/libs/utils/test_lcall.py
@@ -94,11 +94,6 @@ class TestLCallFunction(unittest.IsolatedAsyncioTestCase):
             mock_sleep.assert_any_call(0.2)
 
 
-# =============================================================================
-# Synchronous lcall Tests (for improved coverage)
-# =============================================================================
-
-
 class TestLCallSyncFunction:
     @pytest.mark.unit
     def test_lcall_basic_usage(self):

--- a/tests/libs/utils/test_utils.py
+++ b/tests/libs/utils/test_utils.py
@@ -12,10 +12,6 @@ from lionagi.ln._utils import (
     now_utc,
 )
 
-# =============================================================================
-# now_utc() Tests
-# =============================================================================
-
 
 class TestNowUtc:
     @pytest.mark.unit
@@ -24,11 +20,6 @@ class TestNowUtc:
         assert result is not None
         assert hasattr(result, "year")
         assert hasattr(result, "month")
-
-
-# =============================================================================
-# acreate_path() Async Tests
-# =============================================================================
 
 
 class TestAcreatePath:
@@ -186,11 +177,6 @@ class TestAcreatePath:
         assert result.parent.name == "structure"
 
 
-# =============================================================================
-# get_bins() Tests
-# =============================================================================
-
-
 class TestGetBins:
     @pytest.mark.unit
     def test_get_bins_basic(self):
@@ -256,11 +242,6 @@ class TestGetBins:
             assert bin_length < upper  # Note: < not <=, based on source code logic
 
 
-# =============================================================================
-# import_module() Tests
-# =============================================================================
-
-
 class TestImportModule:
     @pytest.mark.unit
     def test_import_module_package_only(self):
@@ -296,11 +277,6 @@ class TestImportModule:
     def test_import_module_invalid_module_raises(self):
         with pytest.raises(ImportError, match="Failed to import"):
             import_module("os", "nonexistent_module_xyz")
-
-
-# =============================================================================
-# is_import_installed() Tests
-# =============================================================================
 
 
 class TestIsImportInstalled:

--- a/tests/libs/utils/test_utils_path_traversal.py
+++ b/tests/libs/utils/test_utils_path_traversal.py
@@ -3,19 +3,15 @@
 
 """Attack-driven regression tests for create_path/acreate_path directory traversal.
 
-These tests verify that create_path and acreate_path refuse to create files
-outside the supplied base directory when filenames contain path-traversal
-components, absolute-path redirection, or symlink indirection.
-
-Issue: acreate_path only rejected backslashes. A
-caller could pass filename='../escape.txt' or 'sub/../../../escape.txt'
-and receive or create paths outside the intended base directory.
+Issue: acreate_path only rejected backslashes. A caller could pass
+filename='../escape.txt' or 'sub/../../../escape.txt' and receive or create
+paths outside the intended base directory.
 
 Fix: reject '.' and '..' filename components before mkdir; resolve and
 assert the candidate path stays within the resolved base directory. Both
-constructors share this containment check (_build_safe_path) so sync
-create_path and async acreate_path have equivalent symlink-containment
-semantics — the sync variant previously had none at all.
+constructors share this containment check (_build_safe_path), so the sync
+variant now has the same symlink-containment semantics as the async one -
+previously it had none at all.
 """
 
 from pathlib import Path

--- a/tests/libs/validate/test_to_num.py
+++ b/tests/libs/validate/test_to_num.py
@@ -36,10 +36,6 @@ def test_to_num_converts_bool_with_requested_type(value, num_type, expected):
     assert isinstance(result, num_type)
 
 
-# ---------------------------------------------------------------------------
-# ---------------------------------------------------------------------------
-
-
 class TestToNumDirectNumeric:
     def test_int_input(self):
         assert to_num(42) == 42.0

--- a/tests/libs/validate/test_validate_boolean.py
+++ b/tests/libs/validate/test_validate_boolean.py
@@ -16,7 +16,6 @@ class TestValidateBoolean:
 
     @pytest.mark.parametrize("value", [True, False])
     def test_boolean_inputs(self, value: bool):
-        """Test that boolean inputs are returned unchanged."""
         assert validate_boolean(value) is value
 
     @pytest.mark.parametrize("value", sorted(TRUE_VALUES))

--- a/tests/ln/test_fuzzy_match.py
+++ b/tests/ln/test_fuzzy_match.py
@@ -9,10 +9,6 @@ import pytest
 
 from lionagi.ln.fuzzy._fuzzy_match import fuzzy_match_keys
 
-# ---------------------------------------------------------------------------
-# 1. Non-list Sequence types — should work identically to list
-# ---------------------------------------------------------------------------
-
 
 def test_tuple_keys_exact_match():
     d = {"name": "Alice", "age": 30}
@@ -50,11 +46,6 @@ def test_tuple_empty_keys_returns_copy():
     assert result is not d
 
 
-# ---------------------------------------------------------------------------
-# 2. Mapping (dict) path — must use .keys()
-# ---------------------------------------------------------------------------
-
-
 def test_dict_keys_exact_match():
     d = {"name": "Carol", "age": 25}
     schema = {"name": str, "age": int}
@@ -63,10 +54,8 @@ def test_dict_keys_exact_match():
     assert result["age"] == 25
 
 
-# ---------------------------------------------------------------------------
 # 3. Bare str — must be rejected, NOT char-split (str is a Sequence[str] so
 #    a naive dispatch would silently iterate chars; guard must fire first)
-# ---------------------------------------------------------------------------
 
 
 def test_bare_str_raises_type_error():

--- a/tests/ln/test_lazy_imports.py
+++ b/tests/ln/test_lazy_imports.py
@@ -15,10 +15,6 @@ import pytest
 
 import lionagi.ln as ln
 
-# ---------------------------------------------------------------------------
-# Public-symbol resolution
-# ---------------------------------------------------------------------------
-
 
 @pytest.mark.parametrize("name", ln.__all__)
 def test_all_exports_resolve(name):
@@ -45,11 +41,6 @@ def test_lazy_attribute_cached_after_first_access():
     assert "alcall" in vars(ln)
 
 
-# ---------------------------------------------------------------------------
-# dir() parity
-# ---------------------------------------------------------------------------
-
-
 def test_dir_is_superset_of_all():
     d = set(dir(ln))
     assert set(ln.__all__) <= d
@@ -68,11 +59,6 @@ def test_concurrency_module_accessible_via_attribute():
     assert ln.concurrency is direct
 
 
-# ---------------------------------------------------------------------------
-# No-warning import
-# ---------------------------------------------------------------------------
-
-
 def test_import_lionagi_ln_raises_no_warnings():
     result = subprocess.run(
         [sys.executable, "-W", "error", "-c", "import lionagi.ln; print('RUN_OK')"],
@@ -82,11 +68,6 @@ def test_import_lionagi_ln_raises_no_warnings():
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "RUN_OK"
-
-
-# ---------------------------------------------------------------------------
-# Lazy loading — anyio / concurrency / _async_call / _to_list deferred
-# ---------------------------------------------------------------------------
 
 
 def _run_and_report(code: str) -> str:
@@ -161,11 +142,6 @@ def test_spec_module_does_not_eagerly_load_concurrency():
     )
     out = _run_and_report(code)
     assert out == "False False"
-
-
-# ---------------------------------------------------------------------------
-# Functional edge cases through the lazy surface
-# ---------------------------------------------------------------------------
 
 
 def test_to_list_functional_through_lazy_attribute():

--- a/tests/ln/test_proc.py
+++ b/tests/ln/test_proc.py
@@ -12,10 +12,6 @@ import pytest
 
 from lionagi.ln._proc import aterminate_process_group, terminate_process_group
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _fake_proc(pid):
     """Sync-only fake process (subprocess.Popen-shaped)."""
@@ -39,9 +35,7 @@ def _fake_async_proc(pid, wait_delay: float = 0.0):
     return p
 
 
-# ---------------------------------------------------------------------------
 # pid-guard: must never signal pid <= 1
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("pid", [1, 0, -1, None])
@@ -113,11 +107,6 @@ def test_terminate_proc_group_never_signals_callers_group(monkeypatch):
 
     mock_killpg.assert_not_called()
     proc.kill.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# Normal pid (> 1): killpg is called with the right signal
-# ---------------------------------------------------------------------------
 
 
 def test_terminate_sigkill_only():
@@ -224,11 +213,6 @@ async def test_aterminate_sigterm_no_sigkill_when_exits_fast():
     assert (4444, signal.SIGKILL) not in calls
 
 
-# ---------------------------------------------------------------------------
-# Already-dead process: ProcessLookupError is swallowed
-# ---------------------------------------------------------------------------
-
-
 def test_terminate_swallows_processlookuperror():
     """ProcessLookupError from killpg is swallowed; no exception propagates."""
     proc = _fake_proc(pid=2222)
@@ -285,11 +269,6 @@ async def test_aterminate_swallows_processlookuperror():
 
     with patch.object(proc_mod.os, "killpg", side_effect=ProcessLookupError):
         await aterminate_process_group(proc, grace=None)
-
-
-# ---------------------------------------------------------------------------
-# Custom sig_first parameter
-# ---------------------------------------------------------------------------
 
 
 def test_terminate_custom_sig_first():

--- a/tests/ln/test_ssrf.py
+++ b/tests/ln/test_ssrf.py
@@ -10,20 +10,11 @@ import pytest
 
 from lionagi.ln._ssrf import is_ssrf_safe
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _mock_getaddrinfo(ip_str: str):
     """Return a getaddrinfo-shaped list for a single IP."""
     family = socket.AF_INET6 if ":" in ip_str else socket.AF_INET
     return [(family, socket.SOCK_STREAM, 6, "", (ip_str, 0))]
-
-
-# ---------------------------------------------------------------------------
-# 1. Public IPs — must return True
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -38,11 +29,6 @@ def _mock_getaddrinfo(ip_str: str):
 def test_public_ips_safe(ip):
     with patch("socket.getaddrinfo", return_value=_mock_getaddrinfo(ip)):
         assert is_ssrf_safe("example.com") is True
-
-
-# ---------------------------------------------------------------------------
-# 2. Private / reserved IPv4 — must return False
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -65,11 +51,6 @@ def test_public_ips_safe(ip):
 def test_private_ipv4_blocked(ip):
     with patch("socket.getaddrinfo", return_value=_mock_getaddrinfo(ip)):
         assert is_ssrf_safe("evil.internal") is False
-
-
-# ---------------------------------------------------------------------------
-# 3. Private IPv6 — must return False
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -97,11 +78,6 @@ def test_ipv6_link_local_scoped_blocked():
         assert is_ssrf_safe("link-local.example.com") is False
 
 
-# ---------------------------------------------------------------------------
-# 4. IPv4-mapped IPv6 — CRITICAL: must return False
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "ipv4_mapped",
     [
@@ -123,9 +99,7 @@ def test_ipv4_mapped_public_safe():
         assert is_ssrf_safe("dns.example.com") is True
 
 
-# ---------------------------------------------------------------------------
 # 4b. IPv4-compatible IPv6 (::a.b.c.d) — must return False (CWE-918)
-# ---------------------------------------------------------------------------
 # Deprecated form without the 0xffff marker; ipv4_mapped returns None so the
 # ::ffff: unmap path does NOT catch it — separate fix required.
 
@@ -153,11 +127,6 @@ def test_ipv4_compatible_public_safe():
         assert is_ssrf_safe("dns.example.com") is True
 
 
-# ---------------------------------------------------------------------------
-# 5. DNS resolution failure — must fail closed
-# ---------------------------------------------------------------------------
-
-
 def test_dns_failure_returns_false():
     with patch("socket.getaddrinfo", side_effect=OSError("NXDOMAIN")):
         assert is_ssrf_safe("nonexistent.example.invalid") is False
@@ -165,11 +134,6 @@ def test_dns_failure_returns_false():
 
 def test_empty_hostname_returns_false():
     assert is_ssrf_safe("") is False
-
-
-# ---------------------------------------------------------------------------
-# 6. Multiple A records — any private IP blocks the request
-# ---------------------------------------------------------------------------
 
 
 def test_any_private_ip_blocks():
@@ -182,20 +146,10 @@ def test_any_private_ip_blocks():
         assert is_ssrf_safe("mixed.example.com") is False
 
 
-# ---------------------------------------------------------------------------
-# 7. Localhost names
-# ---------------------------------------------------------------------------
-
-
 def test_localhost_blocked():
     """'localhost' resolves to 127.0.0.1 or ::1, both blocked."""
     # Do not mock — use real DNS for this test (localhost is always loopback)
     assert is_ssrf_safe("localhost") is False
-
-
-# ---------------------------------------------------------------------------
-# 8. Integration with reader.py call site
-# ---------------------------------------------------------------------------
 
 
 async def test_reader_ssrf_guard_blocks_metadata_url(monkeypatch):

--- a/tests/lndl/test_coerce_result.py
+++ b/tests/lndl/test_coerce_result.py
@@ -17,18 +17,9 @@ from lionagi.lndl.types import (
     revalidate_with_action_results,
 )
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def make_action_call(name: str = "act") -> ActionCall:
     return ActionCall(name=name, function="fn", arguments={}, raw_call="fn()")
-
-
-# ---------------------------------------------------------------------------
-# Attack-driven tests: the exploit must be rejected
-# ---------------------------------------------------------------------------
 
 
 class TestBoolCoercionAttackCases:
@@ -58,11 +49,6 @@ class TestBoolCoercionAttackCases:
         assert _coerce_result(raw, bool | None) is True
 
 
-# ---------------------------------------------------------------------------
-# None-preservation for Optional[bool]
-# ---------------------------------------------------------------------------
-
-
 class TestBoolCoercionNonePreservation:
     def test_none_result_optional_bool_preserved(self) -> None:
         """None result for bool | None must stay None, not raise."""
@@ -71,11 +57,6 @@ class TestBoolCoercionNonePreservation:
     def test_none_result_required_bool_passes_through(self) -> None:
         """None for required bool passes through so model_validate raises clearly."""
         assert _coerce_result(None, bool) is None
-
-
-# ---------------------------------------------------------------------------
-# Actual bool input must pass through unchanged
-# ---------------------------------------------------------------------------
 
 
 class TestBoolCoercionNativePassthrough:
@@ -90,11 +71,6 @@ class TestBoolCoercionNativePassthrough:
 
     def test_native_true_passthrough_optional_bool(self) -> None:
         assert _coerce_result(True, bool | None) is True
-
-
-# ---------------------------------------------------------------------------
-# Non-bool scalar coercions remain unaffected
-# ---------------------------------------------------------------------------
 
 
 class TestNonBoolScalarCoercionUnchanged:
@@ -113,11 +89,6 @@ class TestNonBoolScalarCoercionUnchanged:
         result = _coerce_result({"k": "v"}, str)
         assert isinstance(result, str)
         assert json.loads(result) == {"k": "v"}
-
-
-# ---------------------------------------------------------------------------
-# End-to-end: revalidate_with_action_results on a bool field
-# ---------------------------------------------------------------------------
 
 
 class FlagModel(BaseModel):

--- a/tests/lndl/test_diagnostics.py
+++ b/tests/lndl/test_diagnostics.py
@@ -19,10 +19,6 @@ from lionagi.lndl.diagnostics import (
     extract_lndl_chunks,
 )
 
-# ---------------------------------------------------------------------------
-# classify_chunk
-# ---------------------------------------------------------------------------
-
 
 class TestClassifyChunk:
     def test_clean_lndl_with_out(self):
@@ -72,11 +68,6 @@ class TestClassifyChunk:
         assert h.status == "clean"
 
 
-# ---------------------------------------------------------------------------
-# classify_result
-# ---------------------------------------------------------------------------
-
-
 class _M(BaseModel):
     n: int
 
@@ -108,11 +99,6 @@ class TestClassifyResult:
         assert classify_result(42) == "dict"
 
 
-# ---------------------------------------------------------------------------
-# LndlRoundRecord
-# ---------------------------------------------------------------------------
-
-
 class TestLndlRoundRecord:
     def test_health_property_uses_classify_chunk(self):
         r = LndlRoundRecord(raw="<lvar a x>1</lvar>OUT{a: [x]}", outcome="success")
@@ -130,11 +116,6 @@ class TestLndlRoundRecord:
         assert r.actions_executed == 2
         assert r.schema == "M"
         assert r.error == "Validation against M failed"
-
-
-# ---------------------------------------------------------------------------
-# LndlTrace
-# ---------------------------------------------------------------------------
 
 
 class TestLndlTrace:
@@ -183,11 +164,6 @@ class TestLndlTrace:
         assert "1 rounds" in s
         assert "success" in s
         assert "clean" in s
-
-
-# ---------------------------------------------------------------------------
-# extract_lndl_chunks
-# ---------------------------------------------------------------------------
 
 
 def _msg(assistant_response: str | None) -> SimpleNamespace:

--- a/tests/lndl/test_parser_assembler.py
+++ b/tests/lndl/test_parser_assembler.py
@@ -23,10 +23,6 @@ from lionagi.lndl.assembler import NOTE_NAMESPACE, _coerce_str_to_list
 from lionagi.lndl.ast import Lact, RLvar
 from lionagi.lndl.normalize import _fix_missing_gt
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _parse(text: str):
     """Convenience: lex + parse and return the Program."""
@@ -34,11 +30,6 @@ def _parse(text: str):
     tokens = lexer.tokenize()
     parser = Parser(tokens, source_text=text)
     return parser.parse()
-
-
-# ---------------------------------------------------------------------------
-# 1. Two-token shortcut resolution
-# ---------------------------------------------------------------------------
 
 
 class TestTwoTokenShortcut:
@@ -109,11 +100,6 @@ class TestTwoTokenShortcut:
         assert lact.extra_id == "compute"
 
 
-# ---------------------------------------------------------------------------
-# 2. Dict field placeholder
-# ---------------------------------------------------------------------------
-
-
 class DictModel(BaseModel):
     data: dict[str, str]
 
@@ -159,11 +145,6 @@ class TestDictFieldPlaceholder:
         prog = _parse(text)
         result = assemble(prog, InfoModel)
         assert result == {"info": {"x": "1", "y": "2", "z": "3"}}
-
-
-# ---------------------------------------------------------------------------
-# 3. Note namespace
-# ---------------------------------------------------------------------------
 
 
 class TestNoteNamespace:
@@ -219,11 +200,6 @@ class TestNoteNamespace:
     def test_note_namespace_constant(self):
         """NOTE_NAMESPACE should be 'note'."""
         assert NOTE_NAMESPACE == "note"
-
-
-# ---------------------------------------------------------------------------
-# 4. Nested groups for list[Model]
-# ---------------------------------------------------------------------------
 
 
 class Item(BaseModel):
@@ -301,11 +277,6 @@ class TestNestedGroupsListModel:
         assert validated.items[2].name == "Three"
 
 
-# ---------------------------------------------------------------------------
-# 5. normalize._fix_missing_gt
-# ---------------------------------------------------------------------------
-
-
 class TestFixMissingGt:
     """_fix_missing_gt repairs <lact alias fn(args)</lact> missing the closing >."""
 
@@ -340,11 +311,6 @@ class TestFixMissingGt:
         result = normalize_lndl_text(bad)
         # After repair the tag should be well-formed
         assert "<lact myalias>multiply(x=1, y=2)</lact>" in result
-
-
-# ---------------------------------------------------------------------------
-# 6. _coerce_str_to_list conservative behavior
-# ---------------------------------------------------------------------------
 
 
 class TestCoerceStrToList:
@@ -386,11 +352,6 @@ class TestCoerceStrToList:
         # Must be preserved as one item, not split at every comma
         assert len(result) == 1
         assert result[0] == prose
-
-
-# ===========================================================================
-# 7. parse_function_call and qualified_name
-# ===========================================================================
 
 
 class TestParseFunctionCall:

--- a/tests/lndl/test_prompt.py
+++ b/tests/lndl/test_prompt.py
@@ -33,9 +33,7 @@ class TestGetLndlSystemPrompt:
         r2 = get_lndl_system_prompt()
         assert r1 == r2
 
-    # ------------------------------------------------------------------
     # Regression guard: DSL marker presence
-    # ------------------------------------------------------------------
 
     def test_prompt_contains_lvar_marker(self):
         """Prompt must contain the <lvar opening tag — lvar binding syntax."""

--- a/tests/lndl/test_types.py
+++ b/tests/lndl/test_types.py
@@ -237,9 +237,7 @@ class TestRevalidateWithActionResults:
         assert result.title == "My Title"
 
 
-# ---------------------------------------------------------------------------
 # Regression: LNDLOutput.__getattr__ must raise AttributeError not KeyError
-# ---------------------------------------------------------------------------
 
 
 class TestLNDLOutputGetAttrRaisesAttributeError:
@@ -290,9 +288,7 @@ class TestLNDLOutputGetAttrRaisesAttributeError:
         assert out.fields == {"x": 1}
 
 
-# ---------------------------------------------------------------------------
 # Regression: _coerce_result handles Optional scalar annotations
-# ---------------------------------------------------------------------------
 
 
 class TestCoerceResultOptionalScalar:
@@ -343,7 +339,7 @@ class TestCoerceResultOptionalScalar:
         parsed = json.loads(result)
         assert parsed == {"a": 1}
 
-    # --- Regression: None result for optional fields must stay None, not become 'None' ---
+    # Regression: None result for optional fields must stay None, not become 'None'
 
     def test_none_result_optional_str_preserved(self):
         """A legitimately-None result for `str | None` must stay None, not become

--- a/tests/tools/test_ast_search.py
+++ b/tests/tools/test_ast_search.py
@@ -19,11 +19,6 @@ _sg_available = (shutil.which("sg") or shutil.which("ast-grep")) is not None
 sg_required = pytest.mark.skipif(not _sg_available, reason="ast-grep (sg) binary not in PATH")
 
 
-# ---------------------------------------------------------------------------
-# Model validation
-# ---------------------------------------------------------------------------
-
-
 def test_request_defaults():
     req = AstSearchRequest(pattern="$X")
     assert req.lang == "python"
@@ -51,11 +46,6 @@ def test_response_unavailable():
     assert resp.matches == []
 
 
-# ---------------------------------------------------------------------------
-# Graceful degradation when sg binary absent
-# ---------------------------------------------------------------------------
-
-
 def test_unavailable_when_no_binary(monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda _: None)
     resp = _ast_search_sync("$X", ".", "python", 50)
@@ -70,11 +60,6 @@ def test_unavailable_message_actionable(monkeypatch):
     assert resp.status == "unavailable"
     # Should tell user how to install
     assert "cargo" in resp.summary or "ast-grep.github.io" in resp.summary
-
-
-# ---------------------------------------------------------------------------
-# Integration tests (only run when sg present)
-# ---------------------------------------------------------------------------
 
 
 @sg_required
@@ -132,11 +117,6 @@ def test_search_summary_nonempty(tmp_path):
     assert resp.summary
 
 
-# ---------------------------------------------------------------------------
-# AstSearchTool class
-# ---------------------------------------------------------------------------
-
-
 def test_to_tool_returns_tool():
     tool = AstSearchTool()
     assert isinstance(tool.to_tool(), Tool)
@@ -169,11 +149,6 @@ async def test_handle_request_rejects_outside_workspace(tmp_path):
     resp = await tool.handle_request(AstSearchRequest(pattern="$X", path=str(f)))
     assert resp.status == "error"
     assert resp.summary
-
-
-# ---------------------------------------------------------------------------
-# CodingToolkit integration
-# ---------------------------------------------------------------------------
 
 
 def test_coding_toolkit_registers_ast_search(tmp_path):

--- a/tests/tools/test_base.py
+++ b/tests/tools/test_base.py
@@ -8,10 +8,6 @@ from pydantic import ValidationError
 
 from lionagi.tools.base import Prompt, Resource, ResourceCategory
 
-# ---------------------------------------------------------------------------
-# ResourceCategory enum
-# ---------------------------------------------------------------------------
-
 
 def test_resource_category_values():
     assert ResourceCategory.FRAMEWORK.value == "framework"
@@ -19,11 +15,6 @@ def test_resource_category_values():
     assert ResourceCategory.UTILITY.value == "utility"
     assert ResourceCategory.PROMPT.value == "prompt"
     assert ResourceCategory.OTHER.value == "other"
-
-
-# ---------------------------------------------------------------------------
-# Resource serializes category and rejects invalid category
-# ---------------------------------------------------------------------------
 
 
 def test_resource_category_serializes_and_rejects_invalid_category():

--- a/tests/tools/test_bash.py
+++ b/tests/tools/test_bash.py
@@ -13,10 +13,6 @@ from pydantic import ValidationError
 from lionagi.protocols.action.tool import Tool
 from lionagi.tools.code.bash import BashRequest, BashResponse, BashTool
 
-# ---------------------------------------------------------------------------
-# BashRequest model
-# ---------------------------------------------------------------------------
-
 
 def test_bash_request_required_command():
     req = BashRequest(command="echo hi")
@@ -45,11 +41,6 @@ def test_bash_request_allow_shell_kwarg_raises_validation_error():
         BashRequest(command="ls", allow_shell=False)
 
 
-# ---------------------------------------------------------------------------
-# BashResponse model
-# ---------------------------------------------------------------------------
-
-
 def test_bash_response_defaults():
     resp = BashResponse(return_code=0)
     assert resp.stdout == ""
@@ -63,11 +54,6 @@ def test_bash_response_fields():
     assert resp.stderr == "err"
     assert resp.return_code == 1
     assert resp.timed_out is True
-
-
-# ---------------------------------------------------------------------------
-# BashTool.handle_request: basic execution
-# ---------------------------------------------------------------------------
 
 
 async def test_handle_request_echo_returns_stdout():
@@ -98,11 +84,6 @@ async def test_handle_request_dict_input():
     assert "dict" in resp.stdout
 
 
-# ---------------------------------------------------------------------------
-# Timeout
-# ---------------------------------------------------------------------------
-
-
 async def test_handle_request_timeout():
     tool = BashTool()
     resp = await tool.handle_request(BashRequest(command="sleep 10", timeout=100))
@@ -114,11 +95,6 @@ async def test_handle_request_timeout_stderr_message():
     tool = BashTool()
     resp = await tool.handle_request(BashRequest(command="sleep 10", timeout=100))
     assert "100" in resp.stderr or "timed out" in resp.stderr.lower()
-
-
-# ---------------------------------------------------------------------------
-# Shell control operators rejected
-# ---------------------------------------------------------------------------
 
 
 async def test_handle_request_semicolon_rejected():
@@ -160,11 +136,6 @@ async def test_handle_request_shell_control_operators_rejected(cmd, operator):
     )
 
 
-# ---------------------------------------------------------------------------
-# Output truncation
-# ---------------------------------------------------------------------------
-
-
 async def test_handle_request_output_truncation(tmp_path):
     # Generate a Python script file that emits well over 100 KB of output.
     # Running it via `python3 <path>` has no shell operators, so shell=False
@@ -178,21 +149,11 @@ async def test_handle_request_output_truncation(tmp_path):
     assert resp.return_code == 0
 
 
-# ---------------------------------------------------------------------------
-# cwd parameter
-# ---------------------------------------------------------------------------
-
-
 async def test_handle_request_cwd(tmp_path):
     tool = BashTool()
     resp = await tool.handle_request(BashRequest(command="pwd", cwd=str(tmp_path)))
     assert resp.return_code == 0
     assert str(tmp_path) in resp.stdout
-
-
-# ---------------------------------------------------------------------------
-# to_tool
-# ---------------------------------------------------------------------------
 
 
 def test_to_tool_returns_tool_instance():
@@ -222,9 +183,7 @@ async def test_to_tool_callable_executes():
     assert "from_tool" in result["stdout"]
 
 
-# ---------------------------------------------------------------------------
 # Security: CWE-284 — shell=False is unconditional; no bypass via kwargs
-# ---------------------------------------------------------------------------
 
 
 async def test_subprocess_always_invoked_with_shell_false(monkeypatch):
@@ -271,21 +230,11 @@ async def test_pipe_operator_does_not_execute():
     assert resp.stdout == ""
 
 
-# ---------------------------------------------------------------------------
-# Malformed command returns permission error response
-# ---------------------------------------------------------------------------
-
-
 async def test_bash_tool_malformed_command_returns_permission_error_response():
     tool = BashTool()
     resp = await tool.handle_request(BashRequest(command="python -c 'unterminated"))
     assert resp.return_code == -1
     assert resp.stderr.startswith("Malformed command")
-
-
-# ---------------------------------------------------------------------------
-# Popen failure returns execution error response
-# ---------------------------------------------------------------------------
 
 
 async def test_bash_tool_popen_failure_returns_execution_error(monkeypatch):
@@ -304,9 +253,7 @@ async def test_bash_tool_popen_failure_returns_execution_error(monkeypatch):
     assert "no exec" in resp.stderr
 
 
-# ---------------------------------------------------------------------------
 # MagicMock pid guard — os.killpg must not be called with non-int pid
-# ---------------------------------------------------------------------------
 
 
 async def test_bash_tool_timeout_mock_pid_calls_kill_not_killpg(monkeypatch):
@@ -382,11 +329,6 @@ async def test_bash_tool_timeout_invalid_pid_calls_kill_not_killpg(monkeypatch, 
     assert killpg_calls == [], f"os.killpg must not be called for pid={invalid_pid!r}"
     mock_proc.kill.assert_called_once()
     assert resp.timed_out is True
-
-
-# ---------------------------------------------------------------------------
-# Tool description stays consistent with the guard
-# ---------------------------------------------------------------------------
 
 
 _ADVICE_LABELS = ("Supported remedies", "Not available here")

--- a/tests/tools/test_check.py
+++ b/tests/tools/test_check.py
@@ -18,10 +18,6 @@ from lionagi.tools.code.check import (
     _ruff_check_sync,
 )
 
-# ---------------------------------------------------------------------------
-# CodeDiagnostic model
-# ---------------------------------------------------------------------------
-
 
 def test_code_diagnostic_as_text_no_fix():
     d = CodeDiagnostic(file="foo.py", line=10, col=5, code="F401", message="unused import")
@@ -45,11 +41,6 @@ def test_code_diagnostic_severity_default():
     assert d.severity == "warning"
 
 
-# ---------------------------------------------------------------------------
-# CodeCheckRequest model
-# ---------------------------------------------------------------------------
-
-
 def test_check_request_required_paths():
     req = CodeCheckRequest(paths=["foo.py"])
     assert req.paths == ["foo.py"]
@@ -64,11 +55,6 @@ def test_check_request_max_diagnostics_bounds():
         CodeCheckRequest(paths=["x.py"], max_diagnostics=501)
 
 
-# ---------------------------------------------------------------------------
-# CodeCheckResponse model
-# ---------------------------------------------------------------------------
-
-
 def test_check_response_ok():
     resp = CodeCheckResponse(status="ok", summary="No issues found.", tool="ruff")
     assert resp.status == "ok"
@@ -80,10 +66,6 @@ def test_check_response_unavailable():
     assert resp.status == "unavailable"
     assert resp.diagnostics == []
 
-
-# ---------------------------------------------------------------------------
-# _ruff_check_sync: integration tests (skip if ruff absent)
-# ---------------------------------------------------------------------------
 
 _ruff_available = shutil.which("ruff") is not None
 ruff_required = pytest.mark.skipif(not _ruff_available, reason="ruff binary not in PATH")
@@ -149,11 +131,6 @@ def test_ruff_check_unavailable_when_no_binary(monkeypatch):
     assert "uv add" in resp.summary
 
 
-# ---------------------------------------------------------------------------
-# CodeCheckTool class
-# ---------------------------------------------------------------------------
-
-
 def test_to_tool_returns_tool():
     t = CodeCheckTool()
     assert isinstance(t.to_tool(), Tool)
@@ -186,11 +163,6 @@ async def test_handle_request_unsupported_tool():
     )
     assert resp.status == "unavailable"
     assert "ruff" in resp.summary
-
-
-# ---------------------------------------------------------------------------
-# Composability: edit a file → code_check on the same file
-# ---------------------------------------------------------------------------
 
 
 @ruff_required
@@ -233,9 +205,7 @@ def test_as_text_format_matches_file_line_col(tmp_path):
         assert parts[1].strip().isdigit()
 
 
-# ---------------------------------------------------------------------------
 # Boundary / security tests
-# ---------------------------------------------------------------------------
 
 
 def test_resolve_check_paths_rejects_outside_workspace(tmp_path):

--- a/tests/tools/test_coding_context.py
+++ b/tests/tools/test_coding_context.py
@@ -6,10 +6,6 @@
 from lionagi.session.branch import Branch
 from lionagi.tools.coding import ALL_CODING_TOOLS, CodingToolkit
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _make_toolkit(tmp_path, notify=False):
     b = Branch()
@@ -23,11 +19,6 @@ def _tool_fn(tools, name):
         if t.func_callable.__name__ == name:
             return t.func_callable
     raise KeyError(f"tool '{name}' not found")
-
-
-# ---------------------------------------------------------------------------
-# Search: grep and find
-# ---------------------------------------------------------------------------
 
 
 async def test_search_grep_finds_pattern(tmp_path):
@@ -52,11 +43,6 @@ async def test_search_grep_no_matches(tmp_path):
         action="grep", pattern="XYZNOTFOUND", path=str(tmp_path)
     )
     assert result["success"] is True and result["total_matches"] == 0
-
-
-# ---------------------------------------------------------------------------
-# Context: status reports message count
-# ---------------------------------------------------------------------------
 
 
 async def test_context_status_empty_branch(tmp_path):
@@ -98,11 +84,6 @@ async def test_context_status_tracks_files_after_read(tmp_path):
     assert result["files_tracked"] == 1
 
 
-# ---------------------------------------------------------------------------
-# Context: evict removes from progression, not pile
-# ---------------------------------------------------------------------------
-
-
 async def test_context_evict_reduces_active_not_total(tmp_path):
     b = Branch()
     tk = CodingToolkit(notify=False, workspace_root=str(tmp_path), tools=ALL_CODING_TOOLS)
@@ -131,11 +112,6 @@ async def test_context_evict_invalid_range(tmp_path):
     result = await context(action="evict", start=5, end=3)
     assert result["success"] is False
     assert "Invalid range" in result["error"]
-
-
-# ---------------------------------------------------------------------------
-# file_state: mtime tracked after read, checked before edit
-# ---------------------------------------------------------------------------
 
 
 async def test_file_state_mtime_tracked_after_read(tmp_path):
@@ -186,9 +162,7 @@ async def test_file_state_allows_edit_when_mtime_matches(tmp_path):
     assert result["success"] is True
 
 
-# ---------------------------------------------------------------------------
 # Stale-read invalidation: evicting a reader-read result forces a re-read
-# ---------------------------------------------------------------------------
 
 
 async def test_stale_read_invalidation_forces_reread_after_evict(tmp_path):

--- a/tests/tools/test_coding_coverage.py
+++ b/tests/tools/test_coding_coverage.py
@@ -23,10 +23,6 @@ from lionagi.tools.coding import (
     _write_file_sync,
 )
 
-# ---------------------------------------------------------------------------
-# _resolve_workspace_path: symlink refusal, denied names, valid paths
-# ---------------------------------------------------------------------------
-
 
 def test_resolve_workspace_path_symlink_raises(tmp_path):
     real = tmp_path / "real.py"
@@ -69,11 +65,6 @@ def test_resolve_workspace_path_relative_resolved_under_root(tmp_path):
 
     result = _resolve_workspace_path("hello.py", tmp_path)
     assert result == f.resolve()
-
-
-# ---------------------------------------------------------------------------
-# _read_image_sync: valid PNG, escape, OSError
-# ---------------------------------------------------------------------------
 
 
 def _make_tiny_png(path):
@@ -121,11 +112,6 @@ def test_read_image_sync_oserror(tmp_path, monkeypatch):
     assert "disk full" in result["error"]
 
 
-# ---------------------------------------------------------------------------
-# _read_file_sync: image delegation, not-a-file, OSError on mtime
-# ---------------------------------------------------------------------------
-
-
 def test_read_file_sync_delegates_to_image_reader(tmp_path):
     img = tmp_path / "shot.png"
     _make_tiny_png(img)
@@ -150,11 +136,6 @@ def test_read_file_sync_nonexistent_returns_error(tmp_path):
     assert "not found" in result["error"].lower()
 
 
-# ---------------------------------------------------------------------------
-# _list_dir_sync: exception from dir_to_files
-# ---------------------------------------------------------------------------
-
-
 def test_list_dir_sync_exception_returns_error(tmp_path, monkeypatch):
     import lionagi.libs.file.process as fp_mod
 
@@ -168,11 +149,6 @@ def test_list_dir_sync_exception_returns_error(tmp_path, monkeypatch):
     assert "disk error" in result["error"]
 
 
-# ---------------------------------------------------------------------------
-# _write_file_sync: OSError writing
-# ---------------------------------------------------------------------------
-
-
 def test_write_file_sync_oserror_returns_error(tmp_path, monkeypatch):
     def raise_oserror(*args, **kwargs):
         raise OSError("no space left")
@@ -183,11 +159,6 @@ def test_write_file_sync_oserror_returns_error(tmp_path, monkeypatch):
     result = _write_file_sync(str(target), "hello", tmp_path)
     assert result["success"] is False
     assert "no space left" in result["error"]
-
-
-# ---------------------------------------------------------------------------
-# _edit_file_sync: OSError on read, old_string not found
-# ---------------------------------------------------------------------------
 
 
 def test_edit_file_sync_old_string_not_found(tmp_path):
@@ -212,11 +183,6 @@ def test_edit_file_sync_oserror_on_read(tmp_path, monkeypatch):
 
     result = _edit_file_sync(str(f), "hello", "bye", False, tmp_path)
     assert result["success"] is False
-
-
-# ---------------------------------------------------------------------------
-# _drain_stream: truncation path
-# ---------------------------------------------------------------------------
 
 
 def test_drain_stream_truncates_at_max(monkeypatch):
@@ -267,11 +233,6 @@ def test_drain_stream_handles_read_exception():
     truncated = _drain_stream(ExplodingStream(), buf)
     assert truncated is False
     assert len(buf) == 0
-
-
-# ---------------------------------------------------------------------------
-# _subprocess_sync: FileNotFoundError, TimeoutExpired
-# ---------------------------------------------------------------------------
 
 
 def test_subprocess_sync_file_not_found_returns_error():
@@ -340,20 +301,13 @@ def test_subprocess_sync_timeout_invalid_pid_calls_kill_not_killpg(invalid_pid):
     mock_proc.kill.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# CodingToolkit.to_tool: raises NotImplementedError
-# ---------------------------------------------------------------------------
-
-
 def test_coding_toolkit_to_tool_raises():
     tk = CodingToolkit(notify=False)
     with pytest.raises(NotImplementedError, match="bind"):
         tk.to_tool()
 
 
-# ---------------------------------------------------------------------------
 # CodingToolkit.security_pre + _build_preprocessor with security hooks
-# ---------------------------------------------------------------------------
 
 
 async def test_security_pre_hook_runs_before_user_hooks(tmp_path):
@@ -410,11 +364,6 @@ async def test_build_preprocessor_no_hooks_returns_none():
 
     reader_tool = next(t for t in tools if t.func_callable.__name__ == "reader")
     assert reader_tool.preprocessor is None
-
-
-# ---------------------------------------------------------------------------
-# Context: get_messages and evict_action_results
-# ---------------------------------------------------------------------------
 
 
 async def test_context_get_messages_returns_summaries(tmp_path):
@@ -476,11 +425,6 @@ async def test_context_unknown_action_returns_error(tmp_path):
     assert "Unknown action" in result["error"]
 
 
-# ---------------------------------------------------------------------------
-# Reader: list_dir with recursive/file_types, unknown action
-# ---------------------------------------------------------------------------
-
-
 async def test_reader_list_dir_with_file_types(tmp_path):
     (tmp_path / "a.py").write_text("x")
     (tmp_path / "b.txt").write_text("y")
@@ -511,11 +455,6 @@ async def test_reader_unknown_action_returns_error(tmp_path):
     assert "Unknown action" in result["error"]
 
 
-# ---------------------------------------------------------------------------
-# Editor: content=None for write, unknown action
-# ---------------------------------------------------------------------------
-
-
 async def test_editor_write_no_content_returns_error(tmp_path):
     from lionagi.session.branch import Branch
 
@@ -542,11 +481,6 @@ async def test_editor_unknown_action_returns_error(tmp_path):
     result = await editor.func_callable(action="blorp", file_path=str(tmp_path / "out.py"))
     assert result["success"] is False
     assert "Unknown action" in result["error"]
-
-
-# ---------------------------------------------------------------------------
-# Search: grep with include filter, unknown action
-# ---------------------------------------------------------------------------
 
 
 async def test_search_grep_with_include_filter(tmp_path):
@@ -579,11 +513,6 @@ async def test_search_unknown_action_returns_error(tmp_path):
     assert "Unknown action" in result["error"]
 
 
-# ---------------------------------------------------------------------------
-# Bash: shell control operator rejection in CodingToolkit
-# ---------------------------------------------------------------------------
-
-
 async def test_bash_shell_control_rejected_in_toolkit(tmp_path):
     from lionagi.session.branch import Branch
 
@@ -608,11 +537,6 @@ async def test_bash_malformed_command_returns_error(tmp_path):
     result = await bash.func_callable(command="echo 'unterminated")
     assert result["return_code"] == -1
     assert "Malformed" in result["stderr"]
-
-
-# ---------------------------------------------------------------------------
-# Sandbox: no active session, already active, no workspace root
-# ---------------------------------------------------------------------------
 
 
 async def test_sandbox_no_active_session_error(tmp_path):
@@ -673,11 +597,6 @@ async def test_sandbox_already_active_blocks_create(tmp_path, monkeypatch):
     result = await sandbox.func_callable(action="create")
     assert result["success"] is False
     assert "already active" in result["error"].lower()
-
-
-# ---------------------------------------------------------------------------
-# _system_status: notify=True path exercised
-# ---------------------------------------------------------------------------
 
 
 async def test_system_status_emitted_via_postprocessor(tmp_path):

--- a/tests/tools/test_coding_toolkit.py
+++ b/tests/tools/test_coding_toolkit.py
@@ -10,10 +10,6 @@ import pytest
 from lionagi.session.branch import Branch
 from lionagi.tools.coding import CodingToolkit
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _make_toolkit(tmp_path, notify=False):
     b = Branch()
@@ -27,11 +23,6 @@ def _tool_fn(tools, name):
         if t.func_callable.__name__ == name:
             return t.func_callable
     raise KeyError(f"tool '{name}' not found")
-
-
-# ---------------------------------------------------------------------------
-# Bind
-# ---------------------------------------------------------------------------
 
 
 def test_bind_returns_lean_default(tmp_path):
@@ -78,11 +69,6 @@ def test_bind_tool_names_opt_in_extras(tmp_path):
         CodingToolkit(workspace_root=str(tmp_path), tools=["reader", "nope"])
 
 
-# ---------------------------------------------------------------------------
-# Reader
-# ---------------------------------------------------------------------------
-
-
 async def test_reader_read_returns_numbered_lines(tmp_path):
     (tmp_path / "f.py").write_text("alpha\nbeta\ngamma\n")
     _, _, tools = _make_toolkit(tmp_path)
@@ -109,11 +95,6 @@ async def test_reader_binary_file_rejected(tmp_path):
     assert "inary" in result["error"]
 
 
-# ---------------------------------------------------------------------------
-# Editor: write
-# ---------------------------------------------------------------------------
-
-
 async def test_editor_write_new_file(tmp_path):
     target = tmp_path / "new.py"
     _, _, tools = _make_toolkit(tmp_path)
@@ -129,11 +110,6 @@ async def test_editor_write_creates_parent_dirs(tmp_path):
     _, _, tools = _make_toolkit(tmp_path)
     result = await _tool_fn(tools, "editor")(action="write", file_path=str(target), content="x=1\n")
     assert result["success"] is True and target.exists()
-
-
-# ---------------------------------------------------------------------------
-# Editor: read-before-write guard
-# ---------------------------------------------------------------------------
 
 
 async def test_editor_read_guard_blocks_unread_existing_file(tmp_path):
@@ -189,11 +165,6 @@ async def test_editor_relative_edit_after_read_succeeds(tmp_path):
     assert f.read_text() == "goodbye world\n"
 
 
-# ---------------------------------------------------------------------------
-# Editor: multiple matches
-# ---------------------------------------------------------------------------
-
-
 async def test_editor_multiple_matches_fails_without_replace_all(tmp_path):
     f = tmp_path / "dup.py"
     f.write_text("foo\nfoo\nbar\n")
@@ -226,11 +197,6 @@ async def test_editor_multiple_matches_succeeds_with_replace_all(tmp_path):
     assert f.read_text().count("baz") == 2
 
 
-# ---------------------------------------------------------------------------
-# Bash
-# ---------------------------------------------------------------------------
-
-
 async def test_bash_echo_returns_stdout(tmp_path):
     _, _, tools = _make_toolkit(tmp_path)
     result = await _tool_fn(tools, "bash")(command="/bin/echo hello")
@@ -248,11 +214,6 @@ async def test_bash_shell_control_rejected(tmp_path):
     result = await _tool_fn(tools, "bash")(command="echo hi; echo there")
     assert result["return_code"] == -1
     assert "Shell control" in result["stderr"] or "rejected" in result["stderr"]
-
-
-# ---------------------------------------------------------------------------
-# Search: workspace containment
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -274,11 +235,6 @@ async def test_search_rejects_path_outside_workspace(tmp_path, action, pattern):
     assert "escapes workspace" in result["error"]
 
 
-# ---------------------------------------------------------------------------
-# Reader rejects workspace escape
-# ---------------------------------------------------------------------------
-
-
 async def test_coding_toolkit_reader_rejects_workspace_escape(tmp_path):
     """ReaderTool rejects paths that escape the workspace root."""
     secret = tmp_path.parent / "secret.txt"
@@ -289,11 +245,6 @@ async def test_coding_toolkit_reader_rejects_workspace_escape(tmp_path):
 
     assert result["success"] is False
     assert "escape" in result["error"].lower() or "workspace" in result["error"].lower()
-
-
-# ---------------------------------------------------------------------------
-# Editor reports ambiguous replacement without writing
-# ---------------------------------------------------------------------------
 
 
 async def test_coding_toolkit_editor_reports_ambiguous_replacement_without_writing(
@@ -315,11 +266,6 @@ async def test_coding_toolkit_editor_reports_ambiguous_replacement_without_writi
     assert result["success"] is False
     # File must be unchanged
     assert target.read_text() == "a\na\n"
-
-
-# ---------------------------------------------------------------------------
-# Schema equivalence: CodingToolkit uses canonical file/ schemas (anti-divergence)
-# ---------------------------------------------------------------------------
 
 
 def test_reader_request_schema_is_canonical():
@@ -356,11 +302,6 @@ def test_canonical_reader_request_has_open_action():
 
     assert hasattr(ReaderAction, "open"), "ReaderAction must include the 'open' member"
     assert ReaderAction.open.value == "open"
-
-
-# ---------------------------------------------------------------------------
-# Reader: open action (docling not required — validate error path without it)
-# ---------------------------------------------------------------------------
 
 
 async def test_reader_open_unsupported_extension_fails(tmp_path):
@@ -417,11 +358,6 @@ async def test_reader_open_caches_and_read_serves_from_cache(tmp_path, monkeypat
     assert "line two" in read_result["content"]
 
 
-# ---------------------------------------------------------------------------
-# Schema validation: path is required in LLM-facing schema (anti-drift)
-# ---------------------------------------------------------------------------
-
-
 def test_coding_toolkit_reader_schema_requires_path(tmp_path):
     """LLM-facing reader schema must mark 'path' as required to guard against schema drift."""
     _, _, tools = _make_toolkit(tmp_path)
@@ -440,11 +376,6 @@ def test_coding_toolkit_reader_request_options_raises_without_path(tmp_path):
     reader_tool = next(t for t in tools if t.func_callable.__name__ == "reader")
     with pytest.raises(ValidationError):
         reader_tool.request_options(action="read")
-
-
-# ---------------------------------------------------------------------------
-# Error shape equivalence: CodingToolkit open vs ReaderTool for empty path
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("action", ["open", "read", "list_dir"])
@@ -471,11 +402,6 @@ async def test_empty_path_exactly_matches_reader_tool(tmp_path, action):
     assert actual == expected
 
 
-# ---------------------------------------------------------------------------
-# Docling smoke: real import path for 'open' action is reachable
-# ---------------------------------------------------------------------------
-
-
 def test_docling_import_is_available():
     """Confirm docling is installed so the 'open' action's real code path is exercisable."""
     from docling.document_converter import DocumentConverter  # noqa: F401
@@ -496,11 +422,6 @@ async def test_reader_open_real_html_fixture(tmp_path):
     # Cache populated — subsequent read should serve from cache
     read_result = await reader_fn(action="read", path=str(html_file), offset=0, limit=10)
     assert read_result["success"] is True
-
-
-# ---------------------------------------------------------------------------
-# Equivalence: nonexistent PDF and offset-beyond-cache for CodingToolkit vs ReaderTool
-# ---------------------------------------------------------------------------
 
 
 async def test_open_nonexistent_pdf_equivalence(tmp_path):

--- a/tests/tools/test_context_tool.py
+++ b/tests/tools/test_context_tool.py
@@ -39,9 +39,6 @@ async def _call(branch, **kw) -> dict:
     return await ContextTool().bind(branch).func_callable(**kw)
 
 
-# -- structural ------------------------------------------------------------
-
-
 async def test_unknown_action_returns_structured_error():
     res = await _call(_make_branch_with_messages(), action="bogus")
     assert res["success"] is False and "bogus" in res["error"]
@@ -67,9 +64,6 @@ async def test_get_messages_clamps_range():
 async def test_evict_invalid_range_returns_error():
     res = await _call(_make_branch_with_messages(), action="evict", start=10, end=5)
     assert res["success"] is False
-
-
-# -- non-destructive eviction ---------------------------------------------
 
 
 async def test_evict_is_non_destructive():
@@ -102,9 +96,6 @@ async def test_evict_action_results_keep_last_zero():
     assert res["success"] and res["removed"] == 6
 
 
-# -- browse + restore ------------------------------------------------------
-
-
 async def test_get_messages_all_shows_evicted():
     b = _build_branch()
     await _call(b, action="evict", start=2, end=5)
@@ -122,9 +113,6 @@ async def test_restore_pulls_back_in_chronological_order():
     assert len(b.progression) == active_after + 2
     order = [b.msgs.progression.index(u) for u in b.progression]
     assert order == sorted(order)  # view stays chronological
-
-
-# -- compact ---------------------------------------------------------------
 
 
 async def test_compact_collapses_tool_io_and_injects_summary():
@@ -156,9 +144,6 @@ async def test_compact_all_mode_collapses_more_than_tool_io():
         _build_branch(), action="compact", start=1, end=7, summary="s", mode="all"
     )
     assert res_all["compacted"] > res_io["compacted"]
-
-
-# -- compact auto=True (model-generated summary) ---------------------------
 
 
 async def test_compact_auto_generates_summary_via_model_call(monkeypatch):

--- a/tests/tools/test_editor.py
+++ b/tests/tools/test_editor.py
@@ -15,10 +15,6 @@ from lionagi.tools.file.editor import (
     EditorTool,
 )
 
-# ---------------------------------------------------------------------------
-# EditorAction enum
-# ---------------------------------------------------------------------------
-
 
 def test_editor_action_write_value():
     assert EditorAction.write == "write"
@@ -28,11 +24,6 @@ def test_editor_action_write_value():
 def test_editor_action_edit_value():
     assert EditorAction.edit == "edit"
     assert EditorAction.edit.value == "edit"
-
-
-# ---------------------------------------------------------------------------
-# EditorRequest model
-# ---------------------------------------------------------------------------
 
 
 def test_editor_request_write_construction():
@@ -57,11 +48,6 @@ def test_editor_request_defaults():
     assert req.replace_all is False
 
 
-# ---------------------------------------------------------------------------
-# EditorResponse model
-# ---------------------------------------------------------------------------
-
-
 def test_editor_response_success():
     resp = EditorResponse(success=True, content="Written: /tmp/f.py")
     assert resp.success is True
@@ -72,11 +58,6 @@ def test_editor_response_failure():
     resp = EditorResponse(success=False, error="something went wrong")
     assert resp.success is False
     assert resp.content is None
-
-
-# ---------------------------------------------------------------------------
-# Write: basic
-# ---------------------------------------------------------------------------
 
 
 async def test_write_new_file(tmp_path):
@@ -129,11 +110,6 @@ async def test_write_dict_input_accepted(tmp_path):
     )
     assert resp.success is True
     assert target.read_text() == "pass\n"
-
-
-# ---------------------------------------------------------------------------
-# Edit: basic
-# ---------------------------------------------------------------------------
 
 
 async def test_edit_replaces_string(tmp_path):
@@ -240,9 +216,7 @@ async def test_edit_missing_new_string_field_fails(tmp_path):
     assert "new_string" in resp.error
 
 
-# ---------------------------------------------------------------------------
 # Security: path escape
-# ---------------------------------------------------------------------------
 
 
 async def test_write_relative_path_escape_rejected(tmp_path):
@@ -277,9 +251,7 @@ async def test_edit_path_escape_rejected(tmp_path):
     assert "escape" in resp.error.lower() or "workspace" in resp.error.lower()
 
 
-# ---------------------------------------------------------------------------
 # Security: symlink rejection
-# ---------------------------------------------------------------------------
 
 
 async def test_write_symlink_rejected(tmp_path):
@@ -317,9 +289,7 @@ async def test_edit_symlink_rejected(tmp_path):
     assert real.read_text() == "hello world\n"
 
 
-# ---------------------------------------------------------------------------
 # Security: denied filenames
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -357,11 +327,6 @@ async def test_edit_denied_filename_blocked(tmp_path):
     assert "protected" in resp.error.lower() or ".env" in resp.error
 
 
-# ---------------------------------------------------------------------------
-# to_tool
-# ---------------------------------------------------------------------------
-
-
 def test_to_tool_returns_tool_instance(tmp_path):
     tool = EditorTool(workspace_root=str(tmp_path))
     assert isinstance(tool.to_tool(), Tool)
@@ -385,11 +350,6 @@ async def test_to_tool_callable_executes(tmp_path):
     )
     assert result["success"] is True
     assert target.read_text() == "via tool\n"
-
-
-# ---------------------------------------------------------------------------
-# Edit requires both old_string and new_string
-# ---------------------------------------------------------------------------
 
 
 async def test_editor_tool_requires_old_and_new_strings_for_edit(tmp_path):

--- a/tests/tools/test_guidance.py
+++ b/tests/tools/test_guidance.py
@@ -11,10 +11,6 @@ from lionagi.tools.code.bash import BashRequest, BashTool
 from lionagi.tools.file.editor import EditorRequest, EditorTool, _edit_sync
 from lionagi.tools.file.reader import ReaderRequest, ReaderTool
 
-# ---------------------------------------------------------------------------
-# Reader: field descriptions contain the line-prefix trap warning
-# ---------------------------------------------------------------------------
-
 
 def test_reader_action_description_warns_line_prefix():
     schema = ReaderRequest.model_json_schema()
@@ -43,21 +39,11 @@ def test_reader_offset_description_has_example():
     assert "200" in offset_desc or "offset" in offset_desc.lower()
 
 
-# ---------------------------------------------------------------------------
-# Reader: tool docstring mentions line-prefix
-# ---------------------------------------------------------------------------
-
-
 def test_reader_tool_docstring_mentions_line_prefix():
     rt = ReaderTool()
     tool = rt.to_tool()
     doc = inspect.getdoc(tool.func_callable) or ""
     assert "\\t" in doc or "prefix" in doc.lower() or "number" in doc.lower()
-
-
-# ---------------------------------------------------------------------------
-# Reader: error messages contain recovery hints
-# ---------------------------------------------------------------------------
 
 
 async def test_reader_not_found_error_has_hint(tmp_path):
@@ -92,11 +78,6 @@ async def test_reader_list_dir_not_dir_suggests_read(tmp_path):
     assert "read" in resp.error.lower()
 
 
-# ---------------------------------------------------------------------------
-# Editor: field descriptions contain line-prefix trap warning
-# ---------------------------------------------------------------------------
-
-
 def test_editor_old_string_description_warns_line_prefix():
     schema = EditorRequest.model_json_schema()
     desc = schema["properties"]["old_string"]["description"]
@@ -115,11 +96,6 @@ def test_editor_action_description_mentions_read_first():
     assert "read" in desc.lower()
 
 
-# ---------------------------------------------------------------------------
-# Editor: tool docstring has recovery guidance
-# ---------------------------------------------------------------------------
-
-
 def test_editor_tool_docstring_has_not_found_hint():
     et = EditorTool()
     tool = et.to_tool()
@@ -132,11 +108,6 @@ def test_editor_tool_docstring_mentions_line_prefix():
     tool = et.to_tool()
     doc = inspect.getdoc(tool.func_callable) or ""
     assert "prefix" in doc.lower() or "\\t" in doc or "number" in doc.lower()
-
-
-# ---------------------------------------------------------------------------
-# Editor: error messages contain recovery hints
-# ---------------------------------------------------------------------------
 
 
 async def test_editor_not_found_error_contains_reread(tmp_path):
@@ -210,11 +181,6 @@ async def test_editor_missing_new_string_error_guides(tmp_path):
     assert "new_string" in resp.error.lower() or "replacement" in resp.error.lower()
 
 
-# ---------------------------------------------------------------------------
-# Bash: field descriptions have cwd guidance
-# ---------------------------------------------------------------------------
-
-
 def test_bash_command_description_warns_operators():
     schema = BashRequest.model_json_schema()
     desc = schema["properties"]["command"]["description"]
@@ -234,11 +200,6 @@ def test_bash_timeout_description_mentions_increase():
     assert "increase" in desc.lower() or "long" in desc.lower()
 
 
-# ---------------------------------------------------------------------------
-# Bash: tool docstring has recovery hints
-# ---------------------------------------------------------------------------
-
-
 def test_bash_tool_docstring_has_recovery_section():
     bt = BashTool()
     tool = bt.to_tool()
@@ -251,11 +212,6 @@ def test_bash_tool_docstring_mentions_cwd_alternative():
     tool = bt.to_tool()
     doc = inspect.getdoc(tool.func_callable) or ""
     assert "cwd" in doc.lower()
-
-
-# ---------------------------------------------------------------------------
-# Bash: operator-rejection error mentions cwd
-# ---------------------------------------------------------------------------
 
 
 async def test_bash_operator_rejection_message_suggests_cwd():

--- a/tests/tools/test_khive_injection.py
+++ b/tests/tools/test_khive_injection.py
@@ -24,10 +24,6 @@ from lionagi.tools.khive_injection import (
     _extract_writeback_pairs,
 )
 
-# ---------------------------------------------------------------------------
-# Policy validation
-# ---------------------------------------------------------------------------
-
 
 def test_profile_id_required():
     with pytest.raises(ValueError, match="profile_id is required"):
@@ -54,11 +50,6 @@ def test_snapshot_id_construction_raises():
     policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1", snapshot_id="snap-1")
     with pytest.raises(ValueError, match="cannot honor policy.snapshot_id"):
         KhiveInjectionProvider(policy)
-
-
-# ---------------------------------------------------------------------------
-# Fixtures / helpers
-# ---------------------------------------------------------------------------
 
 
 def _khive_recall_response(result_id="abc123", content="a prior lesson"):
@@ -118,11 +109,6 @@ def patched_transport():
         yield call_tool
 
 
-# ---------------------------------------------------------------------------
-# Query construction
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_query_construction_uses_role_and_truncated_task_text(patched_transport):
     patched_transport.return_value = _mcp_result(_khive_recall_response())
@@ -138,11 +124,6 @@ async def test_query_construction_uses_role_and_truncated_task_text(patched_tran
     assert "role=implementer" in recall_call_ops
     assert "x" * 400 in recall_call_ops
     assert "x" * 401 not in recall_call_ops
-
-
-# ---------------------------------------------------------------------------
-# Cadence gating
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -195,11 +176,6 @@ async def test_disabled_policy_never_calls_transport(patched_transport):
     assert not patched_transport.called
 
 
-# ---------------------------------------------------------------------------
-# auto_feedback emitted in the same round-trip, explicit profile_id
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_auto_feedback_emitted_with_explicit_profile_id(patched_transport):
     patched_transport.return_value = _mcp_result(_khive_recall_response(result_id="the-first-id"))
@@ -234,11 +210,6 @@ async def test_no_auto_feedback_when_recall_empty(patched_transport):
     assert not any(op.startswith("brain.auto_feedback(") for op in ops_calls)
 
 
-# ---------------------------------------------------------------------------
-# Transport failure containment
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_transport_failure_returns_none_turn_proceeds():
     policy = KhiveInjectionPolicy(profile_id="implementer-recall-v1")
@@ -270,11 +241,6 @@ async def test_auto_feedback_failure_does_not_fail_the_turn(patched_transport):
 
     assert text is not None
     assert "a prior lesson" in text
-
-
-# ---------------------------------------------------------------------------
-# Compose
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -319,11 +285,6 @@ async def test_compose_not_called_when_disabled(patched_transport):
     assert not any(op.startswith("knowledge.compose(") for op in ops_calls)
 
 
-# ---------------------------------------------------------------------------
-# Token cap truncation
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_render_truncated_to_recall_max_tokens(patched_transport):
     huge_content = "lesson " * 5000
@@ -352,11 +313,6 @@ async def test_render_truncated_to_recall_max_tokens(patched_transport):
     )
     assert TokenCalculator.tokenize(body) <= 50
     assert len(text) < len(huge_content)
-
-
-# ---------------------------------------------------------------------------
-# Untrusted-content delimiter (recalled text is data, never an instruction)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -432,11 +388,6 @@ async def test_provide_uses_a_different_nonce_per_call(patched_transport):
     nonce1 = re.match(r'<untrusted-context nonce="([0-9a-f]+)"', text1).group(1)
     nonce2 = re.match(r'<untrusted-context nonce="([0-9a-f]+)"', text2).group(1)
     assert nonce1 != nonce2
-
-
-# ---------------------------------------------------------------------------
-# Namespace pinning (bench-arm contamination guard)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -531,11 +482,6 @@ async def test_no_namespace_kwarg_in_unpinned_writeback(patched_transport):
     ops = patched_transport.call_args_list[0].args[1]["ops"]
     assert ops.startswith("memory.remember(")
     assert "namespace=" not in ops
-
-
-# ---------------------------------------------------------------------------
-# Writeback pair extraction + salience cap
-# ---------------------------------------------------------------------------
 
 
 def _resp(function, output):
@@ -633,11 +579,6 @@ async def test_writeback_transport_failure_contained(patched_transport):
     assert records_written == 0
 
 
-# ---------------------------------------------------------------------------
-# Module-load purity: core lionagi import path stays clean without the mcp extra
-# ---------------------------------------------------------------------------
-
-
 class _TransportImportBlocker:
     """Meta-path finder that raises on any attempt to import the mcp transport,
     proving the import never happens rather than merely not being cached."""
@@ -720,10 +661,6 @@ def test_truncate_cap_semantics():
     assert _truncate("", 5) == ""
     assert _truncate("hi", 10_000) == "hi"
 
-
-# ---------------------------------------------------------------------------
-# Provenance in the rendered block: a bullet a reader can date
-# ---------------------------------------------------------------------------
 
 # Captured from a live `memory.recall`, trimmed to the fields the renderer
 # reads. The dates are in the two forms the store actually returns: an

--- a/tests/tools/test_messenger.py
+++ b/tests/tools/test_messenger.py
@@ -457,11 +457,6 @@ class TestMessengerBindUnknownAction:
         assert "Unknown action: bogus" in result
 
 
-# ---------------------------------------------------------------------------
-# Tool description stays consistent with wakeup's recipient handling
-# ---------------------------------------------------------------------------
-
-
 class TestMessengerWakeupDescription:
     def test_wakeup_list_wakes_first_name_only_and_says_so(self):
         """A list passed to wakeup reaches its first name only, and both

--- a/tests/tools/test_nav.py
+++ b/tests/tools/test_nav.py
@@ -55,11 +55,6 @@ def typed_file(tmp_path: Path) -> Path:
     return f
 
 
-# ---------------------------------------------------------------------------
-# _outline_sync
-# ---------------------------------------------------------------------------
-
-
 def test_outline_finds_class(sample_file):
     resp = _outline_sync(str(sample_file))
     assert resp.success
@@ -125,11 +120,6 @@ def test_outline_two_classes(typed_file):
     assert "Child" in names
 
 
-# ---------------------------------------------------------------------------
-# _find_definition_sync
-# ---------------------------------------------------------------------------
-
-
 def test_find_definition_class(sample_file):
     resp = _find_definition_sync(str(sample_file), "Foo")
     assert resp.success
@@ -166,11 +156,6 @@ def test_find_definition_syntax_error(tmp_path):
     assert not resp.success
 
 
-# ---------------------------------------------------------------------------
-# _find_references_sync
-# ---------------------------------------------------------------------------
-
-
 def test_find_references_returns_uses(typed_file):
     resp = _find_references_sync(str(typed_file), "Base")
     assert resp.success
@@ -194,11 +179,6 @@ def test_find_references_kind(typed_file):
     resp = _find_references_sync(str(typed_file), "Base")
     for item in resp.items:
         assert item.kind == "reference"
-
-
-# ---------------------------------------------------------------------------
-# NavTool async handle_request
-# ---------------------------------------------------------------------------
 
 
 async def test_handle_request_dict_input(tmp_path):
@@ -271,11 +251,6 @@ async def test_handle_request_rejects_outside_workspace(tmp_path):
     assert resp.error
 
 
-# ---------------------------------------------------------------------------
-# NavTool.to_tool
-# ---------------------------------------------------------------------------
-
-
 def test_to_tool_returns_tool():
     tool = NavTool()
     assert isinstance(tool.to_tool(), Tool)
@@ -289,11 +264,6 @@ def test_to_tool_cached():
 def test_to_tool_func_name():
     tool = NavTool()
     assert tool.to_tool().func_callable.__name__ == "code_nav"
-
-
-# ---------------------------------------------------------------------------
-# CodingToolkit integration
-# ---------------------------------------------------------------------------
 
 
 def test_coding_toolkit_registers_code_nav(tmp_path):

--- a/tests/tools/test_reader_guidance.py
+++ b/tests/tools/test_reader_guidance.py
@@ -5,10 +5,6 @@
 
 from lionagi.tools.file.reader import ReaderRequest, ReaderTool
 
-# ---------------------------------------------------------------------------
-# Output format: each line is `<number>\t<code>` — strip prefix before editing
-# ---------------------------------------------------------------------------
-
 
 async def test_reader_output_has_numbered_lines(tmp_path):
     f = tmp_path / "sample.py"

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -19,10 +19,6 @@ from lionagi.tools.sandbox import (
     sandbox_merge,
 )
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _init_git_repo(path: Path) -> None:
     cmds = [
@@ -41,11 +37,6 @@ def _init_git_repo(path: Path) -> None:
 def git_repo(tmp_path):
     _init_git_repo(tmp_path)
     return tmp_path
-
-
-# ---------------------------------------------------------------------------
-# SandboxSession dataclass
-# ---------------------------------------------------------------------------
 
 
 def test_sandbox_session_fields():
@@ -82,11 +73,6 @@ def test_sandbox_session_base_sha_defaults_empty():
         repo_root="/tmp/r",
     )
     assert s.base_sha == ""
-
-
-# ---------------------------------------------------------------------------
-# create_sandbox
-# ---------------------------------------------------------------------------
 
 
 async def test_create_sandbox_creates_worktree(git_repo):
@@ -146,11 +132,6 @@ async def test_create_sandbox_base_sha_matches_worktree_head(git_repo):
     ).stdout.strip()
     assert session.base_sha == worktree_head
     await sandbox_discard(session)
-
-
-# ---------------------------------------------------------------------------
-# sandbox_diff
-# ---------------------------------------------------------------------------
 
 
 async def test_sandbox_diff_empty_for_no_changes(git_repo):
@@ -276,11 +257,6 @@ async def test_sandbox_diff_does_not_mutate_index_modified_tracked_file(git_repo
     await sandbox_discard(session)
 
 
-# ---------------------------------------------------------------------------
-# sandbox_commit
-# ---------------------------------------------------------------------------
-
-
 async def test_sandbox_commit_records_change(git_repo):
     session = await create_sandbox(str(git_repo))
     (Path(session.worktree_path) / "work.py").write_text("x = 1\n")
@@ -297,11 +273,6 @@ async def test_sandbox_commit_nothing_to_commit(git_repo):
     assert result["success"] is True
     assert "Nothing to commit" in result.get("message", "")
     await sandbox_discard(session)
-
-
-# ---------------------------------------------------------------------------
-# sandbox_merge
-# ---------------------------------------------------------------------------
 
 
 async def test_sandbox_merge_applies_changes(git_repo):
@@ -396,11 +367,6 @@ async def test_sandbox_merge_succeeds_on_unprotected_matching_base(git_repo):
 
     assert result["success"] is True and result["merged"] is True
     assert (git_repo / "merged.txt").read_text() == "from sandbox\n"
-
-
-# ---------------------------------------------------------------------------
-# sandbox_discard
-# ---------------------------------------------------------------------------
 
 
 async def test_sandbox_discard_sets_is_active_false(git_repo):
@@ -536,11 +502,6 @@ async def test_sandbox_commit_missing_worktree_returns_error(git_repo):
     assert "no longer exists" in result["error"]
 
 
-# ---------------------------------------------------------------------------
-# Full lifecycle
-# ---------------------------------------------------------------------------
-
-
 async def test_sandbox_full_lifecycle(git_repo):
     # create
     session = await create_sandbox(str(git_repo), name="lifecycle-test")
@@ -574,11 +535,6 @@ async def test_sandbox_full_lifecycle(git_repo):
 
     # verify worktree cleaned up
     assert not os.path.exists(session.worktree_path)
-
-
-# ---------------------------------------------------------------------------
-# Detached HEAD
-# ---------------------------------------------------------------------------
 
 
 async def test_create_sandbox_detached_head_raises(git_repo):
@@ -615,11 +571,6 @@ async def test_sandbox_merge_refuses_detached_head_target(git_repo):
     assert not (git_repo / "merged.txt").exists()
     assert session.is_active is True
     await sandbox_discard(session)
-
-
-# ---------------------------------------------------------------------------
-# Cleanup: branch-deletion-only failure
-# ---------------------------------------------------------------------------
 
 
 async def test_sandbox_discard_branch_delete_failure_keeps_session(git_repo):

--- a/tests/tools/test_sandbox_backend.py
+++ b/tests/tools/test_sandbox_backend.py
@@ -32,10 +32,6 @@ from lionagi.tools.sandbox_backend import (
     select_backend_for_cell,
 )
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _symlink_or_skip(link: Path, target: Path, *, target_is_directory: bool = False) -> None:
     """Create a symlink, or skip the test on platforms without symlink support."""
@@ -116,11 +112,6 @@ class FakeExecOnlyBackend(FakeBackend):
         super().__init__(hosts_prompt_cell=False)
 
 
-# ---------------------------------------------------------------------------
-# ADR-0090 adopted types
-# ---------------------------------------------------------------------------
-
-
 def test_execution_limits_defaults():
     limits = ExecutionLimits()
     assert limits.timeout_s is None
@@ -134,12 +125,6 @@ def test_execution_target_for_worker_preserves_and_overrides():
     assert worker.cwd == "/repo/agent-7"
     assert worker.sandbox_id == "sb-1"
     assert worker.metadata["agent_id"] == "agent-7"
-
-
-# ---------------------------------------------------------------------------
-# (1) Fake-backend test: provision -> run_cell -> collect -> teardown,
-#     for BOTH cell kinds, without launching Daytona.
-# ---------------------------------------------------------------------------
 
 
 async def test_fake_backend_full_lifecycle_prompt_cell():
@@ -183,11 +168,6 @@ async def test_fake_backend_full_lifecycle_exec_cell():
     assert handle.remote_id not in backend.files
 
 
-# ---------------------------------------------------------------------------
-# (2) capabilities()-driven degradation: callers never branch on backend name.
-# ---------------------------------------------------------------------------
-
-
 def test_select_backend_for_cell_degrades_prompt_cell_via_capabilities():
     remote_only = FakeExecOnlyBackend()  # Daytona-shaped: no host-side prompt-cell
     local = FakeBackend()  # can host prompt-cells
@@ -229,11 +209,6 @@ def test_get_backend_returns_shared_instances_by_name():
     assert get_backend("local_worktree") is get_backend("local_worktree")
     with pytest.raises(ValueError):
         get_backend("docker")  # slice 2, not registered yet
-
-
-# ---------------------------------------------------------------------------
-# LocalWorktreeBackend — real git worktree, no network.
-# ---------------------------------------------------------------------------
 
 
 async def test_local_worktree_backend_capabilities_hosts_prompt_cells():
@@ -306,13 +281,6 @@ async def test_local_worktree_backend_nonzero_exit_reported(git_repo):
     await backend.teardown(handle)
 
 
-# ---------------------------------------------------------------------------
-# LocalWorktreeBackend — seed-input/artifact-manifest containment (ADR-0090
-# delta 4): absolute paths, `..` traversal, and symlink escapes must all be
-# rejected before write (seed_inputs) or read (artifact_manifest/collect).
-# ---------------------------------------------------------------------------
-
-
 async def test_local_worktree_backend_rejects_absolute_seed_input_path(git_repo):
     backend = LocalWorktreeBackend()
     handle = await backend.provision(ProvisionSpec(repo_root=str(git_repo)))
@@ -372,11 +340,6 @@ async def test_local_worktree_backend_rejects_symlinked_artifact_escape(git_repo
     with pytest.raises(ValueError, match="escape"):
         await backend.collect(handle, ["link.txt"])
     await backend.teardown(handle)
-
-
-# ---------------------------------------------------------------------------
-# DaytonaBackend — thin adapter, exercised via an injected fake sandbox.
-# ---------------------------------------------------------------------------
 
 
 class _FakeDaytonaSandbox:
@@ -480,14 +443,6 @@ async def test_daytona_backend_provision_without_repo_url_uses_home_dir():
     assert handle.remote_repo_path == "/home/daytona"
     sandbox: _FakeDaytonaSandbox = handle.metadata["sandbox"]
     assert sandbox.cloned == []
-
-
-# ---------------------------------------------------------------------------
-# DaytonaBackend — seed-input/artifact-manifest containment (ADR-0090 delta
-# 4). The remote filesystem can't be resolve()-d locally, so only the
-# string-level checks (absolute, `..`) apply here; symlink-escape checking
-# is scoped to the local backend, which has real filesystem access.
-# ---------------------------------------------------------------------------
 
 
 async def test_daytona_backend_rejects_absolute_seed_input_path():

--- a/tests/tools/test_sandbox_toolkit_facade.py
+++ b/tests/tools/test_sandbox_toolkit_facade.py
@@ -15,10 +15,6 @@ import lionagi.tools.sandbox as sandbox_module
 from lionagi.session.branch import Branch
 from lionagi.tools.coding import CodingToolkit
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _init_git_repo(path: Path) -> None:
     cmds = [
@@ -49,11 +45,6 @@ def _make_sandbox_tool(git_repo, **toolkit_kwargs):
         if t.func_callable.__name__ == "sandbox":
             return tk, t.func_callable
     raise KeyError("sandbox tool not found")
-
-
-# ---------------------------------------------------------------------------
-# Constructor-level sandbox_allow_protected — operator trust decision
-# ---------------------------------------------------------------------------
 
 
 def test_sandbox_allow_protected_defaults_false(git_repo):
@@ -186,11 +177,6 @@ async def test_facade_cleanup_retry_completes_after_partial_merge_cleanup(git_re
     after = await sandbox(action="diff")
     assert after["success"] is False
     assert "No active sandbox" in after["error"]
-
-
-# ---------------------------------------------------------------------------
-# Truthful discard cleanup reporting
-# ---------------------------------------------------------------------------
 
 
 async def test_facade_discard_reports_failure_and_keeps_session(git_repo, monkeypatch):

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -13,10 +13,6 @@ from lionagi.tools.code.search import (
     SearchTool,
 )
 
-# ---------------------------------------------------------------------------
-# SearchAction enum
-# ---------------------------------------------------------------------------
-
 
 def test_search_action_grep_value():
     assert SearchAction.grep == "grep"
@@ -26,11 +22,6 @@ def test_search_action_grep_value():
 def test_search_action_find_value():
     assert SearchAction.find == "find"
     assert SearchAction.find.value == "find"
-
-
-# ---------------------------------------------------------------------------
-# SearchRequest model
-# ---------------------------------------------------------------------------
 
 
 def test_search_request_required_fields():
@@ -76,11 +67,6 @@ async def test_grep_with_explicit_null_coalesces_to_defaults(tmp_path):
     assert resp.count > 0
 
 
-# ---------------------------------------------------------------------------
-# SearchResponse model
-# ---------------------------------------------------------------------------
-
-
 def test_search_response_defaults():
     resp = SearchResponse(success=True)
     assert resp.content is None
@@ -92,11 +78,6 @@ def test_search_response_failure():
     resp = SearchResponse(success=False, error="oops")
     assert resp.success is False
     assert resp.error == "oops"
-
-
-# ---------------------------------------------------------------------------
-# Grep: basic match
-# ---------------------------------------------------------------------------
 
 
 async def test_grep_finds_matching_content(tmp_path):
@@ -127,11 +108,6 @@ async def test_grep_returns_search_response(tmp_path):
     assert isinstance(resp, SearchResponse)
 
 
-# ---------------------------------------------------------------------------
-# Grep: no matches (exit code 1, not an error)
-# ---------------------------------------------------------------------------
-
-
 async def test_grep_no_matches_returns_success(tmp_path):
     (tmp_path / "f.py").write_text("nothing here\n")
     tool = SearchTool()
@@ -144,11 +120,6 @@ async def test_grep_no_matches_returns_success(tmp_path):
     )
     assert resp.success is True
     assert resp.count == 0
-
-
-# ---------------------------------------------------------------------------
-# Grep: regex pattern
-# ---------------------------------------------------------------------------
 
 
 async def test_grep_regex_matches_function_defs(tmp_path):
@@ -165,11 +136,6 @@ async def test_grep_regex_matches_function_defs(tmp_path):
     assert resp.count >= 2
     assert "foo" in resp.content
     assert "bar" in resp.content
-
-
-# ---------------------------------------------------------------------------
-# Grep: include filter restricts file types
-# ---------------------------------------------------------------------------
 
 
 async def test_grep_include_filter_restricts_to_py(tmp_path):
@@ -190,11 +156,6 @@ async def test_grep_include_filter_restricts_to_py(tmp_path):
         assert ".py" in line
 
 
-# ---------------------------------------------------------------------------
-# Grep: max_results capping
-# ---------------------------------------------------------------------------
-
-
 async def test_grep_max_results_capped(tmp_path):
     for i in range(10):
         (tmp_path / f"f{i}.py").write_text("TOKEN\n")
@@ -209,11 +170,6 @@ async def test_grep_max_results_capped(tmp_path):
     )
     assert resp.success is True
     assert resp.count <= 3
-
-
-# ---------------------------------------------------------------------------
-# Find: glob matching
-# ---------------------------------------------------------------------------
 
 
 async def test_find_by_glob_finds_py_files(tmp_path):
@@ -249,11 +205,6 @@ async def test_find_no_matches_returns_success(tmp_path):
     assert resp.count == 0
 
 
-# ---------------------------------------------------------------------------
-# Find: max_results capping
-# ---------------------------------------------------------------------------
-
-
 async def test_find_max_results_capped(tmp_path):
     for i in range(10):
         (tmp_path / f"t{i}.py").write_text("")
@@ -270,11 +221,6 @@ async def test_find_max_results_capped(tmp_path):
     assert resp.count <= 2
 
 
-# ---------------------------------------------------------------------------
-# Dict input
-# ---------------------------------------------------------------------------
-
-
 async def test_dict_input_accepted(tmp_path):
     (tmp_path / "x.py").write_text("hello\n")
     tool = SearchTool()
@@ -287,11 +233,6 @@ async def test_dict_input_accepted(tmp_path):
     )
     assert resp.success is True
     assert resp.count > 0
-
-
-# ---------------------------------------------------------------------------
-# to_tool
-# ---------------------------------------------------------------------------
 
 
 def test_to_tool_returns_tool_instance():
@@ -317,11 +258,6 @@ async def test_to_tool_callable_executes(tmp_path):
     assert result["count"] > 0
 
 
-# ---------------------------------------------------------------------------
-# Grep timeout returns structured error
-# ---------------------------------------------------------------------------
-
-
 async def test_search_tool_grep_timeout_returns_structured_error(monkeypatch):
     import lionagi.tools.code.search as search_mod
 
@@ -341,11 +277,6 @@ async def test_search_tool_grep_timeout_returns_structured_error(monkeypatch):
     assert "timed out" in (resp.error or "").lower()
 
 
-# ---------------------------------------------------------------------------
-# Find nonzero exit with stderr returns error response
-# ---------------------------------------------------------------------------
-
-
 async def test_search_tool_find_stderr_nonzero_is_error(monkeypatch):
     import lionagi.tools.code.search as search_mod
 
@@ -362,11 +293,6 @@ async def test_search_tool_find_stderr_nonzero_is_error(monkeypatch):
 
     assert resp.success is False
     assert "permission denied" in (resp.error or "").lower()
-
-
-# ---------------------------------------------------------------------------
-# grep: FileNotFoundError and generic Exception (lines 103-108)
-# ---------------------------------------------------------------------------
 
 
 async def test_grep_file_not_found_returns_error(monkeypatch):
@@ -401,11 +327,6 @@ async def test_grep_generic_exception_returns_error(monkeypatch):
     assert resp.count == 0
 
 
-# ---------------------------------------------------------------------------
-# grep: exit code 2 (line 112)
-# ---------------------------------------------------------------------------
-
-
 async def test_grep_exit_code_2_returns_error(monkeypatch):
     import lionagi.tools.code.search as search_mod
 
@@ -420,11 +341,6 @@ async def test_grep_exit_code_2_returns_error(monkeypatch):
     )
     assert resp.success is False
     assert "invalid regex" in (resp.error or "")
-
-
-# ---------------------------------------------------------------------------
-# find: TimeoutExpired, FileNotFoundError, generic Exception (lines 132-139)
-# ---------------------------------------------------------------------------
 
 
 async def test_find_timeout_returns_error(monkeypatch):
@@ -481,11 +397,6 @@ async def test_find_generic_exception_returns_error(monkeypatch):
     assert "I/O error" in (resp.error or "")
 
 
-# ---------------------------------------------------------------------------
-# handle_request: unknown action fallback (line 174)
-# ---------------------------------------------------------------------------
-
-
 async def test_handle_request_unknown_action_returns_error():
     from unittest.mock import MagicMock
 
@@ -497,11 +408,6 @@ async def test_handle_request_unknown_action_returns_error():
     assert "Unknown action" in (resp.error or "")
 
 
-# ---------------------------------------------------------------------------
-# to_tool: custom system_tool_name triggers rename (line 192)
-# ---------------------------------------------------------------------------
-
-
 def test_to_tool_custom_system_tool_name():
     class CustomSearchTool(SearchTool):
         system_tool_name = "my_search"
@@ -511,11 +417,9 @@ def test_to_tool_custom_system_tool_name():
     assert t.func_callable.__name__ == "my_search"
 
 
-# ---------------------------------------------------------------------------
 # Regression: rc=-1 (subprocess launch failure) must be success=False
 # (_subprocess_sync returns rc=-1 on launch error; old code only checked
 # rc==2, so rc==-1 fell through to success=True)
-# ---------------------------------------------------------------------------
 
 
 async def test_grep_rc_minus1_is_failure_not_success(monkeypatch):

--- a/tests/tools/test_search_containment.py
+++ b/tests/tools/test_search_containment.py
@@ -16,10 +16,6 @@ from lionagi.tools.code.search import (
     _validate_search_path,
 )
 
-# ---------------------------------------------------------------------------
-# Attack: _validate_search_path rejects escapes before subprocess launch
-# ---------------------------------------------------------------------------
-
 
 class TestValidateSearchPathContainment:
     """Unit tests for the path-containment guard (no subprocess needed)."""
@@ -67,11 +63,6 @@ class TestValidateSearchPathContainment:
         outside.mkdir()
         resolved, err = _validate_search_path(str(outside), None)
         assert err is None
-
-
-# ---------------------------------------------------------------------------
-# Attack: handle_request refuses escaping paths before subprocess
-# ---------------------------------------------------------------------------
 
 
 class TestSearchToolHandleRequestContainment:


### PR DESCRIPTION
Strip section-divider comment banners, restated-test-name docstrings, and internal issue/round tracking references from tests/libs, tests/ln, tests/tools, tests/hooks, tests/agent, and tests/lndl. Preserve every regression rationale, surprising-construction explanation, and pinned external contract; only narration and decoration are removed. No executable code changed (verified per-file with the AST-equality guardrail, before and after ruff format).