### PR TITLE
chore(tests): trim prose in service/providers test suite

### DIFF
--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -162,6 +162,71 @@ different-than-intended TOML value. Every override value is therefore
 serialized as syntactically valid TOML (`toml_override_value()`) instead of
 JSON.
 
+## CLI adapter error-chunk conformance
+
+**`providers/anthropic/claude_code.py`, `providers/google/gemini_code.py`,
+`providers/openai/codex.py`, `providers/pi/cli.py`**
+
+Four CLI adapters each decide, independently, what a stream consumer sees
+when a session ends in failure. Nothing compares the four against each
+other, so a new adapter, or a refactor of an existing one, can reopen a gap
+in silence.
+
+The contract, per adapter:
+
+1. a session finishing with `is_error` set yields exactly one chunk of type
+   `error`;
+2. that chunk carries `is_error`;
+3. a session finishing without `is_error` yields zero `error` chunks.
+
+"Exactly one" (not "at least one") is deliberate: it is the only phrasing
+that can express both "this failure was reported" and "this failure was not
+reported twice." Assertion 3 is the other direction — an adapter that
+reports errors on healthy sessions would otherwise pass.
+
+Where the error chunk gets built differs by adapter, and that difference is
+what makes the guard against double-reporting reachable or not:
+
+- `claude_code` builds it only in the endpoint, behind an
+  already-reported guard. Its parser never builds one, so on any real event
+  sequence today that guard cannot fire — it is pinned intent, not live
+  cover.
+- `gemini_code` builds it in the parser on the failing path; the endpoint
+  guard is what stops a second one. This is the one adapter where "exactly
+  one" is non-vacuous today.
+- `codex` used to build one in both the parser and the endpoint with no
+  guard between them, so a real `turn.failed` event was reported twice.
+  That defect is why "at least one" would have been the wrong contract to
+  test — it passed on codex while the bug was live. A guard was added and
+  codex now satisfies all three assertions.
+- `pi` builds none. A failed pi session instead yields a chunk of type
+  `result` whose content is the error text — the failure survives, wearing
+  the type that means success. A consumer keying on chunk type sees a clean
+  result; one reading content sees an error string; neither can tell it from
+  success by the documented contract. This is pi's tracked, open
+  divergence.
+
+Codex also yields an `error`-type chunk when a resumed session ends
+normally. That is not a violation of assertion 3: the chunk carries
+`is_error=False` and `benign_eos=True`, both set deliberately, and codex's
+healthy fixtures use `turn.completed` so the two cases never collide. A
+consumer keying on chunk type alone still can't distinguish this from a
+failure, but the discriminator fields exist for one that reads them.
+
+Not covered by this contract: the non-streaming path (`_call()` drives the
+same generator and returns the session as a dict, nothing branches on the
+flag), ReAct's final-answer turn (catches broadly and substitutes the last
+response), and per-tool error carriers (`tool_result.is_error` is a separate
+signal — gemini's wire format has no per-tool events to carry it at all).
+
+Fixtures are labelled `RECORDED` or `AUTHORED`; the label matters. An
+authored event dict is written from what the parser reads, so it agrees
+with the parser by construction and inherits its blind spots — a fixture
+built this way cannot reveal a CLI that signals failure through a channel
+nobody reads, and would pass cleanly forever if it did. Only a recorded
+transcript is evidence about the real CLI; an authored one is evidence
+about the model of it encoded in the parser.
+
 ## Codex turn-completed usage delta
 
 **`providers/openai/codex.py`**

--- a/tests/providers/ag2/agent/test_endpoint.py
+++ b/tests/providers/ag2/agent/test_endpoint.py
@@ -12,10 +12,6 @@ import pytest
 
 from lionagi.providers.ag2.agent import AG2AgentRequest, AgentConfig
 
-# ---------------------------------------------------------------------------
-# Helpers / fixtures
-# ---------------------------------------------------------------------------
-
 
 def _make_fake_agent(name: str = "fake-agent") -> MagicMock:
     """Return a minimal MagicMock that quacks like an autogen.beta.Agent."""
@@ -44,11 +40,6 @@ async def _fake_run_beta_agent(
         yield ev
 
 
-# ---------------------------------------------------------------------------
-# Model field tests (no AG2 import needed)
-# ---------------------------------------------------------------------------
-
-
 class TestAG2AgentRequestModel:
     def test_agent_field_defaults_to_none(self):
         req = AG2AgentRequest(prompt="hello")
@@ -74,14 +65,7 @@ class TestAG2AgentRequestModel:
         assert req.agent_config.name == "cfg-only"
 
 
-# ---------------------------------------------------------------------------
-# run_beta_agent signature / routing tests
-# ---------------------------------------------------------------------------
-
-
 class TestRunBetaAgentRouting:
-    """Test that run_beta_agent routes correctly without hitting AG2 imports."""
-
     @pytest.mark.asyncio
     async def test_neither_agent_nor_config_raises(self):
         from lionagi.providers.ag2.agent import run_beta_agent
@@ -152,11 +136,6 @@ class TestRunBetaAgentRouting:
         assert any("agent_config is ignored" in r.message for r in caplog.records), (
             "Expected log message about agent_config being ignored"
         )
-
-
-# ---------------------------------------------------------------------------
-# AG2BetaEndpoint.stream() integration tests (mocked AG2)
-# ---------------------------------------------------------------------------
 
 
 class TestAG2BetaEndpointStream:

--- a/tests/providers/ag2/groupchat/test_ssrf.py
+++ b/tests/providers/ag2/groupchat/test_ssrf.py
@@ -30,11 +30,6 @@ def _autogen_stubs() -> dict:
     }
 
 
-# ---------------------------------------------------------------------------
-# Unit-level: _assert_nlip_url_safe helper
-# ---------------------------------------------------------------------------
-
-
 class TestAssertNlipUrlSafe:
     """Direct tests for the shared SSRF guard helper."""
 
@@ -65,11 +60,6 @@ class TestAssertNlipUrlSafe:
         with patch("lionagi.providers.ag2.nlip.is_ssrf_safe", return_value=True):
             # Must not raise
             _assert_nlip_url_safe("https://nlip.example.com/")
-
-
-# ---------------------------------------------------------------------------
-# Integration: build_group_chat validates nlip_url before NlipRemoteAgent
-# ---------------------------------------------------------------------------
 
 
 class TestBuildGroupChatNlipUrlSSRF:
@@ -137,11 +127,6 @@ class TestBuildGroupChatNlipUrlSSRF:
                     # Stub autogen returns MagicMocks; any downstream error
                     # (AttributeError, etc.) is acceptable — the SSRF guard passed.
                     pass
-
-
-# ---------------------------------------------------------------------------
-# Integration: AG2GroupChatEndpoint.stream() blocks private nlip_url
-# ---------------------------------------------------------------------------
 
 
 class TestAG2GroupChatEndpointNlipUrlSSRF:

--- a/tests/providers/ag2/test_nlip_retry.py
+++ b/tests/providers/ag2/test_nlip_retry.py
@@ -13,10 +13,6 @@ import pytest
 
 from lionagi.providers.ag2 import nlip as nlip_mod
 
-# ---------------------------------------------------------------------------
-# Fakes: httpx.AsyncClient + nlip_sdk (not an installed dependency here)
-# ---------------------------------------------------------------------------
-
 
 class _FakeResponse:
     def __init__(self, data=None, raise_exc: Exception | None = None):
@@ -89,11 +85,6 @@ def _nlip_sdk_stubs() -> dict:
 MESSAGES = [{"role": "user", "content": "hello"}]
 
 
-# ---------------------------------------------------------------------------
-# (a) Backoff timing: sleeps grow, non-zero
-# ---------------------------------------------------------------------------
-
-
 class TestBackoffTiming:
     @pytest.mark.asyncio
     async def test_call_direct_backoff_delays_increase(self, monkeypatch):
@@ -138,11 +129,6 @@ class TestBackoffTiming:
         assert sleep_calls[0] < sleep_calls[1]
 
 
-# ---------------------------------------------------------------------------
-# (b) Raise on final attempt: original exception propagates
-# ---------------------------------------------------------------------------
-
-
 class TestRaiseOnFinalAttempt:
     @pytest.mark.asyncio
     async def test_call_direct_raises_original_timeout_after_exhaustion(self, monkeypatch):
@@ -176,11 +162,6 @@ class TestRaiseOnFinalAttempt:
                 )
 
         assert post_mock.call_count == 2
-
-
-# ---------------------------------------------------------------------------
-# (c) Narrow exception surface: non-retryable errors raise immediately
-# ---------------------------------------------------------------------------
 
 
 class TestNarrowExceptionSurface:
@@ -239,11 +220,6 @@ class TestNarrowExceptionSurface:
         assert sleep_calls == []
 
 
-# ---------------------------------------------------------------------------
-# (d) sdk-path warning logging preserved; direct path stays silent
-# ---------------------------------------------------------------------------
-
-
 class TestRetryLogging:
     @pytest.mark.asyncio
     async def test_call_nlip_sdk_warns_once_per_non_final_retry(self, monkeypatch, caplog):
@@ -283,11 +259,6 @@ class TestRetryLogging:
                 )
 
         assert [r for r in caplog.records if r.levelname == "WARNING"] == []
-
-
-# ---------------------------------------------------------------------------
-# Success paths (sanity: retry then succeed still parses correctly)
-# ---------------------------------------------------------------------------
 
 
 class TestSuccessAfterTransientFailure:

--- a/tests/providers/google/gemini_code/test_ndjson_mapping.py
+++ b/tests/providers/google/gemini_code/test_ndjson_mapping.py
@@ -74,11 +74,6 @@ def _success_obj(**over) -> dict:
     return obj
 
 
-# ---------------------------------------------------------------------------
-# Result projection
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_response_becomes_result_stripped():
     session = await _run_objects([_success_obj()])
@@ -108,11 +103,6 @@ async def test_usage_and_turns_captured():
 async def test_duration_seconds_becomes_ms():
     session = await _run_objects([_success_obj(duration_seconds=2.0)])
     assert session.duration_ms == 2000
-
-
-# ---------------------------------------------------------------------------
-# Error handling
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -192,10 +182,8 @@ async def test_session_id_not_clobbered_by_later_null():
     assert session.session_id == "conv-first"
 
 
