### PR TITLE
chore(tests): trim prose in state/session/work/orchestration tests

### DIFF
--- a/docs/internals/state-lifecycle.md
+++ b/docs/internals/state-lifecycle.md
@@ -1,0 +1,94 @@
+# StateDB lifecycle transitions
+
+`StateDB.update_status()` and the transition-policy layer around it (`PolicyRegistry`,
+`SQLAlchemyLifecycleService`) enforce how sessions, invocations, plays, schedule runs and
+other entities move between statuses. This document collects the regression-shaped
+knowledge that the lifecycle test suite pins, so it lives somewhere other than scattered
+module docstrings.
+
+## Two different failure contracts, easy to confuse
+
+`update_status()` has two failure modes that look similar but are not:
+
+- A **CAS miss** — a stale `expected_statuses` or `expected_updated_at` guard — returns
+  `False` silently. No row changes, no exception. This is an ordinary lost race: someone
+  else updated the row first.
+- Attempting to move a **terminal** entity to a different status without `override=True`
+  raises `TransitionRejectedError` instead. This is a policy violation, not a race.
+
+A caller, or a refactor, that treats one of these as the other is a live bug. The two
+contracts also interact: a terminal row with a stale version guard is still rejected and
+audited, because terminal-exit policy is evaluated before the write-only version conflict
+is even reached.
+
+## One vocabulary, several sources of truth
+
+Valid statuses per entity type are declared in three places that must stay in sync: a
+schema `CHECK` constraint, the `PolicyRegistry`, and the `VALID_STATUSES_BY_ENTITY_TYPE`
+facade in `lionagi/state/db.py`. A status added to one without the others is a silent
+widening or narrowing of what `update_status()` accepts. The lifecycle gate tests pin an
+exact, sorted status list per entity so any addition shows up as a deliberate diff against
+that list, not a change that only a end-to-end scenario would eventually surface.
+
+## PolicyRegistry only guards the public entry point
+
+The transition-policy edge graph in `PolicyRegistry` is enforced by
+`SQLAlchemyLifecycleService.transition()`, the public entry point. `StateDB.update_status()`
+itself does **not** enforce it — see `enforce_edges` in
+`lionagi/state/lifecycle/adapters.py`. Every declared edge for session, invocation, play,
+and schedule_run is expected to apply; sampled undeclared edges must come back as a
+`"rejected"` outcome with an `admin_events` audit row, never a raise and never a silent
+write. Code that calls `StateDB.update_status()` directly bypasses policy enforcement by
+construction — that is a property of the two-layer design, not an oversight to fix in the
+lower layer.
+
+## The reaper guard pattern
+
+Reapers throughout `lionagi/studio/services/lifecycle.py` guard a stale-row transition on
+**both** `expected_statuses` and `expected_updated_at`. Dropping the `expected_updated_at`
+half is easy to miss: a change that drops it still passes every status-only test, because
+status membership alone cannot distinguish "still stale" from "just re-touched between the
+scan and the write." A row that is genuinely stale must be reaped; a row whose
+`updated_at` moved between the scan and the write must not be, even though its status still
+matches. Both outcomes need to be asserted in the same test, against the two-guard shape
+used in production, or a weakened reaper would silently pass.
+
+## SQLite vs PostgreSQL concurrency
+
+`StateDB._tx()` is the sole write choke point. On SQLite it holds a process write lock, so
+several classes of race that are structurally possible on PostgreSQL cannot happen there at
+all:
+
+- **Natural-key upsert race** (`insert_artifact`): the lookup used to run as a separate
+  autocommit `SELECT` before the write transaction opened, so two processes racing the same
+  natural key could both see no existing row and both `INSERT`, with the loser hitting a
+  partial unique index as an `IntegrityError` instead of the documented upsert-with-latest-
+  wins behavior. The fix moved the lookup inside the same atomic statement as the write.
+- **Session-control admission vs. a terminalizing transaction**: a plain status `UPDATE`
+  takes `FOR NO KEY UPDATE` on the session row. That lock mode matters specifically because
+  it does not conflict with the `FOR KEY SHARE` a control insert's foreign key already
+  takes — so an admission that only reads the session would sail past a `FOR UPDATE` holder
+  and pass even with the ordering bug present. Only `FOR NO KEY UPDATE` discriminates.
+- **Compare-and-set resolution racing its own claimant**: `resolve_claimed_session_control`
+  reads a claim, decides from it, then writes under a CAS. On PostgreSQL the claimant can
+  commit its own outcome between those two statements; the CAS correctly refuses, but the
+  caller must not get a receipt for a write that never happened.
+- **Delete vs. an open writer** (`delete_imported_session`): at READ COMMITTED, a delete's
+  retention check reads a snapshot, so a reference committed after that check is invisible
+  to it while the delete it authorized still proceeds — destroying a message a survivor is
+  by then pointing at. The fix takes a table lock as the transaction's first statement,
+  which works because ordinary `INSERT`/`UPDATE` already hold `ROW EXCLUSIVE`, and that
+  conflicts with `EXCLUSIVE`.
+- **Teardown vs. maintenance deadlock**: teardown and `prune_old_data` reach `sessions` and
+  `progressions` in opposite orders — exactly the shape a lock cycle needs. A blocking
+  `LOCK TABLE` would hold two tables while waiting on a third already held by a maintenance
+  pass, and PostgreSQL's deadlock detector would abort one side with `40P01` — a whole pass
+  lost, not a slow one. `NOWAIT` avoids waiting during acquisition; a bounded
+  `lock_timeout` on the later FK-nulling step (which is not covered by `NOWAIT`) makes the
+  teardown give up on its own, inside PostgreSQL's `deadlock_timeout`, so it returns the
+  retryable `55P03` instead of ever reaching `40P01`.
+
+The general lesson: any place `StateDB` takes a lock and touches more than one table on
+PostgreSQL is a deadlock candidate against another writer that touches the same tables in a
+different order, and the fix is either strict lock ordering or a bounded wait — never a
+blocking wait held across multiple tables.

--- a/tests/session/test_branch.py
+++ b/tests/session/test_branch.py
@@ -376,9 +376,7 @@ def test_to_dict_from_dict(branch_with_mock_imodel: Branch):
     assert nm.content.instruction == "hello user"
 
 
-# ---------------------------------------------------------------------------
 # Edge cases (P1)
-# ---------------------------------------------------------------------------
 
 
 def test_branch_connect_rejects_duplicate_tool_name_without_update():
@@ -398,9 +396,7 @@ def test_branch_connect_rejects_duplicate_tool_name_without_update():
     assert "lookup" in branch.tools
 
 
-# ---------------------------------------------------------------------------
 # branch.run() — lines 1370-1391
-# ---------------------------------------------------------------------------
 
 
 async def _drain(gen) -> list:
@@ -490,9 +486,7 @@ async def test_branch_run_forwards_extra_kwargs_as_imodel_kw(monkeypatch):
     assert param.imodel_kw == {"temperature": 0.5, "max_tokens": 100}
 
 
-# ---------------------------------------------------------------------------
 # branch.ReActStream() — lines 1235-1340
-# ---------------------------------------------------------------------------
 
 
 async def test_react_stream_yields_results_from_inner_generator(monkeypatch):

--- a/tests/session/test_branch_actionmanager_coverage.py
+++ b/tests/session/test_branch_actionmanager_coverage.py
@@ -13,9 +13,7 @@ from lionagi.protocols.messages.manager import MessageManager
 from lionagi.service.manager import iModelManager
 from lionagi.session.branch import Branch
 
-# ---------------------------------------------------------------------------
 # Test tools
-# ---------------------------------------------------------------------------
 
 
 def add(a: int, b: int) -> int:
@@ -33,9 +31,7 @@ def greet(name: str) -> str:
     return f"Hello, {name}!"
 
 
-# ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -65,9 +61,7 @@ def populated_manager():
     return m
 
 
-# ===========================================================================
 # Branch tests
-# ===========================================================================
 
 
 class TestBranchSystemMessage:
@@ -222,9 +216,7 @@ class TestBranchSerialization:
         assert "metadata" in d
 
 
-# ===========================================================================
 # ActionManager tests
-# ===========================================================================
 
 
 class TestActionManagerInit:

--- a/tests/session/test_branch_emit.py
+++ b/tests/session/test_branch_emit.py
@@ -71,7 +71,7 @@ async def test_branch_emit_respects_gate():
     assert len(s.observer.by_type(Noticed)) == 2  # both recorded
 
 
-# -- MessageAdded: the full message stream on the one transport ---------------
+# MessageAdded: the full message stream on the one transport
 
 
 async def test_message_added_fires_for_every_message_type():

--- a/tests/session/test_capabilities.py
+++ b/tests/session/test_capabilities.py
@@ -42,7 +42,7 @@ def _assistant(text: str) -> AssistantResponse:
     )
 
 
-# -- renderer ---------------------------------------------------------------
+# renderer
 
 
 def test_render_lists_names_and_schema():
@@ -52,7 +52,7 @@ def test_render_lists_names_and_schema():
     assert "claim" in prompt  # nested schema is shown
 
 
-# -- grant / revoke ---------------------------------------------------------
+# grant / revoke
 
 
 def test_grant_sets_runtime_and_prompt():
@@ -139,7 +139,7 @@ def test_grant_then_revoke_preserves_user_marker_text():
     assert "Base prompt." in sys_text
 
 
-# -- end-to-end: grant → emit → observe -------------------------------------
+# end-to-end: grant → emit → observe
 
 
 async def test_grant_then_emit_observed():

--- a/tests/session/test_control.py
+++ b/tests/session/test_control.py
@@ -18,9 +18,7 @@ from lionagi.session.control import LoopBreak, LoopControl, LoopDirective
 from lionagi.session.session import Session
 from lionagi.session.signal import StructuredOutput
 
-# ---------------------------------------------------------------------------
 # LoopDirective / LoopControl / LoopBreak construction
-# ---------------------------------------------------------------------------
 
 
 class TestControlTypes:
@@ -58,9 +56,7 @@ class TestControlTypes:
         assert issubclass(LoopBreak, Exception)
 
 
-# ---------------------------------------------------------------------------
 # Branch.control() / poll_control() — one-shot semantics
-# ---------------------------------------------------------------------------
 
 
 class TestBranchControlOneShot:
@@ -110,9 +106,7 @@ class TestBranchControlOneShot:
         assert ctrl.reason is None
 
 
-# ---------------------------------------------------------------------------
 # _check_control behavior
-# ---------------------------------------------------------------------------
 
 
 class TestCheckControl:
@@ -154,9 +148,7 @@ class TestCheckControl:
         assert b.poll_control() is None  # consumed
 
 
-# ---------------------------------------------------------------------------
 # CANCEL stops the stream and finally still runs
-# ---------------------------------------------------------------------------
 
 
 class TestCancelFinallyBehavior:
@@ -241,9 +233,7 @@ class TestCancelFinallyBehavior:
         assert b.poll_control() is None  # one-shot
 
 
-# ---------------------------------------------------------------------------
 # End-to-end integration — real run() loop with loop control
-# ---------------------------------------------------------------------------
 
 
 def _make_fake_cli_model_for_control(chunks: list[StreamChunk]):

--- a/tests/session/test_core_bugs.py
+++ b/tests/session/test_core_bugs.py
@@ -14,9 +14,7 @@ from lionagi.session.observer import SessionObserver
 from lionagi.session.session import Session
 from lionagi.session.signal import Signal, StructuredOutput
 
-# ---------------------------------------------------------------------------
 # InstructionContent dict response_format survives serialization
-# ---------------------------------------------------------------------------
 
 
 class TestResponseFormatSerialization:
@@ -75,9 +73,7 @@ class TestResponseFormatSerialization:
         assert "_structure_instance" not in serialized
 
 
-# ---------------------------------------------------------------------------
 # Observer handlers run concurrently (non-blocking)
-# ---------------------------------------------------------------------------
 
 
 class TestConcurrentObserverDispatch:
@@ -173,9 +169,7 @@ class TestConcurrentObserverDispatch:
         assert seqs == sorted(seqs), "Events must be recorded in emission order"
 
 
-# ---------------------------------------------------------------------------
 # Observe by emitting agent role (RoleFilter)
-# ---------------------------------------------------------------------------
 
 
 class TestObserveByRole:
