### PR TITLE
docs(tests): trim prose in tests/operations and tests/engines

### DIFF
--- a/docs/internals/core.md
+++ b/docs/internals/core.md
@@ -36,6 +36,71 @@ Never mutate a returned model class. `LIONAGI_OPERATIVE_MODEL_CACHE_SIZE=0`
 restores per-call classes (disables sharing). See also `models/_build_model.py`
 and `adapters/spec_adapters/pydantic_field.py` below — same cache, different layer.
 
+**Graph-entrypoint conformance suite** (`tests/operations/test_graph_entrypoint_conformance.py`) —
+pins every graph-shaped production surface in the shipped package to the
+`Session.flow`/streaming-kernel execution authority. A manifest classifies
+every graph-shaped function the suite can find: whether it delegates to
+`Session.flow` (directly or through an adapter), reaches the sanctioned
+streaming kernel, is itself the kernel, or is a pure builder/alias that never
+executes anything. The suite statically scans the real source tree for
+qualified `.flow`/`.flow_stream`/`.run_dag` calls, bare calls to a
+locally-imported kernel function, and executor/graph-builder construction
+sites, and fails (with file:line and reason) on anything not in the
+manifest — so a new graph entrypoint that isn't registered breaks the build
+instead of silently growing a second executor.
+
+The executor-construction scan recognizes a direct
+`DependencyAwareExecutor(...)`/`ReactiveExecutor(...)` call, an
+`from ... import X as Y` alias, a one-level-deep bare assignment alias, and a
+literal `getattr(<flow module>, "DependencyAwareExecutor")` lookup (only when
+the receiver statically denotes `lionagi.operations.flow`). Import provenance
+is tracked per lexical scope rather than as one flat module timeline: each
+function/lambda scope starts from a copy of its enclosing scope's provenance,
+first masks every name any local import, assignment, `for`/`async for`
+target, match-capture, or augmented assignment binds anywhere in the body
+(Python function scope isn't statement-ordered, so a name bound only inside
+an `if`/`try`/`for`/`match` is still a lexical local for the whole function),
+discards any parameter-shadowed name, then replays its own body's
+*unconditional* binding events on top of that masked copy. A binding nested
+inside `if`/`try`/`except`/`for`/`while`/`with`/`match`-case is conditional:
+it may only discard provenance (never establish or restore it), since a
+conditional import might not execute and trusting it risks a false positive
+either way. Class bodies get their own add-only environment
+(`_SinkVisitor.visit_ClassDef`). The scanner does not perform general
+data-flow analysis — resolution through a factory return value, a
+non-literal string argument, a multi-hop alias, or a binding inside a
+comprehension/walrus is untracked and is a known residual imprecision.
+
+`global`/`nonlocal` declarations are handled separately from ordinary
+masking, since they resolve against different target scopes: `global`
+overlays provenance from a pristine module-scope snapshot (skipping every
+intermediate function scope, including one whose own parameter shadows the
+name), while `nonlocal` resolves against the nearest enclosing function
+scope, which the ordinary lexical inheritance chain already reproduces. A
+`global`/`nonlocal` statement nested inside a class body does not count as a
+declaration of the surrounding function — a class body is its own namespace
+for this purpose. The scanner's governing invariant is zero false negatives:
+a missed executor-construction site is a coverage hole, while a spurious one
+only costs a review. Where closing a remaining false positive would require
+reasoning about whether a declared name's own binder form actually executes,
+that reasoning is deliberately not attempted — the scanner keeps the
+(possibly stale) inherited/overlaid provenance and reports a site. This is a
+documented conservative over-approximation, not a bug.
+
+Registering a manifest row is necessary but not sufficient: a row naming an
+`expected_target` must also name a `delegation_test` (the exact pytest node
+id of the test that asserts the delegation — call count, argument identity,
+or a mocked target reached), and a row with `persistence="required"` must
+name a `persistence_evidence` node id backed by a real StateDB write. Both
+are validated against real source, not just checked for non-emptiness, so a
+stale or nonexistent reference fails the suite. Known limitation: resolving
+a `delegation_test` id to a real test function does not check what that
+test's body actually asserts — a row can cite a real, passing test that
+exercises an entirely different code path than the one it's cited for. A
+weaker structural companion check (does the cited test's source at least
+mention a token from `expected_target`) catches the obvious case but is not
+a substitute for reading the cited test.
+
 ## `session/`
 
 **`signal.py`** — Signal types and per-node lifecycle projection for the