-# ---------------------------------------------------------------------------
 # state.db persistence chunks (system / result) — the channel run.py reads
 # session_id and provider usage metadata from during `li agent` streaming.
-# ---------------------------------------------------------------------------
 
 
 async def _run_chunks(objects: list[dict], request: GeminiCodeRequest | None = None) -> list:
@@ -355,11 +343,6 @@ async def test_unrelated_runtime_error_is_not_reclassified_as_teardown():
             pass
 
 
-# ---------------------------------------------------------------------------
-# Callbacks
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_on_text_and_on_final_fire():
     texts: list[str] = []
@@ -406,11 +389,6 @@ async def test_on_text_loop_closed_error_propagates():
             pass
 
 
-# ---------------------------------------------------------------------------
-# Model resolution
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "spec,expected",
     [
@@ -439,10 +417,8 @@ def test_resolve_agy_model(spec, expected):
     assert resolve_agy_model(spec) == expected
 
 
-# ---------------------------------------------------------------------------
 # Model resolution — effort folding (agy has no effort flag/kwarg; effort is
 # expressed only as the Low/Medium/High suffix on --model)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -505,10 +481,8 @@ def test_resolve_agy_model_36_flash_defaults_high_never_downgrades():
         assert not resolve_agy_model(spec).startswith("Gemini 3.6 Flash"), spec
 
 
-# ---------------------------------------------------------------------------
 # Model resolution — reapply_effort (li agent -r --effort re-applying effort
 # to an already-resolved persisted model)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(

--- a/tests/providers/openai/codex/test_benign_eos.py
+++ b/tests/providers/openai/codex/test_benign_eos.py
@@ -37,11 +37,6 @@ async def _chunks_from_events(events: list[dict]) -> list[StreamChunk]:
     return collected
 
 
-# ---------------------------------------------------------------------------
-# Test 1: error event with non-empty error (rate_limit) → NOT benign
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_error_event_with_rate_limit_code_is_not_benign():
     """{"error": {"code": "rate_limit"}} has a truthy value so any(err.values()) is True — not benign."""
@@ -54,11 +49,6 @@ async def test_error_event_with_rate_limit_code_is_not_benign():
     assert not error_chunk.metadata.get("benign_eos"), (
         f"rate_limit error must NOT be marked benign_eos; metadata={error_chunk.metadata}"
     )
-
-
-# ---------------------------------------------------------------------------
-# Test 2: turn.failed with empty error payload → NOT benign
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -76,11 +66,6 @@ async def test_turn_failed_with_empty_error_is_not_benign():
     )
 
 
-# ---------------------------------------------------------------------------
-# Test 3: error event with completely empty error dict → benign EOS
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_error_event_with_empty_error_dict_is_benign_eos():
     """{"error":{}} is the resume-EOF sentinel and must be tagged benign_eos=True so run() terminates cleanly."""
@@ -94,11 +79,6 @@ async def test_error_event_with_empty_error_dict_is_benign_eos():
         "empty-error 'error' event must be tagged benign_eos=True; "
         f"metadata={error_chunks[0].metadata}"
     )
-
-
-# ---------------------------------------------------------------------------
-# Invariant: structured-but-falsy error payloads are REAL failures
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -193,10 +173,8 @@ async def test_turn_failed_with_nested_message_still_preferred_over_toplevel():
     assert chunks[0].content == "inner detail"
 
 
-# ---------------------------------------------------------------------------
 # Regression: "error": null must NOT be treated as benign EOS
 # (fix/cli-worker-error-surfacing regression)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/providers/openai/codex/test_empty_payload_fallback.py
+++ b/tests/providers/openai/codex/test_empty_payload_fallback.py
@@ -37,11 +37,6 @@ async def _chunks_from_events(events: list[dict]) -> list[StreamChunk]:
     return collected
 
 
-# ---------------------------------------------------------------------------
-# turn.failed with empty error payload → self-describing message
-# ---------------------------------------------------------------------------
-
-
 async def test_turn_failed_empty_payload_has_self_describing_content():
     """turn.failed with err={} must NOT produce '{}' as content; must be a human-readable description naming the event type."""
     events = [{"type": "turn.failed", "error": {}}]
@@ -75,11 +70,6 @@ async def test_error_event_empty_payload_benign_eos_still_applies():
     # the benign_eos sentinel is the real distinguishing property.
     # Accept any content — what matters is the benign_eos tag.
     assert error_chunks[0].metadata.get("benign_eos") is True
-
-
-# ---------------------------------------------------------------------------
-# Populated message — existing behaviour preserved
-# ---------------------------------------------------------------------------
 
 
 async def test_turn_failed_populated_message_preserved():
@@ -118,11 +108,6 @@ async def test_error_event_top_level_message_preserved():
     assert len(chunks) == 1
     assert chunks[0].type == "error"
     assert chunks[0].content == msg
-
-
-# ---------------------------------------------------------------------------
-# Edge cases: error=null, error missing, {"code": ...} no message, non-dict error
-# ---------------------------------------------------------------------------
 
 
 async def test_turn_failed_error_null_has_self_describing_content():

--- a/tests/providers/test_claude_code_result_usage.py
+++ b/tests/providers/test_claude_code_result_usage.py
@@ -74,7 +74,7 @@ async def test_result_event_with_model_usage_surfaces_it_on_result_chunk():
     """The CLI's "result" event carries a whole-agent-tree per-model
     ``modelUsage`` breakdown (includes Task-tool subagent spend) alongside
     the top-level-loop-only ``usage`` field. It must be forwarded verbatim
-    on the result chunk so _collect_branch_usage can prefer it (#2379)."""
+    on the result chunk so _collect_branch_usage can prefer it."""
     chunks = await _chunks_from_events(
         [
             _result_event(

--- a/tests/providers/test_cli_adapter_error_conformance.py
+++ b/tests/providers/test_cli_adapter_error_conformance.py
@@ -3,12 +3,8 @@
 
 """What every CLI adapter must show a stream consumer when a session fails.
 
-Four CLI adapters each decide, independently, what reaches a consumer when a
-run ends in failure. Two of them agree, two diverge. Each has its own tests, and
-several of those go into more detail on their own adapter than anything here
-does; what none of them does is compare the four, so a fifth adapter, or a
-refactor of an existing one, reopens the class in silence and the next reader
-rebuilds the comparison by hand.
+Full design rationale, the per-adapter comparison, and what this suite does
+not cover: see docs/internals/providers.md#cli-adapter-error-chunk-conformance.
 
 The contract, per adapter, in three separate assertions:
 
@@ -18,99 +14,18 @@ The contract, per adapter, in three separate assertions:
 3. a session finishing WITHOUT ``is_error`` yields ZERO chunks of type
    ``error``.
 
-"Exactly one" is the contract and not a stylistic preference. "At least one"
-cannot express "this failure was not reported twice", so the already-reported
-guard some adapters carry would have no expression here at all. Assertion 3 is
-the other direction: without it, an adapter that reported errors on healthy
-sessions would pass cleanly, and "emits on failure" and "emits unconditionally"
-are different claims that only a healthy fixture can tell apart.
-
-Where the tests patch, and why not one level up
------------------------------------------------
 Each test patches ``<module>._ndjson_from_cli``, the module-private wrapper
-around the shared NDJSON reader. All four adapters call it by bare module-global
-name through two levels of real code (the parser calls an events function, which
-calls the seam), so the fixture is fed to the real parser, the real parser builds
-the real session, and the real ``stream()`` decides what to yield. Nothing here
-hand-builds a session and hands it to an endpoint: that tests the endpoint
-against a state the parser never produces, which is mutation-sensitive and
-unreachable at the same time.
+around the shared NDJSON reader, so the fixture is fed to the real parser and
+the real ``stream()`` decides what to yield -- nothing here hand-builds a
+session and hands it to an endpoint. The CLI-binary guard lives above that
+seam, so each test also points the binary constant at a stub path to keep
+the real events function in the loop.
 