@@ -299,9 +293,7 @@ class TestObserveByRole:
             obs.observe(None, lambda e, ctx: None)
 
 
-# ---------------------------------------------------------------------------
 # Branch / Session serialization and split regressions
-# ---------------------------------------------------------------------------
 
 
 class TestBranchStateRegressions:

--- a/tests/session/test_gate.py
+++ b/tests/session/test_gate.py
@@ -32,7 +32,7 @@ def _adder():
     return add, calls
 
 
-# -- observer.authorize (unit) -----------------------------------------------
+# observer.authorize (unit)
 
 
 @pytest.mark.asyncio
@@ -81,7 +81,7 @@ async def test_branch_authorize_standalone_allows():
     assert await Branch().authorize(ToolInvocation(function="rm")) is True
 
 
-# -- end-to-end tool gating through _act -------------------------------------
+# end-to-end tool gating through _act
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_lifecycle_signals.py
+++ b/tests/session/test_lifecycle_signals.py
@@ -30,9 +30,7 @@ from lionagi.session.signal import (
     lane_for,
 )
 
-# ---------------------------------------------------------------------------
 # lane_for unit tests
-# ---------------------------------------------------------------------------
 
 
 def test_lane_for_empty_stream():
@@ -181,9 +179,7 @@ def test_lane_for_full_happy_path_sequence():
         assert lane_for(sig) == expected, f"step {i}"
 
 
-# ---------------------------------------------------------------------------
 # New signal type tests
-# ---------------------------------------------------------------------------
 
 
 def test_node_queued_fields():
@@ -234,9 +230,7 @@ def test_node_escalated_request_not_payload_matched():
     assert not isinstance(sig.data, EscalationRequest)
 
 
-# ---------------------------------------------------------------------------
 # Engine bridge: NodeQueued emitted via run_dag
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -327,9 +321,7 @@ async def test_run_dag_calls_session_flow_once_with_same_graph():
     assert passed_graph is graph
 
 
-# ---------------------------------------------------------------------------
 # End-to-end projection: collect signals, project lanes, assert sequence
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -388,9 +380,7 @@ async def test_projection_contract_end_to_end():
     assert q_idx < r_idx < s_idx, f"Lane sequence wrong: {lanes_seen}"
 
 
-# ---------------------------------------------------------------------------
 # Reactive injection: injected children also get NodeQueued
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -439,9 +429,7 @@ async def test_reactive_injected_child_receives_node_queued():
         assert op_id in queued_ids, f"op {op_id} was started without a prior NodeQueued"
 
 
-# ---------------------------------------------------------------------------
 # Skipped nodes project to 'failed' lane
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -515,9 +503,7 @@ async def test_skipped_node_projects_to_skipped_lane():
     )
 
 
-# ---------------------------------------------------------------------------
 # execute_stream subscribes via the public observer property
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -576,9 +562,7 @@ async def test_execute_stream_subscribes_spawn_via_public_observer(monkeypatch):
     assert any(e.spawned for e in events)
 
 
-# ---------------------------------------------------------------------------
 # Export contract
-# ---------------------------------------------------------------------------
 
 
 def test_session_package_exports_new_symbols():

--- a/tests/session/test_pr930_regressions.py
+++ b/tests/session/test_pr930_regressions.py
@@ -15,7 +15,7 @@ from lionagi.cli.skill import resolve_skill_path
 from lionagi.service.hooks._types import HookEventTypes
 from lionagi.service.hooks.hook_registry import HookRegistry
 
-# ── Symlink containment ────────────────────────────────
+# Symlink containment
 
 
 class TestSkillSymlinkContainment:
@@ -86,7 +86,7 @@ class TestPlaybookSymlinkContainment:
         assert "symlink escape" in err or "outside" in err
 
 
-# ── HookRegistry alias both spellings ──────────────────
+# HookRegistry alias both spellings
 
 
 class TestHookRegistryAliases:
@@ -109,7 +109,7 @@ class TestHookRegistryAliases:
         assert HookEventTypes.PreEventCreate in reg._hooks
 
 
-# ── max_ops/max_agents zero remains valid ───────────────
+# max_ops/max_agents zero remains valid
 
 
 class TestMaxOpsZeroAccepted:
@@ -128,7 +128,7 @@ class TestMaxOpsZeroAccepted:
         assert err is not None
 
 
-# ── _clamp_claude_effort coverage ────────────────────
+# _clamp_claude_effort coverage
 
 
 class TestClampClaudeEffort:
@@ -153,7 +153,7 @@ class TestClampClaudeEffort:
             assert _clamp_claude_effort(effort, "claude/claude-opus-4-7") == effort
 
 
-# ── _handle_play_shortcut coverage ───────────────────
+# _handle_play_shortcut coverage
 
 
 class TestHandlePlayShortcut:
@@ -212,7 +212,7 @@ class TestHandlePlayShortcut:
         assert code == 1
 
 
-# ── _LazyStderrHandler re-binds stream ───────────────
+# _LazyStderrHandler re-binds stream
 
 
 class TestLazyStderrHandler:

--- a/tests/session/test_run_event_contract.py
+++ b/tests/session/test_run_event_contract.py
@@ -29,9 +29,7 @@ from lionagi.session.signal import (
     build_run_end,
 )
 
-# ---------------------------------------------------------------------------
 # #1539 — schema_version on every signal
-# ---------------------------------------------------------------------------
 
 
 def test_schema_version_constant():
@@ -58,9 +56,7 @@ def test_schema_version_on_run_failed():
     assert RunFailed().schema_version == SIGNAL_SCHEMA_VERSION
 
 
-# ---------------------------------------------------------------------------
 # #1538 — RunEnd carries usage fields
-# ---------------------------------------------------------------------------
 
 
 def test_run_end_default_usage_fields():
@@ -144,10 +140,8 @@ def test_collect_branch_usage_anthropic_convention():
     assert usage["output_tokens"] == 30
 
 
-# ---------------------------------------------------------------------------
 # #2889 — cache-token dimensions (Anthropic cache_read/cache_creation,
 # OpenAI prompt_tokens_details.cached_tokens)
-# ---------------------------------------------------------------------------
 
 
 def test_run_end_cache_token_fields_default():
@@ -245,11 +239,9 @@ def test_collect_multi_branch_usage_sums_cache_dimensions():
     assert usage["cache_write_tokens"] == 10
 
 
-# ---------------------------------------------------------------------------
 # #2379 — claude_code whole-agent-tree usage: a per-model modelUsage
 # breakdown (subagent spend included) must be preferred over the flat,
 # top-level-loop-only usage dict when both are present on the same message.
-# ---------------------------------------------------------------------------
 
 
 def test_collect_branch_usage_prefers_model_usage_whole_tree_over_flat_usage():
@@ -561,9 +553,7 @@ def test_build_run_end_populates_from_branch():
     assert sig.data == "ok"
 
 
-# ---------------------------------------------------------------------------
 # orchestration usage aggregation — sum usage across all DAG leg branches
-# ---------------------------------------------------------------------------
 
 
 def _branch_with_usage(
@@ -639,9 +629,7 @@ def test_collect_multi_branch_usage_skips_branches_that_raise():
     assert usage["output_tokens"] == 5
 
 
-# ---------------------------------------------------------------------------
 # #1537 — NodeSpawned exists and carries expected fields
-# ---------------------------------------------------------------------------
 
 
 def test_node_spawned_defaults():
@@ -688,9 +676,7 @@ def test_node_lifecycle_signals_parent_defaults_none():
         assert sig.depends_on == []
 
 
-# ---------------------------------------------------------------------------
 # #1540 — HookSignal suppressed for MESSAGE_ADD; other points still recorded
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -737,9 +723,7 @@ async def test_hook_bus_records_other_points():
     assert len(hook_sigs) == 1
 
 
-# ---------------------------------------------------------------------------
 # NodeSpawned export from session package
-# ---------------------------------------------------------------------------
 
 
 def test_node_spawned_exported_from_session_package():

--- a/tests/session/test_run_lifecycle.py
+++ b/tests/session/test_run_lifecycle.py
@@ -17,9 +17,7 @@ from lionagi.session.branch import Branch
 from lionagi.session.session import Session
 from lionagi.session.signal import RunEnd, RunFailed, RunStart
 
-# ---------------------------------------------------------------------------
 # Shared helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_fake_cli_model(chunks: list[StreamChunk], session_id: str | None = None):
@@ -50,9 +48,7 @@ async def _drain(gen) -> list:
     return [item async for item in gen]
 
 
-# ---------------------------------------------------------------------------
 # R0 — run() emits RunStart / RunEnd on the observer bus
-# ---------------------------------------------------------------------------
 
 
 async def test_run_generator_emits_run_start_and_run_end():
@@ -116,9 +112,7 @@ async def test_run_generator_run_start_before_first_yield():
     assert received_order[0] == "RunStart", f"order was: {received_order}"
 
 
-# ---------------------------------------------------------------------------
 # R1 — Branch.ReAct() emits exactly ONE RunStart (no double-wrap)
-# ---------------------------------------------------------------------------
 
 
 async def test_react_emits_exactly_one_run_start():
@@ -226,9 +220,7 @@ async def test_react_no_signals_without_observer():
     assert result == "result"
 
 
-# ---------------------------------------------------------------------------
 # empty / empty-dict error chunk treated as end-of-stream
-# ---------------------------------------------------------------------------
 
 
 async def test_run_benign_eos_error_chunk_treated_as_end_of_stream():
@@ -318,9 +310,7 @@ async def test_run_resume_session_produces_non_empty_stream():
     assert "Resumed response" in text_msgs[0].response
 
 
-# ---------------------------------------------------------------------------
 # abandoned generators emit exactly one terminal signal
-# ---------------------------------------------------------------------------
 
 
 async def test_run_aclose_after_instruction_emits_run_end():
@@ -411,9 +401,7 @@ async def test_run_aclose_before_first_yield_no_signals():
     assert len(ends) == 0
 
 
-# ---------------------------------------------------------------------------
 # CLI-backed ReAct emits exactly one RunStart total
-# ---------------------------------------------------------------------------
 
 
 async def test_react_cli_backed_emits_single_run_start():
@@ -555,9 +543,7 @@ async def test_react_run_start_observer_exception_does_not_abort_react():
     assert result is not None, "ReAct must return a result despite RunStart observer boom"
 
 
-# ---------------------------------------------------------------------------
 # observer exception during cleanup preserves streaming_process_func
-# ---------------------------------------------------------------------------
 
 
 async def test_run_observer_exception_on_run_end_restores_stream_func():

--- a/tests/session/test_session_branch_mail.py
+++ b/tests/session/test_session_branch_mail.py
@@ -43,9 +43,7 @@ def _get_oai_config(
     )
 
 
-# ============================================================================
 # Test Fixtures and Helpers
-# ============================================================================
 
 
 def make_mock_branch(name: str = "TestBranch") -> Branch:
@@ -112,9 +110,7 @@ def make_parallel_graph() -> tuple[Graph, dict[str, Operation]]:
     return graph, ops
 
 
-# ============================================================================
 # 1. Basic Flow Execution Tests
-# ============================================================================
 
 
 class TestBranchManagement:
@@ -317,6 +313,4 @@ class TestBranchManagement:
         assert all(b in branch_list for b in branches)
 
 
-# ============================================================================
 # 3. Edge Cases and Error Handling
-# ============================================================================

--- a/tests/session/test_session_flow_execution.py
+++ b/tests/session/test_session_flow_execution.py
@@ -44,9 +44,7 @@ def _get_oai_config(
     )
 
 
-# ============================================================================
 # Test Fixtures and Helpers
-# ============================================================================
 
 
 def make_mock_branch(name: str = "TestBranch") -> Branch:
@@ -113,9 +111,7 @@ def make_parallel_graph() -> tuple[Graph, dict[str, Operation]]:
     return graph, ops
 
 
-# ============================================================================
 # 1. Basic Flow Execution Tests
-# ============================================================================
 
 
 class TestEdgeCasesAndErrors:
@@ -315,9 +311,7 @@ class TestEdgeCasesAndErrors:
         )
 
 
-# ============================================================================
 # 4. Integration Tests
-# ============================================================================
 
 
 class TestSessionFlowIntegration:
@@ -441,9 +435,7 @@ class TestSessionFlowIntegration:
         assert has_error
 
 
-# ============================================================================
 # 6. Async Edge Cases: Cancellation, Timeout, Error Propagation
-# ============================================================================
 
 
 class TestSessionFlowAsyncEdgeCases:
@@ -556,7 +548,6 @@ class TestSessionFlowAsyncEdgeCases:
 
     @pytest.mark.asyncio
     async def test_flow_continues_after_operation_failure(self):
-        """Test that flow continues processing after one operation fails."""
         session = Session()
 
         # Create two branches - one will fail, one will succeed
@@ -609,7 +600,6 @@ class TestSessionFlowAsyncEdgeCases:
 
     @pytest.mark.asyncio
     async def test_concurrent_flow_with_mixed_timings(self):
-        """Test concurrent flow with operations of varying speeds doesn't deadlock."""
         session = Session()
         branch = make_mock_branch()
         session.include_branches(branch)

--- a/tests/session/test_session_lifecycle.py
+++ b/tests/session/test_session_lifecycle.py
@@ -41,9 +41,7 @@ def _get_oai_config(
     )
 
 
-# ============================================================================
 # Test Fixtures and Helpers
-# ============================================================================
 
 
 def make_mock_branch(name: str = "TestBranch") -> Branch:
@@ -110,9 +108,7 @@ def make_parallel_graph() -> tuple[Graph, dict[str, Operation]]:
     return graph, ops
 
 
-# ============================================================================
 # 1. Basic Flow Execution Tests
-# ============================================================================
 
 
 class TestBasicFlowExecution:
@@ -202,6 +198,4 @@ class TestBasicFlowExecution:
         assert op.id in result["operation_results"]
 
 
-# ============================================================================
 # 2. Branch Management Tests
-# ============================================================================

--- a/tests/state/lifecycle/test_notify_settings.py
+++ b/tests/state/lifecycle/test_notify_settings.py
@@ -44,7 +44,7 @@ def _envelope() -> RunTerminalEnvelope:
     )
 
 
-# ── String form ───────────────────────────────────────────────────────────────
+# String form
 
 
 def test_string_form_resolves_to_argv():
@@ -88,7 +88,7 @@ def test_unparseable_string_resolves_disabled_with_diagnostic(caplog):
     assert any("failed to parse" in r.message for r in caplog.records)
 
 
