### PR TITLE
chore(tests): trim prose in apps_studio_server test suite

### DIFF
--- a/tests/apps_studio_server/test_admin.py
+++ b/tests/apps_studio_server/test_admin.py
@@ -105,35 +105,22 @@ def test_admin_doctor_no_db_returns_empty_health(tmp_path, monkeypatch):
 def test_db_health_reports_only_numbers_it_can_actually_measure(tmp_path, monkeypatch):
     """The payload carries no field that merely duplicates another.
 
-    ``wal_pending`` used to be returned as a second copy of ``wal_bytes``. A
-    field named for pending WAL frames invites exactly one inference, that
-    frames are waiting, and the WAL file's size cannot support it: SQLite
-    leaves a checkpointed WAL at its allocated size, so a fully checkpointed
-    store reported a large pending count forever, in the alarming direction.
+    ``wal_pending`` used to duplicate ``wal_bytes``: SQLite leaves a
+    checkpointed WAL file at its allocated size, so a fully checkpointed
+    store reported a large "pending" count forever. It was dropped rather
+    than populated correctly because the only source for a real pending
+    count is ``PRAGMA wal_checkpoint``, which performs a checkpoint rather
+    than reading one -- a health read must not become a writer against the
+    store it reports on. The test pins the whole key set, not just the
+    absence of that one name, so the next duplicate field is also caught.
 
-    It is dropped rather than populated because the only source for the number
-    is ``PRAGMA wal_checkpoint``, which does not read the pending count, it
-    performs a checkpoint. Populating the field would turn a health read into a
-    writer against the store it reports on.
-
-    Pinning the whole key set, not just the absence of that one name, is
-    deliberate: the defect was a duplicate, and the next duplicate will have a
-    different name.
-
-    ``size_alert`` and ``size_threshold_bytes`` were added later and are named
-    here on purpose. The threshold is configuration, not a measurement, and it
-    is not derivable from anything else in the payload, so without it a reader
-    cannot say whether the store is over the limit at all. ``size_alert`` is
-    arithmetically derivable once the threshold is present, which is what makes
-    it worth stating anyway: the comparison is a policy the producer owns, and a
-    reader that re-implements it can drift from the server's own predicate
-    silently, in whichever direction the mistake runs. Both come from the same
-    helper ``/api/stats`` uses, so the two surfaces agree by construction rather
-    than by two consumers happening to compute the same thing.
-
-    The rule this test enforces is unchanged: no field that merely restates
-    another. A derived field earns its place only by carrying a decision, and
-    the reason has to be written down here.
+    ``size_alert`` and ``size_threshold_bytes`` stay: the threshold is
+    configuration that cannot be derived from the rest of the payload, and
+    ``size_alert``, though arithmetically derivable once the threshold is
+    known, is kept because the comparison is a policy the producer owns --
+    a reader that re-implements it can silently drift from the server's own
+    predicate. Both come from the same helper ``/api/stats`` uses, so the
+    two surfaces agree by construction.
     """
     from lionagi.studio.services.admin import db_health
 
@@ -172,7 +159,7 @@ def test_admin_prune_rejects_empty_body(tmp_path, monkeypatch):
     assert r.status_code == 422
 
 
-# ─── _classify_phantom liveness/staleness gate (khive#1793) ──────────────────
+# _classify_phantom liveness/staleness gate
 
 
 def test_fresh_running_session_missing_artifacts_not_reaped(tmp_path):