-The CLI-binary guard (``if not CLAUDE_CLI``, and its three siblings) lives in
-that events function, ABOVE the seam, so patching the seam alone still raises on
-a machine where that CLI is not installed. Each test therefore also points the
-binary constant at a stub path. That keeps the real events function in the loop.
-Three of the four append a terminal ``{"type": "done"}`` themselves, which is why
-no fixture below carries one; gemini's appends nothing and its parser needs no
-sentinel, so the same fixture shape is right for all four for two different
-reasons.
-
-Fixture fidelity
-----------------
-Every fixture is labelled ``RECORDED`` or ``AUTHORED`` and the label is
-load-bearing. An authored event dict is written from what our own parser reads,
-so it agrees with the parser by construction and inherits its blind spots
-exactly -- and the blind spot is the failure mode under test, since a declared
-failure disappears precisely when nobody reads the field. An authored fixture
-therefore cannot contain a field the parser ignores, and cannot reveal a CLI
-that signals failure through a channel we never consult. It would pass, cleanly,
-forever. Only a recording is evidence about the world; an authored dict is
-evidence about our model of it. Replacing the authored ones with captured
-transcripts is tracked separately.
-
-Landing red, on purpose
------------------------
-This suite lands with the remaining known divergence marked ``xfail(strict=True)``.
-Strict matters: non-strict would let the suite stay green on the day a
-divergence is fixed while still claiming the gap is open, and a stale
-expectation reads as current state. It has already earned that once: codex's
-marks were removed because the divergence they named was fixed, and strict is
-what turned that into a failing run rather than a quiet pass.
-
-AN EXPECTED FAILURE IS UNMARKED BY THE DIVERGENCE IT NAMES BEING FIXED, NEVER BY
-A PASSING RUN. An xfail here that starts passing is a signal to investigate, not
-to delete the mark: either the divergence was fixed and this was not updated with
-it, or the test stopped testing what it names. Every mark names what it waits on.
-
-Who emits the error chunk differs, and it decides whether a guard is reachable
------------------------------------------------------------------------------
-The four adapters do not satisfy (or miss) this contract the same way, and the
-difference is in which layer constructs the chunk:
-
-- ``claude_code`` constructs one only in the endpoint, inside an
-  already-reported guard. Its parser never constructs one, so that guard cannot
-  fire on any real event sequence today. It is pinned intent, not live cover.
-- ``gemini_code`` constructs one in the parser on the failing path, and its
-  endpoint guard is what stops a second. Here the guard IS reachable, which
-  makes gemini the one adapter where "exactly one" is non-vacuous today.
-- ``codex`` constructs one in the parser AND one in the endpoint, and until
-  recently there was no guard between them, so a real ``turn.failed`` event was
-  reported twice. That is why "at least one" would have been the wrong
-  contract: it passed on codex while the defect was live. The guard now exists
-  and codex satisfies all three assertions unmarked.
-- ``pi`` constructs none at all.
-
-Codex also yields an ``error``-type chunk when a resumed session ends normally,
-which looks like a violation of the third assertion and is not one. That chunk
-carries ``is_error=False`` and ``benign_eos=True``, both set deliberately, and
-the classification behind them is pinned by its own tests. The fixtures here use
-``turn.completed`` for the healthy codex case, so the two do not collide. A
-consumer keying on chunk type alone still cannot tell that case from a failure,
-but the discriminators exist and removing the chunk would break a decision that
-was made on purpose.
-
-What this suite does not cover
-------------------------------
-- The non-streaming path. ``_call()`` drives the same generator and returns the
-  session as a dict with nothing branching on the flag.
-- ReAct's final-answer turn, which catches broadly and substitutes the last
-  response.
-- Per-tool error carriers, which are a separate signal and not the same
-  contract. Three adapters emit ``tool_result`` chunks carrying their own
-  ``is_error``; gemini emits none, because agy's json format has no per-tool
-  events for it to read.
-- Passing says the adapters agree with each other and with the fixtures. Where a
-  fixture is AUTHORED it says nothing about the real CLI.
+This suite lands with the remaining known divergence (pi) marked
+``xfail(strict=True)``. An expected failure is unmarked by the divergence it
+names being fixed, never by a passing run: a passing xfail here means either
+the divergence was fixed without updating this test, or the test stopped
+testing what it names.
 """
 
 from __future__ import annotations
@@ -134,11 +49,6 @@ _UNMARK_RULE = (
 
 # Each mark names the specific divergence it is waiting on, so it cannot be
 # removed by anything less than that divergence going away.
-#
-# Codex used to be marked here for the double report and for its error chunks
-# not setting is_error. That divergence is fixed and closed out, so the mark is
-# gone and the codex parameters are held to the contract like any other. This
-# is the only reason a mark comes off.
 _PI_GAP = "pi emitting no error chunk and delivering the failure as a result chunk"
 
 
@@ -173,8 +83,6 @@ class Adapter:
     request_kwargs: dict[str, Any] = field(default_factory=lambda: {"prompt": "test"})
 
 
-# --------------------------------------------------------------------------- fixtures
-#
 # Each failing stream is the terminal event shape that sets ``is_error`` on that
 # adapter's session, read off the parser rather than guessed. Each healthy
 # stream is the same event without the failure, so the pair differs in one fact.
@@ -291,9 +199,6 @@ def _params(diverging: dict[str, str]):
     return out
 
 
-# --------------------------------------------------------------------------- the contract
-
-
 @pytest.mark.parametrize("adapter", _params({"pi": _PI_GAP}))
 async def test_a_failed_session_yields_exactly_one_error_chunk(adapter, monkeypatch):
     chunks = await _stream_chunks(adapter, adapter.failing, monkeypatch)
@@ -329,9 +234,6 @@ async def test_a_healthy_session_yields_no_error_chunk(adapter, monkeypatch):
         f"{adapter.id}: the healthy fixture produced no chunks at all, so this asserts "
         "nothing about the error path"
     )
-
-
-# --------------------------------------------------------------------------- per-adapter
 
 
 @pytest.mark.xfail(strict=True, reason=_UNMARK_RULE.format(gap=_PI_GAP))

--- a/tests/providers/test_cli_path_validation.py
+++ b/tests/providers/test_cli_path_validation.py
@@ -9,10 +9,6 @@ from __future__ import annotations
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Shared helper unit tests
-# ---------------------------------------------------------------------------
-
 
 class TestCliPathsHelper:
     """Direct unit tests for the shared helper functions."""
@@ -90,11 +86,6 @@ class TestCliPathsHelper:
 
         with pytest.raises(ValueError, match="traversal"):
             check_add_dir_entries_safe(["ok", "../../bad", "/abs/ok"], "add_dir")
-
-
-# ---------------------------------------------------------------------------
-# Codex provider — CodexCodeRequest
-# ---------------------------------------------------------------------------
 
 
 class TestCodexPathValidation:
@@ -202,11 +193,6 @@ class TestCodexPathValidation:
             add_dir=[str(project_root)],
         )
         assert str(project_root) in req.add_dir
-
-
-# ---------------------------------------------------------------------------
-# Claude Code provider — ClaudeCodeRequest
-# ---------------------------------------------------------------------------
 
 
 class TestClaudeCodePathValidation:
@@ -347,11 +333,6 @@ class TestClaudeCodePathValidation:
             ClaudeCodeRequest(prompt="hi", repo=repo, mcp_config="linked.json")
 
 
-# ---------------------------------------------------------------------------
-# Gemini provider — GeminiCodeRequest
-# ---------------------------------------------------------------------------
-
-
 class TestGeminiPathValidation:
     """include_directories in GeminiCodeRequest must be validated before argv."""
 
@@ -395,11 +376,6 @@ class TestGeminiPathValidation:
 
         with pytest.raises(Exception, match="outside the repository"):
             GeminiCodeRequest(prompt="hi", repo=repo, include_directories=["escape"])
-
-
-# ---------------------------------------------------------------------------
-# Pi provider — PiCodeRequest (extension and skill fields now also validated)
-# ---------------------------------------------------------------------------
 
 
 class TestPiExtensionSkillValidation:

--- a/tests/providers/test_gemini_cli_endpoint.py
+++ b/tests/providers/test_gemini_cli_endpoint.py
@@ -21,10 +21,6 @@ from lionagi.providers.google.gemini_code import (
     stream_gemini_cli,
 )
 
-# ---------------------------------------------------------------------------
-# argv construction
-# ---------------------------------------------------------------------------
-
 
 class TestCmdArgs:
     """as_cmd_args must emit json output-format + a resolved agy model name."""
@@ -105,7 +101,7 @@ class TestCmdArgs:
     def test_explicit_print_timeout_accepts_subnanosecond_fraction_at_go_max(self):
         """Go's time.ParseDuration truncates fractions smaller than a nanosecond,
         so a `.1ns` excess sitting on top of int64's max is still parseable by