-# ── Empty-argv resolution: every path resolves to disabled (1c) ─────────────
+# Empty-argv resolution: every path resolves to disabled (1c)
 
 
 @pytest.mark.parametrize(
@@ -115,7 +115,7 @@ def test_empty_argv_via_settings_path_also_disabled(caplog):
     assert any("empty command" in r.message for r in caplog.records)
 
 
-# ── Mapping form ──────────────────────────────────────────────────────────────
+# Mapping form
 
 
 def test_mapping_form_exec_adapter():
@@ -293,7 +293,7 @@ def test_malformed_settings_never_raises(caplog, monkeypatch):
     assert any("settings resolution failed" in r.message for r in caplog.records)
 
 
-# ── Invalid top-level value / absent key ─────────────────────────────────────
+# Invalid top-level value / absent key
 
 
 def test_invalid_value_type_disabled(caplog):
@@ -312,7 +312,7 @@ def test_absent_notify_key_is_disabled():
         assert resolved.reason is None
 
 
-# ── Precedence: per-run override beats settings for its own scope only ───────
+# Precedence: per-run override beats settings for its own scope only
 
 
 def test_per_run_override_replaces_settings_handler():
@@ -326,7 +326,7 @@ def test_per_run_override_replaces_settings_handler():
     assert resolved_with_override.handler.argv == ("override-cmd",)
 
 
-# ── No-shell safety: the exec adapter never launches via a shell ────────────
+# No-shell safety: the exec adapter never launches via a shell
 
 
 @pytest.mark.asyncio
@@ -384,7 +384,7 @@ async def test_exec_handler_swallows_nonzero_exit_and_timeout(monkeypatch, caplo
     assert any("exited 1" in r.message for r in caplog.records)
 
 
-# ── Adapter outcome visibility: notify_outcome.json + the CLI warn() channel ──
+# Adapter outcome visibility: notify_outcome.json + the CLI warn() channel
 #
 # Outcome recording is never automatic: a bare build_handler(resolved) call
 # (the process-wide default registered by register_settings_terminal_callback)
@@ -660,7 +660,7 @@ async def test_exec_handler_outcome_recording_is_a_noop_without_a_bound_run(tmp_
     assert not run.notify_outcome_path.exists()
 
 
-# ── Run-scoped attribution: bound at registration time, never last-writer-wins ──
+# Run-scoped attribution: bound at registration time, never last-writer-wins
 
 
 @pytest.mark.asyncio
@@ -840,7 +840,7 @@ async def test_cancelled_exec_handler_still_kills_its_child_process_group(tmp_pa
         pytest.fail(f"child pid {child_pid} was still alive after cancellation cleanup")
 
 
-# ── build_handler: a malformed python adapter must never raise ─────────────
+# build_handler: a malformed python adapter must never raise
 
 
 def test_build_handler_bad_python_ref_returns_none_not_raises(caplog):
@@ -948,7 +948,7 @@ def test_register_settings_terminal_callback_malformed_filter_never_raises(monke
     assert any("filter.kinds must be a list of strings" in r.message for r in caplog.records)
 
 
-# ── Legacy argv/env substitution hooks used by the flow `--notify` adapter ──
+# Legacy argv/env substitution hooks used by the flow `--notify` adapter
 
 
 @pytest.mark.asyncio
@@ -988,7 +988,7 @@ async def test_exec_handler_argv_fn_and_env_fn_are_applied_per_call(monkeypatch)
     assert "PATH" in called["env"] or called["env"] is not None
 
 
-# ── Bootstrap: register/unregister on the shared registry ──────────────────
+# Bootstrap: register/unregister on the shared registry
 
 
 def test_register_settings_terminal_callback_installs_and_uninstalls(tmp_path, monkeypatch):
@@ -1108,7 +1108,7 @@ async def test_run_scoped_registration_honors_configured_filter(monkeypatch, tmp
     assert json.loads(run.notify_outcome_path.read_text())["ok"] is True
 
 
-# ── The two silences a run must not confuse ────────────────────────────────
+# The two silences a run must not confuse
 # Registration returns None both when nothing was configured and when a
 # configured notifier was refused. The run's own record is what tells them
 # apart: a refusal writes an unsuccessful outcome carrying the reason, chosen

--- a/tests/state/lifecycle/test_policy_registry.py
+++ b/tests/state/lifecycle/test_policy_registry.py
@@ -162,7 +162,7 @@ def test_contains() -> None:
     assert "bogus" not in registry
 
 
-# ── Registry/policy immutability ────────────────────────────────────────────
+# Registry/policy immutability
 
 
 def test_registered_policy_edge_map_mutation_raises() -> None:
@@ -195,7 +195,7 @@ def test_locally_constructed_registry_accepts_registration_before_sealing() -> N
         registry.register(_policy(entity_type="other_widget", table="other_widgets"))
 
 
-# ── ImmutableEdgeMap: immutable but serialization-safe ──────────────────────
+# ImmutableEdgeMap: immutable but serialization-safe
 
 
 def test_immutable_edge_map_item_assignment_raises() -> None:

--- a/tests/state/lifecycle/test_service.py
+++ b/tests/state/lifecycle/test_service.py
@@ -26,7 +26,7 @@ from lionagi.state.lifecycle import (
 )
 from lionagi.state.lifecycle.service import SQLAlchemyLifecycleService
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -87,7 +87,7 @@ def _command(**overrides) -> TransitionCommand:
     return TransitionCommand(**base)
 
 
-# ── D1: result semantics ────────────────────────────────────────────────────
+# D1: result semantics
 
 
 @pytest.mark.asyncio
@@ -174,7 +174,7 @@ async def test_public_transition_applies_for_dispatch_without_reason_columns(db:
     assert row["status"] == "delivering"
 
 
-# ── delivering -> delivering: the crash-recovery claim must be guarded ─────
+# delivering -> delivering: the crash-recovery claim must be guarded
 
 
 @pytest.mark.asyncio
@@ -441,7 +441,7 @@ async def test_transition_raises_storage_error_style_for_unknown_entity_type(db:
         await service.transition(_command(entity_type="bogus_entity", entity_id=_uid()))
 
 
-# ── D4: algorithm behaviors ─────────────────────────────────────────────────
+# D4: algorithm behaviors
 
 
 @pytest.mark.asyncio

--- a/tests/state/lifecycle/test_terminal_callbacks.py
+++ b/tests/state/lifecycle/test_terminal_callbacks.py
@@ -32,7 +32,7 @@ from lionagi.state.lifecycle.deliveries import (
 )
 from lionagi.state.lifecycle.service import SQLAlchemyLifecycleService
 
-# ── Fixtures (mirrors tests/state/lifecycle/test_service.py) ─────────────────
+# Fixtures (mirrors tests/state/lifecycle/test_service.py)
 
 
 @pytest.fixture
@@ -93,7 +93,7 @@ def _command(**overrides) -> TransitionCommand:
     return TransitionCommand(**base)
 
 
-# ── Registry mechanics ────────────────────────────────────────────────────────
+# Registry mechanics
 
 
 @pytest.mark.asyncio
@@ -324,7 +324,7 @@ async def test_fast_sync_handler_still_runs_and_error_handling_is_unchanged():
     assert ran == ["ok-sync"]
 
 
-# ── Lifecycle-service integration (D1 hook point) ────────────────────────────
+# Lifecycle-service integration (D1 hook point)
 
 
 @pytest.mark.asyncio
@@ -453,7 +453,7 @@ async def test_no_registered_handler_is_a_noop(db: StateDB):
     assert outcome.result == "applied"
 
 
-# ── terminal_deliveries reconciliation (1b, 1b-i, 1b-ii) ─────────────────────
+# terminal_deliveries reconciliation (1b, 1b-i, 1b-ii)
 
 
 @pytest.mark.asyncio

--- a/tests/state/lifecycle/test_wrapper_parity.py
+++ b/tests/state/lifecycle/test_wrapper_parity.py
@@ -20,7 +20,7 @@ from lionagi.state.db import StateDB
 from lionagi.state.reasons import RunReasons
 from lionagi.state.transitions import Actor, StateReason, TransitionRequest, transition
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -61,7 +61,7 @@ async def _make_schedule_run(db: StateDB, *, status: str = "queued") -> str:
     return run_id
 
 
-# ── Missing row: both surfaces raise LookupError ────────────────────────────
+# Missing row: both surfaces raise LookupError
 
 
 @pytest.mark.asyncio
@@ -93,7 +93,7 @@ async def test_legacy_transition_raises_lookup_error_for_missing_row(db: StateDB
         )
 
 
-# ── CAS conflict: both surfaces report a clean skip, no row mutation ───────
+# CAS conflict: both surfaces report a clean skip, no row mutation
 
 
 @pytest.mark.asyncio
@@ -137,7 +137,7 @@ async def test_legacy_transition_cas_conflict_is_a_clean_skip(db: StateDB) -> No
     assert row["status"] == "queued"
 
 
-# ── Same-status write: "append" rule applies identically on both surfaces ──
+# Same-status write: "append" rule applies identically on both surfaces
 
 
 @pytest.mark.asyncio

--- a/tests/state/test_adr0101_task_queue_migration.py
+++ b/tests/state/test_adr0101_task_queue_migration.py
@@ -73,7 +73,7 @@ async def _make_schedule_run(db: StateDB, *, status: str = "running") -> tuple[s
     return sched_id, run_id
 
 
-# ── 1. Migration idempotence ─────────────────────────────────────────────────
+# 1. Migration idempotence
 
 
 async def test_migration_idempotent_on_already_migrated_db(tmp_path):
@@ -370,7 +370,7 @@ async def test_migration_adds_lease_attempts_column_to_legacy_db(tmp_path):
         await state.close()
 
 
-# ── 2. Backup before rebuild ─────────────────────────────────────────────────
+# 2. Backup before rebuild
 
 
 async def test_backup_created_before_rebuild(tmp_path):
@@ -516,7 +516,7 @@ async def test_backup_not_created_when_no_rebuild_needed(tmp_path):
     assert backups == []
 
 
-# ── 3. Transition-vocab enforcement via the CAS transition store ────────────
+# 3. Transition-vocab enforcement via the CAS transition store
 
 
 @pytest.fixture
@@ -683,7 +683,7 @@ async def test_transition_rejects_unknown_patch_column(db: StateDB) -> None:
     assert row["status"] == "running"  # rejected before any SQL ran
 
 
-# ── 4. Load-bearing: schedule-spawned runs stay byte-identical ──────────────
+# 4. Load-bearing: schedule-spawned runs stay byte-identical
 #
 # Golden values captured by running the ORIGINAL (pre-ADR-0071) codebase
 # through the exact same operations below (create_schedule_run then

--- a/tests/state/test_artifact_upsert_race.py
+++ b/tests/state/test_artifact_upsert_race.py
@@ -184,7 +184,7 @@ def _run_race(db_path: Path, jobs: list[tuple[str, str, str, str | None, str | N
     return results
 
 
-# ── Same natural key, all four ADR-0077 shapes ───────────────────────────────
+# Same natural key, all four ADR-0077 shapes
 
 
 @pytest.mark.parametrize(
@@ -222,7 +222,7 @@ def test_concurrent_insert_artifact_same_key_does_not_raise(
     assert _count_artifacts(db_path) == 1, "the same natural key must upsert, not duplicate"
 
 
-# ── Different-keys control: the harness must not itself serialize writers ───
+# Different-keys control: the harness must not itself serialize writers
 
 
 def test_concurrent_insert_artifact_different_keys_both_succeed(tmp_path: Path) -> None:

--- a/tests/state/test_artifact_verifier.py
+++ b/tests/state/test_artifact_verifier.py
@@ -18,7 +18,7 @@ from lionagi.state.artifact_verifier import (
     verify_artifact_contract,
 )
 
-# ── _safe_join ────────────────────────────────────────────────────────────────
+# _safe_join
 
 
 class TestSafeJoin:
@@ -55,7 +55,7 @@ class TestSafeJoin:
             _safe_join(str(tmp_path), "")
 
 
-# ── validate_artifact_contract ───────────────────────────────────────────────
+# validate_artifact_contract
 
 
 class TestValidateArtifactContract:
@@ -102,7 +102,7 @@ class TestValidateArtifactContract:
         validate_artifact_contract({"expected": []})
 
 
-# ── resolve_artifact_contract ─────────────────────────────────────────────────
+# resolve_artifact_contract
 
 
 class TestResolveArtifactContract:
@@ -145,7 +145,7 @@ class TestResolveArtifactContract:
         assert result["expected"][0]["required"] is True
 
 
-# ── verify_artifact_contract ──────────────────────────────────────────────────
+# verify_artifact_contract
 
 
 class TestVerifyArtifactContract:
@@ -219,7 +219,7 @@ class TestVerifyArtifactContract:
         assert len(result["produced"]) == 2
 
 
-# ── missing_artifact_summary / evidence ──────────────────────────────────────
+# missing_artifact_summary / evidence
 
 
 def test_missing_artifact_summary_single():
@@ -241,7 +241,7 @@ def test_missing_artifact_evidence():
     assert evidence == [{"kind": "expected_artifact", "id": "report", "label": "report.md"}]
 
 
-# ── canonical names required by ADR-0064 test plan ───────────────────────────
+# canonical names required by ADR-0064 test plan
 
 
 def test_resolve_contract_both_none():
@@ -427,7 +427,7 @@ def test_safe_join_glob_rejects(tmp_path):
         _safe_join(str(tmp_path), "*.md")
 
 
-# ── A bare filename resolves to whichever worker produced it ──────────────────
+# A bare filename resolves to whichever worker produced it
 #
 # In a multi-agent run each worker writes into its own subdirectory of the
 # artifacts root, and which worker produces a given artifact is decided when the
@@ -582,7 +582,7 @@ def test_the_reported_run_shape_now_passes_end_to_end(tmp_path):
     assert len(result["produced"]) == 5
 
 
-# ── stale_artifact_markers ────────────────────────────────────────────────────
+# stale_artifact_markers
 #
 # A stored verification is a snapshot taken at run completion. These markers
 # never re-verify pass/fail; they only flag, via mtime and presence, whether

--- a/tests/state/test_artifacts.py
+++ b/tests/state/test_artifacts.py
@@ -40,7 +40,7 @@ async def _make_session(db: StateDB, **fields) -> dict:
     return s
 
 
-# ── Insert + read ────────────────────────────────────────────────────────────
+# Insert + read
 
 
 async def test_insert_artifact_with_invocation_link(db: StateDB):
@@ -89,7 +89,7 @@ async def test_get_artifact_missing_returns_none(db: StateDB):
     assert await db.get_artifact("notarealid") is None
 
 
-# ── Validation ───────────────────────────────────────────────────────────────
+# Validation
 
 
 async def test_insert_artifact_requires_kind(db: StateDB):
@@ -102,7 +102,7 @@ async def test_insert_artifact_requires_name(db: StateDB):
         await db.insert_artifact(kind="x", name="", content={})
 
 
-# ── file_path containment (path/symlink containment defect class) ───────────
+# file_path containment (path/symlink containment defect class)
 #
 # Studio artifact file references (ADR-0077 delta 5) must stay relative and
 # non-traversing before the API can ever expose them for preview/download.
@@ -136,7 +136,7 @@ async def test_insert_artifact_accepts_safe_relative_file_path(db: StateDB):
     assert row["file_path"] == "outputs/report.pdf"
 
 
-# ── FK cascade ────────────────────────────────────────────────────────────────
+# FK cascade
 
 
 async def test_artifacts_cascade_when_invocation_deleted(db: StateDB):
@@ -155,7 +155,7 @@ async def test_artifacts_cascade_when_invocation_deleted(db: StateDB):
     assert await db.get_artifact(art_id) is None
 
 
-# ── Idempotency ───────────────────────────────────────────────────────────────
+# Idempotency
 
 
 async def test_insert_artifact_is_idempotent(db: StateDB):
@@ -210,7 +210,7 @@ async def test_insert_artifact_idempotent_updates_content(db: StateDB):
     assert rows[0]["content"]["verdict"] == "APPROVE"
 
 
-# ── Ordering ──────────────────────────────────────────────────────────────────
+# Ordering
 
 
 async def test_list_artifacts_ordered_by_created_at(db: StateDB):

--- a/tests/state/test_check_rebuild_concurrency.py
+++ b/tests/state/test_check_rebuild_concurrency.py
@@ -33,7 +33,7 @@ from lionagi.state.db import StateDB
 _NUM_CONCURRENT_WORKERS = 4
 _BARRIER_TIMEOUT_SECONDS = 15
 
-# ── Legacy fixture builders ─────────────────────────────────────────────────
+# Legacy fixture builders
 
 
 def _create_legacy_session_status_db(db_path: Path) -> None:
@@ -98,7 +98,7 @@ def _create_legacy_invocations_status_db(db_path: Path) -> None:
         conn.executescript(legacy_sql)
 
 
-# ── Multi-process race: sessions status CHECK rebuild ───────────────────────
+# Multi-process race: sessions status CHECK rebuild
 
 
 def _open_state_db_worker_synchronized_begin(
@@ -248,7 +248,7 @@ def test_concurrent_statedb_opens_rebuild_session_status_check(tmp_path: Path) -
     assert table_names == ["sessions"], table_names
 
 
-# ── Guard-helper unit tests (table/marker-agnostic) ──────────────────────────
+# Guard-helper unit tests (table/marker-agnostic)
 
 
 async def test_rebuild_check_constraint_swallows_error_when_winner_already_rebuilt():
@@ -338,7 +338,7 @@ async def test_rebuild_check_constraint_reraises_on_non_sqlite_dialect():
         await state.close()
 
 
-# ── Raw-driver (FK-toggling) rebuild wiring: invocations ────────────────────
+# Raw-driver (FK-toggling) rebuild wiring: invocations
 
 
 async def test_drop_legacy_invocations_status_check_tolerates_concurrent_winner(tmp_path):

--- a/tests/state/test_codex_mirror.py
+++ b/tests/state/test_codex_mirror.py
@@ -325,7 +325,7 @@ async def test_harness_injected_user_turns_are_not_mirrored_as_prompts(db, openi
     assert [m["content"]["instruction"] for m in messages] == ["the actual question"]
 
 
-# ── Orchestrated-rollout absorption ──────────────────────────────────────────
+# Orchestrated-rollout absorption
 
 
 async def test_delete_imported_session_removes_the_whole_graph(db):

--- a/tests/state/test_completion_evidence.py
+++ b/tests/state/test_completion_evidence.py
@@ -14,9 +14,7 @@ from lionagi.state.completion_evidence import (
     has_completion_evidence,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _git(path: Path, *args: str) -> None:
@@ -38,9 +36,7 @@ def git_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
-# ---------------------------------------------------------------------------
 # checked=False cases — the check must have "no opinion", not "no evidence"
-# ---------------------------------------------------------------------------
 
 
 def test_no_cwd_is_unchecked():
@@ -55,9 +51,7 @@ def test_non_git_dir_is_unchecked(tmp_path: Path):
     assert has_completion_evidence(evidence) is False
 
 
-# ---------------------------------------------------------------------------
 # checked=True cases
-# ---------------------------------------------------------------------------
 
 
 def test_clean_tree_no_commits_ahead_has_no_evidence(git_repo: Path):

--- a/tests/state/test_db.py
+++ b/tests/state/test_db.py
@@ -20,7 +20,7 @@ from sqlalchemy import text
 
 from lionagi.state.db import SCHEMA_VERSION, StateDB
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ async def db():
     await state.close()
 
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
+# Helpers
 
 
 def uid() -> str:
@@ -107,7 +107,7 @@ async def _make_live_persist_fixture(db: StateDB) -> tuple[str, str, str, str]:
     return session_id, session_prog_id, branch_id, branch_prog_id
 
 
-# ── Connection lifecycle ───────────────────────────────────────────────────────
+# Connection lifecycle
 
 
 async def test_open_close():
@@ -333,7 +333,7 @@ async def test_context_cancelled_open_shields_partial_engine_disposal(monkeypatc
     assert state._engine is None
 
 
-# ── Schema ─────────────────────────────────────────────────────────────────────
+# Schema
 
 
 async def test_schema_creates_all_tables(db: StateDB):
@@ -653,7 +653,7 @@ async def test_message_types_seeded(db: StateDB):
     assert row["lion_class"] == "__unknown__"
 
 
-# ── Messages ───────────────────────────────────────────────────────────────────
+# Messages
 
 
 async def test_insert_and_get_message(db: StateDB):
@@ -847,7 +847,7 @@ async def test_resolve_lion_class_auto_register(db: StateDB):
     assert row["type_id"] > 5
 
 
-# ── Progressions ───────────────────────────────────────────────────────────────
+# Progressions
 
 
 async def test_create_and_get_progression(db: StateDB):
@@ -878,7 +878,7 @@ async def test_get_progression_missing(db: StateDB):
     assert result == []
 
 
-# ── Sessions ───────────────────────────────────────────────────────────────────
+# Sessions
 
 
 async def test_create_session_with_provenance(db: StateDB):
@@ -997,7 +997,7 @@ async def test_count_sessions(db: StateDB):
     assert failed == 0
 
 
-# ── Branches ───────────────────────────────────────────────────────────────────
+# Branches
 
 
 async def test_create_and_get_branch(db: StateDB):
@@ -1107,7 +1107,7 @@ async def test_get_branch_messages(db: StateDB):
     assert [r["id"] for r in result] == [m["id"] for m in msgs]
 
 
-# ── finalize_branch (BRANCH_END guarded terminal write) ─────────────────────
+# finalize_branch (BRANCH_END guarded terminal write)
 
 
 async def _make_branch(db: StateDB, *, status: str | None = None) -> dict:
@@ -1284,7 +1284,7 @@ async def test_finalize_branch_repeated_call_does_not_flap_terminal_status(db: S
     assert row["ended_at"] == 100.0
 
 
-# ── Shows ─────────────────────────────────────────────────────────────────────
+# Shows
 
 
 async def test_create_and_get_show(db: StateDB):
@@ -1358,7 +1358,7 @@ async def test_update_show_rejects_bad_columns(db: StateDB):
         await db.update_show(show["id"], not_a_column="boom")
 
 
-# ── Plays ─────────────────────────────────────────────────────────────────────
+# Plays
 
 
 async def test_create_and_get_play(db: StateDB):
@@ -1470,7 +1470,7 @@ async def test_update_play_rejects_bad_columns(db: StateDB):
         await db.update_play(play["id"], hacker_column="evil")
 
 
-# ── Definitions ───────────────────────────────────────────────────────────────
+# Definitions
 
 
 async def test_save_and_get_definition(db: StateDB):
@@ -1576,7 +1576,7 @@ async def test_get_definition_missing(db: StateDB):
     assert result_versioned is None
 
 
-# ── Regression: SQL race + JSON roundtrip + provenance ────────────
+# Regression: SQL race + JSON roundtrip + provenance
 
 
 async def test_resolve_lion_class_concurrent_race(tmp_path):
@@ -1834,7 +1834,7 @@ async def test_session_delete_cascades_branches(db: StateDB):
     assert await db.get_branch(bid) is None
 
 
-# ── ADR-0064: Artifact contract storage ───────────────────────────────────────
+# ADR-0064: Artifact contract storage
 
 
 async def test_create_session_with_artifact_contract(db: StateDB):
@@ -1918,7 +1918,7 @@ async def test_new_db_has_artifact_columns(db: StateDB):
     assert "artifact_verification_json" in cols
 
 
-# ── readonly=True: no schema application, no create-on-open ──────────────────
+# readonly=True: no schema application, no create-on-open
 
 
 async def test_readonly_open_rejects_missing_file(tmp_path):
@@ -2041,7 +2041,7 @@ async def test_writable_read_survives_a_concurrent_write_lock(tmp_path):
         await db.close()
 
 
-# ── update_status extra_fields: schedule_run ────────────────────────────────
+# update_status extra_fields: schedule_run
 
 
 async def _make_running_schedule_run(db) -> str:

--- a/tests/state/test_db_artifact_contract.py
+++ b/tests/state/test_db_artifact_contract.py
@@ -37,7 +37,7 @@ async def _make_session(db: StateDB, **fields) -> str:
     return sid
 
 
-# ── test_create_session_with_contract ────────────────────────────────────────
+# test_create_session_with_contract
 
 
 async def test_create_session_with_contract(db: StateDB):
@@ -51,7 +51,7 @@ async def test_create_session_with_contract(db: StateDB):
     assert stored["expected"][0]["id"] == "report"
 
 
-# ── test_create_session_without_contract ─────────────────────────────────────
+# test_create_session_without_contract
 
 
 async def test_create_session_without_contract(db: StateDB):
@@ -62,7 +62,7 @@ async def test_create_session_without_contract(db: StateDB):
     assert row["artifact_contract_json"] is None
 
 
-# ── test_update_artifact_verification ────────────────────────────────────────
+# test_update_artifact_verification
 
 
 async def test_update_artifact_verification(db: StateDB):
@@ -84,7 +84,7 @@ async def test_update_artifact_verification(db: StateDB):
     assert stored["produced"][0]["id"] == "report"
 
 
-# ── test_migration_adds_columns ───────────────────────────────────────────────
+# test_migration_adds_columns
 
 
 async def test_migration_adds_columns():

--- a/tests/state/test_db_cascade.py
+++ b/tests/state/test_db_cascade.py
@@ -23,7 +23,7 @@ async def db():
     await state.close()
 
 
-# ── PRAGMA proof ─────────────────────────────────────────────────────────────
+# PRAGMA proof
 
 
 async def test_pragma_foreign_keys_is_on(db: StateDB):
@@ -33,7 +33,7 @@ async def test_pragma_foreign_keys_is_on(db: StateDB):
     assert row[0] == 1
 
 
-# ── Session → Branch cascade ─────────────────────────────────────────────────
+# Session → Branch cascade
 
 
 async def test_delete_session_cascades_branches(db: StateDB):
@@ -124,7 +124,7 @@ async def test_delete_session_does_not_cascade_progression(db: StateDB):
     assert row["n"] == 1
 
 
-# ── Show → Play cascade ──────────────────────────────────────────────────────
+# Show → Play cascade
 
 
 async def test_delete_show_cascades_plays(db: StateDB):
@@ -207,7 +207,7 @@ async def test_delete_show_with_no_plays_succeeds(db: StateDB):
     assert row["n"] == 0
 
 
-# ── Play.session_id is NOT cascaded ─────────────────────────────────────────
+# Play.session_id is NOT cascaded
 
 
 async def test_delete_session_referenced_by_play_is_rejected(db: StateDB):
@@ -242,7 +242,7 @@ async def test_delete_session_referenced_by_play_is_rejected(db: StateDB):
             await conn.execute(text("DELETE FROM sessions WHERE id = :id"), {"id": sid})
 
 
-# ── Branch.system_msg_id is NOT cascaded ─────────────────────────────────────
+# Branch.system_msg_id is NOT cascaded
 
 
 async def test_delete_message_does_not_cascade_to_branch_system_msg_id(

--- a/tests/state/test_db_locking.py
+++ b/tests/state/test_db_locking.py
@@ -34,7 +34,7 @@ def db_path(tmp_path: Path) -> Path:
     return tmp_path / "shared.db"
 
 
-# ── Multi-connection: concurrent insert_message ──────────────────────────────
+# Multi-connection: concurrent insert_message
 
 
 async def test_two_connections_can_insert_concurrently(db_path: Path):
@@ -93,7 +93,7 @@ async def test_concurrent_resolve_lion_class_no_unique_error(db_path: Path):
         await db2.close()
 
 
-# ── busy_timeout: long-held lock surfaces sensibly ────────────────────────────
+# busy_timeout: long-held lock surfaces sensibly
 
 
 async def test_busy_timeout_eventually_returns_locked_error(
@@ -132,7 +132,7 @@ async def test_busy_timeout_eventually_returns_locked_error(
         await db2.close()
 
 
-# ── fanout: reads must not queue behind a held writer lock ──────────────────
+# fanout: reads must not queue behind a held writer lock
 
 
 async def test_many_concurrent_reads_survive_a_held_write_lock(db_path: Path):
@@ -167,7 +167,7 @@ async def test_many_concurrent_reads_survive_a_held_write_lock(db_path: Path):
         await db.close()
 
 
-# ── save_definition under contention ──────────────────────────────────────────
+# save_definition under contention
 
 
 async def test_concurrent_save_definition_same_key_serialized(

--- a/tests/state/test_db_payload_limits.py
+++ b/tests/state/test_db_payload_limits.py
@@ -37,7 +37,7 @@ def _base_msg(**overrides) -> dict:
     return msg
 
 
-# ── Required-field rejection ─────────────────────────────────────────────────
+# Required-field rejection
 
 
 async def test_insert_message_rejects_null_content(db: StateDB):
@@ -67,7 +67,7 @@ async def test_insert_message_rejects_missing_role(db: StateDB):
         await db.insert_message(msg)
 
 
-# ── Large-payload roundtrip ──────────────────────────────────────────────────
+# Large-payload roundtrip
 
 
 @pytest.mark.parametrize("size_kb", [10, 100, 1024])
@@ -113,7 +113,7 @@ async def test_insert_message_handles_deep_nested_metadata(db: StateDB):
     assert depth == 49
 
 
-# ── Re-fire of mutated message (ON CONFLICT DO UPDATE) ───────────────────────
+# Re-fire of mutated message (ON CONFLICT DO UPDATE)
 
 
 async def test_insert_message_re_fire_updates_content(db: StateDB):
@@ -149,7 +149,7 @@ async def test_insert_message_re_fire_updates_content(db: StateDB):
     assert row["n"] == 1
 
 
-# ── Unicode + binary embedding ───────────────────────────────────────────────
+# Unicode + binary embedding
 
 
 async def test_insert_message_roundtrips_unicode_content(db: StateDB):

--- a/tests/state/test_definitions_kind_check_migration.py
+++ b/tests/state/test_definitions_kind_check_migration.py
@@ -22,7 +22,7 @@ from sqlalchemy import text
 
 from lionagi.state.db import StateDB
 
-# ── Legacy fixture builders ─────────────────────────────────────────────────
+# Legacy fixture builders
 
 
 def _create_legacy_definitions_db(db_path: Path, *, unrelated_skill_literal: bool = False) -> None:
@@ -66,7 +66,7 @@ async def _definitions_create_sql(db_path: Path) -> str:
     return row[0]
 
 
-# ── Arm 1: exact legacy schema migrates ──────────────────────────────────────
+# Arm 1: exact legacy schema migrates
 
 
 async def test_exact_legacy_schema_migrates(tmp_path: Path) -> None:
@@ -96,7 +96,7 @@ async def test_exact_legacy_schema_migrates(tmp_path: Path) -> None:
     )
 
 
-# ── Arm 2: exact widened (current) schema skips the rebuild ────────────────
+# Arm 2: exact widened (current) schema skips the rebuild
 
 
 async def test_current_schema_skips_rebuild(tmp_path: Path) -> None:
@@ -128,7 +128,7 @@ async def test_current_schema_skips_rebuild(tmp_path: Path) -> None:
     assert create_sql_after == create_sql_before
 
 
-# ── Arm 3: the false-positive fixture -- old CHECK + unrelated 'skill' ─────
+# Arm 3: the false-positive fixture -- old CHECK + unrelated 'skill'
 
 
 async def test_legacy_schema_with_unrelated_skill_literal_still_migrates(tmp_path: Path) -> None:
@@ -183,7 +183,7 @@ async def test_old_substring_detector_would_have_false_positived(tmp_path: Path)
     assert old_check_still_present is True
 
 
-# ── Arm 4: failed copy retries ───────────────────────────────────────────────
+# Arm 4: failed copy retries
 
 
 async def test_rebuild_crash_mid_sequence_rolls_back_and_reopen_completes(tmp_path: Path) -> None:

--- a/tests/state/test_dual_backend.py
+++ b/tests/state/test_dual_backend.py
@@ -23,7 +23,7 @@ import pytest
 from lionagi.state.db import SCHEMA_VERSION, StateDB
 from lionagi.state.reasons import RunReasons
 
-# ── Shared helpers ────────────────────────────────────────────────────────────
+# Shared helpers
 
 
 def _uid() -> str:
@@ -240,7 +240,7 @@ async def _run_parity_suite(db: StateDB) -> None:
     assert empties[0]["project"] is None, f"zero-session project must be None: {empties[0]!r}"
 
 
-# ── SQLite leg (always runs) ──────────────────────────────────────────────────
+# SQLite leg (always runs)
 
 
 @pytest.fixture
@@ -257,7 +257,7 @@ async def test_sqlite_parity(sqlite_db: StateDB):
     await _run_parity_suite(sqlite_db)
 
 
-# ── SQLite regression: singleton keying by URL ─────────────────────────────────
+# SQLite regression: singleton keying by URL
 
 
 async def test_sqlite_singleton_keyed_by_url(tmp_path):
@@ -276,7 +276,7 @@ async def test_sqlite_singleton_keyed_by_url(tmp_path):
         await db.close()
 
 
-# ── SQLite regression: multiple concurrent writes (WAL) ───────────────────────
+# SQLite regression: multiple concurrent writes (WAL)
 
 
 async def test_sqlite_concurrent_writes(tmp_path):
@@ -315,7 +315,7 @@ async def test_sqlite_concurrent_writes(tmp_path):
         await db.close()
 
 
-# ── Postgres leg (pg_url fixture: testcontainers, or LIONAGI_TEST_PG_URL) ─────
+# Postgres leg (pg_url fixture: testcontainers, or LIONAGI_TEST_PG_URL)
 
 
 async def test_postgres_parity(pg_url):
@@ -356,7 +356,7 @@ async def test_postgres_schema_creates_all_tables(pg_url):
         await db.close()
 
 
-# ── Dialect SQL correctness (static — no live connection, always runs) ─────────
+# Dialect SQL correctness (static — no live connection, always runs)
 # Guards the Postgres-breaking SQL forms that the gated live leg above would only
 # catch when LIONAGI_TEST_PG_URL is set.
 
@@ -486,7 +486,7 @@ async def test_postgres_capability_claim(pg_url):
         await db.close()
 
 
-# ── merge_session_node_metadata: dialect-parity table ─────────────────────────
+# merge_session_node_metadata: dialect-parity table
 # Postgres's jsonb_strip_nulls, applied to the *entire* merged document,
 # deletes nulls that predate the patch and were never touched by it --
 # SQLite's json_patch never removes them. A real NodeStarted flow segment
@@ -738,7 +738,7 @@ async def test_postgres_json_column_rejects_non_json_text(pg_url):
         await db.close()
 
 
-# ── Postgres leg: lifecycle service load-bearing contract (ADR-0058 Phase 2) ──
+# Postgres leg: lifecycle service load-bearing contract (ADR-0058 Phase 2)
 # The applied/conflict/rejected/rollback/parity cases pinned against SQLite in
 # tests/state/lifecycle/test_service.py and test_wrapper_parity.py must hold
 # identically on PostgreSQL (FOR UPDATE locking, JSON binding, transaction
@@ -979,7 +979,7 @@ async def test_postgres_wrapper_parity_cas_conflict_and_same_status_append(pg_ur
         await db.close()
 
 
-# ── session-control admission takes the session row lock on PostgreSQL ───────
+# session-control admission takes the session row lock on PostgreSQL
 #
 # SQLite serialises writers, so evaluating the running-session condition inside
 # the insert statement is decisive there. PostgreSQL runs two clients at once
@@ -1073,7 +1073,7 @@ async def test_postgres_control_admission_waits_on_a_locked_session_row(pg_url):
         assert after is not None
 
 
-# ── a hand resolution that loses its race reports nothing ────────────────
+# a hand resolution that loses its race reports nothing
 #
 # `resolve_claimed_session_control` reads the current claim, decides from it,
 # then writes under a compare-and-set. On PostgreSQL the claimant can commit its
@@ -1181,7 +1181,7 @@ async def test_postgres_resolve_reports_nothing_when_its_write_lost_the_race(pg_
         )
 
 
-# ── Postgres leg: the delete/writer race on delete_imported_session ───────────
+# Postgres leg: the delete/writer race on delete_imported_session
 # Lives in this module for the reason stated above: it needs the session-scoped
 # `pg_url` fixture, and a second module requesting it in the same run breaks
 # asyncpg's loop-bound connections.
@@ -1558,10 +1558,10 @@ async def test_postgres_teardown_gives_up_rather_than_deadlocking_after_it_holds
         await db.close()
 
 
-# ── Postgres leg: attach_session_invocation's prior-invocation read races ────
-# a concurrent repoint (round-2 review of PR #2884). SQLite serializes this
-# through its own write lock plus BEGIN IMMEDIATE; PostgreSQL at READ
-# COMMITTED does not, so the prior-invocation SELECT takes FOR UPDATE there.
+# Postgres leg: attach_session_invocation's prior-invocation read can race
+# a concurrent repoint. SQLite serializes this through its own write lock
+# plus BEGIN IMMEDIATE; PostgreSQL at READ COMMITTED does not, so the
+# prior-invocation SELECT takes FOR UPDATE there.
 
 
 async def test_postgres_attach_session_invocation_decrements_off_the_value_a_concurrent_repoint_left(

--- a/tests/state/test_engine_schema.py
+++ b/tests/state/test_engine_schema.py
@@ -21,7 +21,7 @@ from lionagi.state.engine import (
 )
 from lionagi.state.schema_meta import metadata
 
-# ── normalize_state_db_url ────────────────────────────────────────────────────
+# normalize_state_db_url
 
 
 def test_normalize_none_returns_sqlite_default():
@@ -82,7 +82,7 @@ def test_normalize_postgresql_asyncpg_already_qualified():
     assert normalize_state_db_url(original) == original
 
 
-# ── mask_db_url ───────────────────────────────────────────────────────────────
+# mask_db_url
 
 
 def test_mask_no_password():
@@ -114,7 +114,7 @@ def test_mask_short_password():
     assert "[3 chars]" in masked
 
 
-# ── dialect_of ────────────────────────────────────────────────────────────────
+# dialect_of
 
 
 def test_dialect_sqlite():
@@ -127,7 +127,7 @@ def test_dialect_postgresql():
     assert dialect_of("postgres://host/db") == "postgresql"
 
 
-# ── make_engine (SQLite only — sync verification) ────────────────────────────
+# make_engine (SQLite only — sync verification)
 
 
 def test_make_engine_sqlite_creates_engine():
@@ -141,7 +141,7 @@ def test_make_engine_sqlite_creates_engine():
     asyncio.run(engine.dispose())
 
 
-# ── make_readonly_engine ──────────────────────────────────────────────────────
+# make_readonly_engine
 
 
 def test_make_readonly_engine_rejects_postgres():
@@ -187,7 +187,7 @@ async def test_make_readonly_engine_rejects_writes(tmp_path):
         await ro_engine.dispose()
 
 
-# ── Schema-parity: MetaData vs schema.sql (SQLite leg, always runs) ──────────
+# Schema-parity: MetaData vs schema.sql (SQLite leg, always runs)
 
 ALL_TABLES = {
     "schema_meta",
@@ -458,7 +458,7 @@ async def test_metadata_unique_enforcement_present(sqlite_meta_engine):
         assert key in found, f"missing unique enforcement: {key}; found={found}"
 
 
-# ── Postgres leg (pg_url fixture: testcontainers, or LIONAGI_TEST_PG_URL) ─────
+# Postgres leg (pg_url fixture: testcontainers, or LIONAGI_TEST_PG_URL)
 
 
 async def test_metadata_create_all_postgres(pg_url):
@@ -500,7 +500,7 @@ def _create_in_schema(sync_conn, schema_name: str) -> None:
     scoped.create_all(sync_conn, checkfirst=True)
 
 
-# ── WAL-reset precondition ────────────────────────────────────────────────────
+# WAL-reset precondition
 
 
 @pytest.mark.parametrize(

--- a/tests/state/test_health.py
+++ b/tests/state/test_health.py
@@ -64,7 +64,7 @@ def test_health_and_staleness_entry_points_share_threshold_boundary(
     )
 
 
-# ── Terminal sessions ────────────────────────────────────────────────────────
+# Terminal sessions
 
 
 def test_completed_session_with_clean_resources_is_healthy():
@@ -108,7 +108,7 @@ def test_terminal_session_artifacts_alone_not_zombie():
     assert h == SessionHealth.HEALTHY
 
 
-# ── Running, process alive ────────────────────────────────────────────────────
+# Running, process alive
 
 
 def test_running_with_recent_messages_is_healthy():
@@ -196,7 +196,7 @@ def test_flow_threshold_more_lenient_than_agent():
     )
 
 
-# ── Running, liveness unknown (no matchable pid) ────────────────────────────
+# Running, liveness unknown (no matchable pid)
 
 
 def test_running_liveness_unknown_but_recently_messaging_is_healthy():
@@ -326,7 +326,7 @@ def test_running_liveness_unknown_no_messages_but_has_artifacts_not_orphaned():
     assert h == SessionHealth.HEALTHY
 
 
-# ── Edge cases ────────────────────────────────────────────────────────────────
+# Edge cases
 
 
 def test_null_status_treated_as_completed():
@@ -359,7 +359,7 @@ def test_missing_invocation_kind_uses_default_threshold():
     assert h == SessionHealth.UNRESPONSIVE
 
 
-# ── worst_health aggregator (grouped runs view) ──────────────────────────────
+# worst_health aggregator (grouped runs view)
 
 
 def test_worst_health_picks_highest_severity():
@@ -386,7 +386,7 @@ def test_severity_table_covers_all_health_levels():
     assert set(HEALTH_SEVERITY) == set(SessionHealth)
 
 
-# ── Running, confirmed dead (recorded pid no longer running) ─────────────────
+# Running, confirmed dead (recorded pid no longer running)
 
 
 def test_running_confirmed_dead_recent_messages_is_stale():

--- a/tests/state/test_invocations.py
+++ b/tests/state/test_invocations.py
@@ -58,7 +58,7 @@ async def _make_session(db: StateDB, *, invocation_id: str | None = None, **fiel
     return session
 
 
-# ── Vocabulary ────────────────────────────────────────────────────────────────
+# Vocabulary
 
 
 def test_invocation_status_vocabulary_matches_adr0025():
@@ -77,7 +77,7 @@ def test_invocation_status_vocabulary_matches_adr0025():
     )
 
 
-# ── CRUD ──────────────────────────────────────────────────────────────────────
+# CRUD
 
 
 async def test_create_and_get_invocation(db: StateDB):
@@ -117,7 +117,7 @@ async def test_update_invocation_rejects_unknown_column(db: StateDB):
         await db.update_invocation(inv["id"], not_a_column="x")
 
 
-# ── Session linkage ───────────────────────────────────────────────────────────
+# Session linkage
 
 
 async def test_create_session_with_invocation_bumps_count(db: StateDB):
@@ -173,7 +173,7 @@ async def test_session_without_invocation_id_is_unaffected(db: StateDB):
     assert fetched["invocation_id"] is None
 
 
-# ── attach_session_invocation (resume backfill, issue #2767) ──────────────────
+# attach_session_invocation: resume backfill
 
 
 async def test_attach_session_invocation_links_an_unlinked_session(db: StateDB):
@@ -246,7 +246,7 @@ async def test_attach_session_invocation_is_a_noop_when_already_current(db: Stat
     assert (await db.get_invocation(inv["id"]))["session_count"] == 1
 
 
-# ── List + filter ─────────────────────────────────────────────────────────────
+# List + filter
 
 
 async def test_list_invocations_filters_by_skill(db: StateDB):
@@ -281,7 +281,7 @@ async def test_list_invocations_filters_by_plugin(db: StateDB):
     assert only_review_toolkit[0]["plugin"] == "review-toolkit"
 
 
-# ── Count (real total, not a page count) ───────────────────────────────────────
+# Count (real total, not a page count)
 
 
 async def test_count_invocations_matches_row_count_below_the_page_limit(db: StateDB):

--- a/tests/state/test_json_bind_non_finite.py
+++ b/tests/state/test_json_bind_non_finite.py
@@ -33,7 +33,7 @@ async def _artifact_count(db: StateDB) -> int:
     return row["n"]
 
 
-# ── The shared JSON-bind serializer ──────────────────────────────────────────
+# The shared JSON-bind serializer
 
 
 @pytest.mark.parametrize("bad", NON_FINITE)
@@ -51,7 +51,7 @@ def test_engine_json_serializer_keeps_ordinary_values():
     assert _dumps_with_uuid({"a": 1.5, "b": None, "c": "x"}) == '{"a": 1.5, "b": null, "c": "x"}'
 
 
-# ── insert_artifact: rejected before a row exists ────────────────────────────
+# insert_artifact: rejected before a row exists
 
 
 @pytest.mark.parametrize("bad", NON_FINITE)
@@ -85,7 +85,7 @@ async def test_insert_artifact_update_rejects_non_finite_without_changing_the_ro
     assert stored == {"score": 1.0}
 
 
-# ── Ordinary content, including a genuine null, still writes ─────────────────
+# Ordinary content, including a genuine null, still writes
 
 
 async def test_ordinary_content_with_a_genuine_null_round_trips(db):
@@ -99,7 +99,7 @@ async def test_ordinary_content_with_a_genuine_null_round_trips(db):
     assert math.isfinite(stored["big"])
 
 
-# ── The TEXT-column JSON write goes through the checked helper ───────────────
+# The TEXT-column JSON write goes through the checked helper
 
 
 async def test_progression_collection_writes_through_the_checked_helper(db):
@@ -126,7 +126,7 @@ async def test_set_progression_replaces_an_ordinary_collection(db):
     assert await db.get_progression("prog-replace") == ["m1", "m2", "m3"]
 
 
-# ── The run-import path writes its collections through the same helper ───────
+# The run-import path writes its collections through the same helper
 #
 # `li state import` reads run files written by other processes and parses them
 # with json.loads, which accepts the non-standard NaN/Infinity tokens. Nothing

--- a/tests/state/test_json_roundtrip.py
+++ b/tests/state/test_json_roundtrip.py
@@ -12,7 +12,7 @@ import pytest
 
 from lionagi.state.db import StateDB
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def uid() -> str:
     return str(uuid.uuid4())
 
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
+# Helpers
 
 
 async def _make_session(db: StateDB) -> str:
@@ -57,7 +57,7 @@ async def _make_show(db: StateDB) -> str:
     return show_id
 
 
-# ── Tests: UUID values round-trip through JSON columns ───────────────────────
+# Tests: UUID values round-trip through JSON columns
 
 
 @pytest.mark.unit

--- a/tests/state/test_lifecycle_gate.py
+++ b/tests/state/test_lifecycle_gate.py
@@ -3,47 +3,12 @@
 
 """StateDB lifecycle gate.
 
-Regression class this module pins, in plain terms:
-
-1. ``StateDB.update_status()`` has two different failure contracts that look
-   similar and have been confused before: a CAS-miss (a stale
-   ``expected_statuses``/``expected_updated_at`` guard) returns ``False``
-   silently, with no row change and no exception — an ordinary lost race.
-   Attempting to move a *terminal* entity to a different status without
-   ``override=True`` is a completely different case: it raises
-   ``TransitionRejectedError``. A caller (or a future refactor) that treats
-   one of these as the other is a live bug, not a style choice. The two
-   contracts can also *interact* — a terminal row with a stale version guard
-   is still rejected and audited because terminal-exit policy is evaluated
-   before a write-only version conflict; this file pins that interaction.
-
-2. New statuses get added to one vocabulary source (a schema ``CHECK``
-   constraint, the ``PolicyRegistry``, or the ``VALID_STATUSES_BY_ENTITY_TYPE``
-   facade in ``lionagi/state/db.py``) without a matching edit everywhere
-   else. This file pins an exact, sorted status list per entity so an
-   addition anywhere shows up here as a deliberate diff, not a silent
-   widening (or narrowing) of what ``update_status()`` accepts.
-
-3. The transition-policy edge graph (``PolicyRegistry``) is only enforced
-   by the *public* ``SQLAlchemyLifecycleService.transition()`` entry point —
-   ``StateDB.update_status()`` never enforces it (see
-   ``lionagi/state/lifecycle/adapters.py``'s ``enforce_edges`` docstring).
-   This file walks every declared edge for session/invocation/play/
-   schedule_run and asserts it applies, then samples undeclared edges and
-   asserts they come back as a ``"rejected"`` outcome (with an
-   ``admin_events`` audit row) — never a raise, never a silent write.
-
-4. The reaper pattern used throughout
-   ``lionagi/studio/services/lifecycle.py`` (guard a stale-row transition on
-   both ``expected_statuses`` *and* ``expected_updated_at``) is easy to
-   weaken without any test noticing: a change that drops the
-   ``expected_updated_at`` guard still passes every status-only test, and
-   still over-reaps a row that was legitimately re-claimed between the scan
-   and the write (status-membership alone cannot distinguish "still stale"
-   from "just re-touched"). This file reproduces that exact guarded-write
-   shape directly against ``StateDB`` and pins both outcomes: a genuinely
-   stale row is reaped, a row whose ``updated_at`` moved between read and
-   write is not.
+Pins: the CAS-miss-vs-terminal-rejection distinction in ``update_status()``,
+per-entity status vocabulary drift across its three sources of truth,
+``PolicyRegistry`` enforcement being scoped to the public
+``SQLAlchemyLifecycleService.transition()`` entry point, and the two-guard
+reaper pattern (``expected_statuses`` + ``expected_updated_at``). See
+``docs/internals/state-lifecycle.md`` for the regression detail behind each.
 
 Everything here runs against a temp-dir sqlite ``StateDB`` (``tmp_path /
 "state.db"``) — never ``~/.lionagi/state.db``, never any shared path.
@@ -85,7 +50,7 @@ def _wait_clock_past(ts: float) -> None:
         time.sleep(0.001)
 
 
-# ── Fixtures / helpers ───────────────────────────────────────────────────────
+# Fixtures / helpers
 
 
 @pytest.fixture
@@ -199,7 +164,7 @@ def _schema_check_status_values(table: str) -> frozenset[str]:
     return frozenset(values)
 
 
-# ── 1. Status vocabulary golden ──────────────────────────────────────────────
+# 1. Status vocabulary golden
 
 # Exact status vocabulary per managed entity, pinned as sorted lists. A
 # status added to (or removed from) any one of the three sources this test
@@ -293,7 +258,7 @@ def test_status_vocabulary_golden_against_schema_check(entity_type: str) -> None
     assert sorted(_schema_check_status_values(table)) == _EXPECTED_STATUSES[entity_type]
 
 
-# ── 2. Transition-policy matrix ──────────────────────────────────────────────
+# 2. Transition-policy matrix
 # Only the *public* SQLAlchemyLifecycleService.transition() entry point
 # enforces the PolicyRegistry's declared-edge graph (StateDB.update_status()
 # does not — see lionagi/state/lifecycle/adapters.py's `enforce_edges`
@@ -401,7 +366,7 @@ async def test_undeclared_edge_sample_rejected_not_raised(
     assert transitions == []
 
 
-# ── 3. CAS behavior: silent False vs raised TransitionRejectedError ─────────
+# 3. CAS behavior: silent False vs raised TransitionRejectedError
 
 
 @pytest.mark.asyncio
@@ -511,7 +476,7 @@ async def test_terminal_row_with_stale_guard_returns_false_not_raise(db: StateDB
     assert row["status"] == "completed"
 
 
-# ── 4. Reaper pattern: version-guarded stale-row transition ─────────────────
+# 4. Reaper pattern: version-guarded stale-row transition
 # Mirrors lionagi.studio.services.lifecycle.reap_stale_plays()'s exact
 # guarded-write shape (expected_statuses=<reapable set> +
 # expected_updated_at=<snapshot>) directly against StateDB, so the guarantee

--- a/tests/state/test_migrations.py
+++ b/tests/state/test_migrations.py
@@ -21,7 +21,7 @@ from lionagi.state.schema_migrations import MIGRATION_COLUMNS
 _NUM_CONCURRENT_WORKERS = 4
 _BARRIER_TIMEOUT_SECONDS = 15
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
+# Helpers
 
 
 async def _column_names(db: aiosqlite.Connection, table: str) -> set[str]:
@@ -127,7 +127,7 @@ def _open_state_db_worker(
         result_queue.put(None)
 
 
-# ── Old-schema fixture ────────────────────────────────────────────────────────
+# Old-schema fixture
 
 
 @pytest.fixture
@@ -226,7 +226,7 @@ async def old_schema_db():
         yield db
 
 
-# ── Tests ─────────────────────────────────────────────────────────────────────
+# Tests
 
 
 async def test_migration_columns_constant_is_importable():
@@ -807,7 +807,7 @@ async def test_statedb_open_exposes_migration_columns():
     await state.close()
 
 
-# ── max_runs / count_schedule_runs (one-shot semantics) ──────────────────────
+# max_runs / count_schedule_runs (one-shot semantics)
 
 
 async def test_count_schedule_runs_excludes_skipped_and_running():
@@ -922,7 +922,7 @@ async def test_max_runs_nullable_defaults_unlimited():
     await state.close()
 
 
-# ── resume_packet round-trip ─────────────────────────────────────────────────
+# resume_packet round-trip
 
 
 async def test_resume_packet_roundtrips_as_dict():

--- a/tests/state/test_projects.py
+++ b/tests/state/test_projects.py
@@ -45,7 +45,7 @@ async def _make_session(
     return session
 
 
-# ── register_project ──────────────────────────────────────────────────────────
+# register_project
 
 
 async def test_register_project_creates_row(db: StateDB):
@@ -89,7 +89,7 @@ async def test_register_project_updates_github_when_provided(db: StateDB):
     assert project["github"] == "https://github.com/org/repo"
 
 
-# ── create_project ─────────────────────────────────────────────────────────────
+# create_project
 
 
 async def test_create_project_studio_source(db: StateDB):
@@ -121,7 +121,7 @@ async def test_create_project_duplicate_raises(db: StateDB):
         await db.create_project("dup-proj")
 
 
-# ── list_projects ─────────────────────────────────────────────────────────────
+# list_projects
 
 
 async def test_list_projects_empty(db: StateDB):
@@ -156,7 +156,7 @@ async def test_list_projects_running_count(db: StateDB):
     assert proj["running_count"] == 1
 
 
-# ── get_project ───────────────────────────────────────────────────────────────
+# get_project
 
 
 async def test_get_project_none_for_missing(db: StateDB):
@@ -171,7 +171,7 @@ async def test_get_project_returns_dict(db: StateDB):
     assert result["name"] == "my-repo"
 
 
-# ── update_project ─────────────────────────────────────────────────────────────
+# update_project
 
 
 async def test_update_project_description(db: StateDB):
@@ -194,7 +194,7 @@ async def test_update_project_rejects_bad_column(db: StateDB):
         await db.update_project("safe", source="evil")
 
 
-# ── delete_project ─────────────────────────────────────────────────────────────
+# delete_project
 
 
 async def test_delete_project_studio_source(db: StateDB):
@@ -211,7 +211,7 @@ async def test_delete_project_non_studio_returns_false(db: StateDB):
     assert await db.get_project("auto-detected") is not None
 
 
-# ── auto-registration via create_session ──────────────────────────────────────
+# auto-registration via create_session
 
 
 async def test_create_session_auto_registers_project(db: StateDB):

--- a/tests/state/test_provenance.py
+++ b/tests/state/test_provenance.py
@@ -30,7 +30,7 @@ def _uid() -> str:
     return str(uuid.uuid4())
 
 
-# ── resolve_model_spec ────────────────────────────────────────────────────────
+# resolve_model_spec
 
 
 def test_resolve_combines_provider_and_model():
@@ -50,7 +50,7 @@ def test_resolve_none_for_both_none():
     assert resolve_model_spec(None, None) is None
 
 
-# ── agent_definition_hash ────────────────────────────────────────────────────
+# agent_definition_hash
 
 
 def test_hash_none_for_missing_agent(tmp_path: Path, monkeypatch):
@@ -131,7 +131,7 @@ def test_hash_is_16_chars():
     assert len(h) == 16
 
 
-# ── DB write path ────────────────────────────────────────────────────────────
+# DB write path
 
 
 async def test_create_session_persists_provenance(db: StateDB):

--- a/tests/state/test_session_naming.py
+++ b/tests/state/test_session_naming.py
@@ -14,7 +14,7 @@ from lionagi.state.session_naming import (
     sanitize_prompt_name,
 )
 
-# ── sanitize_prompt_name ──────────────────────────────────────────────────
+# sanitize_prompt_name
 
 
 def test_sanitize_strips_leading_system_message_banner() -> None:
@@ -76,7 +76,7 @@ def test_sanitize_banner_only_input_returns_none_not_empty_string() -> None:
     assert sanitize_prompt_name("Guidance: LION_SYSTEM_MESSAGE") is None
 
 
-# ── agent_role_label ──────────────────────────────────────────────────────
+# agent_role_label
 
 
 def test_agent_role_label_appends_utc_time_disambiguator() -> None:
@@ -151,7 +151,7 @@ def test_resolve_display_name_agent_tier_accepts_run_id_when_there_is_no_id() ->
     assert resolve_display_name(row) == "explorer · 9f0e · 14:22"
 
 
-# ── resolve_display_name: priority chain ──────────────────────────────────
+# resolve_display_name: priority chain
 
 
 def test_priority_user_label_wins_over_everything() -> None:
@@ -276,7 +276,7 @@ def test_prose_is_left_alone(raw: str) -> None:
     assert sanitize_prompt_name(raw) == raw
 
 
-# ── placeholder stored names ──────────────────────────────────────────────
+# placeholder stored names
 
 
 @pytest.mark.parametrize("placeholder", sorted(_UNINFORMATIVE_STORED_NAMES))

--- a/tests/state/test_session_status_vocabulary.py
+++ b/tests/state/test_session_status_vocabulary.py
@@ -20,7 +20,7 @@ from lionagi.state.db import (
     StateDB,
 )
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -47,7 +47,7 @@ async def _make_session(db: StateDB, *, status: str | None = None) -> dict:
     return session
 
 
-# ── Vocabulary ────────────────────────────────────────────────────────────────
+# Vocabulary
 
 
 def test_vocabulary_has_seven_values():
@@ -77,7 +77,7 @@ def test_admin_targets_exclude_completed_and_timed_out():
     assert ADMIN_TRANSITION_TARGETS == frozenset({"failed", "aborted", "cancelled"})
 
 
-# ── DB-level validation ───────────────────────────────────────────────────────
+# DB-level validation
 
 
 async def test_create_session_accepts_all_seven_statuses(db: StateDB):
@@ -105,7 +105,7 @@ async def test_update_session_rejects_unknown_status(db: StateDB):
         await db.update_session(s["id"], status="stale")
 
 
-# ── Legacy CHECK constraint rebuild ───────────────────────────────────────────
+# Legacy CHECK constraint rebuild
 
 
 async def test_drop_legacy_check_rebuilds_table(tmp_path: Path):
@@ -193,7 +193,7 @@ async def test_drop_legacy_check_is_idempotent(tmp_path: Path):
         await state2.close()
 
 
-# ── CLI exit-code map ─────────────────────────────────────────────────────────
+# CLI exit-code map
 
 
 def test_cli_exit_code_map_matches_adr0025():

--- a/tests/state/test_staleness.py
+++ b/tests/state/test_staleness.py
@@ -45,7 +45,7 @@ async def _make_session(db: StateDB, **fields) -> dict:
     return session
 
 
-# ── staleness_check pure logic ─────────────────────────────────────────────────
+# staleness_check pure logic
 
 
 def test_running_under_threshold_is_active():
@@ -133,7 +133,7 @@ def test_threshold_for_kind_returns_expected_values():
     assert threshold_for_kind("mystery-kind") == DEFAULT_STALE_THRESHOLD
 
 
-# ── touch_session_activity DB heartbeat ────────────────────────────────────────
+# touch_session_activity DB heartbeat
 
 
 async def test_touch_session_activity_bumps_last_message_at(
@@ -180,7 +180,7 @@ async def test_touch_updates_updated_at_too(db: StateDB):
     assert row["updated_at"] == pinned
 
 
-# ── ADR scope check: thresholds dict shape ────────────────────────────────────
+# ADR scope check: thresholds dict shape
 
 
 def test_thresholds_cover_all_invocation_kinds():

--- a/tests/state/test_state_db_url_guards.py
+++ b/tests/state/test_state_db_url_guards.py
@@ -76,7 +76,7 @@ async def _seed_engine_def(name: str) -> str:
     return def_id
 
 
-# ── the helpers themselves ────────────────────────────────────────────────
+# the helpers themselves
 
 
 def test_state_db_file_follows_the_url(moved_sqlite_url, absent_default, tmp_path):
@@ -105,7 +105,7 @@ def test_known_absent_is_false_for_an_in_memory_url(absent_default, monkeypatch)
     assert state_db_known_absent() is False
 
 
-# ── shape 1: a SQLite store moved off the default path ────────────────────
+# shape 1: a SQLite store moved off the default path
 
 
 async def test_engine_defs_are_found_in_a_moved_store(moved_sqlite_url):
@@ -169,7 +169,7 @@ async def test_engine_def_absent_from_a_moved_store_still_reads_as_absent(
     assert await svc.get_engine_def_by_name("never-created") is None
 
 
-# ── shape 2: a URL that is not a local file ───────────────────────────────
+# shape 2: a URL that is not a local file
 
 
 async def test_a_server_url_does_not_answer_from_the_filesystem(absent_default, monkeypatch):
@@ -187,7 +187,7 @@ async def test_a_server_url_does_not_answer_from_the_filesystem(absent_default, 
         await svc.list_engine_defs()
 
 
-# ── the shared readonly seam ──────────────────────────────────────────────────
+# the shared readonly seam
 # Several reporting commands stopped guarding for themselves and now go through
 # one helper. That concentrates the same question in one place: if the helper
 # asks the filesystem while opening the configured store, every reader that
@@ -233,7 +233,7 @@ def test_the_absent_reason_names_the_store_that_was_consulted(moved_sqlite_url, 
     assert "moved" in detail
 
 
-# ── the open mode a schedules read route asks for ─────────────────────────────
+# the open mode a schedules read route asks for
 # Which stores the predicate answers True for is pinned above, beside the
 # predicate. What is left to check here is that a schedules read route actually
 # routes through it, since a route that hardcoded True would pass every one of
@@ -281,7 +281,6 @@ def test_a_store_with_no_file_reports_no_size_rather_than_zero(absent_default, m
     assert sizes["wal_size_bytes"] is None
 
 
-# ---------------------------------------------------------------------------
 # Read-only mode is SQLite-only, so asking for it unconditionally is not a
 # degradation on a server-backed store, it is a failure to open at all. These
 # pin the predicate and the two shapes the failure used to take.

--- a/tests/state/test_status_reasons.py
+++ b/tests/state/test_status_reasons.py
@@ -30,7 +30,7 @@ from lionagi.state.reasons import (
     validate_reason_code,
 )
 
-# ── reasons.py — namespace and validators ────────────────────────────
+# reasons.py — namespace and validators
 
 
 class TestReasonNamespace:
@@ -160,7 +160,7 @@ class TestValidators:
         assert entity_table("sessions") == "sessions"
 
 
-# ── StateDB.update_status() — schema migration + atomic writes ───────
+# StateDB.update_status() — schema migration + atomic writes
 
 
 @pytest.fixture
@@ -529,7 +529,7 @@ class TestUpdateStatusValidation:
         assert count["n"] >= 1  # at least the pre-inserted row
 
 
-# ── Integration: CLI teardown writes a real reason ───────────────────
+# Integration: CLI teardown writes a real reason
 
 
 class TestTeardownReasonResolution:
@@ -617,7 +617,7 @@ class TestTeardownReasonResolution:
         assert cls_name in summary
 
 
-# ── ADR-0057 Phase 2: invocation transition writes reason ────────────
+# ADR-0057 Phase 2: invocation transition writes reason
 
 
 async def _create_invocation(db: StateDB, *, status: str = "running") -> str:
@@ -830,7 +830,7 @@ class TestInvocationTransition:
         assert count["n"] == 0
 
 
-# ── update_session routes status through update_status ──
+# update_session routes status through update_status
 
 
 class TestUpdateSessionRoutesStatusThroughHistory:
@@ -948,7 +948,7 @@ class TestUpdateSessionRoutesStatusThroughHistory:
         assert count["n"] == 0
 
 
-# ── update_status rejects invalid source values ──────────
+# update_status rejects invalid source values
 
 
 class TestUpdateStatusSourceValidation:

--- a/tests/state/test_teams_schema.py
+++ b/tests/state/test_teams_schema.py
@@ -25,7 +25,7 @@ async def db():
     await state.close()
 
 
-# ── Schema invariants ─────────────────────────────────────────────────────────
+# Schema invariants
 
 
 async def test_teams_table_exists_with_status_check(db: StateDB):
@@ -131,7 +131,7 @@ async def test_team_messages_session_id_fk_to_sessions(db: StateDB):
     assert row["session_id"] == sess_id
 
 
-# ── import-teams CLI helper ───────────────────────────────────────────────────
+# import-teams CLI helper
 
 
 async def test_import_teams_loads_json_into_db(tmp_path: Path, monkeypatch):

--- a/tests/state/test_transition_integrity.py
+++ b/tests/state/test_transition_integrity.py
@@ -29,7 +29,7 @@ from lionagi.state.db import (
 from lionagi.state.lifecycle.policy import DEFAULT_REGISTRY
 from lionagi.state.reasons import RunReasons, SessionReasons
 
-# ── Fixtures ────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -84,7 +84,7 @@ async def _make_schedule_run(db: StateDB, *, status: str = "running") -> str:
     return run_id
 
 
-# ── Rejection without override ──────────────────────────────────────────────
+# Rejection without override
 
 
 @pytest.mark.asyncio
@@ -125,7 +125,7 @@ async def test_rejected_transition_is_recorded_in_admin_events(db: StateDB) -> N
     assert details["attempted_status"] == "running"
 
 
-# ── Override path ────────────────────────────────────────────────────────────
+# Override path
 
 
 @pytest.mark.asyncio
@@ -193,7 +193,7 @@ def test_override_requires_actor_and_justification() -> None:
     asyncio.run(_run())
 
 
-# ── Concurrent stale write loses to the guarded write ───────────────────────
+# Concurrent stale write loses to the guarded write
 
 
 @pytest.mark.asyncio
@@ -230,7 +230,7 @@ async def test_concurrent_stale_write_loses_to_guarded_write(db: StateDB) -> Non
     assert row["status"] == "completed"  # the first (newer) write wins
 
 
-# ── Status vocabulary — update_status() rejects unknown statuses ───────────
+# Status vocabulary — update_status() rejects unknown statuses
 
 
 @pytest.mark.asyncio
@@ -313,7 +313,7 @@ def test_valid_vocabulary_admits_every_authoritative_status(
     assert not missing, f"{entity_type} vocabulary omits legal statuses: {sorted(missing)}"
 
 
-# ── Storage-level CAS — the UPDATE itself guards on previous_status ─────────
+# Storage-level CAS — the UPDATE itself guards on previous_status
 
 
 @pytest.mark.asyncio

--- a/tests/work/test_work_forms_rules.py
+++ b/tests/work/test_work_forms_rules.py
@@ -22,9 +22,7 @@ from lionagi.work import (
     validate_form,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_form(
@@ -44,9 +42,7 @@ def _make_form(
     )
 
 
-# ---------------------------------------------------------------------------
 # WorkForm — Element inheritance
-# ---------------------------------------------------------------------------
 
 
 class TestWorkFormElement:
@@ -89,9 +85,7 @@ class TestWorkFormElement:
         assert form in s
 
 
-# ---------------------------------------------------------------------------
 # FieldSpec
-# ---------------------------------------------------------------------------
 
 
 class TestFieldSpec:
@@ -219,9 +213,7 @@ class TestFieldSpec:
         assert spec.coerce(False) is False
 
 
-# ---------------------------------------------------------------------------
 # WorkForm
-# ---------------------------------------------------------------------------
 
 
 class TestWorkForm:
@@ -335,9 +327,7 @@ class TestWorkFormTransitions:
                 assert result.status == to_status
 
 
-# ---------------------------------------------------------------------------
 # validate_form — FieldSpec checks
-# ---------------------------------------------------------------------------
 
 
 class TestValidateForm:
@@ -415,9 +405,7 @@ class TestValidateForm:
         assert result.status == "validated"
 
 
-# ---------------------------------------------------------------------------
 # validate_form — ruleset integration (Fix 2)
-# ---------------------------------------------------------------------------
 
 
 class TestValidateFormWithRuleset:
@@ -504,9 +492,7 @@ class TestValidateFormWithRuleset:
         assert result.status == "validated"
 
 
-# ---------------------------------------------------------------------------
 # fill_form
-# ---------------------------------------------------------------------------
 
 
 class TestFillForm:
@@ -562,9 +548,7 @@ class TestFillForm:
         assert result.values == {"name": "Bob", "age": 30, "active": True}
 
 
-# ---------------------------------------------------------------------------
 # Rule
-# ---------------------------------------------------------------------------
 
 
 class TestRuleRequired:
@@ -830,9 +814,7 @@ class TestRuleCustom:
         assert "RuntimeError" in err
 
 
-# ---------------------------------------------------------------------------
 # RuleSet
-# ---------------------------------------------------------------------------
 
 
 class TestRuleSet:
@@ -947,9 +929,7 @@ class TestRuleSet:
         assert rs.get("r1").field == "y"
 
 
-# ---------------------------------------------------------------------------
 # Integration: fill_form + RuleSet (standalone apply)
-# ---------------------------------------------------------------------------
 
 
 class TestFillFormWithRuleSetStandalone:


### PR DESCRIPTION
Strip decorative comment banners and section dividers, delabel box-drawing section headers into plain comments, remove two internal tracking references (an issue number and a PR-round reference) from comments, and cut two docstrings that only restated their test name.

Extract the design-overview module docstring from
tests/state/test_lifecycle_gate.py into
docs/internals/state-lifecycle.md, covering the StateDB transition contracts, status-vocabulary sources of truth, PolicyRegistry enforcement boundary, the reaper guard pattern, and SQLite/PostgreSQL concurrency semantics it previously held alone.

Documentation only: no assertions, imports, or test behavior changed.