--- a/tests/engines/test_budget_cancel_partial_export.py
+++ b/tests/engines/test_budget_cancel_partial_export.py
@@ -22,9 +22,7 @@ from lionagi.engines.hypothesis import (
     QuestionRaised,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _wire_minimal(eng: HypothesisEngine, run: HypothesisRun) -> None:
@@ -49,9 +47,7 @@ class _StubEngine(Engine):
         return ""
 
 
-# ---------------------------------------------------------------------------
 # Internal cancellation — partial export must happen and return normally
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -176,9 +172,7 @@ async def test_budget_cancel_with_no_conclusions_returns_without_crash() -> None
     assert result in (None, ""), f"Expected None or empty string, got {result!r}"
 
 
-# ---------------------------------------------------------------------------
 # External cancellation — must still propagate as CancelledError
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/engines/test_cancel_active_timeout.py
+++ b/tests/engines/test_cancel_active_timeout.py
@@ -19,9 +19,7 @@ class _StubEngine(Engine):
         return ""
 
 
-# ---------------------------------------------------------------------------
 # Non-cooperative child: catches CancelledError and loops indefinitely
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -121,9 +119,7 @@ async def test_cancel_active_logs_abandonment_for_non_cooperative_task():
     await asyncio.gather(task, return_exceptions=True)
 
 
-# ---------------------------------------------------------------------------
 # Cooperative child: should complete normally without hitting the timeout
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -159,9 +155,7 @@ async def test_cancel_active_awaits_cooperative_task_to_completion():
     assert run._active == set()
 
 
-# ---------------------------------------------------------------------------
 # Default timeout is exposed and is a sensible value
-# ---------------------------------------------------------------------------
 
 
 def test_cancel_timeout_default_on_engine():
@@ -181,9 +175,7 @@ def test_cancel_timeout_configurable():
     assert eng.cancel_timeout_s == 7.5
 
 
-# ---------------------------------------------------------------------------
 # Engine.run() lifetime guarantee preserved with non-cooperative task
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/engines/test_chain_run_base.py
+++ b/tests/engines/test_chain_run_base.py
@@ -25,9 +25,7 @@ from lionagi.engines.research import (
     ResearchEngine,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 class _EmittingFake:
@@ -61,9 +59,7 @@ def _stub_engine() -> _StubEngine:
     return _StubEngine()
 
 
-# ---------------------------------------------------------------------------
 # 1. ChainRun structural invariants
-# ---------------------------------------------------------------------------
 
 
 def test_chain_run_is_subclass_of_engine_run():
@@ -83,9 +79,7 @@ def test_hypothesis_run_subclasses_chain_run():
     assert issubclass(HypothesisRun, EngineRun)
 
 
-# ---------------------------------------------------------------------------
 # 2. collect/emit/find/events_of reside on ChainRun, not on the subclasses
-# ---------------------------------------------------------------------------
 
 
 def test_collect_implementation_lives_on_chain_run():
@@ -109,9 +103,7 @@ def test_events_of_implementation_lives_on_chain_run():
     assert "events_of" in ChainRun.__dict__
 
 
-# ---------------------------------------------------------------------------
 # 3. CodingRun collect+emit functional path
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -178,9 +170,7 @@ async def test_coding_run_emit_does_notify_for_non_chain_event():
     assert len(matching) == 1, f"expected 1 _Other notify; got {len(matching)}"
 
 
-# ---------------------------------------------------------------------------
 # 4. HypothesisRun collect+emit functional path
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -230,9 +220,7 @@ async def test_hypothesis_run_emit_does_notify_for_non_chain_event():
     assert len(matching) == 1
 
 
-# ---------------------------------------------------------------------------
 # 5. ChainRun._chain_event_cls correctness
-# ---------------------------------------------------------------------------
 
 
 def test_coding_run_chain_event_cls_is_coding_chain_event():
@@ -243,9 +231,7 @@ def test_hypothesis_run_chain_event_cls_is_chain_event():
     assert HypothesisRun._chain_event_cls is ChainEvent
 
 
-# ---------------------------------------------------------------------------
 # 6. store initialization from _event_prefix_map
-# ---------------------------------------------------------------------------
 
 
 def test_coding_run_store_initialised_with_event_prefix_keys():
@@ -265,9 +251,7 @@ def test_hypothesis_run_store_initialised_with_event_prefix_keys():
     assert set(run.store.keys()) == set(_EVENT_PREFIX.keys())
 
 
-# ---------------------------------------------------------------------------
 # 7. Research per-stage repair uplift
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/engines/test_coding.py
+++ b/tests/engines/test_coding.py
@@ -44,9 +44,7 @@ class _ScriptedBranch:
         return "ok"
 
 
-# ---------------------------------------------------------------------------
 # Pure helpers
-# ---------------------------------------------------------------------------
 
 
 def test_resolve_cmd_list_runs_shell_false():
@@ -91,9 +89,7 @@ def test_tail_bounds_lines_and_chars():
     assert len(_tail(big, lines=5, max_chars=4000)) <= 4001  # leading ellipsis
 
 
-# ---------------------------------------------------------------------------
 # Ground-truth subprocess runner
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -148,9 +144,7 @@ async def test_test_stage_times_out(tmp_path):
     assert tests.timed_out is True
 
 
-# ---------------------------------------------------------------------------
 # Full pipeline — plan -> implement -> test (pass path)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -206,9 +200,7 @@ def _async(value):
     return _coro()
 
 
-# ---------------------------------------------------------------------------
 # Fix loop — fail then pass on a flipping test command
-# ---------------------------------------------------------------------------
 
 
 def _flip_test_cmd(flag_path) -> list[str]:
@@ -366,9 +358,7 @@ async def test_fix_loop_stops_when_implementer_repeats_change(tmp_path, monkeypa
     assert any(e["type"] == "fix_no_change" for e in events)
 
 
-# ---------------------------------------------------------------------------
 # Implementer emits nothing -> graceful conclude
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -399,9 +389,7 @@ async def test_no_change_proposed_concludes_failed(tmp_path, monkeypatch):
     assert run.events_of(TestsRan) == []
 
 
-# ---------------------------------------------------------------------------
 # Workspace is ground truth when emission fails
-# ---------------------------------------------------------------------------
 
 
 def _make_git_workspace(path) -> None:
@@ -885,9 +873,7 @@ async def test_absolute_files_touched_reaches_verify_diff(tmp_path, monkeypatch)
     assert "(no diff captured" not in verify_instruction
 
 
-# ---------------------------------------------------------------------------
 # Pending-experiment ingestion + hypothesis seed round-trip
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -965,9 +951,7 @@ def test_to_hypothesis_seeds_empty_experiment_ref_still_validates():
     assert rr.experiment_ref == "" and rr.passed is False
 
 
-# ---------------------------------------------------------------------------
 # Judge gate on the fix-loop boundary
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -1010,9 +994,7 @@ async def test_judge_can_stop_fix_loop_early(tmp_path, monkeypatch):
     assert any(e["type"] == "fix_gated" for e in events)
 
 
-# ---------------------------------------------------------------------------
 # Chain events must reach on_event exactly once
-# ---------------------------------------------------------------------------
 
 
 class _BusBranch:

--- a/tests/engines/test_engine_agent_failure.py
+++ b/tests/engines/test_engine_agent_failure.py
@@ -14,9 +14,7 @@ import pytest
 
 from lionagi.engines.engine import Engine, EngineRun
 
-# ---------------------------------------------------------------------------
 # EngineRun._agent_errors accumulation via notify()
-# ---------------------------------------------------------------------------
 
 
 def _make_minimal_engine_run() -> EngineRun:
@@ -65,9 +63,7 @@ def test_notify_still_forwards_to_on_event():
     assert er._agent_errors == ["worker-1: boom"]
 
 
-# ---------------------------------------------------------------------------
 # Engine._total_agent_failure — flagged only when every agent made errored
-# ---------------------------------------------------------------------------
 
 
 async def test_total_agent_failure_true_when_all_agents_errored():

--- a/tests/engines/test_engine_fixes.py
+++ b/tests/engines/test_engine_fixes.py
@@ -22,9 +22,7 @@ from lionagi.engines.hypothesis import (
     QuestionRaised,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers shared across tests
-# ---------------------------------------------------------------------------
 
 
 class _StubEngine(Engine):
@@ -36,9 +34,7 @@ class _SlowEvent(EngineEvent):
     value: str = ""
 
 
-# ---------------------------------------------------------------------------
 # Deadline watchdog cancels in-flight spawned tasks
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -127,9 +123,7 @@ async def test_deadline_watchdog_cleans_up_after_fast_run():
     # finishing promptly is the observable signal that cleanup happened.
 
 
-# ---------------------------------------------------------------------------
 # CodingEngine normalize-before-gate
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -266,9 +260,7 @@ def _coro(value):
     return _inner()
 
 
-# ---------------------------------------------------------------------------
 # CLI-aware emission repair instruction
-# ---------------------------------------------------------------------------
 
 
 def test_cli_repair_instruction_contains_fenced_example():
@@ -428,9 +420,7 @@ async def test_operate_with_repair_no_chat_model_falls_back_to_api_template():
     assert "finding_emitted" in repair_instructions[0]
 
 
-# ---------------------------------------------------------------------------
 # Deadline cancels in-flight operate_with_repair
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -484,9 +474,7 @@ async def test_deadline_cancels_in_flight_operate_with_repair():
     )
 
 
-# ---------------------------------------------------------------------------
 # CLI repair example is syntactically valid JSON
-# ---------------------------------------------------------------------------
 
 
 def test_cli_repair_instruction_example_is_valid_json():
@@ -547,9 +535,7 @@ def test_cli_repair_instruction_fenced_block_validates_against_emission():
     )
 
 
-# ---------------------------------------------------------------------------
 # _active tasks are drained even when _run() raises immediately
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -625,9 +611,7 @@ async def test_external_cancel_during_drain_propagates():
     )
 
 
-# ---------------------------------------------------------------------------
 # _normalize_spec called exactly once via run()
-# ---------------------------------------------------------------------------
 
 
 def test_coding_engine_normalizes_spec_exactly_once(monkeypatch):

--- a/tests/engines/test_engine_result_degradation.py
+++ b/tests/engines/test_engine_result_degradation.py
@@ -23,9 +23,7 @@ from lionagi.ln.concurrency._compat import (
     is_exception_group,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _finding_factory(name: str) -> FindingEmitted:
@@ -71,9 +69,7 @@ def _budget_gated_make_agent(run: Any, emit_factory: Any = _finding_factory):
     return fake_make_agent
 
 
-# ---------------------------------------------------------------------------
 # 1. Repro FRICTION_LOG run 5a — spawned discretionary expansion crash
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -110,9 +106,7 @@ async def test_research_verbose_root_spawn_budget_race_degrades_not_crashes(monk
     assert result.events_by_type(FindingEmitted), "expected real findings collected before the cap"
 
 
-# ---------------------------------------------------------------------------
 # 2. Repro FRICTION_LOG run 3 — root-level (gathered) raw raise
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -144,12 +138,6 @@ async def test_review_root_gather_budget_error_does_not_raise(monkeypatch):
     assert run._budget_notified is True, "the budget-exhaustion signal must still be recorded"
 
 
-# ---------------------------------------------------------------------------
-# 2b. Repro production bug gtd 6b76e4ff (2026-07-17) — verdict computed then
-#     dropped when the deadline fires before synth.operate() returns
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 @pytest.mark.slow_timing
 async def test_review_verdict_emitted_on_exhaustion_not_dropped(monkeypatch):
@@ -159,14 +147,14 @@ async def test_review_verdict_emitted_on_exhaustion_not_dropped(monkeypatch):
     deadline cancels the run must be returned via _partial_export, not
     discarded.
 
-    Reproduces the production bug (gtd 6b76e4ff, 2026-07-17, leo's reactive
-    PR-review daemon): the codex terra engine sometimes needs emission
-    retries before its structured verdict settles. If the deadline watchdog
-    fires while _verdict()'s synth.operate() call is still in flight, the
-    verdict was already computed/emitted onto run.by_type(ReviewVerdict), but
-    pre-fix the base Engine._partial_export no-op (inherited by ReviewEngine)
-    discarded it and Engine.run() returned a bare None — the daemon reported
-    NO-VERDICT despite a verdict existing in the event stream.
+    Reproduces a production bug in a reactive PR-review daemon: a review
+    engine sometimes needs emission retries before its structured verdict
+    settles, and if the deadline watchdog fires while the verdict call is
+    still in flight, the verdict was already computed/emitted onto
+    run.by_type(ReviewVerdict) — but pre-fix, the base Engine._partial_export
+    no-op (inherited by ReviewEngine) discarded it and Engine.run() returned
+    a bare None, so the daemon reported no verdict despite one existing in
+    the event stream.
     """
     verdict = ReviewVerdict(
         verdict="REQUEST-CHANGES",
@@ -220,9 +208,7 @@ async def test_review_verdict_emitted_on_exhaustion_not_dropped(monkeypatch):
     assert "REQUEST-CHANGES" in result.text
 
 
-# ---------------------------------------------------------------------------
 # 3. Masking guard — a real error in a mixed group must still surface
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -322,9 +308,7 @@ async def test_masking_guard_reraises_real_error_buried_in_nested_group():
     )
 
 
-# ---------------------------------------------------------------------------
 # 5. Back-compat: await engine.run(...) stays isinstance(str)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -355,12 +339,10 @@ async def test_back_compat_str_contract_across_prose_engines():
         assert str(result) == result.text
 
 
-# ---------------------------------------------------------------------------
 # 7. A dimension agent's emission failure alone (no deadline/budget hit) must
 #    still flag the result degraded — a verdict blind to a whole skipped
 #    dimension is degraded by construction, independent of *why* it was
 #    skipped.
-# ---------------------------------------------------------------------------
 
 
 class _NeverEmitBranch:
@@ -522,10 +504,8 @@ async def test_clean_run_with_no_skipped_agents_stays_not_degraded():
     assert result.degrade_reason == ""
 
 
-# ---------------------------------------------------------------------------
 # 6. R5 — success path after a filtered discretionary budget raise still
 #    flags degraded (anti-silent-truncation guard for edit 1 + edit 3)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/engines/test_engine_role_profile_and_injection.py
+++ b/tests/engines/test_engine_role_profile_and_injection.py
@@ -17,9 +17,7 @@ import lionagi.engines.engine as engine_mod
 from lionagi.engines.engine import Engine
 from lionagi.tools.khive_injection import KhiveInjectionProvider
 
-# ---------------------------------------------------------------------------
 # Role-profile cache: keyed by (role, cwd), never caches an exception fallback
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
@@ -112,9 +110,7 @@ def test_role_profile_injection_cache_keyed_by_cwd_and_not_negative(monkeypatch,
     assert len(calls) == 2  # one lookup per distinct project dir
 
 
-# ---------------------------------------------------------------------------
 # make_agent(): run-derived khive-injection namespace
-# ---------------------------------------------------------------------------
 
 
 def _provider_entries(branch):
@@ -158,9 +154,7 @@ async def test_make_agent_two_runs_get_distinct_namespaces():
     assert ns1 != ns2  # cross-run memory exposure is exactly what this closes
 
 
-# ---------------------------------------------------------------------------
 # make_agent(): effort-suffix precedence over a profile default
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/engines/test_hypothesis.py
+++ b/tests/engines/test_hypothesis.py
@@ -275,9 +275,7 @@ async def test_empty_findings_raises():
         await eng.run("   ")
 
 
-# ---------------------------------------------------------------------------
 # Chain events must reach on_event exactly once
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/engines/test_hypothesis_routing.py
+++ b/tests/engines/test_hypothesis_routing.py
@@ -59,9 +59,6 @@ def _mute(eng, *stages):
     return calls
 
 
-# ── Defaults and overrides ────────────────────────────────────────────────
-
-
 def test_recursion_and_judge_defaults():
     eng = HypothesisEngine()
     assert eng.max_depth == 2
@@ -132,9 +129,6 @@ def test_judge_bar_escalates():
     assert "register decision" in _judge_bar(1)
     assert "correctness" in _judge_bar(2)
     assert "correctness" in _judge_bar(5)
-
-
-# ── Dedup gate routing ────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -222,9 +216,6 @@ async def test_orphan_dedup_verdict_notifies():
     assert any(e["type"] == "dedup_orphan" for e in events)
 
 
-# ── Filing queue ──────────────────────────────────────────────────────────
-
-
 def _seed_certified_run(eng):
     run = eng.new_run()
     f = run.collect(FindingPosted(description="stale checkpoint overwrites newer segment"))
@@ -283,9 +274,6 @@ def test_no_dedup_stage_means_empty_filing_queue():
     assert filing_queue(run) == []
 
 
-# ── Loud total failure ────────────────────────────────────────────────────
-
-
 @pytest.mark.asyncio
 async def test_all_stages_failing_raises_instead_of_empty_report():
     eng = HypothesisEngine(judge_model=None)
@@ -316,9 +304,6 @@ async def test_partial_progress_still_synthesizes():
     eng._synthesize = fake_synth
     out = await eng.run("seed finding")
     assert out == "PARTIAL-REPORT"
-
-
-# ── Dedup failure fail-open (a broken leg must not drop the finding) ───────
 
 
 @pytest.mark.asyncio
@@ -368,9 +353,6 @@ async def test_dedup_stage_exception_does_not_double_release_with_late_verdict()
     assert [s for s, _ in calls] == ["extract"]
 
 
-# ── Malformed dedup verdicts are rejected, never silently cleared ──────────
-
-
 @pytest.mark.parametrize("bad_verdict", ["uncertain", "Duplicate", "dupe", "NEW", ""])
 def test_dedup_checked_rejects_non_literal_verdicts(bad_verdict):
     with pytest.raises(pydantic.ValidationError):
@@ -381,9 +363,6 @@ def test_dedup_checked_rejects_non_literal_verdicts(bad_verdict):
 def test_dedup_checked_accepts_exact_literal_verdicts(good_verdict):
     d = DedupChecked(finding_ref="F-1", verdict=good_verdict)
     assert d.verdict == good_verdict
-
-
-# ── Local finding idempotence key (finding 12) ──────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -423,9 +402,6 @@ async def test_same_description_and_evidence_exact_repeat_still_dedups_locally()
     await run.emit(FindingPosted(description="CSR chosen for BFS", evidence="benchmark A"))
     await run.wait_quiescence()
     assert len(calls) == 1  # a byte-identical repeat is still a local no-op
-
-
-# ── Recursion bound derived from the indexed parent, not the emission ──────
 
 
 @pytest.mark.asyncio
@@ -624,9 +600,6 @@ async def test_question_gen_from_conclude_route_derived_via_result_chain():
     assert len(calls) == 1
 
 
-# ── Dedup exposes tools to non-CLI models (finding 13) ──────────────────────
-
-
 @pytest.mark.asyncio
 async def test_dedup_stage_passes_actions_true_when_tools_configured():
     eng = HypothesisEngine(dedup_repo="owner/repo", dedup_tools=("bash",), judge_model=None)
@@ -677,9 +650,6 @@ async def test_dedup_stage_no_tools_configured_does_not_force_actions():
     await eng._dedup(run, f)
 
     assert captured["actions"] is False
-
-
-# ── Effort-suffix precedence end-to-end ──
 
 
 @pytest.mark.asyncio

--- a/tests/engines/test_tool_enrichment_repair.py
+++ b/tests/engines/test_tool_enrichment_repair.py
@@ -24,9 +24,7 @@ from lionagi.engines.coding import (
 )
 from lionagi.engines.engine import Engine, EngineRun
 
-# ---------------------------------------------------------------------------
 # Shared helpers
-# ---------------------------------------------------------------------------
 
 
 class _StubEngine(Engine):
@@ -56,9 +54,7 @@ class _ScriptedBranch:
         return "ok"
 
 
-# ---------------------------------------------------------------------------
 # _looks_mechanical unit tests
-# ---------------------------------------------------------------------------
 
 
 def test_looks_mechanical_returns_false_for_passing_tests():
@@ -99,9 +95,7 @@ def test_looks_mechanical_ruff_format_output():
     assert _looks_mechanical(t)
 
 
-# ---------------------------------------------------------------------------
 # worker_extra_tools: merged into make_agent call
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -189,9 +183,7 @@ async def test_plan_and_verify_do_not_get_worker_tools(tmp_path, monkeypatch):
             )
 
 
-# ---------------------------------------------------------------------------
 # worker_mcp_servers: passed to implement agent only
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -238,9 +230,7 @@ async def test_worker_mcp_servers_passed_to_implement_not_verify(tmp_path, monke
             assert call.get("mcp_servers") is None, f"{call['name']} must not receive mcp_servers"
 
 
-# ---------------------------------------------------------------------------
 # worker_extra_prompt: forwarded to implement agent
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -282,9 +272,7 @@ async def test_worker_extra_prompt_forwarded(tmp_path, monkeypatch):
     assert implement_call.get("extra_prompt") == "Always prefer idiomatic Rust."
 
 
-# ---------------------------------------------------------------------------
 # make_agent: mcp_servers + extra_prompt propagate through AgentSpec
-# ---------------------------------------------------------------------------
 
 
 def test_make_agent_mcp_servers_set_on_spec_directly():
@@ -306,9 +294,7 @@ def test_make_agent_extra_prompt_set_via_compose():
     assert spec.extra_prompt == "prefer idiomatic Rust"
 
 
-# ---------------------------------------------------------------------------
 # auto_repair_cmds: AutoRepairApplied events emitted before test gate
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -436,9 +422,7 @@ async def test_auto_repair_recorded_in_measurements(tmp_path, monkeypatch):
     assert "auto_repair_rounds" in result.measurements
 
 
-# ---------------------------------------------------------------------------
 # mechanical round: skips judge, skips worker re-prompt
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -522,9 +506,7 @@ async def test_mechanical_fix_round_skips_judge(tmp_path, monkeypatch):
     assert any(e["type"] == "fix_mechanical" for e in events)
 
 
-# ---------------------------------------------------------------------------
 # fast_test_cmd: used for intermediate rounds, full test_cmd as final gate
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -620,9 +602,7 @@ async def test_fast_test_cmd_used_for_intermediate_rounds(tmp_path, monkeypatch)
     assert fast_calls, f"_fast_test must be called for intermediate rounds; got calls={fast_calls}"
 
 
-# ---------------------------------------------------------------------------
 # worker_grants recorded in measurements
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -693,9 +673,7 @@ async def test_worker_grants_absent_when_not_configured(tmp_path, monkeypatch):
     assert "worker_grants" not in result.measurements
 
 
-# ---------------------------------------------------------------------------
 # AutoRepairApplied event shape
-# ---------------------------------------------------------------------------
 
 
 def test_auto_repair_applied_event_shape():

--- a/tests/engines/test_worker_safety.py
+++ b/tests/engines/test_worker_safety.py
@@ -24,9 +24,7 @@ from lionagi.engines.coding import (
 )
 from lionagi.engines.engine import Engine, EngineRun
 
-# ---------------------------------------------------------------------------
 # Helpers shared across sections
-# ---------------------------------------------------------------------------
 
 
 class _StubEngine(Engine):
@@ -55,9 +53,7 @@ class _ScriptedBranch:
         return "ok"
 
 
-# ---------------------------------------------------------------------------
 # bounded cancel_active timeout
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -115,9 +111,7 @@ async def test_cancel_active_noop_when_empty():
     await run.cancel_active()  # must not raise
 
 
-# ---------------------------------------------------------------------------
 # turn-level timeout into repair loop
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -212,9 +206,7 @@ async def test_turn_timeout_all_rounds_concludes_failed(tmp_path, monkeypatch):
     assert result.passed is False
 
 
-# ---------------------------------------------------------------------------
 # spec lint
-# ---------------------------------------------------------------------------
 
 
 def test_lint_spec_warns_missing_acceptance_criteria():
@@ -322,9 +314,7 @@ async def test_spec_lint_strict_raises_before_run(tmp_path, monkeypatch):
     assert not made, "no agent must be created when strict spec check fails"
 
 
-# ---------------------------------------------------------------------------
 # worker heartbeat + activity events
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -532,9 +522,7 @@ async def test_heartbeat_events_not_in_judge_context(tmp_path, monkeypatch):
     assert not run.events_of(WorkerHeartbeat), "HeartBeat must not pollute the chain store"
 
 
-# ---------------------------------------------------------------------------
 # stage watchdog + partial export on abort
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/operations/react/test_react_stream_finalization.py
+++ b/tests/operations/react/test_react_stream_finalization.py
@@ -12,9 +12,7 @@ from lionagi.operations.ReAct.utils import Analysis, ReActAnalysis
 from lionagi.session.branch import Branch
 from lionagi.testing import LionAGIMockFactory
 
-# ============================================================================
 # Helper Functions and Fixtures
-# ============================================================================
 
 
 def make_mocked_branch_for_react():
@@ -50,14 +48,10 @@ async def async_search(query: str) -> str:
     return f"Search results for: {query}"
 
 
-# ============================================================================
 # 1. Tool Execution Flows
-# ============================================================================
 
 
-# ============================================================================
 # 4. Edge Cases
-# ============================================================================
 
 
 @pytest.mark.asyncio
@@ -286,9 +280,7 @@ async def test_verbose_analysis_output():
         assert result == "Final answer"
 
 
-# ============================================================================
 # Performance and Stress Tests
-# ============================================================================
 
 
 @pytest.mark.asyncio

--- a/tests/operations/react/test_react_stream_init.py
+++ b/tests/operations/react/test_react_stream_init.py
@@ -11,9 +11,7 @@ from lionagi.operations.ReAct.utils import Analysis, ReActAnalysis
 from lionagi.session.branch import Branch
 from lionagi.testing import LionAGIMockFactory
 
-# ============================================================================
 # Helper Functions and Fixtures
-# ============================================================================
 
 
 def make_mocked_branch_for_react():
@@ -49,9 +47,7 @@ async def async_search(query: str) -> str:
     return f"Search results for: {query}"
 
 
-# ============================================================================
 # 1. Tool Execution Flows
-# ============================================================================
 
 
 @pytest.mark.asyncio

--- a/tests/operations/react/test_react_stream_rounds.py
+++ b/tests/operations/react/test_react_stream_rounds.py
@@ -11,9 +11,7 @@ from lionagi.operations.ReAct.utils import Analysis, ReActAnalysis
 from lionagi.session.branch import Branch
 from lionagi.testing import LionAGIMockFactory
 
-# ============================================================================
 # Helper Functions and Fixtures
-# ============================================================================
 
 
 def make_mocked_branch_for_react():
@@ -49,14 +47,10 @@ async def async_search(query: str) -> str:
     return f"Search results for: {query}"
 
 
-# ============================================================================
 # 1. Tool Execution Flows
-# ============================================================================
 
 
-# ============================================================================
 # 2. Multi-Step Reasoning
-# ============================================================================
 
 
 @pytest.mark.asyncio
@@ -211,9 +205,7 @@ async def test_max_extensions_clamped_to_100():
         assert result == "Done"
 
 
-# ============================================================================
 # 3. Integration Scenarios
-# ============================================================================
 
 
 @pytest.mark.asyncio

--- a/tests/operations/run/test_run.py
+++ b/tests/operations/run/test_run.py
@@ -34,9 +34,7 @@ from lionagi.service.imodel import iModel
 from lionagi.service.types.stream_chunk import StreamChunk
 from lionagi.session.branch import Branch
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_fake_cli_model(chunks: list[StreamChunk], session_id: str | None = None):
@@ -87,9 +85,7 @@ def _fail_on_next_checkpoint(_delay: float):
         raise TimeoutError
 
 
-# ---------------------------------------------------------------------------
 # P0 tests — run()
-# ---------------------------------------------------------------------------
 
 
 async def test_run_rejects_non_cli_chat_model():
@@ -533,9 +529,7 @@ async def test_write_branch_snapshot_failed_replace_keeps_prior_snapshot(tmp_pat
     assert target.read_text() == v1
 
 
-# ---------------------------------------------------------------------------
 # P0/P1 tests — run_and_collect()
-# ---------------------------------------------------------------------------
 
 
 async def test_run_and_collect_clears_messages_and_joins_assistant_text(monkeypatch):
@@ -615,13 +609,11 @@ async def test_run_and_collect_parses_when_response_format_is_set(monkeypatch):
     assert parse_calls[0] == '{"value": 42}'
 
 
-# ---------------------------------------------------------------------------
 # Timeout enforcement tests — regression for the "timeout silently ignored"
 # bug where ``branch.operate(timeout=N)`` / ``li agent --timeout N`` flowed
 # through ``imodel_kw`` into ``model.create_event(**kw)`` but the streaming
 # loop never wrapped the consumer with ``anyio.fail_after``, so CLI
 # subprocesses (codex, claude_code) ran unbounded.
-# ---------------------------------------------------------------------------
 
 
 def _make_slow_cli_model(chunk_delay: float, n_chunks: int = 100):
@@ -926,9 +918,7 @@ async def test_gemini_timeout_arms_produce_distinct_caps():
     assert await captured_cap({"timeout": 1200}) != await captured_cap({})
 
 
-# ---------------------------------------------------------------------------
 # Regression: Branch.operate() must flatten **kwargs so timeout reaches run()
-# ---------------------------------------------------------------------------
 
 
 async def test_branch_operate_forwards_timeout_to_run(monkeypatch):
@@ -979,9 +969,7 @@ async def test_branch_operate_forwards_extra_kwargs_to_run(monkeypatch):
     assert received_kw.get("repo") == "/tmp/test"
 
 
-# ---------------------------------------------------------------------------
 # Regression: iModel.stream() must not yield in finally (swallows cancellation)
-# ---------------------------------------------------------------------------
 
 
 async def test_imodel_stream_propagates_cancellation():
@@ -1045,12 +1033,10 @@ async def test_imodel_stream_propagates_cancellation():
     )
 
 
-# ---------------------------------------------------------------------------
 # Worker-liveness watchdog — regression for a CLI subprocess that dies at/near
 # spawn (or otherwise produces no first output): the leg must retry once and
 # then fail loud with WorkerLivenessError instead of hanging as a zombie
 # "running" operation forever.
-# ---------------------------------------------------------------------------
 
 
 def _make_hanging_cli_model(create_event_calls: list, streams_first_output_early: bool = True):

--- a/tests/operations/test_act.py
+++ b/tests/operations/test_act.py
@@ -19,9 +19,7 @@ from lionagi.operations.types import ActionParam
 from lionagi.protocols.messages import ActionRequest
 from lionagi.session.branch import Branch
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_branch_with_tool(tool_fn=None):
@@ -38,9 +36,7 @@ def _make_branch_with_tool(tool_fn=None):
     return branch
 
 
-# ---------------------------------------------------------------------------
 # _act() — happy paths
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -83,9 +79,7 @@ async def test_act_basemodel_with_function_and_arguments():
     assert result.output == 10
 
 
-# ---------------------------------------------------------------------------
 # _act() — error paths
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -355,9 +349,7 @@ async def test_act_verbose_logging(caplog):
     assert result.output == 5
 
 
-# ---------------------------------------------------------------------------
 # act() — strategy dispatch
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -420,9 +412,7 @@ async def test_act_invalid_strategy_raises():
         await act(branch, {"function": "x", "arguments": {}}, action_param)
 
 
-# ---------------------------------------------------------------------------
 # prepare_act_kw
-# ---------------------------------------------------------------------------
 
 
 def test_prepare_act_kw_returns_correct_structure():
@@ -445,9 +435,7 @@ def test_prepare_act_kw_defaults():
     assert kw["action_param"].suppress_errors is True
 
 
-# ---------------------------------------------------------------------------
 # _sequential_act() directly
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_chat.py
+++ b/tests/operations/test_chat.py
@@ -10,9 +10,7 @@ from lionagi.operations.types import ChatParam
 from lionagi.protocols.messages.assistant_response import AssistantResponse
 from lionagi.protocols.messages.instruction import Instruction
 
-# ============================================================================
 # P0 - Critical Coverage Tests
-# ============================================================================
 
 
 class TestAssistantResponseConsolidation:
@@ -422,9 +420,7 @@ class TestReturnFormats:
         assert not isinstance(result, tuple)
 
 
-# ============================================================================
 # P1 - Important Parameter Coverage
-# ============================================================================
 
 
 class TestChatContextParameters:
@@ -542,9 +538,7 @@ class _FalsyIModel:
         return getattr(self._inner, name)
 
 
-# ============================================================================
 # Fixtures
-# ============================================================================
 
 
 @pytest.fixture

--- a/tests/operations/test_chat_prepare.py
+++ b/tests/operations/test_chat_prepare.py
@@ -12,9 +12,7 @@ from lionagi.protocols.messages.assistant_response import AssistantResponseConte
 from lionagi.protocols.messages.instruction import InstructionContent
 from lionagi.session.branch import Branch
 
-# ---------------------------------------------------------------------------
 # _prepare_run_kwargs merges consecutive AssistantResponse messages
-# ---------------------------------------------------------------------------
 
 
 def test_prepare_run_kwargs_collapses_consecutive_assistant_messages():
@@ -59,12 +57,6 @@ def test_prepare_run_kwargs_kw_contains_messages_key():
 
     assert "messages" in kw
     assert isinstance(kw["messages"], list)
-
-
-# ---------------------------------------------------------------------------
-# Fail-loud guard (issue #2308): a non-empty instruction must never silently
-# vanish from the outgoing message list.
-# ---------------------------------------------------------------------------
 
 
 def test_prepare_run_kwargs_raises_when_real_instruction_renders_empty(monkeypatch):
@@ -143,7 +135,6 @@ def test_prepare_run_kwargs_allows_empty_render_when_no_instruction_text(monkeyp
     assert kw["messages"] == []
 
 
-# ---------------------------------------------------------------------------
 # The premise the guard rests on: the current turn is the LAST assembled entry.
 #
 # The guard reads the current turn's render by index, which is only the current
@@ -158,7 +149,6 @@ def test_prepare_run_kwargs_allows_empty_render_when_no_instruction_text(monkeyp
 # These pin the premise itself, one per assembly branch, through the public
 # return: with every entry rendering normally, the last outgoing message is the
 # current turn's.
-# ---------------------------------------------------------------------------
 
 
 def test_current_turn_is_last_message_without_system():

--- a/tests/operations/test_communicate.py
+++ b/tests/operations/test_communicate.py
@@ -92,9 +92,7 @@ async def test_communicate_clear_messages_clears_before_turn():
     assert len(branch.messages) == 2
 
 
-# ---------------------------------------------------------------------------
 # Coverage gap tests for communicate.py lines 48, 60, 71-76, 158-160, 169-178
-# ---------------------------------------------------------------------------
 
 import warnings
 

--- a/tests/operations/test_context_providers.py
+++ b/tests/operations/test_context_providers.py
@@ -14,9 +14,7 @@ from lionagi.operations.types import ChatParam
 from lionagi.protocols.context_providers import ContextProviderRegistry, ProviderReport
 from lionagi.session.branch import Branch
 
-# ---------------------------------------------------------------------------
 # Stub providers
-# ---------------------------------------------------------------------------
 
 
 class _StubProvider:
@@ -108,9 +106,7 @@ def _chat_param(branch, **overrides):
     return ChatParam(**kw)
 
 
-# ---------------------------------------------------------------------------
 # ContextProviderRegistry.gather — unit level
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -249,9 +245,7 @@ def test_registry_is_falsy_when_empty():
     assert registry
 
 
-# ---------------------------------------------------------------------------
 # Branch integration — registry lives on Branch (gate ruling Q1)
-# ---------------------------------------------------------------------------
 
 
 def test_branch_providers_lazily_created_and_zero_cost_when_unused():
@@ -287,9 +281,7 @@ def test_prepare_run_kwargs_renders_explicit_context_blocks(make_mocked_branch):
     assert "call-local-knowledge" in kw["messages"][0]["content"]
 
 
-# ---------------------------------------------------------------------------
 # End-to-end: provider text in rendered first message, absent from record
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -368,9 +360,7 @@ async def test_chat_only_branch_no_tools_works_with_providers(make_mocked_branch
     assert any("floor-knowledge" in m["content"] for m in sent_messages)
 
 
-# ---------------------------------------------------------------------------
 # Systemless branches: no render target — providers skipped, observably
-# ---------------------------------------------------------------------------
 
 
 class _CountingProvider:

--- a/tests/operations/test_edge_conditions_tdd.py
+++ b/tests/operations/test_edge_conditions_tdd.py
@@ -17,9 +17,7 @@ from lionagi.protocols.graph.graph import Graph
 from lionagi.session.branch import Branch
 from lionagi.session.session import Session
 
-# ============================================================================
 # TEST FIXTURES AND HELPERS
-# ============================================================================
 
 
 class ConditionalEdge(EdgeCondition):
@@ -88,9 +86,7 @@ def create_mock_branch(name: str = "TestBranch") -> Branch:
     return branch
 
 
-# ============================================================================
 # SPECIFICATION TESTS - Define Expected Behavior
-# ============================================================================
 
 
 @pytest.mark.asyncio
@@ -323,9 +319,7 @@ async def test_spec_cascading_skip_propagation():
     )
 
 
-# ============================================================================
 # GUARD TESTS - Prevent Specific Regressions
-# ============================================================================
 
 
 @pytest.mark.asyncio
@@ -438,9 +432,7 @@ async def test_guard_conditional_aggregation():
     )
 
 
-# ============================================================================
 # VALIDATION TESTS - Ensure Proper Error Handling
-# ============================================================================
 
 
 @pytest.mark.asyncio
@@ -483,9 +475,7 @@ async def test_validation_circular_conditional_dependency():
         await flow(session, graph, verbose=False)
 
 
-# ============================================================================
 # BEHAVIORAL TESTS - Complex Scenarios
-# ============================================================================
 
 
 @pytest.mark.asyncio
@@ -612,9 +602,7 @@ async def test_behavior_multi_level_conditions():
                 )
 
 
-# ============================================================================
 # PERFORMANCE TESTS - Ensure Efficiency
-# ============================================================================
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_escalation_routing.py
+++ b/tests/operations/test_escalation_routing.py
@@ -35,9 +35,7 @@ def _session(**ops):
     return session
 
 
-# ---------------------------------------------------------------------------
 # higher_tier: re-spawns the op
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -150,9 +148,7 @@ async def test_escalation_child_carries_readable_name_and_parent_pointer():
     assert spawned_signals[0].independent is True
 
 
-# ---------------------------------------------------------------------------
 # give_up: signals without re-spawning
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -203,9 +199,7 @@ async def test_escalation_give_up_emits_node_escalated_signal():
     assert isinstance(sig.escalation_request, EscalationRequest)
 
 
-# ---------------------------------------------------------------------------
 # Default route (no explicit route key) → higher_tier
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -231,9 +225,7 @@ async def test_escalation_default_route_is_higher_tier():
     assert result["spawned_operations"] >= 1
 
 
-# ---------------------------------------------------------------------------
 # Deduplication: same EscalationRequest object only processed once
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -262,9 +254,7 @@ async def test_escalation_request_deduplicated():
     assert len(escalated_signals) <= 1
 
 
-# ---------------------------------------------------------------------------
 # NodeEscalated.escalation_request is stored in a named field, not Signal.data
-# ---------------------------------------------------------------------------
 
 
 def test_node_escalated_request_not_in_data_field():
@@ -275,9 +265,7 @@ def test_node_escalated_request_not_in_data_field():
     assert sig.escalation_request is req
 
 
-# ---------------------------------------------------------------------------
 # SpawnRequest and EscalationRequest coexist without interference
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -312,9 +300,7 @@ async def test_spawn_and_escalation_coexist():
     assert len(result["escalated_operations"]) >= 1
 
 
-# ---------------------------------------------------------------------------
 # Bus-based emission path (observe fires _on_bus_escalation)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -340,15 +326,11 @@ async def test_escalation_via_result_extraction():
     assert escalated_signals[0].route == "give_up"
 
 
-# ---------------------------------------------------------------------------
 # Fire-and-forget signal delivery: observer failure never changes the flow
 # result, and the executor's detached-task set drains after the run.
-# ---------------------------------------------------------------------------
 
 
-# ---------------------------------------------------------------------------
 # Help-signal urgency: urgency="fyi" -> "notify" route, non-hanging
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_fields.py
+++ b/tests/operations/test_fields.py
@@ -13,9 +13,7 @@ from lionagi.operations.fields import (
     get_default_field,
 )
 
-# ---------------------------------------------------------------------------
 # Instruct.handle — lines 119-137
-# ---------------------------------------------------------------------------
 
 
 class TestInstructHandle:
@@ -68,9 +66,7 @@ class TestInstructHandle:
         assert isinstance(result, Instruct)
 
 
-# ---------------------------------------------------------------------------
 # ActionRequestModel.create — lines 235-297
-# ---------------------------------------------------------------------------
 
 
 class TestActionRequestModelCreate:
@@ -148,9 +144,7 @@ class TestActionRequestModelCreate:
         assert result == []
 
 
-# ---------------------------------------------------------------------------
 # _get_default_fields listable/nullable chaining — lines 387-401
-# ---------------------------------------------------------------------------
 
 
 class TestGetDefaultFieldChaining:

--- a/tests/operations/test_flow_gate_reject.py
+++ b/tests/operations/test_flow_gate_reject.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2023-2026, HaiyangLi <quantocean.li at gmail dot com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Gate-reject short-circuit (issue #2860): a gate node's REJECT verdict must
-stop its dependent subtree from running against the rejected baseline,
-without touching independent siblings or non-gate flows."""
+"""Gate-reject short-circuit: a gate node's REJECT verdict must stop its
+dependent subtree from running against the rejected baseline, without
+touching independent siblings or non-gate flows."""
 
 from __future__ import annotations
 

--- a/tests/operations/test_flow_lifecycle_terminal.py
+++ b/tests/operations/test_flow_lifecycle_terminal.py
@@ -56,9 +56,7 @@ class _ProgressLog:
         return [c[1] for c in self.calls if c[0] == op_id]
 
 
-# ---------------------------------------------------------------------------
 # queued/started identity agreement (reference_id fix)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -393,9 +391,7 @@ async def test_executor_raw_callback_diverges_without_reference_id_pre_fix_sympt
     assert names[0] != names[1]
 
 
-# ---------------------------------------------------------------------------
 # exactly one terminal signal after every start
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -552,9 +548,7 @@ async def test_emit_terminal_once_is_idempotent_across_call_sites():
     assert log.statuses_for(op_id) == ["completed"]
 
 
-# ---------------------------------------------------------------------------
 # skipped is its own terminal outcome, not a failure
-# ---------------------------------------------------------------------------
 
 
 def _skip_graph():
@@ -648,9 +642,7 @@ async def test_gate_skipped_node_projects_to_the_skipped_lane_on_the_signal_bus(
     assert lane_for(for_gated) == "skipped"
 
 
-# ---------------------------------------------------------------------------
 # an operation already terminal on arrival must still be answered
-# ---------------------------------------------------------------------------
 
 
 def _one_op_graph(status):

--- a/tests/operations/test_flow_operator_steer.py
+++ b/tests/operations/test_flow_operator_steer.py
@@ -23,9 +23,7 @@ from lionagi.protocols.graph.graph import Graph
 from lionagi.session.session import Session
 from lionagi.testing import TestBranch
 
-# ---------------------------------------------------------------------------
 # Unit: render + lift-out (operates directly on _prepare_operation)
-# ---------------------------------------------------------------------------
 
 
 def test_operator_message_renders_labeled_block_into_instruction():
@@ -101,9 +99,7 @@ def test_no_operator_messages_leaves_instruction_and_context_untouched():
     assert "rendered_into_op" not in op.metadata
 
 
-# ---------------------------------------------------------------------------
 # Consume-once: a steer renders into exactly one downstream op
-# ---------------------------------------------------------------------------
 
 
 def test_consume_once_second_op_does_not_rerender_first_message():
@@ -157,9 +153,7 @@ def test_consume_once_new_message_queued_between_ops_renders_into_next_op_only()
     assert "first steer" not in instr2
 
 
-# ---------------------------------------------------------------------------
 # Acceptance: the rendered block reaches the provider-bound payload
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -226,9 +220,7 @@ async def test_operator_steer_consume_once_across_real_flow_ops():
     assert "[OPERATOR STEER]" not in (calls[1].last_user_message or "")
 
 
-# ---------------------------------------------------------------------------
 # Regression (issue 1681): a steer landing after prepare, before invoke
-# ---------------------------------------------------------------------------
 
 
 def test_steer_appended_after_prepare_is_caught_by_invoke_time_recheck():

--- a/tests/operations/test_flow_pause.py
+++ b/tests/operations/test_flow_pause.py
@@ -33,9 +33,7 @@ def _session_with_ops(**ops):
     return session
 
 
-# ---------------------------------------------------------------------------
 # pause() / resume() as sync no-op-safe controls
-# ---------------------------------------------------------------------------
 
 
 def test_pause_installs_event_and_is_idempotent():
@@ -76,9 +74,7 @@ def test_pause_resume_pause_installs_a_fresh_event():
     assert second_gate is not first_gate
 
 
-# ---------------------------------------------------------------------------
 # Boundary semantics: already-running ops complete; not-yet-started ops block
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -202,9 +198,7 @@ async def test_pause_resume_pause_cycle_gates_each_op_in_turn():
     assert executed == ["op1", "op2"]
 
 
-# ---------------------------------------------------------------------------
 # NodePaused signal + lifecycle-lane projection
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -301,9 +295,7 @@ async def test_node_paused_reemitted_on_resume_then_fresh_pause():
     await asyncio.wait_for(task, timeout=2)
 
 
-# ---------------------------------------------------------------------------
 # Public path: executor.pause()/.resume() around a full execute() run
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -358,9 +350,7 @@ async def test_reactive_executor_inherits_pause_gate():
     assert len(result["completed_operations"]) == 1
 
 
-# ---------------------------------------------------------------------------
 # _emit_best_effort: shared fire-and-forget flow signal scheduling helper
-# ---------------------------------------------------------------------------
 
 
 def test_emit_best_effort_construction_failure_is_logged_and_task_free(caplog):
@@ -472,9 +462,7 @@ async def test_emit_best_effort_task_set_is_empty_after_successful_emission():
     assert signals[0].op_id == "x"
 
 
-# ---------------------------------------------------------------------------
 # Zero-cost: a flow that never touches pause/resume behaves identically
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_flow_perf_smoke.py
+++ b/tests/operations/test_flow_perf_smoke.py
@@ -3,50 +3,41 @@
 
 """Coarse perf smoke gate on the flow executor's per-node scheduling tax.
 
-REGRESSION CLASS this guards against: the executor's per-node scheduling
-overhead (the fixed cost of driving one graph node through dependency
-tracking, predecessor lookup, and edge-condition checks, independent of the
-model call itself) is invisible in normal test runs because every unit test
-uses small graphs. A regression here only shows up once an orchestration run
-with hundreds or thousands of nodes gets noticeably slower in production. A
-recent optimization pass (adjacency edge lookup, a predecessor cache, and an
-alcall fast path) roughly halved this per-node cost; nothing previously
-guarded the floor, so a future change (e.g. an accidental O(V*E)
-reintroduction in predecessor/edge-condition lookups) could silently undo
-that win.
+Regression class guarded: per-node scheduling overhead (dependency
+tracking, predecessor lookup, edge-condition checks — independent of the
+model call) is invisible in normal test runs since every unit test uses
+small graphs; a regression only surfaces once an orchestration run with
+hundreds/thousands of nodes gets noticeably slower in production. A prior
+optimization pass (adjacency edge lookup, a predecessor cache, an alcall
+fast path) roughly halved this cost; nothing previously guarded the floor,
+so e.g. an accidental O(V*E) reintroduction in predecessor/edge-condition
+lookups could silently undo that win.
 
-This is deliberately a CEILING ASSERT, not a benchmark or a percentage-based
-regression check: it drives a 1000-node linear chain and a 1000-node wide
-fan-out through ``Session.flow`` / ``DependencyAwareExecutor`` with a stubbed,
-near-instant ``Branch.chat`` (no network, no real model latency — isolates
-scheduling overhead from provider variance) and asserts each shape completes
-under a generous wall-clock ceiling. Hosted/shared-host CPU variance has been
-observed to exceed 20% on runs like this and has previously false-redded a
-CI perf gate on a diff that was provably unrelated to the hot path, which is
-exactly why this gate uses a wide ceiling tuned to catch an
-order-of-magnitude regression rather than tracking percentage drift.
+This is a ceiling assert, not a benchmark or percentage-based regression
+check: it drives a 1000-node linear chain and a 1000-node wide fan-out
+through ``Session.flow``/``DependencyAwareExecutor`` with a stubbed,
+near-instant ``Branch.chat`` (isolates scheduling overhead from provider
+variance) and asserts each shape completes under a generous wall-clock
+ceiling. Hosted/shared-host CPU variance has been observed to exceed 20% on
+runs like this and previously false-redded a CI perf gate on an unrelated
+diff — hence a wide ceiling tuned to catch an order-of-magnitude regression,
+not percentage drift. Construction reuses the same path production flows use
+(``OperationGraphBuilder`` -> ``Graph`` -> ``Session.flow``).
 
-Construction reuses the same path production flows use
-(``OperationGraphBuilder`` -> ``Graph`` -> ``Session.flow``, with a stubbed
-``Branch.chat``), the same approach used by this repo's flow-kernel
-micro-benchmark scripts.
+Ceiling provenance: local medians on this heavily loaded shared dev host
+(12 repeats/shape, stubbed chat, max_concurrent=50): linear ~5.8-7.0s median
+(worst 17.3s), fan-out ~3.1-3.2s median (worst 14.3s). A quiet,
+process-isolated run of the same code recorded linear=718ms / fanout=502ms.
+The ceilings below are ~10x the noisy local median, clearing both the quiet
+reference and every noisy sample observed here.
 
-Ceiling provenance: local medians measured on this (heavily loaded, shared)
-dev host across two independent runs (12 total repeats per shape, stubbed
-chat, max_concurrent=50): linear ~5.8-7.0s median (worst single sample
-17.3s), fan-out ~3.1-3.2s median (worst single sample 14.3s). A quiet,
-process-isolated measurement of this same post-optimization code recorded
-linear=718ms / fanout=502ms. The ceilings below are ~10x this host's noisy
-local median, which comfortably clears both that quiet-host reference and
-every noisy sample observed here.
-
-The wall-clock CEILING asserts run in the repository's dedicated performance
-lane (advisory, outside the required correctness suite) because they are
-timing-sensitive to shared-host CPU variance. The scheduling CORRECTNESS that
-those ceilings depend on — that the executor drives every node of a linear
-chain and a wide fan-out to COMPLETED — is asserted separately at a small,
-scale-independent size and runs in the required suite, so a scheduling
-regression that fails nodes is caught even when the timing lane is advisory.
+The wall-clock ceiling asserts run in the repository's dedicated
+performance lane (advisory, outside the required correctness suite) since
+they're timing-sensitive to shared-host variance. The scheduling
+correctness those ceilings depend on — every node of a linear chain and a
+wide fan-out reaches COMPLETED — is asserted separately at a small,
+scale-independent size in the required suite, so a scheduling regression
+that fails nodes is still caught when the timing lane is advisory.
 """
 
 from __future__ import annotations

--- a/tests/operations/test_graph_entrypoint_conformance.py
+++ b/tests/operations/test_graph_entrypoint_conformance.py
@@ -5,105 +5,20 @@
 Session.flow / streaming-kernel execution authority.
 
 A ``GraphSurface`` manifest below classifies every graph-shaped function this
-suite can find in the shipped ``lionagi`` package: whether it delegates to
-``Session.flow`` (directly or through an adapter), reaches the sanctioned
-streaming kernel, is itself the kernel, or is a pure builder/alias that never
-executes anything. ``test_every_ast_discovered_graph_candidate_is_registered``
-scans the real source tree for qualified ``.flow``/``.flow_stream``/
-``.run_dag`` calls, bare calls to a locally-imported kernel function (the
-shape ``Session.flow``/``Session.flow_stream`` themselves use), and
-executor/graph-builder construction sites, and fails loudly (printing
-file:line and why it was flagged) if it finds one that is not in the
-manifest — so adding a new graph entrypoint without registering it here
-breaks the build instead of silently growing a second executor.
+suite can find in the shipped ``lionagi`` package (delegates to
+``Session.flow``, reaches the streaming kernel, is the kernel, or is a pure
+builder/alias). ``test_every_ast_discovered_graph_candidate_is_registered``
+scans the real source tree for graph-executor call/construction sites and
+fails on anything not in the manifest, so a new entrypoint that isn't
+registered breaks the build instead of silently growing a second executor.
 
-The executor-construction scan statically recognizes: a direct
-``DependencyAwareExecutor(...)``/``ReactiveExecutor(...)`` call; a
-``from ... import DependencyAwareExecutor as X`` import alias; a bare
-assignment alias one level deep (``X = DependencyAwareExecutor`` or
-``X = <existing alias>``), with imports and assignments replayed in one
-combined source-ordered pass so a later genuine import restores provenance
-an earlier unrelated rebinding discarded (and a later rebinding still drops
-provenance a prior import established, whichever comes last wins); and a
-literal ``getattr(<flow module>, "DependencyAwareExecutor")`` dynamic-lookup
-call — recognized only when the receiver statically denotes
-``lionagi.operations.flow`` — whether assigned to a name first or called
-inline. Import provenance is tracked per lexical scope, not as one flat
-whole-module timeline: each function/lambda scope starts from a copy of its
-enclosing scope's provenance, first masking every name any local import,
-assignment, ``for``/``async for`` target, match-pattern capture, or
-augmented assignment in the function body binds -- ANYWHERE in the body,
-conditional or not, since Python function scope is not statement-ordered: a
-name bound only inside an ``if``/``try``/``for``/``match``-case is still a
-lexical local for the whole function, so an inherited same-named binding
-must not leak through (masking-only binder forms never establish or restore
-provenance themselves) -- and
-also discarding any parameter-shadowed name, then replays its OWN body's
-UNCONDITIONAL binding events (in source order) on top of that masked copy —
-so a function-local reimport genuinely restores what a same-named parameter
-(or a conditional in-body import of the same name) masked. Within a scope, a
-binding event nested inside an ``if``/``try``/``except``/``for``/``while``/
-``with``/``match``-case block is CONDITIONAL: it may only DISCARD provenance
-(a conditional rebinding to something unrecognized is treated as if it might
-have executed, since trusting the name afterward risks a false-positive
-executor site) and may never ESTABLISH or RESTORE it (a conditional import
-might never execute, so applying it anyway risks the same false positive
-from the other direction) — only an unconditional binding, a direct
-statement of the scope's own body, can establish or restore provenance. It
-does not perform general data-flow analysis: resolution through a factory
-function's return value, a non-literal string argument, an alias threaded
-through more than one intermediate assignment, or any binding inside a
-comprehension or walrus assignment is not tracked and remains a residual
-imprecision. (Class bodies ARE tracked: each gets its own add-only
-environment -- see ``_SinkVisitor.visit_ClassDef``.)
-
-A name declared ``global``/``nonlocal`` anywhere in a function's own body is
-NOT a lexical local of that function and must not be masked the way a
-genuine local is, but the two declarations resolve against different target
-scopes and are handled accordingly: ``global`` overlays provenance from a
-pristine MODULE-scope snapshot rather than the lexical-enclosing scope (a
-`global NAME` reference skips every intermediate function scope, including
-one whose own parameter or local happens to shadow the same name), while
-``nonlocal`` resolves against the nearest enclosing FUNCTION scope, which the
-ordinary lexical inheritance chain already reproduces without any extra
-overlay. A ``global``/``nonlocal`` statement nested inside a CLASS body does
-not count as a declaration of the surrounding function at all -- a class
-body is its own namespace for this purpose, unlike the ordinary binding
-events collected within it. This scanner's governing invariant is
-ZERO-FALSE-NEGATIVES: a missed executor-construction site is a coverage hole
-(dangerous), while a spurious one only costs a review (safe); every
-global/nonlocal refinement above exists to close a false-negative, and where
-closing a remaining false-positive would require reasoning about whether a
-declared name's own binder form (a ``for``-target, match-capture, ``with``/
-``except ... as``, ``del``, or augmented assignment reached under the
-declaration) actually executes, that reasoning is deliberately NOT attempted
--- the scanner keeps the (possibly stale) inherited/overlaid provenance and
-reports a site, a documented conservative over-approximation pinned by
-``test_global_declared_executing_binder_is_conservative_overapproximation``.
-
-Registering a location in the manifest is necessary but not sufficient: any
-row that names an ``expected_target`` must also name a ``delegation_test`` —
-the exact pytest node id of the test that actually asserts the delegation
-(call count, argument identity, or a mocked target being reached) — and any
-row with ``persistence="required"`` must name a ``persistence_evidence`` node
-id backed by a real StateDB write. Both are validated against real source
-(not just checked for non-emptiness), so a stale or nonexistent reference
-fails the suite instead of reading as coverage.
-
-Known limitation of the delegation-test-id mechanism:
-``test_every_delegation_test_id_resolves_to_a_real_test_function`` only
-proves the named node id resolves to a real top-level test function in the
-right module — it does not read what that test's body actually asserts, so
-a row can cite a real, passing test that asserts an entirely different
-relationship (this is exactly how the studio-engine-node row's prior
-``EngineRun.run_dag`` claim went unnoticed: the cited coding-engine test is
-real and passing, but only ever exercises ``engine.run``, never
-``run_dag``). ``test_every_delegation_test_source_mentions_its_expected_target``
-adds a loud but weak structural companion — a substring check that the
-cited test's own source at least mentions a token drawn from
-``expected_target`` — which would have caught that exact drift. It is a
-necessary-not-sufficient tripwire, not a substitute for reading the cited
-test yourself before trusting a manifest row.
+For the AST scope/binding-provenance algorithm the scanner uses (per-scope
+masking, conditional vs. unconditional binding events, the global/nonlocal
+overlay rules, and the documented conservative-over-approximation policy),
+see "Graph-entrypoint conformance suite" in ``docs/internals/core.md``. That
+document also covers the manifest's ``delegation_test``/``persistence_evidence``
+validation and a known limitation: resolving a delegation-test id to a real
+test function does not check what that test's body actually asserts.
 """
 
 from __future__ import annotations
@@ -708,30 +623,19 @@ _TRY_STMT_TYPES: tuple[type[ast.stmt], ...] = (
 
 def _scope_declared_names(stmts: list[ast.stmt]) -> tuple[set[str], set[str]]:
     """Every name declared ``global`` and, separately, every name declared
-    ``nonlocal``, anywhere in ONE lexical scope's statement list *stmts* --
-    returned as ``(global_names, nonlocal_names)`` since the two declarations
-    resolve against DIFFERENT target scopes (see ``_SinkVisitor._push_func_scope``:
-    ``global`` overlays provenance from the MODULE scope, ``nonlocal`` keeps
-    inheriting from the lexical-enclosing scope) and must not be merged into
-    one set the way an earlier version of this function did.
+    ``nonlocal``, in one lexical scope's statement list *stmts*, returned as
+    ``(global_names, nonlocal_names)`` — kept as two sets, not merged, since
+    the declarations resolve against different target scopes (see
+    ``_SinkVisitor._push_func_scope``).
 
-    Descends transparently into control-flow bodies -- a ``global``/
-    ``nonlocal`` nested inside an ``if``/``try``/``try``-``except*``/``for``/
-    ``while``/``with``/``match``-case still applies to the whole enclosing
-    function scope (a ``global`` statement is a compile-time scope directive;
-    its surrounding control flow never conditions it) -- but STOPS at a
-    nested ``FunctionDef``/``AsyncFunctionDef``/``Lambda`` (those own their
-    own declarations) AND at a nested ``ClassDef``: a class body is its own
-    namespace, so ``global x`` there only redirects lookups of ``x`` within
-    the CLASS body's own execution; it does not declare the surrounding
-    function's same-named binding at all. Descending into the class body
-    here would wrongly un-mask a same-named local the enclosing function
-    itself never declared global/nonlocal (see
-    test_class_body_global_declaration_does_not_leak_into_enclosing_function).
-    ``_collect_scope_binding_events`` stops at ``ClassDef`` for the matching
-    reason on the binding side: an ordinary assignment in a class body binds
-    the CLASS namespace, never the enclosing function's; the class body gets
-    its own environment in ``_SinkVisitor.visit_ClassDef``."""
+    Descends into control-flow bodies (a ``global``/``nonlocal`` inside
+    if/try/for/while/with/match still applies to the whole enclosing
+    function, since it's a compile-time scope directive that control flow
+    never conditions), but stops at a nested function/lambda (owns its own
+    declarations) and at a nested class body: `global x` there only
+    redirects lookups within the class body's own execution and does not
+    declare the surrounding function's binding (see
+    test_class_body_global_declaration_does_not_leak_into_enclosing_function)."""
     global_names: set[str] = set()
     nonlocal_names: set[str] = set()
 
@@ -774,34 +678,16 @@ def _scope_declared_names(stmts: list[ast.stmt]) -> tuple[set[str], set[str]]:
 def _collect_scope_binding_events(
     stmts: list[ast.stmt], conditional: bool, events: list[_BindingEvent]
 ) -> None:
-    """Collect Import/ImportFrom/simple-Name-Assign binding events (an
-    annotated single-Name assignment with a value counts as one too), plus
-    mask-only ``_NameBindingEvent``s for AugAssign targets and bare
-    annotations (``name: T`` binds nothing at runtime but is a lexical
-    local of the whole scope), out of *stmts* --
-    the statement list of ONE lexical scope (a module body or a function
-    body) -- tagging each with whether it is CONDITIONAL: nested inside an
-    ``if``/``try``/``except``/``for``/``while``/``with`` body, or inside any
-    ``match`` statement's case body (a case might not match, so every case
-    body is conditional regardless of which case, if any, is the one that
-    runs), rather than a direct statement of *stmts* itself. Also emits
-    mask-only ``_NameBindingEvent``s (always CONDITIONAL, since the
-    surrounding loop/case/with/handler may not execute) for ``for``/``async
-    for`` statement targets, match-pattern captures, every ``with``/``async
-    with`` item's ``as`` target (reusing the same Store-name walker as
-    for-targets, so tuple/destructuring ``as (a, b)`` is collected too), and
-    every ``except ... as NAME`` handler name -- these ARE lexical locals of
-    the enclosing function scope (unlike a comprehension target, which is its
-    own separate scope and is never walked here since comprehensions are
-    expressions, not statements). A ``del NAME`` target gets the same
-    mask-only treatment but tagged with the CURRENT *conditional* value
-    (like ``AugAssign``, it is a direct statement of *stmts*, not a nested
-    body). Stops at a nested class body (its assignments and imports bind the
-    CLASS namespace, not this scope; ``_SinkVisitor.visit_ClassDef`` gives it
-    its own environment) and at a nested function, async function, or
-    lambda -- those get their own independent scope when ``_SinkVisitor``
-    reaches them, each replaying only its own body's events on top of a copy
-    of its enclosing scope's provenance."""
+    """Collect binding events (imports, simple Name assignments, and
+    mask-only events for AugAssign/annotation-only/for/match/with/except/del
+    targets) out of *stmts*, the statement list of one lexical scope, tagging
+    each as CONDITIONAL when nested inside if/try/except/for/while/with/match
+    (a case body is conditional regardless of which case runs) rather than a
+    direct statement of *stmts* itself. See "Graph-entrypoint conformance
+    suite" in docs/internals/core.md for why conditional vs. unconditional
+    matters. Stops at a nested class body (own namespace; see
+    ``_SinkVisitor.visit_ClassDef``) or a nested function/lambda (own scope,
+    replayed separately by ``_SinkVisitor``)."""
     for stmt in stmts:
         if isinstance(stmt, (ast.Import, ast.ImportFrom)):
             events.append((stmt, conditional))
@@ -812,14 +698,9 @@ def _collect_scope_binding_events(
         ):
             events.append((stmt, conditional))
         elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
-            # An annotated assignment WITH a value binds exactly like a
-            # simple assignment (it can establish, restore, or clear
-            # provenance, so it must be a full event -- an annotated
-            # `name: object = importlib.import_module(...)` establishing
-            # provenance would otherwise be invisible and its construction
-            # site missed). A BARE annotation (`name: object`) never binds
-            # at runtime but still makes the name a lexical local of the
-            # whole function scope, so it is a mask-only event.
+            # A bare annotation (`name: object`) never binds at runtime but
+            # still makes the name a lexical local, so it gets a mask-only
+            # event; one with a value binds like a plain assignment.
             if stmt.value is not None:
                 events.append((stmt, conditional))
             else:
@@ -881,52 +762,29 @@ def _collect_scope_binding_events(
                 for name in _pattern_capture_names(case.pattern):
                     events.append((_NameBindingEvent(name, stmt.lineno, stmt.col_offset), True))
                 _collect_scope_binding_events(case.body, True, events)
-        # ClassDef: an ordinary assignment (or import) in a class body binds
-        # the CLASS namespace, never the enclosing function's -- Python gives
-        # the class body its own namespace, so emitting its binders here
-        # would wrongly MASK a same-named enclosing binding and hide a real
-        # construction site in the enclosing function (see
+        # ClassDef: a class body binds its own namespace, not the enclosing
+        # function's; emitting its binders here would wrongly mask a
+        # same-named enclosing binding (see
         # test_class_body_assignment_does_not_mask_enclosing_scope_name).
-        # The class body's own view is modeled by _SinkVisitor.visit_ClassDef.
-        # The one thing this deliberately gives up: a `global x` declaration
-        # INSIDE the class body can make a class-body assignment rebind the
-        # module's x at class-definition time, which this scope's replay now
-        # never sees -- but not clearing module provenance there keeps stale-
-        # but-possibly-correct provenance, which can only ADD a reported
-        # site, never miss a real one (the safe direction under this
-        # scanner's zero-false-negatives contract).
-        # FunctionDef/AsyncFunctionDef/Lambda: a new scope: stop here.
+        # Its own view is modeled by _SinkVisitor.visit_ClassDef.
+        # FunctionDef/AsyncFunctionDef/Lambda: a new scope, stop here.
 
 
 def _replay_binding_events(
     events: list[_BindingEvent], bound: dict[str, str], env: _FlowModuleEnv
 ) -> None:
-    """Replay *events* (as collected by ``_collect_scope_binding_events``) in
-    source order (by lineno, col_offset), mutating *bound*/*env* in place.
-
-    An event that would ESTABLISH or RESTORE provenance -- an import, or an
-    assignment recognized as a flow-module expression or a constructor
-    alias -- is applied only when UNCONDITIONAL: a conditional import or a
-    conditional alias-assignment might never execute, and trusting it anyway
-    risks exactly the false-positive executor site a conditionally-dead
-    branch must not produce.
-
-    An event that would CLEAR provenance -- an assignment to anything
-    unrecognized -- is ALWAYS applied, conditional or not: a conditional
-    rebinding might genuinely execute, and the conservative, false-positive-
-    safe choice is to stop trusting the name rather than assume the
-    rebinding didn't happen.
-
-    Net effect: within one scope, unconditional bindings behave exactly like
-    the old flat whole-module pass (source-order, last-one-wins); a
-    conditional import/alias-assignment is a no-op that neither restores nor
-    disturbs whatever provenance already held; a conditional rebinding to an
-    unrecognized value still clears it."""
+    """Replay *events* (from ``_collect_scope_binding_events``) in source
+    order, mutating *bound*/*env* in place. An event that would establish or
+    restore provenance (an import, or an assignment recognized as a
+    flow-module expression or constructor alias) applies only when
+    unconditional, since a conditional one might never execute. An event
+    that would clear provenance (an assignment to anything unrecognized)
+    always applies, conditional or not: a conditional rebinding might
+    genuinely execute, so the safe choice is to stop trusting the name."""
     for node, conditional in sorted(events, key=lambda pair: (pair[0].lineno, pair[0].col_offset)):
         if isinstance(node, _NameBindingEvent):
-            # for-target / match-capture / augassign-target: a lexical local
-            # for masking purposes only (see _scope_bound_names) -- never
-            # recognized as establishing or restoring import provenance.
+            # Mask-only event (for-target/match-capture/augassign/etc.):
+            # never establishes or restores import provenance.
             continue
         if isinstance(node, ast.ImportFrom):
             if conditional:
@@ -953,9 +811,8 @@ def _replay_binding_events(
                 elif alias.name == "importlib":
                     env.importlib_mods.add(alias.asname or "importlib")
         else:
-            # ast.Assign (single Name target) or ast.AnnAssign (Name target,
-            # non-None value) -- collection guarantees no other shape lands
-            # here, and both carry the binding in `.value`.
+            # ast.Assign or ast.AnnAssign (Name target, non-None value);
+            # both carry the binding in `.value`.
             target = node.target.id if isinstance(node, ast.AnnAssign) else node.targets[0].id
             if _is_flow_module_expr(node.value, env):
                 if conditional:
@@ -974,18 +831,12 @@ def _replay_binding_events(
 
 
 def _scope_bound_names(events: list[_BindingEvent]) -> set[str]:
-    """Every name that some binding statement collected in *events* assigns
-    at runtime -- CONDITIONAL bindings included. Used to mask a function
-    scope's inherited provenance before replaying its own unconditional
-    events: Python function scope is not statement-ordered, so a name
-    imported or assigned only inside an ``if``/``try``/``for``/``match``-case
-    anywhere in the body is still a lexical LOCAL for the ENTIRE function --
-    never the enclosing scope's same-named binding -- even on a code path
-    where that conditional statement never executes and the name ends up
-    merely unbound. Trusting an inherited binding for such a name would be
-    the same false-positive shape a conditional import already guards
-    against, just leaking in from the other direction (down from the
-    enclosing scope instead of sideways within one)."""
+    """Every name some binding statement in *events* assigns at runtime,
+    conditional bindings included. Used to mask a function scope's inherited
+    provenance before replaying its own unconditional events: Python
+    function scope is not statement-ordered, so a name bound only inside an
+    if/try/for/match anywhere in the body is still a lexical local for the
+    entire function, never the enclosing scope's same-named binding."""
     names: set[str] = set()
     for node, _conditional in events:
         if isinstance(node, ast.Import):
@@ -1005,39 +856,19 @@ def _scope_bound_names(events: list[_BindingEvent]) -> set[str]:
 
 def _collect_constructor_import_bindings(tree: ast.Module) -> tuple[dict[str, str], _FlowModuleEnv]:
     """Local alias -> canonical name for any `from ... import
-    <ConstructorSinkName> [as alias]` in *tree*'s MODULE scope, regardless of
-    which module path it is re-exported from (``Graph`` in particular is
-    re-exported from several ``lionagi.protocols.*`` modules, so this
-    deliberately does not filter by source module the way
-    ``_collect_kernel_import_bindings`` does), plus every simple one-level
-    assignment alias (``GraphRunner = DependencyAwareExecutor`` or
-    ``GraphRunner = <existing alias>``) and literal dynamic ``getattr``
-    lookup alias (``GraphRunner = getattr(mod, "DependencyAwareExecutor")``)
-    recognized by ``_resolve_constructor_alias_rhs``. Closes the
-    aliased-constructor gap: `from lionagi.operations.flow import
-    DependencyAwareExecutor as GraphRunner` followed by
-    `GraphRunner(...).execute()`, a bare `GraphRunner = DependencyAwareExecutor`
-    assignment, or a `getattr`-based dynamic lookup assigned to a name, must
-    all be recognized as constructing ``DependencyAwareExecutor`` even though
-    the call site only ever mentions the local alias.
+    <ConstructorSinkName> [as alias]` in *tree*'s module scope (not filtered
+    by source module, since e.g. ``Graph`` is re-exported from several
+    ``lionagi.protocols.*`` modules), plus one-level assignment aliases and
+    ``getattr``-based dynamic lookups recognized by
+    ``_resolve_constructor_alias_rhs``. Closes the aliased-constructor gap:
+    an import-as, a bare reassignment, or a dynamic getattr lookup must all
+    still be recognized as constructing the executor even when the call site
+    only mentions the local alias.
 
-    Only the module's OWN top-level statements (plus anything nested inside
-    module-level control flow, which is CONDITIONAL -- see
-    ``_collect_scope_binding_events``/``_replay_binding_events``) feed this
-    pass; a binding inside a nested function/lambda body is that function's
-    OWN scope and is resolved separately by ``_SinkVisitor`` when it enters
-    that scope, starting from a copy of this module-level result.
-
-    Returns ``(alias_map, flow_env)`` where the second element is the
-    import-provenance environment (:class:`_FlowModuleEnv`) of names bound
-    to ``lionagi.operations.flow``, the ``lionagi`` package root,
-    ``importlib``, and ``import_module`` -- used to restrict ``getattr``
-    recognition to receivers that provably denote the flow module. This pair
-    also becomes index 0 of ``_SinkVisitor``'s scope stacks (the pristine
-    MODULE-scope snapshot that never gets mutated in place -- see
-    ``_SinkVisitor.__init__``/``_push_func_scope``), which a ``global``
-    declaration inside any nested function scope overlays its provenance
-    from, rather than the lexical-enclosing scope."""
+    Returns ``(alias_map, flow_env)``; this pair also becomes index 0 of
+    ``_SinkVisitor``'s scope stacks — the pristine module-scope snapshot
+    that a ``global`` declaration inside any nested function overlays its
+    provenance from, rather than the lexical-enclosing scope."""
     bound: dict[str, str] = {}
     env = _FlowModuleEnv.empty()
     events: list[_BindingEvent] = []
@@ -1047,78 +878,19 @@ def _collect_constructor_import_bindings(tree: ast.Module) -> tuple[dict[str, st
 
 
 class _SinkVisitor(ast.NodeVisitor):
-    """Attributes qualified `.flow`/`.flow_stream`/`.run_dag` calls, bare
-    calls to a locally-imported kernel function, and
-    OperationGraphBuilder/executor/Graph construction calls (including
-    through an aliased import, a one-level assignment alias, or a literal
-    `getattr`-based dynamic lookup, assigned or called inline) to the
-    innermost enclosing function or method (dotted "Class.method" or
-    "function").
+    """Attaches qualified `.flow`/`.flow_stream`/`.run_dag` calls, bare
+    kernel-function calls, and executor/builder construction calls to the
+    innermost enclosing function or method (dotted "Class.method").
 
-    Import provenance (:class:`_FlowModuleEnv`) and constructor aliases
-    (``bound``) are tracked per lexical scope, not as one flat whole-module
-    timeline: entering a function or lambda pushes a scoped copy of both,
-    derived from the enclosing scope with any parameter-shadowed name
-    discarded from each. For a function/async function (never a lambda,
-    which can hold no statements), that copy is then further masked for
-    every name the function's OWN body binds ANYWHERE -- via
-    ``_scope_bound_names``, conditional bindings included, since a name
-    bound only inside an ``if``/``try``/``match``-case is still a lexical
-    local for the whole function and must not fall through to the enclosing
-    scope's same-named binding -- and only then advanced by replaying the
-    body's UNCONDITIONAL binding events on top of that masked copy, via the
-    same ``_collect_scope_binding_events``/``_replay_binding_events``
-    machinery ``_collect_constructor_import_bindings`` uses for the module
-    scope. Net effect: a genuine unconditional in-body reimport restores
-    provenance a same-named parameter shadowed (exactly as a module-level
-    reimport restores provenance an unrelated rebinding discarded), while a
-    conditional in-body reimport of an inherited name masks it and leaves it
-    masked -- it does not leak the outer scope's provenance through. The
-    scope is popped again on the way out, restoring the enclosing scope's
-    view for sibling functions.
-
-    A name declared ``global``/``nonlocal`` anywhere in a function's OWN body
-    (via ``_scope_declared_names``, which stops at a nested class body -- see
-    its docstring) is exempt from that masking pass, since it is not a
-    lexical local at all. The two declarations resolve against DIFFERENT
-    target scopes and are handled accordingly: ``global`` is overlaid from a
-    pristine MODULE-scope snapshot (index 0 of the scope stacks, never
-    mutated in place) rather than inherited from the lexical-enclosing
-    scope's copy, since a `global NAME` reference skips every intermediate
-    function scope no matter what any of them locally bind NAME to;
-    ``nonlocal`` needs no such overlay because it resolves against the
-    nearest ENCLOSING FUNCTION scope, which the ordinary lexical copy-chain
-    already reproduces by construction. See the module docstring's
-    zero-false-negatives invariant and ``_push_func_scope`` for the full
-    argument, and the ``test_global_declared_*``/``test_nonlocal_declared_*``
-    regressions for both directions of each.
-
-    A declared name's own binder forms (``for``-target, match-capture,
-    ``with``/``except ... as``, ``del``, augmented assignment) are still only
-    ever mask-only events in ``_replay_binding_events`` -- they never
-    establish or restore provenance there, so a declared name whose ONLY
-    in-scope binder is one of these forms keeps whatever provenance the
-    overlay/inheritance step already gave it, even though that binder form
-    may actually execute and rebind/clear the real module or enclosing
-    binding at runtime. This is a DELIBERATE, documented conservative
-    over-approximation, not a bug: this scanner's contract is
-    zero-false-negatives (a missed executor-construction site is dangerous; a
-    spurious one only costs a review), so keeping stale-but-possibly-correct
-    provenance through a maybe-executing declared binder can only ever ADD a
-    reported site, never drop one that is real. Eliminating this residual
-    would require reasoning about whether the binder actually executes --
-    genuine dead/live-code analysis -- which this scanner intentionally does
-    not do; see
-    test_global_declared_executing_binder_is_conservative_overapproximation,
-    which pins this exact shape as an expected, named false-positive so a
-    future change that trades it for a missed site fails that test instead
-    of quietly regressing.
-
-    The class-body environment (``visit_ClassDef``) applies the same
-    principle system-wide: it is built ADD-ONLY because adding provenance
-    can only add candidate sites, and adding sites is the false-positive-
-    safe side of the zero-false-negatives invariant -- every deliberate
-    imprecision in this scanner errs in that one direction."""
+    Import provenance and constructor aliases are tracked per lexical scope
+    (see "Graph-entrypoint conformance suite" in docs/internals/core.md for
+    the full masking/replay algorithm and the global/nonlocal overlay
+    rules). A declared name's own binder forms (for-target, match-capture,
+    with/except-as, del, augmented assignment) are still mask-only events in
+    ``_replay_binding_events`` and never establish/restore provenance there
+    — a deliberate conservative over-approximation pinned by
+    ``test_global_declared_executing_binder_is_conservative_overapproximation``,
+    not a bug, per the scanner's zero-false-negatives contract."""
 
     def __init__(
         self,
@@ -1155,59 +927,32 @@ class _SinkVisitor(ast.NodeVisitor):
             self.executor_hits.add(qualname)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        """Class bodies get their own environment, built ADD-ONLY on top of
+        """Class bodies get their own environment, built add-only on top of
         the enclosing scope's view.
 
-        A class body is its own namespace but NOT a function scope: name
-        resolution inside it is SEQUENTIAL (a read before any class-local
-        binding of that name falls through to the enclosing scope; there is
-        no scope-wide "assigned anywhere means local everywhere" rule the
-        way function bodies have). That rule is what justifies function
-        scopes' mask-then-replay model -- a use before an unconditional
-        rebinding is an UnboundLocalError at runtime, so no real construction
-        is lost by masking. Class bodies offer no such justification, so any
-        mask or provenance-clear applied to the class view could hide a
-        construction that really reads the enclosing binding. The class
-        environment is therefore strictly additive relative to the enclosing
-        scope:
+        Unlike a function body, a class body resolves names sequentially (a
+        read before any class-local binding falls through to the enclosing
+        scope) rather than by "assigned anywhere means local everywhere", so
+        masking would risk hiding a construction that really reads the
+        enclosing binding. The class environment is therefore additive only:
+        no masking, every establishing event applies including conditional
+        ones, and the enclosing view is unioned back in after replay so a
+        clear never drops enclosing-inherited provenance.
 
-        - no ``_scope_bound_names`` masking at all;
-        - every establishing event in the class body applies, conditional
-          ones included (trusting a maybe-executed class-body import can
-          only ADD a reported site, the safe direction);
-        - after replaying the class body's own events on private copies, the
-          enclosing view is unioned back in, so a replay-applied clear never
-          drops enclosing-inherited provenance;
-        - a class-body ``global`` declaration overlays MODULE-scope
-          provenance additively (class-body lookups of that name go to the
-          module even when an enclosing function masked it) -- and the
-          overlay is re-applied AFTER replay too, so a class-body rebind of
-          a global-declared name (conditional or not, since replay here is
-          forced unconditional) can never erase the module baseline the
-          declaration grants;
-        - the class body's OWN establishing events for global-declared
-          names (a recognized import or constructor/module alias gained
-          during replay relative to the pre-replay snapshot) are propagated
-          additively to every view currently on the scope stacks, module
-          snapshot included: a ``global x`` establishment executes at
-          class-definition time and genuinely rebinds the MODULE's ``x``,
-          which statements after the class definition (in the enclosing
-          function, and via later ``global`` overlays anywhere) really read.
-          Only establishing deltas propagate -- never clears (add-only), and
-          never the module overlay the class merely inherited (propagating
-          that would un-mask enclosing locals the declaration does not
-          touch). On the single-valued constructor-alias channel the
-          establishment OVERWRITES each view's existing attribution (a
-          stale alias kept in a globally-resolving view would hide the real
-          post-rebind executor construction), except that an executor
-          attribution is never replaced by a non-executor one -- the
-          attribution may only move toward reporting an executor, so every
-          direction of rebind errs reportward.
+        A class-body ``global`` declaration overlays module-scope provenance
+        additively, and the class body's own establishing events for
+        global-declared names propagate to every view on the scope stacks
+        (module snapshot included) since a `global x` establishment at
+        class-definition time genuinely rebinds the module's `x`. On the
+        constructor-alias channel an establishment overwrites each view's
+        existing attribution, except an executor attribution is never
+        replaced by a non-executor one — every direction of rebind errs
+        toward reporting a site, consistent with the scanner's
+        zero-false-negatives contract.
 
-        Ordinary (undeclared) class-body binders never leak OUT to the
-        enclosing scope -- ``_collect_scope_binding_events`` stops at
-        ``ClassDef`` -- and the class environment is popped when the body is
-        done."""
+        Ordinary (undeclared) class-body binders never leak out to the
+        enclosing scope, and the class environment is popped when the body
+        is done."""
         self._stack.append(node.name)
         enclosing_env = self._flow_env
         enclosing_bound = self._constructor_aliases
@@ -1345,50 +1090,23 @@ class _SinkVisitor(ast.NodeVisitor):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             events: list[_BindingEvent] = []
             _collect_scope_binding_events(node.body, False, events)
-            # Mask every name the body binds ANYWHERE (conditional included)
-            # before replaying -- see _scope_bound_names: a name imported or
-            # assigned only inside an if/try/match-case is still a lexical
-            # local for the whole function, so an inherited same-named
-            # binding from the enclosing scope must not leak through here.
-            # EXCEPT a name declared `global`/`nonlocal` anywhere in this
-            # scope's OWN body (see _scope_declared_names, which stops at a
-            # nested class body -- a global/nonlocal statement inside a
-            # nested class does NOT declare a name of THIS scope): such a
-            # name is NOT a function-local at all, so it must not be
-            # discarded from inherited provenance the way a genuine local is.
+            # Mask every name the body binds anywhere, except one declared
+            # global/nonlocal in this scope's own body — see "Graph-
+            # entrypoint conformance suite" in docs/internals/core.md.
             global_names, nonlocal_names = _scope_declared_names(node.body)
             declared = global_names | nonlocal_names
             for name in _scope_bound_names(events) - declared:
                 env.discard(name)
                 bound.pop(name, None)
-            # A `global NAME` declaration resolves EVERY reference and
-            # rebinding of NAME in this function against the MODULE scope,
-            # never the lexical-enclosing scope -- even when an enclosing
-            # function's own parameter or local binding shadows the same
-            # name for ITS OWN body (see
-            # test_global_declared_name_resolves_against_module_scope_not_shadowed_param).
-            # `env`/`bound` at this point still hold whatever the lexical
-            # parent's copy carried (correct for `nonlocal`, wrong for
-            # `global`), so every global-declared name is first cleared and
-            # then overlaid from a MODULE-scope snapshot -- the bottom of
-            # the scope stack (index 0). Function-scope replays never mutate
-            # it in place (only ever copies further down; see
-            # _flow_env.copy()/dict(self._constructor_aliases) above); the
-            # ONLY in-place updates it ever receives are class-body global
-            # establishments (see visit_ClassDef) -- additive on the
-            # provenance sets, and on the alias channel a genuine module
-            # rebinding executed at class-definition time may replace a
-            # non-executor attribution (never an executor one) -- so it
-            # always reflects the module's own bindings regardless of how
-            # many function scopes are currently pushed.
-            # `nonlocal`-declared names need no such overlay: nonlocal
-            # resolves against the nearest ENCLOSING FUNCTION scope, and
-            # `env`/`bound` here already start as a copy of that exact
-            # lexical parent's (already fully masked-and-replayed) view, so
-            # inheritance alone reproduces nonlocal's real target by
-            # construction (verified by
+            # global-declared names resolve against the module scope (index
+            # 0 of the stacks), not the lexical-enclosing copy already held
+            # in env/bound, so they're cleared and overlaid from there; see
+            # test_global_declared_name_resolves_against_module_scope_not_shadowed_param.
+            # nonlocal needs no such overlay: env/bound already start as a
+            # copy of the lexical parent's fully-resolved view, so ordinary
+            # inheritance reproduces nonlocal's target by construction (see
             # test_nonlocal_declared_name_not_masked_discovers_executor and
-            # its masked-outer control, test_nonlocal_declared_name_with_masked_outer_binding_finds_no_site).
+            # test_nonlocal_declared_name_with_masked_outer_binding_finds_no_site).
             module_env = self._flow_env_stack[0]
             module_bound = self._bound_stack[0]
             for name in global_names:

--- a/tests/operations/test_lndl_middle.py
+++ b/tests/operations/test_lndl_middle.py
@@ -71,9 +71,7 @@ def lookup(query: str) -> str:
     return f"result for {query}"
 
 
-# ---------------------------------------------------------------------------
 # _classify_round — pure-function unit tests (no branch, no async)
-# ---------------------------------------------------------------------------
 
 
 class TestClassifyRound:
@@ -167,13 +165,11 @@ class TestClassifyRound:
         assert [call.name for call in pending] == ["a", "b"]
 
 
-# ---------------------------------------------------------------------------
 # _render_target_spec — the target schema summary injected into round-1
 # guidance (LNDL_SYSTEM_PROMPT rule 5: "Use the EXACT spec names declared in
 # the schema you are given"). Without this, stripping native response_format
 # from the round chat call leaves a real model with no idea what fields to
 # fill.
-# ---------------------------------------------------------------------------
 
 
 class TestRenderTargetSpec:
@@ -200,9 +196,7 @@ class TestRenderTargetSpec:
         assert spec == "Specs: findings(list[Finding: name, score]), scores(dict[str, float])"
 
 
-# ---------------------------------------------------------------------------
 # _run_round_chat — CLI vs API dispatch
-# ---------------------------------------------------------------------------
 
 
 class TestRunRoundChatDispatch:
@@ -294,9 +288,7 @@ class TestRunRoundChatDispatch:
         assert "OUT{" in result
 
 
-# ---------------------------------------------------------------------------
 # Full Middle loop — round-outcome scenarios, end to end
-# ---------------------------------------------------------------------------
 
 
 class TestSuccessScenarios:

--- a/tests/operations/test_operate.py
+++ b/tests/operations/test_operate.py
@@ -183,9 +183,7 @@ async def test_branch_operate_ignores_caller_supplied_operative():
     assert result.action_responses[0].output == 3
 
 
-# ---------------------------------------------------------------------------
 # Edge cases for prepare_operate_kw (P0)
-# ---------------------------------------------------------------------------
 
 from lionagi.operations.operate.operate import prepare_operate_kw
 
@@ -227,9 +225,7 @@ async def test_operate_handle_validation_raise_reports_expected_model(monkeypatc
         )
 
 
-# ---------------------------------------------------------------------------
 # Additional prepare_operate_kw coverage — field_models
-# ---------------------------------------------------------------------------
 
 import warnings
 
@@ -327,9 +323,7 @@ def test_prepare_operate_kw_snapshot_dir_alone_triggers_run_param():
     assert chat_param.snapshot_dir == "/var/folders/branches"
 
 
-# ---------------------------------------------------------------------------
 # operate() function direct tests — various branches
-# ---------------------------------------------------------------------------
 
 from lionagi.operations.operate.operate import operate
 from lionagi.operations.types import ChatParam
@@ -476,9 +470,7 @@ async def test_operate_with_field_models_builds_operative():
     assert result == {"label": "test_value"}
 
 
-# ---------------------------------------------------------------------------
 # TypeError raised at new boundary (_specs_from_fields) before model call.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -506,10 +498,8 @@ async def test_operate_invalid_field_models_raises_before_model_call():
         )
 
 
-# ---------------------------------------------------------------------------
 # Lock-in: reason=True alone (no response_format / actions / field_models)
 # takes the Operative-construction branch (operate.py:252).
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_parse.py
+++ b/tests/operations/test_parse.py
@@ -33,9 +33,7 @@ class OutputModel(BaseModel):
     summary: str
 
 
-# ============================================================================
 # P0 - Critical Coverage Tests
-# ============================================================================
 
 
 async def parse(branch, **kws):
@@ -230,9 +228,7 @@ class TestBasicParsing:
                 assert result == text
 
 
-# ============================================================================
 # P1 - Important Feature Coverage
-# ============================================================================
 
 
 class TestAdvancedFeatures:
@@ -371,9 +367,7 @@ class TestLndlExtraction:
         assert result == "<lvar answer a>first</lvar>\n\n\nOUT{answer: [a]}\n"
 
 
-# ============================================================================
 # Fixtures
-# ============================================================================
 
 
 @pytest.fixture
@@ -389,9 +383,7 @@ def make_mocked_branch_for_parse(make_mocked_branch):
     return _make_branch
 
 
-# ---------------------------------------------------------------------------
 # parse propagates cancellation without retry
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_react_regressions.py
+++ b/tests/operations/test_react_regressions.py
@@ -199,7 +199,6 @@ async def test_operate_filters_none_action_responses():
     # This is what the FIXED code does - filter out None values
     filtered = [r for r in action_response_models if r is not None]
 
-    # Verify the filtering worked correctly
     assert len(filtered) == 1, "Should filter out None values"
     assert filtered[0].function == "multiply"
     assert filtered[0].output == 15

--- a/tests/operations/test_reactive_flow.py
+++ b/tests/operations/test_reactive_flow.py
@@ -523,9 +523,7 @@ async def test_no_spawn_behaves_like_normal_flow():
     assert len(result["completed_operations"]) == 1
 
 
-# ---------------------------------------------------------------------------
 # Regression: execute() must subscribe via the public observer property
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -599,9 +597,7 @@ async def test_execute_stream_subscribes_via_public_observer_not_private():
     assert any(e.spawned for e in events)
 
 
-# ---------------------------------------------------------------------------
 # NodeSpawned signal: exactly one emission per accepted spawn, correct payload
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -635,10 +631,8 @@ async def test_node_spawned_emitted_once_with_matching_payload():
     assert sig.op_id  # traceable to the injected child operation
 
 
-# ---------------------------------------------------------------------------
 # Fire-and-forget signal delivery: observer failure never changes the flow
 # result, and the executor's detached-task set drains after the run.
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/tests/operations/test_run_error_classification.py
+++ b/tests/operations/test_run_error_classification.py
@@ -51,9 +51,7 @@ async def _drain(gen) -> list:
     return [item async for item in gen]
 
 
-# ---------------------------------------------------------------------------
 # Quota error chunk → ProviderQuotaError raised (still a RuntimeError)
-# ---------------------------------------------------------------------------
 
 
 async def test_run_raises_quota_error_for_usage_limit_chunk():
@@ -76,9 +74,7 @@ async def test_run_quota_error_is_runtime_error():
         await _drain(run(branch, "do something", RunParam()))
 
 
-# ---------------------------------------------------------------------------
 # Auth error chunk → ProviderAuthError
-# ---------------------------------------------------------------------------
 
 
 async def test_run_raises_auth_error_for_invalid_key_chunk():
@@ -90,9 +86,7 @@ async def test_run_raises_auth_error_for_invalid_key_chunk():
         await _drain(run(branch, "do something", RunParam()))
 
 
-# ---------------------------------------------------------------------------
 # Context error chunk → ProviderContextError
-# ---------------------------------------------------------------------------
 
 
 async def test_run_raises_context_error_for_window_exceeded_chunk():
@@ -104,9 +98,7 @@ async def test_run_raises_context_error_for_window_exceeded_chunk():
         await _drain(run(branch, "do something", RunParam()))
 
 
-# ---------------------------------------------------------------------------
 # Unknown error chunk → base ProviderError (still RuntimeError)
-# ---------------------------------------------------------------------------
 
 
 async def test_run_raises_base_provider_error_for_unknown_chunk():
@@ -128,9 +120,7 @@ async def test_run_base_provider_error_is_runtime_error():
         await _drain(run(branch, "do something", RunParam()))
 
 
-# ---------------------------------------------------------------------------
 # Empty content → "(empty error)" guard, base ProviderError
-# ---------------------------------------------------------------------------
 
 
 async def test_run_empty_error_chunk_uses_fallback_string():
@@ -143,9 +133,7 @@ async def test_run_empty_error_chunk_uses_fallback_string():
         await _drain(run(branch, "do something", RunParam()))
 
 
-# ---------------------------------------------------------------------------
 # subprocess RuntimeError path → classified ProviderError
-# ---------------------------------------------------------------------------
 
 
 async def test_run_subprocess_runtime_error_is_classified():
@@ -232,9 +220,7 @@ async def test_run_already_classified_provider_error_not_double_wrapped():
     )
 
 
-# ---------------------------------------------------------------------------
 # Late error must not destroy already-streamed text
-# ---------------------------------------------------------------------------
 
 
 async def test_run_error_after_text_persists_delivered_content():
@@ -271,10 +257,8 @@ async def test_run_error_without_text_persists_nothing():
     assert responses == []
 
 
-# ---------------------------------------------------------------------------
 # Regression: error:null chunk must NOT be swallowed as benign EOS
 # (null normalised to {} matched the benign predicate before the fix)
-# ---------------------------------------------------------------------------
 
 
 async def test_run_raises_provider_error_for_null_error_payload_chunk():
@@ -296,9 +280,7 @@ async def test_run_raises_provider_error_for_null_error_payload_chunk():
         await _drain(run(branch, "do something", RunParam()))
 
 
-# ---------------------------------------------------------------------------
 # Reconnect notice: the provider CLI retrying its own stream is not a failure
-# ---------------------------------------------------------------------------
 
 
 async def test_run_continues_past_reconnect_notice_and_delivers_text():


### PR DESCRIPTION
Cuts narration, comment banners/dividers, and internal tracking references (issue numbers, a gtd task id, a seat name) from the execution-core test suite, keeping every regression rationale and external-contract note the tests encode. Extracts the graph-entrypoint conformance suite's AST scope/binding-provenance algorithm out of a huge module/class-docstring essay into docs/internals/core.md, leaving a pointer in the test file.

Verified documentation-only via ast_equal.py on all 36 touched .py files (0 failures).