### PR TITLE
chore(tests): trim prose in cli/orchestrate suite, strip tracking refs

### DIFF
--- a/docs/internals/cli.md
+++ b/docs/internals/cli.md
@@ -253,6 +253,39 @@ spawned this generation — otherwise a resume that reconstructs every spawned
 node as already-terminal would report `n_spawned=0` and silently skip the
 `with_synthesis`-or-`n_spawned` gate in `_run_flow_inner`.
 
+### `_orchestration.py` — live-persist finalize and escalation-link teardown
+
+A DAG that already produced its result must not lose that result because a
+post-completion, best-effort teardown step raises. Three such steps run after
+a DAG finishes: posting to the team inbox, writing the session
+snapshot/resume pointer, and rendering the graph image. Each is guarded in
+its own try/except — sharing one try/except across all three would mean the
+first raise (the team post) skips the rest, so the snapshot and resume
+pointer would never get written even though the run itself succeeded.
+
+When any of these guarded steps fails, the session still ends with status
+`completed`, but its reason code becomes `COMPLETED_FINALIZE_ERROR` instead
+of `COMPLETED_OK`. That distinction has to survive the hop from the child
+session's record to the parent invocation's record —
+`_resolve_invocation_terminal_flow` must not flatten a degraded-but-not-failed
+child into a plain `COMPLETED_OK` at the invocation level, or a reader of the
+invocation loses the only signal that a teardown step misbehaved.
+
+Escalation-link teardown has its own hazard: `_execute_dag`'s cancellation
+path drains any in-flight escalation-link tasks before returning, and that
+drain must be bounded, not just guarded. `_drain_escalation_links_bounded`
+gives in-flight links a grace period to unwind on their own, then cancels
+whatever survived and awaits those survivors under a second, shorter grace
+window, abandoning (and logging) anything still alive after that. Both grace
+windows matter independently: a link task can swallow a first cancellation
+and only unwind on a second one, so a single unbounded `asyncio.gather()`
+with no drain machinery can hang forever on external cancellation. The bound
+has to hold on both routes into teardown — cancellation landing mid-`run_dag()`
+(caught by an except that also sets `_dag_cancelled`) and cancellation
+landing after `run_dag()` has already returned, inside the `finally` block's
+own drain `gather()` (where that except never runs, so `_dag_cancelled` stays
+`False`) — since only one of those two routes exercises the flag.
+
 ## `team.py` — `li team` persistent messaging (inbox pattern)
 
 `_locked_team`: read-modify-write under an exclusive POSIX flock. Explicit

--- a/tests/cli/orchestrate/test_control_cli.py
+++ b/tests/cli/orchestrate/test_control_cli.py
@@ -62,7 +62,7 @@ async def _make_invocation(db: StateDB, *, status: str = "running") -> str:
     return inv_id
 
 
-# ── pause ───────────────────────────────────────────────────────────────────
+# pause
 
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ def test_pause_no_state_db_returns_exit_unknown(temp_db_path: Path):
     assert rc == EXIT_UNKNOWN
 
 
-# ── resume ──────────────────────────────────────────────────────────────────
+# resume
 
 
 @pytest.mark.asyncio
@@ -149,7 +149,7 @@ async def test_resume_enqueues_row(temp_db_path: Path):
     assert pending[0]["payload"] is None
 
 
-# ── msg ─────────────────────────────────────────────────────────────────────
+# msg
 
 
 @pytest.mark.asyncio
@@ -172,7 +172,7 @@ def test_msg_unknown_id_returns_exit_unknown(temp_db_path: Path):
     assert rc == EXIT_UNKNOWN
 
 
-# ── write-path guards: ambiguity, terminal sessions, non-flow kinds ─────────
+# write-path guards: ambiguity, terminal sessions, non-flow kinds
 
 
 @pytest.mark.asyncio
@@ -241,7 +241,7 @@ async def test_play_kind_session_accepted(temp_db_path: Path):
         assert len(await db.list_pending_session_controls(sid)) == 1
 
 
-# ── multiple controls queue independently ──────────────────────────────────
+# multiple controls queue independently
 
 
 @pytest.mark.asyncio

--- a/tests/cli/orchestrate/test_control_poller.py
+++ b/tests/cli/orchestrate/test_control_poller.py
@@ -81,7 +81,7 @@ class _FinalizeFailsDB:
         raise RuntimeError("database is locked")
 
 
-# ── pause / resume: idempotent apply-then-stamp ─────────────────────────────
+# pause / resume: idempotent apply-then-stamp
 
 
 async def test_pause_applies_and_stamps(tmp_path: Path) -> None:
@@ -166,7 +166,7 @@ async def test_pause_and_resume_are_excluded_from_pending_after_finalize(tmp_pat
         assert pending_after == []
 
 
-# ── message: non-idempotent stamp-then-apply ────────────────────────────────
+# message: non-idempotent stamp-then-apply
 
 
 async def test_message_deep_merges_into_context_when_pending_op_exists(tmp_path: Path) -> None:
@@ -363,7 +363,7 @@ async def test_the_poller_still_records_its_own_outcome_when_nobody_intervenes(
         assert executor.context.content["operator_messages"][-1]["text"] == "steer"
 
 
-# ── unsupported verb / stop (schema-reserved, no CLI verb emits it) ────────
+# unsupported verb / stop (schema-reserved, no CLI verb emits it)
 
 
 async def test_stop_verb_is_rejected_as_unsupported(tmp_path: Path) -> None:
@@ -381,7 +381,7 @@ async def test_stop_verb_is_rejected_as_unsupported(tmp_path: Path) -> None:
         assert finalized["applied_at"] is not None
 
 
-# ── crash safety: apply must never raise into the caller ──────────────────
+# crash safety: apply must never raise into the caller
 
 
 async def test_exception_during_apply_is_caught_and_recorded(tmp_path: Path) -> None:

--- a/tests/cli/orchestrate/test_fan_shape.py
+++ b/tests/cli/orchestrate/test_fan_shape.py
@@ -30,7 +30,7 @@ def _label_counts(builder: OperationGraphBuilder) -> Counter:
     return Counter(tuple(e.label or []) for e in builder.graph.internal_edges.values())
 
 
-# ── flow.py ───────────────────────────────────────────────────────────────────
+# flow.py
 
 
 @pytest.mark.asyncio
@@ -112,7 +112,7 @@ async def test_flow_dag_preserves_declared_dependency_chain(tmp_path):
     assert str(edge.tail) == str(dag_state.node_ids[1])
 
 
-# ── fanout.py ─────────────────────────────────────────────────────────────────
+# fanout.py
 
 
 def test_fanout_node_construction_builds_a_fan():

--- a/tests/cli/orchestrate/test_flow_checkpoint_resume.py
+++ b/tests/cli/orchestrate/test_flow_checkpoint_resume.py
@@ -41,7 +41,7 @@ from lionagi.protocols.types import EventStatus
 from lionagi.session.signal import NodeCompleted, NodeFailed
 from lionagi.state.db import StateDB
 
-# ── Fixtures ────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -196,7 +196,7 @@ def _asyncio_coro(value):
     return _inner()
 
 
-# ── CheckpointWriter: atomic write + schema ──────────────────────────────────
+# CheckpointWriter: atomic write + schema
 
 
 async def test_checkpoint_writer_record_writes_valid_schema_no_leftover_tmp(tmp_path: Path):
@@ -361,7 +361,7 @@ async def test_checkpoint_writer_record_spawned_captures_context_payload(tmp_pat
     assert data["spawned"][0]["context"] == context_payload
 
 
-# ── _apply_checkpoint_precompletion ──────────────────────────────────────────
+# _apply_checkpoint_precompletion
 
 
 def test_apply_checkpoint_precompletion_marks_completed_ops_and_flags_degraded():
@@ -531,7 +531,7 @@ def test_apply_checkpoint_precompletion_refuses_when_spawned_entries_present():
     assert nodes["n-worker"].execution.status is None
 
 
-# ── _reconstruct_spawned_nodes: sound resume-after-partial-reactive-run ─────
+# _reconstruct_spawned_nodes: sound resume-after-partial-reactive-run
 #
 # These use a REAL OperationGraphBuilder/Graph (not the dict-backed _FakeNode
 # fixtures above) because reconstruction adds real Operation nodes and Edge
@@ -966,7 +966,7 @@ def test_apply_checkpoint_precompletion_reconstructs_valid_spawned_entry_without
     assert child_node.metadata["reference_id"] == "spawn-9"
 
 
-# ── _execute_dag: checkpoint write correctness ───────────────────────────────
+# _execute_dag: checkpoint write correctness
 
 
 async def test_checkpoint_captures_nonempty_executor_flow_context_on_completion(tmp_path: Path):
@@ -1578,7 +1578,7 @@ async def test_resumed_run_with_only_restored_spawns_triggers_synthesis(tmp_path
     synthesize_mock.assert_called_once()
 
 
-# ── Spawn-id sequence: resume must not reissue a restored spawn's id ────────
+# Spawn-id sequence: resume must not reissue a restored spawn's id
 
 
 def test_role_node_builder_start_seeds_first_spawn_id_past_restored_ordinal():
@@ -1717,7 +1717,7 @@ async def test_execute_dag_seeds_spawn_sequence_past_gap_in_restored_ordinals(tm
     assert role_node_builder_mock.call_args.kwargs["start"] == 4
 
 
-# ── Resume sequencing: planner skipped, finalization tail still runs ────────
+# Resume sequencing: planner skipped, finalization tail still runs
 
 
 async def test_resume_skips_planner_and_still_calls_finalize_with_zero_pending_ops(tmp_path: Path):
@@ -2019,7 +2019,7 @@ async def test_resume_missing_artifact_still_flips_status_to_failed(
     assert s["status_reason_code"] == "run.failed.missing_artifact"
 
 
-# ── resolve_checkpoint_target ────────────────────────────────────────────────
+# resolve_checkpoint_target
 
 
 async def test_resolve_checkpoint_target_exact_run_id(
@@ -2141,7 +2141,7 @@ async def test_resolve_checkpoint_target_falls_back_to_session_run_id(
     await stop_live_persist(env, status="completed")
 
 
-# ── CLI wiring: `li o flow --resume` argparse + dispatch ────────────────────
+# CLI wiring: `li o flow --resume` argparse + dispatch
 
 
 def _parse_flow_args(argv: list[str]) -> argparse.Namespace:

--- a/tests/cli/orchestrate/test_flow_phases.py
+++ b/tests/cli/orchestrate/test_flow_phases.py
@@ -25,7 +25,7 @@ from lionagi.cli.orchestrate.flow import (
     _synthesize,
 )
 
-# ── Shared stubs ──────────────────────────────────────────────────────────────
+# Shared stubs
 
 
 def _make_env(
@@ -240,7 +240,7 @@ class _FakeBranch:
         return {"id": str(self.id), "created_at": 0, "name": self.name}
 
 
-# ── Tests for _build_dag ──────────────────────────────────────────────────────
+# Tests for _build_dag
 
 
 @pytest.mark.asyncio
@@ -485,7 +485,7 @@ async def test_build_dag_pool_override_passes_to_worker(tmp_path):
     assert calls[1]["model_override"] == "codex/expensive"
 
 
-# ── Tests for _execute_dag ────────────────────────────────────────────────────
+# Tests for _execute_dag
 
 
 @pytest.mark.asyncio
@@ -1111,7 +1111,7 @@ async def test_execute_dag_drains_segment_metadata_write_before_returning(tmp_pa
     assert segment_writes[-1]["segments"], "segment entry for the completed node was not recorded"
 
 
-# ── Reactive spawn artifact enforcement through REAL teardown ─────────────────
+# Reactive spawn artifact enforcement through REAL teardown
 # Replaces the old interim regression test that pinned spawned artifacts as
 # permanently non-required (a spawned node used to have no way to learn its
 # own artifact dir before running). decorate_instruction now tells it that
@@ -1362,7 +1362,7 @@ async def test_execute_dag_segment_writer_merges_into_real_statedb(
     assert meta.get("unverifiable_count") == 2
 
 
-# ── Tests for _synthesize ─────────────────────────────────────────────────────
+# Tests for _synthesize
 
 
 @pytest.mark.asyncio
@@ -1510,7 +1510,7 @@ async def test_synthesize_includes_spawned_artifact_dir(tmp_path):
     assert str(tmp_path / "researcher") in instruction
 
 
-# ── Tests for _finalize_flow ──────────────────────────────────────────────────
+# Tests for _finalize_flow
 
 
 def test_finalize_flow_text_output(tmp_path):
@@ -1756,7 +1756,7 @@ def test_finalize_flow_agents_includes_spawned_node(tmp_path):
     assert spawned_agent["spawned"] is True
 
 
-# ── issue #2053: post-DAG finalize failures must not become DAG failures ──────
+# Post-DAG finalize failures must not become DAG failures.
 
 
 def test_finalize_flow_team_post_failure_still_returns_output_and_records_error(tmp_path):
@@ -1918,7 +1918,7 @@ def test_finalize_flow_artifact_write_failure_is_split_from_finalize_error(tmp_p
     assert len(finalize_calls) == 1
 
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
+# Helpers
 
 
 def _asyncio_coro(value):

--- a/tests/cli/orchestrate/test_flow_planning.py
+++ b/tests/cli/orchestrate/test_flow_planning.py
@@ -400,7 +400,7 @@ async def test_workers_override_keeps_role_modes(tmp_path):
     assert "adversarial" in out  # role behaviour preserved, not stripped like --bare
 
 
-# ── pack routing ─────────────────────────────────────────────────────────
+# pack routing
 
 
 def _pack_env(tmp_path, orc, pack_yaml: str) -> SimpleNamespace:

--- a/tests/cli/orchestrate/test_flow_spec_file.py
+++ b/tests/cli/orchestrate/test_flow_spec_file.py
@@ -193,7 +193,7 @@ class TestLoadFlowSpec:
         assert "spec file must contain a YAML/JSON object" in caplog.text
 
 
-# ── Playbook resolution ─────────────────────────────────────────────
+# Playbook resolution
 
 
 class TestResolvePlaybookPath:
@@ -262,7 +262,7 @@ class TestResolvePlaybookPath:
         assert err is None
         assert p.read_text() == "prompt: project\n"
 
-    # ── Adversarial traversal shapes — the path validator must still hold ──
+    # Adversarial traversal shapes — the path validator must still hold
 
     def test_rejects_dotdot_component(self):
         p, err = _resolve_playbook_path("../x")
@@ -300,7 +300,7 @@ class TestResolvePlaybookPath:
         assert "bare identifier" in err
 
 
-# ── argument-hint parser ─────────────────────────────────────────────
+# argument-hint parser
 
 
 class TestArgumentHintParser:
@@ -329,7 +329,7 @@ class TestArgumentHintParser:
         assert _parse_argument_hint(None) == {}
 
 
-# ── Type coercion ────────────────────────────────────────────────────
+# Type coercion
 
 
 class TestCoerceArgValue:
@@ -354,7 +354,7 @@ class TestCoerceArgValue:
         assert err is None and v is None
 
 
-# ── Prompt interpolation ─────────────────────────────────────────────
+# Prompt interpolation
 
 
 class TestInterpolatePrompt:
@@ -391,7 +391,7 @@ class TestInterpolatePrompt:
         assert out == "{missing} thing."
 
 
-# ── End-to-end via run_orchestrate ───────────────────────────────────
+# End-to-end via run_orchestrate
 
 
 class TestPlaybookEndToEnd:
@@ -770,7 +770,7 @@ class TestPlaybookEndToEnd:
         assert code == 1
 
 
-# ── ADR-0064: artifacts: block pass-through ───────────────────────────────────
+# ADR-0064: artifacts: block pass-through
 
 
 class TestPlaybookArtifactsPassThrough:

--- a/tests/cli/orchestrate/test_flow_terminal_notify.py
+++ b/tests/cli/orchestrate/test_flow_terminal_notify.py
@@ -25,7 +25,7 @@ from lionagi.cli.orchestrate._orchestration import OrchestrationEnv
 from lionagi.cli.orchestrate.flow import _run_flow
 from lionagi.state.db import StateDB
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -92,7 +92,7 @@ def _write_project_settings(project_dir: Path, on_terminal) -> None:
     (lionagi_dir / "settings.yaml").write_text(yaml.dump({"notify": {"on_terminal": on_terminal}}))
 
 
-# ── Tests ─────────────────────────────────────────────────────────────────────
+# Tests
 
 
 async def test_run_flow_notify_fires_with_correct_legacy_payload(

--- a/tests/cli/orchestrate/test_flowop_budget.py
+++ b/tests/cli/orchestrate/test_flowop_budget.py
@@ -20,7 +20,7 @@ from lionagi.cli.orchestrate.flow import (
     op_budget_share,
 )
 
-# ── _format_budget_preamble ────────────────────────────────────────────────
+# _format_budget_preamble
 
 
 def test_format_budget_preamble_contains_expected_fields():
@@ -87,7 +87,7 @@ def test_format_budget_preamble_index_and_count():
     assert "60 seconds" in text
 
 
-# ── Critical-path depth ────────────────────────────────────────────────────
+# Critical-path depth
 #
 # These call the shipped functions rather than a copy of their arithmetic. The
 # previous version of this section defined its own `_equal_split` helper and
@@ -145,7 +145,7 @@ def test_share_falls_back_to_the_op_count_without_dependency_data():
     assert op_budget_share(600, [], 3) == 200
 
 
-# ── The concurrency cap serializes ops the dependency graph says are parallel ──
+# The concurrency cap serializes ops the dependency graph says are parallel
 #
 # Depth alone is not a lower bound on makespan. `--max-concurrent 1` runs four
 # independent ops one after another, and a share computed from depth 1 hands
@@ -199,7 +199,7 @@ def test_share_treats_a_non_positive_cap_as_unbounded():
     assert op_budget_share(900, [[], [], [], [0, 1, 2]], 4) == 450
 
 
-# ── Where the two bounds interact ───────────────────────────────────────────
+# Where the two bounds interact
 #
 # A dependency does not only lengthen the chain, it idles capacity while it is
 # unsatisfied, and the ops it blocks have to be picked up later. Counting
@@ -267,7 +267,7 @@ def test_an_empty_plan_has_no_depth():
     assert max_sequential_depth([], 0, 2) == 0
 
 
-# ── The share an op is actually told ────────────────────────────────────────
+# The share an op is actually told
 #
 # `op_budget_share` being right says nothing about whether the flow uses it.
 # The equal-split divisor this PR removes survived a green suite for exactly
@@ -338,7 +338,7 @@ def test_the_flow_builds_its_preambles_through_the_shared_helper():
     )
 
 
-# ── the deadline instant is captured, not recomputed ───────────────────────
+# the deadline instant is captured, not recomputed
 
 
 def test_no_preambles_without_a_captured_deadline_instant():
@@ -490,7 +490,7 @@ def test_no_budget_preamble_when_total_budget_none():
     assert preambles == {}
 
 
-# ── OrchestrationEnv.total_budget ─────────────────────────────────────────
+# OrchestrationEnv.total_budget
 
 
 def test_orchestration_env_has_total_budget_field():

--- a/tests/cli/orchestrate/test_flowop_budget_vs_executor.py
+++ b/tests/cli/orchestrate/test_flowop_budget_vs_executor.py
@@ -3,54 +3,44 @@
 
 """Does the budget's divisor cover every schedule the executor can produce?
 
-`op_budget_share` divides a flow's total budget by `max_sequential_depth`, so a
-divisor that lands BELOW what the executor actually consumes hands every op more
-time than the flow can afford, and the flow overruns its deadline with later ops
-cancelled part-written. Every other test of that function checks its arithmetic
-against a hand-computed number, which cannot see whether the executor agrees.
-These run the executor.
+`op_budget_share` divides a flow's total budget by `max_sequential_depth`; a
+divisor landing BELOW what the executor actually consumes hands every op more
+time than the flow can afford, overrunning the deadline with later ops
+cancelled part-written. Every other test of that function checks its
+arithmetic against a hand-computed number, which cannot see whether the
+executor agrees -- these run the executor, through the real `flow()` entry
+point production uses. Only the work inside an op belongs to the test.
 
-The scheduling here is real: the same `flow()` entry point production uses. Only
-the work inside an op belongs to the test, and how long that work takes is the
-whole point. An earlier version slept a FIXED amount in every op, which held the
-equal-duration assumption the divisor used to be built on, so it agreed with a
-divisor that undercounted and read as coverage while doing it. Durations here
+An earlier version slept a FIXED amount in every op, which held the
+equal-duration assumption the divisor was built on and so agreed with a
+divisor that undercounted, reading as coverage while doing it. Durations here
 are deliberately unequal, and each shape is swept with the long op in every
-admission position, because a long-running op holding a slot is what makes the
+admission position, since a long-running op holding a slot is what makes the
 ops behind it serialize.
 
-WHAT IS MEASURED, AND WHY IT CHANGED
-------------------------------------
 Every op sleeps exactly one budget unit in the primary pattern, so elapsed
-wall clock divided by that unit is literally the number of op-budgets the flow
-consumed. That is the quantity the divisor bounds: the flow overruns precisely
-when consumption exceeds the divisor.
+wall clock divided by that unit is literally the number of op-budgets
+consumed -- the quantity the divisor bounds: the flow overruns precisely when
+consumption exceeds the divisor.
 
-This replaces an earlier reading that took the longest chain of non-overlapping
-spans. That quantity is not the same one, and it is wrong in BOTH directions:
+This replaces an earlier reading that took the longest chain of
+non-overlapping spans, which is wrong in both directions. It OVER-counts:
+two ops separated by an idle gap are non-overlapping while consuming no
+budget in between, so a chain across a gap some third op owns reads as extra
+free stages (measured: deps [[], [0], [0], [1], [2]] under a cap of 3 with
+one slow op reads a chain of 4, while the same shape at full budget consumes
+3). It UNDER-counts: two ops overlapping by half consume one and a half
+budgets at a chain length of 1. Because the span reading over-counts, it
+would have failed this suite on shapes that do not overrun -- a false alarm
+in a test whose whole job is to be believed.
 
-  it OVER-counts   two ops separated by an idle gap are non-overlapping while
-                   consuming no budget in between, so a chain across a gap that
-                   some third op owns reads as extra stages that cost nothing.
-                   Measured: deps [[], [0], [0], [1], [2]] under a cap of 3 with
-                   one slow op reads a chain of 4, while the same shape with
-                   every op at a full budget consumes 3.
-
-  it UNDER-counts  two ops overlapping by half consume one and a half budgets
-                   at a chain length of 1.
-
-Because the span reading over-counts, it would have failed this suite on shapes
-that do not overrun — a false alarm waiting for a future author, in a test whose
-whole job is to be believed.
-
-THE INSTRUMENT PRICES ITSELF
-----------------------------
 A straight chain consumes exactly one budget per op by construction, so it
-measures this machine's per-op executor overhead in the same units everything
-else is reported in. The work unit has to stay well above that overhead: at
-0.15s the ~5ms per-op cost perturbs which ops get admitted together, so the
-instrument changes the schedule it is measuring and readings move by a whole
-budget between runs. At the unit below, readings sit within 0.06 of an integer.
+also measures this machine's per-op executor overhead in the same units
+everything else is reported in. The work unit has to stay well above that
+overhead: at 0.15s the ~5ms per-op cost perturbs which ops get admitted
+together, so the instrument changes the schedule it is measuring and
+readings move by a whole budget between runs. At the unit below, readings
+sit within 0.06 of an integer.
 """
 
 import asyncio
@@ -209,7 +199,7 @@ async def _run_real_flow(
     return max(finished_at) / BUDGET, peak
 
 
-# --- Instrument controls -------------------------------------------------
+# Instrument controls.
 #
 # Both have an answer that is true by construction rather than by measurement.
 # If either misreads, the timing instrument is not fit to judge anything below
@@ -235,7 +225,7 @@ async def test_independent_ops_fill_the_cap_and_no_more():
     assert consumed == pytest.approx(2, abs=TOLERANCE)
 
 
-# --- The claim -----------------------------------------------------------
+# The claim.
 #
 # Neither pinned number is derived from the function under test. `divisor` is
 # what the function returns today and `consumed` is what the executor was

--- a/tests/cli/orchestrate/test_live_persist.py
+++ b/tests/cli/orchestrate/test_live_persist.py
@@ -22,7 +22,7 @@ from lionagi.cli.orchestrate._orchestration import (
 )
 from lionagi.state.db import StateDB
 
-# ── Fixtures ──────────────────────────────────────────────────────────────────
+# Fixtures
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ def _minimal_env(orc_branch: Branch | None = None) -> OrchestrationEnv:
     )
 
 
-# ── start_live_persist: happy path + invariants ───────────────────────────────
+# start_live_persist: happy path + invariants
 
 
 async def test_start_creates_session_and_registers_hook_on_orc_branch(
@@ -184,7 +184,7 @@ async def test_orchestration_manifest_tracks_start_and_terminal_status(
     assert completed["ended_at"] >= completed["started_at"]
 
 
-# ── start_live_persist: failure path closes the DB ────────────────────────────
+# start_live_persist: failure path closes the DB
 
 
 async def test_start_create_session_failure_closes_db(
@@ -221,7 +221,7 @@ async def test_start_create_session_failure_closes_db(
     )
 
 
-# ── _register_branch_hook: lazy branch row + multi-message paths ──────────────
+# _register_branch_hook: lazy branch row + multi-message paths
 
 
 async def test_register_branch_hook_creates_row_on_first_message(
@@ -506,7 +506,7 @@ async def test_hook_updates_system_msg_id_when_system_replaced(
     await stop_live_persist(env, status="completed")
 
 
-# ── stop_live_persist: invariants ─────────────────────────────────────────────
+# stop_live_persist: invariants
 
 
 async def test_stop_updates_session_bookmarks_and_status(
@@ -760,7 +760,7 @@ async def test_stop_with_none_context_is_noop(temp_db_path: Path):
     await stop_live_persist(env, status="completed")  # MUST NOT raise
 
 
-# ── End-to-end: no aiosqlite thread leak ──────────────────────────────────────
+# End-to-end: no aiosqlite thread leak
 
 
 async def test_start_stop_does_not_leak_aiosqlite_thread(temp_db_path: Path):
@@ -793,7 +793,7 @@ async def test_start_stop_does_not_leak_aiosqlite_thread(temp_db_path: Path):
         )
 
 
-# ── lazy _ensure_branch_row retry after first-init failure ───────────────────
+# lazy _ensure_branch_row retry after first-init failure
 
 
 async def test_ensure_branch_row_retries_after_transient_failure(
@@ -854,7 +854,7 @@ async def test_ensure_branch_row_retries_after_transient_failure(
     await stop_live_persist(env, status="completed")
 
 
-# ── finalize_orchestration() and stop_live_persist() DAG paths ───────────────
+# finalize_orchestration() and stop_live_persist() DAG paths
 
 
 def dag_extras() -> dict:
@@ -895,7 +895,7 @@ def _mock_chat_model(branch: Branch) -> None:
     branch._imodel_manager.registry["chat"] = mock
 
 
-# ── Test 2.1 — finalize returns branch_ids and writes branch snapshots ─────────
+# Test 2.1 — finalize returns branch_ids and writes branch snapshots
 
 
 def test_finalize_returns_branch_ids_and_writes_branch_snapshots(
@@ -942,7 +942,7 @@ def test_finalize_returns_branch_ids_and_writes_branch_snapshots(
     assert hints == []
 
 
-# ── Test 2.2 — finalize stores dag extras for live persist teardown ────────────
+# Test 2.2 — finalize stores dag extras for live persist teardown
 
 
 def test_finalize_stores_dag_extras_for_live_persist_teardown(
@@ -1034,7 +1034,7 @@ def test_finalize_omits_khive_injection_stats_without_registered_providers(
     assert "khive_injection" not in env._finalize_extras
 
 
-# ── Test 2.3 — finalize emits resume hints for orchestrator and workers ────────
+# Test 2.3 — finalize emits resume hints for orchestrator and workers
 
 
 def test_finalize_emits_resume_hints_for_orchestrator_and_workers(
@@ -1070,7 +1070,7 @@ def test_finalize_emits_resume_hints_for_orchestrator_and_workers(
     assert critic_hint is not None and str(critic.id) in critic_hint
 
 
-# ── Test 2.4 — snapshot write failure logs warning and continues ────────────────
+# Test 2.4 — snapshot write failure logs warning and continues
 
 
 def test_finalize_snapshot_write_failure_logs_warning_and_continues(
@@ -1122,7 +1122,7 @@ def test_finalize_snapshot_write_failure_logs_warning_and_continues(
     assert any("finalize: branch snapshot write failed" in rec.message for rec in caplog.records)
 
 
-# ── Test 2.5 — stop persists finalize extras without messages ─────────────────
+# Test 2.5 — stop persists finalize extras without messages
 
 
 async def test_stop_persists_finalize_extras_as_session_node_metadata_without_messages(
@@ -1147,7 +1147,7 @@ async def test_stop_persists_finalize_extras_as_session_node_metadata_without_me
     assert s["ended_at"] is not None
 
 
-# ── Test 2.6 — stop persists dag metadata and message bookmarks together ───────
+# Test 2.6 — stop persists dag metadata and message bookmarks together
 
 
 async def test_stop_persists_dag_metadata_and_message_bookmarks_together(
@@ -1189,7 +1189,7 @@ async def test_stop_persists_dag_metadata_and_message_bookmarks_together(
     assert all(h is not hook for h in worker.on_message_added)
 
 
-# ── Test 2.7 — stop without finalize extras leaves node_metadata unchanged ────
+# Test 2.7 — stop without finalize extras leaves node_metadata unchanged
 
 
 async def test_stop_without_finalize_extras_leaves_existing_node_metadata_unchanged(
@@ -1214,7 +1214,7 @@ async def test_stop_without_finalize_extras_leaves_existing_node_metadata_unchan
     assert after["status"] == "completed"
 
 
-# ── Test 2.8 — stop: get_progression failure logs and closes db ───────────────
+# Test 2.8 — stop: get_progression failure logs and closes db
 
 
 async def test_stop_get_progression_failure_logs_and_closes_db(
@@ -1242,7 +1242,7 @@ async def test_stop_get_progression_failure_logs_and_closes_db(
     assert any("progression unavailable" in rec.message for rec in caplog.records)
 
 
-# ── Test 2.9 — stop: close failure logs warning and clears context ────────────
+# Test 2.9 — stop: close failure logs warning and clears context
 
 
 async def test_stop_close_failure_logs_warning_and_clears_context(
@@ -1270,7 +1270,7 @@ async def test_stop_close_failure_logs_warning_and_clears_context(
     assert any("close failed" in rec.message for rec in caplog.records)
 
 
-# ── Test 2.10 — stop persists cancelled status with dag metadata ───────────────
+# Test 2.10 — stop persists cancelled status with dag metadata
 
 
 async def test_stop_persists_cancelled_status_with_dag_metadata(
@@ -1319,7 +1319,7 @@ async def test_stop_persists_cancelled_status_with_dag_metadata(
     assert worker_row["ended_at"] is not None
 
 
-# ── ADR-0064: artifact contract snapshot and verification ─────────────────────
+# ADR-0064: artifact contract snapshot and verification
 
 
 async def test_start_persists_artifact_contract(
@@ -1433,7 +1433,7 @@ async def test_stop_verification_preserves_non_completed_reason(
     assert v["status"] == "failed"
 
 
-# ── issue #2053: post-completion finalize error must not flip a successful DAG ──
+# A post-completion finalize error must not flip a successful DAG.
 
 
 async def test_stop_finalize_error_stays_completed_with_distinct_reason(
@@ -1490,7 +1490,7 @@ async def test_stop_finalize_error_does_not_override_real_dag_failure_reason(
     assert s["status_reason_code"] == "run.failed.exception"
 
 
-# ── output-write failure is a real failure, not a finalize hiccup ─────────────
+# output-write failure is a real failure, not a finalize hiccup
 
 
 async def test_stop_artifact_write_error_flips_completed_to_failed_with_distinct_reason(
@@ -1549,7 +1549,7 @@ async def test_stop_artifact_write_error_does_not_override_real_dag_failure_reas
     assert s["status_reason_code"] == "run.failed.exception"
 
 
-# ── ADR-0064 + ADR-0057: session→invocation propagation on missing artifact ──
+# ADR-0064 + ADR-0057: session→invocation propagation on missing artifact
 #
 # The tests above prove the *session* row flips to failed/FAILED_MISSING_ARTIFACT.
 # A multi-leg `li play`/`li o flow` run is read by callers (Studio, `li status`,
@@ -2175,17 +2175,17 @@ async def test_all_legs_completed_resolves_invocation_completed(
 async def test_child_finalize_error_surfaces_at_invocation_not_flattened_to_ok(
     temp_db_path: Path,
 ):
-    """issue #2053, seam 2: a child session can be "completed" (its own DAG
-    produced its result) while carrying a COMPLETED_FINALIZE_ERROR reason
-    (a guarded best-effort teardown step -- team post, snapshot, resume
-    pointer, graph -- failed). _resolve_invocation_terminal_flow must not
-    flatten that into plain COMPLETED_OK: a reader of the invocation record
-    needs to see the same degraded-but-not-failed distinction the child
-    record already carries, not a false "all clean" signal.
+    """A child session can be "completed" (its own DAG produced its result)
+    while carrying a COMPLETED_FINALIZE_ERROR reason (a guarded best-effort
+    teardown step -- team post, snapshot, resume pointer, graph -- failed).
+    _resolve_invocation_terminal_flow must not flatten that into plain
+    COMPLETED_OK: a reader of the invocation record needs to see the same
+    degraded-but-not-failed distinction the child record already carries,
+    not a false "all clean" signal.
 
-    This must FAIL against the pre-fix resolver, which only inspects
-    child_statuses (all "completed") and returns RunReasons.COMPLETED_OK
-    regardless of status_reason_code.
+    A resolver that only inspects child_statuses (all "completed") and
+    returns RunReasons.COMPLETED_OK regardless of status_reason_code would
+    fail this.
     """
     from lionagi.cli.orchestrate.flow import _resolve_invocation_terminal_flow
     from lionagi.state.reasons import RunReasons
@@ -2254,14 +2254,14 @@ async def test_child_finalize_error_surfaces_at_invocation_not_flattened_to_ok(
 async def test_finalize_side_effects_guarded_independently(
     temp_db_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """issue #2053, secondary: the best-effort finalize side effects (team
-    post, snapshot/resume-pointer, graph image) must each be guarded on
-    their own -- a raising team post must not skip the snapshot/resume
-    pointer step that runs after it.
+    """The best-effort finalize side effects (team post, snapshot/resume-
+    pointer, graph image) must each be guarded on their own -- a raising
+    team post must not skip the snapshot/resume pointer step that runs
+    after it.
 
-    This must FAIL against the pre-fix code, where all three shared one
-    try/except: the first raise (team post) skipped `finalize_orchestration`
-    entirely, so no session snapshot/resume pointer was ever written.
+    Code that shares one try/except across all three would fail this: the
+    first raise (team post) would skip `finalize_orchestration` entirely,
+    so no session snapshot/resume pointer would ever be written.
     """
     from types import SimpleNamespace
     from unittest.mock import patch
@@ -2350,24 +2350,24 @@ async def test_finalize_side_effects_guarded_independently(
     assert node_metadata["agents"][0]["id"] == "op1"
 
 
-# ── bench545 regressions: plan-time per-leg wiring + escalation backstop ──────
+# Plan-time per-leg wiring + escalation backstop.
 #
-# Both tests below reproduce the actual production gap (play fe9a23ac,
-# artifacts under bench545): the play-level artifact_contract was NULL for
-# the WHOLE run — nothing at plan time ever populated a per-leg contract, so
-# the tests above (which hand-build a `contract` and pass it to
-# start_live_persist directly) do not exercise the gap itself. These two
-# start with NO contract, exactly like bench545, and drive the real
-# _build_dag / _execute_dag phase functions to prove the wiring — not just a
-# role-profile declaration nobody consults — is what closes it.
+# Both tests below reproduce an observed production gap: the play-level
+# artifact_contract was NULL for the whole run — nothing at plan time ever
+# populated a per-leg contract, so the tests above (which hand-build a
+# `contract` and pass it to start_live_persist directly) do not exercise the
+# gap itself. These two start with no contract, exactly like that run, and
+# drive the real _build_dag / _execute_dag phase functions to prove the
+# wiring — not just a role-profile declaration nobody consults — is what
+# closes it.
 
 
 async def test_build_dag_wires_role_artifact_defaults_into_live_contract_and_fails_loud(
     temp_db_path: Path,
     tmp_path: Path,
 ):
-    """A path: no whole-flow contract is declared (play-level NULL, as in
-    bench545). The only source of a per-leg contract is the resolved
+    """A path: no whole-flow contract is declared (play-level NULL, as
+    observed in production). The only source of a per-leg contract is the resolved
     worker's own casts Role (no committed AgentProfile file exists in this
     repo, so w_profile is always None in practice — the role fallback IS the
     real path). _build_dag must itself populate the live contract from the
@@ -2389,7 +2389,7 @@ async def test_build_dag_wires_role_artifact_defaults_into_live_contract_and_fai
     )
     ctx = env._live_persist
     assert ctx is not None
-    assert ctx["artifact_contract"] is None  # bench545 starting state
+    assert ctx["artifact_contract"] is None  # matches the observed production starting state
 
     assignments = [TaskAssignment(task="review the PR", assignee="reviewer")]
     plan_result = _PlanResult(
@@ -2414,8 +2414,8 @@ async def test_build_dag_wires_role_artifact_defaults_into_live_contract_and_fai
     assert entry["path"] == "reviewer/review.md"
     assert entry["required"] is True
 
-    # ...and the session row itself carries it — the exact field bench545
-    # showed stuck at NULL for the whole play.
+    # ...and the session row itself carries it — the exact field the
+    # production run showed stuck at NULL for the whole play.
     async with StateDB() as db:
         s = await db.get_session(ctx["session_id"])
     assert s is not None
@@ -2826,12 +2826,13 @@ async def test_execute_dag_bounds_escalation_link_drain_on_cancellation(
     temp_db_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Round-3 regression: when ``_execute_dag`` itself is cancelled, the
-    shielded finally used to gather ``_escalation_link_tasks`` with no cancel
-    and no timeout — a link write that never returns (hung DB call, stuck
-    await) blocked teardown forever. The drain must now be bounded on the
-    cancellation path: give an in-flight link a short grace period, then
-    cancel it and confirm it actually unwinds before returning."""
+    """Escalation-link drain must be bounded, not just guarded — see
+    docs/internals/cli.md's `_orchestration.py` section. A shielded finally
+    that gathers ``_escalation_link_tasks`` with no cancel and no timeout
+    lets a link write that never returns (hung DB call, stuck await) block
+    teardown forever. This drives cancellation into ``_execute_dag`` itself
+    and confirms an in-flight link gets a short grace period, then is
+    cancelled and actually unwinds before returning."""
     import time
     from types import SimpleNamespace
     from unittest.mock import patch
@@ -2917,24 +2918,23 @@ async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
     temp_db_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """A cancellation landing on ``_execute_dag`` itself after ``run_dag()``
-    already returned lands while the finally is inside its own drain
-    gather, where the except that sets ``_dag_cancelled`` never ran — so
-    that flag stays False, and this is the branch that must bound the
-    drain on its own, not just when cancellation lands mid-``run_dag()``.
+    """Covers the OTHER route into the drain (see docs/internals/cli.md's
+    `_orchestration.py` section): cancellation landing after ``run_dag()``
+    already returned, inside the finally's own drain gather, where the
+    except that sets ``_dag_cancelled`` never runs — that flag stays False,
+    so this branch must bound the drain on its own, independent of the
+    mid-``run_dag()`` case.
 
-    A link task that responds to a *single* cancellation is not enough to
-    exercise this: ``asyncio.gather()``'s own cancellation only needs the
-    one child to unwind once, so a bare, unguarded gather already handles
-    it without any except/drain machinery. This link task instead swallows
-    the *first* cancellation it receives and only unwinds on a second one —
-    a bare gather with no except and no bounded drain genuinely hangs
-    forever on a single external cancel against a task like this, because
-    ``asyncio.gather()`` doesn't settle its own cancellation until every
-    child actually finishes, and a raw ``Task.cancel()`` only delivers once.
-    Verified by temporarily reverting the shield+drain handling below back
-    to that bare-gather shape and running this exact test: it timed out at
-    the 8s deadline instead of finishing at ~2s."""
+    A link task that responds to a single cancellation would not exercise
+    this: ``asyncio.gather()``'s own cancellation only needs one child to
+    unwind once, so a bare, unguarded gather already handles that case. This
+    link task instead swallows the first cancellation it receives and only
+    unwinds on a second one — confirmed by temporarily reverting the
+    shield+drain handling below to a bare-gather shape and re-running this
+    exact test: it timed out at the 8s deadline instead of finishing at
+    ~2s, because ``asyncio.gather()`` doesn't settle its own cancellation
+    until every child finishes, and a raw ``Task.cancel()`` only delivers
+    once."""
     import time
     from types import SimpleNamespace
     from unittest.mock import patch
@@ -2993,8 +2993,9 @@ async def test_execute_dag_bounds_escalation_link_drain_on_late_cancellation(
         on_op_complete = kwargs.get("on_op_complete")
         if on_op_complete is not None:
             on_op_complete(node)
-        # Returns normally — unlike the round-3 test, cancellation has not
-        # landed yet, so the except that sets _dag_cancelled never fires.
+        # Returns normally — unlike the mid-run_dag() cancellation case,
+        # cancellation has not landed yet, so the except that sets
+        # _dag_cancelled never fires.
         return {"operation_results": {}, "spawned_operations": 0, "escalated_operations": []}
 
     engine_run = SimpleNamespace(run_dag=run_dag)
@@ -3029,34 +3030,26 @@ async def test_execute_dag_bounds_escalation_link_drain_survivor_await(
     temp_db_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """``_drain_escalation_links_bounded`` gives in-flight links a grace
-    period, then cancels whatever survived and awaits the survivors — that
-    second await used to have no bound at all, so a link task that never
-    responds to that cancellation would hang it forever, the same class of
-    bug the grace period was added to fix in the first place, just moved
-    one step later. The fix bounds that second await too (a second short
-    grace window) and abandons anything still alive after it, logging how
-    many.
+    """The survivor-await step of ``_drain_escalation_links_bounded`` (see
+    docs/internals/cli.md's `_orchestration.py` section) needs its own bound:
+    after the first grace period, whatever survived gets cancelled and
+    awaited, and that second await must not itself be unbounded.
 
-    Caveat verified while building this test: this specific link task
-    (needs two cancellation deliveries to unwind) exercises the full drain
-    sequence — grace-period gather, explicit cancel of survivors, second
-    bounded gather — end to end, and the whole thing stays comfortably
-    inside the hard deadline below. It does not, on its own, prove the
-    second window's *bound* is load-bearing for this exact shape: anyio's
-    cancel scope keeps re-delivering cancellation for as long as a task
-    keeps re-suspending on a fresh awaitable, so a finite swallow count
-    (however large) tends to resolve inside the *first* grace window rather
-    than surviving into the second. A link task that never responds to
-    cancellation at all defeats both grace windows identically (confirmed
-    empirically: neither the first nor the second `move_on_after` returns
-    control while such a task stays alive) — there is no way to construct a
-    task that reliably survives window one but is bounded by window two, so
-    this test cannot safely isolate that distinction. What it does verify:
-    the drain sequence introduced by this fix does not regress a link task
-    that needs more than a single cancellation to unwind, and the
-    abandonment logic
-    does not itself hang anything."""
+    This exercises the full drain sequence end to end — grace-period gather,
+    explicit cancel of survivors, second bounded gather — with a link task
+    that needs two cancellation deliveries to unwind, and confirms the whole
+    thing stays inside the hard deadline below. It does NOT isolate whether
+    the second window's bound specifically is load-bearing for this shape:
+    anyio's cancel scope keeps re-delivering cancellation as long as a task
+    keeps re-suspending on a fresh awaitable, so a finite swallow count tends
+    to resolve inside the first grace window rather than surviving into the
+    second, and a link task that never responds to cancellation at all
+    defeats both windows identically (confirmed empirically — neither
+    `move_on_after` returns control while such a task stays alive). There is
+    no task shape that reliably survives window one but is bounded by window
+    two, so this test cannot isolate that distinction; it verifies the drain
+    sequence doesn't regress a link task needing more than one cancellation,
+    and that the abandonment logging doesn't itself hang."""
     import time
     from types import SimpleNamespace
     from unittest.mock import patch
@@ -3419,7 +3412,7 @@ async def test_execute_dag_escalation_backstop_catches_reactively_spawned_node(
     assert s["status_reason_code"] == "run.failed.escalated"
 
 
-# ── Node-failure backstop ──────────────────────────────────────────────────────
+# Node-failure backstop
 #
 # A flow whose final node died could still report succeeded: an operation's
 # invoke() raised, DependencyAwareExecutor caught it and set that node's own

--- a/tests/cli/orchestrate/test_manifest.py
+++ b/tests/cli/orchestrate/test_manifest.py
@@ -49,7 +49,7 @@ def _dump_json(tmp_path, data, name="manifest.json"):
     return _write(tmp_path / name, json.dumps(data))
 
 
-# ── success cases ───────────────────────────────────────────────────────
+# success cases
 
 
 def test_minimal_manifest_loads(tmp_path):
@@ -116,7 +116,7 @@ def test_yaml_and_json_parity(tmp_path):
     assert from_yaml == from_json
 
 
-# ── snapshot semantics ──────────────────────────────────────────────────
+# snapshot semantics
 
 
 def test_brief_edit_after_load_has_no_effect(tmp_path):
@@ -151,7 +151,7 @@ def test_manifest_edit_after_load_has_no_effect(tmp_path):
     assert manifest.legs[0].label == "leg-a"
 
 
-# ── top-level schema ────────────────────────────────────────────────────
+# top-level schema
 
 
 def test_manifest_path_must_be_absolute(tmp_path):
@@ -257,7 +257,7 @@ def test_legs_at_ceiling_accepted(tmp_path):
     assert len(manifest.legs) == MAX_LEGS
 
 
-# ── defaults ─────────────────────────────────────────────────────────────
+# defaults
 
 
 def test_defaults_rejects_unknown_key(tmp_path):
@@ -276,7 +276,7 @@ def test_defaults_rejects_model_and_agent_together(tmp_path):
         load_manifest(manifest_path)
 
 
-# ── leg schema ──────────────────────────────────────────────────────────
+# leg schema
 
 
 def test_leg_rejects_unknown_key(tmp_path):
@@ -363,7 +363,7 @@ def test_timeout_at_ceiling_accepted(tmp_path):
     assert manifest.legs[0].timeout == MAX_TIMEOUT_SECONDS
 
 
-# ── label ───────────────────────────────────────────────────────────────
+# label
 
 
 @pytest.mark.parametrize(
@@ -417,7 +417,7 @@ def test_label_collision_after_lowercasing_refused(tmp_path):
         load_manifest(manifest_path)
 
 
-# ── brief ───────────────────────────────────────────────────────────────
+# brief
 
 
 def test_brief_must_be_absolute(tmp_path):
@@ -465,7 +465,7 @@ def test_brief_symlink_is_resolved(tmp_path):
     assert manifest.legs[0].brief_bytes == b"real content\n"
 
 
-# ── cwd ─────────────────────────────────────────────────────────────────
+# cwd
 
 
 def test_cwd_must_be_absolute(tmp_path):
@@ -494,7 +494,7 @@ def test_cwd_must_be_a_directory_not_a_file(tmp_path):
         load_manifest(manifest_path)
 
 
-# ── env ─────────────────────────────────────────────────────────────────
+# env
 
 
 def test_env_map_loads_as_sorted_pairs_with_verbatim_values(tmp_path):
@@ -578,7 +578,7 @@ def test_env_in_defaults_is_refused_as_unknown_key(tmp_path):
         load_manifest(manifest_path)
 
 
-# ── raw-document strictness and snapshot identity ───────────────────────
+# raw-document strictness and snapshot identity
 
 
 def test_shared_brief_literal_is_read_once_with_one_snapshot(tmp_path, monkeypatch):

--- a/tests/cli/orchestrate/test_messenger_wiring.py
+++ b/tests/cli/orchestrate/test_messenger_wiring.py
@@ -401,7 +401,7 @@ async def test_unbound_worker_operate_does_not_serialize_any_tool_schema(tmp_pat
     assert not captured.get("tool_schemas")
 
 
-# ── Team-coordination prompt selection ─────────────────────────────────────
+# Team-coordination prompt selection
 #
 # Regression coverage for the two-channel contradiction: a team-mode worker
 # prompt must describe exactly one coordination channel — the in-process
@@ -511,7 +511,7 @@ async def test_cli_worker_branch_prompt_has_bash_channel_only(tmp_path):
         assert marker not in prompt
 
 
-# ── Mixed-provider teams: messenger roster must match actual reachability ──
+# Mixed-provider teams: messenger roster must match actual reachability
 #
 # In a heterogeneous --workers pool (some CLI-provider specs, some API
 # specs) under team mode, only the API workers end up messenger-bound. A
@@ -614,9 +614,8 @@ async def test_messenger_bound_worker_prompt_flags_cli_teammate_end_to_end(tmp_p
     assert "Unknown recipient" in prompt
 
 
-# ── Attached-team history: messenger-bound workers can't live-poll the
+# Attached-team history: messenger-bound workers can't live-poll the
 # persisted file, so prior messages must be surfaced to them some other way
-# ─────────────────────────────────────────────────────────────────────────
 #
 # `--team-attach` loads an existing team's persisted messages (li team's
 # file channel). A bash-channel worker can still `li team receive` live and
@@ -726,7 +725,7 @@ async def test_messenger_bound_worker_system_prompt_excludes_attached_history_en
     assert "kickoff broadcast" in [m["content"] for m in ctx["prior_team_messages"]["messages"]]
 
 
-# ── Coordinator reachability: the orchestrator is not a messenger target ───
+# Coordinator reachability: the orchestrator is not a messenger target
 #
 # The roster line for "orchestrator" is the one entry team_worker_system()
 # always emits without going through the messenger_names reachability

--- a/tests/cli/orchestrate/test_orchestration_default_agent.py
+++ b/tests/cli/orchestrate/test_orchestration_default_agent.py
@@ -204,7 +204,7 @@ async def test_the_default_does_not_fire_when_a_modelless_agent_was_named(monkey
     assert DEFAULT_ORCHESTRATOR_AGENT not in loaded
 
 
-# ── The resolved name has to leave the function ───────────────────────────────
+# The resolved name has to leave the function
 
 
 @pytest.fixture
@@ -286,7 +286,7 @@ async def test_the_carried_name_is_the_loaded_profiles_own(completing_setup, mon
     assert env.orc_profile_name == "orchestrator"
 
 
-# ── …and reach the record a later reader has ──────────────────────────────────
+# …and reach the record a later reader has
 
 
 @pytest.fixture

--- a/tests/cli/orchestrate/test_security_hardening.py
+++ b/tests/cli/orchestrate/test_security_hardening.py
@@ -25,7 +25,7 @@ def _parse_flow_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(["o", "flow", *argv])
 
 
-# ── Spec field validation ─────────────────────────────────────────────────────
+# Spec field validation
 
 
 class TestSpecValidationRejectsBadTypes:
@@ -132,7 +132,7 @@ class TestSpecValidationRejectsBadTypes:
         err = _validate_spec_fields({"team_mode": True})
         assert err is not None
 
-    # ── Present-null values must be rejected (YAML `null` → Python None) ──
+    # Present-null values must be rejected (YAML `null` → Python None)
 
     def test_workers_null_rejected(self):
         err = _validate_spec_fields({"workers": None})
@@ -335,7 +335,7 @@ class TestSpecValidationAcceptsValidFields:
         assert "workers" in caplog.text
 
 
-# ── Save path containment ─────────────────────────────────────────────────────
+# Save path containment
 
 
 class TestSavePathContainment:
@@ -379,7 +379,7 @@ class TestSavePathContainment:
         run_flow.assert_called_once()
 
 
-# ── ADR-0064: artifacts: field validation in _validate_spec_fields ────────────
+# ADR-0064: artifacts: field validation in _validate_spec_fields
 
 
 class TestArtifactsFieldValidation:

--- a/tests/cli/orchestrate/test_team_lifecycle_wiring.py
+++ b/tests/cli/orchestrate/test_team_lifecycle_wiring.py
@@ -63,7 +63,7 @@ class _FakeExecutor:
         return True
 
 
-# ── TeamLifecycleCoordinator: unit-level (no _execute_dag involved) ────────
+# TeamLifecycleCoordinator: unit-level (no _execute_dag involved)
 
 
 class TestTeamLifecycleCoordinatorOnDoneOnFinished:
@@ -453,7 +453,7 @@ class TestTeamLifecycleCoordinatorExchangeUnion:
         await collect_task
 
 
-# ── Source-level wiring guard (mirrors TestCoordinatorWiredAtMessengerConstruction) ──
+# Source-level wiring guard (mirrors TestCoordinatorWiredAtMessengerConstruction)
 
 
 def test_flow_wires_team_lifecycle_done_and_finished_callbacks():
@@ -464,7 +464,7 @@ def test_flow_wires_team_lifecycle_done_and_finished_callbacks():
     assert "_team_coordinator.on_finished" in src
 
 
-# ── _execute_dag integration against a fake executor (decision-logic only) ──
+# _execute_dag integration against a fake executor (decision-logic only)
 
 
 def _plan_and_dag(agent_id: str, *, worker_branches=None, messenger_bound=None):
@@ -489,7 +489,7 @@ def _plan_and_dag(agent_id: str, *, worker_branches=None, messenger_bound=None):
     return plan_result, dag_state
 
 
-# ── _execute_dag integration against the REAL ReactiveExecutor ─────────────
+# _execute_dag integration against the REAL ReactiveExecutor
 # No fake executor: PlanningEngine.new_run is unpatched, so eng_run.run_dag
 # drives the real ReactiveExecutor. Only branch.operate is stubbed.
 

--- a/tests/cli/orchestrate/test_worker_artifact_directive.py
+++ b/tests/cli/orchestrate/test_worker_artifact_directive.py
@@ -18,7 +18,7 @@ from lionagi.cli.orchestrate._orchestration import (
     collect_worker_artifacts,
 )
 
-# ── Half 1: the prompt names the directory ───────────────────────────────────
+# Half 1: the prompt names the directory
 
 # The sentence the worker prompt used to carry: a claim about text the harness
 # does not control. Its absence is the fix, so it is asserted directly.
@@ -107,7 +107,7 @@ Remain concise."""
     assert "Remain concise." in retargeted
 
 
-# ── build_worker_branch names and records each worker's artifact destination ──
+# build_worker_branch names and records each worker's artifact destination
 
 
 def _build_worker(
@@ -392,7 +392,7 @@ def test_a_reactively_spawned_branch_stops_naming_the_emitters_directory(tmp_pat
     assert str(emitter_dir) not in system_text
 
 
-# ── Half 2: the run reports where each worker actually wrote ─────────────────
+# Half 2: the run reports where each worker actually wrote
 
 
 def _env_with_dirs(dirs: dict[str, Path]) -> SimpleNamespace:


### PR DESCRIPTION
Removes decorative box-drawing comment banners, strips internal tracking references (GitHub issue numbers, an internal benchmark name, a round-count label) from docstrings and comments while preserving the behavior they describe in plain terms, and tightens the densest module/test docstrings without dropping any regression rationale. Extends docs/internals/cli.md with the live-persist finalize-error and escalation-link drain semantics that were previously only documented inline across several test docstrings in test_live_persist.py, replacing them with pointers.

No executable code changed; verified file-by-file with the AST equality guardrail before and after ruff formatting.