-        `agy` and must not be rejected here (#2689)."""
+        `agy` and must not be rejected here."""
         explicit = "9223372036854775807.1ns"
         args = GeminiCodeRequest(prompt="hi", print_timeout=explicit).as_cmd_args()
 
@@ -161,11 +157,6 @@ class TestCmdArgs:
         assert int(emitted.removesuffix("s")) >= 1
 
 
-# ---------------------------------------------------------------------------
-# Subprocess error surfacing
-# ---------------------------------------------------------------------------
-
-
 class TestSubprocessErrorSurfacing:
     """When agy exits nonzero, ndjson_from_cli raises RuntimeError; it propagates."""
 
@@ -182,11 +173,6 @@ class TestSubprocessErrorSurfacing:
             with pytest.raises(RuntimeError, match="authentication required"):
                 async for _ in stream_gemini_cli(GeminiCodeRequest(prompt="hi")):
                     pass
-
-
-# ---------------------------------------------------------------------------
-# Endpoint _call session mapping
-# ---------------------------------------------------------------------------
 
 
 class TestEndpointCall:
@@ -220,11 +206,6 @@ class TestEndpointCall:
         )
 
 
-# ---------------------------------------------------------------------------
-# Default model
-# ---------------------------------------------------------------------------
-
-
 class TestDefaultModel:
     """GeminiCodeRequest default model must be the latest flash family."""
 
@@ -235,11 +216,6 @@ class TestDefaultModel:
     def test_explicit_model_is_preserved(self):
         req = GeminiCodeRequest(prompt="hello", model="gemini-2.5-pro")
         assert req.model == "gemini-2.5-pro"
-
-
-# ---------------------------------------------------------------------------
-# BACKENDS default model
-# ---------------------------------------------------------------------------
 
 
 class TestBackendsDefaultModel:
@@ -254,11 +230,6 @@ class TestBackendsDefaultModel:
         assert "gemini-3.5-flash" in BACKENDS["gemini_code"]
 
 
-# ---------------------------------------------------------------------------
-# CLI_PROVIDERS includes gemini variants
-# ---------------------------------------------------------------------------
-
-
 class TestCliProvidersSet:
     """gemini_code, gemini-cli, gemini_cli, gemini-code must be in CLI_PROVIDERS."""
 
@@ -267,11 +238,6 @@ class TestCliProvidersSet:
 
         for name in ("gemini_code", "gemini-code", "gemini_cli", "gemini-cli"):
             assert name in CLI_PROVIDERS, f"{name!r} not in CLI_PROVIDERS"
-
-
-# ---------------------------------------------------------------------------
-# Run.py error message improvement
-# ---------------------------------------------------------------------------
 
 
 class TestRunErrorMessage:

--- a/tests/providers/test_provider_errors.py
+++ b/tests/providers/test_provider_errors.py
@@ -29,10 +29,6 @@ from lionagi.providers._provider_errors import (
     classify_provider_error,
 )
 
-# ---------------------------------------------------------------------------
-# Quota patterns
-# ---------------------------------------------------------------------------
-
 
 def test_classify_usage_limit_reached_returns_quota_error():
     err = classify_provider_error("You've hit your usage limit reached. Please wait.")
@@ -67,11 +63,6 @@ def test_classify_quota_in_stderr_tail():
     assert isinstance(err, ProviderQuotaError)
 
 
-# ---------------------------------------------------------------------------
-# Auth patterns
-# ---------------------------------------------------------------------------
-
-
 def test_classify_invalid_api_key_returns_auth_error():
     err = classify_provider_error("Error: invalid_api_key provided")
     assert isinstance(err, ProviderAuthError)
@@ -95,11 +86,6 @@ def test_classify_401_unauthorized_returns_auth_error():
 def test_classify_auth_case_insensitive():
     err = classify_provider_error("INVALID API KEY")
     assert isinstance(err, ProviderAuthError)
-
-
-# ---------------------------------------------------------------------------
-# Context-length patterns
-# ---------------------------------------------------------------------------
 
 
 def test_classify_context_window_exceeded_returns_context_error():
@@ -158,11 +144,6 @@ def test_classify_prompt_is_too_long_returns_context_error():
     assert err.retryable is False
 
 
-# ---------------------------------------------------------------------------
-# Quota — date-formatted retry time (real cohort gap: no digit after "at")
-# ---------------------------------------------------------------------------
-
-
 def test_classify_usage_limit_with_date_formatted_retry_time():
     err = classify_provider_error(
         "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage "
@@ -179,20 +160,10 @@ def test_classify_hit_your_usage_limit_returns_quota_error():
     assert isinstance(err, ProviderQuotaError)
 
 
-# ---------------------------------------------------------------------------
-# Capacity patterns
-# ---------------------------------------------------------------------------
-
-
 def test_classify_model_at_capacity_returns_capacity_error():
     err = classify_provider_error("Selected model is at capacity. Please try a different model.")
     assert isinstance(err, ProviderCapacityError)
     assert err.retryable is True
-
-
-# ---------------------------------------------------------------------------
-# Unsupported model/tool patterns
-# ---------------------------------------------------------------------------
 
 
 def test_classify_unsupported_model_for_account_returns_unsupported_error():
@@ -229,11 +200,6 @@ def test_agy_wrapped_stream_disconnect_stays_retryable():
     assert err.retryable is True
 
 
-# ---------------------------------------------------------------------------
-# Safety patterns
-# ---------------------------------------------------------------------------
-
-
 def test_classify_cybersecurity_safety_block_returns_safety_error():
     err = classify_provider_error(
         "This content was flagged for possible cybersecurity risk. If this "
@@ -241,11 +207,6 @@ def test_classify_cybersecurity_safety_block_returns_safety_error():
     )
     assert isinstance(err, ProviderSafetyError)
     assert err.retryable is False
-
-
-# ---------------------------------------------------------------------------
-# Stream-disconnect patterns
-# ---------------------------------------------------------------------------
 
 
 def test_classify_stream_disconnected_returns_stream_disconnect_error():
@@ -261,11 +222,6 @@ def test_classify_agy_loop_closed_teardown_is_retryable():
     err = classify_provider_error("agy teardown failed: Event loop is closed")
     assert isinstance(err, ProviderTeardownError)
     assert err.retryable is True
-
-
-# ---------------------------------------------------------------------------
-# Adapter catch-all (agy) — only fires when nothing more specific matches
-# ---------------------------------------------------------------------------
 
 
 def test_classify_agy_generic_error_status_returns_adapter_error():
@@ -289,11 +245,6 @@ def test_classify_agy_quota_message_still_wins_over_adapter_catchall():
     assert isinstance(err, ProviderQuotaError)
 
 
-# ---------------------------------------------------------------------------
-# Unmatched → base ProviderError (not a subclass)
-# ---------------------------------------------------------------------------
-
-
 def test_classify_unknown_returns_base_provider_error():
     err = classify_provider_error("Some random failure with no known pattern")
     assert type(err) is ProviderError
@@ -302,11 +253,6 @@ def test_classify_unknown_returns_base_provider_error():
 def test_classify_empty_string_returns_base_provider_error():
     err = classify_provider_error("")
     assert type(err) is ProviderError
-
-
-# ---------------------------------------------------------------------------
-# All classes are RuntimeError-compatible
-# ---------------------------------------------------------------------------
 
 
 def test_provider_error_is_runtime_error():
@@ -337,11 +283,6 @@ def test_emission_error_is_runtime_error():
 def test_classify_result_is_runtime_error():
     err = classify_provider_error("usage limit reached")
     assert isinstance(err, RuntimeError)
-
-
-# ---------------------------------------------------------------------------
-# retryable classification — the machine-readable retry/non-retry split
-# ---------------------------------------------------------------------------
 
 
 def test_base_provider_error_defaults_to_non_retryable():
@@ -375,11 +316,6 @@ def test_transient_classes_are_retryable(cls):
 def test_permanent_classes_are_non_retryable(cls):
     assert cls.retryable is False
     assert cls("msg").retryable is False
-
-
-# ---------------------------------------------------------------------------
-# Attrs preserved correctly
-# ---------------------------------------------------------------------------
 
 
 def test_provider_error_attrs_stored():

--- a/tests/service/connections/mcp/test_wrapper.py
+++ b/tests/service/connections/mcp/test_wrapper.py
@@ -151,7 +151,6 @@ class TestMCPConnectionPoolGetClient:
 
         with patch.object(MCPConnectionPool, "_create_client") as mock_create:
             client = await MCPConnectionPool.get_client(inline_config)
-            # Should not create new client
             mock_create.assert_not_called()
 
     @pytest.mark.asyncio
@@ -336,7 +335,6 @@ class TestMCPConnectionPoolCleanup:
             "client2": mock_client2,
         }
 
-        # Should not raise, just log
         await MCPConnectionPool.cleanup()
 
         mock_client1.__aexit__.assert_called_once()
@@ -389,7 +387,6 @@ class TestCreateMCPTool:
             tool = create_mcp_tool(mcp_config, tool_name)
             await tool()
 
-            # Should call with original name, not prefixed
             mock_client.call_tool.assert_called_once_with("actual_name", {})
 
     @pytest.mark.asyncio

--- a/tests/service/connections/providers/test_apikey_resolution.py
+++ b/tests/service/connections/providers/test_apikey_resolution.py
@@ -10,10 +10,6 @@ import pytest
 from lionagi.service.connections.endpoint_config import EndpointConfig
 from lionagi.service.connections.registry import EndpointMeta, EndpointRegistry, EndpointType
 
-# ---------------------------------------------------------------------------
-# Ollama: no key required; auth_type="none"; api_key stays None
-# ---------------------------------------------------------------------------
-
 
 class TestOllamaNoKeyRequired:
     def test_ollama_endpoint_has_no_api_key_env(self):
@@ -64,11 +60,6 @@ class TestOllamaNoKeyRequired:
         assert config._api_key == "ollama_key"
 
 
-# ---------------------------------------------------------------------------
-# Provider api_key_env metadata declared
-# ---------------------------------------------------------------------------
-
-
 def test_api_key_env_metadata_on_provider_configs():
     """All non-Ollama API providers must declare _API_KEY_ENV; Ollama must not."""
     from lionagi.providers.anthropic._config import AnthropicConfigs
@@ -105,11 +96,6 @@ def test_api_key_env_metadata_on_provider_configs():
 
     # Ollama has no key
     assert getattr(OllamaConfigs, "_API_KEY_ENV", None) is None
-
-
-# ---------------------------------------------------------------------------
-# EndpointMeta.create_config resolves api_key via api_key_env
-# ---------------------------------------------------------------------------
 
 
 def test_endpoint_meta_resolves_api_key_from_settings():
@@ -173,11 +159,6 @@ def test_endpoint_meta_respects_api_key_override():
 
     # Explicit override wins over api_key_env resolution
     assert config._api_key == "sk-explicit"
-
-
-# ---------------------------------------------------------------------------
-# Header parity: resolved api_key produces correct auth header
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(

--- a/tests/service/connections/providers/test_cli_behavior_parity.py
+++ b/tests/service/connections/providers/test_cli_behavior_parity.py
@@ -13,10 +13,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Claude EOF JSON repair
-# ---------------------------------------------------------------------------
-
 
 @pytest.mark.asyncio
 async def test_ndjson_from_cli_tail_repair_yields_repaired_object():
@@ -120,11 +116,6 @@ async def test_claude_ndjson_uses_repair_callback():
     assert kw["tail_repair"] is not None, "tail_repair must not be None for Claude"
 
 
-# ---------------------------------------------------------------------------
-# Codex does not double-apply workspace
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_codex_ndjson_does_not_pass_cwd(tmp_path):
     """Codex _ndjson_from_cli must NOT pass cwd= to ndjson_from_cli.
@@ -171,11 +162,6 @@ def test_codex_as_cmd_args_contains_dash_c_flag(tmp_path):
     assert "-C" in args
     c_idx = args.index("-C")
     assert args[c_idx + 1] == str(tmp_path)
-
-
-# ---------------------------------------------------------------------------
-# Pi inherits stdin; Gemini (agy print mode) keeps the DEVNULL default
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/service/connections/providers/test_cli_cancellation.py
+++ b/tests/service/connections/providers/test_cli_cancellation.py
@@ -26,11 +26,6 @@ def _block_real_process_group_signals(monkeypatch):
     monkeypatch.setattr(proc_mod.os, "killpg", fail_if_unmocked)
 
 
-# ---------------------------------------------------------------------------
-# 1. start_new_session=True is always passed to subprocess creation
-# ---------------------------------------------------------------------------
-
-
 class TestSubprocessSessionIsolation:
     """Verify CLI subprocesses are isolated from the parent's process group."""
 
@@ -126,14 +121,7 @@ class TestSubprocessSessionIsolation:
             assert kwargs.get("start_new_session") is True
 
 
-# ---------------------------------------------------------------------------
-# 2. CancelledError propagates through _call() without triggering auto_finish
-# ---------------------------------------------------------------------------
-
-
 class TestCancellationSkipsAutoFinish:
-    """Verify that task cancellation never triggers auto_finish."""
-
     @pytest.mark.asyncio
     async def test_cancelled_error_skips_auto_finish(self):
         from lionagi.providers.anthropic.claude_code import (
@@ -273,11 +261,6 @@ class TestCancellationSkipsAutoFinish:
             assert stream_call_count == 2, "auto_finish should fire on normal completion"
 
 
-# ---------------------------------------------------------------------------
-# 3. _ndjson_from_cli cleanup: CancelledError must not be swallowed
-# ---------------------------------------------------------------------------
-
-
 class TestNdjsonCleanupPropagation:
     """Verify _ndjson_from_cli finally block doesn't swallow CancelledError."""
 
@@ -323,11 +306,6 @@ class TestNdjsonCleanupPropagation:
 
             # Verify cleanup was attempted
             mock_proc.terminate.assert_called()
-
-
-# ---------------------------------------------------------------------------
-# 4. Tool allowlist/blocklist: no spurious quotes in subprocess args
-# ---------------------------------------------------------------------------
 
 
 class TestToolAllowlistArgs:
@@ -390,11 +368,6 @@ class TestToolAllowlistArgs:
         assert '"' not in config_val, f"mcp_config value {config_val!r} has embedded quotes"
 
 
-# ---------------------------------------------------------------------------
-# 5. Mutable default: session must not be shared across calls
-# ---------------------------------------------------------------------------
-
-
 class TestSessionIsolation:
     """Verify each stream_claude_code_cli call gets its own session."""
 
@@ -411,11 +384,6 @@ class TestSessionIsolation:
             f"session default is {session_param.default!r}, not None — "
             "mutable default causes cross-request data leakage"
         )
-
-
-# ---------------------------------------------------------------------------
-# 6. Empty responses guard
-# ---------------------------------------------------------------------------
 
 
 class TestEmptyResponsesGuard:
@@ -444,11 +412,6 @@ class TestEmptyResponsesGuard:
             # Must not raise IndexError on responses[-1]
             result = await endpoint._call({"request": mock_request}, {})
             assert isinstance(result, dict)
-
-
-# ---------------------------------------------------------------------------
-# 7. Process-group kill + non-Unix cleanup
-# ---------------------------------------------------------------------------
 
 
 def _make_mock_proc(pid=12345):
@@ -696,11 +659,6 @@ class TestKillpgUnavailablePlatform:
         # AttributeError from the absent killpg. Asserting terminate() was
         # called instead pins a call that does nothing on a child which has
         # already exited, and would pass whether or not the group was dealt with.
-
-
-# ---------------------------------------------------------------------------
-# 8. Gemini & Pi stderr deadlock prevention
-# ---------------------------------------------------------------------------
 
 
 class TestStderrDeadlockPrevention:

--- a/tests/service/connections/providers/test_ollama.py
+++ b/tests/service/connections/providers/test_ollama.py
@@ -88,7 +88,6 @@ class TestOllamaEndpointConfiguration:
         # api_key should be removed
         endpoint = OllamaChatEndpoint(api_key="should_be_removed")
 
-        # Should not raise error
         assert endpoint is not None
 
     @patch("lionagi.providers.ollama.chat._HAS_OLLAMA", True)
@@ -208,7 +207,6 @@ class TestOllamaModelManagement:
 
         endpoint = OllamaChatEndpoint()
 
-        # Should not raise, but log warning
         with caplog.at_level("DEBUG", logger="lionagi.providers.ollama.chat"):
             endpoint._check_model("llama2")
 

--- a/tests/service/connections/providers/test_pi_cli.py
+++ b/tests/service/connections/providers/test_pi_cli.py
@@ -344,11 +344,6 @@ async def test_pi_cli_endpoint_stream_maps_pi_chunks_to_stream_chunks(monkeypatc
     assert chunks[4].content == "done"
 
 
-# ---------------------------------------------------------------------------
-# Pi file_args path validation (fail-closed)
-# ---------------------------------------------------------------------------
-
-
 class TestPiFileArgsValidation:
     """Pi file_args must reject absolute paths and ``..`` traversal at construction time (fail-closed)."""
 

--- a/tests/service/connections/test_endpoint.py
+++ b/tests/service/connections/test_endpoint.py
@@ -541,7 +541,6 @@ class TestEndpoint:
                 async for chunk in endpoint.stream(request):
                     chunks.append(chunk)
 
-        # Should get 3 non-empty lines converted to StreamChunk objects.
         assert len(chunks) == 3
         assert all(isinstance(chunk, StreamChunk) for chunk in chunks)
         assert [chunk.type for chunk in chunks] == ["text", "text", "text"]
@@ -753,11 +752,6 @@ class TestEndpoint:
         assert mock_execute.called
 
 
-# ---------------------------------------------------------------------------
-# SSRF guard at Endpoint transport boundary (HIGH 2 regression tests)
-# ---------------------------------------------------------------------------
-
-
 class TestEndpointSSRFGuard:
     """Endpoint._call_aiohttp and _stream_aiohttp must block SSRF URLs."""
 
@@ -834,11 +828,6 @@ class TestEndpointSSRFGuard:
         with patch("lionagi.ln._ssrf.is_ssrf_safe", return_value=False):
             with pytest.raises(PermissionError, match="SSRF guard"):
                 await endpoint._call_aiohttp(payload={}, headers={})
-
-
-# ---------------------------------------------------------------------------
-# Provider _call() override regression tests (HIGH: bypass via direct HTTP)
-# ---------------------------------------------------------------------------
 
 
 class TestProviderCallOverrideSSRFGuard:
@@ -927,11 +916,6 @@ class TestProviderCallOverrideSSRFGuard:
                 await endpoint._call(payload={"model": "whisper-large-v3"}, headers={})
 
 
-# ---------------------------------------------------------------------------
-# CLIEndpoint deprecation bridge
-# ---------------------------------------------------------------------------
-
-
 class TestCLIEndpointDeprecation:
     """CLIEndpoint is a deprecated alias for AgenticEndpoint."""
 
@@ -952,11 +936,6 @@ class TestCLIEndpointDeprecation:
         from lionagi.service.connections import AgenticEndpoint, CLIEndpoint
 
         assert CLIEndpoint is AgenticEndpoint
-
-
-# ---------------------------------------------------------------------------
-# Single-retry-path parity tests (collapse of backoff dual-retry layer)
-# ---------------------------------------------------------------------------
 
 
 class TestSingleRetryPathParity:
@@ -1336,11 +1315,9 @@ class TestRetryConfigDefaultRetriesRealErrors:
         assert call_count == 3
 
 
-# ---------------------------------------------------------------------------
-# #2393 — a retried POST to a non-idempotent creation endpoint must carry a
-# stable Idempotency-Key reused across every attempt, so an ambiguous lost
-# response cannot be replayed into a second billable job.
-# ---------------------------------------------------------------------------
+# A retried POST to a non-idempotent creation endpoint must carry a stable
+# Idempotency-Key reused across every attempt, so an ambiguous lost response
+# cannot be replayed into a second billable job.
 
 
 class TestIdempotencyKeyOnRetriedPosts:

--- a/tests/service/connections/test_match_endpoint.py
+++ b/tests/service/connections/test_match_endpoint.py
@@ -220,7 +220,6 @@ class TestMatchEndpoint:
         assert isinstance(openai_endpoint, OpenaiChatEndpoint)
         assert isinstance(anthropic_endpoint, AnthropicMessagesEndpoint)
 
-        # Should be different instances with different configurations
         assert openai_endpoint is not anthropic_endpoint
         assert openai_endpoint.config.provider != anthropic_endpoint.config.provider
 
@@ -236,7 +235,6 @@ class TestMatchEndpoint:
             provider="openai", endpoint="chat", model="gpt-4o", temperature=0.8
         )
 
-        # Should have different configurations
         assert endpoint1.config is not endpoint2.config
 
     def test_match_endpoint_routes_firecrawl_tavily_and_cli_aliases(self):

--- a/tests/service/connections/test_serialize_by_alias.py
+++ b/tests/service/connections/test_serialize_by_alias.py
@@ -13,10 +13,6 @@ from __future__ import annotations
 from lionagi.service.connections.endpoint import Endpoint
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
-# ---------------------------------------------------------------------------
-# Helper: simulate the old override behaviour for a given model class + inputs
-# ---------------------------------------------------------------------------
-
 
 def _old_override_payload(model_cls, config_kwargs: dict, request: dict, extra_kwargs: dict):
     """Reproduces the pre-refactor override logic verbatim."""
@@ -28,11 +24,6 @@ def _old_override_payload(model_cls, config_kwargs: dict, request: dict, extra_k
 def _new_flag_payload(endpoint: Endpoint, request: dict):
     payload, _ = endpoint.create_payload(request)
     return payload
-
-
-# ---------------------------------------------------------------------------
-# Exa Search
-# ---------------------------------------------------------------------------
 
 
 class TestExaSearchPayloadParity:
@@ -67,11 +58,6 @@ class TestExaSearchPayloadParity:
         assert "excludeDomains" not in payload
 
 
-# ---------------------------------------------------------------------------
-# Exa Contents
-# ---------------------------------------------------------------------------
-
-
 class TestExaContentsPayloadParity:
     def test_basic_ids(self):
         from lionagi.providers.exa.contents import ExaContentsEndpoint, ExaContentsRequest
@@ -91,11 +77,6 @@ class TestExaContentsPayloadParity:
         req = {"ids": ["https://example.com"]}
         payload, _ = ep.create_payload(req)
         assert "ids" in payload
-
-
-# ---------------------------------------------------------------------------
-# Exa FindSimilar
-# ---------------------------------------------------------------------------
 
 
 class TestExaFindSimilarPayloadParity:
@@ -118,11 +99,6 @@ class TestExaFindSimilarPayloadParity:
         payload, _ = ep.create_payload(req)
         assert "numResults" in payload
         assert "num_results" not in payload
-
-
-# ---------------------------------------------------------------------------
-# Firecrawl Scrape
-# ---------------------------------------------------------------------------
 
 
 class TestFirecrawlScrapePayloadParity:
@@ -159,11 +135,6 @@ class TestFirecrawlScrapePayloadParity:
         assert "excludeTags" not in payload
 
 
-# ---------------------------------------------------------------------------
-# Firecrawl Map
-# ---------------------------------------------------------------------------
-
-
 class TestFirecrawlMapPayloadParity:
     def test_basic_url(self):
         from lionagi.providers.firecrawl.map import FirecrawlMapEndpoint, FirecrawlMapRequest
@@ -175,11 +146,6 @@ class TestFirecrawlMapPayloadParity:
         got = _new_flag_payload(ep, req)
 
         assert got == expected
-
-
-# ---------------------------------------------------------------------------
-# Firecrawl Crawl
-# ---------------------------------------------------------------------------
 
 
 class TestFirecrawlCrawlPayloadParity:
@@ -202,11 +168,6 @@ class TestFirecrawlCrawlPayloadParity:
         payload, _ = ep.create_payload(req)
         assert "maxDepth" in payload
         assert "max_depth" not in payload
-
-
-# ---------------------------------------------------------------------------
-# Default-false guard: serialize_by_alias=False must NOT affect non-Exa/Firecrawl
-# ---------------------------------------------------------------------------
 
 
 class TestSerializeByAliasDefault:

--- a/tests/service/hooks/integration/test_concurrency_timeouts.py
+++ b/tests/service/hooks/integration/test_concurrency_timeouts.py
@@ -209,7 +209,6 @@ class TestTimeoutBehavior:
             with pytest.raises(MyCancelled):
                 await hook_event.invoke()
 
-            # Should have attempted to set up timeout
             mock_fail_after.assert_called_once_with(1)
 
     @pytest.mark.anyio
@@ -261,7 +260,6 @@ class TestNoDeadlocks:
     @pytest.mark.anyio
     @pytest.mark.slow_timing
     async def test_nested_hook_calls_no_deadlock(self, patch_cancellation):
-        """Test that hooks calling other hooks don't deadlock."""
         hook_sleep = 0.01
         invoke_delay = 0.01
         # Upper bound: each event does hook + invoke (+ optional post-hook).

--- a/tests/service/hooks/integration/test_hooked_event_pre_post_invoke.py
+++ b/tests/service/hooks/integration/test_hooked_event_pre_post_invoke.py
@@ -154,8 +154,6 @@ class TestHookedEventPostHookIntegration:
     async def test_post_hook_error_with_exit_false_keeps_result(
         self, patch_cancellation, patch_logger
     ):
-        """Test that post-hook error with exit=False keeps main result."""
-
         async def post_hook(ev, **kw):
             raise RuntimeError("post-hook error")
 

--- a/tests/service/hooks/test_hooked_event.py
+++ b/tests/service/hooks/test_hooked_event.py
@@ -19,10 +19,6 @@ from lionagi.service.hooks import hooked_event
 from lionagi.service.hooks._types import StreamTerminalState
 from lionagi.service.hooks.hooked_event import HookedEvent
 
-# ---------------------------------------------------------------------------
-# Minimal concrete HookedEvent subclasses for testing
-# ---------------------------------------------------------------------------
-
 
 class SimpleHooked(HookedEvent):
     async def _core_invoke(self):
@@ -42,11 +38,6 @@ class FailingHooked(HookedEvent):
         yield  # make it an async generator
 
 
-# ---------------------------------------------------------------------------
-# Minimal fake HookEvent — avoids setting up a real HookRegistry
-# ---------------------------------------------------------------------------
-
-
 def _fake_hook(
     status: EventStatus = EventStatus.COMPLETED,
     should_exit: bool = False,
@@ -64,11 +55,6 @@ def _fake_hook(
     return _FakeHookEvent()
 
 
-# ---------------------------------------------------------------------------
-# HookedEvent._invoke() — no hooks
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_invoke_no_hooks_returns_core_result():
     """With no hooks attached, _invoke returns _core_invoke result."""
@@ -83,11 +69,6 @@ async def test_invoke_no_hooks_core_error_propagates():
     h = FailingHooked()
     with pytest.raises(ValueError, match="core_failed"):
         await h._invoke()
-
-
-# ---------------------------------------------------------------------------
-# HookedEvent._invoke() — pre-invoke hook paths (lines 80-90)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -137,11 +118,6 @@ async def test_invoke_pre_hook_should_exit_no_cause_raises_generic():
     h._pre_invoke_hook_event = _fake_hook(EventStatus.COMPLETED, should_exit=True, exit_cause=None)
     with pytest.raises(RuntimeError, match="requested exit"):
         await h._invoke()
-
-
-# ---------------------------------------------------------------------------
-# HookedEvent._invoke() — post-invoke hook paths (lines 101-122)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -199,11 +175,6 @@ async def test_invoke_post_hook_should_exit_silenced_when_core_failed():
         await h._invoke()
 
 
-# ---------------------------------------------------------------------------
-# HookedEvent._stream() — pre-hook paths (lines 145-155)
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_stream_no_hooks_yields_chunks():
     """_stream() with no hooks yields all _core_stream chunks."""
@@ -245,11 +216,6 @@ async def test_stream_pre_hook_should_exit_raises():
             pass
 
 
-# ---------------------------------------------------------------------------
-# HookedEvent._stream() — post-hook (lines 163-168)
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_stream_post_hook_does_not_affect_chunks():
     """Post-hook runs after stream; chunks are not affected (lines 163-168)."""
@@ -273,7 +239,7 @@ async def test_stream_post_hook_failure_silenced():
             raise RuntimeError("post hook explodes after stream")
 
     h._post_invoke_hook_event = ExplodingPostHook()
-    # Should NOT raise — stream data already sent
+    # Must not raise: the stream data was already sent before the post-hook ran.
     chunks = [c async for c in h._stream()]
     assert chunks == ["chunk1", "chunk2"]
 
@@ -293,11 +259,6 @@ async def test_stream_post_hook_aborted_status_logs_warning(caplog):
 
     assert chunks == ["chunk1", "chunk2"]
     assert any("Post-stream hook failed" in r.message for r in caplog.records)
-
-
-# ---------------------------------------------------------------------------
-# HookedEvent._stream() — teardown on every way a stream can end
-# ---------------------------------------------------------------------------
 
 
 class SlowStream(HookedEvent):
@@ -606,10 +567,8 @@ async def test_bare_break_defers_teardown_to_generator_finalization():
     assert seen == [StreamTerminalState.Closed]
 
 
-# ---------------------------------------------------------------------------
 # HookedEvent._stream() — a failing teardown must not replace the ending it
 # was there to record
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(

--- a/tests/service/hooks/unit/test_hookevent_behavior.py
+++ b/tests/service/hooks/unit/test_hookevent_behavior.py
@@ -96,7 +96,6 @@ class TestHookEventBasicBehavior:
 
         await hook_event.invoke()
 
-        # Should exit because exit=True and hook failed
         assert hook_event._should_exit is True
 
     @pytest.mark.anyio
@@ -140,7 +139,6 @@ class TestHookEventBasicBehavior:
             event_like=FakeEvent(),
         )
 
-        # Should handle the tuple exception and set error state
         await hook_event.invoke()
 
         assert hook_event.execution.status == EventStatus.FAILED
@@ -186,7 +184,6 @@ class TestHookEventCancellation:
             event_like=FakeEvent(),
         )
 
-        # Should raise cancellation due to timeout
         with pytest.raises(MyCancelled, match="Timeout"):
             await hook_event.invoke()
 
@@ -207,7 +204,6 @@ class TestHookEventDispatchErrorPolicy:
 
         await hook_event.invoke()
 
-        # Should not exit because exit=False
         assert hook_event._should_exit is False
         assert hook_event.execution.status == EventStatus.CANCELLED  # Dispatch errors are CANCELLED
         assert hook_event._exit_cause is not None
@@ -227,7 +223,6 @@ class TestHookEventDispatchErrorPolicy:
 
         await hook_event.invoke()
 
-        # Should exit because exit=True
         assert hook_event._should_exit is True
         assert hook_event.execution.status == EventStatus.CANCELLED  # Dispatch errors are CANCELLED
         assert hook_event._exit_cause is not None

--- a/tests/service/hooks/unit/test_types_contracts.py
+++ b/tests/service/hooks/unit/test_types_contracts.py
@@ -22,13 +22,11 @@ from lionagi.service.imodel import iModel
 
 class TestHookEventTypes:
     def test_hook_event_types_enum_values(self):
-        """Test that HookEventTypes contains the expected values."""
         assert HookEventTypes.PreEventCreate == "pre_event_create"
         assert HookEventTypes.PreInvocation == "pre_invocation"
         assert HookEventTypes.PostInvocation == "post_invocation"
 
     def test_allowed_hooks_types_contains_all(self):
-        """Test that ALLOWED_HOOKS_TYPES contains all HookEventTypes."""
         expected = {
             HookEventTypes.PreEventCreate,
             HookEventTypes.PreInvocation,
@@ -54,7 +52,6 @@ class TestAssociatedEventInfo:
         """Test AssociatedEventInfo works with partial data (total=False)."""
         info = AssociatedEventInfo(lion_class="test.Event")
         assert info["lion_class"] == "test.Event"
-        # Should not have other keys
         assert "event_id" not in info
         assert "event_created_at" not in info
 

--- a/tests/service/hooks/unit/test_utils_get_handler_and_validators.py
+++ b/tests/service/hooks/unit/test_utils_get_handler_and_validators.py
@@ -30,7 +30,6 @@ class TestValidateHooks:
         assert result is None
 
     def test_validate_hooks_rejects_non_dict(self):
-        """Test that validate_hooks rejects non-dictionary input."""
         with pytest.raises(ValidationError):
             validate_hooks("not a dict")
 
@@ -38,7 +37,6 @@ class TestValidateHooks:
             validate_hooks([HookEventTypes.PreInvocation])
 
     def test_validate_hooks_rejects_bad_key_type(self):
-        """Test that validate_hooks rejects non-HookEventTypes keys."""
         with pytest.raises(ValidationError):
             validate_hooks({"pre_invocation": lambda e: None})  # string instead of enum
 
@@ -46,7 +44,6 @@ class TestValidateHooks:
             validate_hooks({42: lambda e: None})  # int key
 
     def test_validate_hooks_rejects_non_callable_values(self):
-        """Test that validate_hooks rejects non-callable hook values."""
         with pytest.raises(ValidationError):
             validate_hooks({HookEventTypes.PreInvocation: "not callable"})
 
@@ -56,7 +53,6 @@ class TestValidateHooks:
 
 class TestValidateStreamHandlers:
     def test_validate_stream_handlers_accepts_correct_dict(self):
-        """Test that validate_stream_handlers accepts a proper handler dictionary."""
         valid_handlers = {
             "chunk_type": lambda ev, ct, ch, **kw: None,
             str: lambda ev, ct, ch, **kw: None,
@@ -65,12 +61,10 @@ class TestValidateStreamHandlers:
         assert result is None
 
     def test_validate_stream_handlers_accepts_empty_dict(self):
-        """Test that validate_stream_handlers accepts an empty dictionary."""
         result = validate_stream_handlers({})
         assert result is None
 
     def test_validate_stream_handlers_rejects_non_dict(self):
-        """Test that validate_stream_handlers rejects non-dictionary input."""
         with pytest.raises(ValidationError):
             validate_stream_handlers("not a dict")
 
@@ -78,7 +72,6 @@ class TestValidateStreamHandlers:
             validate_stream_handlers(["chunk_type"])
 
     def test_validate_stream_handlers_rejects_bad_key_type(self):
-        """Test that validate_stream_handlers rejects invalid key types."""
         with pytest.raises(ValidationError):
             validate_stream_handlers({42: lambda ev, ct, ch: None})  # int key
 
@@ -86,7 +79,6 @@ class TestValidateStreamHandlers:
             validate_stream_handlers({None: lambda ev, ct, ch: None})  # None key
 
     def test_validate_stream_handlers_accepts_string_and_type_keys(self):
-        """Test that validate_stream_handlers accepts both string and type keys."""
         valid_handlers = {
             "string_key": lambda ev, ct, ch, **kw: None,
             str: lambda ev, ct, ch, **kw: None,
@@ -96,7 +88,6 @@ class TestValidateStreamHandlers:
         assert result is None
 
     def test_validate_stream_handlers_rejects_non_callable_values(self):
-        """Test that validate_stream_handlers rejects non-callable values."""
         with pytest.raises(ValidationError):
             validate_stream_handlers({"chunk_type": "not callable"})
 
@@ -107,36 +98,29 @@ class TestValidateStreamHandlers:
 class TestGetHandler:
     @pytest.mark.anyio
     async def test_get_handler_wraps_sync_to_async(self):
-        """Test that get_handler wraps sync functions as awaitables."""
-
         def sync_handler(ev, **kw):
             return ("sync_result", kw.get("x"))
 
         handlers = {"test_key": sync_handler}
         wrapped = get_handler(handlers, "test_key", True)
 
-        # Should be awaitable
         result = await wrapped("event", x=42)
         assert result == ("sync_result", 42)
 
     @pytest.mark.anyio
     async def test_get_handler_returns_async_unchanged(self):
-        """Test that get_handler returns async functions unchanged."""
-
         async def async_handler(ev, **kw):
             return ("async_result", kw.get("x"))
 
         handlers = {"test_key": async_handler}
         wrapped = get_handler(handlers, "test_key", True)
 
-        # Should return the same function
         assert wrapped is async_handler
         result = await wrapped("event", x=42)
         assert result == ("async_result", 42)
 
     @pytest.mark.anyio
     async def test_get_handler_missing_key_with_get_false_returns_none(self):
-        """Test that get_handler returns None for missing keys when get=False."""
         handlers = {}
         result = get_handler(handlers, "missing_key", False)
         assert result is None
@@ -145,31 +129,25 @@ class TestGetHandler:
     async def test_get_handler_missing_key_with_get_true_returns_passthrough(
         self,
     ):
-        """Test that get_handler returns passthrough function for missing keys when get=True."""
         handlers = {}
         wrapped = get_handler(handlers, "missing_key", True)
 
-        # Should return a passthrough function
         result = await wrapped("input")
         assert result == "input"
 
     @pytest.mark.anyio
     async def test_get_handler_default_get_false(self):
-        """Test that get_handler defaults to get=False."""
         handlers = {}
         result = get_handler(handlers, "missing_key")
         assert result is None
 
     @pytest.mark.anyio
     async def test_get_handler_with_none_value(self):
-        """Test that get_handler handles None values correctly."""
         handlers = {"test_key": None}
 
-        # get=False should return None when value is None
         result = get_handler(handlers, "test_key", False)
         assert result is None
 
-        # get=True should return passthrough when value is None
         wrapped = get_handler(handlers, "test_key", True)
         result = await wrapped("input")
         assert result == "input"

--- a/tests/service/imodel/test_edge_cases.py
+++ b/tests/service/imodel/test_edge_cases.py
@@ -16,7 +16,7 @@ class TestiModelProviderSpecificEdgeCases:
             model="claude-3-5-sonnet-20241022",
             api_key="test-key",
         )
-        # Should create successfully, max_tokens required at invoke time
+        # max_tokens is required at invoke time, not construction.
         assert imodel.endpoint.config.provider == "anthropic"
 
     def test_ollama_special_handling(self):
@@ -43,7 +43,6 @@ class TestiModelProviderSpecificEdgeCases:
             model="openrouter/anthropic/claude-3-opus",
             api_key="test-key",
         )
-        # Should parse provider from model path
         assert imodel.endpoint.config.provider == "openrouter"
 
     def test_mixed_case_provider_names(self):

--- a/tests/service/imodel/test_init.py
+++ b/tests/service/imodel/test_init.py
@@ -145,7 +145,6 @@ class TestiModel:
         imodel = base_imodel
 
         # NOTE: request_options removed due to incorrect role literals in generated models
-        # Should return OpenAIChatCompletionsRequest for OpenAI
         from lionagi.providers.openai.chat import OpenAIChatCompletionsRequest
 
         assert imodel.request_options == OpenAIChatCompletionsRequest

--- a/tests/service/imodel/test_validation.py
+++ b/tests/service/imodel/test_validation.py
@@ -24,14 +24,14 @@ class TestiModelValidationErrors:
         api_call = imodel.create_api_calling(
             messages=[{"role": "user", "content": "test"}], max_tokens=-100
         )
-        # Should accept negative value, API will validate
+        # Range validation is deferred to the API, not enforced here.
         assert api_call.payload["max_tokens"] == -100
 
     def test_invalid_messages_structure(self):
         imodel = iModel(provider="openai", model="gpt-4.1-mini", api_key="test-key")
         # Test with malformed messages
         api_call = imodel.create_api_calling(messages=[{"invalid": "structure"}])
-        # Should create payload, validation happens at API level
+        # Message structure validation happens at the API level, not here.
         assert len(api_call.payload["messages"]) == 1
 
     def test_empty_content_in_messages(self):

--- a/tests/service/test_broadcaster.py
+++ b/tests/service/test_broadcaster.py
@@ -74,7 +74,6 @@ class TestBroadcaster:
 
         callback = MagicMock()
 
-        # Should not raise error
         TestBroadcaster.unsubscribe(callback)
         assert TestBroadcaster.get_subscriber_count() == 0
 
@@ -155,7 +154,6 @@ class TestBroadcaster:
         TestBroadcaster.subscribe(failing_callback)
         TestBroadcaster.subscribe(successful_callback)
 
-        # Should not raise, but log the error
         await TestBroadcaster.broadcast(event)
 
         # Both callbacks should be attempted
@@ -174,7 +172,6 @@ class TestBroadcaster:
         TestBroadcaster.subscribe(failing_callback)
         TestBroadcaster.subscribe(successful_callback)
 
-        # Should not raise, but log the error
         await TestBroadcaster.broadcast(event)
 
         # Both callbacks should be attempted
@@ -188,7 +185,6 @@ class TestBroadcaster:
 
         event = SampleEvent()
 
-        # Should not raise error
         await TestBroadcaster.broadcast(event)
         assert TestBroadcaster.get_subscriber_count() == 0
 

--- a/tests/service/test_imodel_hooks.py
+++ b/tests/service/test_imodel_hooks.py
@@ -511,11 +511,6 @@ class TestiModelHooks:
         assert call_log.index("v1") < call_log.index("v2")
 
 
-# ---------------------------------------------------------------------------
-# D12 – process_chunk raises exception from exit tuple
-# ---------------------------------------------------------------------------
-
-
 class TestProcessChunkExitTuple:
     """process_chunk raises hook_result[1] when the hook signals exit with a BaseException."""
 

--- a/tests/service/test_mcp_security.py
+++ b/tests/service/test_mcp_security.py
@@ -541,8 +541,8 @@ class TestPerServerPolicyPersistence:
         """The tool proxy (`create_mcp_tool`'s stored callable) re-enters a
         transport it already holds via the capability-gated
         `_get_reconnect_client` -- that is the ONLY thing that recovers an
-        authorized policy (issue #2356), and it is not reachable through the
-        public `get_client` API."""
+        authorized policy, and it is not reachable through the public
+        `get_client` API."""
         self._reset()
         seen = []
 
@@ -594,8 +594,8 @@ class TestPerServerPolicyPersistence:
             self._reset()
 
     async def test_invocation_without_marker_does_not_recover_recorded_policy(self, monkeypatch):
-        """The bug in issue #2356: a bare, policy-omitting get_client() call
-        used to recover whatever policy an earlier caller authorized for the
+        """The regression: a bare, policy-omitting get_client() call used to
+        recover whatever policy an earlier caller authorized for the
         same resolved transport. A caller that makes no trust decision
         stays fail-closed, even though the exact same transport was
         authorized moments ago (and even holds a live capability for it --
@@ -862,12 +862,12 @@ class TestPerServerPolicyPersistence:
 
 
 class TestFreshLoadDoesNotInheritEarlierCallerTrust:
-    """Issue #2356: `None` at `get_client(security=...)` used to mean two
-    different things -- "the proxy re-entering a transport it already holds"
-    and "a loader that made no trust decision" -- and both hit the same
-    recovery. This reproduces the issue's own repro (two real
-    `ActionManager.load_mcp_config()` calls, client cache cleared between
-    them) and the proxy path that must keep working."""
+    """`None` at `get_client(security=...)` used to mean two different
+    things -- "the proxy re-entering a transport it already holds" and "a
+    loader that made no trust decision" -- and both hit the same recovery.
+    This reproduces that failure (two real `ActionManager.load_mcp_config()`
+    calls, client cache cleared between them) and the proxy path that must
+    keep working."""
 
     def _reset(self):
         MCPConnectionPool._security = None
@@ -984,10 +984,11 @@ class TestProcessGlobalPolicyIsExplicitNotInherited:
     process-global > fail-closed default). This is a deliberate,
     process-owner-level trust decision -- the reviewed real ordering
     (`set_security_config(trusted)` then a bare `get_client()`) is admitted
-    by design. It is NOT the same defect as issue #2356: that bug was one
-    caller silently inheriting a policy a DIFFERENT caller explicitly
-    authorized only for a specific server identity via `get_client(security=...)`
-    or the loader path. A process-global policy applies uniformly to every
+    by design. It is NOT the same defect as the per-transport recovery bug
+    covered above: that bug was one caller silently inheriting a policy a
+    DIFFERENT caller explicitly authorized only for a specific server
+    identity via `get_client(security=...)` or the loader path. A
+    process-global policy applies uniformly to every
     server identity in the process once set, regardless of whether any
     per-server policy was ever recorded, and is set through a distinct,
     dedicated API that has no production caller today."""
@@ -1066,11 +1067,10 @@ class TestProcessGlobalPolicyIsExplicitNotInherited:
 
 
 class TestRecoveryIsUnforgeable:
-    """The exact reproductions in the PR #2362 re-review verdict: recovery
-    must be a capability object, not a config-keyed lookup, so it cannot be
-    reached by a stored bound method, a subclass alias, or a proxy
-    reconstructed from persisted `mcp_config`. Every one of these must fail
-    closed (no prior policy recovered)."""
+    """Recovery must be a capability object, not a config-keyed lookup, so
+    it cannot be reached by a stored bound method, a subclass alias, or a
+    proxy reconstructed from persisted `mcp_config`. Every one of these must
+    fail closed (no prior policy recovered)."""
 
     def _reset(self):
         MCPConnectionPool._security = None

--- a/tests/service/test_ssrf_local_allowlist.py
+++ b/tests/service/test_ssrf_local_allowlist.py
@@ -13,10 +13,6 @@ import pytest
 from lionagi.ln._ssrf import is_ssrf_safe
 from lionagi.service.connections.endpoint_config import EndpointConfig
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 
 def _mock_getaddrinfo(ip_str: str):
     family = socket.AF_INET6 if ":" in ip_str else socket.AF_INET
@@ -41,11 +37,6 @@ def _make_endpoint_with_url(base_url: str, *, allow_local_network: bool = False)
     return ep
 
 
-# ---------------------------------------------------------------------------
-# 1. is_ssrf_safe with allow_local=True — canonical loopback literals allowed
-# ---------------------------------------------------------------------------
-
-
 def test_localhost_allowed_with_allow_local():
     """'localhost' passes when allow_local=True (canonical literal)."""
     assert is_ssrf_safe("localhost", allow_local=True) is True
@@ -61,11 +52,9 @@ def test_ipv6_loopback_allowed_when_allow_local():
     assert is_ssrf_safe("::1", allow_local=True) is True
 
 
-# ---------------------------------------------------------------------------
 # 2. DNS rebinding rejection — Invariant A
 #    A non-canonical hostname that resolves to 127.0.0.1 must be rejected
 #    even with allow_local=True, because the raw hostname check fires first.
-# ---------------------------------------------------------------------------
 
 
 def test_dns_rebinding_external_hostname_resolving_to_loopback_rejected():
@@ -91,11 +80,9 @@ def test_dns_rebinding_loopback_label_resolving_to_loopback_rejected():
         assert is_ssrf_safe("loopback.example", allow_local=True) is False
 
 
-# ---------------------------------------------------------------------------
 # 3. Alternate encodings rejected — Invariant B
 #    Non-canonical spellings of the loopback address are not in the canonical
 #    set and are therefore rejected before DNS resolution.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -121,10 +108,8 @@ def test_alternate_loopback_encoding_rejected(encoding):
     assert is_ssrf_safe(encoding, allow_local=True) is False
 
 
-# ---------------------------------------------------------------------------
 # 4. Defense in depth: post-resolution loopback verification — Invariant C
 #    Even a canonical hostname resolving to a non-loopback IP is rejected.
-# ---------------------------------------------------------------------------
 
 
 def test_canonical_hostname_resolving_to_public_ip_rejected():
@@ -149,10 +134,8 @@ def test_canonical_hostname_resolving_to_imds_rejected():
         assert is_ssrf_safe("localhost", allow_local=True) is False
 
 
-# ---------------------------------------------------------------------------
 # 5. Public IPs rejected under allow_local=True — Invariant D
 #    allow_local is a loopback-only flag; public targets are not permitted.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -170,11 +153,6 @@ def test_public_ip_hostname_rejected_under_allow_local(ip):
     hostname check rejects it before any DNS resolution.
     """
     assert is_ssrf_safe(ip, allow_local=True) is False
-
-
-# ---------------------------------------------------------------------------
-# 6. Invariant E: IMDS / link-local / private / 0.0.0.0 blocked regardless
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -208,11 +186,6 @@ def test_private_ranges_still_blocked_when_allow_local(ip):
         assert is_ssrf_safe("internal.example", allow_local=True) is False
 
 
-# ---------------------------------------------------------------------------
-# 7. is_ssrf_safe default — loopback still blocked (backward compat)
-# ---------------------------------------------------------------------------
-
-
 def test_loopback_blocked_by_default():
     """Without allow_local=True, loopback is blocked (backward-compatible)."""
     with patch("socket.getaddrinfo", return_value=_mock_getaddrinfo("127.0.0.1")):
@@ -222,11 +195,6 @@ def test_loopback_blocked_by_default():
 def test_localhost_blocked_by_default():
     """'localhost' is blocked when allow_local is not set (backward-compatible)."""
     assert is_ssrf_safe("localhost") is False
-
-
-# ---------------------------------------------------------------------------
-# 8. EndpointConfig.allow_local_network field
-# ---------------------------------------------------------------------------
 
 
 def test_endpoint_config_allow_local_network_defaults_false():
@@ -250,11 +218,6 @@ def test_endpoint_config_allow_local_network_can_be_set():
         allow_local_network=True,
     )
     assert config.allow_local_network is True
-
-
-# ---------------------------------------------------------------------------
-# 9. Endpoint._assert_ssrf_safe_url — integration with allow_local_network
-# ---------------------------------------------------------------------------
 
 
 def test_assert_ssrf_safe_url_blocks_localhost_by_default():
@@ -331,11 +294,6 @@ def test_assert_ssrf_safe_url_blocks_public_ip_even_with_allow_local():
     ep = _make_endpoint_with_url("http://8.8.8.8:11434/v1", allow_local_network=True)
     with pytest.raises(PermissionError, match="SSRF guard"):
         ep._assert_ssrf_safe_url()
-
-
-# ---------------------------------------------------------------------------
-# 10. Ollama EndpointConfig carries allow_local_network
-# ---------------------------------------------------------------------------
 
 
 def test_ollama_endpoint_config_carries_allow_local_network():

--- a/tests/service/test_token_calculator.py
+++ b/tests/service/test_token_calculator.py
@@ -8,10 +8,6 @@ import tiktoken
 
 from lionagi.service.token_calculator import TokenCalculator, get_encoding_name
 
-# ---------------------------------------------------------------------------
-# get_encoding_name
-# ---------------------------------------------------------------------------
-
 
 class TestGetEncodingName:
     def test_valid_model_name_returns_encoding(self):
@@ -58,11 +54,6 @@ class TestGetEncodingName:
         """Arbitrary nonsense string falls back to o200k_base."""
         name = get_encoding_name("!@#$%^&*()")
         assert name == "o200k_base"
-
-
-# ---------------------------------------------------------------------------
-# TokenCalculator.tokenize
-# ---------------------------------------------------------------------------
 
 
 class TestTokenize:
@@ -196,11 +187,6 @@ class TestTokenize:
         assert result > 0
 
 
-# ---------------------------------------------------------------------------
-# TokenCalculator._calculate_chatitem
-# ---------------------------------------------------------------------------
-
-
 class TestCalculateChatitem:
     """_calculate_chatitem delegates to tokenize(), which resolves encoding_name first so decoder creation never fails."""
 
@@ -281,11 +267,6 @@ class TestCalculateChatitem:
         assert result > 0
 
 
-# ---------------------------------------------------------------------------
-# TokenCalculator._calculate_embed_item
-# ---------------------------------------------------------------------------
-
-
 class TestCalculateEmbedItem:
     """_calculate_embed_item always resolves encoding_name via tokenize(), so decoder creation never fails even with tokenizer-only calls."""
 
@@ -330,11 +311,6 @@ class TestCalculateEmbedItem:
         result = TokenCalculator._calculate_embed_item([["hello", "world"]], tokenizer)
         assert isinstance(result, int)
         assert result > 0
-
-
-# ---------------------------------------------------------------------------
-# TokenCalculator.calculate_message_tokens
-# ---------------------------------------------------------------------------
 
 
 class TestCalculateMessageTokens:
@@ -450,11 +426,6 @@ class TestCalculateMessageTokens:
         assert result > 200
 
 
-# ---------------------------------------------------------------------------
-# TokenCalculator.calculate_embed_token
-# ---------------------------------------------------------------------------
-
-
 class TestCalculateEmbedToken:
     def test_single_string_input(self):
         """Single string in the list should return positive token count."""
@@ -493,11 +464,6 @@ class TestCalculateEmbedToken:
         """
         result = TokenCalculator.calculate_embed_token([123, 456])
         assert result == 0
-
-
-# ---------------------------------------------------------------------------
-# Integration: tokenize standalone (works correctly)
-# ---------------------------------------------------------------------------
 
 
 class TestTokenizeStandalone:


### PR DESCRIPTION
Reduce comment/docstring density in tests/service and tests/providers without touching any executable code or assertion:

- Strip section-divider comment banners (320 lines across 19 files).
- Delete docstrings/comments that only restate the test/class name with no added rationale.
- Remove internal GitHub issue/PR number references from test docstrings in test_mcp_security.py, test_endpoint.py, test_claude_code_result_usage.py, and test_gemini_cli_endpoint.py.
- Extract the CLI adapter error-chunk conformance design rationale out of test_cli_adapter_error_conformance.py's 111-line module docstring into docs/internals/providers.md, leaving a pointer.

Every touched file was verified with the AST-equality guardrail (doc-trim-tools/ast_equal.py) before and after `ruff format`/`ruff check --fix`; all 34 files pass.