@@ -380,7 +367,7 @@ def test_stale_session_empty_but_existing_artifact_root_not_missing_artifacts(tm
     assert reason == "process_dead"
 
 
-# ─── /api/admin/health + /api/admin/transition ───────────────────────────────
+# /api/admin/health + /api/admin/transition
 
 
 def test_admin_health_reports_status_and_health_buckets(tmp_path, monkeypatch):
@@ -549,7 +536,7 @@ def test_admin_transition_rejects_healthy_session(tmp_path, monkeypatch):
     assert "healthy" in r.json()["detail"].lower()
 
 
-# ─── health guard re-evaluated per session, not pre-computed ─────────────────
+# health guard re-evaluated per session, not pre-computed
 
 
 def test_admin_transition_guard_re_evaluates_health_per_call(tmp_path, monkeypatch):
@@ -605,7 +592,7 @@ def test_admin_transition_guard_re_evaluates_health_per_call(tmp_path, monkeypat
     assert body["skipped"] == []
 
 
-# ─── reason_code in TransitionBody ───────────────────────────────────────────
+# reason_code in TransitionBody
 
 
 def test_admin_transition_with_reason_code_succeeds(tmp_path, monkeypatch):
@@ -1033,28 +1020,21 @@ def test_a_lock_scan_does_not_block_the_loop_that_serves_every_other_request(
 ):
     """The artifact walk runs off the event loop, so other requests keep moving.
 
-    This is the defect rather than a refinement of it. The walk is synchronous
-    filesystem work and the scan is a coroutine, so left inline it holds the
-    loop for the whole traversal and every other request queues behind it.
-    Measured on a running daemon before this change: a static health probe that
-    reads no session data timed out at five seconds while an admin scan was in
+    The walk is synchronous filesystem work and the scan is a coroutine, so
+    left inline it holds the loop for the whole traversal. Measured on a
+    running daemon before this fix: a static health probe that reads no
+    session data timed out at five seconds while an admin scan was in
     flight, and the scan itself ran past four minutes.
 
-    Two arms, because the passing one alone would prove nothing:
+    Two arms: the loop is never held for long while a walk is deliberately
+    blocked, and a walk really ran (otherwise a scan that reached no row at
+    all would leave the loop idle and pass the first assertion vacuously).
 
-    * the loop is never held for long while a walk is deliberately blocked, and
-    * a walk really ran. Without that, a scan that reached no row at all would
-      leave the loop idle and the first assertion would pass having measured an
-      empty population.
-
-    Every coroutine that walks is covered, rather than the one the defect was
-    first noticed in. They offload at separate call sites, so a guard on one of
-    them says nothing about the others, and an untested one is where a later
-    edit puts the walk back on the loop with everything still green.
-
-    The instrument's own sensitivity is established separately, by
-    ``test_the_tick_counter_would_have_caught_a_walk_left_on_the_loop``. A
-    counter that ticks whatever the subject does is not evidence.
+    Every coroutine that walks is covered, not just the one the defect was
+    first noticed in -- they offload at separate call sites, so a guard on
+    one says nothing about the others. The instrument's own sensitivity is
+    checked separately by
+    ``test_the_tick_counter_would_have_caught_a_walk_left_on_the_loop``.
     """
     import lionagi.state.db as state_db_mod
     import lionagi.studio.services.admin as admin_svc

--- a/tests/apps_studio_server/test_admin_maintenance_api.py
+++ b/tests/apps_studio_server/test_admin_maintenance_api.py
@@ -15,9 +15,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 import lionagi.state.db as state_db_mod
 
-# ---------------------------------------------------------------------------
 # Shared fixture helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_client(tmp_path, monkeypatch):
@@ -31,9 +29,7 @@ def _make_client(tmp_path, monkeypatch):
     return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765"), db_path
 
 
-# ---------------------------------------------------------------------------
 # Auth tests
-# ---------------------------------------------------------------------------
 
 
 def test_maintenance_requires_auth_when_token_missing(tmp_path, monkeypatch):
@@ -78,9 +74,7 @@ def test_maintenance_passes_with_correct_token(tmp_path, monkeypatch):
     assert resp.status_code == 200
 
 
-# ---------------------------------------------------------------------------
 # Closed schema: extra fields must be rejected and must not reach service
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -123,9 +117,7 @@ def test_maintenance_rejects_extra_fields_without_calling_service(tmp_path, monk
     assert calls == [], f"Service functions were called despite 422: {calls}"
 
 
-# ---------------------------------------------------------------------------
 # Allowlist / injection rejection
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -163,9 +155,7 @@ def test_maintenance_missing_action_field_returns_422(tmp_path, monkeypatch):
     assert resp.status_code == 422
 
 
-# ---------------------------------------------------------------------------
 # Success paths (service layer monkeypatched)
-# ---------------------------------------------------------------------------
 
 
 def test_maintenance_vacuum_success(tmp_path, monkeypatch):
@@ -226,9 +216,7 @@ def test_maintenance_prune_success(tmp_path, monkeypatch):
     assert data["runs_pruned"] == 1
 
 
-# ---------------------------------------------------------------------------
 # Live path — existing initialized DB
-# ---------------------------------------------------------------------------
 
 
 def test_maintenance_vacuum_live_existing_db(tmp_path, monkeypatch):
@@ -268,9 +256,7 @@ async def _async_list_events(db_path, *, action):
         return await db.list_admin_events(action=action, limit=5)
 
 
-# ---------------------------------------------------------------------------
 # Live path — DB absent should return graceful responses
-# ---------------------------------------------------------------------------
 
 
 def test_maintenance_vacuum_db_absent(tmp_path, monkeypatch):
@@ -294,9 +280,7 @@ def test_maintenance_checkpoint_db_absent(tmp_path, monkeypatch):
     assert data["busy"] is None
 
 
-# ---------------------------------------------------------------------------
 # Lock-contention → 409 with structured detail
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("action", ["vacuum", "checkpoint", "prune"])

--- a/tests/apps_studio_server/test_admin_transition.py
+++ b/tests/apps_studio_server/test_admin_transition.py
@@ -61,9 +61,7 @@ def _make_admin_client(tmp_path, monkeypatch, db_path):
     return TestClient(app, base_url="http://127.0.0.1:8765")
 
 
-# ---------------------------------------------------------------------------
 # Test: WHERE clause snapshot guard — simulated heartbeat between classify/UPDATE
-# ---------------------------------------------------------------------------
 
 
 def test_transition_refused_when_heartbeat_changes_health(tmp_path, monkeypatch):
@@ -136,9 +134,7 @@ def test_transition_refused_when_heartbeat_changes_health(tmp_path, monkeypatch)
     )
 
 
-# ---------------------------------------------------------------------------
 # Test: the raw-SQL CAS write populates duration_ms like every other terminal write
-# ---------------------------------------------------------------------------
 
 
 def test_transition_sessions_populates_duration_ms(tmp_path, monkeypatch):
@@ -177,9 +173,7 @@ def test_transition_sessions_populates_duration_ms(tmp_path, monkeypatch):
     assert row["duration_ms"] == pytest.approx((row["ended_at"] - old_ts) * 1000)
 
 
-# ---------------------------------------------------------------------------
 # Test: an already-terminal session is never touched by the reconcile CAS
-# ---------------------------------------------------------------------------
 
 
 async def _seed_terminal_session(

--- a/tests/apps_studio_server/test_agents_protections.py
+++ b/tests/apps_studio_server/test_agents_protections.py
@@ -33,9 +33,7 @@ def _make_agents_root(tmp_path, monkeypatch):
     return root
 
 
-# ---------------------------------------------------------------------------
 # create_agent()
-# ---------------------------------------------------------------------------
 
 
 def test_create_agent_writes_file_and_defaults_to_editable(tmp_path, monkeypatch):
@@ -202,9 +200,7 @@ def test_padded_unknown_role_is_still_rejected(tmp_path, monkeypatch):
         create_agent("padded-bogus-role", {"role": "  not-a-real-role  "})
 
 
-# ---------------------------------------------------------------------------
 # delete_agent() protections
-# ---------------------------------------------------------------------------
 
 
 def test_delete_ordinary_agent_succeeds(tmp_path, monkeypatch):
@@ -314,9 +310,7 @@ def test_delete_default_agent_refused_even_when_user_owned(tmp_path, monkeypatch
     assert (root / "default.md").exists()
 
 
-# ---------------------------------------------------------------------------
 # update_agent() protections
-# ---------------------------------------------------------------------------
 
 
 def test_edit_system_agent_refused(tmp_path, monkeypatch):
@@ -413,9 +407,7 @@ def test_edit_default_agent_succeeds(tmp_path, monkeypatch):
     assert updated["effort"] == "medium"
 
 
-# ---------------------------------------------------------------------------
 # HTTP route wiring (protection status codes)
-# ---------------------------------------------------------------------------
 
 
 def _make_patched_client(tmp_path, monkeypatch):
@@ -477,12 +469,10 @@ def test_route_delete_ordinary_agent_is_200(tmp_path, monkeypatch):
     assert r2.status_code == 404
 
 
-# ---------------------------------------------------------------------------
 # The generic /definitions/agent/{name} save route is the other write path onto
 # agent files (Studio's own AgentDetail editor uses it, not PUT /agents/{name}).
 # It must honour the same "system agent is not editable" rule or the protection
 # added above is a no-op in practice.
-# ---------------------------------------------------------------------------
 
 
 def _make_definitions_client(tmp_path, monkeypatch):
@@ -573,11 +563,9 @@ def test_definitions_save_route_allows_ordinary_agent(tmp_path, monkeypatch):
     assert (agents_dir / "useragent.md").read_text().strip() == "# updated"
 
 
-# ---------------------------------------------------------------------------
 # The definitions save route also has to run the same cast role/mode
 # validation POST/PUT /api/agents/{name} apply -- otherwise a payload the
 # agents API rejects can still land on disk through the raw markdown door.
-# ---------------------------------------------------------------------------
 
 
 def test_definitions_save_route_rejects_unknown_role(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_agents_roundtrip.py
+++ b/tests/apps_studio_server/test_agents_roundtrip.py
@@ -28,9 +28,7 @@ def _make_agents_root(tmp_path, monkeypatch):
     return root
 
 
-# ---------------------------------------------------------------------------
 # Test 1: yolo/fast_mode surface in get_agent() response
-# ---------------------------------------------------------------------------
 
 
 def test_get_agent_surfaces_yolo_and_fast_mode(tmp_path, monkeypatch):
@@ -59,9 +57,7 @@ def test_get_agent_surfaces_yolo_and_fast_mode(tmp_path, monkeypatch):
     assert result.get("fast_mode") is False
 
 
-# ---------------------------------------------------------------------------
 # Test 1b: lion_system surfaces in get_agent() response
-# ---------------------------------------------------------------------------
 
 
 def test_get_agent_surfaces_lion_system(tmp_path, monkeypatch):
@@ -98,9 +94,7 @@ def test_get_agent_surfaces_lion_system(tmp_path, monkeypatch):
     assert result.get("fast_mode") is False
 
 
-# ---------------------------------------------------------------------------
 # Tests 1c/1d/1e: absent bool fields emit CLI defaults
-# ---------------------------------------------------------------------------
 
 
 def test_get_agent_lion_system_defaults_true(tmp_path, monkeypatch):
@@ -190,9 +184,7 @@ def test_get_agent_fast_mode_defaults_false(tmp_path, monkeypatch):
     )
 
 
-# ---------------------------------------------------------------------------
 # Test 2: update_agent() writes yolo field to disk and get_agent() reads it back
-# ---------------------------------------------------------------------------
 
 
 def test_update_agent_writes_yolo_field(tmp_path, monkeypatch):
@@ -225,9 +217,7 @@ def test_update_agent_writes_yolo_field(tmp_path, monkeypatch):
     assert fresh.get("yolo") is False
 
 
-# ---------------------------------------------------------------------------
 # Test 2b: update_agent() writes lion_system field to disk
-# ---------------------------------------------------------------------------
 
 
 def test_update_agent_writes_lion_system_field(tmp_path, monkeypatch):
@@ -259,9 +249,7 @@ def test_update_agent_writes_lion_system_field(tmp_path, monkeypatch):
     assert fresh.get("lion_system") is True
 
 
-# ---------------------------------------------------------------------------
 # Test 3: reasoning_effort → effort migration
-# ---------------------------------------------------------------------------
 
 
 def test_get_agent_migrates_reasoning_effort_to_effort(tmp_path, monkeypatch):
@@ -289,9 +277,7 @@ def test_get_agent_migrates_reasoning_effort_to_effort(tmp_path, monkeypatch):
     assert "reasoning_effort" not in result
 
 
-# ---------------------------------------------------------------------------
 # Test 4: model without provider prefix round-trips through update_agent()
-# ---------------------------------------------------------------------------
 
 
 def test_update_agent_canonicalises_model_with_provider(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_approvals.py
+++ b/tests/apps_studio_server/test_approvals.py
@@ -47,9 +47,7 @@ async def _init_db(db_path: Path) -> None:
         pass  # opens + applies schema (creates the approvals table too)
 
 
-# ---------------------------------------------------------------------------
 # Unit-level: service functions directly (no HTTP, no principal concerns)
-# ---------------------------------------------------------------------------
 
 
 def test_propose_returns_pending_row_with_hash(tmp_path, monkeypatch):
@@ -299,9 +297,7 @@ def test_get_unknown_approval_returns_none(tmp_path, monkeypatch):
     assert _run(approvals_mod.get_approval("does-not-exist")) is None
 
 
-# ---------------------------------------------------------------------------
 # HTTP-level: routes + the grant-route principal separation
-# ---------------------------------------------------------------------------
 
 
 def test_propose_route_creates_pending_approval(tmp_path, monkeypatch):
@@ -439,9 +435,7 @@ def test_grant_route_404_for_unknown_id(tmp_path, monkeypatch):
     assert resp.status_code == 404
 
 
-# ---------------------------------------------------------------------------
 # Evidence chain: hash-chained audit trail on the ledger
-# ---------------------------------------------------------------------------
 
 
 def _evidence_rows(db_path: Path) -> list[dict]:

--- a/tests/apps_studio_server/test_async_fs_io.py
+++ b/tests/apps_studio_server/test_async_fs_io.py
@@ -14,9 +14,7 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # Helpers / shared fixtures
-# ---------------------------------------------------------------------------
 
 
 def _make_client(
@@ -99,9 +97,7 @@ def _make_client(
     return TestClient(app, base_url="http://127.0.0.1:8765")
 
 
-# ---------------------------------------------------------------------------
 # Runs detail — offloaded to worker thread
-# ---------------------------------------------------------------------------
 
 
 def test_run_detail_reads_from_statedb(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -155,9 +151,7 @@ def test_run_detail_404_with_thread_offload(
     assert r.status_code == 404
 
 
-# ---------------------------------------------------------------------------
 # Agents — offloaded to worker thread
-# ---------------------------------------------------------------------------
 
 
 def test_agents_list_uses_thread_offload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -193,9 +187,7 @@ def test_agent_update_uses_thread_offload(tmp_path: Path, monkeypatch: pytest.Mo
     assert data["model"] == "anthropic/claude-sonnet-4-20250514"
 
 
-# ---------------------------------------------------------------------------
 # Playbooks — offloaded to worker thread
-# ---------------------------------------------------------------------------
 
 
 def test_playbooks_list_uses_thread_offload(
@@ -222,9 +214,7 @@ def test_playbook_detail_uses_thread_offload(
     assert data["name"] == "test-pb"
 
 
-# ---------------------------------------------------------------------------
 # Skills — offloaded to worker thread
-# ---------------------------------------------------------------------------
 
 
 def test_skills_list_uses_thread_offload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -248,9 +238,7 @@ def test_skill_detail_uses_thread_offload(tmp_path: Path, monkeypatch: pytest.Mo
     assert data["content"] == "Skill body."
 
 
-# ---------------------------------------------------------------------------
 # Thread offload verification — confirms anyio.to_thread.run_sync is used
-# ---------------------------------------------------------------------------
 
 
 def test_run_detail_returns_404_for_nonexistent_id(

--- a/tests/apps_studio_server/test_attention_dispositions.py
+++ b/tests/apps_studio_server/test_attention_dispositions.py
@@ -44,9 +44,7 @@ async def _init_db(db_path: Path) -> None:
         pass  # opens + applies schema (creates the attention tables too)
 
 
-# ---------------------------------------------------------------------------
 # Unit-level: service functions directly (no HTTP)
-# ---------------------------------------------------------------------------
 
 
 def test_upsert_creates_pending_row(tmp_path, monkeypatch):
@@ -661,9 +659,7 @@ def test_attention_dispositions_upgrade_from_pre_revision_store(tmp_path, monkey
     assert recreated["state"] == "acknowledged"
 
 
-# ---------------------------------------------------------------------------
 # HTTP-level: routes
-# ---------------------------------------------------------------------------
 
 
 def test_http_put_get_delete_roundtrip(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_audit_remediation.py
+++ b/tests/apps_studio_server/test_audit_remediation.py
@@ -15,9 +15,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 import lionagi.state.db as state_db_mod
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
@@ -36,9 +34,7 @@ def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
     return TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
 
-# ---------------------------------------------------------------------------
 # Artifact GET routes bearer auth guard
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -118,9 +114,7 @@ class TestArtifactAuthBypass:
         assert resp.status_code != 401
 
 
-# ---------------------------------------------------------------------------
 # Scheduler fire task lifecycle — tracking and cancellation on shutdown
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -191,9 +185,7 @@ class TestSchedulerFireTaskLifecycle:
         assert len(engine._fire_tasks) == 0, "Outstanding fire tasks remain after stop()"
 
 
-# ---------------------------------------------------------------------------
 # Schedule action kind validation
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvValidation:
@@ -254,9 +246,7 @@ class TestBuildArgvValidation:
             build_argv({"action_kind": ""}, {})
 
 
-# ---------------------------------------------------------------------------
 # Orphaned subprocess on cancel + invalid-kind run recording
-# ---------------------------------------------------------------------------
 
 
 def _interval_schedule(**over):
@@ -552,10 +542,8 @@ class TestInvocationReasonAggregation:
         assert reason_code == RunReasons.ABORTED_USER
 
 
-# ---------------------------------------------------------------------------
 # Router-level PATCH validation (HTTP 400 for invalid flow_yaml transitions),
 # covering the ValueError→HTTPException translation in services/schedules.py.
-# ---------------------------------------------------------------------------
 
 
 class TestSchedulePatchRouterValidation:
@@ -619,9 +607,7 @@ class TestSchedulePatchRouterValidation:
         assert r.status_code == 404, f"expected 404, got {r.status_code}: {r.text}"
 
 
-# ---------------------------------------------------------------------------
 # CWE-88 argument injection — router-level 400 responses
-# ---------------------------------------------------------------------------
 
 
 class TestScheduleArgvInjectionRouterValidation:
@@ -764,12 +750,10 @@ class TestScheduleArgvInjectionRouterValidation:
         assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
 
 
-# ---------------------------------------------------------------------------
 # CWE-88 argument injection — real-service router tests
 #
 # These tests use the REAL service layer (no mock) with a temp SQLite DB to
 # validate that flag-injection rejections propagate through the router as 400.
-# ---------------------------------------------------------------------------
 
 
 def _real_svc_client(monkeypatch, tmp_path: Path) -> TestClient:
@@ -910,9 +894,7 @@ class TestScheduleArgvInjectionRealService:
         )
 
 
-# ---------------------------------------------------------------------------
 # CWE-918 github_repo path manipulation — real-service router tests
-# ---------------------------------------------------------------------------
 
 
 class TestGithubRepoRealServiceValidation:
@@ -1185,7 +1167,7 @@ class TestGithubRepoRealServiceValidation:
         )
         assert r.status_code == 400, f"expected 400, got {r.status_code}: {r.text}"
 
-    # -- PATCH preserves bad stored value (MAJOR #3) --
+    # PATCH preserves bad stored value
 
     def test_patch_unrelated_field_rejects_bad_stored_github_repo(
         self, monkeypatch, tmp_path

--- a/tests/apps_studio_server/test_batch3_logic.py
+++ b/tests/apps_studio_server/test_batch3_logic.py
@@ -16,9 +16,7 @@ aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
 from tests.apps_studio_server._helpers import run_async as _run  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # is_session_stream_done() gates on terminal status AND stale time
-# ---------------------------------------------------------------------------
 
 
 class TestIsSessionStreamDone:
@@ -170,9 +168,7 @@ class TestGetSessionStreamState:
         assert result["status"] == "completed"
 
 
-# ---------------------------------------------------------------------------
 # update_playbook() rejects invalid links via validate_playbook()
-# ---------------------------------------------------------------------------
 
 
 class TestUpdatePlaybookValidation:

--- a/tests/apps_studio_server/test_cost_visibility.py
+++ b/tests/apps_studio_server/test_cost_visibility.py
@@ -84,9 +84,7 @@ def _make_client(monkeypatch, db_path: Path) -> TestClient:
     return TestClient(app, base_url="http://127.0.0.1:8765")
 
 
-# ---------------------------------------------------------------------------
 # Cost column on run/session lists
-# ---------------------------------------------------------------------------
 
 
 def test_runs_list_preserves_null_cost_as_unreported(tmp_path, monkeypatch):
@@ -147,9 +145,7 @@ def test_invalid_sort_returns_422(tmp_path, monkeypatch):
     assert r.status_code == 422
 
 
-# ---------------------------------------------------------------------------
 # Spend panel aggregate (/api/stats/spend)
-# ---------------------------------------------------------------------------
 
 
 def test_spend_stats_empty_db_is_unreported_not_zero(tmp_path, monkeypatch):
@@ -264,9 +260,7 @@ def test_spend_stats_missing_db_file_is_not_created_by_read(tmp_path, monkeypatc
     assert not db_path.exists()
 
 
-# ---------------------------------------------------------------------------
 # Per-dimension rollups (/api/stats/spend/rollup)
-# ---------------------------------------------------------------------------
 
 
 def test_rollup_by_project_sums_reported_and_counts_unreported_per_group(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_daemon_api_gate.py
+++ b/tests/apps_studio_server/test_daemon_api_gate.py
@@ -2,32 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 """Studio daemon API contract gate.
 
-Regression class this guards, in plain terms: CLI/daemon contract drift that
-was discovered live rather than caught by CI. Two known instances of this
-class: a URL-prefix bug where a client (mis-)configured base URL caused every
-request to double up the "/api" prefix (".../api/api/..."), and a CWD bug
-where a spawned subprocess inherited the daemon's working directory instead
-of resolving one explicitly, so behavior depended on how the daemon itself
-happened to be launched. Neither was caught by a test; both were found by an
-operator hitting a broken request in practice.
+Guards against CLI/daemon contract drift that was previously discovered
+live rather than by CI: a URL-prefix bug where a misconfigured client base
+URL doubled up the "/api" prefix (".../api/api/..."), and a CWD bug where a
+spawned subprocess inherited the daemon's working directory instead of
+resolving one explicitly, so behavior depended on how the daemon happened
+to be launched.
 
-This suite pins the daemon's actual, observed contract:
+Pins the daemon's actual, observed contract: (1) the full sorted
+(method, path) route table, excluding FastAPI's auto-generated docs/schema
+routes, as a golden list so adding/renaming/removing an endpoint forces a
+deliberate edit here; (2) that `/api` appears exactly once in every mounted
+route path; (3) per-endpoint success/404/422/400 response shape (status
+code + sorted top-level JSON keys, not full payloads) for the admin,
+session, and schedule endpoint families.
 
-  1. The full sorted (method, path) route table (excluding FastAPI's
-     auto-generated docs/schema routes) as a golden list. Adding, renaming,
-     or removing an endpoint forces a deliberate edit here instead of
-     silently drifting.
-  2. The `/api` prefix contract: it appears exactly once in every mounted
-     API route path (the shape of the double-prefix regression class).
-  3. Per-endpoint success/404/422/400 response shape (status code + sorted
-     top-level JSON object keys, not full payloads) for the admin, session,
-     and schedule endpoint families -- the areas gate 5 was scoped to.
-
-Everything here is read empirically from the routers themselves
+Everything is read empirically from the routers themselves
 (lionagi/studio/services/admin.py, sessions.py, schedules.py) and from
-running the live app against a temp SQLite DB, per the existing suite's
-`_patch_db` / `monkeypatch.setattr(..., DEFAULT_DB_PATH, ...)` pattern (see
-test_admin.py, test_schedule_runs_route.py) -- never against ~/.lionagi.
+running the live app against a temp SQLite DB, following the existing
+suite's `_patch_db` / `monkeypatch.setattr(..., DEFAULT_DB_PATH, ...)`
+pattern -- never against ~/.lionagi.
 """
 
 from __future__ import annotations
@@ -47,9 +41,7 @@ from lionagi.state.db import StateDB  # noqa: E402
 
 from ._helpers import run_async  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # 1. Golden route table -- excludes FastAPI's auto-generated docs/schema routes.
-# ---------------------------------------------------------------------------
 
 _DOCS_PATHS = frozenset({"/openapi.json", "/docs", "/redoc", "/docs/oauth2-redirect"})
 
@@ -312,9 +304,9 @@ def test_find_duplicate_routes_empty_for_unique_entries():
 
 
 def test_normalize_route_match_shape_erases_param_names_but_keeps_converters():
-    """The reviewer's exact distinction: two untyped params with different
-    names collapse to one shape; a typed converter stays distinct from the
-    untyped param even when the name matches."""
+    """Two untyped params with different names collapse to one shape; a
+    typed converter stays distinct from the untyped param even when the
+    name matches."""
     shape_schedule_id = _compiled_match_shape("/api/schedules/{schedule_id}")
     shape_id = _compiled_match_shape("/api/schedules/{id}")
     shape_id_int = _compiled_match_shape("/api/schedules/{id:int}")
@@ -345,7 +337,11 @@ def test_duplicate_route_registration_is_caught_on_a_live_fastapi_app():
 
 
 def test_duplicate_route_registration_with_different_param_names_is_caught():
-    """The reviewer's exact regression: /api/schedules/{schedule_id} and /api/schedules/{id} read as different source but compile to the same dispatch target, so the gate must name them as duplicates even though no two path strings are equal -- one route goes through an APIRouter + prefix (like real studio routers), proving match-shape normalization survives prefix compilation."""
+    """/api/schedules/{schedule_id} and /api/schedules/{id} read as different
+    source but compile to the same dispatch target, so the gate must name
+    them as duplicates even though no two path strings are equal -- one
+    route goes through an APIRouter + prefix (like real studio routers),
+    proving match-shape normalization survives prefix compilation."""
     from fastapi import APIRouter, FastAPI
 
     app = FastAPI()
@@ -369,9 +365,7 @@ def test_duplicate_route_registration_with_different_param_names_is_caught():
     assert sorted(paths) == ["/api/schedules/{id}", "/api/schedules/{schedule_id}"]
 
 
-# ---------------------------------------------------------------------------
 # 2. The /api prefix contract -- the double-prefix regression class.
-# ---------------------------------------------------------------------------
 
 
 def test_api_prefix_appears_exactly_once_in_every_route_path():
@@ -384,9 +378,7 @@ def test_api_prefix_appears_exactly_once_in_every_route_path():
         assert path.count("/api") == 1, f"route path repeats the /api prefix: {path!r}"
 
 
-# ---------------------------------------------------------------------------
 # Shared fixtures/helpers for the per-family response-shape pins below.
-# ---------------------------------------------------------------------------
 
 
 def _patch_db(monkeypatch, db_path: Path) -> None:
@@ -451,9 +443,7 @@ async def _seed_running_session(db_path: Path, session_id: str) -> None:
         )
 
 
-# ---------------------------------------------------------------------------
 # 3a. Admin endpoint family.
-# ---------------------------------------------------------------------------
 
 
 def test_admin_doctor_response_shape(tmp_path, monkeypatch):
@@ -565,9 +555,7 @@ def test_admin_prune_old_data_response_shape(tmp_path, monkeypatch):
     assert sorted(r.json().keys()) == ["dispatch_purged", "runs_pruned", "sessions_pruned"]
 
 
-# ---------------------------------------------------------------------------
 # 3b. Sessions endpoint family.
-# ---------------------------------------------------------------------------
 
 _SESSION_DETAIL_KEYS = sorted(
     [
@@ -664,9 +652,7 @@ def test_sessions_detail_malformed_cursor_400_shape(tmp_path, monkeypatch):
     assert sorted(r.json().keys()) == ["detail"]
 
 
-# ---------------------------------------------------------------------------
 # 3c. Schedules endpoint family.
-# ---------------------------------------------------------------------------
 
 _SCHEDULE_DETAIL_KEYS = sorted(
     [

--- a/tests/apps_studio_server/test_db_helper_batch2.py
+++ b/tests/apps_studio_server/test_db_helper_batch2.py
@@ -12,9 +12,7 @@ aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
 from tests.apps_studio_server._helpers import run_async as _run  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # open_db() configures busy_timeout, WAL, and row_factory
-# ---------------------------------------------------------------------------
 
 
 class TestOpenDb:

--- a/tests/apps_studio_server/test_db_maintenance.py
+++ b/tests/apps_studio_server/test_db_maintenance.py
@@ -499,19 +499,19 @@ def test_a_session_that_reopens_past_the_lock_takes_the_whole_pass_down(
     """Nothing may be committed for a session that reopened mid-sequence.
 
     The prune clears associations and deletes transition history before it
-    deletes the session, so a per-statement condition protects each statement
-    on its own and still lets the sequence land half-applied: the earlier
-    writes are already done when the reopen arrives, and the delete then skips
-    the row, leaving a live session whose history and links are gone. The lock
-    is what keeps this from being reachable; the parametrization drives the
-    reopen past it at each step, and every case asserts the session survives
-    whole, so nothing short of abandoning the pass passes here.
+    deletes the session; a per-statement condition protects each statement
+    on its own but still lets the sequence land half-applied -- the earlier
+    writes are already done when the reopen arrives, and the delete then
+    skips the row, leaving a live session whose history and links are gone.
+    The lock is what makes this unreachable; the parametrization drives the
+    reopen past it at each step, and every case asserts the session
+    survives whole.
 
-    The reopen rides the prune's own transaction here, so it is rolled back
-    along with everything else and the status reads terminal again afterwards.
-    A real resume commits on its own and would keep its status; what this
-    checks is the part that is the same either way, which is that none of the
-    prune's writes reached the database.
+    The reopen here rides the prune's own transaction, so it rolls back
+    along with everything else and the status reads terminal again
+    afterwards (a real resume commits on its own and would keep its
+    status). What this checks is the part that's the same either way: none
+    of the prune's writes reached the database.
     """
     from lionagi.studio.services import db_maintenance as maint
 

--- a/tests/apps_studio_server/test_definitions.py
+++ b/tests/apps_studio_server/test_definitions.py
@@ -12,9 +12,7 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 # _run kept for non-integration sync test paths (e.g. ValueError checks without fastapi)
 from tests.apps_studio_server._helpers import run_async as _run  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # H-BE-3: save_definition() writes DB first, then disk
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -241,9 +239,7 @@ async def test_save_definition_unknown_kind_raises(tmp_path, monkeypatch):
         await defs_mod.save_definition("widget", "my-widget", "content")
 
 
-# ---------------------------------------------------------------------------
 # CRITICAL: path/glob injection — service boundary validation
-# ---------------------------------------------------------------------------
 
 
 def _make_patched_client(tmp_path, monkeypatch):
@@ -398,9 +394,7 @@ async def test_save_definition_accepts_valid_kinds(kind, tmp_path, monkeypatch):
     assert result["version"] >= 1
 
 
-# ---------------------------------------------------------------------------
 # HIGH: concurrent save race — disk must reflect the HIGHER version's content
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -461,9 +455,7 @@ async def test_concurrent_save_disk_reflects_highest_version(tmp_path, monkeypat
     )
 
 
-# ---------------------------------------------------------------------------
 # MEDIUM: StateDB failure — no file written, exception propagates
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -542,9 +534,7 @@ def test_save_definition_db_failure_returns_500_from_router(tmp_path, monkeypatc
     assert r.status_code == 500, f"Expected 500, got {r.status_code}"
 
 
-# ---------------------------------------------------------------------------
 # HIGH-R3-BE-1: symlinked agent definitions must be readable + writable
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -640,9 +630,7 @@ async def test_save_definition_writes_through_symlink(tmp_path, monkeypatch):
     assert symlink.is_symlink(), "symlink must remain a symlink after save"
 
 
-# ---------------------------------------------------------------------------
 # MEDIUM-R3-BE-2: missing kind directory must not 500
-# ---------------------------------------------------------------------------
 
 
 def test_find_definition_file_missing_base_returns_none(tmp_path):
@@ -660,10 +648,8 @@ def test_find_definition_file_missing_base_returns_none(tmp_path):
     assert result is None
 
 
-# ---------------------------------------------------------------------------
 # Nested definitions listed under the containing directory's name must also
 # be fetchable by that same name, even when the filename inside differs.
-# ---------------------------------------------------------------------------
 
 
 def test_find_definition_file_resolves_nested_dir_with_different_filename(tmp_path):

--- a/tests/apps_studio_server/test_definitions_batch2.py
+++ b/tests/apps_studio_server/test_definitions_batch2.py
@@ -11,9 +11,7 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from tests.apps_studio_server._helpers import run_async as _run  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # Shared fake DB plumbing
-# ---------------------------------------------------------------------------
 
 
 class _FakeCursor:
@@ -37,9 +35,7 @@ class _FakeDB:
         pass
 
 
-# ---------------------------------------------------------------------------
 # list_definitions uses ONE DB connection for N definition files
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration

--- a/tests/apps_studio_server/test_engine_defs_api.py
+++ b/tests/apps_studio_server/test_engine_defs_api.py
@@ -423,9 +423,6 @@ async def test_update_options_whitespace_test_cmd_on_coding_raises(patched_svc):
         await svc.update_engine_def(def_id, {"options": {"test_cmd": "   "}})
 
 
-# ── Issue #1444: empty-body PUT must not return 404 for existing def ─────────
-
-
 async def test_update_empty_fields_existing_returns_truthy(patched_svc):
     """Empty fields dict on an existing def is a no-op, not a not-found."""
     svc, db_path = patched_svc
@@ -443,7 +440,7 @@ async def test_update_empty_fields_missing_returns_false(patched_svc):
 
 
 async def test_update_endpoint_empty_body_existing_200(patched_app):
-    """PUT {} on an existing def must return 200, not 404 (closes #1444)."""
+    """PUT {} on an existing def must return 200, not 404."""
     _, db_path, client = patched_app
     def_id = await _seed_engine_def(db_path, name="empty-body-def", kind="review")
     async with client as ac:

--- a/tests/apps_studio_server/test_engine_runs_api.py
+++ b/tests/apps_studio_server/test_engine_runs_api.py
@@ -15,9 +15,7 @@ aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 import lionagi.state.db as state_db_mod
 from lionagi.state.db import StateDB  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _rid() -> str:
@@ -49,9 +47,7 @@ async def _seed_engine_run(
     return rid
 
 
-# ---------------------------------------------------------------------------
 # Studio service layer: engine_runs service
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -170,9 +166,7 @@ async def test_service_spec_json_round_trips(patched_engine_runs_svc):
     assert row["spec_json"] == spec
 
 
-# ---------------------------------------------------------------------------
 # HTTP endpoint layer
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture

--- a/tests/apps_studio_server/test_launches_api.py
+++ b/tests/apps_studio_server/test_launches_api.py
@@ -15,9 +15,7 @@ import lionagi.state.db as state_db_mod
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_client(monkeypatch, fake_db: Path | None = None) -> TestClient:
@@ -78,9 +76,7 @@ def _fresh_launch_state():
     svc._user_cancelled.clear()
 
 
-# ---------------------------------------------------------------------------
 # Basic happy-path
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -148,9 +144,7 @@ class TestLaunchHappyPath:
         assert data["action_kind"] == "agent"
 
 
-# ---------------------------------------------------------------------------
 # Invalid action_kind
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -181,9 +175,7 @@ class TestLaunchInvalidKind:
         assert resp.status_code == 422, resp.text
 
 
-# ---------------------------------------------------------------------------
 # Injection rejection — validation goes through build_argv
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -259,9 +251,7 @@ class TestLaunchInjectionRejection:
         assert resp.status_code == 422, resp.text
 
 
-# ---------------------------------------------------------------------------
 # Auth coverage — launch endpoint covered by bearer middleware
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -315,9 +305,7 @@ class TestLaunchAuth:
         assert resp.status_code == 202
 
 
-# ---------------------------------------------------------------------------
 # argv goes through build_argv (validated shared path)
-# ---------------------------------------------------------------------------
 
 
 class TestLaunchArgvPath:
@@ -461,9 +449,7 @@ class TestLaunchArgvPath:
         _validate_request({"action_kind": "play", "action_playbook": "my-playbook"})
 
 
-# ---------------------------------------------------------------------------
 # _spawn_detached terminal update uses registered reason codes
-# ---------------------------------------------------------------------------
 
 
 class TestSpawnDetachedTerminalUpdate:
@@ -595,9 +581,7 @@ class TestSpawnDetachedEndedAtAtomicity:
         assert isinstance(captured.get("extra_fields", {}).get("ended_at"), float)
 
 
-# ---------------------------------------------------------------------------
 # MAJOR 1 — Admission cap: 429 when in-flight launches >= MAX_LAUNCHES
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -662,9 +646,7 @@ class TestLaunchAdmissionCap:
         assert second.status_code == 429, second.text
 
 
-# ---------------------------------------------------------------------------
 # MAJOR 2 — Shutdown drains _detached_tasks + writes cancelled row
-# ---------------------------------------------------------------------------
 
 
 class TestShutdownDrains:
@@ -755,9 +737,7 @@ class TestShutdownDrains:
         assert captured["reason_code"] == RunReasons.CANCELLED_SYSTEM
 
 
-# ---------------------------------------------------------------------------
 # MAJOR 3 — build_argv called BEFORE create_invocation
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvBeforeCreate:
@@ -812,9 +792,7 @@ class TestBuildArgvBeforeCreate:
         assert create_calls == [], "create_invocation must NOT be called if build_argv raises"
 
 
-# ---------------------------------------------------------------------------
 # Engine kind — launch a saved engine definition
-# ---------------------------------------------------------------------------
 
 
 def _stub_engine_def(monkeypatch, defn: dict | None, *, by_name_only: bool = False):
@@ -1004,9 +982,7 @@ class TestEngineScheduleAssembly:
         assert schedule["action_model"] == "claude-sonnet-4-5"
 
 
-# ---------------------------------------------------------------------------
 # build_argv engine kind — argv shape (flags first, '--', then positionals)
-# ---------------------------------------------------------------------------
 
 
 class TestBuildArgvEngineKind:
@@ -1234,9 +1210,7 @@ class TestCodingKindRequiresTestCmd:
         mock_db.create_invocation.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
 # cancel_launch — POST /api/invocations/{id}/cancel
-# ---------------------------------------------------------------------------
 
 
 class TestCancelLaunch:
@@ -1278,9 +1252,7 @@ class TestCancelLaunch:
         asyncio.run(_run())
 
 
-# ---------------------------------------------------------------------------
 # End-to-end smoke — the control loop the Den extension drives
-# ---------------------------------------------------------------------------
 
 
 class TestLaunchCancelRetrySmoke:
@@ -1369,9 +1341,7 @@ class TestLaunchCancelRetrySmoke:
         asyncio.run(_run())
 
 
-# ---------------------------------------------------------------------------
 # flow_yaml kind — YAML-driven flow launch
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -1449,9 +1419,7 @@ class TestLaunchFlowYamlKind:
         assert captured["schedule"]["action_flow_yaml"] == "prompt: hi\n"
 
 
-# ---------------------------------------------------------------------------
 # command kind — allow-listed executable, spawned directly (never through `li`)
-# ---------------------------------------------------------------------------
 
 _COMMAND_ALLOWLIST_ENV = "LIONAGI_SCHEDULER_COMMAND_ALLOWLIST"
 

--- a/tests/apps_studio_server/test_leo.py
+++ b/tests/apps_studio_server/test_leo.py
@@ -45,9 +45,7 @@ def _clear_leo_sessions():
     leo_svc._SESSIONS.clear()
 
 
-# ---------------------------------------------------------------------------
 # Retired HTTP surface and direct session compatibility
-# ---------------------------------------------------------------------------
 
 
 def test_legacy_leo_routes_are_retired(tmp_path, monkeypatch):
@@ -68,9 +66,7 @@ def test_leo_compatibility_session_unique_ids():
     assert len(ids) == 3
 
 
-# ---------------------------------------------------------------------------
 # Session registry bounds: capacity eviction (LRU) and idle expiry
-# ---------------------------------------------------------------------------
 
 
 def test_session_registry_evicts_lru_over_cap(monkeypatch):
@@ -161,9 +157,7 @@ def test_session_registry_idle_eviction_runs_on_create():
     assert stale.id not in leo_svc._SESSIONS
 
 
-# ---------------------------------------------------------------------------
 # Direct compatibility handler rejects an unknown session
-# ---------------------------------------------------------------------------
 
 
 def test_leo_compatibility_message_unknown_session():
@@ -179,10 +173,8 @@ def test_leo_compatibility_message_unknown_session():
         )
 
 
-# ---------------------------------------------------------------------------
 # Auth gate — retired paths remain under the global /api/* bearer boundary,
 # even though an authenticated caller receives a route-level 404.
-# ---------------------------------------------------------------------------
 
 
 def test_leo_requires_bearer_when_token_set(tmp_path, monkeypatch):
@@ -221,9 +213,7 @@ def test_leo_correct_token_reaches_retired_route_404(tmp_path, monkeypatch):
     assert r.status_code == 404
 
 
-# ---------------------------------------------------------------------------
 # Tool registry shape
-# ---------------------------------------------------------------------------
 
 
 def test_leo_tool_registry_shape():
@@ -248,9 +238,7 @@ def test_leo_tool_registry_shape():
     assert "tool_run_maintenance" in names
 
 
-# ---------------------------------------------------------------------------
 # Proposed-action gating: mutating tools return proposals, never execute
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -321,9 +309,7 @@ async def test_tool_run_maintenance_invalid_action():
     assert "proposed_action" not in result
 
 
-# ---------------------------------------------------------------------------
 # UI-drive tools: declarative commands, no server-side effect
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -375,9 +361,7 @@ async def test_tool_prefill_schedule_returns_command():
     assert "prompt" in cmd["params"]
 
 
-# ---------------------------------------------------------------------------
 # Message turn with a fake Branch (no LLM network)
-# ---------------------------------------------------------------------------
 
 
 def _fake_branch_with_response(text: str) -> MagicMock:
@@ -513,9 +497,7 @@ def test_leo_prior_turn_proposals_not_reemitted():
     assert "done" in types
 
 
-# ---------------------------------------------------------------------------
 # Compatibility handler rejects a second turn while the session is busy
-# ---------------------------------------------------------------------------
 
 
 def test_leo_concurrent_turn_second_gets_409():
@@ -539,9 +521,7 @@ def test_leo_concurrent_turn_second_gets_409():
     asyncio.run(scenario())
 
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _parse_sse(body: str) -> list[dict[str, Any]]:

--- a/tests/apps_studio_server/test_library_redaction.py
+++ b/tests/apps_studio_server/test_library_redaction.py
@@ -95,9 +95,7 @@ def _make_redaction_client(tmp_path, monkeypatch):
     return TestClient(app, base_url="http://127.0.0.1:8765"), agents_dir
 
 
-# ---------------------------------------------------------------------------
 # Prompt body: leaks in the normal view, redacted in the demo view.
-# ---------------------------------------------------------------------------
 
 
 def test_redacted_view_hides_prompt_body_normal_view_still_serves_it(tmp_path, monkeypatch):
@@ -128,9 +126,7 @@ def test_redacted_view_hides_prompt_body_normal_view_still_serves_it(tmp_path, m
     assert "<redacted," in redacted_definition.text
 
 
-# ---------------------------------------------------------------------------
 # Unrecognized, env/secret-shaped frontmatter value: dropped by key name.
-# ---------------------------------------------------------------------------
 
 
 def test_env_shaped_frontmatter_value_is_masked_in_redacted_view(tmp_path, monkeypatch):
@@ -155,9 +151,7 @@ def test_env_shaped_frontmatter_value_is_masked_in_redacted_view(tmp_path, monke
     assert "internal_api_key" not in entry
 
 
-# ---------------------------------------------------------------------------
 # Safe-by-construction fields ride through unchanged in the redacted view.
-# ---------------------------------------------------------------------------
 
 
 def test_keep_fields_survive_redaction(tmp_path, monkeypatch):
@@ -194,10 +188,8 @@ def test_keep_fields_survive_redaction(tmp_path, monkeypatch):
     assert DESCRIPTION_SENTINEL not in str(list_entry)
 
 
-# ---------------------------------------------------------------------------
 # A sibling route serving the same object (version history) must not be an
 # unredacted mirror one click away from the covered detail route.
-# ---------------------------------------------------------------------------
 
 
 def test_version_history_route_is_also_redacted(tmp_path, monkeypatch):
@@ -220,10 +212,8 @@ def test_version_history_route_is_also_redacted(tmp_path, monkeypatch):
     assert SECRET_ENV_VALUE not in redacted_version.text
 
 
-# ---------------------------------------------------------------------------
 # The save path is not a bypass: a redacted payload posted back must be
 # refused, and must not touch the file on disk, while the switch is on.
-# ---------------------------------------------------------------------------
 
 
 def test_save_definition_refuses_placeholder_payload_while_demo_mode_on(tmp_path, monkeypatch):
@@ -276,11 +266,9 @@ def test_save_definition_still_works_normally_while_demo_mode_off(tmp_path, monk
     assert (agents_dir / "demoagent.md").read_text().strip() == "# updated content"
 
 
-# ---------------------------------------------------------------------------
 # A safe key's name is not a promise about its shape. A mapping or list
 # smuggled in under a safe key (role/effort/...) must be dropped, not passed
 # through by name match alone -- on every path that reads the allowlist.
-# ---------------------------------------------------------------------------
 
 
 def test_nested_value_under_safe_key_is_dropped_not_passed_through(tmp_path, monkeypatch):
@@ -348,11 +336,9 @@ def test_mcp_list_agents_drops_nested_secret_under_safe_key(tmp_path, monkeypatc
     assert NESTED_SECRET not in str(result)
 
 
-# ---------------------------------------------------------------------------
 # POST /agents/{name} and PUT /agents/{name} must not return the raw service
 # result in demo mode -- a harmless metadata edit must not be a side door to
 # the full prompt/guidance the GET routes already redact.
-# ---------------------------------------------------------------------------
 
 
 def test_create_and_update_agent_responses_are_redacted_in_demo_mode(tmp_path, monkeypatch):
@@ -404,11 +390,9 @@ def test_create_and_update_agent_responses_are_redacted_in_demo_mode(tmp_path, m
     assert PROMPT_SENTINEL in (agents_dir / "newagent2.md").read_text()
 
 
-# ---------------------------------------------------------------------------
 # The plugin-agent route is a full-content mirror of the same kind of
 # owner-authored markdown the Library agent routes protect -- it must not be
 # a silent bypass one path segment over.
-# ---------------------------------------------------------------------------
 
 
 def test_plugin_agent_route_is_redacted_in_demo_mode(tmp_path, monkeypatch):
@@ -439,11 +423,9 @@ def test_plugin_agent_route_is_redacted_in_demo_mode(tmp_path, monkeypatch):
     assert "<redacted," in redacted.text
 
 
-# ---------------------------------------------------------------------------
 # The definitions listing carries the same path/disk_path fields the single
 # get_definition() route already abbreviates -- the listing must match it
 # instead of shipping the unabridged on-disk location for every agent.
-# ---------------------------------------------------------------------------
 
 
 def test_definitions_listing_path_is_projected_in_demo_mode(tmp_path, monkeypatch):
@@ -473,11 +455,9 @@ def test_definitions_listing_path_is_projected_in_demo_mode(tmp_path, monkeypatc
     assert r_entry["disk_path"] == "demoagent.md"
 
 
-# ---------------------------------------------------------------------------
 # rollback_definition() must write the real content back, not the redacted
 # placeholder that get_version() shows an external caller -- a rollback is a
 # write, and redaction applies to reads that leave the service.
-# ---------------------------------------------------------------------------
 
 
 def test_rollback_succeeds_with_real_content_in_demo_mode(tmp_path, monkeypatch):
@@ -500,11 +480,9 @@ def test_rollback_succeeds_with_real_content_in_demo_mode(tmp_path, monkeypatch)
     assert "<redacted," not in on_disk
 
 
-# ---------------------------------------------------------------------------
 # Negative control: with the projection disabled (redact=False), the same
 # routes DO leak -- confirming the tests above exercise the projection
 # rather than passing independently of it.
-# ---------------------------------------------------------------------------
 
 
 def test_negative_control_projection_disabled_leaks_by_default(tmp_path, monkeypatch):
@@ -520,12 +498,10 @@ def test_negative_control_projection_disabled_leaks_by_default(tmp_path, monkeyp
     assert SECRET_ENV_VALUE in listing.text
 
 
-# ---------------------------------------------------------------------------
 # /api/plugins/{name} embeds each agent's {name, description} and the
 # plugin's on-disk path directly -- it must project both through the same
 # table the dedicated /plugins/{plugin}/agents/{agent} route already applies,
 # not mirror them unfiltered one path segment over.
-# ---------------------------------------------------------------------------
 
 
 def test_plugin_detail_route_redacts_nested_agents_and_path(tmp_path, monkeypatch):
@@ -567,11 +543,9 @@ def test_plugin_detail_route_redacts_nested_agents_and_path(tmp_path, monkeypatc
     assert body["path"] == "nested"
 
 
-# ---------------------------------------------------------------------------
 # /api/plugins (the list route) builds each entry from the same summary the
 # detail route abbreviates -- it must agree with /api/plugins/{name} instead
 # of shipping the unabridged on-disk path one route over.
-# ---------------------------------------------------------------------------
 
 
 def test_plugin_list_route_redacts_path_matching_detail_route(tmp_path, monkeypatch):
@@ -612,7 +586,6 @@ def test_plugin_list_route_redacts_path_matching_detail_route(tmp_path, monkeypa
     assert detail.json()["path"] == redacted_entry["path"]
 
 
-# ---------------------------------------------------------------------------
 # A scalar-shaped safe key's guard is only as good as the value it inspects.
 # list_agents()/get_agent() used to str()-coerce provider/model *before* the
 # classification table saw them, so a nested mapping smuggled in under
@@ -620,7 +593,6 @@ def test_plugin_list_route_redacts_path_matching_detail_route(tmp_path, monkeypa
 # scalar check waved through. This plants the nested value in an actual
 # on-disk agent file (not a monkeypatched, already-dict-shaped MCP row) so
 # the service layer's own coercion is what's under test.
-# ---------------------------------------------------------------------------
 
 
 def test_nested_provider_from_real_yaml_frontmatter_is_dropped(tmp_path, monkeypatch):
@@ -665,12 +637,10 @@ def test_nested_provider_from_real_yaml_frontmatter_is_dropped(tmp_path, monkeyp
     assert row["provider"] is None
 
 
-# ---------------------------------------------------------------------------
 # abbreviate_path() must refuse to str()-serialize a non-path-like value
 # rather than smuggle its content through as a "filename" -- a `path:` key
 # collides with the reserved field project_agent_fields adds for every
 # profile record.
-# ---------------------------------------------------------------------------
 
 
 def test_abbreviate_path_rejects_non_path_like_value():
@@ -714,13 +684,11 @@ def test_malformed_path_frontmatter_value_is_dropped_not_serialized(tmp_path, mo
     assert NESTED_SECRET not in redacted_definition.text
 
 
-# ---------------------------------------------------------------------------
 # snapshot_current() re-saves any definition whose disk content differs from
 # its latest stored version. The internal equality check must compare
 # against the raw stored content, not get_version()'s redacted response text
 # -- otherwise an unchanged agent file in demo mode never matches its own
 # redacted-placeholder comparison and gets re-snapshotted on every call.
-# ---------------------------------------------------------------------------
 
 
 def test_snapshot_current_does_not_resnapshot_unchanged_agent_in_demo_mode(tmp_path, monkeypatch):
@@ -741,11 +709,9 @@ def test_snapshot_current_does_not_resnapshot_unchanged_agent_in_demo_mode(tmp_p
     assert current.json()["version"] == 1
 
 
-# ---------------------------------------------------------------------------
 # Route-enumeration coverage: fails loudly when a new route is registered
 # under an area that reads agent-profile content without a redaction
 # decision having been made for it.
-# ---------------------------------------------------------------------------
 
 
 def test_route_enumeration_covers_known_agent_profile_routes():

--- a/tests/apps_studio_server/test_lifecycle_reapers.py
+++ b/tests/apps_studio_server/test_lifecycle_reapers.py
@@ -224,9 +224,7 @@ def test_reap_stale_invocations_zero_session_within_grace(tmp_path, monkeypatch)
 
 def test_reap_stale_invocations_deadline_lost_cas_does_not_stamp_ended_at(tmp_path, monkeypatch):
     """A lost CAS race on the deadline path must not leave ended_at stamped
-    while status is still "running" — the same "status and ended_at
-    disagree" defect as issue #2844, on the invocation deadline path.
-    """
+    while status is still "running"."""
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
 
@@ -253,9 +251,7 @@ def test_reap_stale_invocations_zero_session_lost_cas_does_not_stamp_ended_at(
     tmp_path, monkeypatch
 ):
     """A lost CAS race on the zero-session path must not leave ended_at
-    stamped while status is still "running" — the same "status and ended_at
-    disagree" defect as issue #2844, on the invocation zero-session path.
-    """
+    stamped while status is still "running"."""
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
 
@@ -876,9 +872,7 @@ def test_reap_phantom_sessions_skips_healthy_running(tmp_path, monkeypatch):
 
 def test_reap_phantom_sessions_lost_cas_does_not_stamp_ended_at(tmp_path, monkeypatch):
     """A lost CAS race on the status write must not leave ended_at stamped
-    while status is still "running" — that mismatch is exactly the
-    "status and ended_at disagree" defect from issue #2844.
-    """
+    while status is still "running"."""
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)
 

--- a/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
+++ b/tests/apps_studio_server/test_lifecycle_schedule_run_reaper.py
@@ -217,23 +217,21 @@ def test_reap_stale_schedule_runs_excludes_leased_task_queue_rows(tmp_path, monk
 def test_pre_terminal_write_bumps_updated_at_so_reaper_does_not_race_completion(
     tmp_path, monkeypatch
 ):
-    """A schedule_run legitimately running past the stale window is about
-    to finish: _fire_inner() first writes exit_code/ended_at via
-    update_schedule_run() (fields-only, no status), then transitions the
-    row to its terminal status via update_status(). If a periodic reaper
-    scan landed in that gap while the row's updated_at was still the old
-    stale snapshot, its expected_updated_at guard would still match and it
-    could mark the row timed_out out from under the run that is in the
-    middle of legitimately completing.
+    """A schedule_run legitimately running past the stale window is about to
+    finish: _fire_inner() first writes exit_code/ended_at via
+    update_schedule_run() (fields-only, no status), then transitions the row
+    to terminal via update_status(). If a periodic reaper scan landed in
+    that gap while updated_at was still the old stale snapshot, its
+    expected_updated_at guard would still match and could mark the row
+    timed_out out from under a run that is legitimately completing.
 
     update_schedule_run()'s field-only write now bumps updated_at on every
-    call (mirroring update_status()'s own behavior), so a reaper scan
-    landing in this exact window sees a fresh updated_at and skips the row
-    outright -- it never even reaches the CAS write. This directly
-    simulates that interleaving: seed a stale running row, perform the
-    pre-terminal field write, run the reaper, then perform the terminal
-    transition -- the row must land in its true terminal status, not
-    timed_out.
+    call (mirroring update_status()), so a reaper scan landing in this
+    window sees a fresh updated_at and skips the row before it ever reaches
+    the CAS write. This simulates the interleaving directly: seed a stale
+    running row, perform the pre-terminal field write, run the reaper, then
+    perform the terminal transition -- the row must land in its true
+    terminal status, not timed_out.
     """
     db_path = tmp_path / "state.db"
     _monkey_db(monkeypatch, db_path)

--- a/tests/apps_studio_server/test_listing_bounds.py
+++ b/tests/apps_studio_server/test_listing_bounds.py
@@ -583,26 +583,25 @@ class TestStoreProbe:
         """The tests above must not inherit a ``SIG_DFL`` from an earlier test.
 
         Several of them close an event loop while a database connection's
-        worker thread may still be finishing. Closing a loop closes the read
-        end of its self-pipe before the write end, so a thread handing back a
-        result in that window writes to a pipe whose peer is gone. Under the
-        interpreter default that is an ``OSError`` asyncio already swallows.
-        Under ``SIG_DFL`` the kernel kills the process first, and it dies with
-        its buffered output still buffered: no traceback, no failing
-        assertion, just a worker that stopped and a report blaming whichever
-        test it was holding.
+        worker thread may still be finishing; closing a loop closes the read
+        end of its self-pipe before the write end, so a thread handing back
+        a result in that window writes to a pipe whose peer is gone. Under
+        the interpreter default that's an ``OSError`` asyncio swallows.
+        Under ``SIG_DFL`` the kernel kills the process first, with buffered
+        output still buffered: no traceback, no failing assertion, just a
+        worker that stopped.
 
-        The CLI sets ``SIG_DFL`` on entry, deliberately, because a command in
-        a pipeline should die quietly when its reader leaves. ``signal.signal``
-        is process-wide, so any test that drives the CLI in-process hands that
-        to every test after it. A fixture in ``tests/conftest.py`` puts it
-        back; this asserts the tests here actually got the benefit.
+        The CLI sets ``SIG_DFL`` on entry deliberately, so a command in a
+        pipeline dies quietly when its reader leaves. ``signal.signal`` is
+        process-wide, so any test that drives the CLI in-process leaks that
+        policy to every test after it; a fixture in ``tests/conftest.py``
+        restores it, and this asserts the restore actually happened.
 
-        Order-dependent by nature: it can only catch the leak when something
-        that changes the policy ran earlier in this same process. Run this
-        file after ``tests/cli`` with ``-n 0`` to see it fail without that
-        fixture. Distributed across workers it may pass without proving
-        anything, which is why it is written to never fail falsely.
+        Order-dependent by nature -- it only catches the leak when something
+        that changed the policy ran earlier in this same process (run this
+        file after ``tests/cli`` with ``-n 0`` to see it fail without the
+        fixture). Distributed across workers it may pass without proving
+        anything, so it is written to never fail falsely.
         """
         import signal
 

--- a/tests/apps_studio_server/test_mcp_servers.py
+++ b/tests/apps_studio_server/test_mcp_servers.py
@@ -36,9 +36,7 @@ STDIO_CONFIG = {
 URL_CONFIG = {"url": "https://example.invalid/mcp"}
 
 
-# ---------------------------------------------------------------------------
 # Shape validation
-# ---------------------------------------------------------------------------
 
 
 def test_validate_shape_rejects_missing_transport():
@@ -113,9 +111,7 @@ async def test_validate_config_malformed_never_attempts_connection(monkeypatch):
     assert called is False
 
 
-# ---------------------------------------------------------------------------
 # CRUD
-# ---------------------------------------------------------------------------
 
 
 def test_register_list_get_roundtrip(tmp_path, monkeypatch):
@@ -289,11 +285,9 @@ def test_enable_disable_nonexistent_returns_none(tmp_path, monkeypatch):
     assert mcp_mod.set_enabled("nope", False) is None
 
 
-# ---------------------------------------------------------------------------
 # Secret handling — never returned raw, never written to the synced file
 # for a disabled server, never present in the on-disk registry as anything
 # other than what the user configured.
-# ---------------------------------------------------------------------------
 
 
 def test_list_and_get_never_return_raw_secret(tmp_path, monkeypatch):
@@ -345,9 +339,7 @@ def test_synced_mcp_json_is_readable_by_mcp_resolve_contract(tmp_path, monkeypat
     assert servers["myserver"]["env"]["API_KEY"] == "sk-super-secret-value"
 
 
-# ---------------------------------------------------------------------------
 # Connection checking — a real attempt, and honest about whether one ran
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -539,10 +531,8 @@ async def test_check_server_connection_does_not_resurrect_deleted_server(tmp_pat
     assert mcp_mod.get_server("myserver") is None
 
 
-# ---------------------------------------------------------------------------
 # At-rest permissions -- the registry and derived file hold secret env
 # values verbatim, so neither may be group/world readable.
-# ---------------------------------------------------------------------------
 
 
 def _mode(path) -> int:
@@ -612,9 +602,7 @@ def test_save_registry_writes_temp_file_owner_only(tmp_path, monkeypatch):
     assert all(mode == 0o600 for mode in seen_modes)
 
 
-# ---------------------------------------------------------------------------
 # Routes (end-to-end through the FastAPI app)
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -693,14 +681,12 @@ def test_route_validate_malformed(mcp_client):
     assert body["errors"]
 
 
-# ---------------------------------------------------------------------------
 # Validate/Save parity -- Validate must accept exactly the edits Save
 # accepts. Save (PUT) merges a patch onto the stored config; a Validate that
 # shape-checks the raw patch instead rejects perfectly ordinary partial
 # edits (e.g. one that only changes `args`) and, worse, the env-deletion
 # patch Save requires to drop a key (an explicit `null` value, since a
 # client never sees secret values to resend them).
-# ---------------------------------------------------------------------------
 
 
 _PARITY_PATCH_CORPUS = [
@@ -826,7 +812,6 @@ def test_create_time_malformed_falsy_values_are_rejected_not_laundered(
     )
 
 
-# ---------------------------------------------------------------------------
 # URL-transport parity -- `_validate_shape` used to gate every args/env shape
 # check behind `has_command`, so a URL config (no `command` at all) skipped
 # them outright; `_merge_config` separately laundered a fresh url+malformed
@@ -835,7 +820,6 @@ def test_create_time_malformed_falsy_values_are_rejected_not_laundered(
 # malformed field in the same request) and update-time (a patch that edits
 # only the malformed field on an already-registered url server, never
 # resending `url`) -- the two shapes each mechanism above was specific to.
-# ---------------------------------------------------------------------------
 
 _URL_MALFORMED_PATCH_CORPUS = [
     ("env_list", {"env": []}),
@@ -988,11 +972,9 @@ def test_validate_create_time_null_env_against_empty_base_is_key_absent(tmp_path
     assert result["errors"] is None
 
 
-# ---------------------------------------------------------------------------
 # A stored status belongs to the configuration it sits on -- the connection
 # check refuses to write one for a configuration it never probed, and an
 # ordinary edit must not leave one behind for a configuration it replaced.
-# ---------------------------------------------------------------------------
 
 
 def test_update_server_clears_a_status_obtained_for_the_replaced_config(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_operator_conversation_lifecycle.py
+++ b/tests/apps_studio_server/test_operator_conversation_lifecycle.py
@@ -56,7 +56,7 @@ def _patch_state_db(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
     monkeypatch.setattr(runs_mod, "RUNS_ROOT", path.parent / "runs")
 
 
-# ─── Rename ──────────────────────────────────────────────────────────────
+# Rename
 
 
 @pytest.mark.asyncio
@@ -154,7 +154,7 @@ async def test_a_null_pinned_or_status_is_rejected_rather_than_acted_on(tmp_path
     await coordinator.shutdown()
 
 
-# ─── Organize: pin + archive ────────────────────────────────────────────
+# Organize: pin + archive
 
 
 @pytest.mark.asyncio
@@ -209,7 +209,7 @@ async def test_archiving_a_conversation_with_an_active_turn_conflicts(tmp_path, 
     await coordinator.shutdown()
 
 
-# ─── Fork ────────────────────────────────────────────────────────────────
+# Fork
 
 
 @pytest.mark.asyncio
@@ -368,7 +368,7 @@ async def test_forking_a_conversation_that_does_not_exist_raises_not_found(tmp_p
         await store.fork_conversation("does-not-exist")
 
 
-# ─── HTTP contract ──────────────────────────────────────────────────────
+# HTTP contract
 
 
 @pytest.mark.asyncio

--- a/tests/apps_studio_server/test_operator_fleet_inspection.py
+++ b/tests/apps_studio_server/test_operator_fleet_inspection.py
@@ -327,13 +327,11 @@ async def test_get_artifact_caps_and_redacts_content(monkeypatch):
     _assert_private_input_is_removed(result, source)
 
 
-# ---------------------------------------------------------------------------
 # An unreadable store must not answer like an empty one
 #
 # Each guard gets both arms. The unknown-arm alone would pass against a `known`
 # hardcoded to False, and the known-arm alone would pass against one hardcoded
 # True, so neither on its own shows the flag carries information.
-# ---------------------------------------------------------------------------
 
 
 async def test_list_sessions_reports_unknown_when_the_store_cannot_be_opened(monkeypatch):

--- a/tests/apps_studio_server/test_operator_invocation_and_artifact_reads.py
+++ b/tests/apps_studio_server/test_operator_invocation_and_artifact_reads.py
@@ -34,9 +34,7 @@ def _assert_planted_values_are_scrubbed(raw_source: object, tool_result: object)
     assert PLANTED_STORE_URL not in result_text
 
 
-# ---------------------------------------------------------------------------
 # get_invocation
-# ---------------------------------------------------------------------------
 
 
 async def test_get_invocation_returns_projected_fields_for_known_id(monkeypatch):
@@ -134,9 +132,7 @@ async def test_get_invocation_reports_unknown_for_missing_invocation_id(monkeypa
     assert result == {"known": False}
 
 
-# ---------------------------------------------------------------------------
 # list_artifacts
-# ---------------------------------------------------------------------------
 
 
 async def test_list_artifacts_returns_metadata_for_known_owner(monkeypatch):
@@ -210,9 +206,7 @@ async def test_list_artifacts_returns_empty_for_unknown_owner_id(monkeypatch):
     assert result["truncated"] is False
 
 
-# ---------------------------------------------------------------------------
 # get_artifact
-# ---------------------------------------------------------------------------
 
 
 async def test_get_artifact_returns_full_projection_for_known_id(monkeypatch):
@@ -290,9 +284,7 @@ async def test_get_artifact_reports_unknown_for_missing_artifact_id(monkeypatch)
     assert result == {"known": False}
 
 
-# ---------------------------------------------------------------------------
 # connection mode
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -335,9 +327,7 @@ async def test_the_read_tools_ask_for_a_read_only_open_where_the_store_offers_on
     assert seen == [True, False]
 
 
-# ---------------------------------------------------------------------------
 # redaction: the key-marker layer
-# ---------------------------------------------------------------------------
 
 # Deliberately shapeless: no prefix, no separator, no key=value or bearer form,
 # so none of redact.py's pattern layers can claim it. Whatever redacts this can

--- a/tests/apps_studio_server/test_operator_run_detail.py
+++ b/tests/apps_studio_server/test_operator_run_detail.py
@@ -244,17 +244,16 @@ async def test_run_detail_status_reason_summary_over_text_cap_is_truncated_and_r
 async def test_run_detail_summary_flag_follows_the_capped_string_not_the_raw_one(db_path):
     """The rule-separating arm for the truncation flag.
 
-    The over-cap row above cannot protect this: there the raw string and the
+    The over-cap row above can't protect this: there the raw string and the
     scrubbed string are BOTH over the cap, so a flag derived from either one
-    reports True and the test passes under either rule. It is green whichever
-    rule is in force, which makes it no guard at all against the flag drifting
-    back to the raw length.
+    reports True and passes under either rule -- no guard against the flag
+    drifting back to the raw length.
 
-    This fixture makes the two rules disagree. The summary is a run of absolute
-    paths, so scrubbing collapses each to its leaf and carries the length back
-    across the cap: raw is over, scrubbed is well under. Nothing is cut, so the
-    honest answer is False -- and a raw-derived flag answers True, telling the
-    reader a complete string was clipped.
+    This fixture makes the two rules disagree: the summary is a run of
+    absolute paths, so scrubbing collapses each to its leaf and pulls the
+    length back under the cap (raw is over, scrubbed is well under).
+    Nothing is cut, so the honest answer is False -- a raw-derived flag
+    would answer True, telling the reader a complete string was clipped.
     """
     from lionagi.studio.operator.redact import PER_ITEM_TEXT_CAP, scrub_text
     from lionagi.studio.operator.run_detail import run_detail

--- a/tests/apps_studio_server/test_operator_run_findings.py
+++ b/tests/apps_studio_server/test_operator_run_findings.py
@@ -370,18 +370,18 @@ async def test_a_secret_nested_under_a_credential_name_is_withheld_on_both_read_
 ):
     """A credential field name has to cover what is stored underneath it.
 
-    The two read layers share one rule about which field names name a secret,
-    and the point of sharing it is that a caller cannot be served on one path
-    what it is denied on the other. Asking that rule directly cannot see this
-    gap: both layers agree `auth` names a credential, and one of them still
-    served the object stored under it, because only one consulted the name
-    before descending into a container. So this asks both public tools for the
-    same payload and requires the same answer of them.
+    The two read layers share one rule about which field names a secret, so
+    a caller must not be served on one path what it is denied on the other.
+    Testing that rule directly can't see this gap: both layers agree `auth`
+    names a credential, but one of them served the object stored under it
+    anyway because only one consulted the name before descending into a
+    container. So this asks both public tools for the same payload and
+    requires the same answer.
 
-    The planted value is deliberately shapeless -- it has spaces, no known
-    prefix, and no header or assignment form -- so nothing except the field
-    name can withhold it. A secret that looked like one would pass here
-    whether the name was consulted or not.
+    The planted value is deliberately shapeless -- spaces, no known prefix,
+    no header or assignment form -- so nothing except the field name can
+    withhold it; a secret that looked like one would pass here regardless
+    of whether the name was consulted.
     """
     import json
 

--- a/tests/apps_studio_server/test_operator_session_reads.py
+++ b/tests/apps_studio_server/test_operator_session_reads.py
@@ -123,9 +123,7 @@ def db_path(tmp_path: Path, monkeypatch: Any) -> Path:
     return path
 
 
-# --------------------------------------------------------------------------
 # list_sessions
-# --------------------------------------------------------------------------
 
 
 async def test_list_sessions_happy_path(db_path):
@@ -182,9 +180,7 @@ async def test_list_sessions_redacts_secret_shaped_name(db_path):
     assert SECRET_VALUE not in str(result)
 
 
-# --------------------------------------------------------------------------
 # session_detail
-# --------------------------------------------------------------------------
 
 
 async def test_session_detail_happy_path(db_path):
@@ -292,9 +288,7 @@ async def test_session_detail_falls_back_on_invalid_cursor(db_path):
     assert result["source"] == "fallback"
 
 
-# --------------------------------------------------------------------------
 # session_signals
-# --------------------------------------------------------------------------
 
 
 async def test_session_signals_happy_path(db_path):

--- a/tests/apps_studio_server/test_playbooks_builtin_api.py
+++ b/tests/apps_studio_server/test_playbooks_builtin_api.py
@@ -35,9 +35,7 @@ EXPECTED_BUILTIN_NAMES = {
 }
 
 
-# ---------------------------------------------------------------------------
 # Bundled data integrity
-# ---------------------------------------------------------------------------
 
 
 def test_bundled_root_exists_and_has_expected_names():
@@ -64,9 +62,7 @@ def test_bundled_files_match_examples_playbooks_byte_for_byte():
         )
 
 
-# ---------------------------------------------------------------------------
 # list_builtin_playbooks / get_builtin_playbook (service layer, real bundled data)
-# ---------------------------------------------------------------------------
 
 
 class TestListBuiltinPlaybooks:
@@ -135,9 +131,7 @@ class TestGetBuiltinPlaybook:
         assert svc.get_builtin_playbook(bad_name) is None
 
 
-# ---------------------------------------------------------------------------
 # install_builtin_playbook — idempotent materialize into ~/.lionagi/playbooks
-# ---------------------------------------------------------------------------
 
 
 class TestInstallBuiltinPlaybook:
@@ -189,9 +183,7 @@ class TestInstallBuiltinPlaybook:
             svc.install_builtin_playbook("..")
 
 
-# ---------------------------------------------------------------------------
 # Route-level smoke tests (real app, real bundled data, isolated user dir)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration

--- a/tests/apps_studio_server/test_route_registry.py
+++ b/tests/apps_studio_server/test_route_registry.py
@@ -22,9 +22,7 @@ from lionagi.studio.registry import iter_studio_routes as _iter_at_import  # noq
 _AREAS_AT_IMPORT = {r.area for r in _iter_at_import()}
 _KEYS_AT_IMPORT = [(r.path, r.method) for r in _iter_at_import()]
 
-# ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(autouse=True)
@@ -41,9 +39,7 @@ def _isolated_registry():
     _DEDUP_KEYS.update(saved_keys)
 
 
-# ---------------------------------------------------------------------------
 # 1. studio_route registers a StudioRoute; handler is returned unchanged
-# ---------------------------------------------------------------------------
 
 
 def test_registration_stores_route_and_returns_original():
@@ -105,9 +101,7 @@ def test_registration_stores_all_passed_fields():
     assert len(route.dependencies) == 1
 
 
-# ---------------------------------------------------------------------------
 # 2. tags=None defaults to (area,); explicit tags preserved verbatim
-# ---------------------------------------------------------------------------
 
 
 def test_tags_none_defaults_to_area():
@@ -140,9 +134,7 @@ def test_explicit_empty_tags_preserved():
     assert _ROUTES[0].tags == ()
 
 
-# ---------------------------------------------------------------------------
 # 3. iter_studio_routes returns immutable tuple sorted by order; area filter works
-# ---------------------------------------------------------------------------
 
 
 def test_iter_returns_tuple_sorted_by_order():
@@ -195,9 +187,7 @@ def test_iter_returns_immutable_tuple():
     assert isinstance(result, tuple)
 
 
-# ---------------------------------------------------------------------------
 # 4. Dedup guard raises on same (path, method, module, qualname)
-# ---------------------------------------------------------------------------
 
 
 def test_dedup_guard_raises_on_duplicate():
@@ -226,9 +216,7 @@ def test_dedup_same_path_different_method_allowed():
     assert len(_ROUTES) == 2
 
 
-# ---------------------------------------------------------------------------
 # 5. load_studio_route_modules registers every migrated area (phase 1+)
-# ---------------------------------------------------------------------------
 
 _MIGRATED_AREAS = {
     "casts",
@@ -277,9 +265,7 @@ def test_loaded_registry_has_no_duplicate_routes():
     assert len(_KEYS_AT_IMPORT) == len(set(_KEYS_AT_IMPORT)), "duplicate (path, method) in registry"
 
 
-# ---------------------------------------------------------------------------
 # 6. Live app still exposes its full route table (behavior-preservation gate)
-# ---------------------------------------------------------------------------
 
 
 def test_live_app_health_route_present():

--- a/tests/apps_studio_server/test_run_file.py
+++ b/tests/apps_studio_server/test_run_file.py
@@ -224,11 +224,9 @@ async def test_truncated_binary_file_over_cap_still_returns_415(
     assert exc_info.value.status_code == 415
 
 
-# ---------------------------------------------------------------------------
 # Bounded read: the cap must be enforced by the read itself, not by slicing
 # an already-materialized full read (Path.read_bytes() then [:cap] would
 # allocate the whole file before the cap applies).
-# ---------------------------------------------------------------------------
 
 
 async def test_content_read_never_calls_path_read_bytes(patched_runs_svc, tmp_path, monkeypatch):
@@ -315,12 +313,10 @@ async def test_short_reads_still_mark_oversized_file_truncated(
     assert total_returned <= 17  # cap + 1 total, even across many short reads
 
 
-# ---------------------------------------------------------------------------
 # Symlink swap after validation (TOCTOU): resolve_workspace_path validates a
 # path that was a regular file at check time; a later open-by-path would
 # follow whatever occupies that name at open time. The no-follow descriptor
 # walk must refuse the swapped target instead.
-# ---------------------------------------------------------------------------
 
 
 async def test_open_helper_refuses_target_swapped_to_symlink_after_validation(tmp_path):
@@ -370,10 +366,8 @@ async def test_open_helper_refuses_intermediate_dir_swapped_to_symlink(tmp_path)
         runs_svc._open_regular_file_no_follow(root, resolved)
 
 
-# ---------------------------------------------------------------------------
 # Endpoint-level coverage: exercise GET /api/runs/{run_id}/file through the
 # actual FastAPI route (TestClient), not just the service function directly.
-# ---------------------------------------------------------------------------
 
 
 def _make_client(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:

--- a/tests/apps_studio_server/test_run_resume_degraded_context.py
+++ b/tests/apps_studio_server/test_run_resume_degraded_context.py
@@ -4,14 +4,15 @@
 
 test_run_resume_dispatch.py's degraded-context coverage stubs
 ``launch_detached_argv`` itself, so it only proves the flag is appended (or
-withheld) in the built argv — it never exercises what happens to a refusal
-once a detached process actually runs and fails. This module keeps
-``_launches.launch_detached_argv`` and ``_spawn_detached`` real (only the
-OS-level subprocess spawn — ``spawn_and_wait`` — is stubbed, the same
-boundary test_launches_api.py stubs at), so a checkpoint with multiple
-pending inherited-context operations drives the full path: dispatch ->
-detached launch -> subprocess failure -> ``_failure_reason_summary`` ->
-persisted invocation row -> the summary a client would read.
+withheld) in the built argv -- it never exercises what happens to a
+refusal once a detached process actually runs and fails. This module
+keeps ``_launches.launch_detached_argv`` and ``_spawn_detached`` real
+(only the OS-level subprocess spawn, ``spawn_and_wait``, is stubbed, the
+same boundary test_launches_api.py stubs at), so a checkpoint with
+multiple pending inherited-context operations drives the full path:
+dispatch -> detached launch -> subprocess failure ->
+``_failure_reason_summary`` -> persisted invocation row -> the summary a
+client would read.
 """
 
 from __future__ import annotations

--- a/tests/apps_studio_server/test_runs_detail.py
+++ b/tests/apps_studio_server/test_runs_detail.py
@@ -18,9 +18,7 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from lionagi.state.db import StateDB  # noqa: E402
 from lionagi.state.reasons import RunReasons  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # Shared seed helpers (mirror test_sessions_detail.py idioms)
-# ---------------------------------------------------------------------------
 
 
 async def seed_session(
@@ -102,9 +100,7 @@ def patched_runs_svc(tmp_path: Path, monkeypatch: Any):
     return runs_svc, db_path
 
 
-# ---------------------------------------------------------------------------
 # Test 1 — get_run returns None for a missing run id
-# ---------------------------------------------------------------------------
 
 
 async def test_get_run_returns_none_for_missing_id(patched_runs_svc):
@@ -117,9 +113,7 @@ async def test_get_run_returns_none_for_missing_id(patched_runs_svc):
     assert result is None
 
 
-# ---------------------------------------------------------------------------
 # Test 2 — get_run returns None when DB file does not exist
-# ---------------------------------------------------------------------------
 
 
 async def test_get_run_returns_none_when_db_absent(patched_runs_svc):
@@ -130,9 +124,7 @@ async def test_get_run_returns_none_when_db_absent(patched_runs_svc):
     assert result is None
 
 
-# ---------------------------------------------------------------------------
 # Test 3 — get_run returns all required keys for a DB-seeded run
-# ---------------------------------------------------------------------------
 
 
 _REQUIRED_KEYS = {
@@ -169,9 +161,7 @@ async def test_get_run_returns_all_required_keys(patched_runs_svc):
     assert not missing, f"Missing keys in get_run response: {missing}"
 
 
-# ---------------------------------------------------------------------------
 # Test 4 — get_run maps session fields to correct response keys
-# ---------------------------------------------------------------------------
 
 
 async def test_get_run_maps_session_fields_correctly(patched_runs_svc):
@@ -203,9 +193,7 @@ async def test_get_run_maps_session_fields_correctly(patched_runs_svc):
     assert result["task"] == ""
 
 
-# ---------------------------------------------------------------------------
 # Test 5 — step_count matches branch count; steps list is populated
-# ---------------------------------------------------------------------------
 
 
 async def test_get_run_step_count_and_steps_from_branches(patched_runs_svc):
@@ -225,9 +213,7 @@ async def test_get_run_step_count_and_steps_from_branches(patched_runs_svc):
     assert step_names == {"alpha", "beta"}
 
 
-# ---------------------------------------------------------------------------
 # Test 6 — artifact_contract_json and artifact_verification_json are passed through
-# ---------------------------------------------------------------------------
 
 
 async def test_get_run_passes_artifact_json_fields(patched_runs_svc):
@@ -252,9 +238,7 @@ async def test_get_run_passes_artifact_json_fields(patched_runs_svc):
     assert resolved["staleness_check"] == "unknown"
 
 
-# ---------------------------------------------------------------------------
 # Test 7 — graph is populated from node_metadata when present
-# ---------------------------------------------------------------------------
 
 
 async def test_get_run_graph_from_node_metadata(patched_runs_svc):
@@ -275,9 +259,7 @@ async def test_get_run_graph_from_node_metadata(patched_runs_svc):
     assert graph["nodes"][0]["id"] == "collect"
 
 
-# ---------------------------------------------------------------------------
 # Test 8 — graph is None when no node_metadata present
-# ---------------------------------------------------------------------------
 
 
 async def test_get_run_graph_is_none_without_node_metadata(patched_runs_svc):
@@ -291,9 +273,7 @@ async def test_get_run_graph_is_none_without_node_metadata(patched_runs_svc):
     assert result["graph"] is None
 
 
-# ---------------------------------------------------------------------------
 # Test 9 — steps is None when no branches exist
-# ---------------------------------------------------------------------------
 
 
 async def test_get_run_steps_is_none_with_no_branches(patched_runs_svc):
@@ -309,9 +289,7 @@ async def test_get_run_steps_is_none_with_no_branches(patched_runs_svc):
     assert result["branches"] == []
 
 
-# ---------------------------------------------------------------------------
 # Test 10 — HTTP endpoint returns 404 for missing run
-# ---------------------------------------------------------------------------
 
 
 def test_get_run_endpoint_returns_404_for_missing(tmp_path, monkeypatch):
@@ -329,9 +307,7 @@ def test_get_run_endpoint_returns_404_for_missing(tmp_path, monkeypatch):
     assert r.status_code == 404
 
 
-# ---------------------------------------------------------------------------
 # Test 11 — detail route satisfies the list Run contract (no field drift)
-# ---------------------------------------------------------------------------
 
 # The fields the extension's `Run` TS interface (apps/vscode/src/api/types.ts)
 # requires from GET /api/runs/{id}. The detail route once dropped these (e.g.
@@ -449,9 +425,7 @@ async def test_get_run_zombie_recorded_pid_reports_stale(patched_runs_svc, monke
     assert result["effective_health"] == "stale"
 
 
-# ---------------------------------------------------------------------------
 # get_run() / _build_steps_from_db() over the default 200-message window
-# ---------------------------------------------------------------------------
 
 
 async def seed_over_limit_branch(

--- a/tests/apps_studio_server/test_runs_list.py
+++ b/tests/apps_studio_server/test_runs_list.py
@@ -147,7 +147,7 @@ def test_runs_list_invalid_page_rejected(tmp_path, monkeypatch):
     assert r.status_code == 422
 
 
-# ─── GET /api/runs/projects — per-project counts for the lazy runs explorer ───
+# GET /api/runs/projects — per-project counts for the lazy runs explorer
 
 
 def test_runs_projects_groups_counts_and_sorted(tmp_path, monkeypatch):
@@ -199,7 +199,7 @@ def test_runs_list_project_null_filter(tmp_path, monkeypatch):
     assert r2.json()["total"] == 2
 
 
-# ─── GET /api/runs?search= — session/agent name contains filter ─────────────
+# GET /api/runs?search= — session/agent name contains filter
 
 
 def test_runs_list_search_matches_name_or_agent_name(tmp_path, monkeypatch):
@@ -334,7 +334,7 @@ def test_runs_list_search_composes_with_pagination(tmp_path, monkeypatch):
     assert all("target" in run["name"] for run in data["runs"])
 
 
-# ─── ADR-0057/FIX-1: UNRESPONSIVE maps to 'stale' in runs list ───────────────
+# ADR-0057: UNRESPONSIVE maps to 'stale' in runs list
 
 
 async def _seed_running_session_with_activity(
@@ -476,9 +476,9 @@ def test_runs_list_node_metadata_dead_pid_reports_stale_without_monkeypatch(tmp_
 
 def test_runs_list_reports_status_ended_at_mismatch_count(tmp_path, monkeypatch):
     """A row whose status is 'running' but whose ended_at is already stamped
-    (issue #2844 -- status and ended_at disagreeing) must be visible as a
-    recomputed consistency count on the listing envelope, not something a
-    caller can only find by cross-checking every row's two fields by hand."""
+    must be visible as a recomputed consistency count on the listing
+    envelope, not something a caller can only find by cross-checking every
+    row's two fields by hand."""
     db_path = tmp_path / "state.db"
     good_running_id = str(uuid.uuid4())
     good_completed_id = str(uuid.uuid4())

--- a/tests/apps_studio_server/test_schema_batch2.py
+++ b/tests/apps_studio_server/test_schema_batch2.py
@@ -15,9 +15,7 @@ aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
 from tests.apps_studio_server._helpers import run_async as _run  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # status_source column migration and round-trip
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration

--- a/tests/apps_studio_server/test_security_batch1.py
+++ b/tests/apps_studio_server/test_security_batch1.py
@@ -26,9 +26,7 @@ def _make_fake_home(tmp_path: Path) -> Path:
     return fake_home
 
 
-# ---------------------------------------------------------------------------
 # public_path() must never return absolute paths
-# ---------------------------------------------------------------------------
 
 
 class TestPublicPath:
@@ -64,9 +62,7 @@ class TestPublicPath:
         assert result == "system.log"
 
 
-# ---------------------------------------------------------------------------
 # definitions disk_path must not be absolute
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -100,9 +96,7 @@ class TestDefinitionsDiskPath:
         assert "myagent" in disk_path
 
 
-# ---------------------------------------------------------------------------
 # plugins path field must not be absolute
-# ---------------------------------------------------------------------------
 
 
 class TestPluginsPathSanitization:
@@ -170,9 +164,7 @@ class TestPluginsPathSanitization:
         )
 
 
-# ---------------------------------------------------------------------------
 # marketplace plugin source paths must be bounded to repo root
-# ---------------------------------------------------------------------------
 
 
 class TestMarketplaceSourcePaths:
@@ -262,9 +254,7 @@ class TestMarketplaceSourcePaths:
         assert "abs" not in names
 
 
-# ---------------------------------------------------------------------------
 # optional bearer token auth
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration

--- a/tests/apps_studio_server/test_services_store_resolution.py
+++ b/tests/apps_studio_server/test_services_store_resolution.py
@@ -1,20 +1,18 @@
 """The studio services open the store the daemon serves.
 
-Every service in this layer used to name ``DEFAULT_DB_PATH`` at import. That is
-the right file until ``LIONAGI_STATE_DB_URL`` moves the store, and then it is a
-different database from the one the daemon writes: the routes report on rows
-nobody is serving, and SQLite creates the unrelated file on connect if it is
-not already there.
+Every service in this layer used to name ``DEFAULT_DB_PATH`` at import.
+That is the right file until ``LIONAGI_STATE_DB_URL`` moves the store, and
+then it is a different database from the one the daemon writes: the routes
+report on rows nobody is serving, and SQLite creates the unrelated file on
+connect if it is not already there.
 
-Two things are worth pinning. The first is that nothing changes for a
-deployment that has not moved anything, since that is what makes changing every
-service at once safe. The second is that a health answer and a data answer come
-from the same store, because two services resolving separately is the defect
-this replaces rather than a smaller version of it.
+Two things are pinned: a deployment that has not moved anything sees no
+change, and a health answer and a data answer come from the same store
+(two services resolving separately was the original defect).
 
-The default path is present and wrong in these tests, not absent. A service
-still reading it would then answer from an empty database instead of raising,
-which is the failure that has to be visible here.
+The default path is present and wrong in these tests, not absent, so a
+service still reading it answers from an empty database instead of
+raising -- that silent-wrong-answer failure is what must stay visible.
 """
 
 from __future__ import annotations

--- a/tests/apps_studio_server/test_sessions_detail.py
+++ b/tests/apps_studio_server/test_sessions_detail.py
@@ -17,9 +17,7 @@ aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 from lionagi.state.claude_mirror import session_db_id  # noqa: E402
 from lionagi.state.db import SESSION_TERMINAL_STATUSES, StateDB  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # Shared test data
-# ---------------------------------------------------------------------------
 
 
 def dag_metadata() -> dict:
@@ -35,9 +33,7 @@ def dag_metadata() -> dict:
     }
 
 
-# ---------------------------------------------------------------------------
 # Fixtures and helpers
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -97,9 +93,7 @@ async def overwrite_session_node_metadata(db_path: Path, session_id: str, raw: s
         await db.commit()
 
 
-# ---------------------------------------------------------------------------
 # Test 1.1 — falsy / unparseable inputs return None
-# ---------------------------------------------------------------------------
 
 
 def test_graph_from_metadata_none_empty_and_invalid_json_return_none():
@@ -110,9 +104,7 @@ def test_graph_from_metadata_none_empty_and_invalid_json_return_none():
     assert _graph_from_metadata("{not-json") is None
 
 
-# ---------------------------------------------------------------------------
 # Test 1.2 — non-dict root and empty operations list return None
-# ---------------------------------------------------------------------------
 
 
 def test_graph_from_metadata_rejects_non_dict_and_missing_operations():
@@ -123,9 +115,7 @@ def test_graph_from_metadata_rejects_non_dict_and_missing_operations():
     assert _graph_from_metadata(json.dumps({"agents": [], "operations": []})) is None
 
 
-# ---------------------------------------------------------------------------
 # Test 1.3 — valid DAG: correct node fields and dependency edge
-# ---------------------------------------------------------------------------
 
 
 def test_graph_from_metadata_builds_nodes_and_dependency_edges():
@@ -161,9 +151,7 @@ def test_graph_from_metadata_builds_nodes_and_dependency_edges():
     ]
 
 
-# ---------------------------------------------------------------------------
 # Test 1.4 — malformed agents/operations entries are silently filtered
-# ---------------------------------------------------------------------------
 
 
 def test_graph_from_metadata_filters_malformed_agents_and_operations():
@@ -194,9 +182,7 @@ def test_graph_from_metadata_filters_malformed_agents_and_operations():
     assert graph["edges"] == []
 
 
-# ---------------------------------------------------------------------------
 # Test 1.5 — unknown agent_id yields blank role and assignment
-# ---------------------------------------------------------------------------
 
 
 def test_graph_from_metadata_unknown_agent_uses_blank_role_and_assignment():
@@ -217,9 +203,7 @@ def test_graph_from_metadata_unknown_agent_uses_blank_role_and_assignment():
     assert graph["edges"] == []
 
 
-# ---------------------------------------------------------------------------
 # Test 1.6 — string depends_on must not produce character-level edges
-# ---------------------------------------------------------------------------
 
 
 def test_graph_from_metadata_malformed_depends_on_does_not_create_character_edges():
@@ -238,9 +222,7 @@ def test_graph_from_metadata_malformed_depends_on_does_not_create_character_edge
     assert graph["edges"] == []
 
 
-# ---------------------------------------------------------------------------
 # Test 1.7 — get_session: valid DAG metadata → full graph in response
-# ---------------------------------------------------------------------------
 
 
 async def test_get_session_returns_graph_from_session_node_metadata(patched_sessions_db):
@@ -270,9 +252,7 @@ async def test_get_session_returns_graph_from_session_node_metadata(patched_sess
     ]
 
 
-# ---------------------------------------------------------------------------
 # Test 1.8 — get_session: null metadata → graph is None, duration is None
-# ---------------------------------------------------------------------------
 
 
 async def test_get_session_returns_none_graph_for_null_node_metadata(patched_sessions_db):
@@ -295,9 +275,7 @@ async def test_get_session_returns_none_graph_for_null_node_metadata(patched_ses
     assert result["source_kind"] == "live"
 
 
-# ---------------------------------------------------------------------------
 # Artifact verification display state
-# ---------------------------------------------------------------------------
 
 
 ARTIFACT_CONTRACT = {"expected": [{"id": "report", "path": "REPORT.md", "required": True}]}
@@ -425,9 +403,7 @@ async def test_get_session_keeps_verification_null_when_no_contract_exists(patch
     assert result["artifact_verification_json"] is None
 
 
-# ---------------------------------------------------------------------------
 # Test 1.8a — get_session_by_cc_id: legacy rows fall back to deterministic id
-# ---------------------------------------------------------------------------
 
 
 async def test_get_session_by_cc_id_falls_back_for_legacy_row(patched_sessions_db):
@@ -443,9 +419,7 @@ async def test_get_session_by_cc_id_falls_back_for_legacy_row(patched_sessions_d
     assert result["name"] == "Test Session"
 
 
-# ---------------------------------------------------------------------------
 # Test 1.9 — get_session: corrupt raw metadata → graph is None, no exception
-# ---------------------------------------------------------------------------
 
 
 async def test_get_session_returns_none_graph_for_raw_invalid_node_metadata(patched_sessions_db):
@@ -460,9 +434,7 @@ async def test_get_session_returns_none_graph_for_raw_invalid_node_metadata(patc
     assert result["graph"] is None
 
 
-# ---------------------------------------------------------------------------
 # Test 1.10 — get_session: branch + ordered messages + DAG graph together
-# ---------------------------------------------------------------------------
 
 
 async def test_get_session_orders_branch_messages_and_keeps_dag_graph(patched_sessions_db):
@@ -537,11 +509,6 @@ async def test_get_session_orders_branch_messages_and_keeps_dag_graph(patched_se
     )
 
 
-# ===========================================================================
-# Round 2 helpers
-# ===========================================================================
-
-
 async def seed_branch(
     db_path: Path,
     *,
@@ -572,9 +539,7 @@ async def seed_branch(
     return prog_id
 
 
-# ---------------------------------------------------------------------------
 # Tests 3.1–3.6 — list_sessions
-# ---------------------------------------------------------------------------
 
 
 async def test_list_sessions_returns_empty_when_db_absent(patched_sessions_db):
@@ -770,9 +735,7 @@ async def test_list_sessions_branch_and_message_counts(patched_sessions_db):
     assert row["message_count"] == 2
 
 
-# ---------------------------------------------------------------------------
 # Tests 4.1–4.5 — get_session_messages_after
-# ---------------------------------------------------------------------------
 
 
 async def test_get_session_messages_after_returns_empty_when_db_absent(patched_sessions_db):
@@ -1008,9 +971,7 @@ async def test_get_session_messages_after_message_shape_matches_expected_fields(
     ]
 
 
-# ---------------------------------------------------------------------------
 # Tests 5.1–5.3 — session_exists
-# ---------------------------------------------------------------------------
 
 
 async def test_session_exists_returns_true_for_existing_session(patched_sessions_db):
@@ -1034,9 +995,7 @@ async def test_session_exists_returns_false_when_db_file_absent(patched_sessions
     assert await svc.session_exists("any-id") is False
 
 
-# ---------------------------------------------------------------------------
 # Message pagination — detail responses window from the progression tail
-# ---------------------------------------------------------------------------
 
 
 async def seed_paginated_session(db_path: Path, *, count: int = 10) -> list[str]:
@@ -1129,9 +1088,7 @@ async def test_get_session_limit_clamped_to_max(patched_sessions_db):
     assert branch["message_total"] == 5
 
 
-# ---------------------------------------------------------------------------
 # message_cursor — stable pagination under concurrent progression appends
-# ---------------------------------------------------------------------------
 
 
 async def test_get_session_cursor_pages_are_stable_under_concurrent_appends(patched_sessions_db):
@@ -1237,9 +1194,7 @@ async def test_get_session_rejects_cursor_from_a_different_session(patched_sessi
         await svc.get_session("sess-paged", message_limit=1, message_cursor=foreign_cursor)
 
 
-# ---------------------------------------------------------------------------
 # Action-stat aggregation must match the canonical persisted lion_class values
-# ---------------------------------------------------------------------------
 
 
 async def test_get_session_action_stats_match_canonical_fully_qualified_lion_class(

--- a/tests/apps_studio_server/test_shows.py
+++ b/tests/apps_studio_server/test_shows.py
@@ -16,9 +16,7 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402 — must follow importorskip
 
-# ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -70,9 +68,7 @@ def show_with_play(shows_root: Path) -> str:
     return topic
 
 
-# ---------------------------------------------------------------------------
 # Tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -116,9 +112,7 @@ def test_show_detail_not_found(patched_app):
     assert r.status_code == 404
 
 
-# ---------------------------------------------------------------------------
 # /api/shows/gated-plays — real gate signal for the Mission Control queue
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -393,9 +387,7 @@ def test_gated_plays_truncated_meta_json_is_reported_unavailable(shows_root: Pat
     assert entry["live_state"] == "unavailable"
 
 
-# ---------------------------------------------------------------------------
 # Path traversal tests (Fix 1)
-# ---------------------------------------------------------------------------
 
 
 def test_path_traversal_encoded_dotdot_shows(patched_app):
@@ -436,9 +428,7 @@ async def test_watch_show_invalid_topic_yields_done(tmp_path, monkeypatch):
     assert json.loads(events[0].removeprefix("data: ").strip()) == {"type": "done"}
 
 
-# ---------------------------------------------------------------------------
 # strict status_source provenance
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -505,9 +495,7 @@ def test_show_detail_status_source_is_sqlite_with_db(sqlite_patched_app):
     )
 
 
-# ---------------------------------------------------------------------------
 # Docker regression test: get_show works from DB even when show dir is absent
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -598,11 +586,6 @@ def test_get_show_returns_404_when_dir_absent_and_no_db_row(docker_patched_app):
     client, _topic = docker_patched_app
     r = client.get("/api/shows/nonexistent-topic-xyz")
     assert r.status_code == 404
-
-
-# ---------------------------------------------------------------------------
-# import_shows() must not write an undeclared plays.status value (issue #2619)
-# ---------------------------------------------------------------------------
 
 
 def test_import_shows_refuses_undeclared_play_status(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_signals_sse.py
+++ b/tests/apps_studio_server/test_signals_sse.py
@@ -17,9 +17,7 @@ aiosqlite = pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
 
 from lionagi.state.db import StateDB  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # Helpers shared with test_sessions_detail.py conventions
-# ---------------------------------------------------------------------------
 
 
 async def _seed_session(db_path: Path, session_id: str = "sig-sess-1") -> None:
@@ -40,9 +38,7 @@ async def _seed_session(db_path: Path, session_id: str = "sig-sess-1") -> None:
         )
 
 
-# ---------------------------------------------------------------------------
 # StateDB: insert_session_signal + get_session_signals_after
-# ---------------------------------------------------------------------------
 
 
 async def test_insert_signal_returns_sequential_seq(tmp_path):
@@ -145,9 +141,7 @@ async def test_get_signals_payload_round_trips(tmp_path):
     assert row["payload"] == payload
 
 
-# ---------------------------------------------------------------------------
 # Studio service layer: signals.get_signals_after
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -220,9 +214,7 @@ async def test_service_get_signals_after_seq_filter(patched_signals_db):
     assert rows[1]["seq"] == 4
 
 
-# ---------------------------------------------------------------------------
 # HTTP endpoint: GET /api/sessions/{id}/signals
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -402,11 +394,9 @@ async def test_signals_endpoint_ordering_by_seq(patched_app):
     assert [r["seq"] for r in signal_rows] == [1, 2, 3]
 
 
-# ---------------------------------------------------------------------------
 # Production bind-site integration: observer.bind_db_persistence via the
 # CLI persist layer.  These tests prove the ignition wire exists and that
 # signals flow end-to-end from emit() → session_signals table → SSE service.
-# ---------------------------------------------------------------------------
 
 
 async def test_bind_db_persistence_production_path(tmp_path):
@@ -543,10 +533,8 @@ async def test_setup_agent_persist_wires_signal_bind(tmp_path, monkeypatch):
     await teardown_persist(ctx, status="completed")
 
 
-# ---------------------------------------------------------------------------
 # MAJOR-1: Concurrent emit must not drop rows (regression for BEGIN IMMEDIATE
 # on shared connection without per-instance asyncio lock).
-# ---------------------------------------------------------------------------
 
 
 async def test_concurrent_emit_all_rows_present(tmp_path):
@@ -590,9 +578,7 @@ async def test_concurrent_emit_all_rows_present(tmp_path):
     assert seqs == list(range(1, n + 1)), f"seq gaps detected: {seqs}"
 
 
-# ---------------------------------------------------------------------------
 # MAJOR-2: Payload safety — non-serialisable objects and large payloads.
-# ---------------------------------------------------------------------------
 
 
 async def test_payload_sanitizer_node_escalated_arbitrary_request(tmp_path):
@@ -755,9 +741,7 @@ async def test_payload_sanitizer_message_added_stores_ref_not_body(tmp_path):
     assert "data" not in payload
 
 
-# ---------------------------------------------------------------------------
 # MINOR: Bearer auth rejection for /api/sessions/{id}/signals
-# ---------------------------------------------------------------------------
 
 
 def test_signals_endpoint_requires_bearer_auth(tmp_path, monkeypatch):
@@ -796,9 +780,7 @@ def test_signals_endpoint_requires_bearer_auth(tmp_path, monkeypatch):
     )
 
 
-# ---------------------------------------------------------------------------
 # MINOR: Generator cancellation — client disconnect stops the SSE generator.
-# ---------------------------------------------------------------------------
 
 
 async def test_signals_generator_cancellation_on_disconnect(tmp_path, monkeypatch):
@@ -860,11 +842,9 @@ async def test_signals_generator_cancellation_on_disconnect(tmp_path, monkeypatc
         pytest.fail(f"generator.aclose() raised unexpected {type(exc).__name__}: {exc}")
 
 
-# ---------------------------------------------------------------------------
 # Invariant: _write_lock must be connection-wide — concurrent signal emits
 # must not race with update_status, update_session, or insert_message on
 # the same bound StateDB connection.
-# ---------------------------------------------------------------------------
 
 
 async def test_concurrent_emit_and_update_status_no_failures(tmp_path):
@@ -1092,11 +1072,9 @@ async def test_concurrent_emit_and_artifact_verification_no_failures(tmp_path):
     assert seqs == list(range(1, n + 1)), f"seq gaps after artifact race: {seqs}"
 
 
-# ---------------------------------------------------------------------------
 # Invariant: byte cap must hold on the FINAL serialized form, including JSON
 # escaping overhead. Regression: quote/backslash-heavy payloads stored 32 KB
 # instead of the claimed 16 KB cap.
-# ---------------------------------------------------------------------------
 
 
 async def test_payload_byte_cap_final_form_plain(tmp_path):

--- a/tests/apps_studio_server/test_skills_service.py
+++ b/tests/apps_studio_server/test_skills_service.py
@@ -13,9 +13,7 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from lionagi.studio.services.skills import validate_skill_content  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # validate_skill_content() — both arms per finding
-# ---------------------------------------------------------------------------
 
 VALID_SKILL = """---
 name: my-skill
@@ -98,9 +96,7 @@ def test_validate_skill_content_rejects_null_frontmatter():
     assert any("YAML" in e or "mapping" in e for e in errors)
 
 
-# ---------------------------------------------------------------------------
 # definitions.py — skill kind save / get / rollback
-# ---------------------------------------------------------------------------
 
 from tests.apps_studio_server._helpers import run_async as _run  # noqa: E402
 

--- a/tests/apps_studio_server/test_smoke.py
+++ b/tests/apps_studio_server/test_smoke.py
@@ -12,9 +12,7 @@ import pytest
 fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 from fastapi.testclient import TestClient  # noqa: E402 — must follow importorskip
 
-# ---------------------------------------------------------------------------
 # Helpers / shared fixtures
-# ---------------------------------------------------------------------------
 
 
 def _make_client(
@@ -93,9 +91,7 @@ def _make_client(
     return TestClient(app, base_url="http://127.0.0.1:8765")
 
 
-# ---------------------------------------------------------------------------
 # Stats
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -116,9 +112,7 @@ def test_stats_route(tmp_path, monkeypatch):
         assert isinstance(data[key], int)
 
 
-# ---------------------------------------------------------------------------
 # Shows
-# ---------------------------------------------------------------------------
 
 
 def test_shows_list(tmp_path, monkeypatch):
@@ -128,9 +122,7 @@ def test_shows_list(tmp_path, monkeypatch):
     assert isinstance(r.json(), list)
 
 
-# ---------------------------------------------------------------------------
 # Playbooks
-# ---------------------------------------------------------------------------
 
 
 def test_playbooks_list_returns_dict(tmp_path, monkeypatch):
@@ -151,9 +143,7 @@ def test_playbooks_list_empty(tmp_path, monkeypatch):
     assert r.json()["playbooks"] == []
 
 
-# ---------------------------------------------------------------------------
 # Runs
-# ---------------------------------------------------------------------------
 
 
 def test_runs_list_returns_dict(tmp_path, monkeypatch):
@@ -263,9 +253,7 @@ def test_run_detail_contract_fields(tmp_path, monkeypatch):
     assert data["worker_name"] == "my-worker"
 
 
-# ---------------------------------------------------------------------------
 # Path traversal — runs (Fix 1)
-# ---------------------------------------------------------------------------
 
 
 def test_path_traversal_encoded_dotdot_runs(tmp_path, monkeypatch):
@@ -280,9 +268,7 @@ def test_path_traversal_encoded_slash_runs(tmp_path, monkeypatch):
     assert r.status_code == 404
 
 
-# ---------------------------------------------------------------------------
 # Agents (Fix 3)
-# ---------------------------------------------------------------------------
 
 
 def test_agents_list_returns_dict(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_spa_serving.py
+++ b/tests/apps_studio_server/test_spa_serving.py
@@ -15,9 +15,7 @@ fastapi = pytest.importorskip("fastapi", reason="studio extra not installed")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
-# ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -78,9 +76,7 @@ def no_dist_client(
     yield TestClient(app, raise_server_exceptions=False, base_url="http://127.0.0.1:8765")
 
 
-# ---------------------------------------------------------------------------
 # SPA fallback routes
-# ---------------------------------------------------------------------------
 
 
 class TestSPAFallback:
@@ -115,9 +111,7 @@ class TestSPAFallback:
         assert "root" in resp.text
 
 
-# ---------------------------------------------------------------------------
 # /api/* paths must NOT be swallowed by the SPA fallback
-# ---------------------------------------------------------------------------
 
 
 class TestAPIPathsNotSwallowed:
@@ -150,9 +144,7 @@ class TestAPIPathsNotSwallowed:
         assert resp.json() == {"status": "ok"}
 
 
-# ---------------------------------------------------------------------------
 # No-cache headers on index.html
-# ---------------------------------------------------------------------------
 
 
 class TestNoCacheHeaders:
@@ -173,9 +165,7 @@ class TestNoCacheHeaders:
         )
 
 
-# ---------------------------------------------------------------------------
 # No-dist (API-only) mode
-# ---------------------------------------------------------------------------
 
 
 class TestNoDist:
@@ -197,9 +187,7 @@ class TestNoDist:
         assert resp.json() == {"status": "ok"}
 
 
-# ---------------------------------------------------------------------------
 # CORS HEAD method present after SPA mount (registration-order regression guard)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -238,9 +226,7 @@ class TestCORSAfterSPAMount:
         assert "HEAD" in allowed, f"HEAD must be in Access-Control-Allow-Methods; got {raw!r}"
 
 
-# ---------------------------------------------------------------------------
 # Auth-mode interplay: shell public, API guarded
-# ---------------------------------------------------------------------------
 
 
 class TestSPAWithAuthToken:

--- a/tests/apps_studio_server/test_startup_warmup.py
+++ b/tests/apps_studio_server/test_startup_warmup.py
@@ -1,17 +1,18 @@
 """The startup WAL checkpoint is deferred off the readiness path; reconciliation
 is not.
 
-The studio lifespan keeps stale-session reconciliation pre-yield (stateful /api
-routes read the rows it corrects) but defers the WAL checkpoint to a background
-task so /health serves as soon as reconciliation completes, without waiting on
-the checkpoint. These tests pin both halves of
-that contract, that the deferred checkpoint still runs with actor='startup', that
-a shutdown landing mid-checkpoint cancels it cleanly, and that a checkpoint
-failure is logged rather than silently dropped.
+The studio lifespan keeps stale-session reconciliation pre-yield (stateful
+/api routes read the rows it corrects) but defers the WAL checkpoint to a
+background task so /health serves as soon as reconciliation completes,
+without waiting on the checkpoint. These tests pin that contract: the
+deferred checkpoint still runs with actor='startup', a shutdown landing
+mid-checkpoint cancels it cleanly, and a checkpoint failure is logged
+rather than silently dropped.
 
-The real scheduler is patched out: its first tick runs the same maintenance
-functions (and spawns aiosqlite workers), which would otherwise pollute these
-assertions and leave a worker posting to a closed loop at teardown.
+The real scheduler is patched out: its first tick runs the same
+maintenance functions (and spawns aiosqlite workers), which would
+otherwise pollute these assertions and leave a worker posting to a closed
+loop at teardown.
 """
 
 from __future__ import annotations

--- a/tests/apps_studio_server/test_startup_warnings.py
+++ b/tests/apps_studio_server/test_startup_warnings.py
@@ -30,9 +30,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 _STUDIO_APP_LOGGER = "lionagi.studio.app"
 
 
-# ---------------------------------------------------------------------------
 # Handler spy infrastructure
-# ---------------------------------------------------------------------------
 
 
 class _RecordList(list["logging.LogRecord"]):
@@ -68,9 +66,7 @@ def _spy_logger(name: str) -> Generator[_RecordList]:
         logger.setLevel(orig_level)
 
 
-# ---------------------------------------------------------------------------
 # Client factory
-# ---------------------------------------------------------------------------
 
 
 async def _anoop(*args: object, **kwargs: object) -> None:
@@ -145,9 +141,7 @@ def _bare_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Generator[T
             client.portal = None
 
 
-# ---------------------------------------------------------------------------
 # Warning: no auth token
-# ---------------------------------------------------------------------------
 
 
 class TestNoAuthWarning:
@@ -200,9 +194,7 @@ class TestNoAuthWarning:
         )
 
 
-# ---------------------------------------------------------------------------
 # Escalated warning: 0.0.0.0 bind without token
-# ---------------------------------------------------------------------------
 
 
 class TestEscalatedWarningOnWildcardBind:
@@ -246,9 +238,7 @@ class TestEscalatedWarningOnWildcardBind:
         )
 
 
-# ---------------------------------------------------------------------------
 # CORS method set is bounded (not '*')
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
@@ -362,9 +352,7 @@ class TestCORSBoundedMethods:
         assert "HEAD" in allowlist, f"HEAD must be in the CORS allowlist; got {sorted(allowlist)}"
 
 
-# ---------------------------------------------------------------------------
 # CORS wildcard origin warning
-# ---------------------------------------------------------------------------
 
 
 class TestCORSWildcardOriginWarning:
@@ -408,9 +396,7 @@ class TestCORSWildcardOriginWarning:
         )
 
 
-# ---------------------------------------------------------------------------
 # CLI wires the resolved bind host into the warning source
-# ---------------------------------------------------------------------------
 
 
 class TestCLIHostWiring:

--- a/tests/apps_studio_server/test_stats_db_health.py
+++ b/tests/apps_studio_server/test_stats_db_health.py
@@ -105,9 +105,7 @@ def test_stats_db_health_missing_db_returns_zeroes(tmp_path, monkeypatch):
     assert db["sessions_by_status"] == {}
 
 
-# ---------------------------------------------------------------------------
 # stats reports the store the daemon serves, not a path of its own
-# ---------------------------------------------------------------------------
 
 
 def test_stats_size_comes_from_the_configured_store(tmp_path, monkeypatch):
@@ -142,9 +140,7 @@ def test_stats_size_comes_from_the_configured_store(tmp_path, monkeypatch):
     assert db["tables"]["sessions"] == 2
 
 
-# ---------------------------------------------------------------------------
 # invocation node_metadata parse failure must return None, not the raw string
-# ---------------------------------------------------------------------------
 
 
 async def _seed_invocation_with_bad_metadata(db_path: Path, inv_id: str) -> None:
@@ -202,9 +198,7 @@ def test_invocation_list_bad_metadata_becomes_none(tmp_path, monkeypatch):
     )
 
 
-# ---------------------------------------------------------------------------
 # the size alert is one decision, and both health surfaces report it
-# ---------------------------------------------------------------------------
 
 
 def test_doctor_and_stats_agree_on_the_size_alert(tmp_path, monkeypatch):

--- a/tests/apps_studio_server/test_workflow_compile.py
+++ b/tests/apps_studio_server/test_workflow_compile.py
@@ -19,7 +19,7 @@ from lionagi.studio.services.workflow_compile import (
     compile_workflow_def,
 )
 
-# ─── StudioExprCondition: allowed grammar ───────────────────────────────────
+# StudioExprCondition: allowed grammar
 
 
 async def test_eq_comparison_true():
@@ -75,7 +75,7 @@ async def test_non_dict_context_normalized_to_empty_dict():
         await cond.apply(None)
 
 
-# ─── Hostile inputs — MUST reject at construction, never crash ─────────────
+# Hostile inputs — MUST reject at construction, never crash
 
 HOSTILE_EXPRS = [
     "__class__",
@@ -147,7 +147,7 @@ def test_name_not_in_context_rejected_at_eval_not_construction():
         asyncio.run(cond.apply({"result": "x", "context": {}}))
 
 
-# ─── compile_workflow_def ────────────────────────────────────────────────────
+# compile_workflow_def
 
 
 def _make_spec(**overrides: Any) -> dict[str, Any]:
@@ -287,7 +287,7 @@ async def test_compile_null_budget_override_falls_back_to_def():
     assert engine_op.parameters["engine_max_agents"] == 5  # def value, not None
 
 
-# ─── Per-node cwd ──────────────────────────────────────────────────────
+# Per-node cwd
 
 
 async def _resolve_coding_kind(ref: str) -> dict[str, Any]:
@@ -624,7 +624,7 @@ async def test_compile_cycle_raises():
         await compile_workflow_def(spec, resolve_engine_def=_resolve_ok)
 
 
-# ─── build_early_graph ───────────────────────────────────────────────────────
+# build_early_graph
 
 
 def test_build_early_graph_shape():

--- a/tests/apps_studio_server/test_workflow_defs_api.py
+++ b/tests/apps_studio_server/test_workflow_defs_api.py
@@ -190,7 +190,7 @@ def test_route_registration():
     assert ("POST", "/workflow-defs/{def_id}/run") in paths
 
 
-# ─── gate-kind removal (workflow-exec Fork 1) ───────────────────────────────
+# gate-kind removal
 
 
 async def test_gate_kind_rejected_at_create(patched_svc):
@@ -239,7 +239,7 @@ async def test_gate_node_load_guard_names_the_node(patched_svc):
     assert "gate" in str(exc_info.value.detail)
 
 
-# ─── chat node config (WorkflowChatConfig) ──────────────────────────────────
+# chat node config (WorkflowChatConfig)
 
 
 def _spec_with_chat(config: dict[str, Any]) -> dict[str, Any]:
@@ -294,7 +294,7 @@ async def test_chat_node_no_model_passes(patched_svc):
     assert "id" in result
 
 
-# ─── edge condition field (WorkflowEdge.condition) ──────────────────────────
+# edge condition field (WorkflowEdge.condition)
 
 
 async def test_edge_condition_empty_string_raises(patched_svc):

--- a/tests/apps_studio_server/test_workflow_run.py
+++ b/tests/apps_studio_server/test_workflow_run.py
@@ -410,7 +410,7 @@ async def test_workflow_run_bare_chat_model_rejected_at_compile_defense_in_depth
     assert "chat1" in str(exc_info.value)
 
 
-# ─── Per-node cwd end-to-end ──────────────────────────────────────────────────
+# Per-node cwd end-to-end
 
 
 async def test_workflow_run_node_cwd_reaches_engine_invocation(patched_env, tmp_path):

--- a/tests/apps_studio_server/test_workflow_run_persist.py
+++ b/tests/apps_studio_server/test_workflow_run_persist.py
@@ -4,23 +4,22 @@
 """Regression test for the flow-created clone-branch persistence gap.
 
 `workflow_run._setup_run_persist` registers per-branch persistence
-(`register_branch_hook`) only for the branches present on `session.branches`
-at setup time. `session.flow()` -> `FlowExecutor._preallocate_all_branches`
-then clones `session.default_branch` for every operation that has a
-predecessor and no explicit `branch_id` (exactly what the Studio compiler
-produces for any multi-step workflow). Those clones are born *after* setup,
-so without the `on_branch_created` seam their transcripts never persist —
-even though the run-DAG *signals* still render, because those persist via a
-separate session-level observer, not the per-branch message hook.
+(`register_branch_hook`) only for branches present on `session.branches` at
+setup time. `session.flow()` -> `FlowExecutor._preallocate_all_branches`
+then clones `session.default_branch` for every operation with a predecessor
+and no explicit `branch_id` -- exactly what the Studio compiler produces for
+any multi-step workflow. Those clones are born *after* setup, so without the
+`on_branch_created` seam their transcripts never persist, even though the
+run-DAG signals still render (those persist via a separate session-level
+observer, not the per-branch message hook).
 
-This test proves the fix by exercising the exact code path
-`workflow_run.run_workflow_def` uses (`Session.flow(..., on_branch_created=...)`
-wired to `register_branch_hook`), forcing a real branch clone, producing a
-real persisted message on it (via `branch.communicate()`, which -- unlike
-the Studio "chat" node kind -- actually calls `branch.msgs.a_add_message()`
-and so fires the `on_message_added` -> `MESSAGE_ADD` hook chain that
-`register_branch_hook` wires into StateDB), and then reading the message
-back out of a *fresh* StateDB connection.
+This exercises the exact path `workflow_run.run_workflow_def` uses
+(`Session.flow(..., on_branch_created=...)` wired to `register_branch_hook`):
+forces a real branch clone, produces a real persisted message on it via
+`branch.communicate()` (which, unlike the Studio "chat" node kind, calls
+`branch.msgs.a_add_message()` and fires the `on_message_added` ->
+`MESSAGE_ADD` hook chain), then reads the message back from a fresh
+StateDB connection.
 """
 
 from __future__ import annotations
@@ -125,7 +124,7 @@ async def test_flow_clone_branch_transcript_persists(patched_env):
     )
     assert "error" not in result["operation_results"].get(op2_id, {})
 
-    # --- Prove op2 actually ran on a CLONE branch (predecessor, no branch_id) ---
+    # Prove op2 actually ran on a CLONE branch (predecessor, no branch_id)
     assert len(created_branches) == 1, (
         "expected exactly one clone: op1 has no predecessor (stays on default "
         "branch); op2 depends on op1 with no explicit branch_id, so "
@@ -138,7 +137,7 @@ async def test_flow_clone_branch_transcript_persists(patched_env):
         "the session's original default branch"
     )
 
-    # --- Query a FRESH StateDB connection (ctx["db"] is closed by teardown) ---
+    # Query a FRESH StateDB connection (ctx["db"] is closed by teardown)
     from lionagi.state.db import StateDB
 
     db = StateDB(db_path)


### PR DESCRIPTION
Removes comment-banner dividers, restated-name docstrings, and stale internal tracking references (issue/PR numbers, a reviewer mention) across 53 files in tests/apps_studio_server/, while preserving every regression rationale and design fact the docstrings recorded. No executable code or test assertions changed; verified file-by-file with the AST-equality guardrail before and after ruff formatting.